### PR TITLE
chore: disable feedback widget behind a feature flag

### DIFF
--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -5,7 +5,20 @@ import { ErrorCategory, logSystemError } from "@/lib/logging";
 const FEEDBACK_SERVICE_URL = process.env.FEEDBACK_SERVICE_URL || "";
 const FEEDBACK_API_KEY = process.env.FEEDBACK_API_KEY || "";
 
+// Feedback widget is disabled by default. Re-enable by setting
+// NEXT_PUBLIC_FEEDBACK_ENABLED=true (the sidebar button gates on the same
+// flag). When disabled, the route short-circuits and never proxies to the
+// external feedback service.
+const FEEDBACK_ENABLED = process.env.NEXT_PUBLIC_FEEDBACK_ENABLED === "true";
+
 export async function POST(request: Request): Promise<NextResponse> {
+  if (!FEEDBACK_ENABLED) {
+    return NextResponse.json(
+      { error: "Feedback service is disabled" },
+      { status: 503 }
+    );
+  }
+
   try {
     // Validate configuration
     if (!FEEDBACK_SERVICE_URL) {

--- a/components/navigation-sidebar.tsx
+++ b/components/navigation-sidebar.tsx
@@ -951,6 +951,12 @@ export function NavigationSidebar(): React.ReactNode {
             );
           })}
           {(() => {
+            // Feedback widget is disabled by default. Re-enable by setting
+            // NEXT_PUBLIC_FEEDBACK_ENABLED=true (the POST /api/feedback route
+            // gates on the same flag).
+            if (process.env.NEXT_PUBLIC_FEEDBACK_ENABLED !== "true") {
+              return null;
+            }
             const reportButton = (
               <button
                 aria-label="Report an issue"

--- a/tests/unit/feedback-route-disabled.test.ts
+++ b/tests/unit/feedback-route-disabled.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for POST /api/feedback feature-flag gate.
+ *
+ * The user feedback widget is disabled by default. The route must
+ * short-circuit with 503 and never proxy to the external feedback service
+ * unless NEXT_PUBLIC_FEEDBACK_ENABLED === "true". Re-enabling the flag
+ * restores the proxy behaviour (proving the change is reversible).
+ *
+ * FEEDBACK_ENABLED / FEEDBACK_SERVICE_URL / FEEDBACK_API_KEY are read into
+ * module-level consts at import time, so each case stubs env then
+ * re-imports the route via vi.resetModules() + dynamic import.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// `@/lib/logging` declares `import "server-only"` transitively, which throws
+// under vitest unless stubbed.
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: vi.fn().mockResolvedValue(null),
+    },
+  },
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: {
+    INFRASTRUCTURE: "infrastructure",
+    EXTERNAL_SERVICE: "external_service",
+  },
+  logSystemError: vi.fn(),
+}));
+
+function loadRoute(): Promise<typeof import("@/app/api/feedback/route")> {
+  vi.resetModules();
+  return import("@/app/api/feedback/route");
+}
+
+describe("POST /api/feedback feature-flag gate", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      );
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("returns 503 and does not call the external service when disabled (default)", async () => {
+    vi.stubEnv("NEXT_PUBLIC_FEEDBACK_ENABLED", "");
+    vi.stubEnv("FEEDBACK_SERVICE_URL", "https://feedback.example.com");
+    vi.stubEnv("FEEDBACK_API_KEY", "secret");
+
+    const { POST } = await loadRoute();
+    const form = new FormData();
+    form.append("message", "this should never be forwarded");
+    const res = await POST(
+      new Request("http://localhost/api/feedback", {
+        method: "POST",
+        body: form,
+      })
+    );
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toEqual({
+      error: "Feedback service is disabled",
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('treats any value other than the literal "true" as disabled', async () => {
+    vi.stubEnv("NEXT_PUBLIC_FEEDBACK_ENABLED", "1");
+    vi.stubEnv("FEEDBACK_SERVICE_URL", "https://feedback.example.com");
+    vi.stubEnv("FEEDBACK_API_KEY", "secret");
+
+    const { POST } = await loadRoute();
+    const form = new FormData();
+    form.append("message", "still disabled");
+    const res = await POST(
+      new Request("http://localhost/api/feedback", {
+        method: "POST",
+        body: form,
+      })
+    );
+
+    expect(res.status).toBe(503);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("proxies to the external service when re-enabled via the flag", async () => {
+    vi.stubEnv("NEXT_PUBLIC_FEEDBACK_ENABLED", "true");
+    vi.stubEnv("FEEDBACK_SERVICE_URL", "https://feedback.example.com");
+    vi.stubEnv("FEEDBACK_API_KEY", "secret");
+
+    const { POST } = await loadRoute();
+    const form = new FormData();
+    form.append("message", "forward me");
+    const res = await POST(
+      new Request("http://localhost/api/feedback", {
+        method: "POST",
+        body: form,
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://feedback.example.com",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Disables the user feedback widget (the "Report an issue" button in the bottom-left navigation sidebar) and turns off the feedback submission service.
- Hides the sidebar button behind `NEXT_PUBLIC_FEEDBACK_ENABLED` (defaults to off).
- Short-circuits `POST /api/feedback` with a 503 when the flag is not `"true"`, so it no longer proxies to the external feedback service.
- Keeps all code in place: set `NEXT_PUBLIC_FEEDBACK_ENABLED=true` (and redeploy) to re-enable, no code change required.
- The ERC-8004 agent-reputation feedback system (`/api/feedback/[id]`, `agentic-wallet/feedback`, `schema-feedback`) is intentionally untouched -- it is unrelated infrastructure that only shares the "feedback" name.

## Behavior

- Default (flag unset/empty/any value other than `"true"`): button is not rendered; `POST /api/feedback` returns `503 { "error": "Feedback service is disabled" }` and never calls the external service.
- Re-enabled (`NEXT_PUBLIC_FEEDBACK_ENABLED=true`): button renders again and the route proxies submissions as before.

The flag pattern mirrors the existing `NEXT_PUBLIC_AI_PROMPT_ENABLED` gate already used in the codebase.

## Test plan

- [x] New unit tests `tests/unit/feedback-route-disabled.test.ts` (3 cases): disabled-by-default returns 503 + no external fetch; non-`"true"` value still disabled; re-enabled proxies to the service.
- [x] `pnpm type-check` clean.
- [x] Lint clean for changed lines (`route.ts`, the new test, and the sidebar gate).
- [x] Full unit suite green: 294 files / 5513 passed / 1 skipped, no regressions.
- [x] Review team (correctness, regression/caller sweep, test verification): no blockers; ERC-8004 confirmed unaffected.

## Follow-ups (out of scope, not in this PR)

- Add unit coverage for the pre-existing `flag="true"` + missing `FEEDBACK_SERVICE_URL`/`FEEDBACK_API_KEY` 500 branches.
- Strip a pre-existing Linear-ID comment in `app/api/feedback/route.ts`.