### PR TITLE
fix(workflow-picker): hide soft-deleted workflows; label only schedulable disabled

### DIFF
--- a/components/navigation-sidebar.tsx
+++ b/components/navigation-sidebar.tsx
@@ -3,7 +3,6 @@
 import {
   BarChart3,
   Bookmark,
-  Check,
   ChevronDown,
   ChevronLeft,
   ChevronRight,
@@ -118,9 +117,6 @@ function WorkflowItem({
         <span className="ml-2 shrink-0 text-muted-foreground text-xs">
           Disabled
         </span>
-      )}
-      {!showDisabled && isActive && (
-        <Check className="ml-2 size-3.5 shrink-0 text-muted-foreground" />
       )}
     </button>
   );

--- a/components/navigation-sidebar.tsx
+++ b/components/navigation-sidebar.tsx
@@ -38,6 +38,7 @@ import { usePersistedNavState } from "@/lib/hooks/use-persisted-nav-state";
 import { isAnonymousUser } from "@/lib/is-anonymous";
 import { registerSidebarRefetch } from "@/lib/refetch-sidebar";
 import { cn } from "@/lib/utils";
+import { filterPickerVisible } from "@/lib/workflow/soft-delete";
 import { FLYOUT_WIDTH, FlyoutPanel, STRIP_WIDTH } from "./flyout-panel";
 
 export const COLLAPSED_WIDTH = 60;
@@ -50,9 +51,14 @@ type WorkflowEntry = {
   updatedAt: string;
   projectId?: string | null;
   tagId?: string | null;
-  // KEEP-440: set when the workflow has been soft-deleted. Deleted rows stay
-  // in the list with a marker so the user has an audit trail / recovery window.
+  // Soft-delete timestamp. Hidden from the sidebar picker via
+  // filterPickerVisible(), but the API still returns these rows so audit /
+  // recovery surfaces (executions history, marketplace listings) can render
+  // them.
   deletedAt?: string | null;
+  // When false, the picker greys the row out and tags it "Disabled" without
+  // strikethrough. The row stays selectable.
+  enabled?: boolean;
 };
 
 function groupWorkflows(workflows: WorkflowEntry[]): {
@@ -84,32 +90,27 @@ function WorkflowItem({
   activeWorkflowId: string | undefined;
 }): React.ReactNode {
   const router = useRouter();
-  const isDeleted = Boolean(workflow.deletedAt);
+  const isDisabled = workflow.enabled === false;
+  const isActive = workflow.id === activeWorkflowId;
   return (
     <button
       className={cn(
         "flex w-full items-center justify-between rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-muted",
-        workflow.id === activeWorkflowId && "bg-muted"
+        isActive && "bg-muted"
       )}
       onClick={() => router.push(`/workflows/${workflow.id}`)}
       type="button"
     >
-      <span
-        className={cn(
-          "truncate",
-          isDeleted && "text-muted-foreground line-through"
-        )}
-      >
+      <span className={cn("truncate", isDisabled && "text-muted-foreground")}>
         {workflow.name}
       </span>
-      {isDeleted ? (
+      {isDisabled && (
         <span className="ml-2 shrink-0 text-muted-foreground text-xs">
-          Deleted
+          Disabled
         </span>
-      ) : (
-        workflow.id === activeWorkflowId && (
-          <Check className="ml-2 size-3.5 shrink-0 text-muted-foreground" />
-        )
+      )}
+      {!isDisabled && isActive && (
+        <Check className="ml-2 size-3.5 shrink-0 text-muted-foreground" />
       )}
     </button>
   );
@@ -624,7 +625,7 @@ export function NavigationSidebar(): React.ReactNode {
 
   const isAnonymous = isAnonymousUser(session?.user);
 
-  const visibleWorkflows = workflows.filter((w) => w.name !== "__current__");
+  const visibleWorkflows = filterPickerVisible(workflows);
 
   const workflowId =
     typeof params.workflowId === "string" ? params.workflowId : undefined;

--- a/components/navigation-sidebar.tsx
+++ b/components/navigation-sidebar.tsx
@@ -39,6 +39,11 @@ import { isAnonymousUser } from "@/lib/is-anonymous";
 import { registerSidebarRefetch } from "@/lib/refetch-sidebar";
 import { cn } from "@/lib/utils";
 import { filterPickerVisible } from "@/lib/workflow/soft-delete";
+import {
+  getWorkflowTriggerType,
+  shouldShowDisabledBadge,
+  type WorkflowTriggerType,
+} from "@/lib/workflow/store";
 import { FLYOUT_WIDTH, FlyoutPanel, STRIP_WIDTH } from "./flyout-panel";
 
 export const COLLAPSED_WIDTH = 60;
@@ -56,8 +61,13 @@ type WorkflowEntry = {
   // recovery surfaces (executions history, marketplace listings) can render
   // them.
   deletedAt?: string | null;
-  // When false, the picker greys the row out and tags it "Disabled" without
-  // strikethrough. The row stays selectable.
+  // The trigger type drives whether the "Disabled" label is meaningful --
+  // see shouldShowDisabledBadge. Derived once at the SavedWorkflow boundary
+  // so WorkflowItem doesn't have to carry the full nodes payload.
+  triggerType?: WorkflowTriggerType;
+  // When false on a trigger that supports the enable switch, the picker
+  // greys the row out and tags it "Disabled" without strikethrough. The row
+  // stays selectable.
   enabled?: boolean;
 };
 
@@ -90,7 +100,7 @@ function WorkflowItem({
   activeWorkflowId: string | undefined;
 }): React.ReactNode {
   const router = useRouter();
-  const isDisabled = workflow.enabled === false;
+  const showDisabled = shouldShowDisabledBadge(workflow);
   const isActive = workflow.id === activeWorkflowId;
   return (
     <button
@@ -101,15 +111,15 @@ function WorkflowItem({
       onClick={() => router.push(`/workflows/${workflow.id}`)}
       type="button"
     >
-      <span className={cn("truncate", isDisabled && "text-muted-foreground")}>
+      <span className={cn("truncate", showDisabled && "text-muted-foreground")}>
         {workflow.name}
       </span>
-      {isDisabled && (
+      {showDisabled && (
         <span className="ml-2 shrink-0 text-muted-foreground text-xs">
           Disabled
         </span>
       )}
-      {!isDisabled && isActive && (
+      {!showDisabled && isActive && (
         <Check className="ml-2 size-3.5 shrink-0 text-muted-foreground" />
       )}
     </button>
@@ -625,7 +635,10 @@ export function NavigationSidebar(): React.ReactNode {
 
   const isAnonymous = isAnonymousUser(session?.user);
 
-  const visibleWorkflows = filterPickerVisible(workflows);
+  const visibleWorkflows = filterPickerVisible(workflows).map((w) => ({
+    ...w,
+    triggerType: getWorkflowTriggerType(w.nodes),
+  }));
 
   const workflowId =
     typeof params.workflowId === "string" ? params.workflowId : undefined;

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -44,6 +44,7 @@ import { useAuthPrompt } from "@/components/auth/provider";
 import { isAnonymousUser } from "@/lib/is-anonymous";
 import { api, ApiError, type Project, type Tag } from "@/lib/api-client";
 import { useSession } from "@/lib/auth-client";
+import { refetchSidebar } from "@/lib/refetch-sidebar";
 import { getCustomLogo } from "@/lib/workflow/editor/extension-registry";
 import { integrationsAtom } from "@/lib/integrations-store";
 import type { IntegrationType } from "@/lib/types/integration";
@@ -1173,6 +1174,9 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
         enabled,
       });
       state.setIsEnabled(enabled);
+      // The sidebar picker derives its "Disabled" label from this column,
+      // so it needs a refetch to drop the stale row state.
+      refetchSidebar();
       toast.success(enabled ? "Workflow enabled" : "Workflow disabled");
     } catch (error) {
       console.error("Failed to update enabled state:", error);

--- a/lib/workflow/soft-delete.ts
+++ b/lib/workflow/soft-delete.ts
@@ -44,6 +44,8 @@ export function filterPickerVisible<
   T extends { name: string; deletedAt?: Date | string | null },
 >(entries: T[]): T[] {
   return entries.filter(
-    (entry) => entry.name !== "__current__" && !entry.deletedAt
+    // `== null` matches both null and undefined without coercing the
+    // `Date | string` arms, which would mis-handle a `new Date(0)` or "".
+    (entry) => entry.name !== "__current__" && entry.deletedAt == null
   );
 }

--- a/lib/workflow/soft-delete.ts
+++ b/lib/workflow/soft-delete.ts
@@ -32,3 +32,18 @@ export function isWorkflowDeleted(workflow: {
 export function softDeleteValues(): { deletedAt: Date; isListed: boolean } {
   return { deletedAt: new Date(), isListed: false };
 }
+
+/**
+ * Filter the owner-facing workflow list down to entries that belong in the
+ * sidebar picker. Soft-deleted rows are dropped (audit/recovery still keeps
+ * them in the API payload for other surfaces) and the internal `__current__`
+ * stub is excluded. Disabled rows are intentionally kept -- the picker greys
+ * them out and tags them rather than hiding them.
+ */
+export function filterPickerVisible<
+  T extends { name: string; deletedAt?: Date | string | null },
+>(entries: T[]): T[] {
+  return entries.filter(
+    (entry) => entry.name !== "__current__" && !entry.deletedAt
+  );
+}

--- a/lib/workflow/store.ts
+++ b/lib/workflow/store.ts
@@ -1,9 +1,9 @@
 import type { Edge, EdgeChange, Node, NodeChange } from "@xyflow/react";
 import { applyEdgeChanges, applyNodeChanges } from "@xyflow/react";
 import { atom } from "jotai";
+import { api } from "@/lib/api-client";
 import { computeAutoLayout } from "@/lib/workflow/editor/auto-layout";
 import { buildExecutionLogsMap } from "@/lib/workflow/editor/template-helpers";
-import { api } from "@/lib/api-client";
 
 export type WorkflowNodeType = "trigger" | "action" | "add";
 
@@ -31,6 +31,36 @@ export function shouldShowEnableSwitch(
     triggerType === WorkflowTriggerEnum.BLOCK ||
     triggerType === WorkflowTriggerEnum.WEBHOOK
   );
+}
+
+/**
+ * Pull the trigger type off the trigger node in a workflow's node list.
+ * Used by surfaces that need to gate behavior on what fires the workflow
+ * without dragging the full editor store into view -- e.g. the sidebar
+ * picker deciding whether to surface a "Disabled" label.
+ */
+export function getWorkflowTriggerType(
+  nodes: Array<{ data?: { type?: string; config?: Record<string, unknown> } }>
+): WorkflowTriggerType | undefined {
+  const triggerNode = nodes.find((node) => node.data?.type === "trigger");
+  const raw = triggerNode?.data?.config?.triggerType;
+  return typeof raw === "string" ? (raw as WorkflowTriggerType) : undefined;
+}
+
+/**
+ * Show the "Disabled" label in the sidebar picker only when the workflow has
+ * a trigger type whose schedule the user can actually flip with the enable
+ * switch. Manual workflows persist `enabled = false` by default but can't be
+ * disabled through the UI -- labeling them would be noise.
+ */
+export function shouldShowDisabledBadge(workflow: {
+  enabled?: boolean | null;
+  triggerType?: WorkflowTriggerType | null;
+}): boolean {
+  if (workflow.enabled !== false) {
+    return false;
+  }
+  return shouldShowEnableSwitch(workflow.triggerType ?? undefined);
 }
 
 export type WorkflowNodeData = {

--- a/lib/workflow/store.ts
+++ b/lib/workflow/store.ts
@@ -44,7 +44,13 @@ export function getWorkflowTriggerType(
 ): WorkflowTriggerType | undefined {
   const triggerNode = nodes.find((node) => node.data?.type === "trigger");
   const raw = triggerNode?.data?.config?.triggerType;
-  return typeof raw === "string" ? (raw as WorkflowTriggerType) : undefined;
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  // "Scheduled" is a legacy spelling that still lives in some workflow rows;
+  // executor / metrics / mcp normalize it the same way before comparing.
+  const normalized = raw === "Scheduled" ? "Schedule" : raw;
+  return normalized as WorkflowTriggerType;
 }
 
 /**

--- a/tests/unit/workflow-enable-switch.test.ts
+++ b/tests/unit/workflow-enable-switch.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  getWorkflowTriggerType,
+  shouldShowDisabledBadge,
   shouldShowEnableSwitch,
   WorkflowTriggerEnum,
 } from "@/lib/workflow/store";
@@ -20,5 +22,88 @@ describe("shouldShowEnableSwitch", () => {
 
   it("returns false when no trigger is configured yet", () => {
     expect(shouldShowEnableSwitch(undefined)).toBe(false);
+  });
+});
+
+describe("getWorkflowTriggerType", () => {
+  it("returns the triggerType from the trigger node when present", () => {
+    const nodes = [
+      {
+        data: {
+          type: "trigger",
+          config: { triggerType: WorkflowTriggerEnum.SCHEDULE },
+        },
+      },
+      { data: { type: "action", config: { actionType: "webhook/send" } } },
+    ];
+    expect(getWorkflowTriggerType(nodes)).toBe(WorkflowTriggerEnum.SCHEDULE);
+  });
+
+  it("returns undefined when there is no trigger node", () => {
+    const nodes = [
+      { data: { type: "action", config: { actionType: "webhook/send" } } },
+    ];
+    expect(getWorkflowTriggerType(nodes)).toBeUndefined();
+  });
+
+  it("returns undefined when the trigger node has no config.triggerType", () => {
+    const nodes = [{ data: { type: "trigger" } }];
+    expect(getWorkflowTriggerType(nodes)).toBeUndefined();
+  });
+
+  it("returns undefined for an empty node list", () => {
+    expect(getWorkflowTriggerType([])).toBeUndefined();
+  });
+});
+
+describe("shouldShowDisabledBadge", () => {
+  it("returns false when enabled is true (workflow is on)", () => {
+    expect(
+      shouldShowDisabledBadge({
+        enabled: true,
+        triggerType: WorkflowTriggerEnum.SCHEDULE,
+      })
+    ).toBe(false);
+  });
+
+  it("returns true for a disabled schedulable workflow", () => {
+    expect(
+      shouldShowDisabledBadge({
+        enabled: false,
+        triggerType: WorkflowTriggerEnum.SCHEDULE,
+      })
+    ).toBe(true);
+  });
+
+  it.each([
+    WorkflowTriggerEnum.EVENT,
+    WorkflowTriggerEnum.SCHEDULE,
+    WorkflowTriggerEnum.BLOCK,
+    WorkflowTriggerEnum.WEBHOOK,
+  ])("returns true for %s triggers when enabled = false", (trigger) => {
+    expect(
+      shouldShowDisabledBadge({ enabled: false, triggerType: trigger })
+    ).toBe(true);
+  });
+
+  it("returns false for Manual triggers regardless of enabled flag", () => {
+    // Manual workflows default to enabled = false in the DB but have no UI
+    // toggle, so labeling them "Disabled" would be misleading noise.
+    expect(
+      shouldShowDisabledBadge({
+        enabled: false,
+        triggerType: WorkflowTriggerEnum.MANUAL,
+      })
+    ).toBe(false);
+  });
+
+  it("returns false when triggerType is undefined (workflow has no trigger yet)", () => {
+    expect(shouldShowDisabledBadge({ enabled: false })).toBe(false);
+  });
+
+  it("returns false when enabled is undefined", () => {
+    expect(
+      shouldShowDisabledBadge({ triggerType: WorkflowTriggerEnum.SCHEDULE })
+    ).toBe(false);
   });
 });

--- a/tests/unit/workflow-enable-switch.test.ts
+++ b/tests/unit/workflow-enable-switch.test.ts
@@ -54,6 +54,18 @@ describe("getWorkflowTriggerType", () => {
   it("returns undefined for an empty node list", () => {
     expect(getWorkflowTriggerType([])).toBeUndefined();
   });
+
+  it("normalizes the legacy 'Scheduled' spelling to 'Schedule'", () => {
+    // Older workflow rows persist `triggerType: "Scheduled"`; executor,
+    // metrics, and mcp call sites all canonicalize the same way before
+    // comparing, so the picker has to as well or it misses the badge.
+    const nodes = [
+      {
+        data: { type: "trigger", config: { triggerType: "Scheduled" } },
+      },
+    ];
+    expect(getWorkflowTriggerType(nodes)).toBe(WorkflowTriggerEnum.SCHEDULE);
+  });
 });
 
 describe("shouldShowDisabledBadge", () => {

--- a/tests/unit/workflow-soft-delete.test.ts
+++ b/tests/unit/workflow-soft-delete.test.ts
@@ -36,6 +36,7 @@ vi.mock("@/lib/db/schema", () => ({
 
 import { getWorkflowAccess } from "@/lib/workflow/access";
 import {
+  filterPickerVisible,
   isWorkflowDeleted,
   workflowNotDeleted,
 } from "@/lib/workflow/soft-delete";
@@ -100,5 +101,65 @@ describe("getWorkflowAccess soft-delete signal", () => {
     });
 
     expect(access.isDeleted).toBe(false);
+  });
+});
+
+describe("filterPickerVisible", () => {
+  type PickerRow = {
+    id: string;
+    name: string;
+    deletedAt?: Date | string | null;
+    enabled?: boolean;
+  };
+
+  it("excludes soft-deleted rows (deletedAt set)", () => {
+    const rows: PickerRow[] = [
+      { id: "a", name: "Alpha", deletedAt: null },
+      { id: "b", name: "Beta", deletedAt: new Date() },
+      { id: "c", name: "Gamma", deletedAt: "2026-05-29T00:00:00.000Z" },
+    ];
+
+    expect(filterPickerVisible(rows).map((row) => row.id)).toEqual(["a"]);
+  });
+
+  it("excludes the internal __current__ stub", () => {
+    const rows: PickerRow[] = [
+      { id: "current", name: "__current__", deletedAt: null },
+      { id: "a", name: "Alpha", deletedAt: null },
+    ];
+
+    expect(filterPickerVisible(rows).map((row) => row.id)).toEqual(["a"]);
+  });
+
+  it("keeps disabled rows visible (enabled: false)", () => {
+    const rows: PickerRow[] = [
+      { id: "a", name: "Alpha", deletedAt: null, enabled: true },
+      { id: "b", name: "Beta", deletedAt: null, enabled: false },
+    ];
+
+    expect(filterPickerVisible(rows).map((row) => row.id)).toEqual(["a", "b"]);
+  });
+
+  it("treats missing deletedAt the same as null", () => {
+    const rows: PickerRow[] = [
+      { id: "a", name: "Alpha" },
+      { id: "b", name: "Beta", deletedAt: null },
+    ];
+
+    expect(filterPickerVisible(rows).map((row) => row.id)).toEqual(["a", "b"]);
+  });
+
+  it("preserves input order", () => {
+    const rows: PickerRow[] = [
+      { id: "c", name: "Gamma", deletedAt: null },
+      { id: "a", name: "Alpha", deletedAt: null },
+      { id: "b", name: "Beta", deletedAt: null },
+    ];
+
+    expect(filterPickerVisible(rows).map((row) => row.id)).toEqual([
+      "c",
+      "a",
+      "b",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- The sidebar workflow picker now hides soft-deleted workflows entirely instead of rendering them with strikethrough + a "Deleted" badge. They remain in the `/api/workflows` payload so audit / executions history surfaces still see them.
- Disabled workflows render with muted text and a "Disabled" badge -- no strikethrough -- and only when the trigger is one whose schedule the user can actually flip (Schedule / Webhook / Event / Block). Manual triggers no longer pick up a misleading label even though they default to `enabled = false` in the DB.
- Toggling the enable switch in the editor header now triggers a sidebar refetch, so the picker repaints immediately.
- The small Check icon that used to render on the currently-viewed row was removed -- the bg-muted highlight already carries that signal.

## Implementation

- `lib/workflow/soft-delete.ts` -- new `filterPickerVisible(entries)` helper that drops `deletedAt`-set rows and the internal `__current__` stub.
- `lib/workflow/store.ts` -- new `getWorkflowTriggerType(nodes)` (pulls the trigger off the trigger node) and `shouldShowDisabledBadge({enabled, triggerType})` (returns true only when the row is `enabled === false` and the trigger has an enable switch via `shouldShowEnableSwitch`).
- `components/navigation-sidebar.tsx` -- adds `enabled` and `triggerType` to `WorkflowEntry`, derives `triggerType` once at the visibleWorkflows boundary, and gates the badge on the predicate above.
- `components/workflow/workflow-toolbar.tsx` -- `updateWorkflowEnabled` calls `refetchSidebar()` after the update succeeds.

## Verification

- 31 unit tests across `tests/unit/workflow-soft-delete.test.ts` (5 new cases for the picker filter) and `tests/unit/workflow-enable-switch.test.ts` (10 new cases for `getWorkflowTriggerType` and `shouldShowDisabledBadge`, including the Manual-exemption case).
- `pnpm type-check` clean.
- Visually verified locally against a test user seeded with workflows in all 6 states (Manual on/off, Schedule on/off, Webhook off, soft-deleted): only the Schedule and Webhook `enabled = false` rows show the "Disabled" badge; the soft-deleted row is absent; toggling the header switch updates the picker immediately.

## Test plan

- [x] Soft-deleted workflow does not appear in the sidebar picker
- [x] Disabled Schedule workflow shows greyed text + "Disabled" badge, no strikethrough
- [x] Disabled Webhook workflow shows greyed text + "Disabled" badge
- [x] Disabled Manual workflow renders like an enabled one (Manual exempt)
- [x] Active workflows render normally
- [x] Toggling enable/disable in the editor header updates the picker badge without a manual refresh
- [x] `pnpm test:unit` covers the new helpers
- [x] `pnpm type-check` clean