### PR TITLE
perf: cache /api/metrics/db scrape to cut DB CPU

### DIFF
--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -1218,6 +1218,9 @@ function getDbMetricsCacheTtlMs(): number {
 }
 
 type DbMetricsCacheEntry = {
+  // Monotonic timestamps from performance.now(), not Date.now() — wall
+  // clock can step backwards on NTP adjustments and invalidate the
+  // TTL math. performance.now() is process-monotonic.
   startedAt: number;
   completedAt: number | null;
   promise: Promise<void>;
@@ -1287,7 +1290,7 @@ export function updateDbMetrics(): Promise<void> {
       return lastDbMetricsRefresh.promise;
     }
     // Completed: serve cached if within TTL of completion (not start).
-    if (Date.now() - lastDbMetricsRefresh.completedAt < ttl) {
+    if (performance.now() - lastDbMetricsRefresh.completedAt < ttl) {
       dbMetricsCacheLookupsTotal.inc({ result: "hit" });
       return lastDbMetricsRefresh.promise;
     }
@@ -1299,7 +1302,7 @@ export function updateDbMetrics(): Promise<void> {
     // Already logged inside refreshDbMetricsNow.
   });
   const entry: DbMetricsCacheEntry = {
-    startedAt: Date.now(),
+    startedAt: performance.now(),
     completedAt: null,
     promise: wrapped,
   };
@@ -1311,7 +1314,7 @@ export function updateDbMetrics(): Promise<void> {
   // (which would surface as an unhandled rejection).
   raw.then(
     () => {
-      entry.completedAt = Date.now();
+      entry.completedAt = performance.now();
       dbMetricsRefreshTotal.inc({ outcome: "success" });
     },
     () => {

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -1192,13 +1192,75 @@ const WORKFLOW_DURATION_BUCKETS = [
 ];
 const STEP_DURATION_BUCKETS = [50, 100, 250, 500, 1000, 2000, 5000];
 
+// Module-level TTL cache for updateDbMetrics. The scrape path runs ~35
+// aggregate queries (including unindexed seq scans over workflow_executions
+// and workflow_execution_logs) and the ServiceMonitor scrapes every 30s per
+// pod. Without this cache, each pod hits the DB on every scrape; with it,
+// concurrent scrapes share an in-flight refresh and back-to-back scrapes
+// within DB_METRICS_CACHE_TTL_MS reuse the prior result.
+//
+// Set DB_METRICS_CACHE_TTL_MS=0 to disable the cache (refresh on every call).
+const DEFAULT_DB_METRICS_CACHE_TTL_MS = 60_000;
+
+function getDbMetricsCacheTtlMs(): number {
+  const raw = process.env.DB_METRICS_CACHE_TTL_MS;
+  if (raw === undefined) {
+    return DEFAULT_DB_METRICS_CACHE_TTL_MS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0
+    ? parsed
+    : DEFAULT_DB_METRICS_CACHE_TTL_MS;
+}
+
+let lastDbMetricsRefresh: { at: number; promise: Promise<void> } | null = null;
+
 /**
- * Update DB-sourced metrics from database
- *
- * Called before each metrics scrape to ensure fresh data from the database.
- * This is necessary because workflow runner jobs exit before Prometheus can scrape them.
+ * Reset the cache. Intended for tests; not exported from the package barrel.
  */
-export async function updateDbMetrics(): Promise<void> {
+export function __resetDbMetricsCacheForTest(): void {
+  lastDbMetricsRefresh = null;
+}
+
+/**
+ * Update DB-sourced metrics from database.
+ *
+ * Wraps the underlying refresh in a per-process TTL cache so two scrapes
+ * within the TTL share one DB round-trip. Concurrent callers during an
+ * in-flight refresh receive the same promise. On rejection the cache slot
+ * is cleared so the next caller retries instead of seeing a stale failure.
+ */
+export function updateDbMetrics(): Promise<void> {
+  const ttl = getDbMetricsCacheTtlMs();
+  if (ttl <= 0) {
+    // No caching, but still swallow so the route doesn't 500. The inner
+    // refresh already logged the error before rethrowing.
+    return refreshDbMetricsNow().catch(() => {
+      // Already logged.
+    });
+  }
+  const now = Date.now();
+  if (lastDbMetricsRefresh && now - lastDbMetricsRefresh.at < ttl) {
+    return lastDbMetricsRefresh.promise;
+  }
+  const raw = refreshDbMetricsNow();
+  // Public promise swallows so the metrics endpoint doesn't 500.
+  const wrapped = raw.catch(() => {
+    // Already logged inside refreshDbMetricsNow.
+  });
+  const entry = { at: now, promise: wrapped };
+  lastDbMetricsRefresh = entry;
+  // On the raw (unswallowed) rejection, evict the slot so the next scrape
+  // retries immediately instead of holding a poisoned-but-resolved entry.
+  raw.catch(() => {
+    if (lastDbMetricsRefresh === entry) {
+      lastDbMetricsRefresh = null;
+    }
+  });
+  return wrapped;
+}
+
+async function refreshDbMetricsNow(): Promise<void> {
   try {
     // Dynamic import to avoid circular dependencies
     const {
@@ -1445,7 +1507,10 @@ export async function updateDbMetrics(): Promise<void> {
     updateHubVoteMetrics(voteStats);
   } catch (error) {
     console.error("[Prometheus] Failed to update DB metrics:", error);
-    // Don't throw - allow other metrics to still be returned
+    // Propagate so the TTL cache wrapper evicts the failed entry instead
+    // of pinning it; updateDbMetrics() catches before returning to callers,
+    // preserving the previous "metrics endpoint never 500s" behavior.
+    throw error;
   }
 }
 

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -1319,19 +1319,26 @@ export function updateDbMetrics(): Promise<void> {
   // so subsequent TTL checks measure from there, and evicts the slot on
   // failure so the next scrape retries instead of holding a poisoned
   // entry. The two-arg form avoids creating an orphan rejected promise
-  // (which would surface as an unhandled rejection).
-  raw.then(
-    () => {
-      entry.completedAt = performance.now();
-      dbMetricsRefreshTotal.inc({ outcome: "success" });
-    },
-    () => {
-      if (lastDbMetricsRefresh === entry) {
-        lastDbMetricsRefresh = null;
+  // (which would surface as an unhandled rejection). The trailing .catch
+  // guards against the settle callbacks themselves throwing (e.g. if
+  // prom-client is in a bad state), which would otherwise produce a second
+  // unhandled rejection from the returned promise.
+  raw
+    .then(
+      () => {
+        entry.completedAt = performance.now();
+        dbMetricsRefreshTotal.inc({ outcome: "success" });
+      },
+      () => {
+        if (lastDbMetricsRefresh === entry) {
+          lastDbMetricsRefresh = null;
+        }
+        dbMetricsRefreshTotal.inc({ outcome: "error" });
       }
-      dbMetricsRefreshTotal.inc({ outcome: "error" });
-    }
-  );
+    )
+    .catch(() => {
+      // settle callback threw; counters are best-effort
+    });
   return wrapped;
 }
 

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -1204,10 +1204,14 @@ const DEFAULT_DB_METRICS_CACHE_TTL_MS = 60_000;
 
 function getDbMetricsCacheTtlMs(): number {
   const raw = process.env.DB_METRICS_CACHE_TTL_MS;
-  if (raw === undefined) {
+  if (raw === undefined || raw === "") {
     return DEFAULT_DB_METRICS_CACHE_TTL_MS;
   }
-  const parsed = Number.parseInt(raw, 10);
+  // Use Number() (not parseInt) so trailing junk like "60s" or "60000abc"
+  // is rejected outright instead of silently parsed as 60 / 60000. A
+  // malformed env var that silently degrades to the wrong TTL is harder
+  // to notice than one that falls back to the documented default.
+  const parsed = Number(raw);
   return Number.isFinite(parsed) && parsed >= 0
     ? parsed
     : DEFAULT_DB_METRICS_CACHE_TTL_MS;

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -1213,7 +1213,13 @@ function getDbMetricsCacheTtlMs(): number {
     : DEFAULT_DB_METRICS_CACHE_TTL_MS;
 }
 
-let lastDbMetricsRefresh: { at: number; promise: Promise<void> } | null = null;
+type DbMetricsCacheEntry = {
+  startedAt: number;
+  completedAt: number | null;
+  promise: Promise<void>;
+};
+
+let lastDbMetricsRefresh: DbMetricsCacheEntry | null = null;
 
 /**
  * Reset the cache. Intended for tests; not exported from the package barrel.
@@ -1227,8 +1233,11 @@ export function __resetDbMetricsCacheForTest(): void {
  *
  * Wraps the underlying refresh in a per-process TTL cache so two scrapes
  * within the TTL share one DB round-trip. Concurrent callers during an
- * in-flight refresh receive the same promise. On rejection the cache slot
- * is cleared so the next caller retries instead of seeing a stale failure.
+ * in-flight refresh receive the same promise, even past the TTL — this
+ * prevents the cache from amplifying load when a refresh under DB stress
+ * takes longer than the TTL itself. Once the refresh completes, TTL is
+ * measured from completion. On rejection the cache slot is cleared so the
+ * next caller retries instead of seeing a stale failure.
  */
 export function updateDbMetrics(): Promise<void> {
   const ttl = getDbMetricsCacheTtlMs();
@@ -1239,24 +1248,43 @@ export function updateDbMetrics(): Promise<void> {
       // Already logged.
     });
   }
-  const now = Date.now();
-  if (lastDbMetricsRefresh && now - lastDbMetricsRefresh.at < ttl) {
-    return lastDbMetricsRefresh.promise;
+  if (lastDbMetricsRefresh) {
+    // In-flight: share the promise regardless of TTL to avoid starting a
+    // second concurrent refresh when the first hasn't finished yet.
+    if (lastDbMetricsRefresh.completedAt === null) {
+      return lastDbMetricsRefresh.promise;
+    }
+    // Completed: serve cached if within TTL of completion (not start).
+    if (Date.now() - lastDbMetricsRefresh.completedAt < ttl) {
+      return lastDbMetricsRefresh.promise;
+    }
   }
   const raw = refreshDbMetricsNow();
   // Public promise swallows so the metrics endpoint doesn't 500.
   const wrapped = raw.catch(() => {
     // Already logged inside refreshDbMetricsNow.
   });
-  const entry = { at: now, promise: wrapped };
+  const entry: DbMetricsCacheEntry = {
+    startedAt: Date.now(),
+    completedAt: null,
+    promise: wrapped,
+  };
   lastDbMetricsRefresh = entry;
-  // On the raw (unswallowed) rejection, evict the slot so the next scrape
-  // retries immediately instead of holding a poisoned-but-resolved entry.
-  raw.catch(() => {
-    if (lastDbMetricsRefresh === entry) {
-      lastDbMetricsRefresh = null;
+  // Combined settle handler in two-arg form: stamps completion on success
+  // so subsequent TTL checks measure from there, and evicts the slot on
+  // failure so the next scrape retries instead of holding a poisoned
+  // entry. The two-arg form avoids creating an orphan rejected promise
+  // (which would surface as an unhandled rejection).
+  raw.then(
+    () => {
+      entry.completedAt = Date.now();
+    },
+    () => {
+      if (lastDbMetricsRefresh === entry) {
+        lastDbMetricsRefresh = null;
+      }
     }
-  });
+  );
   return wrapped;
 }
 

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -1221,6 +1221,26 @@ type DbMetricsCacheEntry = {
 
 let lastDbMetricsRefresh: DbMetricsCacheEntry | null = null;
 
+// Per-pod observability for the cache itself. Without these, the only
+// post-deploy signal for whether the cache is working is the indirect
+// "DB CPU went down" reading on CloudWatch. The two counters split cache
+// lookup outcomes (every updateDbMetrics call) from refresh outcomes
+// (every actual DB round-trip) so PromQL can express both
+// "cache hit rate" and "refresh failure rate" cleanly.
+const dbMetricsCacheLookupsTotal = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_db_metrics_cache_lookups_total",
+  "Outcomes of /api/metrics/db cache lookups (per pod)",
+  ["result"]
+);
+
+const dbMetricsRefreshTotal = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_db_metrics_refresh_total",
+  "Outcomes of /api/metrics/db DB round-trips (per pod)",
+  ["outcome"]
+);
+
 /**
  * Reset the cache. Intended for tests; not exported from the package barrel.
  */
@@ -1242,23 +1262,33 @@ export function __resetDbMetricsCacheForTest(): void {
 export function updateDbMetrics(): Promise<void> {
   const ttl = getDbMetricsCacheTtlMs();
   if (ttl <= 0) {
+    dbMetricsCacheLookupsTotal.inc({ result: "disabled" });
     // No caching, but still swallow so the route doesn't 500. The inner
     // refresh already logged the error before rethrowing.
-    return refreshDbMetricsNow().catch(() => {
-      // Already logged.
-    });
+    return refreshDbMetricsNow().then(
+      () => {
+        dbMetricsRefreshTotal.inc({ outcome: "success" });
+      },
+      () => {
+        dbMetricsRefreshTotal.inc({ outcome: "error" });
+        // Already logged inside refreshDbMetricsNow.
+      }
+    );
   }
   if (lastDbMetricsRefresh) {
     // In-flight: share the promise regardless of TTL to avoid starting a
     // second concurrent refresh when the first hasn't finished yet.
     if (lastDbMetricsRefresh.completedAt === null) {
+      dbMetricsCacheLookupsTotal.inc({ result: "in_flight_dedup" });
       return lastDbMetricsRefresh.promise;
     }
     // Completed: serve cached if within TTL of completion (not start).
     if (Date.now() - lastDbMetricsRefresh.completedAt < ttl) {
+      dbMetricsCacheLookupsTotal.inc({ result: "hit" });
       return lastDbMetricsRefresh.promise;
     }
   }
+  dbMetricsCacheLookupsTotal.inc({ result: "miss" });
   const raw = refreshDbMetricsNow();
   // Public promise swallows so the metrics endpoint doesn't 500.
   const wrapped = raw.catch(() => {
@@ -1278,11 +1308,13 @@ export function updateDbMetrics(): Promise<void> {
   raw.then(
     () => {
       entry.completedAt = Date.now();
+      dbMetricsRefreshTotal.inc({ outcome: "success" });
     },
     () => {
       if (lastDbMetricsRefresh === entry) {
         lastDbMetricsRefresh = null;
       }
+      dbMetricsRefreshTotal.inc({ outcome: "error" });
     }
   );
   return wrapped;

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -1249,9 +1249,17 @@ const dbMetricsRefreshTotal = getOrCreateCounter(
 );
 
 /**
- * Reset the cache. Intended for tests; not exported from the package barrel.
+ * Reset the cache. Test-only — throws if called outside NODE_ENV=test.
+ * Exported because tests need to clear the module-level state between
+ * cases. Gated so production code that accidentally calls it fails loud
+ * instead of silently invalidating the cache mid-flight.
  */
 export function __resetDbMetricsCacheForTest(): void {
+  if (process.env.NODE_ENV !== "test") {
+    throw new Error(
+      "__resetDbMetricsCacheForTest is test-only; do not call in production"
+    );
+  }
   lastDbMetricsRefresh = null;
 }
 

--- a/tests/unit/db-metrics-cache.test.ts
+++ b/tests/unit/db-metrics-cache.test.ts
@@ -203,6 +203,52 @@ describe("updateDbMetrics TTL cache", () => {
     expect(dbMocks.getWorkflowStatsFromDb).toHaveBeenCalledTimes(1);
   });
 
+  it("shares an in-flight refresh even after the TTL has elapsed", async () => {
+    // Guards against the cache amplifying load when a refresh under DB
+    // stress takes longer than the TTL: the second scrape must share the
+    // first in-flight refresh instead of starting a concurrent one.
+    process.env.DB_METRICS_CACHE_TTL_MS = "60000";
+
+    let resolveWorkflow: ((value: unknown) => void) | undefined;
+    dbMocks.getWorkflowStatsFromDb.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveWorkflow = resolve;
+        })
+    );
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    let first: Promise<void>;
+    let second: Promise<void>;
+    try {
+      first = updateDbMetrics();
+      // Let the dynamic import and Promise.all reach the controlled mock
+      // so resolveWorkflow gets bound before we manipulate it below.
+      await flushMicrotasks();
+      // Advance well past the TTL while the first refresh is still hanging.
+      vi.setSystemTime(new Date("2026-01-01T00:02:00Z"));
+      second = updateDbMetrics();
+    } finally {
+      vi.useRealTimers();
+    }
+
+    resolveWorkflow?.({
+      totalSuccess: 0,
+      totalError: 0,
+      totalRunning: 0,
+      totalPending: 0,
+      totalCancelled: 0,
+      executionsByStatusAndOrgSlug: [],
+      durationBuckets: [0, 0, 0, 0, 0, 0, 0, 0, 0],
+      durationSum: 0,
+      durationCount: 0,
+    });
+
+    await Promise.all([first, second]);
+    expect(dbMocks.getWorkflowStatsFromDb).toHaveBeenCalledTimes(1);
+  });
+
   it("clears the cache slot on rejection so the next call retries", async () => {
     process.env.DB_METRICS_CACHE_TTL_MS = "60000";
 

--- a/tests/unit/db-metrics-cache.test.ts
+++ b/tests/unit/db-metrics-cache.test.ts
@@ -171,6 +171,25 @@ describe("updateDbMetrics TTL cache", () => {
     expect(dbMocks.getBillingStatsFromDb).toHaveBeenCalledTimes(2);
   });
 
+  it("falls back to default TTL when env var is malformed", async () => {
+    // "60s" with a unit suffix would have been silently parsed as 60ms by
+    // parseInt, giving the wrong cache behavior. Number() rejects it, so
+    // the default 60000ms is used and only one DB hit happens within 30s.
+    process.env.DB_METRICS_CACHE_TTL_MS = "60s";
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    try {
+      await updateDbMetrics();
+      vi.setSystemTime(new Date("2026-01-01T00:00:30Z"));
+      await updateDbMetrics();
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(dbMocks.getWorkflowStatsFromDb).toHaveBeenCalledTimes(1);
+  });
+
   it("disables caching when DB_METRICS_CACHE_TTL_MS=0", async () => {
     process.env.DB_METRICS_CACHE_TTL_MS = "0";
 

--- a/tests/unit/db-metrics-cache.test.ts
+++ b/tests/unit/db-metrics-cache.test.ts
@@ -11,13 +11,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-// Stub every helper updateDbMetrics() imports so the test never touches the
-// real DB. Each stub is a vi.fn we can assert call counts on.
-const stub = (returnValue: unknown): ReturnType<typeof vi.fn> =>
-  vi.fn(async () => returnValue);
-
-const dbMocks = {
-  getWorkflowStatsFromDb: stub({
+// Stub return shapes for every helper updateDbMetrics() imports. Kept
+// in a map so rebindDefaultDbMockImplementations() can re-apply them
+// after mockReset() wipes the default implementation between tests.
+const DEFAULT_DB_RETURNS: Record<string, unknown> = {
+  getWorkflowStatsFromDb: {
     totalSuccess: 0,
     totalError: 0,
     totalRunning: 0,
@@ -27,65 +25,76 @@ const dbMocks = {
     durationBuckets: [0, 0, 0, 0, 0, 0, 0, 0, 0],
     durationSum: 0,
     durationCount: 0,
-  }),
-  getStepStatsFromDb: stub({
+  },
+  getStepStatsFromDb: {
     countsByType: {},
     durationBuckets: [0, 0, 0, 0, 0, 0, 0, 0],
     durationSum: 0,
     durationCount: 0,
-  }),
-  getDailyActiveUsersFromDb: stub(0),
-  getUserStatsFromDb: stub({
+  },
+  getDailyActiveUsersFromDb: 0,
+  getUserStatsFromDb: {
     total: 0,
     verified: 0,
     anonymous: 0,
     withWorkflows: 0,
     withIntegrations: 0,
-  }),
-  getOrgStatsFromDb: stub({
+  },
+  getOrgStatsFromDb: {
     total: 0,
     membersTotal: 0,
     membersByRole: {},
     invitationsPending: 0,
     withWorkflows: 0,
-  }),
-  getWorkflowDefinitionStatsFromDb: stub({
+  },
+  getWorkflowDefinitionStatsFromDb: {
     total: 0,
     public: 0,
     private: 0,
     anonymous: 0,
-  }),
-  getScheduleStatsFromDb: stub({
+  },
+  getScheduleStatsFromDb: {
     total: 0,
     enabled: 0,
     disabled: 0,
     byLastStatus: {},
-  }),
-  getIntegrationStatsFromDb: stub({ total: 0, managed: 0, byType: {} }),
-  getInfraStatsFromDb: stub({
+  },
+  getIntegrationStatsFromDb: { total: 0, managed: 0, byType: {} },
+  getInfraStatsFromDb: {
     apiKeysTotal: 0,
     chainsTotal: 0,
     chainsEnabled: 0,
     walletsTotal: 0,
     sessionsActive: 0,
-  }),
-  getUserListFromDb: stub([]),
-  getOrgListFromDb: stub([]),
-  getVoteStatsFromDb: stub({
+  },
+  getUserListFromDb: [],
+  getOrgListFromDb: [],
+  getVoteStatsFromDb: {
     totalVotes: 0,
     totalUpvotes: 0,
     totalDownvotes: 0,
     topWorkflows: [],
     mostClonedWorkflows: [],
     topVoters: [],
-  }),
-  getBillingStatsFromDb: stub({
+  },
+  getBillingStatsFromDb: {
     orgsByPlan: [],
     orgsExecutions: [],
     mrrCentsByPlan: [],
     mrrCentsTotal: 0,
-  }),
+  },
 };
+
+const dbMocks: Record<string, ReturnType<typeof vi.fn>> = Object.fromEntries(
+  Object.keys(DEFAULT_DB_RETURNS).map((name) => [name, vi.fn()])
+);
+
+function rebindDefaultDbMockImplementations(): void {
+  for (const [name, ret] of Object.entries(DEFAULT_DB_RETURNS)) {
+    dbMocks[name].mockImplementation(async () => ret);
+  }
+}
+rebindDefaultDbMockImplementations();
 
 vi.mock("@/lib/metrics/db-metrics", () => dbMocks);
 
@@ -123,9 +132,15 @@ describe("updateDbMetrics TTL cache", () => {
 
   beforeEach(() => {
     __resetDbMetricsCacheForTest();
+    // mockReset (not mockClear) so any pending mockImplementationOnce /
+    // mockRejectedValueOnce queue from a prior test cannot leak in.
+    // mockClear only resets call history.
     for (const fn of Object.values(dbMocks)) {
-      fn.mockClear();
+      fn.mockReset();
     }
+    // mockReset also wipes the default implementation; re-establish it
+    // so non-overridden helpers return the resolved stub shape again.
+    rebindDefaultDbMockImplementations();
   });
 
   afterEach(() => {

--- a/tests/unit/db-metrics-cache.test.ts
+++ b/tests/unit/db-metrics-cache.test.ts
@@ -139,11 +139,12 @@ describe("updateDbMetrics TTL cache", () => {
   it("hits the DB once when called twice inside the TTL window", async () => {
     process.env.DB_METRICS_CACHE_TTL_MS = "60000";
 
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    // toFake includes "performance" because the cache uses performance.now()
+    // for its TTL math (monotonic; immune to NTP step adjustments).
+    vi.useFakeTimers({ toFake: ["Date", "performance"] });
     try {
       await updateDbMetrics();
-      vi.setSystemTime(new Date("2026-01-01T00:00:30Z"));
+      vi.advanceTimersByTime(30_000);
       await updateDbMetrics();
     } finally {
       vi.useRealTimers();
@@ -157,11 +158,10 @@ describe("updateDbMetrics TTL cache", () => {
   it("refreshes after the TTL elapses", async () => {
     process.env.DB_METRICS_CACHE_TTL_MS = "60000";
 
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    vi.useFakeTimers({ toFake: ["Date", "performance"] });
     try {
       await updateDbMetrics();
-      vi.setSystemTime(new Date("2026-01-01T00:01:01Z"));
+      vi.advanceTimersByTime(61_000);
       await updateDbMetrics();
     } finally {
       vi.useRealTimers();
@@ -177,11 +177,10 @@ describe("updateDbMetrics TTL cache", () => {
     // the default 60000ms is used and only one DB hit happens within 30s.
     process.env.DB_METRICS_CACHE_TTL_MS = "60s";
 
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    vi.useFakeTimers({ toFake: ["Date", "performance"] });
     try {
       await updateDbMetrics();
-      vi.setSystemTime(new Date("2026-01-01T00:00:30Z"));
+      vi.advanceTimersByTime(30_000);
       await updateDbMetrics();
     } finally {
       vi.useRealTimers();
@@ -251,8 +250,7 @@ describe("updateDbMetrics TTL cache", () => {
         })
     );
 
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    vi.useFakeTimers({ toFake: ["Date", "performance"] });
     let first: Promise<void>;
     let second: Promise<void>;
     try {
@@ -261,7 +259,7 @@ describe("updateDbMetrics TTL cache", () => {
       // so resolveWorkflow gets bound before we manipulate it below.
       await flushMicrotasks();
       // Advance well past the TTL while the first refresh is still hanging.
-      vi.setSystemTime(new Date("2026-01-01T00:02:00Z"));
+      vi.advanceTimersByTime(120_000);
       second = updateDbMetrics();
     } finally {
       vi.useRealTimers();
@@ -286,13 +284,12 @@ describe("updateDbMetrics TTL cache", () => {
   it("emits cache_lookups{result} and refresh{outcome} counters", async () => {
     process.env.DB_METRICS_CACHE_TTL_MS = "60000";
 
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    vi.useFakeTimers({ toFake: ["Date", "performance"] });
     try {
       // miss + refresh success
       await updateDbMetrics();
       // hit (no refresh)
-      vi.setSystemTime(new Date("2026-01-01T00:00:30Z"));
+      vi.advanceTimersByTime(30_000);
       await updateDbMetrics();
     } finally {
       vi.useRealTimers();

--- a/tests/unit/db-metrics-cache.test.ts
+++ b/tests/unit/db-metrics-cache.test.ts
@@ -89,8 +89,16 @@ const dbMocks = {
 
 vi.mock("@/lib/metrics/db-metrics", () => dbMocks);
 
+// getApiProcessMetrics starts an RPC health probe (background interval).
+// Stub it so the test doesn't leak timers.
+vi.mock("@/lib/metrics/rpc-health-probe", () => ({
+  startRpcHealthProbe: vi.fn(),
+  stopRpcHealthProbe: vi.fn(),
+}));
+
 import {
   __resetDbMetricsCacheForTest,
+  getApiProcessMetrics,
   updateDbMetrics,
 } from "@/lib/metrics/collectors/prometheus";
 
@@ -102,6 +110,13 @@ async function flushMicrotasks(times = 20): Promise<void> {
     await Promise.resolve();
   }
 }
+
+const CACHE_LOOKUP_MISS_RE =
+  /keeperhub_db_metrics_cache_lookups_total\{result="miss"\}\s+\d+/;
+const CACHE_LOOKUP_HIT_RE =
+  /keeperhub_db_metrics_cache_lookups_total\{result="hit"\}\s+\d+/;
+const REFRESH_SUCCESS_RE =
+  /keeperhub_db_metrics_refresh_total\{outcome="success"\}\s+\d+/;
 
 describe("updateDbMetrics TTL cache", () => {
   const originalTtl = process.env.DB_METRICS_CACHE_TTL_MS;
@@ -247,6 +262,27 @@ describe("updateDbMetrics TTL cache", () => {
 
     await Promise.all([first, second]);
     expect(dbMocks.getWorkflowStatsFromDb).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits cache_lookups{result} and refresh{outcome} counters", async () => {
+    process.env.DB_METRICS_CACHE_TTL_MS = "60000";
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    try {
+      // miss + refresh success
+      await updateDbMetrics();
+      // hit (no refresh)
+      vi.setSystemTime(new Date("2026-01-01T00:00:30Z"));
+      await updateDbMetrics();
+    } finally {
+      vi.useRealTimers();
+    }
+
+    const out = await getApiProcessMetrics();
+    expect(out).toMatch(CACHE_LOOKUP_MISS_RE);
+    expect(out).toMatch(CACHE_LOOKUP_HIT_RE);
+    expect(out).toMatch(REFRESH_SUCCESS_RE);
   });
 
   it("clears the cache slot on rejection so the next call retries", async () => {

--- a/tests/unit/db-metrics-cache.test.ts
+++ b/tests/unit/db-metrics-cache.test.ts
@@ -346,9 +346,7 @@ describe("updateDbMetrics TTL cache", () => {
     await updateDbMetrics();
     await updateDbMetrics();
 
-    expect(
-      dbMocks.getWorkflowStatsFromDb.mock.calls.length
-    ).toBeGreaterThanOrEqual(2);
+    expect(dbMocks.getWorkflowStatsFromDb).toHaveBeenCalledTimes(2);
 
     errSpy.mockRestore();
   });

--- a/tests/unit/db-metrics-cache.test.ts
+++ b/tests/unit/db-metrics-cache.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Cache behaviour for updateDbMetrics().
+ *
+ * Context: /api/metrics/db is scraped every 30s per pod and each call
+ * triggers ~35 aggregate queries (full seq scans on workflow_executions
+ * and workflow_execution_logs). The cache wraps the refresh so back-to-back
+ * scrapes within DB_METRICS_CACHE_TTL_MS reuse one DB round-trip and
+ * concurrent scrapes share the in-flight promise.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// Stub every helper updateDbMetrics() imports so the test never touches the
+// real DB. Each stub is a vi.fn we can assert call counts on.
+const stub = (returnValue: unknown): ReturnType<typeof vi.fn> =>
+  vi.fn(async () => returnValue);
+
+const dbMocks = {
+  getWorkflowStatsFromDb: stub({
+    totalSuccess: 0,
+    totalError: 0,
+    totalRunning: 0,
+    totalPending: 0,
+    totalCancelled: 0,
+    executionsByStatusAndOrgSlug: [],
+    durationBuckets: [0, 0, 0, 0, 0, 0, 0, 0, 0],
+    durationSum: 0,
+    durationCount: 0,
+  }),
+  getStepStatsFromDb: stub({
+    countsByType: {},
+    durationBuckets: [0, 0, 0, 0, 0, 0, 0, 0],
+    durationSum: 0,
+    durationCount: 0,
+  }),
+  getDailyActiveUsersFromDb: stub(0),
+  getUserStatsFromDb: stub({
+    total: 0,
+    verified: 0,
+    anonymous: 0,
+    withWorkflows: 0,
+    withIntegrations: 0,
+  }),
+  getOrgStatsFromDb: stub({
+    total: 0,
+    membersTotal: 0,
+    membersByRole: {},
+    invitationsPending: 0,
+    withWorkflows: 0,
+  }),
+  getWorkflowDefinitionStatsFromDb: stub({
+    total: 0,
+    public: 0,
+    private: 0,
+    anonymous: 0,
+  }),
+  getScheduleStatsFromDb: stub({
+    total: 0,
+    enabled: 0,
+    disabled: 0,
+    byLastStatus: {},
+  }),
+  getIntegrationStatsFromDb: stub({ total: 0, managed: 0, byType: {} }),
+  getInfraStatsFromDb: stub({
+    apiKeysTotal: 0,
+    chainsTotal: 0,
+    chainsEnabled: 0,
+    walletsTotal: 0,
+    sessionsActive: 0,
+  }),
+  getUserListFromDb: stub([]),
+  getOrgListFromDb: stub([]),
+  getVoteStatsFromDb: stub({
+    totalVotes: 0,
+    totalUpvotes: 0,
+    totalDownvotes: 0,
+    topWorkflows: [],
+    mostClonedWorkflows: [],
+    topVoters: [],
+  }),
+  getBillingStatsFromDb: stub({
+    orgsByPlan: [],
+    orgsExecutions: [],
+    mrrCentsByPlan: [],
+    mrrCentsTotal: 0,
+  }),
+};
+
+vi.mock("@/lib/metrics/db-metrics", () => dbMocks);
+
+import {
+  __resetDbMetricsCacheForTest,
+  updateDbMetrics,
+} from "@/lib/metrics/collectors/prometheus";
+
+// Flush enough microtasks for refreshDbMetricsNow()'s dynamic import +
+// Promise.all of 13 helpers to settle. Vitest fake timers don't drive
+// microtask queues, so we just yield to the runtime.
+async function flushMicrotasks(times = 20): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe("updateDbMetrics TTL cache", () => {
+  const originalTtl = process.env.DB_METRICS_CACHE_TTL_MS;
+
+  beforeEach(() => {
+    __resetDbMetricsCacheForTest();
+    for (const fn of Object.values(dbMocks)) {
+      fn.mockClear();
+    }
+  });
+
+  afterEach(() => {
+    if (originalTtl === undefined) {
+      delete process.env.DB_METRICS_CACHE_TTL_MS;
+    } else {
+      process.env.DB_METRICS_CACHE_TTL_MS = originalTtl;
+    }
+  });
+
+  it("hits the DB once when called twice inside the TTL window", async () => {
+    process.env.DB_METRICS_CACHE_TTL_MS = "60000";
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    try {
+      await updateDbMetrics();
+      vi.setSystemTime(new Date("2026-01-01T00:00:30Z"));
+      await updateDbMetrics();
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(dbMocks.getWorkflowStatsFromDb).toHaveBeenCalledTimes(1);
+    expect(dbMocks.getBillingStatsFromDb).toHaveBeenCalledTimes(1);
+    expect(dbMocks.getStepStatsFromDb).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes after the TTL elapses", async () => {
+    process.env.DB_METRICS_CACHE_TTL_MS = "60000";
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    try {
+      await updateDbMetrics();
+      vi.setSystemTime(new Date("2026-01-01T00:01:01Z"));
+      await updateDbMetrics();
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(dbMocks.getWorkflowStatsFromDb).toHaveBeenCalledTimes(2);
+    expect(dbMocks.getBillingStatsFromDb).toHaveBeenCalledTimes(2);
+  });
+
+  it("disables caching when DB_METRICS_CACHE_TTL_MS=0", async () => {
+    process.env.DB_METRICS_CACHE_TTL_MS = "0";
+
+    await updateDbMetrics();
+    await updateDbMetrics();
+    await updateDbMetrics();
+
+    expect(dbMocks.getWorkflowStatsFromDb).toHaveBeenCalledTimes(3);
+  });
+
+  it("deduplicates concurrent callers into one DB round-trip", async () => {
+    process.env.DB_METRICS_CACHE_TTL_MS = "60000";
+
+    let resolveWorkflow: ((value: unknown) => void) | undefined;
+    dbMocks.getWorkflowStatsFromDb.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveWorkflow = resolve;
+        })
+    );
+
+    const first = updateDbMetrics();
+    const second = updateDbMetrics();
+
+    // Drain enough microtasks that the dynamic import inside
+    // refreshDbMetricsNow has resolved and Promise.all has started its
+    // 13 helper calls, before we assert how many of them fired.
+    await flushMicrotasks();
+
+    expect(dbMocks.getWorkflowStatsFromDb).toHaveBeenCalledTimes(1);
+
+    resolveWorkflow?.({
+      totalSuccess: 0,
+      totalError: 0,
+      totalRunning: 0,
+      totalPending: 0,
+      totalCancelled: 0,
+      executionsByStatusAndOrgSlug: [],
+      durationBuckets: [0, 0, 0, 0, 0, 0, 0, 0, 0],
+      durationSum: 0,
+      durationCount: 0,
+    });
+
+    await Promise.all([first, second]);
+    expect(dbMocks.getWorkflowStatsFromDb).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the cache slot on rejection so the next call retries", async () => {
+    process.env.DB_METRICS_CACHE_TTL_MS = "60000";
+
+    // Silence the expected error log so the test output stays clean.
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {
+      // noop
+    });
+
+    dbMocks.getWorkflowStatsFromDb.mockRejectedValueOnce(
+      new Error("simulated DB outage")
+    );
+
+    // First call: refresh rejects internally; the cache wrapper logs and
+    // returns a resolved promise to the caller, but evicts the slot so a
+    // subsequent call retries instead of seeing the failed entry pinned
+    // for the full TTL.
+    await updateDbMetrics();
+    await updateDbMetrics();
+
+    expect(
+      dbMocks.getWorkflowStatsFromDb.mock.calls.length
+    ).toBeGreaterThanOrEqual(2);
+
+    errSpy.mockRestore();
+  });
+});

--- a/tests/unit/db-metrics-cache.test.ts
+++ b/tests/unit/db-metrics-cache.test.ts
@@ -111,13 +111,24 @@ import {
   updateDbMetrics,
 } from "@/lib/metrics/collectors/prometheus";
 
-// Flush enough microtasks for refreshDbMetricsNow()'s dynamic import +
-// Promise.all of 13 helpers to settle. Vitest fake timers don't drive
-// microtask queues, so we just yield to the runtime.
-async function flushMicrotasks(times = 20): Promise<void> {
-  for (let i = 0; i < times; i++) {
+// Poll microtask turns until a mock has been invoked at least once.
+// Used to wait for refreshDbMetricsNow()'s dynamic import + Promise.all
+// of 13 helpers to settle before we manipulate a controlled mock.
+// Replaces a magic-number "await Promise.resolve() 20 times" pattern
+// that broke implicit if the chain length changed.
+async function waitForMockCall(
+  fn: ReturnType<typeof vi.fn>,
+  maxTicks = 100
+): Promise<void> {
+  for (let i = 0; i < maxTicks; i++) {
+    if (fn.mock.calls.length > 0) {
+      return;
+    }
     await Promise.resolve();
   }
+  throw new Error(
+    "waitForMockCall: mock was not invoked within the tick budget"
+  );
 }
 
 const CACHE_LOOKUP_MISS_RE =
@@ -228,10 +239,10 @@ describe("updateDbMetrics TTL cache", () => {
     const first = updateDbMetrics();
     const second = updateDbMetrics();
 
-    // Drain enough microtasks that the dynamic import inside
-    // refreshDbMetricsNow has resolved and Promise.all has started its
-    // 13 helper calls, before we assert how many of them fired.
-    await flushMicrotasks();
+    // Wait for the helper to actually be invoked rather than guessing how
+    // many microtask turns it takes to get past the dynamic import +
+    // Promise.all wiring inside refreshDbMetricsNow.
+    await waitForMockCall(dbMocks.getWorkflowStatsFromDb);
 
     expect(dbMocks.getWorkflowStatsFromDb).toHaveBeenCalledTimes(1);
 
@@ -272,7 +283,7 @@ describe("updateDbMetrics TTL cache", () => {
       first = updateDbMetrics();
       // Let the dynamic import and Promise.all reach the controlled mock
       // so resolveWorkflow gets bound before we manipulate it below.
-      await flushMicrotasks();
+      await waitForMockCall(dbMocks.getWorkflowStatsFromDb);
       // Advance well past the TTL while the first refresh is still hanging.
       vi.advanceTimersByTime(120_000);
       second = updateDbMetrics();


### PR DESCRIPTION
## Summary

- Wraps `updateDbMetrics()` in a per-process TTL cache (default 60s, overridable via `DB_METRICS_CACHE_TTL_MS`) so each pod's scrape-to-DB rate drops from every 30s to every 60s.
- Concurrent callers during an in-flight refresh share the same promise. An in-flight refresh is shared regardless of TTL, so a slow refresh under DB stress cannot trigger a second concurrent refresh and amplify load.
- Failed refreshes evict the slot so the next scrape retries instead of pinning a poisoned entry for the full TTL. Public surface still swallows errors, preserving the existing "metrics endpoint never 500s" behavior.
- Two new counters on `apiRegistry` (per-pod, scraped via `/api/metrics/api`) so cache effectiveness is directly observable post-deploy:
  - `keeperhub_db_metrics_cache_lookups_total{result="hit"|"miss"|"in_flight_dedup"|"disabled"}`
  - `keeperhub_db_metrics_refresh_total{outcome="success"|"error"}`

## Context

`/api/metrics/db` runs ~35 aggregate queries against `workflow_executions` and `workflow_execution_logs` on every scrape. The ServiceMonitor scrapes every 30s per pod (`deploy/keeperhub/{prod,staging}/values.yaml:120-124`) and `replicaCount: 2`, so today the DB sees 4 full rounds per 2 minutes.

Staging EXPLAIN ANALYZE confirms the cost shape:

| Query | Plan | Time (staging) |
|---|---|---|
| `getBillingStatsFromDb` | Nested Loop using composite index | 220ms |
| `getWorkflowStatsFromDb` | **Parallel Seq Scan on workflow_executions** | **1,088ms** |
| `getStepStatsFromDb` | **Parallel Seq Scan on workflow_execution_logs** | **397ms** |

Prod profiling (separate measurement) showed `getBillingStatsFromDb` averaging 5.9s, so the seq-scan branch dominates under prod load.

## Expected impact

Each pod's cache is independent, so the win is per-pod TTL smoothing rather than cross-pod sharing:

- Today: 2 pods x scrape every 30s = 4 DB rounds per 2 min.
- After: 2 pods x cache-protected scrape with 60s TTL = 2 DB rounds per 2 min per pod budget halved.

Plus: concurrent scrapes within an in-flight refresh dedupe into one round-trip, eliminating the connection-pool contention case when a slow refresh straddles the next scrape interval.

## Rollback

`DB_METRICS_CACHE_TTL_MS=0` disables the cache without a redeploy (refreshes on every call, same behavior as before this change). Full revert is `git revert`.

## Validation after deploy

The new counters make cache effectiveness directly visible:

```promql
# Cache hit rate per pod
sum(rate(keeperhub_db_metrics_cache_lookups_total{result="hit"}[5m])) by (pod)
  / sum(rate(keeperhub_db_metrics_cache_lookups_total[5m])) by (pod)

# DB refresh rate per pod (this is what hits the database)
sum(rate(keeperhub_db_metrics_refresh_total[5m])) by (pod)

# Refresh failure rate
sum(rate(keeperhub_db_metrics_refresh_total{outcome="error"}[5m])) by (pod)
  / sum(rate(keeperhub_db_metrics_refresh_total[5m])) by (pod)
```

If the cache is silently ineffective (env var typo, NODE_ENV mismatch, hot-reload state issue), `result="hit"` will stay at zero and the issue is visible without waiting for downstream DB CPU effects.

## Hardening from review

After the initial implementation, a code review surfaced and these commits address:

- **In-flight refresh sharing** so a refresh longer than TTL doesn't start a second concurrent one (would amplify load under exactly the wrong condition).
- **Cache-effectiveness observability** via the two counters above (was a blind spot).
- **Monotonic clock** (`performance.now()`) for TTL math so an NTP step adjustment can't invalidate the cache window.
- **Strict env parsing** (`Number()` not `parseInt`) so `DB_METRICS_CACHE_TTL_MS=60s` falls back to default instead of silently parsing as 60ms.
- **Gated test-only export** so production accidents fail loud instead of silently clearing cache state mid-flight.
- **Test robustness:** `mockReset` over `mockClear` (clears queued impls between tests), and polling for mock invocation instead of a fixed `flushMicrotasks(20)` magic number.

## Follow-ups (not in this PR)

- **Indexes** on `workflow_executions(status, error_type, workflow_id) INCLUDE (duration)` and `workflow_execution_logs(node_type, status) INCLUDE (duration)` to turn the Parallel Seq Scans into Index Only Scans. Being handled separately.
- **Single-pod scraping** for `/api/metrics/db` (the endpoint comment already claims this model). Requires chart-side work in `techops-services/helm-charts` since the ServiceMonitor template lives there. Separate ticket warranted.
- **Time-window the unbounded queries.** `getWorkflowStatsFromDb` and `getStepStatsFromDb` scan all history forever; the cache bounds frequency but the per-call cost still grows linearly with table size.

## Test plan

- [x] Unit tests: `tests/unit/db-metrics-cache.test.ts` - 8 tests covering TTL window hit, TTL expiry, malformed-env fallback, TTL=0 bypass, in-flight dedup, in-flight-past-TTL sharing, counter emission, and eviction-on-rejection.
- [x] Regression check: `tests/unit/prometheus-collector.test.ts` still passes.
- [x] Lint and type-check clean on touched files.
- [ ] Deploy to staging, watch `keeperhub_db_metrics_cache_lookups_total` and DB CPU.
- [ ] Confirm `keeperhub_db_metrics_refresh_total{outcome="success"}` rate roughly halves vs current scrape rate.