### PR TITLE
perf: reconcile incident indexes and add covering indexes for db metrics

### DIFF
--- a/drizzle/0095_keep_669_reconcile_incident_indexes.sql
+++ b/drizzle/0095_keep_669_reconcile_incident_indexes.sql
@@ -1,0 +1,66 @@
+-- @requires-db-prep
+-- KEEP-669: reconcile the 2026-05-29 DB CPU incident indexes (PR #1402) and
+-- add the durable covering indexes for /api/metrics/db.
+--
+-- Two distinct groups below:
+--
+-- GROUP A - reconciliation (already on prod, missing everywhere else).
+--   During the incident, two partial composite indexes were created BY HAND
+--   directly on prod (~19:14 UTC) to bring CPU down after the helm +
+--   DB-migration rollback. They exist on prod but in no migration file, so
+--   staging, PR envs and fresh clones are missing them - silent drift. These
+--   statements capture the EXACT prod definitions; on prod the IF NOT EXISTS
+--   clauses make them no-ops, on other envs they build the matching index.
+--
+-- GROUP B - durable fix (net-new on every environment, including prod).
+--   The incident root cause was /api/metrics/db running unindexed aggregations
+--   (getWorkflowStatsFromDb / getStepStatsFromDb) that seq-scanned
+--   workflow_executions and workflow_execution_logs. These covering indexes
+--   put the GROUP BY keys in the index and INCLUDE (duration) so both the
+--   breakdown and the duration-histogram queries are satisfied by an
+--   index-only scan - cost bounded by index size, not row count, instead of a
+--   full parallel seq scan that grows linearly forever.
+--
+-- The `-- @requires-db-prep` directive blocks merge until an operator has
+-- applied each index via `CREATE INDEX CONCURRENTLY IF NOT EXISTS` out-of-band
+-- and set the `db-prepped-<target-branch>` label (same runbook as 0075).
+-- This matters for GROUP B specifically: those are real builds, and
+-- workflow_execution_logs is ~1.9 GB on prod - a plain in-transaction
+-- CREATE INDEX would take an ACCESS EXCLUSIVE lock for the whole build and
+-- risk a repeat incident. drizzle-kit wraps each migration in a transaction
+-- and CONCURRENTLY cannot run in a transaction, hence the out-of-band step;
+-- the IF NOT EXISTS clauses then make this migration a no-op on prod at deploy
+-- time. On dev / PR-env DBs the tables are small so the plain CREATE INDEX is
+-- sub-second.
+--
+-- Operator runbook (per target environment):
+--   1. Connect to the target DB.
+--   2. For each index NOT already present, run the statement as
+--      `CREATE INDEX CONCURRENTLY IF NOT EXISTS`, one at a time, outside a
+--      transaction block. (On prod, GROUP A already exists - only GROUP B
+--      needs building.)
+--   3. Verify no INVALID indexes were left behind:
+--      SELECT relname FROM pg_index JOIN pg_class ON pg_class.oid = indexrelid
+--      WHERE NOT indisvalid;
+--   4. Add the `db-prepped-<branch>` label to the PR.
+
+-- GROUP A: reconcile manual incident indexes (verbatim prod definitions;
+-- status IN (...) is Postgres's normalized form of status = ANY (ARRAY[...])).
+
+CREATE INDEX IF NOT EXISTS "idx_workflow_executions_status_duration"
+  ON "workflow_executions" ("status", "duration")
+  WHERE status IN ('success', 'error') AND duration IS NOT NULL;--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_exec_logs_status_duration"
+  ON "workflow_execution_logs" ("status", "duration")
+  WHERE status IN ('success', 'error') AND duration IS NOT NULL;--> statement-breakpoint
+
+-- GROUP B: durable covering indexes for /api/metrics/db aggregations.
+
+CREATE INDEX IF NOT EXISTS "idx_workflow_executions_stats_covering"
+  ON "workflow_executions" ("status", "error_type", "workflow_id")
+  INCLUDE ("duration");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_exec_logs_stats_covering"
+  ON "workflow_execution_logs" ("node_type", "status")
+  INCLUDE ("duration");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -666,6 +666,13 @@
       "when": 1779843900001,
       "tag": "0094_chain_status",
       "breakpoints": true
+    },
+    {
+      "idx": 95,
+      "version": "7",
+      "when": 1779843900002,
+      "tag": "0095_keep_669_reconcile_incident_indexes",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Context

On 2026-05-29 the PR #1402 deploy raised prod DB CPU to 100 percent. The cause was `/api/metrics/db` running unindexed aggregations (`getWorkflowStatsFromDb` / `getStepStatsFromDb`) that full-table-scanned `workflow_executions` and `workflow_execution_logs`. Mitigation was a helm + DB-migration rollback, after which an operator created indexes by hand directly on prod to bring CPU down.

Those manual indexes exist on prod but in no migration file, so staging, PR envs, and fresh clones are missing them. This migration reconciles that drift and adds the durable covering indexes.

## What this does

Single migration `0095_keep_669_reconcile_incident_indexes.sql`, two groups:

- **Group A - reconciliation.** Captures the two hand-built prod indexes verbatim (`idx_workflow_executions_status_duration`, `idx_exec_logs_status_duration`). `IF NOT EXISTS` makes these no-ops on prod and real builds everywhere else.
- **Group B - durable fix.** New covering indexes so the metrics aggregations become index-only scans instead of seq scans:
  - `idx_workflow_executions_stats_covering (status, error_type, workflow_id) INCLUDE (duration)`
  - `idx_exec_logs_stats_covering (node_type, status) INCLUDE (duration)`

## Operator action required before merge

This migration carries `-- @requires-db-prep`, so merge is blocked until the `db-prepped-staging` label is set. Group B indexes are net-new on every environment including prod and must be built out-of-band with `CREATE INDEX CONCURRENTLY IF NOT EXISTS`, one at a time, outside a transaction, before the deploy runs `db:migrate`. `workflow_execution_logs` is ~1.9 GB on prod; a non-concurrent in-transaction build (drizzle-kit's default) would take a multi-minute ACCESS EXCLUSIVE lock and risk a repeat incident. Group A already exists on prod, so only Group B needs building there. Runbook is in the migration header.

Validate with `EXPLAIN` that the planner picks the index-only scan before relying on it.

## Notes

- Journal timestamp is monotonic; no schema snapshot is generated (matches the hand-written index migration `0075`).
- All four indexed columns verified present in `lib/db/schema.ts`.
