### PR TITLE
refactor(auth): surface disposable-email rejection message to user

### DIFF
--- a/components/auth/dialog.tsx
+++ b/components/auth/dialog.tsx
@@ -19,6 +19,7 @@ import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
 import { authClient, signIn, signUp } from "@/lib/auth-client";
+import { DISPOSABLE_EMAIL_REJECTION_MESSAGE } from "@/lib/auth-disposable-emails-message";
 import { AUTH_SUCCESS_EVENT } from "@/lib/auth-events";
 import {
   getEnabledAuthProviders,
@@ -774,6 +775,17 @@ export const AuthDialog = ({
 
       if (signUpResponse.error) {
         const errorMsg = signUpResponse.error.message || "Sign up failed";
+
+        // Server-side disposable-email rejection: the better-auth
+        // databaseHooks.user.create.before hook throws an APIError
+        // carrying DISPOSABLE_EMAIL_REJECTION_MESSAGE. Match the constant
+        // directly so the surfaced text never drifts out of sync.
+        if (errorMsg === DISPOSABLE_EMAIL_REJECTION_MESSAGE) {
+          setError(DISPOSABLE_EMAIL_REJECTION_MESSAGE);
+          resetCaptcha();
+          setLoading(false);
+          return;
+        }
 
         // Check if error is about existing user (might be unverified)
         if (

--- a/lib/auth-disposable-emails-message.ts
+++ b/lib/auth-disposable-emails-message.ts
@@ -1,0 +1,11 @@
+// Single source of truth for the user-facing rejection message when a signup
+// is blocked because the email domain is in the disposable / temporary list.
+// Server (lib/auth.ts databaseHooks.user.create.before) throws an APIError
+// carrying this message; client (components/auth/dialog.tsx) imports the same
+// constant so the surfaced text never drifts between the two sides.
+//
+// Kept in its own file so the client bundle does not pull in the 5,488-domain
+// JSON or the Set construction from lib/auth-disposable-emails.ts.
+
+export const DISPOSABLE_EMAIL_REJECTION_MESSAGE =
+  "Disposable or temporary email addresses aren't allowed. Please use a permanent email.";

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { captureMessage } from "@sentry/nextjs";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { APIError } from "better-auth/api";
 import {
   anonymous,
   // start custom keeperhub code //
@@ -19,6 +20,7 @@ import { nanoid } from "nanoid";
 import { rateLimitBypassRule, testEndpointsEnabled } from "@/lib/admin-auth";
 import { isUserDeactivated } from "@/lib/auth-deactivation-guard";
 import { isDisposableEmailDomain } from "@/lib/auth-disposable-emails";
+import { DISPOSABLE_EMAIL_REJECTION_MESSAGE } from "@/lib/auth-disposable-emails-message";
 import { isFreshSignup } from "@/lib/auth-notification-guard";
 import { sendInvitationEmail, sendVerificationOTP } from "@/lib/email";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
@@ -480,15 +482,19 @@ export const auth = betterAuth({
         before: async (user) => {
           // Reject signups from disposable / temporary email domains on both
           // paths -- email+password and OAuth callbacks both flow through
-          // user.create. The blocklist combines a curated headline set with
-          // the maintained disposable-email-domains JSON as fallback.
+          // user.create. Throwing APIError surfaces the shared rejection
+          // message to the client verbatim so the dialog can render a
+          // specific UX instead of better-auth's generic "Failed to create
+          // user" string.
           await Promise.resolve();
           const email = typeof user.email === "string" ? user.email : null;
           if (email && isDisposableEmailDomain(email)) {
             console.warn(
               `[Auth] Rejected signup for disposable email domain: ${email}`
             );
-            return false;
+            throw new APIError("BAD_REQUEST", {
+              message: DISPOSABLE_EMAIL_REJECTION_MESSAGE,
+            });
           }
         },
         after: async (user) => {


### PR DESCRIPTION
## Summary

Follow-up to the `ref/block-disposable-email-signups` landing. Today, when the server's `databaseHooks.user.create.before` hook rejects a disposable-email signup, the client surface is a generic "Failed to create user" / "Sign up failed" -- the user has no idea what to fix.

This PR threads a clear message end-to-end without letting the strings drift between server and client.

- **Shared constant** in `lib/auth-disposable-emails-message.ts` (kept in its own file so the client bundle does not pull in the 5,488-domain JSON or the `Set` construction from `lib/auth-disposable-emails.ts`).
- **Server** (`lib/auth.ts`) throws `APIError("BAD_REQUEST", { message: DISPOSABLE_EMAIL_REJECTION_MESSAGE })` instead of returning `false`. `better-call`'s `APIError.body.message` becomes the HTTP 400 response body, which `better-fetch` then spreads onto `signUpResponse.error` client-side.
- **Client** (`components/auth/dialog.tsx`) imports the same constant and matches `errorMsg === DISPOSABLE_EMAIL_REJECTION_MESSAGE` directly, so the surfaced text cannot drift between the two sides. New branch lives before the existing "already exists" branch so disposable rejections route cleanly without falling through to OTP re-send.

## Interface verification

- `APIError` body shape: `{ message?: string; code?: string; cause?: unknown }` ([better-call/dist/error.d.mts]).
- `BetterFetchResponse` error case: `error: (E & { status, statusText })` -- body spread directly onto `error` ([@better-fetch/fetch/dist/index.d.cts]).
- Pre-existing `signUpResponse.error.message || "Sign up failed"` at `dialog.tsx:776` confirms empirically that better-auth populates `error.message` from the HTTP body.

## Files

- `lib/auth-disposable-emails-message.ts` -- single-source constant
- `lib/auth.ts` -- `databaseHooks.user.create.before` throws `APIError` with the constant
- `components/auth/dialog.tsx` -- new match arm renders the same string into the form's error state