### PR TITLE
fix(security): bucket IPv4 trust to /24 and decouple verify-IP OTP send

### DIFF
--- a/app/api/user/verify-ip/route.ts
+++ b/app/api/user/verify-ip/route.ts
@@ -14,7 +14,7 @@ import {
   verifications,
 } from "@/lib/db/schema";
 import { sendVerificationOTP } from "@/lib/email";
-import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { ErrorCategory, logSystemError, logSystemWarn } from "@/lib/logging";
 import {
   checkDualFactorRateLimit,
   resetDualFactor,
@@ -29,6 +29,7 @@ import {
   assessIpTrust,
   buildRiskFlagsJsonForIp,
   clearTrustCacheEntry,
+  logIpVerify,
 } from "@/lib/security/login-risk";
 import { verifyUserTotp } from "@/lib/security/totp-verify";
 import { generateId } from "@/lib/utils/id";
@@ -104,6 +105,7 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   const cookieValue = readPendingIpCookie(request.headers);
   if (!cookieValue) {
+    logIpVerify("verify-ip:no_pending_ip", { hasCookie: false });
     return NextResponse.json(
       {
         error: "No pending IP verification",
@@ -114,6 +116,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   }
   const decoded = decodePendingIpCookie(cookieValue, serverSecret);
   if (!decoded.ok) {
+    logIpVerify("verify-ip:bad_cookie", { reason: decoded.reason });
     return NextResponse.json(
       {
         error:
@@ -121,21 +124,6 @@ export async function POST(request: Request): Promise<NextResponse> {
             ? "Verification window expired. Sign in again."
             : "Invalid verification state. Sign in again.",
         code: decoded.reason,
-      },
-      { status: 401 }
-    );
-  }
-
-  // Bind the dual-factor exchange to the IP that the cookie was
-  // issued for. A thief on a different network cannot satisfy the
-  // gate even with valid factors because assessIpTrust here will
-  // resolve a different IP than the one stored in the payload.
-  const ipTrust = await assessIpTrust(decoded.payload.userId);
-  if (ipTrust.ip && ipTrust.ip !== decoded.payload.ip) {
-    return NextResponse.json(
-      {
-        error: "Verification must be completed from the same network.",
-        code: "ip_mismatch",
       },
       { status: 401 }
     );
@@ -156,6 +144,10 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   const rateLimit = checkDualFactorRateLimit(decoded.payload.userId, ACTION);
   if (!rateLimit.allowed) {
+    logIpVerify("verify-ip:rate_limited", {
+      userId: decoded.payload.userId,
+      retryAfter: rateLimit.retryAfter,
+    });
     return NextResponse.json(
       {
         error: "Too many attempts. Wait and try again.",
@@ -168,6 +160,9 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   const bothPresent = totpCode.length === 6 && inboxCode.length === 6;
 
+  // The email-OTP request is not gated on the IP re-check: the user may
+  // request the code from a rotating egress IP. Only the session-minting
+  // path below binds to the network pinned in the cookie.
   if (!bothPresent) {
     const otp = generateEmailOtp();
     const encrypted = await symmetricEncrypt({
@@ -193,6 +188,10 @@ export async function POST(request: Request): Promise<NextResponse> {
       type: "confirm-action",
     });
     if (!sent) {
+      logIpVerify("verify-ip:email_send_failed", {
+        userId: decoded.payload.userId,
+        email: decoded.payload.email,
+      });
       return NextResponse.json(
         {
           error: "Failed to send confirmation email",
@@ -201,11 +200,50 @@ export async function POST(request: Request): Promise<NextResponse> {
         { status: 503 }
       );
     }
+    logIpVerify("verify-ip:otp_sent", {
+      userId: decoded.payload.userId,
+      email: decoded.payload.email,
+      cookieIp: decoded.payload.ip,
+    });
     return NextResponse.json(
       {
         error:
           "Enter the 6-digit code from your authenticator app and the code emailed to you.",
         code: "factors_required",
+      },
+      { status: 401 }
+    );
+  }
+
+  // Both codes present -> session-minting path. Bind the exchange to the
+  // network the cookie was issued for: a thief on a different network
+  // cannot finish even with valid factors because assessIpTrust resolves
+  // a different /24-or-/64 key than the one pinned in the payload. The
+  // raw (pre-normalization) IPs are logged so a rotating egress address
+  // is visible end to end.
+  const ipTrust = await assessIpTrust(decoded.payload.userId);
+  const ipMatch = !ipTrust.ip || ipTrust.ip === decoded.payload.ip;
+  logIpVerify("verify-ip:final_check", {
+    userId: decoded.payload.userId,
+    cookieIp: decoded.payload.ip,
+    currentRawIp: ipTrust.rawIp,
+    currentNormalizedIp: ipTrust.ip,
+    match: ipMatch,
+  });
+  if (!ipMatch) {
+    logSystemWarn(
+      ErrorCategory.AUTH,
+      "[verify-ip] ip_mismatch on session-minting attempt",
+      new Error("ip_mismatch"),
+      {
+        endpoint: "/api/user/verify-ip",
+        user_id: decoded.payload.userId,
+      }
+    );
+    return NextResponse.json(
+      {
+        error: "Verification must be completed from the same network.",
+        code: "ip_mismatch",
       },
       { status: 401 }
     );

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -9,6 +9,12 @@ const isTestEnv = !!process.env.CI || process.env.NODE_ENV === "test";
 
 const SENDGRID_API_URL = "https://api.sendgrid.com/v3/mail/send";
 
+// Cap the outbound SendGrid call so a stalled connection surfaces as a
+// failed send (returns false) instead of hanging the request that's
+// awaiting it -- otherwise a caller like the verify-IP OTP step spins
+// on "Sending..." indefinitely.
+const SENDGRID_TIMEOUT_MS = 10_000;
+
 type SendEmailOptions = {
   to: string;
   subject: string;
@@ -88,6 +94,7 @@ export async function sendEmail(options: SendEmailOptions): Promise<boolean> {
         "Content-Type": "application/json",
       },
       body: JSON.stringify(emailData),
+      signal: AbortSignal.timeout(SENDGRID_TIMEOUT_MS),
     });
 
     if (!response.ok) {

--- a/lib/security/ip-normalize.ts
+++ b/lib/security/ip-normalize.ts
@@ -5,8 +5,12 @@
  * `user_trusted_ips` both go through this so a textual mismatch
  * never causes a false-negative.
  *
- *   - IPv4 (32 bits): returned unchanged. /32 is what the address
- *     itself already represents.
+ *   - IPv4 (32 bits): collapsed to the /24 prefix (last octet zeroed).
+ *     Consumer egress IPs routinely rotate within a provider's /24
+ *     (carrier-grade NAT, dual-WAN failover, corporate proxy pools),
+ *     so the same end user reaches us from several host addresses in
+ *     one network. The /24 is the network we track trust against --
+ *     the IPv4 analogue of the /64 bucketing applied to IPv6 below.
  *   - IPv6 (128 bits): collapsed to the /64 prefix with zero-padded
  *     groups. Cloudflare zeros out the lower 64 bits of an IPv6
  *     CF-Connecting-IP for privacy, so the same end user produces
@@ -38,14 +42,31 @@ function padGroup(group: string): string {
  */
 export function formatIpForDisplay(ip: string): string {
   if (!ip.includes(":")) {
-    return ip;
+    // Normalized IPv4 is the /24 network base (last octet zeroed), so
+    // render it as CIDR to read as a network rather than a host.
+    return ip.endsWith(".0") ? `${ip}/24` : ip;
   }
   return ip.replace(TRAILING_ZERO_GROUPS_RE, "");
 }
 
+const IPV4_OCTET_RE = /^\d{1,3}$/;
+
+function bucketIpv4ToSlash24(ip: string): string {
+  const octets = ip.split(".");
+  if (octets.length !== 4) {
+    return ip;
+  }
+  for (const octet of octets) {
+    if (!IPV4_OCTET_RE.test(octet) || Number(octet) > 255) {
+      return ip;
+    }
+  }
+  return `${octets[0]}.${octets[1]}.${octets[2]}.0`;
+}
+
 export function normalizeIpForTrust(ip: string): string {
   if (!ip.includes(":")) {
-    return ip;
+    return bucketIpv4ToSlash24(ip);
   }
   let expanded = ip.toLowerCase();
   if (expanded.includes("::")) {

--- a/lib/security/login-risk.ts
+++ b/lib/security/login-risk.ts
@@ -256,10 +256,25 @@ export async function buildRiskFlagsJsonForIp(
  */
 export type IpTrust = {
   ip: string | null;
+  rawIp: string | null;
   trusted: boolean;
   country: string | null;
   reason: "no_cf" | "known" | "first" | "untrusted";
 };
+
+/**
+ * Structured trace for the IP-verification gate. Logs the raw
+ * (pre-normalization) client IP alongside the normalized /24-or-/64
+ * trust key at every stage so a rotating egress IP -- the failure mode
+ * where a user gets the new-network modal but the codes never line up
+ * -- is greppable end to end via `[ip-verify]`.
+ */
+export function logIpVerify(
+  stage: string,
+  fields: Record<string, unknown>
+): void {
+  console.info(`[ip-verify] ${stage}`, fields);
+}
 
 async function resolveLoginIp(): Promise<string | null> {
   try {
@@ -398,6 +413,12 @@ export async function gateRequestIp(userId: string): Promise<RequestIpGate> {
   }
   const result: RequestIpGate = { kind: "untrusted", ip, country };
   rememberTrust(key, { result, expiresAt: now + UNTRUSTED_TTL_MS });
+  logIpVerify("gate-untrusted", {
+    userId,
+    rawIp,
+    normalizedIp: ip,
+    country,
+  });
   return result;
 }
 
@@ -405,7 +426,13 @@ export async function assessIpTrust(userId: string): Promise<IpTrust> {
   const rawIp = await resolveLoginIp();
   const { country } = await resolveLoginLocation();
   if (!rawIp) {
-    return { ip: null, trusted: true, country, reason: "no_cf" };
+    logIpVerify("assess", {
+      userId,
+      rawIp: null,
+      normalizedIp: null,
+      reason: "no_cf",
+    });
+    return { ip: null, rawIp: null, trusted: true, country, reason: "no_cf" };
   }
 
   // IPv6 trust is bucketed at /64 to handle CF's lower-64-bits
@@ -421,7 +448,8 @@ export async function assessIpTrust(userId: string): Promise<IpTrust> {
     .where(and(eq(userTrustedIps.userId, userId), eq(userTrustedIps.ip, ip)))
     .limit(1);
   if (hit) {
-    return { ip, trusted: true, country, reason: "known" };
+    logIpVerify("assess", { userId, rawIp, normalizedIp: ip, reason: "known" });
+    return { ip, rawIp, trusted: true, country, reason: "known" };
   }
 
   const [anyTrusted] = await db
@@ -430,8 +458,15 @@ export async function assessIpTrust(userId: string): Promise<IpTrust> {
     .where(eq(userTrustedIps.userId, userId))
     .limit(1);
   if (!anyTrusted) {
-    return { ip, trusted: true, country, reason: "first" };
+    logIpVerify("assess", { userId, rawIp, normalizedIp: ip, reason: "first" });
+    return { ip, rawIp, trusted: true, country, reason: "first" };
   }
 
-  return { ip, trusted: false, country, reason: "untrusted" };
+  logIpVerify("assess", {
+    userId,
+    rawIp,
+    normalizedIp: ip,
+    reason: "untrusted",
+  });
+  return { ip, rawIp, trusted: false, country, reason: "untrusted" };
 }


### PR DESCRIPTION
## Problem

A 2FA user signing in from a new network sees the `/verify-ip` modal ("Confirm this new sign-in") but never receives the email code, and the prompt spins on "Sending...".

## Root cause

`normalizeIpForTrust` bucketed IPv6 to `/64` but left IPv4 byte-exact (`/32`). When a user's public source IP rotates within one provider block (CGNAT, dual-WAN, and mobile pools are common, especially in LATAM), the host octet differs within the same `/24` between two connections seconds apart: the page navigation that mints the `pending_ip_verify` cookie, and the OTP-send POST to `/api/user/verify-ip`.

The verify-IP route ran the IP re-check at the top of the handler, gating the OTP send itself. A rotated host failed the byte-exact match and returned `ip_mismatch` (a 401) before sending. The modal's prefetch never receives `factors_required`, so it stays in the pre-send "Sending..." state and no email is dispatched. The early-return paths logged nothing, so the failure was invisible.

## Changes

- **IPv4 buckets to `/24`** in `normalizeIpForTrust`, mirroring the existing IPv6 `/64` rule. `formatIpForDisplay` renders the normalized key as CIDR.
- **OTP send is no longer IP-gated.** The IP-binding check moves to the both-codes / session-minting branch only. Requesting the code never depends on a rotating address; only minting the session still binds to the pinned network.
- **SendGrid call gets an `AbortSignal` timeout** so a stalled send fails closed (returns false) instead of hanging the awaiting request indefinitely.
- **`[ip-verify]` tracing** records the raw pre-normalization IP next to the normalized key at the proxy gate, trust assessment, and every verify-IP early return, so a rotating egress is greppable end to end.

## Operational notes

- Existing IPv4 rows in `user_trusted_ips` are stored as full hosts and will not match the new `/24` key, so affected users re-verify once; after that the `/24` is trusted and rotation within the block stops prompting.
- A follow-up backfill (zeroing the last IPv4 octet, with dedup for the unique `(user_id, ip)` constraint) could skip that one re-verification. Not included here; would land as a deliberate migration.

## Security tradeoff

`/24` trust covers up to 256 host addresses in the block, which can include other CGNAT subscribers behind the same pool. For a gate that sits on top of full MFA this is a reasonable trade and matches the IPv6 `/64` granularity already in use. ASN+country pinning is a tighter alternative if desired later.