### PR TITLE
chore: fill window in dev:login Chromium

### DIFF
--- a/scripts/dev-login-browser.ts
+++ b/scripts/dev-login-browser.ts
@@ -40,6 +40,12 @@ async function main(): Promise<void> {
 
   const ctx = await chromium.launchPersistentContext(profileDir, {
     headless: false,
+    // Playwright defaults to a fixed 1280x720 viewport that does not track
+    // window resizing, so the UI renders letterboxed when the window is
+    // maximized or fullscreened. `viewport: null` makes the page follow the
+    // real OS window size; `--start-maximized` opens it filling the screen.
+    viewport: null,
+    args: ["--start-maximized"],
   });
 
   await ctx.addCookies([


### PR DESCRIPTION
## Summary

- `pnpm dev:login` opened its signed-in Chromium with Playwright's default fixed 1280x720 viewport, which does not track window resizing. The KeeperHub UI rendered letterboxed (content not filling the window) when the window was maximized or fullscreened.
- Set `viewport: null` on `launchPersistentContext` so the page follows the real OS window size and repaints on resize/fullscreen.
- Pass `--start-maximized` so the window opens filling the screen.

## Implementation

- `scripts/dev-login-browser.ts` -- add `viewport: null` and `args: ["--start-maximized"]` to the `chromium.launchPersistentContext` options.

## Verification

- Re-ran `pnpm dev:login`; the Chromium window opens maximized and the UI fills the window and tracks fullscreen/resize.
- Dev-only script; no production runtime or auth code touched.