### PR TITLE
ci: add metrics DB review label gate

### DIFF
--- a/.github/workflows/metrics-db-review-gate.yml
+++ b/.github/workflows/metrics-db-review-gate.yml
@@ -1,0 +1,116 @@
+name: Metrics DB Review Gate
+
+# Forces a human sign-off when a PR changes metrics code, as a guardrail for
+# the 2026-05-29 DB CPU incident class: heavy aggregate queries whose cost
+# only manifests at production data volume and therefore cannot be caught by
+# tests. See docs/incidents/2026-05-29-db-cpu-spike.md.
+#
+# Behaviour:
+#   - The job ALWAYS runs (no path filter on the trigger). A required check
+#     that is skipped by a path filter shows as pending forever and blocks the
+#     PR, so the path match is computed inside the job instead.
+#   - If the PR does not touch app/api/metrics/**, lib/metrics/**, or
+#     lib/db/index.ts, the check passes as a no-op.
+#   - If it does, the check fails until the `metrics-db-reviewed` label is
+#     applied by someone OTHER than the PR author. The label asserts that any
+#     new or changed aggregate queries are optimised and that the tables those
+#     aggregations scan are appropriately indexed.
+#
+# The `labeled` / `unlabeled` trigger types are required: without them the
+# status check would not re-evaluate when the label is flipped and would stay
+# red until the next push.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - staging
+      - prod
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  metrics-db-review-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes under metrics paths
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Directory pathspecs match every file beneath them, so a new file
+          # added anywhere under the metrics trees is covered without glob
+          # upkeep. lib/db/index.ts is gated as a single file - it holds the
+          # metricsDb pool and its concurrency cap (the incident lever) - while
+          # the rest of lib/db is intentionally left out: schema.ts and the
+          # query helpers churn on nearly every feature PR, so gating them
+          # would turn the label into a rubber stamp.
+          CHANGED=$(git diff --name-only "$BASE_SHA...$HEAD_SHA" -- app/api/metrics lib/metrics lib/db/index.ts)
+          if [ -n "$CHANGED" ]; then
+            echo "touched=true" >> "$GITHUB_OUTPUT"
+            echo "Metrics paths changed in this PR:"
+            printf '  %s\n' $CHANGED
+            {
+              echo "files<<EOF"
+              printf '%s\n' "$CHANGED"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "touched=false" >> "$GITHUB_OUTPUT"
+            echo "PR does not touch app/api/metrics/**, lib/metrics/**, or lib/db/index.ts."
+          fi
+
+      - name: No metrics changes - gate passes
+        if: steps.detect.outputs.touched != 'true'
+        run: echo "No metrics paths changed; review gate passes automatically."
+
+      - name: Require metrics-db-reviewed label applied by a non-author
+        if: steps.detect.outputs.touched == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          LABEL: metrics-db-reviewed
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          FILES: ${{ steps.detect.outputs.files }}
+        run: |
+          set -euo pipefail
+
+          # 1. The label must be present on the PR.
+          if ! printf '%s' "$LABELS_JSON" | jq -e --arg L "$LABEL" 'any(. == $L)' >/dev/null; then
+            echo "::error::This PR changes metrics or metrics-DB code:"
+            printf '::error::  %s\n' $FILES
+            echo "::error::The '$LABEL' label is required. A reviewer (not the PR author) must confirm that new or changed aggregate queries are optimised, that the tables they scan are appropriately indexed, and that any change to the metricsDb pool concurrency has been measured against the scrape timeout, then apply the label."
+            exit 1
+          fi
+
+          # 2. The label must have been applied by someone other than the author.
+          #    The webhook payload only names the actor on a `labeled` event, and
+          #    a later push erases that signal, so the most recent labeler is
+          #    resolved from the issue timeline instead - robust across every
+          #    trigger type.
+          LABELER=$(gh api "repos/$REPO/issues/$PR_NUMBER/timeline" --paginate \
+            --jq "map(select(.event == \"labeled\" and .label.name == \"$LABEL\")) | last | .actor.login // \"\"")
+
+          if [ -z "$LABELER" ]; then
+            echo "::error::'$LABEL' is present but no matching 'labeled' timeline event was found, so its applier cannot be verified. Remove and re-apply the label."
+            exit 1
+          fi
+
+          if [ "$LABELER" = "$PR_AUTHOR" ]; then
+            echo "::error::'$LABEL' was applied by the PR author ('$PR_AUTHOR'). Self-approval does not satisfy the review gate - another team member must review the query and index impact and apply the label."
+            exit 1
+          fi
+
+          echo "'$LABEL' applied by '$LABELER' (PR author: '$PR_AUTHOR'). Metrics DB review confirmed; gate passes."


### PR DESCRIPTION
Follow-up from the 2026-05-29 DB CPU spike (P1). The incident-class change - a heavy aggregate query added without index analysis, or the metrics DB pool concurrency raised without measurement - only manifests at prod data volume and cannot be caught by tests, so the guardrail lives in CI.

## What this adds

A required-status-check-shaped workflow (`metrics-db-review-gate.yml`) that forces a human sign-off when a PR changes metrics code:

- Always runs (no path filter on the trigger) so it never sits pending-and-blocking as a skipped required check. Path match is computed inside the job, mirroring `pr-title-check.yml`.
- Triggers on PRs to `staging` and `prod`, with `labeled`/`unlabeled` types so the check re-evaluates the instant the label is flipped (not just on the next push).
- `git diff` over `app/api/metrics`, `lib/metrics`, and `lib/db/index.ts`. The metrics trees are gated wholesale; `lib/db/index.ts` is gated as a single file because it holds the `metricsDb` pool and its concurrency cap (the incident lever) while the rest of `lib/db` (schema, query helpers) churns too often to gate without turning the label into a rubber stamp.
- No matching changes: passes as a no-op.
- Matching changes: fails until the `metrics-db-reviewed` label is present AND was applied by someone other than the PR author. The non-author check resolves the labeler from the issue timeline (the webhook only names the actor on the `labeled` event, and a later push would erase that signal).

The label asserts a reviewer confirmed any new/changed aggregate queries are optimised, the scanned tables are appropriately indexed, and any metricsDb pool concurrency change was measured against the scrape timeout. It is a pure attestation (no EXPLAIN artifact required).

## Activation (post-merge, manual)

This workflow is inert until it is marked a required check in branch protection for `staging` and `prod`. The check name is `metrics-db-review-gate`. It only appears in the required-checks list after it has run on at least one PR, so the order is: merge -> let it run once -> add as required.

The `metrics-db-reviewed` label has been created in the repo.