### PR TITLE
perf: cache analytics read paths and page the runs gas aggregation

### DIFF
--- a/lib/analytics/cache.ts
+++ b/lib/analytics/cache.ts
@@ -1,0 +1,127 @@
+import "server-only";
+
+/**
+ * Per-process TTL cache for the analytics read paths.
+ *
+ * The /analytics dashboard fans out summary / time-series / networks on every
+ * load AND the SSE stream recomputes the summary whenever an org's checksum
+ * changes (see lib/analytics/stream-start.ts). For a busy org that is a full
+ * aggregation - including the unindexed JSONB gas scans over
+ * workflow_execution_logs - every few seconds per connected viewer. This cache
+ * collapses that: callers for the same (org, range, project, window) within the
+ * TTL share a single DB round-trip, and concurrent callers during an in-flight
+ * refresh share the same promise instead of each starting their own scan.
+ *
+ * Mirrors the proven shape of the /api/metrics/db cache
+ * (lib/metrics/collectors/prometheus.ts): monotonic performance.now()
+ * timestamps, TTL measured from completion (not start), in-flight dedup past
+ * the TTL so a slow refresh under DB stress cannot be amplified, and eviction
+ * on failure so the next caller retries instead of seeing a pinned error.
+ *
+ * Set ANALYTICS_CACHE_TTL_MS=0 to disable (recompute on every call).
+ */
+
+const DEFAULT_ANALYTICS_CACHE_TTL_MS = 30_000;
+
+function getAnalyticsCacheTtlMs(): number {
+  const raw = process.env.ANALYTICS_CACHE_TTL_MS;
+  if (raw === undefined || raw === "") {
+    return DEFAULT_ANALYTICS_CACHE_TTL_MS;
+  }
+  // Number() (not parseInt) so trailing junk like "30s" is rejected outright
+  // rather than silently parsed as 30, which would be a 1000x-wrong TTL.
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0
+    ? parsed
+    : DEFAULT_ANALYTICS_CACHE_TTL_MS;
+}
+
+type CacheEntry = {
+  // Monotonic timestamps from performance.now(): wall-clock can step backwards
+  // on NTP adjustments and invalidate the TTL math.
+  startedAt: number;
+  completedAt: number | null;
+  promise: Promise<unknown>;
+};
+
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Build a stable cache key. Undefined parts collapse to "" so the key is
+ * deterministic regardless of which optional filters are present.
+ */
+export function analyticsCacheKey(
+  scope: string,
+  parts: (string | undefined)[]
+): string {
+  return [scope, ...parts.map((p) => p ?? "")].join("|");
+}
+
+/**
+ * Run `loader` behind the TTL cache for `key`. Rejections propagate to the
+ * caller (the routes and the SSE start already handle their own errors) and
+ * evict the slot so the failure is not cached.
+ */
+export function cachedAnalytics<T>(
+  key: string,
+  loader: () => Promise<T>
+): Promise<T> {
+  const ttl = getAnalyticsCacheTtlMs();
+  if (ttl <= 0) {
+    return loader();
+  }
+
+  const existing = cache.get(key);
+  if (existing) {
+    // In-flight: share the promise regardless of TTL so a refresh that is
+    // slower than the TTL cannot spawn a second concurrent scan.
+    if (existing.completedAt === null) {
+      return existing.promise as Promise<T>;
+    }
+    // Completed: serve cached while within TTL of completion.
+    if (performance.now() - existing.completedAt < ttl) {
+      return existing.promise as Promise<T>;
+    }
+  }
+
+  const promise = loader();
+  const entry: CacheEntry = {
+    startedAt: performance.now(),
+    completedAt: null,
+    promise,
+  };
+  cache.set(key, entry);
+
+  // Bookkeeping only. The two-arg form avoids creating an orphan rejected
+  // promise (which would surface as an unhandled rejection); the trailing
+  // .catch guards against the settle callbacks themselves throwing.
+  promise
+    .then(
+      () => {
+        entry.completedAt = performance.now();
+      },
+      () => {
+        if (cache.get(key) === entry) {
+          cache.delete(key);
+        }
+      }
+    )
+    .catch(() => {
+      // settle callback threw; nothing actionable here
+    });
+
+  return promise;
+}
+
+/**
+ * Clear the cache. Test-only - throws outside NODE_ENV=test so production code
+ * that calls it by mistake fails loud instead of silently dropping the cache.
+ */
+export function __resetAnalyticsCacheForTest(): void {
+  if (process.env.NODE_ENV !== "test") {
+    throw new Error(
+      "__resetAnalyticsCacheForTest is test-only; do not call in production"
+    );
+  }
+  cache.clear();
+}

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -103,9 +103,27 @@ function addBucketToMap(
 }
 
 /**
- * Fetch KPI summary for the analytics dashboard. Cached per
- * (org, range, project, window) - both the GET route and the SSE summary push
- * go through here, so the cache covers the dominant recompute path.
+ * Only named ranges are cached. A custom range carries caller-supplied
+ * start/end strings that are effectively single-use and unbounded, so keying
+ * the per-process cache on them would grow the Map without limit for no
+ * hit-rate benefit (and is a cheap memory-pressure vector). Recompute those
+ * directly; the named ranges are what the dashboard and SSE push hammer.
+ */
+export function isCacheableRange(
+  range: TimeRange,
+  customStart?: string,
+  customEnd?: string
+): boolean {
+  return (
+    range !== "custom" && customStart === undefined && customEnd === undefined
+  );
+}
+
+/**
+ * Fetch KPI summary for the analytics dashboard. Named ranges are cached per
+ * (org, range, project) - both the GET route and the SSE summary push go
+ * through here, so the cache covers the dominant recompute path. Custom ranges
+ * bypass the cache (see isCacheableRange).
  */
 export function getAnalyticsSummary(
   organizationId: string,
@@ -114,22 +132,20 @@ export function getAnalyticsSummary(
   customEnd?: string,
   projectId?: string
 ): Promise<AnalyticsSummary> {
-  return cachedAnalytics(
-    analyticsCacheKey("summary", [
+  const compute = () =>
+    computeAnalyticsSummary(
       organizationId,
       range,
-      projectId,
       customStart,
       customEnd,
-    ]),
-    () =>
-      computeAnalyticsSummary(
-        organizationId,
-        range,
-        customStart,
-        customEnd,
-        projectId
-      )
+      projectId
+    );
+  if (!isCacheableRange(range, customStart, customEnd)) {
+    return compute();
+  }
+  return cachedAnalytics(
+    analyticsCacheKey("summary", [organizationId, range, projectId]),
+    compute
   );
 }
 
@@ -425,8 +441,8 @@ async function getWorkflowGasTotal(
 }
 
 /**
- * Fetch time-series bucketed data for charts. Cached per
- * (org, range, project, window).
+ * Fetch time-series bucketed data for charts. Named ranges cached per
+ * (org, range, project); custom ranges bypass the cache (see isCacheableRange).
  */
 export function getTimeSeries(
   organizationId: string,
@@ -435,22 +451,14 @@ export function getTimeSeries(
   customEnd?: string,
   projectId?: string
 ): Promise<TimeSeriesBucket[]> {
+  const compute = () =>
+    computeTimeSeries(organizationId, range, customStart, customEnd, projectId);
+  if (!isCacheableRange(range, customStart, customEnd)) {
+    return compute();
+  }
   return cachedAnalytics(
-    analyticsCacheKey("time-series", [
-      organizationId,
-      range,
-      projectId,
-      customStart,
-      customEnd,
-    ]),
-    () =>
-      computeTimeSeries(
-        organizationId,
-        range,
-        customStart,
-        customEnd,
-        projectId
-      )
+    analyticsCacheKey("time-series", [organizationId, range, projectId]),
+    compute
   );
 }
 
@@ -570,7 +578,8 @@ function mergeBuckets(
 }
 
 /**
- * Fetch gas breakdown by network. Cached per (org, range, project, window).
+ * Fetch gas breakdown by network. Named ranges cached per (org, range,
+ * project); custom ranges bypass the cache (see isCacheableRange).
  */
 export function getNetworkBreakdown(
   organizationId: string,
@@ -579,22 +588,20 @@ export function getNetworkBreakdown(
   customEnd?: string,
   projectId?: string
 ): Promise<NetworkBreakdown[]> {
-  return cachedAnalytics(
-    analyticsCacheKey("networks", [
+  const compute = () =>
+    computeNetworkBreakdown(
       organizationId,
       range,
-      projectId,
       customStart,
       customEnd,
-    ]),
-    () =>
-      computeNetworkBreakdown(
-        organizationId,
-        range,
-        customStart,
-        customEnd,
-        projectId
-      )
+      projectId
+    );
+  if (!isCacheableRange(range, customStart, customEnd)) {
+    return compute();
+  }
+  return cachedAnalytics(
+    analyticsCacheKey("networks", [organizationId, range, projectId]),
+    compute
   );
 }
 
@@ -851,11 +858,17 @@ async function fetchWorkflowRuns(
   // value-identical. The prior subquery scoped only to org + window, so the
   // JSONB gas extraction ran over the whole slice on every load even though
   // only `limit` rows are returned.
+  //
+  // The order/limit here must match the outer query exactly, including the
+  // secondary `id` key: started_at alone is not unique, so without a stable
+  // tiebreaker the two independent ORDER BY ... LIMIT evaluations could select
+  // different rows at the boundary and drop a boundary row's gas. `id` is a
+  // unique total order, so both queries resolve ties identically.
   const pagedExecutionIds = db
     .select({ id: workflowExecutions.id })
     .from(workflowExecutions)
     .where(and(...conditions))
-    .orderBy(desc(workflowExecutions.startedAt))
+    .orderBy(desc(workflowExecutions.startedAt), desc(workflowExecutions.id))
     .limit(limit);
 
   // KEEP-470: gas + network still come from per-log aggregation (no top-level
@@ -909,7 +922,9 @@ async function fetchWorkflowRuns(
     .leftJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
     .leftJoin(logSummary, eq(workflowExecutions.id, logSummary.executionId))
     .where(and(...conditions))
-    .orderBy(desc(workflowExecutions.startedAt))
+    // Secondary `id` key must match pagedExecutionIds above so the page and the
+    // gas subquery resolve started_at ties to the same rows.
+    .orderBy(desc(workflowExecutions.startedAt), desc(workflowExecutions.id))
     .limit(limit);
 
   return result.map((row) => ({

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -11,6 +11,7 @@ import {
   directExecutions,
   organizationSpendCaps,
 } from "@/lib/db/schema-extensions";
+import { analyticsCacheKey, cachedAnalytics } from "./cache";
 import {
   getBucketInterval,
   getPreviousPeriodStart,
@@ -102,9 +103,37 @@ function addBucketToMap(
 }
 
 /**
- * Fetch KPI summary for the analytics dashboard.
+ * Fetch KPI summary for the analytics dashboard. Cached per
+ * (org, range, project, window) - both the GET route and the SSE summary push
+ * go through here, so the cache covers the dominant recompute path.
  */
-export async function getAnalyticsSummary(
+export function getAnalyticsSummary(
+  organizationId: string,
+  range: TimeRange,
+  customStart?: string,
+  customEnd?: string,
+  projectId?: string
+): Promise<AnalyticsSummary> {
+  return cachedAnalytics(
+    analyticsCacheKey("summary", [
+      organizationId,
+      range,
+      projectId,
+      customStart,
+      customEnd,
+    ]),
+    () =>
+      computeAnalyticsSummary(
+        organizationId,
+        range,
+        customStart,
+        customEnd,
+        projectId
+      )
+  );
+}
+
+async function computeAnalyticsSummary(
   organizationId: string,
   range: TimeRange,
   customStart?: string,
@@ -396,9 +425,36 @@ async function getWorkflowGasTotal(
 }
 
 /**
- * Fetch time-series bucketed data for charts.
+ * Fetch time-series bucketed data for charts. Cached per
+ * (org, range, project, window).
  */
-export async function getTimeSeries(
+export function getTimeSeries(
+  organizationId: string,
+  range: TimeRange,
+  customStart?: string,
+  customEnd?: string,
+  projectId?: string
+): Promise<TimeSeriesBucket[]> {
+  return cachedAnalytics(
+    analyticsCacheKey("time-series", [
+      organizationId,
+      range,
+      projectId,
+      customStart,
+      customEnd,
+    ]),
+    () =>
+      computeTimeSeries(
+        organizationId,
+        range,
+        customStart,
+        customEnd,
+        projectId
+      )
+  );
+}
+
+async function computeTimeSeries(
   organizationId: string,
   range: TimeRange,
   customStart?: string,
@@ -514,9 +570,35 @@ function mergeBuckets(
 }
 
 /**
- * Fetch gas breakdown by network.
+ * Fetch gas breakdown by network. Cached per (org, range, project, window).
  */
-export async function getNetworkBreakdown(
+export function getNetworkBreakdown(
+  organizationId: string,
+  range: TimeRange,
+  customStart?: string,
+  customEnd?: string,
+  projectId?: string
+): Promise<NetworkBreakdown[]> {
+  return cachedAnalytics(
+    analyticsCacheKey("networks", [
+      organizationId,
+      range,
+      projectId,
+      customStart,
+      customEnd,
+    ]),
+    () =>
+      computeNetworkBreakdown(
+        organizationId,
+        range,
+        customStart,
+        customEnd,
+        projectId
+      )
+  );
+}
+
+async function computeNetworkBreakdown(
   organizationId: string,
   range: TimeRange,
   customStart?: string,
@@ -762,16 +844,19 @@ async function fetchWorkflowRuns(
     conditions.push(lt(workflowExecutions.startedAt, new Date(cursor)));
   }
 
-  const scopedExecutionIds = db
+  // Restrict the gas/network aggregation to the executions this page will
+  // actually return. The outer query selects the page via the same conditions
+  // + order + limit, and the leftJoin to log_summary does not change which rows
+  // come back - so narrowing the aggregate to those <= limit execution IDs is
+  // value-identical. The prior subquery scoped only to org + window, so the
+  // JSONB gas extraction ran over the whole slice on every load even though
+  // only `limit` rows are returned.
+  const pagedExecutionIds = db
     .select({ id: workflowExecutions.id })
     .from(workflowExecutions)
-    .where(
-      and(
-        sql`${workflowExecutions.workflowId} IN (${orgWorkflowIds})`,
-        gte(workflowExecutions.startedAt, rangeStart),
-        lt(workflowExecutions.startedAt, rangeEnd)
-      )
-    );
+    .where(and(...conditions))
+    .orderBy(desc(workflowExecutions.startedAt))
+    .limit(limit);
 
   // KEEP-470: gas + network still come from per-log aggregation (no top-level
   // column exists for them yet). Transaction hashes now come from the
@@ -798,7 +883,7 @@ async function fetchWorkflowRuns(
     .from(workflowExecutionLogs)
     .where(
       and(
-        sql`${workflowExecutionLogs.executionId} IN (${scopedExecutionIds})`,
+        sql`${workflowExecutionLogs.executionId} IN (${pagedExecutionIds})`,
         sql`${logOutputField("gasUsed")} IS NOT NULL`
       )
     )

--- a/lib/analytics/stream-start.ts
+++ b/lib/analytics/stream-start.ts
@@ -4,7 +4,7 @@ import type {
   TimeRange,
 } from "@/lib/analytics/types";
 
-export const POLL_INTERVAL_MS = 2000;
+export const POLL_INTERVAL_MS = 5000;
 export const HEARTBEAT_INTERVAL_MS = 30_000;
 export const MAX_LIFETIME_MS = 5 * 60 * 1000;
 export const MIN_EVENT_INTERVAL_MS = 1000;

--- a/tests/e2e/playwright/analytics-gas.test.ts
+++ b/tests/e2e/playwright/analytics-gas.test.ts
@@ -108,4 +108,47 @@ test.describe("Analytics Gas Tracking", () => {
       expect(BigInt(network.totalGasWei)).toBeGreaterThan(BigInt(0));
     }
   });
+
+  test("workflow runs API attaches gas to the returned page", async ({
+    page,
+  }) => {
+    await signIn(page, ANALYTICS_EMAIL, ANALYTICS_PASSWORD);
+    await page.goto("/analytics", { waitUntil: "domcontentloaded" });
+
+    const response = await page.request.get(
+      "/api/analytics/runs?range=7d&source=workflow"
+    );
+    const responseBody = await response.text();
+    expect(
+      response.ok(),
+      `Runs API returned ${response.status()}: ${responseBody}`
+    ).toBe(true);
+
+    const data = JSON.parse(responseBody) as {
+      runs: { source: string; gasUsedWei: string | null }[];
+      total: number;
+      pageSize: number;
+    };
+
+    // Pagination metadata is present and the page is non-empty.
+    expect(data.pageSize).toBeGreaterThan(0);
+    expect(data.runs.length).toBeGreaterThan(0);
+
+    // The source filter is honoured for every returned row.
+    for (const run of data.runs) {
+      expect(run.source).toBe("workflow");
+    }
+
+    // Gas is now aggregated only for the executions on this page (the
+    // log_summary subquery is scoped to the paged execution IDs). At least one
+    // seeded web3-write run must still carry non-zero gas - this is what would
+    // regress if the page-scoped aggregation dropped or mis-joined gas.
+    const withGas = data.runs.filter(
+      (r) => r.gasUsedWei !== null && r.gasUsedWei !== "0"
+    );
+    expect(withGas.length).toBeGreaterThan(0);
+    for (const run of withGas) {
+      expect(BigInt(run.gasUsedWei as string)).toBeGreaterThan(BigInt(0));
+    }
+  });
 });

--- a/tests/unit/analytics-cache.test.ts
+++ b/tests/unit/analytics-cache.test.ts
@@ -1,4 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// cache.ts is a server-only module; stub the marker so it can be imported
+// under vitest (the package throws when resolved outside a Server Component).
+vi.mock("server-only", () => ({}));
+
 import {
   __resetAnalyticsCacheForTest,
   analyticsCacheKey,

--- a/tests/unit/analytics-cache.test.ts
+++ b/tests/unit/analytics-cache.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetAnalyticsCacheForTest,
+  analyticsCacheKey,
+  cachedAnalytics,
+} from "@/lib/analytics/cache";
+
+describe("cachedAnalytics", () => {
+  let current = 0;
+  let nowSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    current = 0;
+    nowSpy = vi.spyOn(performance, "now").mockImplementation(() => current);
+    delete process.env.ANALYTICS_CACHE_TTL_MS;
+    __resetAnalyticsCacheForTest();
+  });
+
+  afterEach(() => {
+    nowSpy.mockRestore();
+    delete process.env.ANALYTICS_CACHE_TTL_MS;
+  });
+
+  it("runs the loader once and serves the cached value within the TTL", async () => {
+    const loader = vi.fn(() => Promise.resolve("v1"));
+
+    const first = await cachedAnalytics("k", loader);
+    current = 29_999; // < 30s default, measured from completion (t=0)
+    const second = await cachedAnalytics("k", loader);
+
+    expect(first).toBe("v1");
+    expect(second).toBe("v1");
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it("recomputes once the TTL has elapsed since completion", async () => {
+    let n = 0;
+    const loader = vi.fn(() => {
+      n += 1;
+      return Promise.resolve(`v${n}`);
+    });
+
+    const first = await cachedAnalytics("k", loader);
+    current = 30_001; // past the 30s default
+    const second = await cachedAnalytics("k", loader);
+
+    expect(first).toBe("v1");
+    expect(second).toBe("v2");
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares a single in-flight refresh between concurrent callers", async () => {
+    let resolve: ((v: string) => void) | undefined;
+    const loader = vi.fn(
+      () =>
+        new Promise<string>((r) => {
+          resolve = r;
+        })
+    );
+
+    const p1 = cachedAnalytics("k", loader);
+    const p2 = cachedAnalytics("k", loader);
+
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    resolve?.("done");
+
+    expect(await p1).toBe("done");
+    expect(await p2).toBe("done");
+  });
+
+  it("does not cache failures - the next caller retries", async () => {
+    const loader = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce("ok");
+
+    await expect(cachedAnalytics("k", loader)).rejects.toThrow("boom");
+    const retried = await cachedAnalytics("k", loader);
+
+    expect(retried).toBe("ok");
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it("recomputes on every call when the TTL is disabled (0)", async () => {
+    process.env.ANALYTICS_CACHE_TTL_MS = "0";
+    const loader = vi.fn(() => Promise.resolve("v"));
+
+    await cachedAnalytics("k", loader);
+    await cachedAnalytics("k", loader);
+
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it("isolates entries by key", async () => {
+    const loader = vi.fn(() => Promise.resolve("v"));
+
+    await cachedAnalytics("a", loader);
+    await cachedAnalytics("b", loader);
+
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("analyticsCacheKey", () => {
+  it("collapses undefined parts to a stable string", () => {
+    expect(
+      analyticsCacheKey("summary", [
+        "org1",
+        "7d",
+        undefined,
+        undefined,
+        undefined,
+      ])
+    ).toBe("summary|org1|7d|||");
+  });
+
+  it("distinguishes present optional filters", () => {
+    expect(
+      analyticsCacheKey("summary", ["org1", "custom", "proj1", "s", "e"])
+    ).toBe("summary|org1|custom|proj1|s|e");
+  });
+});

--- a/tests/unit/analytics-cacheable-range.test.ts
+++ b/tests/unit/analytics-cacheable-range.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+
+// queries.ts is a server-only module that also pulls in the db client; stub
+// both so the pure isCacheableRange predicate can be imported under vitest
+// without resolving the server-only marker or opening a DB connection.
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/db", () => ({ db: {} }));
+
+import { isCacheableRange } from "@/lib/analytics/queries";
+
+describe("isCacheableRange", () => {
+  it("caches named ranges with no custom window", () => {
+    expect(isCacheableRange("1h")).toBe(true);
+    expect(isCacheableRange("24h")).toBe(true);
+    expect(isCacheableRange("7d")).toBe(true);
+    expect(isCacheableRange("30d")).toBe(true);
+  });
+
+  it("never caches the custom range", () => {
+    expect(isCacheableRange("custom")).toBe(false);
+    expect(isCacheableRange("custom", "2026-01-01", "2026-02-01")).toBe(false);
+  });
+
+  it("does not cache a named range carrying a custom start or end", () => {
+    // The unbounded key dimension is the caller-supplied window, so any
+    // start/end present must bypass the cache regardless of the range label.
+    expect(isCacheableRange("7d", "2026-01-01", undefined)).toBe(false);
+    expect(isCacheableRange("7d", undefined, "2026-02-01")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

The `/analytics` dashboard was saturating prod DB CPU. Every viewer's SSE stream recomputed the full KPI summary - including unindexed JSONB gas scans over `workflow_execution_logs` - on each checksum change, and the runs table aggregated gas over the entire org+window slice on every load.

## Changes

- Add a keyed per-process TTL cache (`lib/analytics/cache.ts`) and wrap `getAnalyticsSummary` / `getTimeSeries` / `getNetworkBreakdown`. Both the GET routes and the SSE summary push go through these, so concurrent viewers for the same `(org, range, project, window)` share one DB round-trip per TTL (default 30s, `ANALYTICS_CACHE_TTL_MS` to override). In-flight calls dedup; failures are not cached. Mirrors the existing `/api/metrics/db` cache shape.
- Widen the SSE checksum poll from 2s to 5s.
- Scope the runs-table gas/network aggregation to the page's execution IDs instead of the whole org+window slice. The `leftJoin` does not change which rows are returned, so the gas/network values are identical; the JSONB extraction now runs over `<= limit` executions instead of every row in range.

## Tests

- Unit (`tests/unit/analytics-cache.test.ts`): hit/miss, TTL expiry, in-flight dedup, no-cache-on-failure, disable via `TTL=0`, key isolation.
- E2E (`analytics-gas.test.ts`): asserts the runs API attaches non-zero gas to the returned page and honours the source filter.

## Risk / follow-ups

- Up to TTL staleness on the live dashboard (the deliberate tradeoff).
- Cold-cache scans are unchanged; the durable fix is to promote gas/network out of JSONB into indexed columns (tracked separately).
