### PR TITLE
fix: guard localStorage access in mobile warning dialog

### DIFF
--- a/components/mobile-warning-dialog.tsx
+++ b/components/mobile-warning-dialog.tsx
@@ -11,7 +11,13 @@ export function MobileWarningDialog() {
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
-    const dismissed = localStorage.getItem(STORAGE_KEY);
+    let dismissed: string | null = null;
+    try {
+      dismissed = localStorage.getItem(STORAGE_KEY);
+    } catch {
+      // Safari Private Browsing / Lockdown Mode blocks storage access and
+      // throws SecurityError. Treat as not dismissed and show the warning.
+    }
     if (!dismissed && window.innerWidth < MOBILE_BREAKPOINT) {
       setOpen(true);
     }
@@ -22,7 +28,11 @@ export function MobileWarningDialog() {
   }
 
   const handleContinue = () => {
-    localStorage.setItem(STORAGE_KEY, "true");
+    try {
+      localStorage.setItem(STORAGE_KEY, "true");
+    } catch {
+      // Storage unavailable; dismiss for this session only.
+    }
     setOpen(false);
   };
 


### PR DESCRIPTION
## Summary

`MobileWarningDialog` reads `localStorage` in its mount effect without a guard.
iOS Safari in Private Browsing / Lockdown Mode refuses storage access and throws
`SecurityError: The operation is insecure.` (DOMException code 18). Because the
component mounts globally via the root layout, an unguarded throw here surfaces
as a handled error on every page for those users.

## Change

Wrap both the read (mount effect) and write (dismiss handler) in try/catch and
fail open: if storage is unavailable, show the warning and let dismiss work for
the session. No new abstraction; matches the inline try/catch pattern already
used in `app-banner.tsx` and `pending-template-runner.tsx`.

Note: landing as hardening, not asserting it closes the production iOS Safari
SecurityError, since the minified stack can't be mapped to an exact frame
without source maps. Leaving that issue open to verify against recurrence.