### PR TITLE
fix(auth): trust signup IP at TOTP enrollment

### DIFF
--- a/app/api/user/totp/enroll/route.ts
+++ b/app/api/user/totp/enroll/route.ts
@@ -18,6 +18,7 @@ import {
 import {
   buildPendingSignupClearCookie,
 } from "@/lib/pending-signup-cookie";
+import { recordTrustedIpFromRequest } from "@/lib/security/login-risk";
 import { verifyUserTotp } from "@/lib/security/totp-verify";
 
 type RequestBody = {
@@ -252,6 +253,13 @@ export async function POST(request: Request): Promise<NextResponse> {
         mfaVerifiedAt: new Date(),
       });
     });
+
+    // This path mints the first session by hand, so the
+    // session.create.before hook that normally records the source IP in
+    // user_trusted_ips never runs. Trust the signup IP here (first
+    // attestation) so a later sign-in from the same network isn't
+    // bounced to /verify-ip for an IP the user already signed up from.
+    await recordTrustedIpFromRequest(userId);
 
     const responseBody: EnrollResponse = {
       backupCodes,

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -23,11 +23,11 @@ import { isDisposableEmailDomain } from "@/lib/auth-disposable-emails";
 import { DISPOSABLE_EMAIL_REJECTION_MESSAGE } from "@/lib/auth-disposable-emails-message";
 import { isFreshSignup } from "@/lib/auth-notification-guard";
 import { sendInvitationEmail, sendVerificationOTP } from "@/lib/email";
-import { ErrorCategory, logSystemError } from "@/lib/logging";
 import {
   assessIpTrust,
   assessLoginRisk,
   serializeRiskFlags,
+  upsertTrustedIp,
 } from "@/lib/security/login-risk";
 import { TRUSTED_ORIGINS } from "@/lib/trusted-origins";
 import { wrapWithSessionTokenHash } from "./auth-session-token-hash";
@@ -46,7 +46,6 @@ import {
   sessions,
   twoFactor as twoFactorTable,
   users,
-  userTrustedIps,
   verifications,
   workflowExecutionLogs,
   workflowExecutions,
@@ -643,30 +642,7 @@ export const auth = betterAuth({
           // (user_id, ip) constraint makes the upsert idempotent so a
           // repeat sign-in from a known IP just bumps last_seen_at.
           if (ipTrust.ip && ipTrust.trusted) {
-            try {
-              await db
-                .insert(userTrustedIps)
-                .values({
-                  userId,
-                  ip: ipTrust.ip,
-                  country: ipTrust.country,
-                })
-                .onConflictDoUpdate({
-                  target: [userTrustedIps.userId, userTrustedIps.ip],
-                  set: { lastSeenAt: new Date() },
-                });
-            } catch (err) {
-              // Trust list bookkeeping must never block sign-in. If
-              // the insert fails the next sign-in from the same IP
-              // will hit the /verify-ip gate, which is the correct
-              // fail-closed direction.
-              logSystemError(
-                ErrorCategory.DATABASE,
-                "[ip-trust] failed to upsert trusted IP",
-                err,
-                { user_id: userId, ip: ipTrust.ip }
-              );
-            }
+            await upsertTrustedIp(userId, ipTrust.ip, ipTrust.country);
           }
           const [userRow] = await db
             .select({ twoFactorEnabled: users.twoFactorEnabled })

--- a/lib/security/login-risk.ts
+++ b/lib/security/login-risk.ts
@@ -2,6 +2,7 @@ import { and, desc, eq } from "drizzle-orm";
 import { headers } from "next/headers";
 import { db } from "@/lib/db";
 import { sessions, userTrustedIps } from "@/lib/db/schema";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { normalizeIpForTrust } from "@/lib/security/ip-normalize";
 import {
   type ResolvedLocation,
@@ -469,4 +470,59 @@ export async function assessIpTrust(userId: string): Promise<IpTrust> {
     reason: "untrusted",
   });
   return { ip, rawIp, trusted: false, country, reason: "untrusted" };
+}
+
+/**
+ * Idempotently record an IP in a user's trusted list. The unique
+ * (user_id, ip) constraint makes the upsert safe to repeat: a known IP
+ * just bumps last_seen_at. Best-effort by design. A failure is logged
+ * and swallowed because trust-list bookkeeping must never block the
+ * sign-in that triggered it. If the write is lost, the next sign-in
+ * from the same IP hits the /verify-ip gate, which is the correct
+ * fail-closed direction.
+ */
+export async function upsertTrustedIp(
+  userId: string,
+  ip: string,
+  country: string | null
+): Promise<void> {
+  try {
+    await db
+      .insert(userTrustedIps)
+      .values({ userId, ip, country })
+      .onConflictDoUpdate({
+        target: [userTrustedIps.userId, userTrustedIps.ip],
+        set: { lastSeenAt: new Date() },
+      });
+  } catch (err) {
+    logSystemError(
+      ErrorCategory.DATABASE,
+      "[ip-trust] failed to upsert trusted IP",
+      err,
+      { user_id: userId, ip }
+    );
+  }
+}
+
+/**
+ * Record the current request's source IP as trusted for this user,
+ * mirroring the databaseHooks.session.create.before path in lib/auth.ts.
+ * Called by the pending-signup TOTP enroll path, which mints a user's
+ * first session by inserting the row directly and so never runs that
+ * hook. Without it a credential signup never records its origin IP, so a
+ * later sign-in from that very network is treated as new and bounced to
+ * /verify-ip. (OAuth signup does not need this: its callback mints a
+ * Better Auth session first, which runs the hook before being discarded.)
+ *
+ * Records only on a positive trust decision: first-ever attestation or
+ * an already-known IP, exactly as the hook does. An untrusted IP is left
+ * for the /verify-ip gate to resolve.
+ */
+export async function recordTrustedIpFromRequest(
+  userId: string
+): Promise<void> {
+  const ipTrust = await assessIpTrust(userId);
+  if (ipTrust.ip && ipTrust.trusted) {
+    await upsertTrustedIp(userId, ipTrust.ip, ipTrust.country);
+  }
 }


### PR DESCRIPTION
## Problem

Credential signup mints no Better Auth session until the pending-signup TOTP enroll step. That step inserts the session row directly via Drizzle, bypassing the `session.create.before` hook in `lib/auth.ts` that is the only place an IP gets auto-recorded into `user_trusted_ips` at authentication time.

The result: the network a user signs up from is never trusted. A later sign-in from that exact network is then treated as new and bounced to `/verify-ip`, even though the user already proved password + email OTP + TOTP from that machine during signup. Pure friction, no security value for the signup network.

(OAuth signup is unaffected: its callback mints a real Better Auth session first, which runs the hook before the session is discarded.)

## Fix

- Extract the hook's trusted-IP upsert into a shared `upsertTrustedIp()` helper in `lib/security/login-risk.ts`; refactor `session.create.before` to use it (no behavior change there).
- Add `recordTrustedIpFromRequest()`, which mirrors the hook's "trust on first/known IP" decision.
- Call it in the pending-signup branch of `app/api/user/totp/enroll/route.ts` right after the session is minted, so the signup IP is trusted from the start. Best-effort; never blocks enrollment.

## Scope

- Email verification and TOTP enrollment remain mandatory on signup. Unchanged.
- A genuinely new network still hits `/verify-ip`. Unchanged.
- Only the redundant IP gate for the network the user signed up from is removed.

