### PR TITLE
fix(deploy): restrict workflow-runner egress to required destinations

### DIFF
--- a/deploy/keeperhub/prod/networkpolicy.yaml
+++ b/deploy/keeperhub/prod/networkpolicy.yaml
@@ -1,15 +1,33 @@
-# Defense-in-depth: even if the JS-level SSRF guard in lib/sandbox/child-source.ts
-# or lib/safe-fetch.ts is bypassed, workflow runner pods must not be able to
-# reach the EC2 instance metadata service (IMDS, 169.254.169.254). Selector
-# matches the `app: workflow-runner` label set by keeperhub-executor/k8s-job.ts.
+# Defense-in-depth egress hardening for workflow runner Jobs. Even if the
+# JS-level SSRF guard in lib/sandbox/child-source.ts or lib/safe-fetch.ts is
+# bypassed, runner pods must not be able to reach the EC2 instance metadata
+# service (IMDS, 169.254.169.254) or pivot to arbitrary in-VPC / RFC1918 /
+# CGNAT hosts (RDS admin ports, other pods, peered VPCs, the node itself).
+# Selector matches the `app: workflow-runner` label set by
+# keeperhub-executor/k8s-job.ts.
 #
-# Egress allow rule uses 0.0.0.0/0 with an explicit `except` so we keep
-# legitimate outbound traffic working (RDS in 10.0/8, cluster DNS, public RPC
-# endpoints) while denying the link-local range. IPv6 link-local and ULA are
-# blocked too (AWS IMDSv6 is at fd00:ec2::254 inside fc00::/7).
+# Egress is a union of explicit allows; everything else is denied. The runner
+# legitimately needs exactly four destinations, so each gets its own rule:
+#   1. kube-dns        - resolve public + in-cluster hostnames
+#   2. keeperhub-sandbox (:8787) - delegated code-step execution
+#   3. keeperhub-executor (:3080) - metrics ingest (EXECUTOR_METRICS_INGEST_URL)
+#   4. RDS Postgres (:5432) - the runner writes execution state directly via
+#      DATABASE_URL; reached by IP in the dedicated DB subnets (not a Service,
+#      so it must be an ipBlock, not a podSelector)
+# Everything else is the public-internet rule: 0.0.0.0/0 (and ::/0 for NAT64)
+# with every private/CGNAT/loopback/link-local range stripped via `except`.
+# In-cluster Services are reached by ClusterIP; the VPC CNI Network Policy
+# Agent evaluates egress on the post-DNAT backend pod IP, so podSelector rules
+# match the real destination even though the Service CIDR sits inside an
+# excepted range. Public egress is intentionally left port-unrestricted so
+# blockchain RPC / webhook endpoints on non-443 ports keep working;
+# destination filtering at L7 is handled by SAFE_FETCH_ENFORCE.
 #
 # Enforced by the AWS VPC CNI Network Policy Agent on EKS (cluster runs
 # v1.21+ amazon-vpc-cni with NETWORK_POLICY_ENFORCING_MODE=standard).
+#
+# Prod VPC is 10.0.0.0/16; DB subnets are 10.0.100.0/24, 10.0.101.0/24,
+# 10.0.102.0/24 (us-east-2 a/b/c).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -22,11 +40,65 @@ spec:
   policyTypes:
     - Egress
   egress:
+    # 1. DNS resolution via kube-dns (CoreDNS) only.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # 2. keeperhub-sandbox Service - delegated code-step execution.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: keeperhub
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: keeperhub-sandbox
+      ports:
+        - protocol: TCP
+          port: 8787
+    # 3. keeperhub-executor Service - counter-metric ingest.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: keeperhub
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: keeperhub-executor
+      ports:
+        - protocol: TCP
+          port: 3080
+    # 4. RDS Postgres in the dedicated DB subnets only.
+    - to:
+        - ipBlock:
+            cidr: 10.0.100.0/24
+        - ipBlock:
+            cidr: 10.0.101.0/24
+        - ipBlock:
+            cidr: 10.0.102.0/24
+      ports:
+        - protocol: TCP
+          port: 5432
+    # 5. Public internet, all ports, with private/CGNAT/loopback/link-local
+    #    ranges stripped. IPv6 keeps NAT64 reachable while blocking link-local
+    #    and ULA (AWS IMDSv6 at fd00:ec2::254 falls inside fc00::/7).
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
             except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
               - 169.254.0.0/16
+              - 100.64.0.0/10
+              - 127.0.0.0/8
         - ipBlock:
             cidr: ::/0
             except:

--- a/deploy/keeperhub/staging/networkpolicy.yaml
+++ b/deploy/keeperhub/staging/networkpolicy.yaml
@@ -1,15 +1,33 @@
-# Defense-in-depth: even if the JS-level SSRF guard in lib/sandbox/child-source.ts
-# or lib/safe-fetch.ts is bypassed, workflow runner pods must not be able to
-# reach the EC2 instance metadata service (IMDS, 169.254.169.254). Selector
-# matches the `app: workflow-runner` label set by keeperhub-executor/k8s-job.ts.
+# Defense-in-depth egress hardening for workflow runner Jobs. Even if the
+# JS-level SSRF guard in lib/sandbox/child-source.ts or lib/safe-fetch.ts is
+# bypassed, runner pods must not be able to reach the EC2 instance metadata
+# service (IMDS, 169.254.169.254) or pivot to arbitrary in-VPC / RFC1918 /
+# CGNAT hosts (RDS admin ports, other pods, peered VPCs, the node itself).
+# Selector matches the `app: workflow-runner` label set by
+# keeperhub-executor/k8s-job.ts.
 #
-# Egress allow rule uses 0.0.0.0/0 with an explicit `except` so we keep
-# legitimate outbound traffic working (RDS in 10.1/16, cluster DNS, public RPC
-# endpoints) while denying the link-local range. IPv6 link-local and ULA are
-# blocked too (AWS IMDSv6 is at fd00:ec2::254 inside fc00::/7).
+# Egress is a union of explicit allows; everything else is denied. The runner
+# legitimately needs exactly four destinations, so each gets its own rule:
+#   1. kube-dns        - resolve public + in-cluster hostnames
+#   2. keeperhub-sandbox (:8787) - delegated code-step execution
+#   3. keeperhub-executor (:3080) - metrics ingest (EXECUTOR_METRICS_INGEST_URL)
+#   4. RDS Postgres (:5432) - the runner writes execution state directly via
+#      DATABASE_URL; reached by IP in the dedicated DB subnets (not a Service,
+#      so it must be an ipBlock, not a podSelector)
+# Everything else is the public-internet rule: 0.0.0.0/0 (and ::/0 for NAT64)
+# with every private/CGNAT/loopback/link-local range stripped via `except`.
+# In-cluster Services are reached by ClusterIP; the VPC CNI Network Policy
+# Agent evaluates egress on the post-DNAT backend pod IP, so podSelector rules
+# match the real destination even though the Service CIDR sits inside an
+# excepted range. Public egress is intentionally left port-unrestricted so
+# blockchain RPC / webhook endpoints on non-443 ports keep working;
+# destination filtering at L7 is handled by SAFE_FETCH_ENFORCE.
 #
 # Enforced by the AWS VPC CNI Network Policy Agent on EKS (cluster runs
 # v1.21+ amazon-vpc-cni with NETWORK_POLICY_ENFORCING_MODE=standard).
+#
+# Staging VPC is 10.1.0.0/16; DB subnets are 10.1.100.0/24, 10.1.101.0/24,
+# 10.1.102.0/24 (us-east-1 a/b/c).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -22,11 +40,65 @@ spec:
   policyTypes:
     - Egress
   egress:
+    # 1. DNS resolution via kube-dns (CoreDNS) only.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # 2. keeperhub-sandbox Service - delegated code-step execution.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: keeperhub
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: keeperhub-sandbox
+      ports:
+        - protocol: TCP
+          port: 8787
+    # 3. keeperhub-executor Service - counter-metric ingest.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: keeperhub
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: keeperhub-executor
+      ports:
+        - protocol: TCP
+          port: 3080
+    # 4. RDS Postgres in the dedicated DB subnets only.
+    - to:
+        - ipBlock:
+            cidr: 10.1.100.0/24
+        - ipBlock:
+            cidr: 10.1.101.0/24
+        - ipBlock:
+            cidr: 10.1.102.0/24
+      ports:
+        - protocol: TCP
+          port: 5432
+    # 5. Public internet, all ports, with private/CGNAT/loopback/link-local
+    #    ranges stripped. IPv6 keeps NAT64 reachable while blocking link-local
+    #    and ULA (AWS IMDSv6 at fd00:ec2::254 falls inside fc00::/7).
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
             except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
               - 169.254.0.0/16
+              - 100.64.0.0/10
+              - 127.0.0.0/8
         - ipBlock:
             cidr: ::/0
             except:


### PR DESCRIPTION
## Problem

`workflow-runner-block-imds` only blocked link-local (`169.254.0.0/16`). Runner pods could still reach all of RFC1918, CGNAT and in-VPC services (RDS, Redis, other pods) over egress. A runner compromised through an SSRF vector that slips past the L7 `SAFE_FETCH_ENFORCE` guard could pivot to internal hosts. This is a SEV-1 postmortem follow-up.

## Change

Replaced the single permissive egress rule with a union of explicit allows; everything else is denied. The runner needs exactly four destinations, each gets its own rule:

- **DNS** to kube-dns only (UDP/TCP 53)
- **keeperhub-sandbox** `:8787` - delegated code-step execution
- **keeperhub-executor** `:3080` - metrics ingest (`EXECUTOR_METRICS_INGEST_URL`)
- **RDS Postgres** `:5432` - scoped to the dedicated DB subnets (the runner writes execution state directly via `DATABASE_URL`)
- **public internet** (all ports) with `10/8`, `172.16/12`, `192.168/16`, `169.254/16`, `100.64/10`, `127/8` stripped; IPv6 keeps NAT64 reachable while blocking link-local and ULA (IMDSv6 sits in `fc00::/7`)

In-cluster Services are matched by `podSelector` rather than CIDR because the VPC CNI Network Policy Agent evaluates egress on the post-DNAT backend pod IP. Public egress is left port-unrestricted on purpose so non-443 RPC / webhook endpoints keep working; destination filtering at L7 stays the job of `SAFE_FETCH_ENFORCE`.

Both files edited (staging applies on this merge, prod applies on the later `staging` -> `prod` PR); only the RDS subnet CIDRs differ between envs.

## Network facts (verified live, read-only, 2026-06-01)

| | prod (techops-prod, us-east-2) | staging (techops-staging, us-east-1) |
|---|---|---|
| VPC CIDR | `10.0.0.0/16` | `10.1.0.0/16` |
| DB subnets | `10.0.100.0/24`, `.101.0/24`, `.102.0/24` | `10.1.100.0/24`, `.101.0/24`, `.102.0/24` |
| Pods | all in `10.x` (no `100.64` secondary CIDR) | same shape |

## Validation

- Both manifests pass `kubectl apply --dry-run=server` against the live API servers (reports `configured` - in-place update of the existing policy, same name, no orphan).

## Post-merge verification plan (staging, before promoting to prod)

1. Run a real workflow on staging - proves DB + sandbox + DNS + public RPC still work end to end.
2. Throwaway `app=workflow-runner` debug pod: confirm IMDS `169.254.169.254` and an arbitrary `10.1.x` host are denied, while RDS `:5432` and public `443` succeed.

Risk: staging applies to all runner Jobs on merge. If a workflow needs an in-cluster endpoint not accounted for here, it would fail at run time (not deploy time) - the verification step above is what catches that before prod.