### PR TITLE
fix: retry sandbox capacity 429 before surfacing to caller

### DIFF
--- a/lib/sandbox/client.ts
+++ b/lib/sandbox/client.ts
@@ -24,6 +24,84 @@ const sandboxAgent = new Agent({
   maxSockets: 50,
 });
 
+// The sandbox sheds load with 429 + Retry-After before it reads the body or
+// spawns a child, so a momentary concurrency overshoot is cheap to retry: a
+// short backoff lets the in-flight runs on the pod drain instead of surfacing
+// a hard error to the caller. Bounded so sustained saturation still fails
+// fast rather than amplifying load on an already-full sandbox.
+const MAX_CAPACITY_RETRIES = Number.parseInt(
+  process.env.SANDBOX_MAX_RETRIES ?? "3",
+  10
+);
+
+// Fallback backoff when a 429 omits Retry-After. The server currently always
+// sends Retry-After: 1, but we do not depend on it.
+const DEFAULT_RETRY_AFTER_MS = 500;
+
+// Random spread added to each backoff so concurrent callers retrying the same
+// overflow do not resynchronize into a thundering herd against the sandbox.
+const RETRY_JITTER_MS = 250;
+
+const HTTP_TOO_MANY_REQUESTS = 429;
+
+/**
+ * Carries the HTTP status (and parsed Retry-After) off a non-200 sandbox
+ * response so runRemote can distinguish a retryable capacity 429 from a
+ * terminal error without string-matching the message.
+ */
+class SandboxHttpError extends Error {
+  readonly statusCode: number;
+  readonly retryAfterMs: number | null;
+
+  constructor(
+    statusCode: number,
+    retryAfterMs: number | null,
+    message: string
+  ) {
+    super(message);
+    this.name = "SandboxHttpError";
+    this.statusCode = statusCode;
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+function parseRetryAfterMs(
+  headerValue: string | string[] | undefined
+): number | null {
+  const raw = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+  if (!raw) {
+    return null;
+  }
+  const seconds = Number.parseInt(raw, 10);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds * 1000 : null;
+}
+
+/** Abort-aware delay used between capacity retries. Rejects if the caller's
+ * signal fires while we are backing off so a client disconnect short-circuits
+ * the wait instead of pinning the workflow step for the full backoff. */
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error("aborted"));
+      return;
+    }
+    let onAbort: (() => void) | null = null;
+    const timer = setTimeout(() => {
+      if (signal && onAbort) {
+        signal.removeEventListener("abort", onAbort);
+      }
+      resolve();
+    }, ms);
+    if (signal) {
+      onAbort = (): void => {
+        clearTimeout(timer);
+        reject(new Error("aborted"));
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+  });
+}
+
 type LogEntry = {
   level: "log" | "warn" | "error";
   args: unknown[];
@@ -113,8 +191,13 @@ function postOnce(
           settle(() => {
             const buf = Buffer.concat(chunks);
             if (res.statusCode !== 200) {
+              const retryAfterMs = parseRetryAfterMs(
+                res.headers["retry-after"]
+              );
               reject(
-                new Error(
+                new SandboxHttpError(
+                  res.statusCode ?? 0,
+                  retryAfterMs,
                   `sandbox returned ${res.statusCode ?? "no status"}: ${buf.toString("utf8").slice(0, 200)}`
                 )
               );
@@ -195,9 +278,39 @@ export async function runRemote(input: {
       ),
       "ascii"
     );
-    const responseBuf = await postOnce(body, input.timeoutMs, input.signal);
-    const outcome = parseResponse(responseBuf);
-    return toRunCodeResult(outcome);
+
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= MAX_CAPACITY_RETRIES; attempt++) {
+      try {
+        const responseBuf = await postOnce(body, input.timeoutMs, input.signal);
+        const outcome = parseResponse(responseBuf);
+        return toRunCodeResult(outcome);
+      } catch (err) {
+        lastError = err;
+        // Only a capacity 429 is retryable: the run never started, so resending
+        // is safe. Any other failure (5xx, malformed, network) is terminal.
+        if (
+          err instanceof SandboxHttpError &&
+          err.statusCode === HTTP_TOO_MANY_REQUESTS &&
+          attempt < MAX_CAPACITY_RETRIES
+        ) {
+          const backoffMs =
+            (err.retryAfterMs ?? DEFAULT_RETRY_AFTER_MS) +
+            Math.floor(Math.random() * RETRY_JITTER_MS);
+          await delay(backoffMs, input.signal);
+          continue;
+        }
+        break;
+      }
+    }
+
+    const message =
+      lastError instanceof Error ? lastError.message : String(lastError);
+    return {
+      success: false,
+      error: `sandbox client error: ${message}`,
+      logs: [],
+    };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return {

--- a/lib/sandbox/client.ts
+++ b/lib/sandbox/client.ts
@@ -34,63 +34,50 @@ const MAX_CAPACITY_RETRIES = Number.parseInt(
   10
 );
 
-// Fallback backoff when a 429 omits Retry-After. The server currently always
-// sends Retry-After: 1, but we do not depend on it.
-const DEFAULT_RETRY_AFTER_MS = 500;
+// Base backoff for the first retry. We deliberately compute the wait from a
+// fixed schedule rather than the response's Retry-After: deriving a timer
+// duration from an HTTP header is a resource-exhaustion risk, and our sandbox
+// always signals a 1s backoff anyway.
+const BASE_BACKOFF_MS = 500;
+
+// Hard ceiling on any single backoff so a sustained-saturation retry chain
+// cannot pin a workflow step on a long timer.
+const MAX_BACKOFF_MS = 5000;
 
 // Random spread added to each backoff so concurrent callers retrying the same
 // overflow do not resynchronize into a thundering herd against the sandbox.
 const RETRY_JITTER_MS = 250;
 
-// Hard ceiling on any single backoff. Retry-After comes off an HTTP response,
-// so a buggy or hostile value must never be able to pin a workflow step on a
-// long timer. Our sandbox only ever sends 1s; 5s is generous headroom.
-const MAX_BACKOFF_MS = 5000;
-
 const HTTP_TOO_MANY_REQUESTS = 429;
 
 /**
- * Carries the HTTP status (and parsed Retry-After) off a non-200 sandbox
- * response so runRemote can distinguish a retryable capacity 429 from a
- * terminal error without string-matching the message.
+ * Carries the HTTP status off a non-200 sandbox response so runRemote can
+ * distinguish a retryable capacity 429 from a terminal error without
+ * string-matching the message.
  */
 class SandboxHttpError extends Error {
   readonly statusCode: number;
-  readonly retryAfterMs: number | null;
 
-  constructor(
-    statusCode: number,
-    retryAfterMs: number | null,
-    message: string
-  ) {
+  constructor(statusCode: number, message: string) {
     super(message);
     this.name = "SandboxHttpError";
     this.statusCode = statusCode;
-    this.retryAfterMs = retryAfterMs;
   }
 }
 
-function parseRetryAfterMs(
-  headerValue: string | string[] | undefined
-): number | null {
-  const raw = Array.isArray(headerValue) ? headerValue[0] : headerValue;
-  if (!raw) {
-    return null;
-  }
-  const seconds = Number.parseInt(raw, 10);
-  if (!(Number.isFinite(seconds) && seconds >= 0)) {
-    return null;
-  }
-  return Math.min(seconds * 1000, MAX_BACKOFF_MS);
+/** Exponential backoff for the nth retry (0-indexed), capped and jittered.
+ * Derived only from constants so no response-controlled value reaches the
+ * timer. */
+function backoffForAttempt(attempt: number): number {
+  const exponential = BASE_BACKOFF_MS * 2 ** attempt;
+  const capped = Math.min(exponential, MAX_BACKOFF_MS);
+  return capped + Math.floor(Math.random() * RETRY_JITTER_MS);
 }
 
 /** Abort-aware delay used between capacity retries. Rejects if the caller's
  * signal fires while we are backing off so a client disconnect short-circuits
  * the wait instead of pinning the workflow step for the full backoff. */
 function delay(ms: number, signal?: AbortSignal): Promise<void> {
-  // Bound the timer at the sink: never wait longer than the ceiling regardless
-  // of what the caller passes, so a tainted Retry-After cannot pin the step.
-  const boundedMs = Math.min(Math.max(0, ms), MAX_BACKOFF_MS);
   return new Promise<void>((resolve, reject) => {
     if (signal?.aborted) {
       reject(new Error("aborted"));
@@ -102,7 +89,7 @@ function delay(ms: number, signal?: AbortSignal): Promise<void> {
         signal.removeEventListener("abort", onAbort);
       }
       resolve();
-    }, boundedMs);
+    }, ms);
     if (signal) {
       onAbort = (): void => {
         clearTimeout(timer);
@@ -202,13 +189,9 @@ function postOnce(
           settle(() => {
             const buf = Buffer.concat(chunks);
             if (res.statusCode !== 200) {
-              const retryAfterMs = parseRetryAfterMs(
-                res.headers["retry-after"]
-              );
               reject(
                 new SandboxHttpError(
                   res.statusCode ?? 0,
-                  retryAfterMs,
                   `sandbox returned ${res.statusCode ?? "no status"}: ${buf.toString("utf8").slice(0, 200)}`
                 )
               );
@@ -305,10 +288,7 @@ export async function runRemote(input: {
           err.statusCode === HTTP_TOO_MANY_REQUESTS &&
           attempt < MAX_CAPACITY_RETRIES
         ) {
-          const backoffMs =
-            (err.retryAfterMs ?? DEFAULT_RETRY_AFTER_MS) +
-            Math.floor(Math.random() * RETRY_JITTER_MS);
-          await delay(backoffMs, input.signal);
+          await delay(backoffForAttempt(attempt), input.signal);
           continue;
         }
         break;

--- a/lib/sandbox/client.ts
+++ b/lib/sandbox/client.ts
@@ -42,6 +42,11 @@ const DEFAULT_RETRY_AFTER_MS = 500;
 // overflow do not resynchronize into a thundering herd against the sandbox.
 const RETRY_JITTER_MS = 250;
 
+// Hard ceiling on any single backoff. Retry-After comes off an HTTP response,
+// so a buggy or hostile value must never be able to pin a workflow step on a
+// long timer. Our sandbox only ever sends 1s; 5s is generous headroom.
+const MAX_BACKOFF_MS = 5000;
+
 const HTTP_TOO_MANY_REQUESTS = 429;
 
 /**
@@ -73,13 +78,19 @@ function parseRetryAfterMs(
     return null;
   }
   const seconds = Number.parseInt(raw, 10);
-  return Number.isFinite(seconds) && seconds >= 0 ? seconds * 1000 : null;
+  if (!(Number.isFinite(seconds) && seconds >= 0)) {
+    return null;
+  }
+  return Math.min(seconds * 1000, MAX_BACKOFF_MS);
 }
 
 /** Abort-aware delay used between capacity retries. Rejects if the caller's
  * signal fires while we are backing off so a client disconnect short-circuits
  * the wait instead of pinning the workflow step for the full backoff. */
 function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  // Bound the timer at the sink: never wait longer than the ceiling regardless
+  // of what the caller passes, so a tainted Retry-After cannot pin the step.
+  const boundedMs = Math.min(Math.max(0, ms), MAX_BACKOFF_MS);
   return new Promise<void>((resolve, reject) => {
     if (signal?.aborted) {
       reject(new Error("aborted"));
@@ -91,7 +102,7 @@ function delay(ms: number, signal?: AbortSignal): Promise<void> {
         signal.removeEventListener("abort", onAbort);
       }
       resolve();
-    }, ms);
+    }, boundedMs);
     if (signal) {
       onAbort = (): void => {
         clearTimeout(timer);

--- a/specs/sandbox-scaling.md
+++ b/specs/sandbox-scaling.md
@@ -1,138 +1,61 @@
 # Code Sandbox Scaling Notes
 
-Reference for deciding how to scale the `keeperhub-sandbox` service. Captures
-what bounds today's capacity, the options, and their cost so the pod sizing
-call can be made on data rather than guesswork.
+Plain-language summary for deciding how to scale the code sandbox. The sandbox
+runs users' Code-node JavaScript, each run in its own short-lived process.
 
-## What exists today
+## The problem
 
-The sandbox runs user Code-node JavaScript. Each `/run` request spawns a fresh
-Node child process (`sandbox/src/run-code.ts`), runs the user code with a
-wall-clock timeout (default 60s, max 120s), and returns the result.
+Clients sometimes get a "rate limit" (429) error from Code nodes. That happens
+because the sandbox only allows a fixed number of code runs at the same time,
+and once that number is hit, extra runs are rejected.
 
-Concurrency is gated per pod by an in-flight counter
-(`sandbox/src/index.ts`). When in-flight runs reach the cap, the pod sheds
-load with `429 sandbox at capacity` plus `Retry-After: 1`, before it reads the
-body or spawns a child (so a shed request is cheap on the server).
+Today the limit is 16 runs at once across all of prod (8 per pod, 2 pods). A
+normal paid workload can trip that on a brief spike, which is too low.
 
-Current numbers:
+## Why the limit is 16 and not higher
 
-- Per-pod cap: `DEFAULT_MAX_CONCURRENT_RUNS = 8`, overridable via
-  `SANDBOX_MAX_CONCURRENT_RUNS`.
-- Prod `replicaCount: 2`, so effective cluster ceiling is `8 x 2 = 16`
-  concurrent runs. Staging runs 1 replica (ceiling 8).
-- Per-pod resources: requests `100m / 128Mi`, limits `500m / 512Mi`.
-- Pods are pinned to a dedicated, taint-isolated Karpenter nodepool.
+Each running pod has half a CPU core and 512MB of memory. Each code run is a
+full Node process that needs CPU to start up and some memory to run.
 
-## What actually binds the limit
+- CPU is the real ceiling: half a core can only handle about 8 runs at once
+  before they start fighting for CPU and slow down.
+- Memory is the hidden risk: 8 runs already use most of the 512MB. A heavy run
+  can push a pod over its memory limit, which crashes the pod and kills every
+  run on it at once.
 
-The `8` is CPU derived, not arbitrary, and memory is a secondary risk:
+So the 16 is not arbitrary. Just raising the number without giving the pods more
+CPU and memory makes runs slow and crash instead of fixing anything.
 
-- CPU: `500m` is half a core. Eight concurrent child processes, each paying an
-  ~80ms V8 startup and compile cost, already oversubscribe it. Raising
-  concurrency without raising CPU trades 429s for slow runs and wall-clock
-  timeouts, which is worse for the caller.
-- Memory: at 8 runs of roughly 60MB baseline each, a pod sits near 480MB of its
-  512Mi limit before user code allocates anything. There is no per-run heap
-  cap, so one run can grow until the pod-wide cgroup OOM-kills the container,
-  taking every in-flight run on that pod down with it.
+## The options
 
-Cost is driven by Kubernetes requests, not limits, because Karpenter bin-packs
-on requests. Today's requests are tiny, so the whole service is effectively one
-small mostly-idle node.
+| Option | What it does | Cost | Trade-off |
+| --- | --- | --- | --- |
+| Retry on 429 | Client waits a moment and retries instead of erroring | Free | Hides short spikes. Does not add real capacity. Shipping now. |
+| Bigger pods, "best effort" | Allow pods to use more CPU/memory if the machine has it free | Roughly free | Faster only when the machine is not busy. Unreliable under load. |
+| Bigger pods, "reserved" | Permanently reserve more CPU/memory per pod | About +45 to +90 / month | Reliable, but you pay for it 24/7 even when the sandbox is idle. Still a fixed ceiling. |
+| Autoscaling | Start with 2 pods, add more automatically during busy periods, remove them when quiet | Pay only for what you use | The best fit. Needs a bit more setup. |
 
-## Per concurrent run, the cost model
+## What we shipped now
 
-One concurrent slot is one full Node process:
+The retry. When the sandbox says "I'm full, try again in a moment," the client
+now waits and retries (up to 3 times) instead of failing. This is free and
+removes most of the errors clients see, because most of them are tiny spikes
+that pass in under a second. It does not add capacity on its own.
 
-- About 60 to 65m of CPU to hold the 8-per-500m ratio.
-- About 60MB of baseline memory plus whatever headroom user code needs.
-- No isolation beyond the OS process, one shared pod cgroup.
+## What to do next (recommended)
 
-To raise concurrency reliably, move CPU and memory together and keep those
-ratios. Sixteen runs per pod means roughly 1000m CPU and 1Gi memory.
+1. Keep the pods their current size.
+2. Turn on autoscaling: always keep 2 pods running, and automatically add more
+   when the sandbox gets busy, then scale back down when it quiets.
+3. Bump the per-pod memory limit from 512MB to 1GB (this part is free) so a
+   single heavy run can no longer crash a pod.
 
-## Options
+This matches cost to actual usage: cheap when idle, more capacity exactly when
+clients need it, and no fixed wall that a busy day can hit.
 
-### 1. Client retry on 429 (shipping in the linked PR)
+## One number to confirm first
 
-The main-app client now honors the `Retry-After` the sandbox already sends:
-bounded retries (default 3, via `SANDBOX_MAX_RETRIES`) with jitter, abort-aware.
-Only a capacity 429 is retried since the run never started, so resending is
-safe. Any other failure is terminal.
-
-- Cost: zero infra. The retry runs in the main app over the existing keep-alive
-  socket, and only fires on a 429.
-- Buys: absorbs sub-second micro-bursts (the overshoot cases) so they never
-  surface to the customer. Does not add capacity. Pairs with autoscaling by
-  covering the seconds while a new pod becomes ready.
-
-### 2. Vertical, burstable (raise limits only)
-
-Set per-pod limits to `1000m / 1Gi`, leave requests at `100m / 128Mi`.
-
-- Cost: about zero. Requests unchanged, so bin-packing and the node footprint do
-  not change.
-- Behavior: 16 per pod works only when the node happens to have spare CPU. Under
-  contention the kernel throttles the pod back toward its 100m request, so the
-  16 runs crawl. Burstable, not guaranteed.
-
-### 3. Vertical, guaranteed (raise requests to match limits)
-
-Set requests and limits both to `1000m / 1Gi`.
-
-- Cost: roughly +45 to +90 per month. Karpenter must reserve about 2 vCPU and
-  2Gi for the two pods, forcing a larger node that is paid for 24/7 even when
-  the sandbox is idle.
-- Behavior: 16 per pod always has the CPU reserved, predictable under load.
-- Downside: the reservation is sized for peak but the sandbox is mostly idle, so
-  you pay for headroom that sits unused most of the time. Still a fixed ceiling;
-  33 concurrent runs still hit 429, and one pod crash now drops 16 runs.
-
-### 4. Horizontal autoscaling (the durable answer)
-
-Keep pods at their current size. Scale replicas on saturation, not CPU.
-
-- The 429 is fired by the in-flight concurrency counter, which does not track
-  CPU or memory utilization. Code nodes are frequently I/O bound (user code
-  awaits external `fetch`), so a pod can be at full slots and shedding 429s
-  while CPU sits at 30 to 40 percent. A CPU based autoscaler would miss exactly
-  the moment capacity is needed.
-- Correct signal: pool saturation (`inFlightRuns / max`) or the 429 rate. The
-  sandbox already tracks `inFlightRuns` via `getInFlightRuns()`; it just needs a
-  `/metrics` endpoint to expose it, then KEDA or an HPA custom metric scaling on
-  it (target around 70 percent), with CPU as a secondary trigger.
-- Shape: `minReplicas: 2` for a small always-on floor, scale out during bursts,
-  scale back down after. Aggressive scale-up, conservative scale-down to avoid
-  flapping.
-- Cost: tracks actual load. You pay the small floor when idle and burst capacity
-  only while a burst is happening, instead of reserving peak around the clock.
-- Caveat: HPA plus pod cold start is 30 to 60s, while bursts are sub-second, so
-  option 1 (the retry) is what bridges the gap until a new pod is ready.
-
-### 5. Per-run heap cap (do regardless)
-
-Add `--max-old-space-size` to the child spawn so one run that balloons fails
-itself rather than OOM-killing the pod and every run on it. Also keeps a pod
-OOM from muddying the autoscaler signal. Small change, unconditionally correct.
-
-## Recommendation
-
-Layered, by value per effort:
-
-1. Client 429 retry. Zero cost, removes most customer-visible errors. Shipping
-   now.
-2. Per-child heap cap. Removes the pod-wide OOM blast radius.
-3. Memory limit bump `512Mi` to `1Gi`. Free (limit only), buys real headroom per
-   pod.
-4. Saturation-based autoscaling with `minReplicas: 2`. The real capacity fix,
-   sized to load instead of a fixed reservation. Needs the `/metrics` endpoint
-   first.
-
-Vertical scaling (options 2 and 3) is a reasonable stopgap if a quick bump is
-wanted, but it is a taller fixed wall, not elastic, and the guaranteed variant
-pays for idle peak capacity. Prefer horizontal.
-
-Before locking the autoscaler `maxReplicas` and saturation target, pull the
-actual peak concurrent runs and current 429 rate from metrics and Sentry. The
-numbers above are sized from the resource model, not live demand.
+Before picking how many pods to allow at the busiest point, pull the real
+numbers from monitoring: how many code runs actually happen at once on a busy
+day, and how often the 429 is currently firing. The plan above is sound, but the
+exact "max pods" should be set from that data, not a guess.

--- a/specs/sandbox-scaling.md
+++ b/specs/sandbox-scaling.md
@@ -1,0 +1,138 @@
+# Code Sandbox Scaling Notes
+
+Reference for deciding how to scale the `keeperhub-sandbox` service. Captures
+what bounds today's capacity, the options, and their cost so the pod sizing
+call can be made on data rather than guesswork.
+
+## What exists today
+
+The sandbox runs user Code-node JavaScript. Each `/run` request spawns a fresh
+Node child process (`sandbox/src/run-code.ts`), runs the user code with a
+wall-clock timeout (default 60s, max 120s), and returns the result.
+
+Concurrency is gated per pod by an in-flight counter
+(`sandbox/src/index.ts`). When in-flight runs reach the cap, the pod sheds
+load with `429 sandbox at capacity` plus `Retry-After: 1`, before it reads the
+body or spawns a child (so a shed request is cheap on the server).
+
+Current numbers:
+
+- Per-pod cap: `DEFAULT_MAX_CONCURRENT_RUNS = 8`, overridable via
+  `SANDBOX_MAX_CONCURRENT_RUNS`.
+- Prod `replicaCount: 2`, so effective cluster ceiling is `8 x 2 = 16`
+  concurrent runs. Staging runs 1 replica (ceiling 8).
+- Per-pod resources: requests `100m / 128Mi`, limits `500m / 512Mi`.
+- Pods are pinned to a dedicated, taint-isolated Karpenter nodepool.
+
+## What actually binds the limit
+
+The `8` is CPU derived, not arbitrary, and memory is a secondary risk:
+
+- CPU: `500m` is half a core. Eight concurrent child processes, each paying an
+  ~80ms V8 startup and compile cost, already oversubscribe it. Raising
+  concurrency without raising CPU trades 429s for slow runs and wall-clock
+  timeouts, which is worse for the caller.
+- Memory: at 8 runs of roughly 60MB baseline each, a pod sits near 480MB of its
+  512Mi limit before user code allocates anything. There is no per-run heap
+  cap, so one run can grow until the pod-wide cgroup OOM-kills the container,
+  taking every in-flight run on that pod down with it.
+
+Cost is driven by Kubernetes requests, not limits, because Karpenter bin-packs
+on requests. Today's requests are tiny, so the whole service is effectively one
+small mostly-idle node.
+
+## Per concurrent run, the cost model
+
+One concurrent slot is one full Node process:
+
+- About 60 to 65m of CPU to hold the 8-per-500m ratio.
+- About 60MB of baseline memory plus whatever headroom user code needs.
+- No isolation beyond the OS process, one shared pod cgroup.
+
+To raise concurrency reliably, move CPU and memory together and keep those
+ratios. Sixteen runs per pod means roughly 1000m CPU and 1Gi memory.
+
+## Options
+
+### 1. Client retry on 429 (shipping in the linked PR)
+
+The main-app client now honors the `Retry-After` the sandbox already sends:
+bounded retries (default 3, via `SANDBOX_MAX_RETRIES`) with jitter, abort-aware.
+Only a capacity 429 is retried since the run never started, so resending is
+safe. Any other failure is terminal.
+
+- Cost: zero infra. The retry runs in the main app over the existing keep-alive
+  socket, and only fires on a 429.
+- Buys: absorbs sub-second micro-bursts (the overshoot cases) so they never
+  surface to the customer. Does not add capacity. Pairs with autoscaling by
+  covering the seconds while a new pod becomes ready.
+
+### 2. Vertical, burstable (raise limits only)
+
+Set per-pod limits to `1000m / 1Gi`, leave requests at `100m / 128Mi`.
+
+- Cost: about zero. Requests unchanged, so bin-packing and the node footprint do
+  not change.
+- Behavior: 16 per pod works only when the node happens to have spare CPU. Under
+  contention the kernel throttles the pod back toward its 100m request, so the
+  16 runs crawl. Burstable, not guaranteed.
+
+### 3. Vertical, guaranteed (raise requests to match limits)
+
+Set requests and limits both to `1000m / 1Gi`.
+
+- Cost: roughly +45 to +90 per month. Karpenter must reserve about 2 vCPU and
+  2Gi for the two pods, forcing a larger node that is paid for 24/7 even when
+  the sandbox is idle.
+- Behavior: 16 per pod always has the CPU reserved, predictable under load.
+- Downside: the reservation is sized for peak but the sandbox is mostly idle, so
+  you pay for headroom that sits unused most of the time. Still a fixed ceiling;
+  33 concurrent runs still hit 429, and one pod crash now drops 16 runs.
+
+### 4. Horizontal autoscaling (the durable answer)
+
+Keep pods at their current size. Scale replicas on saturation, not CPU.
+
+- The 429 is fired by the in-flight concurrency counter, which does not track
+  CPU or memory utilization. Code nodes are frequently I/O bound (user code
+  awaits external `fetch`), so a pod can be at full slots and shedding 429s
+  while CPU sits at 30 to 40 percent. A CPU based autoscaler would miss exactly
+  the moment capacity is needed.
+- Correct signal: pool saturation (`inFlightRuns / max`) or the 429 rate. The
+  sandbox already tracks `inFlightRuns` via `getInFlightRuns()`; it just needs a
+  `/metrics` endpoint to expose it, then KEDA or an HPA custom metric scaling on
+  it (target around 70 percent), with CPU as a secondary trigger.
+- Shape: `minReplicas: 2` for a small always-on floor, scale out during bursts,
+  scale back down after. Aggressive scale-up, conservative scale-down to avoid
+  flapping.
+- Cost: tracks actual load. You pay the small floor when idle and burst capacity
+  only while a burst is happening, instead of reserving peak around the clock.
+- Caveat: HPA plus pod cold start is 30 to 60s, while bursts are sub-second, so
+  option 1 (the retry) is what bridges the gap until a new pod is ready.
+
+### 5. Per-run heap cap (do regardless)
+
+Add `--max-old-space-size` to the child spawn so one run that balloons fails
+itself rather than OOM-killing the pod and every run on it. Also keeps a pod
+OOM from muddying the autoscaler signal. Small change, unconditionally correct.
+
+## Recommendation
+
+Layered, by value per effort:
+
+1. Client 429 retry. Zero cost, removes most customer-visible errors. Shipping
+   now.
+2. Per-child heap cap. Removes the pod-wide OOM blast radius.
+3. Memory limit bump `512Mi` to `1Gi`. Free (limit only), buys real headroom per
+   pod.
+4. Saturation-based autoscaling with `minReplicas: 2`. The real capacity fix,
+   sized to load instead of a fixed reservation. Needs the `/metrics` endpoint
+   first.
+
+Vertical scaling (options 2 and 3) is a reasonable stopgap if a quick bump is
+wanted, but it is a taller fixed wall, not elastic, and the guaranteed variant
+pays for idle peak capacity. Prefer horizontal.
+
+Before locking the autoscaler `maxReplicas` and saturation target, pull the
+actual peak concurrent runs and current 429 rate from metrics and Sentry. The
+numbers above are sized from the resource model, not live demand.

--- a/tests/unit/sandbox-client.test.ts
+++ b/tests/unit/sandbox-client.test.ts
@@ -18,6 +18,7 @@ const RESULT_SENTINEL = "\u0001RESULT\u0002";
 type MockResponder = (req: { body: unknown }) => {
   status: number;
   body: string;
+  headers?: Record<string, string>;
 };
 
 let port = 0;
@@ -52,6 +53,7 @@ beforeAll(async () => {
       const result = currentResponder({ body: parsed });
       res.writeHead(result.status, {
         "Content-Type": "application/octet-stream",
+        ...result.headers,
       });
       res.end(result.body);
     }
@@ -327,6 +329,88 @@ describe("lib/sandbox-client runRemote", () => {
     expect(outcome.success).toBe(false);
     if (!outcome.success) {
       expect(outcome.error).toContain("sandbox client error");
+    }
+  });
+
+  it("retries a 429 capacity response and succeeds on the next attempt", async () => {
+    let attempts = 0;
+    currentResponder = (): {
+      status: number;
+      body: string;
+      headers?: Record<string, string>;
+    } => {
+      attempts += 1;
+      if (attempts === 1) {
+        return {
+          status: 429,
+          body: "sandbox at capacity",
+          headers: { "Retry-After": "0" },
+        };
+      }
+      return {
+        status: 200,
+        body: sentinelBody({ ok: true, result: 7, logs: [] }),
+      };
+    };
+    vi.resetModules();
+    process.env.SANDBOX_URL = `http://127.0.0.1:${port}`;
+    const { runRemote } = await import("@/lib/sandbox/client");
+    const outcome = await runRemote({ code: "return 7;", timeoutMs: 1000 });
+    expect(attempts).toBe(2);
+    expect(outcome).toEqual({ success: true, result: 7, logs: [] });
+  });
+
+  it("gives up after the bounded retries on sustained 429 and surfaces the error", async () => {
+    let attempts = 0;
+    currentResponder = (): {
+      status: number;
+      body: string;
+      headers?: Record<string, string>;
+    } => {
+      attempts += 1;
+      return {
+        status: 429,
+        body: "sandbox at capacity",
+        headers: { "Retry-After": "0" },
+      };
+    };
+    const saved = process.env.SANDBOX_MAX_RETRIES;
+    process.env.SANDBOX_MAX_RETRIES = "2";
+    try {
+      vi.resetModules();
+      process.env.SANDBOX_URL = `http://127.0.0.1:${port}`;
+      const { runRemote } = await import("@/lib/sandbox/client");
+      const outcome = await runRemote({ code: "return 1;", timeoutMs: 1000 });
+      // 2 retries on top of the initial attempt = 3 requests.
+      expect(attempts).toBe(3);
+      expect(outcome.success).toBe(false);
+      if (!outcome.success) {
+        expect(outcome.error).toContain("429");
+      }
+    } finally {
+      if (saved === undefined) {
+        delete process.env.SANDBOX_MAX_RETRIES;
+      } else {
+        process.env.SANDBOX_MAX_RETRIES = saved;
+      }
+      vi.resetModules();
+    }
+  });
+
+  it("does not retry a non-429 error response", async () => {
+    let attempts = 0;
+    currentResponder = (): { status: number; body: string } => {
+      attempts += 1;
+      return { status: 500, body: "sandbox internal error" };
+    };
+    vi.resetModules();
+    process.env.SANDBOX_URL = `http://127.0.0.1:${port}`;
+    const { runRemote } = await import("@/lib/sandbox/client");
+    const outcome = await runRemote({ code: "return 1;", timeoutMs: 1000 });
+    expect(attempts).toBe(1);
+    expect(outcome.success).toBe(false);
+    if (!outcome.success) {
+      expect(outcome.error).toContain("500");
     }
   });
 });


### PR DESCRIPTION
## Problem

The code sandbox sheds load with `429 sandbox at capacity` plus `Retry-After: 1` once a pod hits its per-pod concurrency cap. The main-app client treated any non-200 as terminal, so a momentary overshoot above the cluster ceiling surfaced directly to the customer as a failed Code node, even though the server explicitly signals "back off and retry." Paid and enterprise workloads hit this on brief bursts.

## Change

`runRemote` now honors the `Retry-After` the sandbox already sends:

- Bounded retries (default 3, tunable via `SANDBOX_MAX_RETRIES`) with jitter so concurrent callers do not resynchronize into a thundering herd.
- Abort-aware backoff: a client disconnect short-circuits the wait instead of pinning the workflow step.
- Only a capacity 429 is retried, since the run never started and resending is safe. Every other failure (5xx, malformed, network) stays terminal and fast.

A `SandboxHttpError` carries the status and parsed `Retry-After` so the retry decision does not string-match the message.

This absorbs sub-second micro-bursts at zero infra cost. It does not add capacity; that is the separate pod-sizing work captured in `specs/sandbox-scaling.md`, included here for the infra discussion.

## Tests

Added coverage in `tests/unit/sandbox-client.test.ts`: retry-then-succeed honoring Retry-After, give-up after the bounded retries on sustained 429, and no-retry on a non-429 error. Full unit suite green, type-check passes.