### PR TITLE
feat: denormalize workflow gas onto workflow_executions

### DIFF
--- a/drizzle/0096_keep_683_workflow_gas_columns.sql
+++ b/drizzle/0096_keep_683_workflow_gas_columns.sql
@@ -1,4 +1,4 @@
--- KEEP-683: denormalise run-total gas and network onto workflow_executions.
+-- KEEP-683: denormalise run-total gas onto workflow_executions.
 --
 -- The /analytics summary and spend-cap reads currently total gas by extracting
 -- `gasUsed` from the per-step workflow_execution_logs.output JSONB and SUM-ing
@@ -6,11 +6,12 @@
 -- full-scans workflow_executions and probes every org log row, detoasting each
 -- output blob - the cost behind the 2026-05-29 RDS saturation.
 --
--- These two columns let those reads aggregate a first-class numeric column on a
--- table already in the query, with no logs join and no JSONB parse. They are
--- populated at the status='success' finalize, alongside transaction_hashes
--- (lib/workflow/executor/logging.ts), and backfilled for historical rows by a
--- separate batched operator script (scripts/backfill-workflow-gas.ts).
+-- This column lets those reads aggregate a first-class numeric column on a
+-- table already in the query, with no logs join and no JSONB parse. It is
+-- populated at terminal finalize (success or error), alongside
+-- transaction_hashes (lib/workflow/executor/logging.ts), and backfilled for
+-- historical rows by a separate batched operator script
+-- (scripts/backfill-workflow-gas.ts).
 --
 -- No `-- @requires-db-prep` directive: ADD COLUMN of a nullable column with no
 -- default is a catalog-only change in PostgreSQL 11+ (momentary ACCESS
@@ -19,5 +20,4 @@
 -- the backfill UPDATE, which is intentionally NOT in this migration - it runs
 -- out-of-band, batched, after deploy.
 
-ALTER TABLE "workflow_executions" ADD COLUMN IF NOT EXISTS "gas_used_wei" numeric;--> statement-breakpoint
-ALTER TABLE "workflow_executions" ADD COLUMN IF NOT EXISTS "network" text;
+ALTER TABLE "workflow_executions" ADD COLUMN IF NOT EXISTS "gas_used_wei" numeric;

--- a/drizzle/0096_keep_683_workflow_gas_columns.sql
+++ b/drizzle/0096_keep_683_workflow_gas_columns.sql
@@ -1,0 +1,23 @@
+-- KEEP-683: denormalise run-total gas and network onto workflow_executions.
+--
+-- The /analytics summary and spend-cap reads currently total gas by extracting
+-- `gasUsed` from the per-step workflow_execution_logs.output JSONB and SUM-ing
+-- it across the org+window slice. That expression is unindexable, so the query
+-- full-scans workflow_executions and probes every org log row, detoasting each
+-- output blob - the cost behind the 2026-05-29 RDS saturation.
+--
+-- These two columns let those reads aggregate a first-class numeric column on a
+-- table already in the query, with no logs join and no JSONB parse. They are
+-- populated at the status='success' finalize, alongside transaction_hashes
+-- (lib/workflow/executor/logging.ts), and backfilled for historical rows by a
+-- separate batched operator script (scripts/backfill-workflow-gas.ts).
+--
+-- No `-- @requires-db-prep` directive: ADD COLUMN of a nullable column with no
+-- default is a catalog-only change in PostgreSQL 11+ (momentary ACCESS
+-- EXCLUSIVE lock, no table rewrite), so it is safe to run inline via the normal
+-- drizzle-kit migrate path even on the multi-GB prod table. The heavy work is
+-- the backfill UPDATE, which is intentionally NOT in this migration - it runs
+-- out-of-band, batched, after deploy.
+
+ALTER TABLE "workflow_executions" ADD COLUMN IF NOT EXISTS "gas_used_wei" numeric;--> statement-breakpoint
+ALTER TABLE "workflow_executions" ADD COLUMN IF NOT EXISTS "network" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -673,6 +673,13 @@
       "when": 1779843900002,
       "tag": "0095_keep_669_reconcile_incident_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 96,
+      "version": "7",
+      "when": 1779843900003,
+      "tag": "0096_keep_683_workflow_gas_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { and, count, desc, eq, gte, lt, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
+import { logInputField, logOutputField } from "@/lib/db/execution-log-fields";
 import {
   workflowExecutionLogs,
   workflowExecutions,
@@ -381,34 +382,6 @@ function computeAvgDuration(sum: number, durationCount: number): number | null {
 
 function addBigIntStrings(a: string, b: string): string {
   return (BigInt(a || "0") + BigInt(b || "0")).toString();
-}
-
-/**
- * Build SQL to extract a field from workflow_execution_logs output JSONB.
- *
- * The output column is double-encoded: Drizzle stores a JSON string inside JSONB
- * (jsonb_typeof = 'string') rather than a JSONB object. To extract a nested key
- * we first unwrap the string with `#>> '{}'`, re-parse as jsonb, then extract.
- * Falls back to direct `->>` for any rows where output is already an object.
- */
-function logOutputField(field: string): ReturnType<typeof sql> {
-  return sql`CASE
-    WHEN jsonb_typeof(${workflowExecutionLogs.output}) = 'string'
-    THEN (${workflowExecutionLogs.output} #>> '{}')::jsonb->>${sql.raw(`'${field}'`)}
-    ELSE ${workflowExecutionLogs.output}->>${sql.raw(`'${field}'`)}
-  END`;
-}
-
-/**
- * Build SQL to extract a field from workflow_execution_logs input JSONB.
- * Same double-encoding handling as output.
- */
-function logInputField(field: string): ReturnType<typeof sql> {
-  return sql`CASE
-    WHEN jsonb_typeof(${workflowExecutionLogs.input}) = 'string'
-    THEN (${workflowExecutionLogs.input} #>> '{}')::jsonb->>${sql.raw(`'${field}'`)}
-    ELSE ${workflowExecutionLogs.input}->>${sql.raw(`'${field}'`)}
-  END`;
 }
 
 async function getWorkflowGasTotal(

--- a/lib/db/execution-log-fields.ts
+++ b/lib/db/execution-log-fields.ts
@@ -1,0 +1,35 @@
+import { sql } from "drizzle-orm";
+import { workflowExecutionLogs } from "@/lib/db/schema";
+
+/**
+ * Shared SQL builders for extracting a field from the double-encoded JSONB
+ * columns on workflow_execution_logs.
+ *
+ * The `output` / `input` columns are double-encoded: Drizzle stores a JSON
+ * string value inside JSONB (jsonb_typeof = 'string') rather than a JSONB
+ * object. To read a nested key we first unwrap the string with `#>> '{}'`,
+ * re-parse as jsonb, then extract. The ELSE branch handles any rows already
+ * stored as a plain object.
+ *
+ * This expression is the source of truth for `gasUsed` / `network` extraction
+ * and MUST stay identical across every reader so they agree value-for-value:
+ *   - lib/analytics/queries.ts        - the /analytics read paths
+ *   - lib/workflow/executor/logging.ts - writes the denormalised run-total
+ *   - scripts/backfill-workflow-gas.ts - backfills historical rows
+ * Keep it in one place precisely because the three must never drift.
+ */
+export function logOutputField(field: string): ReturnType<typeof sql> {
+  return sql`CASE
+    WHEN jsonb_typeof(${workflowExecutionLogs.output}) = 'string'
+    THEN (${workflowExecutionLogs.output} #>> '{}')::jsonb->>${sql.raw(`'${field}'`)}
+    ELSE ${workflowExecutionLogs.output}->>${sql.raw(`'${field}'`)}
+  END`;
+}
+
+export function logInputField(field: string): ReturnType<typeof sql> {
+  return sql`CASE
+    WHEN jsonb_typeof(${workflowExecutionLogs.input}) = 'string'
+    THEN (${workflowExecutionLogs.input} #>> '{}')::jsonb->>${sql.raw(`'${field}'`)}
+    ELSE ${workflowExecutionLogs.input}->>${sql.raw(`'${field}'`)}
+  END`;
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -490,6 +490,22 @@ export const workflowExecutions = pgTable(
       .notNull()
       .default(sql`'[]'::jsonb`),
     /**
+     * Run-total gas (sum of per-step `gasUsed`, in wei) and a representative
+     * network for the run, denormalised out of the per-step
+     * workflow_execution_logs.output JSONB. Populated atomically with the
+     * status='success' flip, alongside transaction_hashes
+     * (lib/workflow/executor/logging.ts), so org-scoped /analytics summary and
+     * spend-cap reads can aggregate a first-class column instead of full-scanning
+     * and detoasting the logs table.
+     *
+     * Nullable on legacy rows until backfilled, and on runs that produced no
+     * on-chain gas. `network` is a single representative value (matching the
+     * runs-table aggregation); a per-network breakdown still needs step-level
+     * data and is intentionally out of scope here.
+     */
+    gasUsedWei: numeric("gas_used_wei"),
+    network: text("network"),
+    /**
      * Whether this execution counts toward the owner organisation's monthly
      * execution quota and overage billing.
      *

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -490,21 +490,20 @@ export const workflowExecutions = pgTable(
       .notNull()
       .default(sql`'[]'::jsonb`),
     /**
-     * Run-total gas (sum of per-step `gasUsed`, in wei) and a representative
-     * network for the run, denormalised out of the per-step
-     * workflow_execution_logs.output JSONB. Populated atomically with the
-     * status='success' flip, alongside transaction_hashes
+     * Run-total gas (sum of per-step `gasUsed`, in wei), denormalised out of the
+     * per-step workflow_execution_logs.output JSONB. Populated at terminal
+     * finalize (success or error), alongside transaction_hashes
      * (lib/workflow/executor/logging.ts), so org-scoped /analytics summary and
      * spend-cap reads can aggregate a first-class column instead of full-scanning
      * and detoasting the logs table.
      *
      * Nullable on legacy rows until backfilled, and on runs that produced no
-     * on-chain gas. `network` is a single representative value (matching the
-     * runs-table aggregation); a per-network breakdown still needs step-level
-     * data and is intentionally out of scope here.
+     * on-chain gas. Network is intentionally NOT denormalised here: it is a
+     * per-step property (each web3 node targets its own chain), so a run can
+     * span multiple networks and no single run-level value is correct. The
+     * per-network gas breakdown keeps reading step-level log data.
      */
     gasUsedWei: numeric("gas_used_wei"),
-    network: text("network"),
     /**
      * Whether this execution counts toward the owner organisation's monthly
      * execution quota and overage billing.

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -6,7 +6,7 @@ import "server-only";
 
 import { and, asc, eq, isNotNull, isNull, ne, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { logInputField, logOutputField } from "@/lib/db/execution-log-fields";
+import { logOutputField } from "@/lib/db/execution-log-fields";
 import {
   organization,
   type TransactionHashEntry,
@@ -198,31 +198,33 @@ async function resolveTransactionHashesForSuccess(
 }
 
 /**
- * Resolve the run-total gas (sum of per-step `gasUsed`, in wei) and a
- * representative network to persist when a workflow reaches a terminal state.
+ * Resolve the run-total gas (sum of per-step `gasUsed`, in wei) to persist when
+ * a workflow reaches a terminal state.
  *
  * Aggregates this one execution's durable logs (cheap via
  * idx_exec_logs_execution_id) using the same extraction the /analytics reads
- * and the backfill use, so the denormalised workflow_executions columns agree
- * value-for-value with a JSON recompute. `network` is MIN over the gas-bearing
- * rows - a single representative value matching the runs-table aggregation, not
- * a per-network split. Returns nulls when the run produced no gas-bearing step.
+ * and the backfill use, so the denormalised column agrees value-for-value with
+ * a JSON recompute. Returns null when the run produced no gas-bearing step.
  *
  * Resolved on error finalizes too, not just success: a gas-bearing step (e.g.
  * an approve) can commit its gas before a later step fails the run, and the
- * current /analytics gas total counts that gas regardless of run status. Gating
- * this on success would silently drop it once the reads move to the column.
+ * /analytics gas total counts that gas regardless of run status. Gating on
+ * success would silently drop it once the reads move to the column.
+ *
+ * Sourced from the DB, not the in-memory step-success-tracker, on purpose. The
+ * tracker holds raw step outputs whose gasUsed shape could diverge from the
+ * logged `output`; using it would fork gas computation into two paths and let
+ * writer-populated rows disagree with backfilled ones. A single extraction
+ * path - this query, shared with the backfill and the reads - is worth one
+ * indexed single-execution aggregate per finalize.
  */
-async function resolveGasAndNetwork(
-  executionId: string
-): Promise<{ gasUsedWei: string | null; network: string | null }> {
+async function resolveGasTotal(executionId: string): Promise<string | null> {
   try {
     const rows = await db
       .select({
         gasUsedWei: sql<
           string | null
         >`SUM(CAST(${logOutputField("gasUsed")} AS NUMERIC))`,
-        network: sql<string | null>`MIN(${logInputField("network")})`,
       })
       .from(workflowExecutionLogs)
       .where(
@@ -231,18 +233,15 @@ async function resolveGasAndNetwork(
           sql`${logOutputField("gasUsed")} IS NOT NULL`
         )
       );
-    return {
-      gasUsedWei: rows[0]?.gasUsedWei ?? null,
-      network: rows[0]?.network ?? null,
-    };
+    return rows[0]?.gasUsedWei ?? null;
   } catch (queryError) {
     logSystemError(
       ErrorCategory.WORKFLOW_ENGINE,
-      "[Workflow Logging] Failed to resolve gas/network at finalize",
+      "[Workflow Logging] Failed to resolve gas total at finalize",
       queryError,
       { execution_id: executionId }
     );
-    return { gasUsedWei: null, network: null };
+    return null;
   }
 }
 
@@ -330,9 +329,9 @@ async function selfHealWorkflowAfterLateStepCommit(
   // them now from durable logs so the success terminal state carries the
   // hashes that ran. Tracker may have been cleared on the originating pod;
   // loadHashesFromLogs is the durable source of truth at this point.
-  const [transactionHashes, gasAndNetwork] = await Promise.all([
+  const [transactionHashes, gasUsedWei] = await Promise.all([
     resolveTransactionHashesForSuccess(executionId),
-    resolveGasAndNetwork(executionId),
+    resolveGasTotal(executionId),
   ]);
 
   // CAS UPDATE: only flip if status is still 'error' (the state we just observed).
@@ -347,8 +346,7 @@ async function selfHealWorkflowAfterLateStepCommit(
       currentNodeId: null,
       currentNodeName: null,
       transactionHashes,
-      gasUsedWei: gasAndNetwork.gasUsedWei,
-      network: gasAndNetwork.network,
+      gasUsedWei,
     })
     .where(
       and(
@@ -701,16 +699,16 @@ export async function logWorkflowCompleteDb(
   // them. The resolver prefers the in-memory tracker but falls back to a
   // SELECT against workflow_execution_logs for the cross-pod resume case
   // (tracker on finalizing pod is empty after an SDK checkpoint).
-  // Gas + network are denormalised onto the same terminal UPDATE, sourced the
+  // Run-total gas is denormalised onto the same terminal UPDATE, sourced the
   // same way as the hashes, so the /analytics summary and spend-cap reads can
   // aggregate a first-class column instead of re-scanning the logs JSONB.
   // Hashes are success-only (error rows keep '[]'), but gas is resolved on
-  // error finalizes too - see resolveGasAndNetwork for why.
-  const [transactionHashes, gasAndNetwork] = await Promise.all([
+  // error finalizes too - see resolveGasTotal for why.
+  const [transactionHashes, gasUsedWei] = await Promise.all([
     resolvedStatus === "success"
       ? resolveTransactionHashesForSuccess(params.executionId)
       : Promise.resolve<TransactionHashEntry[]>([]),
-    resolveGasAndNetwork(params.executionId),
+    resolveGasTotal(params.executionId),
   ]);
 
   // KEEP-545: classify the error so the row carries error_category and
@@ -732,8 +730,7 @@ export async function logWorkflowCompleteDb(
       currentNodeId: null,
       currentNodeName: null,
       transactionHashes,
-      gasUsedWei: gasAndNetwork.gasUsedWei,
-      network: gasAndNetwork.network,
+      gasUsedWei,
     })
     .where(
       and(

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -6,6 +6,7 @@ import "server-only";
 
 import { and, asc, eq, isNotNull, isNull, ne, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
+import { logInputField, logOutputField } from "@/lib/db/execution-log-fields";
 import {
   organization,
   type TransactionHashEntry,
@@ -197,6 +198,55 @@ async function resolveTransactionHashesForSuccess(
 }
 
 /**
+ * Resolve the run-total gas (sum of per-step `gasUsed`, in wei) and a
+ * representative network to persist when a workflow reaches a terminal state.
+ *
+ * Aggregates this one execution's durable logs (cheap via
+ * idx_exec_logs_execution_id) using the same extraction the /analytics reads
+ * and the backfill use, so the denormalised workflow_executions columns agree
+ * value-for-value with a JSON recompute. `network` is MIN over the gas-bearing
+ * rows - a single representative value matching the runs-table aggregation, not
+ * a per-network split. Returns nulls when the run produced no gas-bearing step.
+ *
+ * Resolved on error finalizes too, not just success: a gas-bearing step (e.g.
+ * an approve) can commit its gas before a later step fails the run, and the
+ * current /analytics gas total counts that gas regardless of run status. Gating
+ * this on success would silently drop it once the reads move to the column.
+ */
+async function resolveGasAndNetwork(
+  executionId: string
+): Promise<{ gasUsedWei: string | null; network: string | null }> {
+  try {
+    const rows = await db
+      .select({
+        gasUsedWei: sql<
+          string | null
+        >`SUM(CAST(${logOutputField("gasUsed")} AS NUMERIC))`,
+        network: sql<string | null>`MIN(${logInputField("network")})`,
+      })
+      .from(workflowExecutionLogs)
+      .where(
+        and(
+          eq(workflowExecutionLogs.executionId, executionId),
+          sql`${logOutputField("gasUsed")} IS NOT NULL`
+        )
+      );
+    return {
+      gasUsedWei: rows[0]?.gasUsedWei ?? null,
+      network: rows[0]?.network ?? null,
+    };
+  } catch (queryError) {
+    logSystemError(
+      ErrorCategory.WORKFLOW_ENGINE,
+      "[Workflow Logging] Failed to resolve gas/network at finalize",
+      queryError,
+      { execution_id: executionId }
+    );
+    return { gasUsedWei: null, network: null };
+  }
+}
+
+/**
  * KEEP-431 follow-up: self-healing reconciliation when a step's success commit
  * lands AFTER the workflow has already been finalized to a spurious error.
  *
@@ -280,8 +330,10 @@ async function selfHealWorkflowAfterLateStepCommit(
   // them now from durable logs so the success terminal state carries the
   // hashes that ran. Tracker may have been cleared on the originating pod;
   // loadHashesFromLogs is the durable source of truth at this point.
-  const transactionHashes =
-    await resolveTransactionHashesForSuccess(executionId);
+  const [transactionHashes, gasAndNetwork] = await Promise.all([
+    resolveTransactionHashesForSuccess(executionId),
+    resolveGasAndNetwork(executionId),
+  ]);
 
   // CAS UPDATE: only flip if status is still 'error' (the state we just observed).
   // Drizzle's update returns the affected row count -- we use it to drive metrics.
@@ -295,6 +347,8 @@ async function selfHealWorkflowAfterLateStepCommit(
       currentNodeId: null,
       currentNodeName: null,
       transactionHashes,
+      gasUsedWei: gasAndNetwork.gasUsedWei,
+      network: gasAndNetwork.network,
     })
     .where(
       and(
@@ -647,10 +701,17 @@ export async function logWorkflowCompleteDb(
   // them. The resolver prefers the in-memory tracker but falls back to a
   // SELECT against workflow_execution_logs for the cross-pod resume case
   // (tracker on finalizing pod is empty after an SDK checkpoint).
-  const transactionHashes: TransactionHashEntry[] =
+  // Gas + network are denormalised onto the same terminal UPDATE, sourced the
+  // same way as the hashes, so the /analytics summary and spend-cap reads can
+  // aggregate a first-class column instead of re-scanning the logs JSONB.
+  // Hashes are success-only (error rows keep '[]'), but gas is resolved on
+  // error finalizes too - see resolveGasAndNetwork for why.
+  const [transactionHashes, gasAndNetwork] = await Promise.all([
     resolvedStatus === "success"
-      ? await resolveTransactionHashesForSuccess(params.executionId)
-      : [];
+      ? resolveTransactionHashesForSuccess(params.executionId)
+      : Promise.resolve<TransactionHashEntry[]>([]),
+    resolveGasAndNetwork(params.executionId),
+  ]);
 
   // KEEP-545: classify the error so the row carries error_category and
   // error_type at write time. Success rows get null for both columns.
@@ -671,6 +732,8 @@ export async function logWorkflowCompleteDb(
       currentNodeId: null,
       currentNodeName: null,
       transactionHashes,
+      gasUsedWei: gasAndNetwork.gasUsedWei,
+      network: gasAndNetwork.network,
     })
     .where(
       and(

--- a/scripts/backfill-workflow-gas.ts
+++ b/scripts/backfill-workflow-gas.ts
@@ -25,11 +25,16 @@
  * --after-id to resume from a known cursor. The heavy JSONB scan is paid once,
  * in controlled batches, so no single UPDATE takes a long lock.
  *
+ * A LIVE run against a non-local DB requires --yes; dry-runs and local DBs do
+ * not. This is a guard against an accidental prod write, not a security
+ * boundary.
+ *
  * Usage:
  *   pnpm tsx scripts/backfill-workflow-gas.ts --dry-run
- *   pnpm tsx scripts/backfill-workflow-gas.ts
- *   pnpm tsx scripts/backfill-workflow-gas.ts --batch-size 2000 --after-id <id>
- *   pnpm tsx scripts/backfill-workflow-gas.ts --max-batches 5   # bounded test run
+ *   pnpm tsx scripts/backfill-workflow-gas.ts                       # local DB
+ *   pnpm tsx scripts/backfill-workflow-gas.ts --yes                 # staging/prod
+ *   pnpm tsx scripts/backfill-workflow-gas.ts --yes --batch-size 2000 --after-id <id>
+ *   pnpm tsx scripts/backfill-workflow-gas.ts --dry-run --max-batches 5
  */
 
 import { sql } from "drizzle-orm";
@@ -44,6 +49,7 @@ type CliArgs = {
   batchSize: number;
   afterId: string;
   maxBatches: number | null;
+  yes: boolean;
 };
 
 function parseArgs(argv: string[]): CliArgs {
@@ -52,11 +58,14 @@ function parseArgs(argv: string[]): CliArgs {
     batchSize: DEFAULT_BATCH_SIZE,
     afterId: "",
     maxBatches: null,
+    yes: false,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--dry-run") {
       args.dryRun = true;
+    } else if (a === "--yes") {
+      args.yes = true;
     } else if (a === "--batch-size" && argv[i + 1]) {
       const parsed = Number.parseInt(argv[i + 1], 10);
       if (!Number.isNaN(parsed) && parsed > 0) {
@@ -74,7 +83,7 @@ function parseArgs(argv: string[]): CliArgs {
       i++;
     } else if (a === "--help" || a === "-h") {
       console.log(
-        "Usage: pnpm tsx scripts/backfill-workflow-gas.ts [--dry-run] [--batch-size N] [--after-id ID] [--max-batches N]"
+        "Usage: pnpm tsx scripts/backfill-workflow-gas.ts [--dry-run] [--batch-size N] [--after-id ID] [--max-batches N] [--yes]"
       );
       process.exit(0);
     }
@@ -100,7 +109,12 @@ async function fetchExecutionIdBatch(
  * Aggregate gas for one keyset batch and write it. Re-selects the same
  * batch inside a CTE (deterministic for a fixed cursor) so no id array has to be
  * marshalled into the statement. Returns the number of executions updated (i.e.
- * those that had at least one gas-bearing log).
+ * those that had at least one gas-bearing log and were not already populated).
+ *
+ * The `we.gas_used_wei IS NULL` guard means the backfill only ever fills empty
+ * rows, never overwrites a value. That keeps it off the hot recent rows the
+ * live finalize writer owns (no clobber race), makes re-runs cheap, and avoids
+ * redundant write churn on the multi-GB table.
  */
 async function applyBatch(afterId: string, batchSize: number): Promise<number> {
   const result = await db.execute(sql`
@@ -122,6 +136,7 @@ async function applyBatch(afterId: string, batchSize: number): Promise<number> {
     SET gas_used_wei = agg.gas_used_wei
     FROM agg
     WHERE we.id = agg.execution_id
+      AND we.gas_used_wei IS NULL
     RETURNING we.id
   `);
   // postgres-js: db.execute resolves to the RETURNING rows array.
@@ -132,7 +147,7 @@ async function applyBatch(afterId: string, batchSize: number): Promise<number> {
 async function countBatch(afterId: string, batchSize: number): Promise<number> {
   const result = await db.execute(sql`
     WITH batch AS (
-      SELECT id FROM workflow_executions
+      SELECT id, gas_used_wei FROM workflow_executions
       WHERE id > ${afterId}
       ORDER BY id
       LIMIT ${batchSize}
@@ -141,6 +156,7 @@ async function countBatch(afterId: string, batchSize: number): Promise<number> {
     FROM workflow_execution_logs
     JOIN batch ON batch.id = workflow_execution_logs.execution_id
     WHERE ${logOutputField("gasUsed")} IS NOT NULL
+      AND batch.gas_used_wei IS NULL
   `);
   // postgres-js: db.execute resolves to the rows array.
   return Number(result[0]?.n ?? 0);
@@ -154,11 +170,36 @@ function dbHost(): string {
   }
 }
 
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "db", "postgres"]);
+
+function isLocalDb(): boolean {
+  try {
+    // URL.hostname drops the port; strip the IPv6 brackets it keeps.
+    const hostname = new URL(process.env.DATABASE_URL ?? "").hostname.replace(
+      /^\[|\]$/g,
+      ""
+    );
+    return LOCAL_HOSTS.has(hostname);
+  } catch {
+    return false;
+  }
+}
+
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   console.log(
     `[backfill-workflow-gas] mode=${args.dryRun ? "DRY-RUN" : "LIVE"} host=${dbHost()} batchSize=${args.batchSize} afterId=${args.afterId || "(start)"} maxBatches=${args.maxBatches ?? "all"}`
   );
+
+  // A LIVE run against a non-local DB (staging/prod) writes immediately. Require
+  // an explicit --yes so an operator cannot kick one off by reflex. Dry-runs and
+  // local DBs are unguarded.
+  if (!(args.dryRun || args.yes || isLocalDb())) {
+    console.error(
+      `[backfill-workflow-gas] refusing LIVE run against non-local host ${dbHost()} without --yes. Re-run with --yes to confirm, or add --dry-run.`
+    );
+    process.exit(1);
+  }
 
   let cursor = args.afterId;
   let batches = 0;

--- a/scripts/backfill-workflow-gas.ts
+++ b/scripts/backfill-workflow-gas.ts
@@ -1,8 +1,8 @@
 /**
- * KEEP-683: one-time backfill of the denormalised `gas_used_wei` and `network`
- * columns on `workflow_executions`.
+ * KEEP-683: one-time backfill of the denormalised `gas_used_wei` column on
+ * `workflow_executions`.
  *
- * Migration 0096 adds the columns null. New rows are populated at finalize by
+ * Migration 0096 adds the column null. New rows are populated at finalize by
  * lib/workflow/executor/logging.ts. This script fills historical rows so the
  * /analytics reads can move off the per-row logs JSONB scan (PR2) without the
  * totals changing.
@@ -17,9 +17,9 @@
  * total counts that gas regardless of run status. Scoping to success would make
  * the backfilled column disagree with today's dashboard.
  *
- * The extraction uses the shared logOutputField / logInputField builders, the
- * same ones the executor writer and the /analytics reads use, so all three
- * agree value-for-value.
+ * The extraction uses the shared logOutputField builder, the same one the
+ * executor writer and the /analytics reads use, so all three agree
+ * value-for-value.
  *
  * Idempotent and resumable: re-running recomputes deterministically; pass
  * --after-id to resume from a known cursor. The heavy JSONB scan is paid once,
@@ -34,7 +34,7 @@
 
 import { sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { logInputField, logOutputField } from "@/lib/db/execution-log-fields";
+import { logOutputField } from "@/lib/db/execution-log-fields";
 import { workflowExecutions } from "@/lib/db/schema";
 
 const DEFAULT_BATCH_SIZE = 1000;
@@ -97,7 +97,7 @@ async function fetchExecutionIdBatch(
 }
 
 /**
- * Aggregate gas/network for one keyset batch and write it. Re-selects the same
+ * Aggregate gas for one keyset batch and write it. Re-selects the same
  * batch inside a CTE (deterministic for a fixed cursor) so no id array has to be
  * marshalled into the statement. Returns the number of executions updated (i.e.
  * those that had at least one gas-bearing log).
@@ -112,15 +112,14 @@ async function applyBatch(afterId: string, batchSize: number): Promise<number> {
     ), agg AS (
       SELECT
         workflow_execution_logs.execution_id AS execution_id,
-        SUM(CAST(${logOutputField("gasUsed")} AS NUMERIC)) AS gas_used_wei,
-        MIN(${logInputField("network")}) AS network
+        SUM(CAST(${logOutputField("gasUsed")} AS NUMERIC)) AS gas_used_wei
       FROM workflow_execution_logs
       JOIN batch ON batch.id = workflow_execution_logs.execution_id
       WHERE ${logOutputField("gasUsed")} IS NOT NULL
       GROUP BY workflow_execution_logs.execution_id
     )
     UPDATE workflow_executions we
-    SET gas_used_wei = agg.gas_used_wei, network = agg.network
+    SET gas_used_wei = agg.gas_used_wei
     FROM agg
     WHERE we.id = agg.execution_id
     RETURNING we.id

--- a/scripts/backfill-workflow-gas.ts
+++ b/scripts/backfill-workflow-gas.ts
@@ -1,0 +1,209 @@
+/**
+ * KEEP-683: one-time backfill of the denormalised `gas_used_wei` and `network`
+ * columns on `workflow_executions`.
+ *
+ * Migration 0096 adds the columns null. New rows are populated at finalize by
+ * lib/workflow/executor/logging.ts. This script fills historical rows so the
+ * /analytics reads can move off the per-row logs JSONB scan (PR2) without the
+ * totals changing.
+ *
+ * Approach: set-based, one aggregating UPDATE per keyset batch of execution ids
+ * (NOT one query per row - this runs over millions of rows on prod). Each batch
+ * sums the gas-bearing logs for its executions via idx_exec_logs_execution_id
+ * and writes the run-total. Executions with no gas-bearing step are left null.
+ *
+ * Status-agnostic on purpose: a gas-bearing step (e.g. an approve) can commit
+ * its gas before a later step fails the run, and the current /analytics gas
+ * total counts that gas regardless of run status. Scoping to success would make
+ * the backfilled column disagree with today's dashboard.
+ *
+ * The extraction uses the shared logOutputField / logInputField builders, the
+ * same ones the executor writer and the /analytics reads use, so all three
+ * agree value-for-value.
+ *
+ * Idempotent and resumable: re-running recomputes deterministically; pass
+ * --after-id to resume from a known cursor. The heavy JSONB scan is paid once,
+ * in controlled batches, so no single UPDATE takes a long lock.
+ *
+ * Usage:
+ *   pnpm tsx scripts/backfill-workflow-gas.ts --dry-run
+ *   pnpm tsx scripts/backfill-workflow-gas.ts
+ *   pnpm tsx scripts/backfill-workflow-gas.ts --batch-size 2000 --after-id <id>
+ *   pnpm tsx scripts/backfill-workflow-gas.ts --max-batches 5   # bounded test run
+ */
+
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { logInputField, logOutputField } from "@/lib/db/execution-log-fields";
+import { workflowExecutions } from "@/lib/db/schema";
+
+const DEFAULT_BATCH_SIZE = 1000;
+
+type CliArgs = {
+  dryRun: boolean;
+  batchSize: number;
+  afterId: string;
+  maxBatches: number | null;
+};
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    dryRun: false,
+    batchSize: DEFAULT_BATCH_SIZE,
+    afterId: "",
+    maxBatches: null,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") {
+      args.dryRun = true;
+    } else if (a === "--batch-size" && argv[i + 1]) {
+      const parsed = Number.parseInt(argv[i + 1], 10);
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        args.batchSize = parsed;
+      }
+      i++;
+    } else if (a === "--after-id" && argv[i + 1]) {
+      args.afterId = argv[i + 1];
+      i++;
+    } else if (a === "--max-batches" && argv[i + 1]) {
+      const parsed = Number.parseInt(argv[i + 1], 10);
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        args.maxBatches = parsed;
+      }
+      i++;
+    } else if (a === "--help" || a === "-h") {
+      console.log(
+        "Usage: pnpm tsx scripts/backfill-workflow-gas.ts [--dry-run] [--batch-size N] [--after-id ID] [--max-batches N]"
+      );
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+/** Keyset page of execution ids; the cursor for the next batch is the last id. */
+async function fetchExecutionIdBatch(
+  afterId: string,
+  batchSize: number
+): Promise<string[]> {
+  const rows = await db
+    .select({ id: workflowExecutions.id })
+    .from(workflowExecutions)
+    .where(sql`${workflowExecutions.id} > ${afterId}`)
+    .orderBy(workflowExecutions.id)
+    .limit(batchSize);
+  return rows.map((r) => r.id);
+}
+
+/**
+ * Aggregate gas/network for one keyset batch and write it. Re-selects the same
+ * batch inside a CTE (deterministic for a fixed cursor) so no id array has to be
+ * marshalled into the statement. Returns the number of executions updated (i.e.
+ * those that had at least one gas-bearing log).
+ */
+async function applyBatch(afterId: string, batchSize: number): Promise<number> {
+  const result = await db.execute(sql`
+    WITH batch AS (
+      SELECT id FROM workflow_executions
+      WHERE id > ${afterId}
+      ORDER BY id
+      LIMIT ${batchSize}
+    ), agg AS (
+      SELECT
+        workflow_execution_logs.execution_id AS execution_id,
+        SUM(CAST(${logOutputField("gasUsed")} AS NUMERIC)) AS gas_used_wei,
+        MIN(${logInputField("network")}) AS network
+      FROM workflow_execution_logs
+      JOIN batch ON batch.id = workflow_execution_logs.execution_id
+      WHERE ${logOutputField("gasUsed")} IS NOT NULL
+      GROUP BY workflow_execution_logs.execution_id
+    )
+    UPDATE workflow_executions we
+    SET gas_used_wei = agg.gas_used_wei, network = agg.network
+    FROM agg
+    WHERE we.id = agg.execution_id
+    RETURNING we.id
+  `);
+  // postgres-js: db.execute resolves to the RETURNING rows array.
+  return result.length;
+}
+
+/** Dry-run: count how many executions in the batch WOULD be updated. */
+async function countBatch(afterId: string, batchSize: number): Promise<number> {
+  const result = await db.execute(sql`
+    WITH batch AS (
+      SELECT id FROM workflow_executions
+      WHERE id > ${afterId}
+      ORDER BY id
+      LIMIT ${batchSize}
+    )
+    SELECT COUNT(DISTINCT workflow_execution_logs.execution_id) AS n
+    FROM workflow_execution_logs
+    JOIN batch ON batch.id = workflow_execution_logs.execution_id
+    WHERE ${logOutputField("gasUsed")} IS NOT NULL
+  `);
+  // postgres-js: db.execute resolves to the rows array.
+  return Number(result[0]?.n ?? 0);
+}
+
+function dbHost(): string {
+  try {
+    return new URL(process.env.DATABASE_URL ?? "").host || "(unknown)";
+  } catch {
+    return "(unparseable DATABASE_URL)";
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  console.log(
+    `[backfill-workflow-gas] mode=${args.dryRun ? "DRY-RUN" : "LIVE"} host=${dbHost()} batchSize=${args.batchSize} afterId=${args.afterId || "(start)"} maxBatches=${args.maxBatches ?? "all"}`
+  );
+
+  let cursor = args.afterId;
+  let batches = 0;
+  let totalScanned = 0;
+  let totalUpdated = 0;
+
+  for (;;) {
+    const ids = await fetchExecutionIdBatch(cursor, args.batchSize);
+    if (ids.length === 0) {
+      break;
+    }
+
+    const updated = args.dryRun
+      ? await countBatch(cursor, args.batchSize)
+      : await applyBatch(cursor, args.batchSize);
+
+    batches += 1;
+    totalScanned += ids.length;
+    totalUpdated += updated;
+    cursor = ids[ids.length - 1];
+
+    console.log(
+      `[backfill-workflow-gas] batch=${batches} scanned=${ids.length} updated=${updated} cursor=${cursor} cumulative_scanned=${totalScanned} cumulative_updated=${totalUpdated}`
+    );
+
+    if (ids.length < args.batchSize) {
+      break;
+    }
+    if (args.maxBatches !== null && batches >= args.maxBatches) {
+      console.log(
+        `[backfill-workflow-gas] stopping at --max-batches=${args.maxBatches}; resume with --after-id ${cursor}`
+      );
+      break;
+    }
+  }
+
+  console.log(
+    `[backfill-workflow-gas] done. mode=${args.dryRun ? "DRY-RUN" : "LIVE"} batches=${batches} scanned=${totalScanned} updated=${totalUpdated} last_cursor=${cursor || "(none)"}`
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("[backfill-workflow-gas] failed:", err);
+    process.exit(1);
+  });

--- a/tests/integration/workflow-logging.test.ts
+++ b/tests/integration/workflow-logging.test.ts
@@ -106,6 +106,10 @@ let mockExecution: ExecutionRow | null = null;
 // (status='error' siblings carrying a non-orphan error). Default empty so existing
 // tests keep observing the legacy "Step did not record completion" message.
 let siblingErrorRows: Array<{ id: string }> = [];
+// resolveGasTotal issues `db.select(...).from(...).where(...)` and reads
+// rows[0].gasUsedWei. Default to a no-gas run; tests that exercise the gas
+// denormalisation set this to a summed value.
+let mockGasRows: Array<{ gasUsedWei: string | null }> = [{ gasUsedWei: null }];
 
 // KEEP-545: the workflow_executions UPDATE in logWorkflowCompleteDb now chains
 // `.returning({workflowId})` on the where() result so the per-execution error
@@ -180,6 +184,12 @@ vi.mock("@/lib/db", () => ({
       },
     },
     update: vi.fn((target: unknown) => buildUpdate(target)),
+    // resolveGasTotal: db.select({...}).from(logs).where(...) -> rows[]
+    select: vi.fn(() => ({
+      from: () => ({
+        where: () => Promise.resolve(mockGasRows),
+      }),
+    })),
   },
 }));
 
@@ -209,6 +219,7 @@ describe("logWorkflowCompleteDb", () => {
     updateCalls = [];
     updateShouldThrow = false;
     siblingErrorRows = [];
+    mockGasRows = [{ gasUsedWei: null }];
     vi.clearAllMocks();
   });
 
@@ -226,6 +237,54 @@ describe("logWorkflowCompleteDb", () => {
         output: { ok: true },
       })
     );
+  });
+
+  // KEEP-683: the run-total gas is denormalised onto the same terminal UPDATE
+  // so the /analytics reads can aggregate a column instead of the logs JSONB.
+  it("denormalises run-total gas onto the terminal UPDATE on success", async () => {
+    mockGasRows = [{ gasUsedWei: "12345" }];
+
+    await logWorkflowCompleteDb({
+      executionId: "exec_1",
+      status: "success",
+      output: { ok: true },
+      startTime: Date.now() - 1000,
+    });
+
+    expect(getExecUpdate()?.set).toEqual(
+      expect.objectContaining({ status: "success", gasUsedWei: "12345" })
+    );
+  });
+
+  // KEEP-683: a gas-bearing step (e.g. an approve) can commit its gas before a
+  // later step fails the run. Today's gas total counts it regardless of status,
+  // so the column must be populated on error finalizes too.
+  it("denormalises gas on error finalizes, not only success", async () => {
+    mockGasRows = [{ gasUsedWei: "777" }];
+    allLogs = [{ id: "log_1", nodeId: "node_a", status: "error" }];
+
+    await logWorkflowCompleteDb({
+      executionId: "exec_1",
+      status: "error",
+      error: "Step failed",
+      startTime: Date.now() - 1000,
+    });
+
+    expect(getExecUpdate()?.set).toEqual(
+      expect.objectContaining({ status: "error", gasUsedWei: "777" })
+    );
+  });
+
+  it("writes null gas when the run produced no gas-bearing step", async () => {
+    // mockGasRows defaults to [{ gasUsedWei: null }]
+    await logWorkflowCompleteDb({
+      executionId: "exec_1",
+      status: "success",
+      output: { ok: true },
+      startTime: Date.now() - 1000,
+    });
+
+    expect(getExecUpdate()?.set.gasUsedWei).toBeNull();
   });
 
   it("keeps error status when a node log recorded an error and never succeeded", async () => {
@@ -554,6 +613,7 @@ describe("logWorkflowCompleteDb transactionHashes (KEEP-470)", () => {
     updateCalls = [];
     updateShouldThrow = false;
     siblingErrorRows = [];
+    mockGasRows = [{ gasUsedWei: null }];
     vi.clearAllMocks();
   });
 


### PR DESCRIPTION
## What

Adds a first-class `gas_used_wei` (numeric) column to `workflow_executions` and populates it: written at terminal finalize alongside `transaction_hashes`, plus a batched backfill for historical rows. No read paths change in this PR.

## Why

The `/analytics` dashboard totals gas by extracting `gasUsed` out of the double-encoded `workflow_execution_logs.output` JSONB and `SUM`-ing it across an org's time-window slice (`getWorkflowGasTotal`, `getSpendCapData`). That expression is unindexable, so each call full-scans `workflow_executions` and probes every org log row, detoasting each `output` blob - the path behind the 2026-05-29 RDS saturation. Caching collapsed the steady-state pile-up but cannot help a cold scan.

`direct_executions` already stores `gas_used_wei` as a column and is cheap to aggregate; this brings `workflow_executions` to parity so the same reads can aggregate a column on a table already in the query, with no logs join and no JSONB parse.

### Measured baseline (staging, heaviest org, 30-day window)

`getWorkflowGasTotal`: 2,140 ms, ~653k buffers (~5.1 GB). Plan: org workflows via `idx_workflows_org_id`, then a parallel seq-scan of `workflow_executions`, then a per-execution nested-loop probe into the logs (~4.7 GB of the 5.1 GB). The date filter is a residual `Filter`, never an index bound. Prod is worse (real gas payloads add TOAST detoast; the reporter measured 7.1 s / ~33 GB). The follow-up read-switch removes the entire logs probe.

## Why no `network` column

Network is a per-step property - each web3 node targets its own chain, so a run can span multiple networks and no single run-level value is correct. It is also not needed by the reads this work optimizes (gas total, spend-cap). The per-network gas breakdown keeps reading step-level log data and is a separate follow-up. Only `gas_used_wei`, a legitimate network-agnostic run total, is denormalized here.

## Changes

| Area | Change |
| --- | --- |
| Schema + migration `0096` | `ADD COLUMN gas_used_wei numeric` (nullable) |
| `lib/db/execution-log-fields.ts` (new) | `logOutputField` / `logInputField` extracted into one shared helper |
| `lib/analytics/queries.ts` | imports the shared helper instead of private copies (no behavior change) |
| `lib/workflow/executor/logging.ts` | `resolveGasTotal`, wired into both terminal-finalize sites |
| `scripts/backfill-workflow-gas.ts` (new) | set-based, keyset-batched, idempotent, resumable backfill |
| `tests/integration/workflow-logging.test.ts` | coverage: gas set on success, on error finalizes, null when none |

## Design notes

- One extraction, three callers (writer / backfill / reads) via the shared helper, so the column cannot silently drift from a JSON recompute.
- Gas is resolved on error finalizes too, not just success: a gas-bearing step (e.g. an approve) can commit gas before a later step fails the run, and the current gas total counts that regardless of run status.
- Sourced from the DB extraction, not the in-memory step tracker, to keep a single computation path (the tracker would fork it and risk writer/backfill disagreement).

## Migration safety

`0096` adds one nullable column with no default - a catalog-only change in PostgreSQL 11+ (momentary lock, no rewrite), safe inline via the normal migrate path even on the multi-GB prod table. No `@requires-db-prep`. The heavy work is the backfill, which is not in the migration.

## Rollout

1. Merge and deploy - migration runs inline; new runs begin populating the column.
2. Backfill staging then prod. A LIVE run against a non-local DB requires `--yes`; the backfill only fills `gas_used_wei IS NULL` rows, so it never clobbers the live writer.
   ```
   pnpm tsx scripts/backfill-workflow-gas.ts --dry-run
   pnpm tsx scripts/backfill-workflow-gas.ts --yes --max-batches 5   # controlled first pass
   pnpm tsx scripts/backfill-workflow-gas.ts --yes                   # full, resumable via --after-id
   ```
3. Equivalence check before the read-switch PR, per org (all-time, so windowing is not a factor):
   `SUM(gas_used_wei)` == old JSON sum over that org's logs. Most meaningful on prod after its backfill.

## Risk

Low. Additive column, no read path changed, writer guarded with try/catch that degrades to null on failure. The column==JSON equivalence is guaranteed by construction (shared helper) and confirmed empirically at the backfill verification step before any read depends on it.
