### PR TITLE
perf: switch analytics gas reads to the denormalized column

### DIFF
--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -390,23 +390,29 @@ async function getWorkflowGasTotal(
   rangeEnd: Date,
   projectId?: string
 ): Promise<string> {
+  // Reads the denormalised run-total `gas_used_wei` written at finalize
+  // (lib/workflow/executor/logging.ts) instead of re-summing the per-step logs
+  // JSONB. No logs join, no JSONB parse, no TOAST detoast - the org+window slice
+  // is aggregated straight off workflow_executions. SUM skips NULL, so runs with
+  // no gas need no explicit filter.
+  //
+  // The window is now `workflow_executions.started_at` (when the run started),
+  // not the per-step `started_at`. Since the column is a run-level rollup that
+  // is the correct axis, and it matches every other summary metric, which is
+  // already keyed to run start. Boundary-straddling runs can reattribute by the
+  // gap between run start and a late step; immaterial at dashboard granularity.
   const result = await db
     .select({
-      totalGas: sql<string>`COALESCE(SUM(CAST(${logOutputField("gasUsed")} AS NUMERIC)), 0)::text`,
+      totalGas: sql<string>`COALESCE(SUM(CAST(${workflowExecutions.gasUsedWei} AS NUMERIC)), 0)::text`,
     })
-    .from(workflowExecutionLogs)
-    .innerJoin(
-      workflowExecutions,
-      eq(workflowExecutionLogs.executionId, workflowExecutions.id)
-    )
+    .from(workflowExecutions)
     .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
     .where(
       and(
         eq(workflows.organizationId, organizationId),
         projectId ? eq(workflows.projectId, projectId) : undefined,
-        gte(workflowExecutionLogs.startedAt, rangeStart),
-        lt(workflowExecutionLogs.startedAt, rangeEnd),
-        sql`${logOutputField("gasUsed")} IS NOT NULL`
+        gte(workflowExecutions.startedAt, rangeStart),
+        lt(workflowExecutions.startedAt, rangeEnd)
       )
     );
 
@@ -1166,21 +1172,20 @@ export async function getSpendCapData(organizationId: string): Promise<{
           )
         ),
       db
+        // Same denormalised-column read as getWorkflowGasTotal: today's run
+        // gas straight off workflow_executions, no logs JSONB scan. gas_used_wei
+        // already reflects only gas-bearing (success) step output, so the
+        // previous log status='success' filter is subsumed. Windowed by run
+        // start rather than per-step time (see getWorkflowGasTotal).
         .select({
-          totalWei: sql<string>`COALESCE(SUM(CAST(${logOutputField("gasUsed")} AS NUMERIC)), 0)::text`,
+          totalWei: sql<string>`COALESCE(SUM(CAST(${workflowExecutions.gasUsedWei} AS NUMERIC)), 0)::text`,
         })
-        .from(workflowExecutionLogs)
-        .innerJoin(
-          workflowExecutions,
-          eq(workflowExecutionLogs.executionId, workflowExecutions.id)
-        )
+        .from(workflowExecutions)
         .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
         .where(
           and(
             eq(workflows.organizationId, organizationId),
-            eq(workflowExecutionLogs.status, "success"),
-            gte(workflowExecutionLogs.startedAt, todayStart),
-            sql`${logOutputField("gasUsed")} IS NOT NULL`
+            gte(workflowExecutions.startedAt, todayStart)
           )
         ),
     ]


### PR DESCRIPTION
Stacked on #1433 (base branch is `feature/KEEP-683-denormalize-workflow-gas`, not `staging`). Draft until #1433 merges and the backfill has run - retarget to `staging` then.

## What

Switches the two heaviest `/analytics` gas reads off the per-step logs JSONB scan and onto the denormalized `workflow_executions.gas_used_wei` column added in #1433:

- `getWorkflowGasTotal` - powers the summary KPI for both the current and previous period
- the workflow portion of `getSpendCapData` - today's gas against the daily cap

Both now `SUM(workflow_executions.gas_used_wei)` over the org+window via the `workflows` join only. No logs table, no JSONB parse, no TOAST detoast.

## Why / impact

This is the cold-scan that caching could not fix and that drove the 2026-05-29 RDS saturation. With the value as a first-class numeric column on a table already in the query, the org+window slice aggregates directly and the date filter pushes into an index.

### Staging EXPLAIN, heaviest org, 30-day window

The new column is not on staging yet (#1433 not deployed there), so this is a shape-identical proxy: `SUM(duration)` (an existing numeric column) over the exact same `workflow_executions JOIN workflows WHERE org + started_at` the gas query now uses.

| Metric | Before (logs JSONB) | After (column) |
| --- | --- | --- |
| Execution time | 2,140 ms | 397 ms |
| Buffer traffic | ~653k buffers (~5.1 GB) | ~20.7k buffers (~162 MB) |
| Date filter | residual `Filter`, not index-bound | pushed into `idx_workflow_executions_workflow_started` |
| Logs probe / TOAST | full per-execution probe + detoast | none |

The date filter is now index-pushed - the exact thing that was structurally impossible on the old log-keyed path. Staging has no TOAST pressure; on prod the win is larger because the old path's blob detoast is eliminated entirely.

## Behavioral note

Gas is now windowed by run start (`workflow_executions.started_at`) rather than per-step time, because the column is a run-level rollup. This makes gas consistent with every other summary metric (all already keyed to run start). Only boundary-straddling runs reattribute, by the gap between run start and a late gas-bearing step - immaterial at dashboard granularity. The full per-network breakdown, which genuinely needs step-level time/network, is unchanged and tracked as a separate follow-up.

## Not changed

- `getNetworkBreakdown` and the runs-table aggregation still read the logs (network breakdown needs step granularity; the runs path is already paged and cheap).

## Merge prerequisites

1. #1433 merged and deployed (columns exist, writer populating new rows).
2. Backfill run on the target env and the equivalence check passed: per org, all-time `SUM(gas_used_wei)` equals the old JSON sum over that org's logs.

Only then does switching the read keep totals stable.
