### PR TITLE
release: promote staging to prod

### DIFF
--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -390,23 +390,29 @@ async function getWorkflowGasTotal(
   rangeEnd: Date,
   projectId?: string
 ): Promise<string> {
+  // Reads the denormalised run-total `gas_used_wei` written at finalize
+  // (lib/workflow/executor/logging.ts) instead of re-summing the per-step logs
+  // JSONB. No logs join, no JSONB parse, no TOAST detoast - the org+window slice
+  // is aggregated straight off workflow_executions. SUM skips NULL, so runs with
+  // no gas need no explicit filter.
+  //
+  // The window is now `workflow_executions.started_at` (when the run started),
+  // not the per-step `started_at`. Since the column is a run-level rollup that
+  // is the correct axis, and it matches every other summary metric, which is
+  // already keyed to run start. Boundary-straddling runs can reattribute by the
+  // gap between run start and a late step; immaterial at dashboard granularity.
   const result = await db
     .select({
-      totalGas: sql<string>`COALESCE(SUM(CAST(${logOutputField("gasUsed")} AS NUMERIC)), 0)::text`,
+      totalGas: sql<string>`COALESCE(SUM(CAST(${workflowExecutions.gasUsedWei} AS NUMERIC)), 0)::text`,
     })
-    .from(workflowExecutionLogs)
-    .innerJoin(
-      workflowExecutions,
-      eq(workflowExecutionLogs.executionId, workflowExecutions.id)
-    )
+    .from(workflowExecutions)
     .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
     .where(
       and(
         eq(workflows.organizationId, organizationId),
         projectId ? eq(workflows.projectId, projectId) : undefined,
-        gte(workflowExecutionLogs.startedAt, rangeStart),
-        lt(workflowExecutionLogs.startedAt, rangeEnd),
-        sql`${logOutputField("gasUsed")} IS NOT NULL`
+        gte(workflowExecutions.startedAt, rangeStart),
+        lt(workflowExecutions.startedAt, rangeEnd)
       )
     );
 
@@ -1166,21 +1172,20 @@ export async function getSpendCapData(organizationId: string): Promise<{
           )
         ),
       db
+        // Same denormalised-column read as getWorkflowGasTotal: today's run
+        // gas straight off workflow_executions, no logs JSONB scan. gas_used_wei
+        // already reflects only gas-bearing (success) step output, so the
+        // previous log status='success' filter is subsumed. Windowed by run
+        // start rather than per-step time (see getWorkflowGasTotal).
         .select({
-          totalWei: sql<string>`COALESCE(SUM(CAST(${logOutputField("gasUsed")} AS NUMERIC)), 0)::text`,
+          totalWei: sql<string>`COALESCE(SUM(CAST(${workflowExecutions.gasUsedWei} AS NUMERIC)), 0)::text`,
         })
-        .from(workflowExecutionLogs)
-        .innerJoin(
-          workflowExecutions,
-          eq(workflowExecutionLogs.executionId, workflowExecutions.id)
-        )
+        .from(workflowExecutions)
         .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
         .where(
           and(
             eq(workflows.organizationId, organizationId),
-            eq(workflowExecutionLogs.status, "success"),
-            gte(workflowExecutionLogs.startedAt, todayStart),
-            sql`${logOutputField("gasUsed")} IS NOT NULL`
+            gte(workflowExecutions.startedAt, todayStart)
           )
         ),
     ]


### PR DESCRIPTION
Promotes `staging` to `prod` - wave 2 of the gas-denormalization work (2 commits, read-switch only).

## What

Flips the two heaviest `/analytics` gas reads off the per-step `workflow_execution_logs.output` JSONB scan and onto the `workflow_executions.gas_used_wei` column:
- `getWorkflowGasTotal` (summary KPI, current + previous period)
- the workflow portion of `getSpendCapData` (today's gas vs daily cap)

No migration, no schema change, no `@requires-db-prep`. Only `lib/analytics/queries.ts` changes.

## Why this is safe to deploy now

The column it reads is already live and verified on prod from wave 1 (#1435):
- Backfill completed (4,940 historical rows, clean full walk) and the writer is populating new runs.
- Equivalence gate passed on prod: **0 per-org mismatches, identical grand totals** (col == json to the wei). So the read-switch reads a column already proven equal to the old JSON computation.

Because the column is correct, flipping the reads keeps the dashboard numbers stable.

## Impact

Removes the logs join, the JSONB parse, and the TOAST detoast from the gas reads. Staging proxy EXPLAIN (heaviest org, 30d): 2,140 ms / ~5.1 GB -> 397 ms / ~162 MB, with the date filter now index-pushed. On prod this eliminates the ~33 GB per-load scan behind the 2026-05-29 RDS CPU incident.

## Behavioral note

Gas is now windowed by run-start time (`workflow_executions.started_at`) rather than per-step time, because the column is a run-level rollup. This makes gas consistent with every other summary metric; only boundary-straddling runs reattribute, immaterially at dashboard granularity. The per-network breakdown still reads step-level data and is unchanged.

## Before merging

Confirm the staging deploy of #1434 is healthy (read-switch live, `/analytics` renders, no new errors). Prod correctness is already established by the wave-1 gate; staging is the runtime sanity check on the read-switch code.
