### PR TITLE
ci(metrics): deploy metrics-collector single-replica to staging/prod

### DIFF
--- a/.github/workflows/deploy-metrics-collector.yaml
+++ b/.github/workflows/deploy-metrics-collector.yaml
@@ -1,0 +1,118 @@
+# Type: standalone | Builds and deploys the metrics collector (TECH-6484).
+# Runs independently from ci-pipeline.yml: it has no e2e tests and its own ECR
+# repo. It reuses lib/metrics + lib/db, so changes there (and to the Dockerfile
+# stage / bake target) rebuild it.
+on:
+  push:
+    branches:
+      - staging
+      - prod
+    paths:
+      - "keeperhub-metrics-collector/**"
+      - "deploy/metrics-collector/**"
+      - "lib/metrics/**"
+      - "lib/db/**"
+      - "docker-bake.hcl"
+      - "Dockerfile"
+      - ".github/workflows/deploy-metrics-collector.yaml"
+  workflow_dispatch: {}
+
+name: deploy-metrics-collector
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: deploy-metrics-collector-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
+    runs-on: ubuntu-latest
+    env:
+      REGION: ${{ vars.TO_REGION }}
+      CLUSTER_NAME: ${{ vars.TO_CLUSTER_NAME }}
+      ENVIRONMENT_TAG: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
+      NAMESPACE: keeperhub
+      COLLECTOR_ECR_NAME: keeperhub-metrics-collector-${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
+      HELM_FILE: deploy/metrics-collector/${{ github.ref_name == 'prod' && 'prod' || 'staging' }}/values.yaml
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Check commit message for skip flags
+        id: skip
+        run: |
+          MSG=$(git log -1 --format=%B)
+          echo "skip_build=$([[ "$MSG" == *"[skip build]"* ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "skip_deploy=$([[ "$MSG" == *"[skip deploy]"* ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.REGION }}
+
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Extract commit hash
+        id: vars
+        shell: bash
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        if: steps.skip.outputs.skip_build != 'true'
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push metrics-collector image
+        if: steps.skip.outputs.skip_build != 'true'
+        uses: docker/bake-action@v7
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          METRICS_COLLECTOR_ECR_REPO: ${{ env.COLLECTOR_ECR_NAME }}
+          IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
+          ENVIRONMENT_TAG: ${{ env.ENVIRONMENT_TAG }}
+        with:
+          files: docker-bake.hcl
+          targets: metrics-collector
+          push: true
+
+      - name: Replace variables in Helm values file
+        if: steps.skip.outputs.skip_deploy != 'true'
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
+        run: |
+          sed -i "s|\${ECR_REGISTRY}|${ECR_REGISTRY}|g" "$HELM_FILE"
+          sed -i "s|\${IMAGE_TAG}|${IMAGE_TAG}|g" "$HELM_FILE"
+
+      - name: Configure kubectl
+        if: steps.skip.outputs.skip_deploy != 'true'
+        run: aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }} --region ${{ env.REGION }}
+
+      - name: Ensure namespace exists
+        if: steps.skip.outputs.skip_deploy != 'true'
+        run: kubectl create namespace ${{ env.NAMESPACE }} --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Deploy metrics-collector
+        if: steps.skip.outputs.skip_deploy != 'true'
+        uses: bitovi/github-actions-deploy-eks-helm@v1.2.12
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          config-files: ${{ env.HELM_FILE }}
+          chart-path: techops-services/common
+          namespace: ${{ env.NAMESPACE }}
+          timeout: 5m0s
+          name: keeperhub-metrics-collector
+          chart-repository: https://techops-services.github.io/helm-charts
+          version: 0.2.1
+          atomic: true

--- a/deploy/metrics-collector/prod/values.yaml
+++ b/deploy/metrics-collector/prod/values.yaml
@@ -1,0 +1,94 @@
+# Metrics Collector - Prod (TECH-6484)
+# Single-replica service that serves the DB-sourced Prometheus gauges (the
+# former /api/metrics/db scrape) off the request-serving pods. Because it is a
+# single replica with its own release labels, the ServiceMonitor below scrapes
+# the DB gauges deterministically from exactly one pod -- no hashmod, no
+# duplicate DB load from the app pods.
+
+replicaCount: 1
+
+service:
+  enabled: true
+  name: keeperhub-metrics-collector-prod
+  type: ClusterIP
+  port: 9090
+  containerPort: 9090
+  tls:
+    enabled: false
+
+ingress:
+  enabled: false
+
+image:
+  repository: ${ECR_REGISTRY}/keeperhub-metrics-collector-prod
+  tag: collector-${IMAGE_TAG}
+  pullPolicy: Always
+
+deployment:
+  enabled: true
+
+serviceAccount:
+  create: false
+  name: keeperhub-prod
+
+podAnnotations:
+  reloader.stakater.com/auto: "true"
+
+# Scrapes the DB-sourced gauges from this single pod. Named db-metrics so it
+# reads the same on dashboards as the app monitor it replaces.
+serviceMonitors:
+  enabled: true
+  monitors:
+    - name: db-metrics
+      port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+
+resources:
+  limits:
+    memory: 512Mi
+    cpu: 500m
+  requests:
+    cpu: 50m
+    memory: 256Mi
+
+command: ["/bin/sh"]
+args:
+  - "-c"
+  - |
+    echo "$(date) - [MetricsCollector] Starting..."
+    tsx keeperhub-metrics-collector/index.ts
+
+env:
+  DATABASE_URL:
+    type: parameterStore
+    name: db-url
+    parameter_name: /eks/techops-prod/keeperhub/db-url
+  PORT:
+    type: kv
+    value: "9090"
+  METRICS_COLLECTOR:
+    type: kv
+    value: "prometheus"
+  NODE_ENV:
+    type: kv
+    value: "production"
+
+externalSecrets:
+  clusterSecretStoreName: techops-prod
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 20
+  periodSeconds: 30
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 10
+  periodSeconds: 10

--- a/deploy/metrics-collector/staging/values.yaml
+++ b/deploy/metrics-collector/staging/values.yaml
@@ -1,0 +1,94 @@
+# Metrics Collector - Staging (TECH-6484)
+# Single-replica service that serves the DB-sourced Prometheus gauges (the
+# former /api/metrics/db scrape) off the request-serving pods. Because it is a
+# single replica with its own release labels, the ServiceMonitor below scrapes
+# the DB gauges deterministically from exactly one pod -- no hashmod, no
+# duplicate DB load from the app pods.
+
+replicaCount: 1
+
+service:
+  enabled: true
+  name: keeperhub-metrics-collector-staging
+  type: ClusterIP
+  port: 9090
+  containerPort: 9090
+  tls:
+    enabled: false
+
+ingress:
+  enabled: false
+
+image:
+  repository: ${ECR_REGISTRY}/keeperhub-metrics-collector-staging
+  tag: collector-${IMAGE_TAG}
+  pullPolicy: Always
+
+deployment:
+  enabled: true
+
+serviceAccount:
+  create: false
+  name: keeperhub-staging
+
+podAnnotations:
+  reloader.stakater.com/auto: "true"
+
+# Scrapes the DB-sourced gauges from this single pod. Named db-metrics so it
+# reads the same on dashboards as the app monitor it replaces.
+serviceMonitors:
+  enabled: true
+  monitors:
+    - name: db-metrics
+      port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+
+resources:
+  limits:
+    memory: 512Mi
+    cpu: 500m
+  requests:
+    cpu: 50m
+    memory: 256Mi
+
+command: ["/bin/sh"]
+args:
+  - "-c"
+  - |
+    echo "$(date) - [MetricsCollector] Starting..."
+    tsx keeperhub-metrics-collector/index.ts
+
+env:
+  DATABASE_URL:
+    type: parameterStore
+    name: db-url
+    parameter_name: /eks/techops-staging/keeperhub/db-url
+  PORT:
+    type: kv
+    value: "9090"
+  METRICS_COLLECTOR:
+    type: kv
+    value: "prometheus"
+  NODE_ENV:
+    type: kv
+    value: "staging"
+
+externalSecrets:
+  clusterSecretStoreName: techops-staging
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 20
+  periodSeconds: 30
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 10
+  periodSeconds: 10


### PR DESCRIPTION
## What

Deploys `keeperhub-metrics-collector` single-replica to staging/prod (the deploy half of TECH-6484).

- `deploy/metrics-collector/{staging,prod}/values.yaml` — `replicaCount: 1`, serves `/metrics` on `:9090`, a ServiceMonitor that scrapes the DB gauges from this one pod (deterministic, no hashmod). Minimal env: only `DATABASE_URL`.
- `.github/workflows/deploy-metrics-collector.yaml` — standalone (events-style) trigger on staging/prod + dispatch; bakes the `metrics-collector` target and helm-deploys via the shared `techops-services/common` chart (release `keeperhub-metrics-collector`, namespace `keeperhub`).

## Do not merge yet — ordered dependencies

1. **Depends on #1437** (the service + image target).
2. **Depends on the `keeperhub-metrics-collector-{staging,prod}` ECR repo existing** — terraform is drafted in `techops_infrastructure`; the TFC workspace must be created + applied first. Otherwise the post-merge deploy run fails on a missing repo (and re-fails on later staging pushes touching the broad trigger paths).

## No cutover

The app's `db-metrics` ServiceMonitor and `/api/metrics/db` route stay in place. Cutover (remove the app monitor + env-gate the route to 404) is a later step, after the collector is verified scraping in staging.
