### PR TITLE
feat(metrics): dedicated keeperhub-metrics-collector service (TECH-6484)

### DIFF
--- a/.github/workflows/collector-build-check.yml
+++ b/.github/workflows/collector-build-check.yml
@@ -1,0 +1,49 @@
+name: Metrics Collector Build Check
+
+# Smoke-builds the metrics-collector Docker stage and asserts its runtime
+# import graph resolves. The metrics-collector image is otherwise only built on
+# push to staging/prod, so without this a value-import of a builder-generated
+# module in lib/metrics or lib/db (not copied into the trimmed image) would only
+# surface on the post-merge staging deploy. Cheap: the stage depends on source
+# only, not the Next builder. (TECH-6484)
+on:
+  pull_request:
+    branches:
+      - staging
+    paths:
+      - "keeperhub-metrics-collector/**"
+      - "lib/metrics/**"
+      - "lib/db/**"
+      - "Dockerfile"
+      - "docker-bake.hcl"
+      - ".github/workflows/collector-build-check.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build metrics-collector image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: metrics-collector
+          push: false
+          load: true
+          tags: keeperhub-metrics-collector:pr-check
+          cache-from: type=gha,scope=metrics-collector
+          cache-to: type=gha,scope=metrics-collector,mode=max
+
+      - name: Assert collector import graph resolves
+        run: |
+          docker run --rm keeperhub-metrics-collector:pr-check \
+            tsx keeperhub-metrics-collector/import-check.ts

--- a/.github/workflows/deploy-metrics-collector.yaml
+++ b/.github/workflows/deploy-metrics-collector.yaml
@@ -1,0 +1,118 @@
+# Type: standalone | Builds and deploys the metrics collector (TECH-6484).
+# Runs independently from ci-pipeline.yml: it has no e2e tests and its own ECR
+# repo. It reuses lib/metrics + lib/db, so changes there (and to the Dockerfile
+# stage / bake target) rebuild it.
+on:
+  push:
+    branches:
+      - staging
+      - prod
+    paths:
+      - "keeperhub-metrics-collector/**"
+      - "deploy/metrics-collector/**"
+      - "lib/metrics/**"
+      - "lib/db/**"
+      - "docker-bake.hcl"
+      - "Dockerfile"
+      - ".github/workflows/deploy-metrics-collector.yaml"
+  workflow_dispatch: {}
+
+name: deploy-metrics-collector
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: deploy-metrics-collector-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
+    runs-on: ubuntu-latest
+    env:
+      REGION: ${{ vars.TO_REGION }}
+      CLUSTER_NAME: ${{ vars.TO_CLUSTER_NAME }}
+      ENVIRONMENT_TAG: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
+      NAMESPACE: keeperhub
+      COLLECTOR_ECR_NAME: keeperhub-metrics-collector-${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
+      HELM_FILE: deploy/metrics-collector/${{ github.ref_name == 'prod' && 'prod' || 'staging' }}/values.yaml
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Check commit message for skip flags
+        id: skip
+        run: |
+          MSG=$(git log -1 --format=%B)
+          echo "skip_build=$([[ "$MSG" == *"[skip build]"* ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "skip_deploy=$([[ "$MSG" == *"[skip deploy]"* ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.REGION }}
+
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Extract commit hash
+        id: vars
+        shell: bash
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        if: steps.skip.outputs.skip_build != 'true'
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push metrics-collector image
+        if: steps.skip.outputs.skip_build != 'true'
+        uses: docker/bake-action@v7
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          METRICS_COLLECTOR_ECR_REPO: ${{ env.COLLECTOR_ECR_NAME }}
+          IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
+          ENVIRONMENT_TAG: ${{ env.ENVIRONMENT_TAG }}
+        with:
+          files: docker-bake.hcl
+          targets: metrics-collector
+          push: true
+
+      - name: Replace variables in Helm values file
+        if: steps.skip.outputs.skip_deploy != 'true'
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
+        run: |
+          sed -i "s|\${ECR_REGISTRY}|${ECR_REGISTRY}|g" "$HELM_FILE"
+          sed -i "s|\${IMAGE_TAG}|${IMAGE_TAG}|g" "$HELM_FILE"
+
+      - name: Configure kubectl
+        if: steps.skip.outputs.skip_deploy != 'true'
+        run: aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }} --region ${{ env.REGION }}
+
+      - name: Ensure namespace exists
+        if: steps.skip.outputs.skip_deploy != 'true'
+        run: kubectl create namespace ${{ env.NAMESPACE }} --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Deploy metrics-collector
+        if: steps.skip.outputs.skip_deploy != 'true'
+        uses: bitovi/github-actions-deploy-eks-helm@v1.2.12
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          config-files: ${{ env.HELM_FILE }}
+          chart-path: techops-services/common
+          namespace: ${{ env.NAMESPACE }}
+          timeout: 5m0s
+          name: keeperhub-metrics-collector
+          chart-repository: https://techops-services.github.io/helm-charts
+          version: 0.2.1
+          atomic: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ COPY drizzle/ ./drizzle/
 COPY hooks/ ./hooks/
 COPY keeperhub-events/ ./keeperhub-events/
 COPY keeperhub-executor/ ./keeperhub-executor/
+COPY keeperhub-metrics-collector/ ./keeperhub-metrics-collector/
 COPY keeperhub-scheduler/ ./keeperhub-scheduler/
 COPY lib/ ./lib/
 COPY plugins/ ./plugins/
@@ -317,8 +318,10 @@ CMD ["node", "server.js"]
 # former /api/metrics/db scrape) off the request-serving pods. Executor-style:
 # reuses lib/metrics + lib/db verbatim via tsx. Copies the full root
 # node_modules (the imported lib code has transitive deps beyond the
-# collector's own package.json) plus the generated lib files the import graph
-# may touch.
+# collector's own package.json). The metrics import graph touches no
+# builder-generated file at runtime -- lib/db/schema only references the
+# generated lib/types/integration via `import type`, which tsx erases -- so
+# this stage depends on source only, not the (expensive) Next builder stage.
 # ==============================================================================
 FROM node:24-alpine AS metrics-collector
 WORKDIR /app
@@ -330,13 +333,6 @@ COPY --link --from=source /app/keeperhub-metrics-collector ./keeperhub-metrics-c
 COPY --link --from=source /app/lib ./lib
 COPY --link --from=source /app/package.json ./package.json
 COPY --link --from=source /app/tsconfig.json ./tsconfig.json
-
-# Auto-generated files from the builder stage (referenced across lib/)
-COPY --link --from=builder /app/lib/step-registry.ts ./lib/step-registry.ts
-COPY --link --from=builder /app/lib/credential-map.ts ./lib/credential-map.ts
-COPY --link --from=builder /app/lib/workflow/codegen/registry.ts ./lib/workflow/codegen/registry.ts
-COPY --link --from=builder /app/lib/output-display-configs.ts ./lib/output-display-configs.ts
-COPY --link --from=builder /app/lib/types/integration.ts ./lib/types/integration.ts
 
 # Shim server-only (runs outside Next.js)
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -310,3 +310,41 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 
 # Start the application
 CMD ["node", "server.js"]
+
+# ==============================================================================
+# Stage: metrics-collector (TECH-6484)
+# Single-replica service that serves the DB-sourced Prometheus gauges (the
+# former /api/metrics/db scrape) off the request-serving pods. Executor-style:
+# reuses lib/metrics + lib/db verbatim via tsx. Copies the full root
+# node_modules (the imported lib code has transitive deps beyond the
+# collector's own package.json) plus the generated lib files the import graph
+# may touch.
+# ==============================================================================
+FROM node:24-alpine AS metrics-collector
+WORKDIR /app
+RUN npm install -g pnpm@9 tsx@4
+COPY --link --from=deps /etc/ssl/certs/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
+
+COPY --link --from=deps /app/node_modules ./node_modules
+COPY --link --from=source /app/keeperhub-metrics-collector ./keeperhub-metrics-collector
+COPY --link --from=source /app/lib ./lib
+COPY --link --from=source /app/package.json ./package.json
+COPY --link --from=source /app/tsconfig.json ./tsconfig.json
+
+# Auto-generated files from the builder stage (referenced across lib/)
+COPY --link --from=builder /app/lib/step-registry.ts ./lib/step-registry.ts
+COPY --link --from=builder /app/lib/credential-map.ts ./lib/credential-map.ts
+COPY --link --from=builder /app/lib/workflow/codegen/registry.ts ./lib/workflow/codegen/registry.ts
+COPY --link --from=builder /app/lib/output-display-configs.ts ./lib/output-display-configs.ts
+COPY --link --from=builder /app/lib/types/integration.ts ./lib/types/integration.ts
+
+# Shim server-only (runs outside Next.js)
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+RUN find /app/node_modules -path "*server-only*/index.js" | while read -r f; do echo 'module.exports = {};' > "$f"; done
+
+ENV NODE_ENV=production
+
+EXPOSE 9090
+
+# Build with: docker build --target metrics-collector -t keeperhub-metrics-collector .
+CMD ["tsx", "keeperhub-metrics-collector/index.ts"]

--- a/deploy/metrics-collector/prod/values.yaml
+++ b/deploy/metrics-collector/prod/values.yaml
@@ -1,0 +1,94 @@
+# Metrics Collector - Prod (TECH-6484)
+# Single-replica service that serves the DB-sourced Prometheus gauges (the
+# former /api/metrics/db scrape) off the request-serving pods. Because it is a
+# single replica with its own release labels, the ServiceMonitor below scrapes
+# the DB gauges deterministically from exactly one pod -- no hashmod, no
+# duplicate DB load from the app pods.
+
+replicaCount: 1
+
+service:
+  enabled: true
+  name: keeperhub-metrics-collector-prod
+  type: ClusterIP
+  port: 9090
+  containerPort: 9090
+  tls:
+    enabled: false
+
+ingress:
+  enabled: false
+
+image:
+  repository: ${ECR_REGISTRY}/keeperhub-metrics-collector-prod
+  tag: collector-${IMAGE_TAG}
+  pullPolicy: Always
+
+deployment:
+  enabled: true
+
+serviceAccount:
+  create: false
+  name: keeperhub-prod
+
+podAnnotations:
+  reloader.stakater.com/auto: "true"
+
+# Scrapes the DB-sourced gauges from this single pod. Named db-metrics so it
+# reads the same on dashboards as the app monitor it replaces.
+serviceMonitors:
+  enabled: true
+  monitors:
+    - name: db-metrics
+      port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+
+resources:
+  limits:
+    memory: 512Mi
+    cpu: 500m
+  requests:
+    cpu: 50m
+    memory: 256Mi
+
+command: ["/bin/sh"]
+args:
+  - "-c"
+  - |
+    echo "$(date) - [MetricsCollector] Starting..."
+    tsx keeperhub-metrics-collector/index.ts
+
+env:
+  DATABASE_URL:
+    type: parameterStore
+    name: db-url
+    parameter_name: /eks/techops-prod/keeperhub/db-url
+  PORT:
+    type: kv
+    value: "9090"
+  METRICS_COLLECTOR:
+    type: kv
+    value: "prometheus"
+  NODE_ENV:
+    type: kv
+    value: "production"
+
+externalSecrets:
+  clusterSecretStoreName: techops-prod
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 20
+  periodSeconds: 30
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 10
+  periodSeconds: 10

--- a/deploy/metrics-collector/prod/values.yaml
+++ b/deploy/metrics-collector/prod/values.yaml
@@ -53,12 +53,8 @@ resources:
     cpu: 50m
     memory: 256Mi
 
-command: ["/bin/sh"]
-args:
-  - "-c"
-  - |
-    echo "$(date) - [MetricsCollector] Starting..."
-    tsx keeperhub-metrics-collector/index.ts
+# Startup comes from the Dockerfile CMD (tsx keeperhub-metrics-collector/index.ts);
+# no helm command/args override -- single source of truth.
 
 env:
   DATABASE_URL:

--- a/deploy/metrics-collector/staging/values.yaml
+++ b/deploy/metrics-collector/staging/values.yaml
@@ -53,12 +53,8 @@ resources:
     cpu: 50m
     memory: 256Mi
 
-command: ["/bin/sh"]
-args:
-  - "-c"
-  - |
-    echo "$(date) - [MetricsCollector] Starting..."
-    tsx keeperhub-metrics-collector/index.ts
+# Startup comes from the Dockerfile CMD (tsx keeperhub-metrics-collector/index.ts);
+# no helm command/args override -- single source of truth.
 
 env:
   DATABASE_URL:

--- a/deploy/metrics-collector/staging/values.yaml
+++ b/deploy/metrics-collector/staging/values.yaml
@@ -1,0 +1,94 @@
+# Metrics Collector - Staging (TECH-6484)
+# Single-replica service that serves the DB-sourced Prometheus gauges (the
+# former /api/metrics/db scrape) off the request-serving pods. Because it is a
+# single replica with its own release labels, the ServiceMonitor below scrapes
+# the DB gauges deterministically from exactly one pod -- no hashmod, no
+# duplicate DB load from the app pods.
+
+replicaCount: 1
+
+service:
+  enabled: true
+  name: keeperhub-metrics-collector-staging
+  type: ClusterIP
+  port: 9090
+  containerPort: 9090
+  tls:
+    enabled: false
+
+ingress:
+  enabled: false
+
+image:
+  repository: ${ECR_REGISTRY}/keeperhub-metrics-collector-staging
+  tag: collector-${IMAGE_TAG}
+  pullPolicy: Always
+
+deployment:
+  enabled: true
+
+serviceAccount:
+  create: false
+  name: keeperhub-staging
+
+podAnnotations:
+  reloader.stakater.com/auto: "true"
+
+# Scrapes the DB-sourced gauges from this single pod. Named db-metrics so it
+# reads the same on dashboards as the app monitor it replaces.
+serviceMonitors:
+  enabled: true
+  monitors:
+    - name: db-metrics
+      port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+
+resources:
+  limits:
+    memory: 512Mi
+    cpu: 500m
+  requests:
+    cpu: 50m
+    memory: 256Mi
+
+command: ["/bin/sh"]
+args:
+  - "-c"
+  - |
+    echo "$(date) - [MetricsCollector] Starting..."
+    tsx keeperhub-metrics-collector/index.ts
+
+env:
+  DATABASE_URL:
+    type: parameterStore
+    name: db-url
+    parameter_name: /eks/techops-staging/keeperhub/db-url
+  PORT:
+    type: kv
+    value: "9090"
+  METRICS_COLLECTOR:
+    type: kv
+    value: "prometheus"
+  NODE_ENV:
+    type: kv
+    value: "staging"
+
+externalSecrets:
+  clusterSecretStoreName: techops-staging
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 20
+  periodSeconds: 30
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 10
+  periodSeconds: 10

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -26,6 +26,7 @@ variable "EVENTS_ECR_TRACKER_REPO" { default = "" }
 variable "SCHEDULER_ECR_REPO" { default = "" }
 variable "EXECUTOR_ECR_REPO" { default = "" }
 variable "SANDBOX_ECR_REPO" { default = "" }
+variable "METRICS_COLLECTOR_ECR_REPO" { default = "" }
 
 group "default" {
   targets = ["app", "migrator", "workflow-runner"]
@@ -43,8 +44,12 @@ group "sandbox" {
   targets = ["sandbox"]
 }
 
+group "metrics-collector" {
+  targets = ["metrics-collector"]
+}
+
 group "all" {
-  targets = ["app", "migrator", "workflow-runner", "event-tracker", "schedule-dispatcher", "block-dispatcher", "executor", "sandbox"]
+  targets = ["app", "migrator", "workflow-runner", "event-tracker", "schedule-dispatcher", "block-dispatcher", "executor", "sandbox", "metrics-collector"]
 }
 
 target "app" {
@@ -214,5 +219,21 @@ target "sandbox" {
   ])
   cache-from = ["type=registry,ref=${ECR_REGISTRY}/${SANDBOX_ECR_REPO}:cache"]
   cache-to   = ["type=registry,ref=${ECR_REGISTRY}/${SANDBOX_ECR_REPO}:cache,mode=max"]
+  attest     = []
+}
+
+# Metrics collector (TECH-6484). Context is repo root because the stage reuses
+# lib/ and the root node_modules. Tag prefix `collector-`.
+target "metrics-collector" {
+  context    = "."
+  dockerfile = "Dockerfile"
+  target     = "metrics-collector"
+  tags = compact([
+    "${ECR_REGISTRY}/${METRICS_COLLECTOR_ECR_REPO}:collector-${IMAGE_TAG}",
+    "${ECR_REGISTRY}/${METRICS_COLLECTOR_ECR_REPO}:collector-latest",
+    ENVIRONMENT_TAG != "" ? "${ECR_REGISTRY}/${METRICS_COLLECTOR_ECR_REPO}:${ENVIRONMENT_TAG}" : "",
+  ])
+  cache-from = ["type=registry,ref=${ECR_REGISTRY}/${METRICS_COLLECTOR_ECR_REPO}:cache"]
+  cache-to   = ["type=registry,ref=${ECR_REGISTRY}/${METRICS_COLLECTOR_ECR_REPO}:cache,mode=max"]
   attest     = []
 }

--- a/keeperhub-metrics-collector/import-check.ts
+++ b/keeperhub-metrics-collector/import-check.ts
@@ -1,0 +1,30 @@
+/**
+ * Import-graph smoke check for the metrics-collector image (TECH-6484).
+ *
+ * Run inside the built metrics-collector container by the collector-build-check
+ * CI job. It dynamically imports the collector's two entry modules; if a future
+ * change adds a runtime (value) import of a builder-generated module that the
+ * trimmed image does not copy, this fails here at PR time instead of on the
+ * post-merge staging deploy. (server.test.ts mocks the metrics module, so it
+ * does not exercise this real import path.)
+ */
+async function main(): Promise<void> {
+  const [api, dbMetrics] = await Promise.all([
+    import("../lib/metrics/prometheus-api"),
+    import("../lib/metrics/db-metrics"),
+  ]);
+
+  console.log(
+    `IMPORTS_OK prometheus-api=${Object.keys(api).length} db-metrics=${Object.keys(dbMetrics).length}`
+  );
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error("IMPORT_FAIL:", message);
+  process.exit(1);
+});
+
+// Marks this file as a module so `main` is module-scoped (avoids a global-scope
+// name collision with other script-style entrypoints under tsc's project view).
+export {};

--- a/keeperhub-metrics-collector/index.ts
+++ b/keeperhub-metrics-collector/index.ts
@@ -1,0 +1,34 @@
+/**
+ * keeperhub-metrics-collector
+ *
+ * Single-replica service that serves the DB-sourced Prometheus gauges that used
+ * to live on /api/metrics/db on the common app pods. It reuses the app's
+ * metrics code verbatim (updateDbMetrics refreshes the dbRegistry from Postgres,
+ * getDbMetrics serializes it), so the exposed gauge families are identical.
+ * Running it as its own single-replica deployment keeps the heavy aggregate
+ * scan off the request-serving pods and makes the scrape deterministic.
+ *
+ * Env:
+ *   PORT          HTTP port for /metrics and /health (default 9090)
+ *   DATABASE_URL  Postgres connection (consumed by lib/db)
+ */
+import type { Server } from "node:http";
+import { buildServer } from "./server";
+
+const PORT = Number.parseInt(process.env.PORT ?? "9090", 10) || 9090;
+
+const server: Server = buildServer();
+
+server.listen(PORT, () => {
+  console.log(
+    `[MetricsCollector] serving /metrics and /health on port ${PORT}`
+  );
+});
+
+function shutdown(signal: string): void {
+  console.log(`[MetricsCollector] received ${signal}, shutting down`);
+  server.close(() => process.exit(0));
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));

--- a/keeperhub-metrics-collector/package.json
+++ b/keeperhub-metrics-collector/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@keeperhub/metrics-collector",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Single-replica service that serves the DB-sourced Prometheus gauges (the former /api/metrics/db scrape) off the request-serving pods",
+  "scripts": {
+    "collector": "tsx keeperhub-metrics-collector/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "drizzle-orm": "^0.45.2",
+    "postgres": "^3.4.0",
+    "prom-client": "^15.1.3"
+  },
+  "devDependencies": {
+    "tsx": "^4.0.0"
+  }
+}

--- a/keeperhub-metrics-collector/server.test.ts
+++ b/keeperhub-metrics-collector/server.test.ts
@@ -1,0 +1,75 @@
+import type { AddressInfo, Server } from "node:net";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const updateDbMetrics = vi.fn();
+const getDbMetrics = vi.fn();
+const getPrometheusContentType = vi.fn();
+
+// Mock the app's metrics module so the HTTP wiring is tested without a DB.
+vi.mock("../lib/metrics/prometheus-api", () => ({
+  updateDbMetrics: () => updateDbMetrics(),
+  getDbMetrics: () => getDbMetrics(),
+  getPrometheusContentType: () => getPrometheusContentType(),
+}));
+
+const { buildServer } = await import("./server");
+
+describe("metrics-collector server (TECH-6484)", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    updateDbMetrics.mockReset().mockResolvedValue(undefined);
+    getDbMetrics.mockReset().mockResolvedValue("keeperhub_user_total 0\n");
+    getPrometheusContentType
+      .mockReset()
+      .mockReturnValue("text/plain; version=0.0.4; charset=utf-8");
+
+    server = buildServer();
+    await new Promise<void>((resolve) => {
+      server.listen(0, () => resolve());
+    });
+    const port = (server.address() as AddressInfo).port;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  it("GET /metrics refreshes then serves the DB registry", async () => {
+    const res = await fetch(`${baseUrl}/metrics`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/plain");
+    expect(await res.text()).toContain("keeperhub_user_total");
+    expect(updateDbMetrics).toHaveBeenCalledTimes(1);
+    expect(getDbMetrics).toHaveBeenCalledTimes(1);
+  });
+
+  it("GET /health returns ok without touching the DB", async () => {
+    const res = await fetch(`${baseUrl}/health`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; service: string };
+    expect(body.status).toBe("ok");
+    expect(body.service).toBe("keeperhub-metrics-collector");
+    expect(updateDbMetrics).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the refresh throws", async () => {
+    updateDbMetrics.mockRejectedValueOnce(new Error("db down"));
+
+    const res = await fetch(`${baseUrl}/metrics`);
+
+    expect(res.status).toBe(500);
+  });
+
+  it("404s unknown paths", async () => {
+    const res = await fetch(`${baseUrl}/nope`);
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/keeperhub-metrics-collector/server.ts
+++ b/keeperhub-metrics-collector/server.ts
@@ -1,0 +1,70 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+// server-only is a no-op under Node/tsx; this reuses the app's metrics code
+// verbatim so the exposed gauges are byte-for-byte identical to the former
+// /api/metrics/db endpoint.
+import {
+  getDbMetrics,
+  getPrometheusContentType,
+  updateDbMetrics,
+} from "../lib/metrics/prometheus-api";
+
+/**
+ * Build the metrics-collector HTTP server.
+ *
+ *   GET /metrics  refreshes the DB-sourced gauges (updateDbMetrics, which is
+ *                 TTL- and pool-gated in lib/) and serves the dbRegistry.
+ *   GET /health   liveness/readiness probe.
+ *
+ * Returned without listening so tests can bind an ephemeral port.
+ */
+export function buildServer(): Server {
+  return createServer((req: IncomingMessage, res: ServerResponse): void => {
+    if (req.method !== "GET") {
+      res.writeHead(405);
+      res.end();
+      return;
+    }
+
+    if (req.url === "/health") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          status: "ok",
+          service: "keeperhub-metrics-collector",
+          timestamp: new Date().toISOString(),
+        })
+      );
+      return;
+    }
+
+    if (req.url === "/metrics") {
+      // serveMetrics owns all its error handling and never rejects.
+      serveMetrics(res);
+      return;
+    }
+
+    res.writeHead(404);
+    res.end();
+  });
+}
+
+async function serveMetrics(res: ServerResponse): Promise<void> {
+  try {
+    await updateDbMetrics();
+    const metrics = await getDbMetrics();
+    res.writeHead(200, {
+      "Content-Type": getPrometheusContentType(),
+      "Cache-Control": "no-store, no-cache, must-revalidate",
+    });
+    res.end(metrics);
+  } catch (error) {
+    console.error("[MetricsCollector] Failed to serve metrics:", error);
+    res.writeHead(500);
+    res.end("Failed to collect metrics");
+  }
+}


### PR DESCRIPTION
> Infra note: the `keeperhub-metrics-collector-{staging,prod}` ECR repos are **already created/applied** ([techops-services/infrastructure#241](https://github.com/techops-services/infrastructure/pull/241) records the terraform on main). No blocker for this PR — the deploy workflow can push to the repos once merged.

## What

Adds `keeperhub-metrics-collector` (TECH-6484): a dedicated single-replica service that serves the DB-sourced Prometheus gauges (the former `/api/metrics/db` scrape) **off the request-serving pods**, plus its image and deploy wiring. Consolidates the previously-split #1437 (service+image) and #1438 (deploy).

## Why

The `db-metrics` ServiceMonitor scrapes every app pod, so the heavy aggregate scan runs once per pod per window (2x today). A dedicated single replica makes the scan deterministic (one pod) and decouples it from app replica count — and keeps it off the latency-sensitive request pods. Composes with the cache (KEEP-669), the `max:2` metrics pool (KEEP-679), and index-only scans (migration 0095) already on staging.

## How

Executor-style: build-context = repo root, reuses `lib/metrics` + `lib/db` **verbatim** via `tsx` (zero query duplication / schema drift).

- `keeperhub-metrics-collector/` — `node:http` server (`PORT` 9090) serving `GET /metrics` (`updateDbMetrics` -> `getDbMetrics`) and `GET /health`; `server.test.ts` covers the wiring.
- `Dockerfile` `metrics-collector` stage — **source-only** (no Next builder): the metrics graph references no builder-generated file at runtime (`lib/db/schema` uses `lib/types/integration` only via `import type`, erased by tsx); `server-only` shimmed.
- `docker-bake.hcl` target/group + `METRICS_COLLECTOR_ECR_REPO`.
- `deploy/metrics-collector/{staging,prod}/values.yaml` — `replicaCount: 1`, ServiceMonitor scraping `/metrics` deterministically from one pod; minimal env (only `DATABASE_URL`).
- `.github/workflows/deploy-metrics-collector.yaml` — standalone build + helm-deploy via `techops-services/common`.

## Validation

- `pnpm type-check` clean, `pnpm check` (biome) clean, collector tests pass (4).
- **Built the image** (`docker build --target metrics-collector`): no Next build runs; `prometheus-api` + `db-metrics` import cleanly in the trimmed container; `/health` -> 200; `/metrics` constructs and runs the real aggregate queries (only the DB connection fails under a dummy URL — no missing modules).

## No cutover

The app's `db-metrics` ServiceMonitor and `/api/metrics/db` route are intentionally untouched. Cutover (remove the app monitor + env-gate the route to 404) is a follow-up, after the collector is verified scraping in staging.
