### PR TITLE
feat(metrics): cut over /api/metrics/db to the collector + PR-env wiring (TECH-6484)

### DIFF
--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -15,6 +15,7 @@ jobs:
       should-deploy-events: ${{ steps.check.outputs.should-deploy-events }}
       should-deploy-events-only: ${{ steps.check.outputs.should-deploy-events-only }}
       should-build-executor: ${{ steps.check.outputs.should-build-executor }}
+      should-deploy-collector: ${{ steps.check.outputs.should-deploy-collector }}
     steps:
       - name: Checkout code (for change detection)
         if: github.event.action == 'synchronize'
@@ -30,6 +31,7 @@ jobs:
           echo "should-deploy-events=false" >> $GITHUB_OUTPUT
           echo "should-deploy-events-only=false" >> $GITHUB_OUTPUT
           echo "should-build-executor=false" >> $GITHUB_OUTPUT
+          echo "should-deploy-collector=false" >> $GITHUB_OUTPUT
 
           HAS_DEPLOY_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'deploy-pr-environment') }}"
           HAS_TEST_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'run-e2e-tests-pr-deploy') }}"
@@ -44,6 +46,12 @@ jobs:
           # dispatchers are consumed; this label adds a PR-specific build for
           # ticket-driven validation. See KEEP-556.
           HAS_EXECUTOR_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'deploy-pr-executor') }}"
+          # Metrics-collector PR deploy is opt-in alongside deploy-pr-environment
+          # (TECH-6484), same pattern as deploy-pr-executor. Default off; when
+          # set, CI builds a PR-specific collector image and deploys it as a
+          # satellite so the PR's collector code can be exercised against the
+          # PR's DB. ServiceMonitors are off in PR envs - verify via curl.
+          HAS_METRICS_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'deploy-pr-metrics') }}"
           ACTION="${{ github.event.action }}"
           ADDED_LABEL="${{ github.event.label.name }}"
 
@@ -58,6 +66,9 @@ jobs:
               fi
               if [[ "$HAS_EXECUTOR_LABEL" == "true" ]]; then
                 echo "should-build-executor=true" >> $GITHUB_OUTPUT
+              fi
+              if [[ "$HAS_METRICS_LABEL" == "true" ]]; then
+                echo "should-deploy-collector=true" >> $GITHUB_OUTPUT
               fi
             elif [[ "$ADDED_LABEL" == "run-e2e-tests-pr-deploy" ]]; then
               echo "should-test=true" >> $GITHUB_OUTPUT
@@ -85,6 +96,12 @@ jobs:
                 if [[ "$HAS_TEST_LABEL" == "true" ]]; then
                   echo "should-test=true" >> $GITHUB_OUTPUT
                 fi
+              fi
+            elif [[ "$ADDED_LABEL" == "deploy-pr-metrics" ]]; then
+              # Metrics-only path: PR env already deployed. Build a PR collector
+              # image and deploy just that satellite (TECH-6484).
+              if [[ "$HAS_DEPLOY_LABEL" == "true" ]]; then
+                echo "should-deploy-collector=true" >> $GITHUB_OUTPUT
               fi
             fi
           elif [[ "$ACTION" == "unlabeled" ]]; then
@@ -121,6 +138,9 @@ jobs:
               fi
               if [[ "$HAS_EXECUTOR_LABEL" == "true" ]]; then
                 echo "should-build-executor=true" >> $GITHUB_OUTPUT
+              fi
+              if [[ "$HAS_METRICS_LABEL" == "true" ]]; then
+                echo "should-deploy-collector=true" >> $GITHUB_OUTPUT
               fi
             fi
             # Run tests if both labels present (even without deploy)
@@ -217,6 +237,57 @@ jobs:
             type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
             type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:${{ matrix.image.cache_key }}
           cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:${{ matrix.image.cache_key }},mode=max
+
+  # Builds a PR-specific metrics-collector image when the deploy-pr-metrics
+  # label is present alongside deploy-pr-environment (TECH-6484). Pushed to the
+  # staging collector ECR with a collector-${sha_short} tag; never pushes
+  # collector-latest so concurrent staging deploys are unaffected.
+  build-collector-image:
+    needs: check-labels
+    if: needs.check-labels.outputs.should-deploy-collector == 'true'
+    runs-on: ubuntu-latest
+    environment: staging
+    env:
+      REGION: ${{ vars.TO_REGION }}
+      COLLECTOR_ECR_NAME: keeperhub-metrics-collector-staging
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.REGION }}
+
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Extract commit hash
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push collector image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: metrics-collector
+          push: true
+          provenance: false
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.COLLECTOR_ECR_NAME }}:collector-${{ steps.vars.outputs.sha_short }}
+          cache-from: |
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.COLLECTOR_ECR_NAME }}:cache
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.COLLECTOR_ECR_NAME }}:cache-pr
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.COLLECTOR_ECR_NAME }}:cache-pr,mode=max
 
   # Builds a PR-specific event-tracker image when the deploy-pr-events
   # label is present alongside deploy-pr-environment. Without it, the PR
@@ -361,7 +432,7 @@ jobs:
           cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.EXECUTOR_ECR_NAME }}:cache-pr,mode=max
 
   deploy:
-    needs: [check-labels, build-images, build-events-image, build-executor-image]
+    needs: [check-labels, build-images, build-events-image, build-executor-image, build-collector-image]
     # Cannot use the `success()` shorthand here because GHA evaluates it
     # as false whenever ANY needed job is skipped. build-events-image is
     # skipped on purpose for PRs without the deploy-pr-events label, so
@@ -374,7 +445,8 @@ jobs:
       needs.check-labels.outputs.should-deploy == 'true' &&
       needs.build-images.result == 'success' &&
       (needs.build-events-image.result == 'success' || needs.build-events-image.result == 'skipped') &&
-      (needs.build-executor-image.result == 'success' || needs.build-executor-image.result == 'skipped')
+      (needs.build-executor-image.result == 'success' || needs.build-executor-image.result == 'skipped') &&
+      (needs.build-collector-image.result == 'success' || needs.build-collector-image.result == 'skipped')
     runs-on: ubuntu-latest
     environment: staging
     env:
@@ -530,6 +602,10 @@ jobs:
           # / event triggers. The template prepends "executor-" itself, so we
           # set only the bare tag here (matches the {{IMAGE_TAG}} pattern).
           EXECUTOR_IMAGE_TAG: ${{ needs.check-labels.outputs.should-build-executor == 'true' && steps.vars.outputs.sha_short || 'latest' }}
+          # PR-specific collector image tag when deploy-pr-metrics was set
+          # (build-collector-image ran); else the collector-latest baseline.
+          # Bare tag; the template prepends "collector-". (TECH-6484)
+          COLLECTOR_IMAGE_TAG: ${{ needs.check-labels.outputs.should-deploy-collector == 'true' && steps.vars.outputs.sha_short || 'latest' }}
         run: |
           # Percent-encode DB_PASSWORD so base64 characters (+/=) don't break URL parsing
           # in the pod. Init containers previously encoded at runtime but that path was
@@ -542,6 +618,7 @@ jobs:
           envsubst < deploy/pr-environment/block-dispatcher.template.yaml > ${{ github.workspace }}/block-pr-${{ env.PR_NUMBER }}.yaml
           envsubst < deploy/pr-environment/event-tracker.template.yaml > ${{ github.workspace }}/event-pr-${{ env.PR_NUMBER }}.yaml
           envsubst < deploy/pr-environment/executor.template.yaml > ${{ github.workspace }}/executor-pr-${{ env.PR_NUMBER }}.yaml
+          envsubst < deploy/pr-environment/metrics-collector.template.yaml > ${{ github.workspace }}/metrics-pr-${{ env.PR_NUMBER }}.yaml
           envsubst < deploy/pr-environment/sandbox.template.yaml > ${{ github.workspace }}/sandbox-pr-${{ env.PR_NUMBER }}.yaml
 
       - name: Clean up stale Helm releases
@@ -563,6 +640,18 @@ jobs:
             techops-services/common \
             -f ${GITHUB_WORKSPACE}/values-pr-${PR_NUMBER}.yaml \
             --namespace "${NAMESPACE}" --timeout 10m0s --atomic --version 0.2.1
+
+      # Opt-in (deploy-pr-metrics label). Deploys the metrics-collector
+      # satellite against the PR DB so its /metrics can be curled directly
+      # (ServiceMonitors are off in PR envs). TECH-6484.
+      - name: Deploy metrics collector (PR, opt-in)
+        if: needs.check-labels.outputs.should-deploy-collector == 'true'
+        run: |
+          set -euo pipefail
+          helm upgrade --install metrics-pr-${PR_NUMBER} \
+            techops-services/common \
+            -f ${GITHUB_WORKSPACE}/metrics-pr-${PR_NUMBER}.yaml \
+            --namespace "${NAMESPACE}" --timeout 5m0s --atomic --version 0.2.1
 
       - name: Deploy satellite services (parallel)
         run: |

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -98,10 +98,17 @@ jobs:
                 fi
               fi
             elif [[ "$ADDED_LABEL" == "deploy-pr-metrics" ]]; then
-              # Metrics-only path: PR env already deployed. Build a PR collector
-              # image and deploy just that satellite (TECH-6484).
+              # Metrics path: PR env already deployed. Build a PR collector image
+              # and re-run the deploy (which now includes the collector step).
+              # should-deploy=true is required because the collector deploy step
+              # lives inside the should-deploy-gated deploy job - same pattern as
+              # the deploy-pr-executor incremental path. (TECH-6484)
               if [[ "$HAS_DEPLOY_LABEL" == "true" ]]; then
+                echo "should-deploy=true" >> $GITHUB_OUTPUT
                 echo "should-deploy-collector=true" >> $GITHUB_OUTPUT
+                if [[ "$HAS_TEST_LABEL" == "true" ]]; then
+                  echo "should-test=true" >> $GITHUB_OUTPUT
+                fi
               fi
             fi
           elif [[ "$ACTION" == "unlabeled" ]]; then

--- a/app/api/metrics/db/route.ts
+++ b/app/api/metrics/db/route.ts
@@ -3,12 +3,22 @@
  *
  * Exposes only database-sourced gauge metrics. These are identical across pods,
  * so only one pod needs to be scraped for these metrics.
+ *
+ * TECH-6484: these gauges are now served by the dedicated
+ * keeperhub-metrics-collector service. When METRICS_DB_OFFLOADED is set, this
+ * route returns 404 so the heavy aggregate scan never runs on the
+ * request-serving pods (the app's db-metrics ServiceMonitor is removed too).
+ * The flag keeps the cutover reversible via config without a code revert.
  */
 
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 
 export async function GET(): Promise<NextResponse> {
+  if (process.env.METRICS_DB_OFFLOADED === "true") {
+    return new NextResponse("Not Found", { status: 404 });
+  }
+
   if (process.env.METRICS_COLLECTOR !== "prometheus") {
     return new NextResponse("Not Found", { status: 404 });
   }

--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -117,14 +117,9 @@ serviceMonitors:
       path: /api/metrics/api
       interval: 30s
       scrapeTimeout: 10s
-    - name: db-metrics
-      port: http
-      path: /api/metrics/db
-      interval: 30s
-      # 12s (not 10s): this endpoint blocks on the serialised db-metrics
-      # refresh, which is several seconds at prod scale. See KEEP-682 to
-      # measure refresh duration and revisit if it approaches this timeout.
-      scrapeTimeout: 12s
+    # db-metrics removed (TECH-6484): the DB-sourced gauges are now scraped from
+    # the dedicated keeperhub-metrics-collector single-replica service, not from
+    # the app pods. The app route is also gated off via METRICS_DB_OFFLOADED.
 
 resources:
   limits:
@@ -144,6 +139,11 @@ env:
   METRICS_COLLECTOR:
     type: kv
     value: "prometheus"
+  # TECH-6484: /api/metrics/db is served by keeperhub-metrics-collector now;
+  # gate the app route to 404 so the heavy scan never runs on these pods.
+  METRICS_DB_OFFLOADED:
+    type: kv
+    value: "true"
   RPC_PROBE_INTERVAL_MS:
     type: kv
     value: "30000"

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -117,14 +117,9 @@ serviceMonitors:
       path: /api/metrics/api
       interval: 30s
       scrapeTimeout: 10s
-    - name: db-metrics
-      port: http
-      path: /api/metrics/db
-      interval: 30s
-      # 12s (not 10s): this endpoint blocks on the serialised db-metrics
-      # refresh. Staging refresh is well under this, but kept in parity with
-      # prod to avoid config drift. See KEEP-682.
-      scrapeTimeout: 12s
+    # db-metrics removed (TECH-6484): the DB-sourced gauges are now scraped from
+    # the dedicated keeperhub-metrics-collector single-replica service, not from
+    # the app pods. The app route is also gated off via METRICS_DB_OFFLOADED.
 
 resources:
   limits:
@@ -145,6 +140,11 @@ env:
   METRICS_COLLECTOR:
     type: kv
     value: "prometheus"
+  # TECH-6484: /api/metrics/db is served by keeperhub-metrics-collector now;
+  # gate the app route to 404 so the heavy scan never runs on these pods.
+  METRICS_DB_OFFLOADED:
+    type: kv
+    value: "true"
   RPC_PROBE_INTERVAL_MS:
     type: kv
     value: "30000"

--- a/deploy/pr-environment/metrics-collector.template.yaml
+++ b/deploy/pr-environment/metrics-collector.template.yaml
@@ -1,0 +1,83 @@
+# Metrics Collector for PR environments (TECH-6484)
+#
+# Serves the DB-sourced Prometheus gauges from the PR's database, off the app
+# pods. Opt-in via the deploy-pr-metrics label: CI builds a PR-specific image
+# (collector-${sha_short}) and renders this template with
+# COLLECTOR_IMAGE_TAG=${sha_short}. ServiceMonitors are disabled in PR envs, so
+# verify by curling /metrics on the pod directly.
+#
+# Variables substituted by envsubst at deploy time:
+#   ${PR_NUMBER}, ${ECR_REGISTRY}, ${COLLECTOR_IMAGE_TAG}, ${ENCODED_DB_PASSWORD}
+
+replicaCount: 1
+
+service:
+  enabled: true
+  name: keeperhub-metrics-collector-pr-${PR_NUMBER}
+  type: ClusterIP
+  port: 9090
+  containerPort: 9090
+  tls:
+    enabled: false
+
+ingress:
+  enabled: false
+
+image:
+  repository: ${ECR_REGISTRY}/keeperhub-metrics-collector-staging
+  tag: collector-${COLLECTOR_IMAGE_TAG}
+  pullPolicy: Always
+
+deployment:
+  enabled: true
+
+serviceAccount:
+  create: false
+  name: keeperhub-pr-${PR_NUMBER}
+
+podAnnotations:
+  reloader.stakater.com/auto: "true"
+
+serviceMonitors:
+  enabled: false
+
+resources:
+  limits:
+    memory: 512Mi
+    cpu: 300m
+  requests:
+    cpu: 50m
+    memory: 128Mi
+
+command: ["/bin/sh"]
+args:
+  - "-c"
+  - |
+    echo "$(date) - [MetricsCollector] Starting..."
+    tsx keeperhub-metrics-collector/index.ts
+
+env:
+  DATABASE_URL:
+    type: kv
+    value: "postgresql://keeperhub:${ENCODED_DB_PASSWORD}@keeperhub-pr-${PR_NUMBER}-db-rw.pr-${PR_NUMBER}.svc.cluster.local:5432/keeperhub"
+  PORT:
+    type: kv
+    value: "9090"
+  METRICS_COLLECTOR:
+    type: kv
+    value: "prometheus"
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 20
+  periodSeconds: 30
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 10
+  periodSeconds: 10

--- a/deploy/pr-environment/metrics-collector.template.yaml
+++ b/deploy/pr-environment/metrics-collector.template.yaml
@@ -49,12 +49,7 @@ resources:
     cpu: 50m
     memory: 128Mi
 
-command: ["/bin/sh"]
-args:
-  - "-c"
-  - |
-    echo "$(date) - [MetricsCollector] Starting..."
-    tsx keeperhub-metrics-collector/index.ts
+# Startup comes from the Dockerfile CMD; no helm command/args override.
 
 env:
   DATABASE_URL:

--- a/lib/metrics/METRICS_REFERENCE.md
+++ b/lib/metrics/METRICS_REFERENCE.md
@@ -26,6 +26,8 @@ Metrics are collected from two sources depending on the collector type:
 
 > **Note:** Runtime code (executor, routes) also increments workflow metrics for console logging, but Prometheus relies solely on DB snapshots. This dual approach ensures complete data even when workflow runners exit before scrape.
 
+> **Note (TECH-6484):** The DB-sourced gauges are served by the dedicated single-replica `keeperhub-metrics-collector` service (`deploy/metrics-collector/`), not by the app pods. It reuses this module's `updateDbMetrics` / `getDbMetrics` and serves them on `/metrics`. Its ServiceMonitor scrapes the gauges deterministically from one pod. The app's `/api/metrics/db` route is gated off via `METRICS_DB_OFFLOADED` and its `db-metrics` ServiceMonitor removed, so the heavy aggregate scan no longer runs on the request-serving pods. `/api/metrics/api` (per-pod, in-memory) is unchanged.
+
 ---
 
 ## Architecture Context


### PR DESCRIPTION
## ⚠️ Deployment sequence (read before merging)

This PR **turns off** the app's DB-metrics scrape. It is safe **only after** the dedicated collector (PR #1439) is live and confirmed scraping. Merging out of order creates a metrics gap.

**Required order:**
1. Merge **#1439** → collector deploys to staging (app still serving db-metrics too — harmless overlap).
2. **Verify in staging:** the `keeperhub-metrics-collector-…-db-metrics` Prometheus target is `Up` with gauges matching `/api/metrics/db`.
3. **Then merge this PR** → app stops serving db-metrics; collector is the sole source → no gap.
4. **Prod:** promote the collector first (verify target `Up` in prod), **then** promote this cutover. Never ship both to prod in one promotion (same gap risk).

Principle: always overlap (two sources briefly, `max()` dedupes), never gap.

## What

**Cutover (Stage 4):**
- `app/api/metrics/db` route → 404 when `METRICS_DB_OFFLOADED=true` (reversible via config).
- Remove the `db-metrics` ServiceMonitor from `deploy/keeperhub/{staging,prod}` and set `METRICS_DB_OFFLOADED=true`. `/api/metrics/api` unchanged.

**PR-env wiring (Stage 5):**
- `deploy/pr-environment/metrics-collector.template.yaml` + `deploy-pr-environment.yaml` `deploy-pr-metrics` opt-in label (build + deploy a PR collector). Default off — existing PR envs unaffected.
- `METRICS_REFERENCE.md` note.

## Validation

- Type-check / biome clean; all changed YAML parses.
- **The `deploy-pr-metrics` path was exercised end-to-end** (throwaway combined PR): built a PR-sha collector image and deployed a real pod (`/metrics` 200). The `deploy-pr-metrics` **label was created** in the repo.
- **Fixed a gap found during that run** (`a9076653`): the metrics-only label (added to an already-deployed PR) now re-runs the deploy so the collector actually lands, mirroring `deploy-pr-executor`.

Depends on #1439 (image stage + deploy config).
