### PR TITLE
DO NOT MERGE: TECH-6484 collector PR-env validation (throwaway)

### DIFF
--- a/.github/workflows/collector-build-check.yml
+++ b/.github/workflows/collector-build-check.yml
@@ -1,0 +1,49 @@
+name: Metrics Collector Build Check
+
+# Smoke-builds the metrics-collector Docker stage and asserts its runtime
+# import graph resolves. The metrics-collector image is otherwise only built on
+# push to staging/prod, so without this a value-import of a builder-generated
+# module in lib/metrics or lib/db (not copied into the trimmed image) would only
+# surface on the post-merge staging deploy. Cheap: the stage depends on source
+# only, not the Next builder. (TECH-6484)
+on:
+  pull_request:
+    branches:
+      - staging
+    paths:
+      - "keeperhub-metrics-collector/**"
+      - "lib/metrics/**"
+      - "lib/db/**"
+      - "Dockerfile"
+      - "docker-bake.hcl"
+      - ".github/workflows/collector-build-check.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build metrics-collector image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: metrics-collector
+          push: false
+          load: true
+          tags: keeperhub-metrics-collector:pr-check
+          cache-from: type=gha,scope=metrics-collector
+          cache-to: type=gha,scope=metrics-collector,mode=max
+
+      - name: Assert collector import graph resolves
+        run: |
+          docker run --rm keeperhub-metrics-collector:pr-check \
+            tsx keeperhub-metrics-collector/import-check.ts

--- a/.github/workflows/deploy-metrics-collector.yaml
+++ b/.github/workflows/deploy-metrics-collector.yaml
@@ -1,0 +1,118 @@
+# Type: standalone | Builds and deploys the metrics collector (TECH-6484).
+# Runs independently from ci-pipeline.yml: it has no e2e tests and its own ECR
+# repo. It reuses lib/metrics + lib/db, so changes there (and to the Dockerfile
+# stage / bake target) rebuild it.
+on:
+  push:
+    branches:
+      - staging
+      - prod
+    paths:
+      - "keeperhub-metrics-collector/**"
+      - "deploy/metrics-collector/**"
+      - "lib/metrics/**"
+      - "lib/db/**"
+      - "docker-bake.hcl"
+      - "Dockerfile"
+      - ".github/workflows/deploy-metrics-collector.yaml"
+  workflow_dispatch: {}
+
+name: deploy-metrics-collector
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: deploy-metrics-collector-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
+    runs-on: ubuntu-latest
+    env:
+      REGION: ${{ vars.TO_REGION }}
+      CLUSTER_NAME: ${{ vars.TO_CLUSTER_NAME }}
+      ENVIRONMENT_TAG: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
+      NAMESPACE: keeperhub
+      COLLECTOR_ECR_NAME: keeperhub-metrics-collector-${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
+      HELM_FILE: deploy/metrics-collector/${{ github.ref_name == 'prod' && 'prod' || 'staging' }}/values.yaml
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Check commit message for skip flags
+        id: skip
+        run: |
+          MSG=$(git log -1 --format=%B)
+          echo "skip_build=$([[ "$MSG" == *"[skip build]"* ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "skip_deploy=$([[ "$MSG" == *"[skip deploy]"* ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.REGION }}
+
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Extract commit hash
+        id: vars
+        shell: bash
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        if: steps.skip.outputs.skip_build != 'true'
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push metrics-collector image
+        if: steps.skip.outputs.skip_build != 'true'
+        uses: docker/bake-action@v7
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          METRICS_COLLECTOR_ECR_REPO: ${{ env.COLLECTOR_ECR_NAME }}
+          IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
+          ENVIRONMENT_TAG: ${{ env.ENVIRONMENT_TAG }}
+        with:
+          files: docker-bake.hcl
+          targets: metrics-collector
+          push: true
+
+      - name: Replace variables in Helm values file
+        if: steps.skip.outputs.skip_deploy != 'true'
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
+        run: |
+          sed -i "s|\${ECR_REGISTRY}|${ECR_REGISTRY}|g" "$HELM_FILE"
+          sed -i "s|\${IMAGE_TAG}|${IMAGE_TAG}|g" "$HELM_FILE"
+
+      - name: Configure kubectl
+        if: steps.skip.outputs.skip_deploy != 'true'
+        run: aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }} --region ${{ env.REGION }}
+
+      - name: Ensure namespace exists
+        if: steps.skip.outputs.skip_deploy != 'true'
+        run: kubectl create namespace ${{ env.NAMESPACE }} --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Deploy metrics-collector
+        if: steps.skip.outputs.skip_deploy != 'true'
+        uses: bitovi/github-actions-deploy-eks-helm@v1.2.12
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          config-files: ${{ env.HELM_FILE }}
+          chart-path: techops-services/common
+          namespace: ${{ env.NAMESPACE }}
+          timeout: 5m0s
+          name: keeperhub-metrics-collector
+          chart-repository: https://techops-services.github.io/helm-charts
+          version: 0.2.1
+          atomic: true

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -15,6 +15,7 @@ jobs:
       should-deploy-events: ${{ steps.check.outputs.should-deploy-events }}
       should-deploy-events-only: ${{ steps.check.outputs.should-deploy-events-only }}
       should-build-executor: ${{ steps.check.outputs.should-build-executor }}
+      should-deploy-collector: ${{ steps.check.outputs.should-deploy-collector }}
     steps:
       - name: Checkout code (for change detection)
         if: github.event.action == 'synchronize'
@@ -30,6 +31,7 @@ jobs:
           echo "should-deploy-events=false" >> $GITHUB_OUTPUT
           echo "should-deploy-events-only=false" >> $GITHUB_OUTPUT
           echo "should-build-executor=false" >> $GITHUB_OUTPUT
+          echo "should-deploy-collector=false" >> $GITHUB_OUTPUT
 
           HAS_DEPLOY_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'deploy-pr-environment') }}"
           HAS_TEST_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'run-e2e-tests-pr-deploy') }}"
@@ -44,6 +46,12 @@ jobs:
           # dispatchers are consumed; this label adds a PR-specific build for
           # ticket-driven validation. See KEEP-556.
           HAS_EXECUTOR_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'deploy-pr-executor') }}"
+          # Metrics-collector PR deploy is opt-in alongside deploy-pr-environment
+          # (TECH-6484), same pattern as deploy-pr-executor. Default off; when
+          # set, CI builds a PR-specific collector image and deploys it as a
+          # satellite so the PR's collector code can be exercised against the
+          # PR's DB. ServiceMonitors are off in PR envs - verify via curl.
+          HAS_METRICS_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'deploy-pr-metrics') }}"
           ACTION="${{ github.event.action }}"
           ADDED_LABEL="${{ github.event.label.name }}"
 
@@ -58,6 +66,9 @@ jobs:
               fi
               if [[ "$HAS_EXECUTOR_LABEL" == "true" ]]; then
                 echo "should-build-executor=true" >> $GITHUB_OUTPUT
+              fi
+              if [[ "$HAS_METRICS_LABEL" == "true" ]]; then
+                echo "should-deploy-collector=true" >> $GITHUB_OUTPUT
               fi
             elif [[ "$ADDED_LABEL" == "run-e2e-tests-pr-deploy" ]]; then
               echo "should-test=true" >> $GITHUB_OUTPUT
@@ -85,6 +96,12 @@ jobs:
                 if [[ "$HAS_TEST_LABEL" == "true" ]]; then
                   echo "should-test=true" >> $GITHUB_OUTPUT
                 fi
+              fi
+            elif [[ "$ADDED_LABEL" == "deploy-pr-metrics" ]]; then
+              # Metrics-only path: PR env already deployed. Build a PR collector
+              # image and deploy just that satellite (TECH-6484).
+              if [[ "$HAS_DEPLOY_LABEL" == "true" ]]; then
+                echo "should-deploy-collector=true" >> $GITHUB_OUTPUT
               fi
             fi
           elif [[ "$ACTION" == "unlabeled" ]]; then
@@ -121,6 +138,9 @@ jobs:
               fi
               if [[ "$HAS_EXECUTOR_LABEL" == "true" ]]; then
                 echo "should-build-executor=true" >> $GITHUB_OUTPUT
+              fi
+              if [[ "$HAS_METRICS_LABEL" == "true" ]]; then
+                echo "should-deploy-collector=true" >> $GITHUB_OUTPUT
               fi
             fi
             # Run tests if both labels present (even without deploy)
@@ -217,6 +237,57 @@ jobs:
             type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
             type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:${{ matrix.image.cache_key }}
           cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:${{ matrix.image.cache_key }},mode=max
+
+  # Builds a PR-specific metrics-collector image when the deploy-pr-metrics
+  # label is present alongside deploy-pr-environment (TECH-6484). Pushed to the
+  # staging collector ECR with a collector-${sha_short} tag; never pushes
+  # collector-latest so concurrent staging deploys are unaffected.
+  build-collector-image:
+    needs: check-labels
+    if: needs.check-labels.outputs.should-deploy-collector == 'true'
+    runs-on: ubuntu-latest
+    environment: staging
+    env:
+      REGION: ${{ vars.TO_REGION }}
+      COLLECTOR_ECR_NAME: keeperhub-metrics-collector-staging
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.REGION }}
+
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Extract commit hash
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push collector image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: metrics-collector
+          push: true
+          provenance: false
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.COLLECTOR_ECR_NAME }}:collector-${{ steps.vars.outputs.sha_short }}
+          cache-from: |
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.COLLECTOR_ECR_NAME }}:cache
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.COLLECTOR_ECR_NAME }}:cache-pr
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.COLLECTOR_ECR_NAME }}:cache-pr,mode=max
 
   # Builds a PR-specific event-tracker image when the deploy-pr-events
   # label is present alongside deploy-pr-environment. Without it, the PR
@@ -361,7 +432,7 @@ jobs:
           cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.EXECUTOR_ECR_NAME }}:cache-pr,mode=max
 
   deploy:
-    needs: [check-labels, build-images, build-events-image, build-executor-image]
+    needs: [check-labels, build-images, build-events-image, build-executor-image, build-collector-image]
     # Cannot use the `success()` shorthand here because GHA evaluates it
     # as false whenever ANY needed job is skipped. build-events-image is
     # skipped on purpose for PRs without the deploy-pr-events label, so
@@ -374,7 +445,8 @@ jobs:
       needs.check-labels.outputs.should-deploy == 'true' &&
       needs.build-images.result == 'success' &&
       (needs.build-events-image.result == 'success' || needs.build-events-image.result == 'skipped') &&
-      (needs.build-executor-image.result == 'success' || needs.build-executor-image.result == 'skipped')
+      (needs.build-executor-image.result == 'success' || needs.build-executor-image.result == 'skipped') &&
+      (needs.build-collector-image.result == 'success' || needs.build-collector-image.result == 'skipped')
     runs-on: ubuntu-latest
     environment: staging
     env:
@@ -530,6 +602,10 @@ jobs:
           # / event triggers. The template prepends "executor-" itself, so we
           # set only the bare tag here (matches the {{IMAGE_TAG}} pattern).
           EXECUTOR_IMAGE_TAG: ${{ needs.check-labels.outputs.should-build-executor == 'true' && steps.vars.outputs.sha_short || 'latest' }}
+          # PR-specific collector image tag when deploy-pr-metrics was set
+          # (build-collector-image ran); else the collector-latest baseline.
+          # Bare tag; the template prepends "collector-". (TECH-6484)
+          COLLECTOR_IMAGE_TAG: ${{ needs.check-labels.outputs.should-deploy-collector == 'true' && steps.vars.outputs.sha_short || 'latest' }}
         run: |
           # Percent-encode DB_PASSWORD so base64 characters (+/=) don't break URL parsing
           # in the pod. Init containers previously encoded at runtime but that path was
@@ -542,6 +618,7 @@ jobs:
           envsubst < deploy/pr-environment/block-dispatcher.template.yaml > ${{ github.workspace }}/block-pr-${{ env.PR_NUMBER }}.yaml
           envsubst < deploy/pr-environment/event-tracker.template.yaml > ${{ github.workspace }}/event-pr-${{ env.PR_NUMBER }}.yaml
           envsubst < deploy/pr-environment/executor.template.yaml > ${{ github.workspace }}/executor-pr-${{ env.PR_NUMBER }}.yaml
+          envsubst < deploy/pr-environment/metrics-collector.template.yaml > ${{ github.workspace }}/metrics-pr-${{ env.PR_NUMBER }}.yaml
           envsubst < deploy/pr-environment/sandbox.template.yaml > ${{ github.workspace }}/sandbox-pr-${{ env.PR_NUMBER }}.yaml
 
       - name: Clean up stale Helm releases
@@ -563,6 +640,18 @@ jobs:
             techops-services/common \
             -f ${GITHUB_WORKSPACE}/values-pr-${PR_NUMBER}.yaml \
             --namespace "${NAMESPACE}" --timeout 10m0s --atomic --version 0.2.1
+
+      # Opt-in (deploy-pr-metrics label). Deploys the metrics-collector
+      # satellite against the PR DB so its /metrics can be curled directly
+      # (ServiceMonitors are off in PR envs). TECH-6484.
+      - name: Deploy metrics collector (PR, opt-in)
+        if: needs.check-labels.outputs.should-deploy-collector == 'true'
+        run: |
+          set -euo pipefail
+          helm upgrade --install metrics-pr-${PR_NUMBER} \
+            techops-services/common \
+            -f ${GITHUB_WORKSPACE}/metrics-pr-${PR_NUMBER}.yaml \
+            --namespace "${NAMESPACE}" --timeout 5m0s --atomic --version 0.2.1
 
       - name: Deploy satellite services (parallel)
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ COPY drizzle/ ./drizzle/
 COPY hooks/ ./hooks/
 COPY keeperhub-events/ ./keeperhub-events/
 COPY keeperhub-executor/ ./keeperhub-executor/
+COPY keeperhub-metrics-collector/ ./keeperhub-metrics-collector/
 COPY keeperhub-scheduler/ ./keeperhub-scheduler/
 COPY lib/ ./lib/
 COPY plugins/ ./plugins/
@@ -317,8 +318,10 @@ CMD ["node", "server.js"]
 # former /api/metrics/db scrape) off the request-serving pods. Executor-style:
 # reuses lib/metrics + lib/db verbatim via tsx. Copies the full root
 # node_modules (the imported lib code has transitive deps beyond the
-# collector's own package.json) plus the generated lib files the import graph
-# may touch.
+# collector's own package.json). The metrics import graph touches no
+# builder-generated file at runtime -- lib/db/schema only references the
+# generated lib/types/integration via `import type`, which tsx erases -- so
+# this stage depends on source only, not the (expensive) Next builder stage.
 # ==============================================================================
 FROM node:24-alpine AS metrics-collector
 WORKDIR /app
@@ -330,13 +333,6 @@ COPY --link --from=source /app/keeperhub-metrics-collector ./keeperhub-metrics-c
 COPY --link --from=source /app/lib ./lib
 COPY --link --from=source /app/package.json ./package.json
 COPY --link --from=source /app/tsconfig.json ./tsconfig.json
-
-# Auto-generated files from the builder stage (referenced across lib/)
-COPY --link --from=builder /app/lib/step-registry.ts ./lib/step-registry.ts
-COPY --link --from=builder /app/lib/credential-map.ts ./lib/credential-map.ts
-COPY --link --from=builder /app/lib/workflow/codegen/registry.ts ./lib/workflow/codegen/registry.ts
-COPY --link --from=builder /app/lib/output-display-configs.ts ./lib/output-display-configs.ts
-COPY --link --from=builder /app/lib/types/integration.ts ./lib/types/integration.ts
 
 # Shim server-only (runs outside Next.js)
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -310,3 +310,41 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 
 # Start the application
 CMD ["node", "server.js"]
+
+# ==============================================================================
+# Stage: metrics-collector (TECH-6484)
+# Single-replica service that serves the DB-sourced Prometheus gauges (the
+# former /api/metrics/db scrape) off the request-serving pods. Executor-style:
+# reuses lib/metrics + lib/db verbatim via tsx. Copies the full root
+# node_modules (the imported lib code has transitive deps beyond the
+# collector's own package.json) plus the generated lib files the import graph
+# may touch.
+# ==============================================================================
+FROM node:24-alpine AS metrics-collector
+WORKDIR /app
+RUN npm install -g pnpm@9 tsx@4
+COPY --link --from=deps /etc/ssl/certs/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
+
+COPY --link --from=deps /app/node_modules ./node_modules
+COPY --link --from=source /app/keeperhub-metrics-collector ./keeperhub-metrics-collector
+COPY --link --from=source /app/lib ./lib
+COPY --link --from=source /app/package.json ./package.json
+COPY --link --from=source /app/tsconfig.json ./tsconfig.json
+
+# Auto-generated files from the builder stage (referenced across lib/)
+COPY --link --from=builder /app/lib/step-registry.ts ./lib/step-registry.ts
+COPY --link --from=builder /app/lib/credential-map.ts ./lib/credential-map.ts
+COPY --link --from=builder /app/lib/workflow/codegen/registry.ts ./lib/workflow/codegen/registry.ts
+COPY --link --from=builder /app/lib/output-display-configs.ts ./lib/output-display-configs.ts
+COPY --link --from=builder /app/lib/types/integration.ts ./lib/types/integration.ts
+
+# Shim server-only (runs outside Next.js)
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+RUN find /app/node_modules -path "*server-only*/index.js" | while read -r f; do echo 'module.exports = {};' > "$f"; done
+
+ENV NODE_ENV=production
+
+EXPOSE 9090
+
+# Build with: docker build --target metrics-collector -t keeperhub-metrics-collector .
+CMD ["tsx", "keeperhub-metrics-collector/index.ts"]

--- a/app/api/metrics/db/route.ts
+++ b/app/api/metrics/db/route.ts
@@ -3,12 +3,22 @@
  *
  * Exposes only database-sourced gauge metrics. These are identical across pods,
  * so only one pod needs to be scraped for these metrics.
+ *
+ * TECH-6484: these gauges are now served by the dedicated
+ * keeperhub-metrics-collector service. When METRICS_DB_OFFLOADED is set, this
+ * route returns 404 so the heavy aggregate scan never runs on the
+ * request-serving pods (the app's db-metrics ServiceMonitor is removed too).
+ * The flag keeps the cutover reversible via config without a code revert.
  */
 
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 
 export async function GET(): Promise<NextResponse> {
+  if (process.env.METRICS_DB_OFFLOADED === "true") {
+    return new NextResponse("Not Found", { status: 404 });
+  }
+
   if (process.env.METRICS_COLLECTOR !== "prometheus") {
     return new NextResponse("Not Found", { status: 404 });
   }

--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -117,14 +117,9 @@ serviceMonitors:
       path: /api/metrics/api
       interval: 30s
       scrapeTimeout: 10s
-    - name: db-metrics
-      port: http
-      path: /api/metrics/db
-      interval: 30s
-      # 12s (not 10s): this endpoint blocks on the serialised db-metrics
-      # refresh, which is several seconds at prod scale. See KEEP-682 to
-      # measure refresh duration and revisit if it approaches this timeout.
-      scrapeTimeout: 12s
+    # db-metrics removed (TECH-6484): the DB-sourced gauges are now scraped from
+    # the dedicated keeperhub-metrics-collector single-replica service, not from
+    # the app pods. The app route is also gated off via METRICS_DB_OFFLOADED.
 
 resources:
   limits:
@@ -144,6 +139,11 @@ env:
   METRICS_COLLECTOR:
     type: kv
     value: "prometheus"
+  # TECH-6484: /api/metrics/db is served by keeperhub-metrics-collector now;
+  # gate the app route to 404 so the heavy scan never runs on these pods.
+  METRICS_DB_OFFLOADED:
+    type: kv
+    value: "true"
   RPC_PROBE_INTERVAL_MS:
     type: kv
     value: "30000"

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -117,14 +117,9 @@ serviceMonitors:
       path: /api/metrics/api
       interval: 30s
       scrapeTimeout: 10s
-    - name: db-metrics
-      port: http
-      path: /api/metrics/db
-      interval: 30s
-      # 12s (not 10s): this endpoint blocks on the serialised db-metrics
-      # refresh. Staging refresh is well under this, but kept in parity with
-      # prod to avoid config drift. See KEEP-682.
-      scrapeTimeout: 12s
+    # db-metrics removed (TECH-6484): the DB-sourced gauges are now scraped from
+    # the dedicated keeperhub-metrics-collector single-replica service, not from
+    # the app pods. The app route is also gated off via METRICS_DB_OFFLOADED.
 
 resources:
   limits:
@@ -145,6 +140,11 @@ env:
   METRICS_COLLECTOR:
     type: kv
     value: "prometheus"
+  # TECH-6484: /api/metrics/db is served by keeperhub-metrics-collector now;
+  # gate the app route to 404 so the heavy scan never runs on these pods.
+  METRICS_DB_OFFLOADED:
+    type: kv
+    value: "true"
   RPC_PROBE_INTERVAL_MS:
     type: kv
     value: "30000"

--- a/deploy/metrics-collector/prod/values.yaml
+++ b/deploy/metrics-collector/prod/values.yaml
@@ -1,0 +1,94 @@
+# Metrics Collector - Prod (TECH-6484)
+# Single-replica service that serves the DB-sourced Prometheus gauges (the
+# former /api/metrics/db scrape) off the request-serving pods. Because it is a
+# single replica with its own release labels, the ServiceMonitor below scrapes
+# the DB gauges deterministically from exactly one pod -- no hashmod, no
+# duplicate DB load from the app pods.
+
+replicaCount: 1
+
+service:
+  enabled: true
+  name: keeperhub-metrics-collector-prod
+  type: ClusterIP
+  port: 9090
+  containerPort: 9090
+  tls:
+    enabled: false
+
+ingress:
+  enabled: false
+
+image:
+  repository: ${ECR_REGISTRY}/keeperhub-metrics-collector-prod
+  tag: collector-${IMAGE_TAG}
+  pullPolicy: Always
+
+deployment:
+  enabled: true
+
+serviceAccount:
+  create: false
+  name: keeperhub-prod
+
+podAnnotations:
+  reloader.stakater.com/auto: "true"
+
+# Scrapes the DB-sourced gauges from this single pod. Named db-metrics so it
+# reads the same on dashboards as the app monitor it replaces.
+serviceMonitors:
+  enabled: true
+  monitors:
+    - name: db-metrics
+      port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+
+resources:
+  limits:
+    memory: 512Mi
+    cpu: 500m
+  requests:
+    cpu: 50m
+    memory: 256Mi
+
+command: ["/bin/sh"]
+args:
+  - "-c"
+  - |
+    echo "$(date) - [MetricsCollector] Starting..."
+    tsx keeperhub-metrics-collector/index.ts
+
+env:
+  DATABASE_URL:
+    type: parameterStore
+    name: db-url
+    parameter_name: /eks/techops-prod/keeperhub/db-url
+  PORT:
+    type: kv
+    value: "9090"
+  METRICS_COLLECTOR:
+    type: kv
+    value: "prometheus"
+  NODE_ENV:
+    type: kv
+    value: "production"
+
+externalSecrets:
+  clusterSecretStoreName: techops-prod
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 20
+  periodSeconds: 30
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 10
+  periodSeconds: 10

--- a/deploy/metrics-collector/prod/values.yaml
+++ b/deploy/metrics-collector/prod/values.yaml
@@ -53,12 +53,8 @@ resources:
     cpu: 50m
     memory: 256Mi
 
-command: ["/bin/sh"]
-args:
-  - "-c"
-  - |
-    echo "$(date) - [MetricsCollector] Starting..."
-    tsx keeperhub-metrics-collector/index.ts
+# Startup comes from the Dockerfile CMD (tsx keeperhub-metrics-collector/index.ts);
+# no helm command/args override -- single source of truth.
 
 env:
   DATABASE_URL:

--- a/deploy/metrics-collector/staging/values.yaml
+++ b/deploy/metrics-collector/staging/values.yaml
@@ -53,12 +53,8 @@ resources:
     cpu: 50m
     memory: 256Mi
 
-command: ["/bin/sh"]
-args:
-  - "-c"
-  - |
-    echo "$(date) - [MetricsCollector] Starting..."
-    tsx keeperhub-metrics-collector/index.ts
+# Startup comes from the Dockerfile CMD (tsx keeperhub-metrics-collector/index.ts);
+# no helm command/args override -- single source of truth.
 
 env:
   DATABASE_URL:

--- a/deploy/metrics-collector/staging/values.yaml
+++ b/deploy/metrics-collector/staging/values.yaml
@@ -1,0 +1,94 @@
+# Metrics Collector - Staging (TECH-6484)
+# Single-replica service that serves the DB-sourced Prometheus gauges (the
+# former /api/metrics/db scrape) off the request-serving pods. Because it is a
+# single replica with its own release labels, the ServiceMonitor below scrapes
+# the DB gauges deterministically from exactly one pod -- no hashmod, no
+# duplicate DB load from the app pods.
+
+replicaCount: 1
+
+service:
+  enabled: true
+  name: keeperhub-metrics-collector-staging
+  type: ClusterIP
+  port: 9090
+  containerPort: 9090
+  tls:
+    enabled: false
+
+ingress:
+  enabled: false
+
+image:
+  repository: ${ECR_REGISTRY}/keeperhub-metrics-collector-staging
+  tag: collector-${IMAGE_TAG}
+  pullPolicy: Always
+
+deployment:
+  enabled: true
+
+serviceAccount:
+  create: false
+  name: keeperhub-staging
+
+podAnnotations:
+  reloader.stakater.com/auto: "true"
+
+# Scrapes the DB-sourced gauges from this single pod. Named db-metrics so it
+# reads the same on dashboards as the app monitor it replaces.
+serviceMonitors:
+  enabled: true
+  monitors:
+    - name: db-metrics
+      port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+
+resources:
+  limits:
+    memory: 512Mi
+    cpu: 500m
+  requests:
+    cpu: 50m
+    memory: 256Mi
+
+command: ["/bin/sh"]
+args:
+  - "-c"
+  - |
+    echo "$(date) - [MetricsCollector] Starting..."
+    tsx keeperhub-metrics-collector/index.ts
+
+env:
+  DATABASE_URL:
+    type: parameterStore
+    name: db-url
+    parameter_name: /eks/techops-staging/keeperhub/db-url
+  PORT:
+    type: kv
+    value: "9090"
+  METRICS_COLLECTOR:
+    type: kv
+    value: "prometheus"
+  NODE_ENV:
+    type: kv
+    value: "staging"
+
+externalSecrets:
+  clusterSecretStoreName: techops-staging
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 20
+  periodSeconds: 30
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 10
+  periodSeconds: 10

--- a/deploy/pr-environment/metrics-collector.template.yaml
+++ b/deploy/pr-environment/metrics-collector.template.yaml
@@ -1,0 +1,83 @@
+# Metrics Collector for PR environments (TECH-6484)
+#
+# Serves the DB-sourced Prometheus gauges from the PR's database, off the app
+# pods. Opt-in via the deploy-pr-metrics label: CI builds a PR-specific image
+# (collector-${sha_short}) and renders this template with
+# COLLECTOR_IMAGE_TAG=${sha_short}. ServiceMonitors are disabled in PR envs, so
+# verify by curling /metrics on the pod directly.
+#
+# Variables substituted by envsubst at deploy time:
+#   ${PR_NUMBER}, ${ECR_REGISTRY}, ${COLLECTOR_IMAGE_TAG}, ${ENCODED_DB_PASSWORD}
+
+replicaCount: 1
+
+service:
+  enabled: true
+  name: keeperhub-metrics-collector-pr-${PR_NUMBER}
+  type: ClusterIP
+  port: 9090
+  containerPort: 9090
+  tls:
+    enabled: false
+
+ingress:
+  enabled: false
+
+image:
+  repository: ${ECR_REGISTRY}/keeperhub-metrics-collector-staging
+  tag: collector-${COLLECTOR_IMAGE_TAG}
+  pullPolicy: Always
+
+deployment:
+  enabled: true
+
+serviceAccount:
+  create: false
+  name: keeperhub-pr-${PR_NUMBER}
+
+podAnnotations:
+  reloader.stakater.com/auto: "true"
+
+serviceMonitors:
+  enabled: false
+
+resources:
+  limits:
+    memory: 512Mi
+    cpu: 300m
+  requests:
+    cpu: 50m
+    memory: 128Mi
+
+command: ["/bin/sh"]
+args:
+  - "-c"
+  - |
+    echo "$(date) - [MetricsCollector] Starting..."
+    tsx keeperhub-metrics-collector/index.ts
+
+env:
+  DATABASE_URL:
+    type: kv
+    value: "postgresql://keeperhub:${ENCODED_DB_PASSWORD}@keeperhub-pr-${PR_NUMBER}-db-rw.pr-${PR_NUMBER}.svc.cluster.local:5432/keeperhub"
+  PORT:
+    type: kv
+    value: "9090"
+  METRICS_COLLECTOR:
+    type: kv
+    value: "prometheus"
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 20
+  periodSeconds: 30
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 10
+  periodSeconds: 10

--- a/deploy/pr-environment/metrics-collector.template.yaml
+++ b/deploy/pr-environment/metrics-collector.template.yaml
@@ -49,12 +49,7 @@ resources:
     cpu: 50m
     memory: 128Mi
 
-command: ["/bin/sh"]
-args:
-  - "-c"
-  - |
-    echo "$(date) - [MetricsCollector] Starting..."
-    tsx keeperhub-metrics-collector/index.ts
+# Startup comes from the Dockerfile CMD; no helm command/args override.
 
 env:
   DATABASE_URL:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -26,6 +26,7 @@ variable "EVENTS_ECR_TRACKER_REPO" { default = "" }
 variable "SCHEDULER_ECR_REPO" { default = "" }
 variable "EXECUTOR_ECR_REPO" { default = "" }
 variable "SANDBOX_ECR_REPO" { default = "" }
+variable "METRICS_COLLECTOR_ECR_REPO" { default = "" }
 
 group "default" {
   targets = ["app", "migrator", "workflow-runner"]
@@ -43,8 +44,12 @@ group "sandbox" {
   targets = ["sandbox"]
 }
 
+group "metrics-collector" {
+  targets = ["metrics-collector"]
+}
+
 group "all" {
-  targets = ["app", "migrator", "workflow-runner", "event-tracker", "schedule-dispatcher", "block-dispatcher", "executor", "sandbox"]
+  targets = ["app", "migrator", "workflow-runner", "event-tracker", "schedule-dispatcher", "block-dispatcher", "executor", "sandbox", "metrics-collector"]
 }
 
 target "app" {
@@ -214,5 +219,21 @@ target "sandbox" {
   ])
   cache-from = ["type=registry,ref=${ECR_REGISTRY}/${SANDBOX_ECR_REPO}:cache"]
   cache-to   = ["type=registry,ref=${ECR_REGISTRY}/${SANDBOX_ECR_REPO}:cache,mode=max"]
+  attest     = []
+}
+
+# Metrics collector (TECH-6484). Context is repo root because the stage reuses
+# lib/ and the root node_modules. Tag prefix `collector-`.
+target "metrics-collector" {
+  context    = "."
+  dockerfile = "Dockerfile"
+  target     = "metrics-collector"
+  tags = compact([
+    "${ECR_REGISTRY}/${METRICS_COLLECTOR_ECR_REPO}:collector-${IMAGE_TAG}",
+    "${ECR_REGISTRY}/${METRICS_COLLECTOR_ECR_REPO}:collector-latest",
+    ENVIRONMENT_TAG != "" ? "${ECR_REGISTRY}/${METRICS_COLLECTOR_ECR_REPO}:${ENVIRONMENT_TAG}" : "",
+  ])
+  cache-from = ["type=registry,ref=${ECR_REGISTRY}/${METRICS_COLLECTOR_ECR_REPO}:cache"]
+  cache-to   = ["type=registry,ref=${ECR_REGISTRY}/${METRICS_COLLECTOR_ECR_REPO}:cache,mode=max"]
   attest     = []
 }

--- a/keeperhub-metrics-collector/import-check.ts
+++ b/keeperhub-metrics-collector/import-check.ts
@@ -1,0 +1,30 @@
+/**
+ * Import-graph smoke check for the metrics-collector image (TECH-6484).
+ *
+ * Run inside the built metrics-collector container by the collector-build-check
+ * CI job. It dynamically imports the collector's two entry modules; if a future
+ * change adds a runtime (value) import of a builder-generated module that the
+ * trimmed image does not copy, this fails here at PR time instead of on the
+ * post-merge staging deploy. (server.test.ts mocks the metrics module, so it
+ * does not exercise this real import path.)
+ */
+async function main(): Promise<void> {
+  const [api, dbMetrics] = await Promise.all([
+    import("../lib/metrics/prometheus-api"),
+    import("../lib/metrics/db-metrics"),
+  ]);
+
+  console.log(
+    `IMPORTS_OK prometheus-api=${Object.keys(api).length} db-metrics=${Object.keys(dbMetrics).length}`
+  );
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error("IMPORT_FAIL:", message);
+  process.exit(1);
+});
+
+// Marks this file as a module so `main` is module-scoped (avoids a global-scope
+// name collision with other script-style entrypoints under tsc's project view).
+export {};

--- a/keeperhub-metrics-collector/index.ts
+++ b/keeperhub-metrics-collector/index.ts
@@ -1,0 +1,34 @@
+/**
+ * keeperhub-metrics-collector
+ *
+ * Single-replica service that serves the DB-sourced Prometheus gauges that used
+ * to live on /api/metrics/db on the common app pods. It reuses the app's
+ * metrics code verbatim (updateDbMetrics refreshes the dbRegistry from Postgres,
+ * getDbMetrics serializes it), so the exposed gauge families are identical.
+ * Running it as its own single-replica deployment keeps the heavy aggregate
+ * scan off the request-serving pods and makes the scrape deterministic.
+ *
+ * Env:
+ *   PORT          HTTP port for /metrics and /health (default 9090)
+ *   DATABASE_URL  Postgres connection (consumed by lib/db)
+ */
+import type { Server } from "node:http";
+import { buildServer } from "./server";
+
+const PORT = Number.parseInt(process.env.PORT ?? "9090", 10) || 9090;
+
+const server: Server = buildServer();
+
+server.listen(PORT, () => {
+  console.log(
+    `[MetricsCollector] serving /metrics and /health on port ${PORT}`
+  );
+});
+
+function shutdown(signal: string): void {
+  console.log(`[MetricsCollector] received ${signal}, shutting down`);
+  server.close(() => process.exit(0));
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));

--- a/keeperhub-metrics-collector/package.json
+++ b/keeperhub-metrics-collector/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@keeperhub/metrics-collector",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Single-replica service that serves the DB-sourced Prometheus gauges (the former /api/metrics/db scrape) off the request-serving pods",
+  "scripts": {
+    "collector": "tsx keeperhub-metrics-collector/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "drizzle-orm": "^0.45.2",
+    "postgres": "^3.4.0",
+    "prom-client": "^15.1.3"
+  },
+  "devDependencies": {
+    "tsx": "^4.0.0"
+  }
+}

--- a/keeperhub-metrics-collector/server.test.ts
+++ b/keeperhub-metrics-collector/server.test.ts
@@ -1,0 +1,75 @@
+import type { AddressInfo, Server } from "node:net";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const updateDbMetrics = vi.fn();
+const getDbMetrics = vi.fn();
+const getPrometheusContentType = vi.fn();
+
+// Mock the app's metrics module so the HTTP wiring is tested without a DB.
+vi.mock("../lib/metrics/prometheus-api", () => ({
+  updateDbMetrics: () => updateDbMetrics(),
+  getDbMetrics: () => getDbMetrics(),
+  getPrometheusContentType: () => getPrometheusContentType(),
+}));
+
+const { buildServer } = await import("./server");
+
+describe("metrics-collector server (TECH-6484)", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    updateDbMetrics.mockReset().mockResolvedValue(undefined);
+    getDbMetrics.mockReset().mockResolvedValue("keeperhub_user_total 0\n");
+    getPrometheusContentType
+      .mockReset()
+      .mockReturnValue("text/plain; version=0.0.4; charset=utf-8");
+
+    server = buildServer();
+    await new Promise<void>((resolve) => {
+      server.listen(0, () => resolve());
+    });
+    const port = (server.address() as AddressInfo).port;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  it("GET /metrics refreshes then serves the DB registry", async () => {
+    const res = await fetch(`${baseUrl}/metrics`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/plain");
+    expect(await res.text()).toContain("keeperhub_user_total");
+    expect(updateDbMetrics).toHaveBeenCalledTimes(1);
+    expect(getDbMetrics).toHaveBeenCalledTimes(1);
+  });
+
+  it("GET /health returns ok without touching the DB", async () => {
+    const res = await fetch(`${baseUrl}/health`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; service: string };
+    expect(body.status).toBe("ok");
+    expect(body.service).toBe("keeperhub-metrics-collector");
+    expect(updateDbMetrics).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the refresh throws", async () => {
+    updateDbMetrics.mockRejectedValueOnce(new Error("db down"));
+
+    const res = await fetch(`${baseUrl}/metrics`);
+
+    expect(res.status).toBe(500);
+  });
+
+  it("404s unknown paths", async () => {
+    const res = await fetch(`${baseUrl}/nope`);
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/keeperhub-metrics-collector/server.ts
+++ b/keeperhub-metrics-collector/server.ts
@@ -1,0 +1,70 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+// server-only is a no-op under Node/tsx; this reuses the app's metrics code
+// verbatim so the exposed gauges are byte-for-byte identical to the former
+// /api/metrics/db endpoint.
+import {
+  getDbMetrics,
+  getPrometheusContentType,
+  updateDbMetrics,
+} from "../lib/metrics/prometheus-api";
+
+/**
+ * Build the metrics-collector HTTP server.
+ *
+ *   GET /metrics  refreshes the DB-sourced gauges (updateDbMetrics, which is
+ *                 TTL- and pool-gated in lib/) and serves the dbRegistry.
+ *   GET /health   liveness/readiness probe.
+ *
+ * Returned without listening so tests can bind an ephemeral port.
+ */
+export function buildServer(): Server {
+  return createServer((req: IncomingMessage, res: ServerResponse): void => {
+    if (req.method !== "GET") {
+      res.writeHead(405);
+      res.end();
+      return;
+    }
+
+    if (req.url === "/health") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          status: "ok",
+          service: "keeperhub-metrics-collector",
+          timestamp: new Date().toISOString(),
+        })
+      );
+      return;
+    }
+
+    if (req.url === "/metrics") {
+      // serveMetrics owns all its error handling and never rejects.
+      serveMetrics(res);
+      return;
+    }
+
+    res.writeHead(404);
+    res.end();
+  });
+}
+
+async function serveMetrics(res: ServerResponse): Promise<void> {
+  try {
+    await updateDbMetrics();
+    const metrics = await getDbMetrics();
+    res.writeHead(200, {
+      "Content-Type": getPrometheusContentType(),
+      "Cache-Control": "no-store, no-cache, must-revalidate",
+    });
+    res.end(metrics);
+  } catch (error) {
+    console.error("[MetricsCollector] Failed to serve metrics:", error);
+    res.writeHead(500);
+    res.end("Failed to collect metrics");
+  }
+}

--- a/lib/metrics/METRICS_REFERENCE.md
+++ b/lib/metrics/METRICS_REFERENCE.md
@@ -26,6 +26,8 @@ Metrics are collected from two sources depending on the collector type:
 
 > **Note:** Runtime code (executor, routes) also increments workflow metrics for console logging, but Prometheus relies solely on DB snapshots. This dual approach ensures complete data even when workflow runners exit before scrape.
 
+> **Note (TECH-6484):** The DB-sourced gauges are served by the dedicated single-replica `keeperhub-metrics-collector` service (`deploy/metrics-collector/`), not by the app pods. It reuses this module's `updateDbMetrics` / `getDbMetrics` and serves them on `/metrics`. Its ServiceMonitor scrapes the gauges deterministically from one pod. The app's `/api/metrics/db` route is gated off via `METRICS_DB_OFFLOADED` and its `db-metrics` ServiceMonitor removed, so the heavy aggregate scan no longer runs on the request-serving pods. `/api/metrics/api` (per-pod, in-memory) is unchanged.
+
 ---
 
 ## Architecture Context


### PR DESCRIPTION
Throwaway PR to validate the real metrics-collector pod + the deploy-pr-metrics PR-env wiring before #1442 merges. Combines #1439 (service+image) and #1442 (PR-env wiring). Will be closed + torn down after validation. Do not review/merge.