### PR TITLE
feat(mcp): anonymous /mcp/public marketplace endpoint

### DIFF
--- a/app/.well-known/mcp.json/route.ts
+++ b/app/.well-known/mcp.json/route.ts
@@ -1,5 +1,11 @@
-// Static MCP server card. Lets ERC-8004 indexers (e.g. 8004scan) discover
-// the tool catalog without performing an authenticated tools/list call.
+// Static MCP server card. Lets ERC-8004 indexers (e.g. 8004scan, thespawn)
+// discover the tool catalog. The advertised `endpoint` is the ANONYMOUS
+// /mcp/public marketplace surface, so a marketplace liveness probe can complete
+// an unauthenticated initialize + tools/list (and call listed workflows). The
+// authenticated, org-scoped surface is advertised separately under
+// `authenticatedEndpoint` (OAuth-gated /mcp).
+
+import { PUBLIC_TOOLS } from "@/lib/mcp/oauth-scopes";
 
 const TRAILING_SLASH = /\/$/;
 
@@ -61,17 +67,31 @@ export function GET(request: Request): Response {
     description:
       "Web3 workflow automation platform. Build and deploy on-chain automations through a visual builder. Workflows are callable by AI agents via MCP and x402 micropayments.",
     iconUrl: `${baseUrl}/keeperhub_logo.png`,
-    endpoint: `${baseUrl}/mcp`,
+    endpoint: `${baseUrl}/mcp/public`,
     transport: {
       type: "streamable-http",
-      endpoint: "/mcp",
+      endpoint: "/mcp/public",
     },
     capabilities: { tools: {} },
-    tools: TOOLS,
+    tools: [...PUBLIC_TOOLS],
     authentication: {
-      required: true,
-      type: "oauth2",
-      resource_metadata: `${baseUrl}/.well-known/oauth-protected-resource`,
+      required: false,
+    },
+    // Full org-scoped surface (manage your own workflows, integrations, wallet,
+    // executions). OAuth-gated; org clients connect here, not to the public
+    // endpoint above.
+    authenticatedEndpoint: {
+      endpoint: `${baseUrl}/mcp`,
+      transport: {
+        type: "streamable-http",
+        endpoint: "/mcp",
+      },
+      tools: TOOLS,
+      authentication: {
+        required: true,
+        type: "oauth2",
+        resource_metadata: `${baseUrl}/.well-known/oauth-protected-resource`,
+      },
     },
     erc8004: {
       agent_id: 31_875,

--- a/app/mcp/public/route.ts
+++ b/app/mcp/public/route.ts
@@ -1,0 +1,286 @@
+import "server-only";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { McpEventStore } from "@/lib/mcp/event-store";
+import { getInternalApiBaseUrl } from "@/lib/mcp/internal-url";
+import { logMcpEvent } from "@/lib/mcp/logging";
+import { SCOPE_MCP_PUBLIC } from "@/lib/mcp/oauth-scopes";
+import { checkIpRateLimit, getClientIp } from "@/lib/mcp/rate-limit";
+import { createMcpServer } from "@/lib/mcp/server";
+import { buildSessionErrorResponse } from "@/lib/mcp/session-error";
+import {
+  createSessionToken,
+  verifySessionTokenDetailed,
+} from "@/lib/mcp/session-token";
+import {
+  deleteSession,
+  getSession,
+  type SessionEntry,
+  setSession,
+  touchSession,
+} from "@/lib/mcp/sessions";
+
+export const dynamic = "force-dynamic";
+
+// Anonymous marketplace surface. Unauthenticated callers (x402 agents, ERC-8004
+// indexers, marketplace probers) can `initialize`, `tools/list`, and call the
+// PUBLIC_TOOLS allowlist -- which proxies endpoints that are already public
+// over HTTP. The authenticated org surface lives at /mcp and is never reachable
+// from here: this route never reads Authorization, pins a non-empty org
+// sentinel, and runs under the terminal `mcp:public` scope (registration is
+// filtered to public tools in createMcpServer).
+const ANON_ORG = "__anon_public__";
+const ANON_KEY = "anon";
+
+// Per-IP limits keyed on the real client IP (cf-connecting-ip). A `tools/call`
+// gets a stricter bucket than discovery so anonymous execution can't be used to
+// hammer the workflow executor; the underlying REST call route keeps its own
+// IP/quota/concurrency limits as defense in depth.
+const LIST_LIMIT = 60;
+const CALL_LIMIT = 10;
+const WINDOW_MS = 60_000;
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers":
+    "Content-Type, Mcp-Session-Id, Mcp-Protocol-Version",
+  "Access-Control-Expose-Headers": "Mcp-Session-Id",
+} as const;
+
+function jsonRpcError(
+  status: number,
+  code: number,
+  message: string,
+  extraHeaders: Record<string, string> = {}
+): Response {
+  return new Response(
+    JSON.stringify({ jsonrpc: "2.0", error: { code, message }, id: null }),
+    {
+      status,
+      headers: {
+        "Content-Type": "application/json",
+        ...CORS_HEADERS,
+        ...extraHeaders,
+      },
+    }
+  );
+}
+
+function isInitializeBody(body: unknown): boolean {
+  if (Array.isArray(body)) {
+    return body.length > 0 && body.every((item) => isInitializeRequest(item));
+  }
+  return isInitializeRequest(body);
+}
+
+function isToolCallBody(body: unknown): boolean {
+  const isCall = (item: unknown): boolean =>
+    !!item &&
+    typeof item === "object" &&
+    (item as Record<string, unknown>).method === "tools/call";
+  return Array.isArray(body) ? body.some(isCall) : isCall(body);
+}
+
+/**
+ * Mirror of the /mcp buildSession, hardcoded to the anonymous identity. The
+ * authHeader is ALWAYS the empty string, so even if a public tool handler hit
+ * an org-scoped internal endpoint it would carry no credentials and the inner
+ * route would reject it.
+ */
+function buildPublicSession(sessionId: string): {
+  transport: WebStandardStreamableHTTPServerTransport;
+  entry: SessionEntry;
+} {
+  const eventStore = new McpEventStore();
+  const internalApiBaseUrl = getInternalApiBaseUrl();
+
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: () => sessionId,
+    eventStore,
+    onsessioninitialized: (sid) => setSession(sid, entry),
+    onsessionclosed: (sid) => deleteSession(sid),
+    enableJsonResponse: true,
+  });
+
+  const server = createMcpServer(internalApiBaseUrl, "", SCOPE_MCP_PUBLIC);
+
+  const entry: SessionEntry = {
+    transport,
+    server,
+    eventStore,
+    organizationId: ANON_ORG,
+    apiKeyId: ANON_KEY,
+    scope: SCOPE_MCP_PUBLIC,
+    createdAt: Date.now(),
+    lastActivity: Date.now(),
+  };
+
+  return { transport, entry };
+}
+
+/** Patch the Accept header the MCP SDK requires (some clients omit SSE). */
+function ensureMcpAcceptHeader(request: Request): Request {
+  const accept = request.headers.get("accept") ?? "";
+  if (
+    accept.includes("application/json") &&
+    accept.includes("text/event-stream")
+  ) {
+    return request;
+  }
+  const headers = new Headers(request.headers);
+  headers.set("accept", "application/json, text/event-stream");
+  // Rebuild from url+method with NO body: the early body parse already consumed
+  // request.body, and the SDK transport gets the parsed value via parsedBody.
+  // Constructing `new Request(request, ...)` from a used Request would throw.
+  return new Request(request.url, { method: request.method, headers });
+}
+
+export function OPTIONS(): Response {
+  return new Response(null, { status: 204, headers: CORS_HEADERS });
+}
+
+// Some marketplace probers issue a GET before POSTing. Mirror the /mcp health
+// shape but advertise that this surface is anonymous (no OAuth required).
+export function GET(request: Request): Response {
+  if (request.headers.get("mcp-session-id")) {
+    // JSON-only transport: no server-initiated SSE stream to resume here.
+    return jsonRpcError(405, -32_601, "Method not allowed");
+  }
+  return new Response(
+    JSON.stringify({
+      name: "keeperhub",
+      version: "1.2.0",
+      protocol: "mcp",
+      status: "ok",
+      authentication: { required: false },
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+        ...CORS_HEADERS,
+      },
+    }
+  );
+}
+
+export async function POST(request: Request): Promise<Response> {
+  let body: unknown;
+  let bodyParsed = false;
+  try {
+    body = await request.json();
+    bodyParsed = true;
+  } catch {
+    // handled below
+  }
+
+  if (!bodyParsed) {
+    return jsonRpcError(400, -32_700, "Invalid JSON body");
+  }
+
+  // Per-IP rate limiting on the real client IP (never the org, which is the
+  // shared anon sentinel here).
+  const ip = getClientIp(request);
+  const listGate = checkIpRateLimit(`mcp-public:${ip}`, LIST_LIMIT, WINDOW_MS);
+  if (!listGate.allowed) {
+    return jsonRpcError(429, -32_029, "Rate limit exceeded", {
+      "Retry-After": String(listGate.retryAfter),
+    });
+  }
+  if (isToolCallBody(body)) {
+    const callGate = checkIpRateLimit(
+      `mcp-public-call:${ip}`,
+      CALL_LIMIT,
+      WINDOW_MS
+    );
+    if (!callGate.allowed) {
+      return jsonRpcError(429, -32_029, "Rate limit exceeded", {
+        "Retry-After": String(callGate.retryAfter),
+      });
+    }
+  }
+
+  const sessionId = request.headers.get("mcp-session-id");
+
+  if (sessionId) {
+    const resolved = await resolvePublicSession(sessionId);
+    if (!resolved.ok) {
+      return buildSessionErrorResponse(resolved.code, {
+        headers: CORS_HEADERS,
+      });
+    }
+    return resolved.transport.handleRequest(ensureMcpAcceptHeader(request), {
+      parsedBody: body,
+    });
+  }
+
+  if (!isInitializeBody(body)) {
+    return buildSessionErrorResponse("session_not_initialized", {
+      headers: CORS_HEADERS,
+    });
+  }
+
+  const newSessionId = await createSessionToken({
+    org: ANON_ORG,
+    key: ANON_KEY,
+    scope: SCOPE_MCP_PUBLIC,
+  });
+  const { transport, entry } = buildPublicSession(newSessionId);
+  await entry.server.connect(transport);
+  logMcpEvent("mcp.public.session.created", { ip });
+
+  return transport.handleRequest(ensureMcpAcceptHeader(request), {
+    parsedBody: body,
+  });
+}
+
+type ResolveResult =
+  | { ok: true; transport: WebStandardStreamableHTTPServerTransport }
+  | { ok: false; code: "session_not_found" | "session_expired" };
+
+async function resolvePublicSession(sessionId: string): Promise<ResolveResult> {
+  const cached = getSession(sessionId);
+  if (cached) {
+    // A session minted by the authenticated /mcp route can never be replayed
+    // here: it carries a real org and a non-public scope.
+    if (
+      cached.organizationId !== ANON_ORG ||
+      cached.scope !== SCOPE_MCP_PUBLIC
+    ) {
+      return { ok: false, code: "session_not_found" };
+    }
+    touchSession(sessionId);
+    return { ok: true, transport: cached.transport };
+  }
+
+  const result = await verifySessionTokenDetailed(sessionId);
+  if (!result.payload) {
+    const expiredBeyondRenewal =
+      "reason" in result &&
+      (result.reason === "too_old" ||
+        result.reason === "max_lifetime_exceeded");
+    return {
+      ok: false,
+      code: expiredBeyondRenewal ? "session_expired" : "session_not_found",
+    };
+  }
+  if (
+    result.payload.org !== ANON_ORG ||
+    result.payload.scope !== SCOPE_MCP_PUBLIC
+  ) {
+    return { ok: false, code: "session_not_found" };
+  }
+
+  const { transport, entry } = buildPublicSession(sessionId);
+  await entry.server.connect(transport);
+  const reconstructed = transport as unknown as {
+    _initialized: boolean;
+    sessionId: string;
+  };
+  reconstructed._initialized = true;
+  reconstructed.sessionId = sessionId;
+  setSession(sessionId, entry);
+  return { ok: true, transport };
+}

--- a/lib/mcp/oauth-scopes.ts
+++ b/lib/mcp/oauth-scopes.ts
@@ -10,6 +10,31 @@ export const SUPPORTED_SCOPES = [
 
 export type OAuthScope = (typeof SUPPORTED_SCOPES)[number];
 
+// Server-internal scope for the anonymous /mcp/public endpoint. It is NOT in
+// SUPPORTED_SCOPES on purpose: callers can never request it through the OAuth
+// authorize flow, so it can only ever be assigned by the server to an
+// unauthenticated marketplace caller. It grants EXACTLY the tools in
+// PUBLIC_TOOLS and nothing else.
+export const SCOPE_MCP_PUBLIC = "mcp:public";
+
+// The only tools an anonymous caller may list or invoke. Each one proxies an
+// endpoint that is already public over HTTP (no org/user scoping), so exposing
+// it over MCP reveals no new data. This is a hand-curated allowlist, NOT a
+// derivation from READ_TOOLS -- several read tools (validate_workflow,
+// prepare_test_pin_data, list_workflows, get_wallet_integration, ...) are
+// org-scoped and must never be anonymously reachable.
+export const PUBLIC_TOOLS = new Set<string>([
+  "search_workflows",
+  "get_workflow_listing",
+  "search_templates",
+  "list_action_schemas",
+  "search_plugins",
+  "search_protocol_actions",
+  "get_plugin",
+  "tools_documentation",
+  "call_workflow",
+]);
+
 const READ_TOOLS = new Set<string>([
   "list_workflows",
   "get_workflow",
@@ -61,6 +86,14 @@ export function parseScopes(scopeString: string): string[] {
 
 export function isToolAllowed(toolName: string, scopeString: string): boolean {
   const scopes = parseScopes(scopeString);
+
+  // Public scope is terminal and deny-by-default: it grants ONLY the public
+  // allowlist and never falls through to read/write/admin. Checked first so a
+  // (server-only) public token can never be widened, even if some future code
+  // path concatenated another scope onto it.
+  if (scopes.includes(SCOPE_MCP_PUBLIC)) {
+    return PUBLIC_TOOLS.has(toolName);
+  }
 
   if (scopes.includes(SCOPE_MCP_ADMIN)) {
     return true;

--- a/lib/mcp/rate-limit.ts
+++ b/lib/mcp/rate-limit.ts
@@ -70,6 +70,14 @@ export function checkIpRateLimit(
 }
 
 export function getClientIp(request: Request): string {
+  // Prefer `cf-connecting-ip`: Cloudflare sets it to the real client IP at the
+  // edge and overwrites any client-supplied value, so it cannot be spoofed to
+  // defeat per-IP rate limits. `x-forwarded-for`/`x-real-ip` are attacker-
+  // controllable and only used as a fallback for non-CF/local environments.
+  const cfIp = request.headers.get("cf-connecting-ip")?.trim();
+  if (cfIp) {
+    return cfIp;
+  }
   return (
     request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
     request.headers.get("x-real-ip") ??

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -2,7 +2,35 @@ import {
   McpServer,
   ResourceTemplate,
 } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { PUBLIC_TOOLS, SCOPE_MCP_PUBLIC } from "./oauth-scopes";
 import { registerMetaTools, registerTools } from "./tools";
+
+/**
+ * Wrap an McpServer so `registerTools`/`registerMetaTools` can only register
+ * tools that are in PUBLIC_TOOLS. `tools/list` reflects *registered* tools
+ * (scope only gates calls), so for the anonymous public surface we must drop
+ * non-public tools at registration time -- otherwise an anonymous list would
+ * leak the full org/write catalog. All other server methods pass through bound
+ * to the real instance (so the SDK's private class fields keep working).
+ */
+export function publicToolRegistrar(server: McpServer): McpServer {
+  return new Proxy(server, {
+    get(target, prop, receiver) {
+      if (prop === "tool") {
+        const register = target.tool.bind(target);
+        return (name: string, ...rest: unknown[]): unknown => {
+          if (!PUBLIC_TOOLS.has(name)) {
+            return;
+          }
+          // biome-ignore lint/suspicious/noExplicitAny: forwarding the SDK's overloaded tool() signature verbatim
+          return (register as (...a: any[]) => unknown)(name, ...rest);
+        };
+      }
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
 
 async function fetchJson(
   internalApiBaseUrl: string,
@@ -91,9 +119,17 @@ export function createMcpServer(
     version: "1.2.0",
   });
 
-  registerTools(server, internalApiBaseUrl, authHeader, scope);
-  registerMetaTools(server, internalApiBaseUrl, authHeader, scope);
-  registerResources(server, internalApiBaseUrl, authHeader);
+  const isPublic = scope === SCOPE_MCP_PUBLIC;
+  const registrar = isPublic ? publicToolRegistrar(server) : server;
+
+  registerTools(registrar, internalApiBaseUrl, authHeader, scope);
+  registerMetaTools(registrar, internalApiBaseUrl, authHeader, scope);
+
+  // Resources (keeperhub://workflows*) read org-scoped data, so they are never
+  // registered on the anonymous public surface.
+  if (!isPublic) {
+    registerResources(server, internalApiBaseUrl, authHeader);
+  }
 
   return server;
 }

--- a/tests/unit/mcp-public-route.test.ts
+++ b/tests/unit/mcp-public-route.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockCheckIpRateLimit,
+  mockGetSession,
+  mockCreateSessionToken,
+  mockVerifyDetailed,
+  mockHandleRequest,
+} = vi.hoisted(() => ({
+  mockCheckIpRateLimit: vi.fn(),
+  mockGetSession: vi.fn(),
+  mockCreateSessionToken: vi.fn(),
+  mockVerifyDetailed: vi.fn(),
+  mockHandleRequest: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/mcp/logging", () => ({ logMcpEvent: vi.fn() }));
+vi.mock("@/lib/mcp/internal-url", () => ({
+  getInternalApiBaseUrl: vi.fn(() => "http://internal"),
+}));
+vi.mock("@/lib/mcp/event-store", () => ({ McpEventStore: vi.fn() }));
+vi.mock("@/lib/mcp/rate-limit", () => ({
+  checkIpRateLimit: mockCheckIpRateLimit,
+  getClientIp: vi.fn(() => "1.2.3.4"),
+}));
+vi.mock("@/lib/mcp/server", () => ({
+  createMcpServer: vi.fn(() => ({
+    connect: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+vi.mock("@/lib/mcp/session-token", () => ({
+  createSessionToken: mockCreateSessionToken,
+  verifySessionTokenDetailed: mockVerifyDetailed,
+}));
+vi.mock("@/lib/mcp/sessions", () => ({
+  deleteSession: vi.fn(),
+  getSession: mockGetSession,
+  setSession: vi.fn(),
+  touchSession: vi.fn(),
+}));
+vi.mock(
+  "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js",
+  () => ({
+    // Regular (non-arrow) function so it can be invoked with `new`.
+    WebStandardStreamableHTTPServerTransport: vi.fn(function (this: {
+      handleRequest: typeof mockHandleRequest;
+    }) {
+      this.handleRequest = mockHandleRequest;
+    }),
+  })
+);
+
+import { POST } from "@/app/mcp/public/route";
+
+function makeRequest(headers: Record<string, string>, body: string): Request {
+  return new Request("http://localhost:3000/mcp/public", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body,
+  });
+}
+
+const INIT_BODY = JSON.stringify({
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "probe", version: "0" },
+  },
+});
+
+const TOOLS_LIST_BODY = JSON.stringify({
+  jsonrpc: "2.0",
+  id: 2,
+  method: "tools/list",
+});
+
+const TOOLS_CALL_BODY = JSON.stringify({
+  jsonrpc: "2.0",
+  id: 3,
+  method: "tools/call",
+  params: { name: "search_workflows", arguments: {} },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCheckIpRateLimit.mockReturnValue({ allowed: true });
+  mockHandleRequest.mockResolvedValue(new Response(null, { status: 200 }));
+});
+
+describe("/mcp/public — anonymous identity pinning (f)", () => {
+  it("mints a session JWT with the anon sentinel org and mcp:public scope", async () => {
+    mockCreateSessionToken.mockResolvedValue("anon-session-id");
+    const response = await POST(makeRequest({}, INIT_BODY));
+
+    expect(response.status).toBe(200);
+    expect(mockCreateSessionToken).toHaveBeenCalledWith({
+      org: "__anon_public__",
+      key: "anon",
+      scope: "mcp:public",
+    });
+  });
+});
+
+describe("/mcp/public — cross-surface session isolation (a)", () => {
+  it("rejects a cached org session (non-anon org / non-public scope)", async () => {
+    const handleRequest = vi.fn();
+    mockGetSession.mockReturnValue({
+      organizationId: "org-1",
+      scope: "mcp:read",
+      transport: { handleRequest },
+    });
+
+    const response = await POST(
+      makeRequest({ "mcp-session-id": "org-session" }, TOOLS_LIST_BODY)
+    );
+
+    expect(response.status).toBe(404);
+    const json = (await response.json()) as {
+      error: { code: number; data: { reason: string } };
+    };
+    expect(json.error.code).toBe(-32_001);
+    expect(json.error.data.reason).toBe("session_not_found");
+    // The org session's transport must never be invoked from the public route.
+    expect(handleRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects a JWT-reconstructed org session on the slow path", async () => {
+    mockGetSession.mockReturnValue(undefined);
+    mockVerifyDetailed.mockResolvedValue({
+      payload: {
+        org: "org-1",
+        key: "k",
+        scope: "mcp:read",
+        iat: 1,
+        exp: 9_999_999_999,
+      },
+      expired: false,
+    });
+
+    const response = await POST(
+      makeRequest({ "mcp-session-id": "org-jwt" }, TOOLS_LIST_BODY)
+    );
+
+    expect(response.status).toBe(404);
+    const json = (await response.json()) as {
+      error: { data: { reason: string } };
+    };
+    expect(json.error.data.reason).toBe("session_not_found");
+  });
+});
+
+describe("/mcp/public — per-IP rate limiting (c)", () => {
+  it("returns 429 with Retry-After when the list bucket is exhausted", async () => {
+    mockCheckIpRateLimit.mockReturnValue({ allowed: false, retryAfter: 30 });
+
+    const response = await POST(makeRequest({}, INIT_BODY));
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe("30");
+    const json = (await response.json()) as { error: { code: number } };
+    expect(json.error.code).toBe(-32_029);
+  });
+
+  it("consults the stricter call bucket only for tools/call bodies", async () => {
+    await POST(makeRequest({}, TOOLS_CALL_BODY));
+
+    const keys = mockCheckIpRateLimit.mock.calls.map((call) => call[0]);
+    const callBucket = mockCheckIpRateLimit.mock.calls.find((call) =>
+      String(call[0]).startsWith("mcp-public-call:")
+    );
+    expect(keys.some((k) => String(k).startsWith("mcp-public:"))).toBe(true);
+    expect(callBucket).toBeDefined();
+    expect(callBucket?.[1]).toBe(10);
+  });
+
+  it("does NOT consult the call bucket for a tools/list body", async () => {
+    // tools/list with no session falls through to session_not_initialized,
+    // but the call bucket must not have been consulted.
+    await POST(makeRequest({}, TOOLS_LIST_BODY));
+
+    const callBucket = mockCheckIpRateLimit.mock.calls.find((call) =>
+      String(call[0]).startsWith("mcp-public-call:")
+    );
+    expect(callBucket).toBeUndefined();
+  });
+});

--- a/tests/unit/mcp-public-scope.test.ts
+++ b/tests/unit/mcp-public-scope.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  isToolAllowed,
+  PUBLIC_TOOLS,
+  SCOPE_MCP_PUBLIC,
+} from "@/lib/mcp/oauth-scopes";
+
+// server.ts pulls in the MCP SDK + the full tool registry; stub them so we can
+// import the registration filter in isolation.
+vi.mock("@modelcontextprotocol/sdk/server/mcp.js", () => ({
+  McpServer: vi.fn(),
+  ResourceTemplate: vi.fn(),
+}));
+vi.mock("@/lib/mcp/tools", () => ({
+  registerTools: vi.fn(),
+  registerMetaTools: vi.fn(),
+}));
+
+import { publicToolRegistrar } from "@/lib/mcp/server";
+
+// Every tool that reads org/user data, mutates state, or executes onchain.
+// None of these may EVER be anonymously listable or callable.
+const FORBIDDEN_TOOLS = [
+  "list_workflows",
+  "get_workflow",
+  "list_integrations",
+  "get_wallet_integration",
+  "create_workflow",
+  "update_workflow",
+  "delete_workflow",
+  "execute_workflow",
+  "execute_transfer",
+  "execute_contract_call",
+  "execute_check_and_execute",
+  "execute_protocol_action",
+  "deploy_template",
+  "ai_generate_workflow",
+  "list_workflow",
+  "unlist_workflow",
+  "update_workflow_listing",
+  "validate_workflow",
+  "prepare_test_pin_data",
+  "get_execution",
+  "get_direct_execution_status",
+  "get_template",
+];
+
+describe("mcp:public scope — deny by default", () => {
+  it("grants exactly the PUBLIC_TOOLS allowlist", () => {
+    for (const tool of PUBLIC_TOOLS) {
+      expect(isToolAllowed(tool, SCOPE_MCP_PUBLIC)).toBe(true);
+    }
+  });
+
+  it("denies every org-scoped / write / execute tool", () => {
+    for (const tool of FORBIDDEN_TOOLS) {
+      expect(PUBLIC_TOOLS.has(tool)).toBe(false);
+      expect(isToolAllowed(tool, SCOPE_MCP_PUBLIC)).toBe(false);
+    }
+  });
+
+  it("excludes the org-scoped read traps that masquerade as read-only", () => {
+    expect(PUBLIC_TOOLS.has("validate_workflow")).toBe(false);
+    expect(PUBLIC_TOOLS.has("prepare_test_pin_data")).toBe(false);
+    expect(PUBLIC_TOOLS.has("list_integrations")).toBe(false);
+    expect(PUBLIC_TOOLS.has("get_wallet_integration")).toBe(false);
+  });
+
+  it("never escalates even if another scope is concatenated onto mcp:public", () => {
+    expect(isToolAllowed("delete_workflow", "mcp:public mcp:admin")).toBe(
+      false
+    );
+    expect(isToolAllowed("execute_transfer", "mcp:public mcp:write")).toBe(
+      false
+    );
+  });
+
+  it("denies unknown tools", () => {
+    expect(isToolAllowed("__does_not_exist__", SCOPE_MCP_PUBLIC)).toBe(false);
+  });
+});
+
+describe("publicToolRegistrar — no catalog leak in tools/list", () => {
+  it("forwards public tool registrations and drops every other tool", () => {
+    const tool = vi.fn();
+    const wrapped = publicToolRegistrar({
+      tool,
+    } as unknown as Parameters<typeof publicToolRegistrar>[0]);
+    // The SDK's tool() overloads are irrelevant to the registration filter;
+    // call through a permissive signature so the test exercises runtime names.
+    const register = wrapped.tool as unknown as (
+      name: string,
+      ...args: unknown[]
+    ) => void;
+
+    const noop = (): Record<string, never> => ({});
+    register("search_workflows", "desc", {}, {}, noop);
+    register("call_workflow", "desc", {}, {}, noop);
+    register("delete_workflow", "desc", {}, {}, noop);
+    register("execute_transfer", "desc", {}, {}, noop);
+    register("get_wallet_integration", "desc", {}, {}, noop);
+
+    const registered = tool.mock.calls.map((call) => call[0]);
+    expect(registered).toContain("search_workflows");
+    expect(registered).toContain("call_workflow");
+    expect(registered).not.toContain("delete_workflow");
+    expect(registered).not.toContain("execute_transfer");
+    expect(registered).not.toContain("get_wallet_integration");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a dedicated **anonymous** MCP endpoint `app/mcp/public/route.ts` so marketplace indexers (thespawn) can complete an unauthenticated `initialize` + `tools/list` (the liveness check they score as "callable") and call **listed** workflows over x402 — matching how top-rated agents (XPRTL S/93) expose an anonymous, per-call-priced MCP surface.
- **The OAuth-gated `/mcp` is byte-for-byte unchanged.** Org clients keep connecting there (via the hardcoded plugin URL) and keep their 401 OAuth trigger.
- The anonymous surface serves **only** a hand-curated `PUBLIC_TOOLS` allowlist (7 read tools that proxy already-public HTTP endpoints + `call_workflow`, which stays listed-only). Org/wallet/write/execute tools are neither listable nor callable anonymously.

## Why

thespawn flags KeeperHub "not a callable endpoint" because its liveness probe needs an anonymous `tools/list`, which `/mcp` refuses (401). Confirmed against the top agent (XPRTL anon `tools/list` → 200) and the second indexer 8004scan (reports "Healthy" — it only checks reachability). KeeperHub uniquely couldn't just make `/mcp` anonymous like XPRTL because `/mcp` also serves the private org surface locked down by the recent security work — hence a separate endpoint.

## Security model (post-SEV-1)

- **No `Authorization` ever threaded** on the anon path (`authHeader=""`); even a mis-wired tool would carry no credentials to internal APIs.
- **`mcp:public` is terminal deny-by-default** — never widens to read/write/admin; not in `SUPPORTED_SCOPES` so it can't be OAuth-requested.
- **Two layers** prevent catalog leak: `createMcpServer` registers only public tools under `mcp:public` (so `tools/list` can't list them), and `isToolAllowed` gates every call.
- **Excludes the org-scoped read traps** `validate_workflow` / `prepare_test_pin_data` (they look read-only but scope to the caller's org).
- **Session isolation**: an org session can't be replayed on `/mcp/public` and vice versa (org/scope checks both directions).
- **Per-IP rate limits** keyed on unspoofable `cf-connecting-ip`, stricter on `tools/call`.
- `call_workflow` reaches **only listed** workflows via the existing `/api/mcp/workflows/[slug]/call` guards (`isListed` + reachable; paid → 402).

A 4-agent review (correctness, regression, verification, adversarial exposure audit) ran on the diff. All data-exposure invariants verified; the one BLOCKER found (a non-SSE-`Accept` POST 500'd via a consumed-Request rebuild) is fixed, and the flagged route-level test gaps were added.

## Repro / verification (local dev)

- [x] anon `initialize` → 200, session pinned `org=__anon_public__`, `scope=mcp:public`
- [x] anon `tools/list` → 200, **exactly the 9 public tools**; `delete_workflow`/`execute_*`/`get_wallet_integration` absent
- [x] anon `call search_workflows` → 200, returns real marketplace data
- [x] anon `call delete_workflow` → "Tool not found"
- [x] non-SSE-`Accept` POST → 200 (blocker fix)
- [x] `GET /mcp/public` → 200 health
- [x] `/mcp` anon `tools/list` → **401** (unchanged)
- [x] `mcp.json` → `endpoint` = `/mcp/public`, 9 public tools, `authenticatedEndpoint` = `/mcp`

## Tests

- [x] `tests/unit/mcp-public-scope.test.ts` — deny-by-default for every org/write/execute tool + the registration no-leak filter
- [x] `tests/unit/mcp-public-route.test.ts` — cross-surface session isolation, per-IP rate-limit buckets, anon-identity pinning
- [x] `pnpm type-check` clean, `pnpm check` clean, existing MCP suite (84 tests) green

## Follow-ups (non-blocking)

- Per-workflow / per-owner **anonymous free-exec cap**: a free listed workflow can be called anonymously, billing the owner's execution quota; in-memory per-pod rate limits scale with attacker IP count. Recommend a per-(workflow) anon-call cap and a shared-store limiter.
- `data/agent-registry.json` `mcpTools` still lists the full 30-tool catalog under the MCP service; it now over-advertises vs the anonymous `/mcp/public` (9 tools). Cosmetic metadata; update on the next onchain card re-pin.