### PR TITLE
hotfix(agent): rotate advertised agent wallet to current address

### DIFF
--- a/app/api/agent-registry/route.ts
+++ b/app/api/agent-registry/route.ts
@@ -82,7 +82,7 @@ export async function GET(_request: Request): Promise<NextResponse> {
         { name: "ens", endpoint: "keeperhub.eth" },
         {
           name: "agentWallet",
-          endpoint: "eip155:1:0xc300b53616532fdb0116bce916c9307377362b51",
+          endpoint: "eip155:1:0xaa70faa583c0889164cfd9b45aa075f6c4388fee",
         },
       ],
       supportedTrust: ["reputation"],

--- a/data/agent-registry.json
+++ b/data/agent-registry.json
@@ -137,7 +137,7 @@
     { "name": "ens", "endpoint": "keeperhub.eth" },
     {
       "name": "agentWallet",
-      "endpoint": "eip155:1:0xc300b53616532fdb0116bce916c9307377362b51"
+      "endpoint": "eip155:1:0xaa70faa583c0889164cfd9b45aa075f6c4388fee"
     }
   ],
   "marketplace": {
@@ -146,8 +146,8 @@
     "platformFeePercent": 30,
     "creatorSharePercent": 70,
     "platformFeeRecipient": {
-      "base": "eip155:8453:0xc300b53616532fdb0116bce916c9307377362b51",
-      "tempo": "eip155:4217:0xc300b53616532fdb0116bce916c9307377362b51"
+      "base": "eip155:8453:0xaa70faa583c0889164cfd9b45aa075f6c4388fee",
+      "tempo": "eip155:4217:0xaa70faa583c0889164cfd9b45aa075f6c4388fee"
     }
   },
   "payment": {

--- a/docs/ai-tools/agentic-wallet.md
+++ b/docs/ai-tools/agentic-wallet.md
@@ -38,9 +38,9 @@ The wallet handles payment; the agent still needs a way to discover and call Kee
 
 With MCP + wallet both installed, ask your agent in plain language:
 
-> Use KeeperHub to check the ETH balance of `0xC300B53616532FDB0116bcE916c9307377362B51`.
+> Use KeeperHub to check the ETH balance of `0xAA70fAa583c0889164cFD9b45Aa075F6c4388Fee`.
 
-> Run the KeeperHub `mcp-test` workflow for `0xC300...`.
+> Run the KeeperHub `mcp-test` workflow for `0xAA70...`.
 
 The agent discovers available workflows at runtime through the KeeperHub meta-tools (`search_workflows` + `call_workflow`) and picks the best match. When a paid workflow returns a `402`, the wallet intercepts the challenge, signs through the server-side proxy (x402 on Base USDC or MPP on Tempo USDC.e), and the call retries transparently. Most KeeperHub paid workflows accept both protocols; today the wallet pays via x402 by default and uses MPP when the workflow is MPP-only. If the amount exceeds your `auto_approve_max_usd` the safety hook surfaces an inline permission prompt before any payment is authorised.
 

--- a/tests/unit/agent-registry-route.test.ts
+++ b/tests/unit/agent-registry-route.test.ts
@@ -108,7 +108,7 @@ describe("GET /api/agent-registry", () => {
       (s: { name: string; endpoint: string }) => s.name === "agentWallet"
     );
     expect(agentWalletService?.endpoint).toBe(
-      "eip155:1:0xc300b53616532fdb0116bce916c9307377362b51"
+      "eip155:1:0xaa70faa583c0889164cfd9b45aa075f6c4388fee"
     );
   });
 


### PR DESCRIPTION
## Summary

Rotates the advertised agent wallet from the deprecated `0xC300…362B51` to the current `0xAA70…8Fee` (the agent's onchain owner) across every place the repo advertises it:

- `data/agent-registry.json` — `agentWallet` service + `platformFeeRecipient` (base + tempo)
- `app/api/agent-registry/route.ts` — served `agentWallet`
- `tests/unit/agent-registry-route.test.ts` — expectation
- `docs/ai-tools/agentic-wallet.md` — example address (×2)

## Why

The old wallet is deprecated and should no longer be advertised. The public ERC-8004 card (and its onchain-pinned copy) plus the docs still pointed at it, so an agent reading `agentWallet` / `platformFeeRecipient` directly — or following the doc example — could route funds to a stale address.

**Active x402 payments are unaffected:** the `402 PAYMENT-REQUIRED` `payTo` is built per-workflow from `creatorWalletAddress` (`lib/payments/router.ts:109`, `payment-gate.ts:53`), not this address. The exposure was the advertised card/doc metadata only.

## Propagation (action required after merge)

The onchain ERC-8004 card is IPFS-pinned; this PR updates the **served** endpoints, but indexers (8004scan / thespawn) read the **pinned** card. To propagate, run the re-pin flow with the owner key:
- `scripts/pin-agent-card.ts` → new IPFS CID
- `scripts/update-agent-uri.ts` → `setAgentURI(31875, <new CID>)`

## Test plan

- [x] `agent-registry-route.test.ts` updated + passes (13/13)
- [x] `pnpm type-check` clean
- [x] No `0xC300…` remains anywhere in the repo