### PR TITLE
feat(executor): harden workflow-runner Job pods (dedicated SA, no token, non-root, secret refs)

### DIFF
--- a/.github/workflows/deploy-executor.yaml
+++ b/.github/workflows/deploy-executor.yaml
@@ -121,6 +121,11 @@ jobs:
         run: |
           kubectl create namespace ${{ env.NAMESPACE }} --dry-run=client -o yaml | kubectl apply -f -
 
+      - name: Apply workflow-runner ServiceAccount
+        if: steps.skip.outputs.skip_deploy != 'true'
+        run: |
+          kubectl apply -f deploy/executor/${{ env.ENVIRONMENT_TAG }}/runner-sa.yaml
+
       - name: Deploy executor
         if: steps.skip.outputs.skip_deploy != 'true'
         uses: bitovi/github-actions-deploy-eks-helm@v1.2.12

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -495,9 +495,21 @@ jobs:
           ) > "${LOGDIR}/sandbox-pre.log" 2>&1 &
           SANDBOX_PRE_PID=$!
 
-          # Wait for all four, print logs for failures
+          # Workflow-runner ServiceAccount - the executor sets this dedicated
+          # zero-RBAC SA (with no projected token) on the runner Job pods it
+          # builds in code. It must exist in the PR namespace before any
+          # workflow runs, otherwise runner pods fail to schedule (SA not
+          # found). Staging/prod create it via deploy-executor.yaml; the PR
+          # env never runs that workflow, so apply it here.
+          (
+            envsubst '$PR_NUMBER' < deploy/pr-environment/runner-sa.template.yaml | kubectl apply -f -
+            echo "Workflow-runner SA applied."
+          ) > "${LOGDIR}/runner-pre.log" 2>&1 &
+          RUNNER_PRE_PID=$!
+
+          # Wait for all five, print logs for failures
           FAILED=0
-          for COMPONENT in postgres:$PG_PID localstack:$LS_PID redis:$REDIS_PID sandbox-pre:$SANDBOX_PRE_PID; do
+          for COMPONENT in postgres:$PG_PID localstack:$LS_PID redis:$REDIS_PID sandbox-pre:$SANDBOX_PRE_PID runner-pre:$RUNNER_PRE_PID; do
             NAME="${COMPONENT%%:*}"
             PID="${COMPONENT##*:}"
             if wait "$PID"; then
@@ -543,6 +555,20 @@ jobs:
           envsubst < deploy/pr-environment/event-tracker.template.yaml > ${{ github.workspace }}/event-pr-${{ env.PR_NUMBER }}.yaml
           envsubst < deploy/pr-environment/executor.template.yaml > ${{ github.workspace }}/executor-pr-${{ env.PR_NUMBER }}.yaml
           envsubst < deploy/pr-environment/sandbox.template.yaml > ${{ github.workspace }}/sandbox-pr-${{ env.PR_NUMBER }}.yaml
+
+          # Provision the runner's DATABASE_URL as a Secret. The hardened runner
+          # reads DATABASE_URL via secretKeyRef (RUNNER_SECRET_PREFIX), but the
+          # PR env injects the executor's DATABASE_URL as a kv literal pointing
+          # at the ephemeral per-PR Postgres - so no chart-managed db-url Secret
+          # exists. Create one matching the chart's <release>-common-<slug>
+          # naming and the executor's exact connection string. The executor
+          # Helm release does not manage this name (DATABASE_URL is kv there),
+          # so there is no ownership conflict.
+          RUNNER_DB_URL="postgresql://keeperhub:${ENCODED_DB_PASSWORD}@keeperhub-pr-${{ env.PR_NUMBER }}-db-rw.pr-${{ env.PR_NUMBER }}.svc.cluster.local:5432/keeperhub"
+          kubectl create secret generic "executor-pr-${{ env.PR_NUMBER }}-common-db-url" \
+            -n "${NAMESPACE}" \
+            --from-literal="executor-pr-${{ env.PR_NUMBER }}-common-db-url=${RUNNER_DB_URL}" \
+            --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Clean up stale Helm releases
         run: |

--- a/deploy/executor/prod/runner-sa.yaml
+++ b/deploy/executor/prod/runner-sa.yaml
@@ -1,0 +1,35 @@
+# Dedicated ServiceAccount for workflow-runner Job pods (prod cluster).
+#
+# The runner Jobs are built in code by keeperhub-executor/k8s-job.ts and used
+# to be created under the namespace `default` ServiceAccount. They run
+# user-defined workflow steps, so the SA they use must carry no privileges.
+#
+# Why this is a raw manifest applied by deploy-executor.yaml:
+# The pods are not Helm-rendered (the executor submits the Job object via the
+# Kubernetes API), so this SA has to exist in the namespace independently. The
+# pod template sets serviceAccountName to this SA and automountServiceAccountToken
+# to false, so the projected token is never mounted into the runner container.
+#
+# Why no IRSA annotation:
+# An IRSA `eks.amazonaws.com/role-arn` annotation would re-inject an AWS STS
+# token that an escape could trade for temporary AWS credentials. The runner
+# reaches AWS only through explicit env-provided credentials, so it needs no
+# federated identity of its own.
+#
+# Why no RoleBindings anywhere:
+# No Role or RoleBinding targets this SA, so even if a token were somehow
+# projected it would grant zero Kubernetes API access. Grep this repo for
+# `keeperhub-workflow-runner` - nothing binds a role to it.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keeperhub-workflow-runner
+  namespace: keeperhub
+  labels:
+    app.kubernetes.io/name: keeperhub-workflow-runner
+    app.kubernetes.io/instance: keeperhub-workflow-runner
+    app.kubernetes.io/component: workflow-runner
+    app.kubernetes.io/part-of: keeperhub
+  # Intentionally no annotations. In particular: NO
+  # eks.amazonaws.com/role-arn.
+automountServiceAccountToken: false

--- a/deploy/executor/staging/runner-sa.yaml
+++ b/deploy/executor/staging/runner-sa.yaml
@@ -1,0 +1,35 @@
+# Dedicated ServiceAccount for workflow-runner Job pods (staging cluster).
+#
+# The runner Jobs are built in code by keeperhub-executor/k8s-job.ts and used
+# to be created under the namespace `default` ServiceAccount. They run
+# user-defined workflow steps, so the SA they use must carry no privileges.
+#
+# Why this is a raw manifest applied by deploy-executor.yaml:
+# The pods are not Helm-rendered (the executor submits the Job object via the
+# Kubernetes API), so this SA has to exist in the namespace independently. The
+# pod template sets serviceAccountName to this SA and automountServiceAccountToken
+# to false, so the projected token is never mounted into the runner container.
+#
+# Why no IRSA annotation:
+# An IRSA `eks.amazonaws.com/role-arn` annotation would re-inject an AWS STS
+# token that an escape could trade for temporary AWS credentials. The runner
+# reaches AWS only through explicit env-provided credentials, so it needs no
+# federated identity of its own.
+#
+# Why no RoleBindings anywhere:
+# No Role or RoleBinding targets this SA, so even if a token were somehow
+# projected it would grant zero Kubernetes API access. Grep this repo for
+# `keeperhub-workflow-runner` - nothing binds a role to it.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keeperhub-workflow-runner
+  namespace: keeperhub
+  labels:
+    app.kubernetes.io/name: keeperhub-workflow-runner
+    app.kubernetes.io/instance: keeperhub-workflow-runner
+    app.kubernetes.io/component: workflow-runner
+    app.kubernetes.io/part-of: keeperhub
+  # Intentionally no annotations. In particular: NO
+  # eks.amazonaws.com/role-arn.
+automountServiceAccountToken: false

--- a/deploy/pr-environment/executor.template.yaml
+++ b/deploy/pr-environment/executor.template.yaml
@@ -110,6 +110,17 @@ env:
   K8S_NAMESPACE:
     type: kv
     value: "pr-${PR_NUMBER}"
+  # Hardened runner Job pods use a dedicated zero-RBAC SA (created by
+  # deploy/pr-environment/runner-sa.template.yaml) and pull secrets via
+  # secretKeyRef. In the PR env the executor Helm release is
+  # executor-pr-${PR_NUMBER}, so its External Secrets land as
+  # executor-pr-${PR_NUMBER}-common-<slug>; point the runner there.
+  RUNNER_SERVICE_ACCOUNT:
+    type: kv
+    value: "keeperhub-workflow-runner"
+  RUNNER_SECRET_PREFIX:
+    type: kv
+    value: "executor-pr-${PR_NUMBER}-common"
   HEALTH_PORT:
     type: kv
     value: "3080"

--- a/deploy/pr-environment/runner-sa.template.yaml
+++ b/deploy/pr-environment/runner-sa.template.yaml
@@ -1,0 +1,24 @@
+# Dedicated ServiceAccount template for the per-PR workflow-runner Job pods.
+#
+# Variables substituted by envsubst at deploy time: ${PR_NUMBER}
+#
+# Mirrors deploy/executor/<env>/runner-sa.yaml for the PR namespace. The
+# executor builds runner Jobs in code (keeperhub-executor/k8s-job.ts) and sets
+# serviceAccountName to this SA with automountServiceAccountToken: false, so the
+# runner pod never carries a projected token. The runner makes no in-cluster
+# Kubernetes API calls; no Role or RoleBinding targets this SA, so it has zero
+# API permissions even if a token were somehow projected. No IRSA annotation,
+# so the runner has no federated AWS identity of its own.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keeperhub-workflow-runner
+  namespace: pr-${PR_NUMBER}
+  labels:
+    app.kubernetes.io/name: keeperhub-workflow-runner
+    app.kubernetes.io/instance: keeperhub-workflow-runner-pr-${PR_NUMBER}
+    app.kubernetes.io/component: workflow-runner
+    app.kubernetes.io/part-of: keeperhub
+  # Intentionally no annotations. In particular: NO
+  # eks.amazonaws.com/role-arn.
+automountServiceAccountToken: false

--- a/keeperhub-executor/config.ts
+++ b/keeperhub-executor/config.ts
@@ -16,6 +16,19 @@ export const CONFIG = {
   runnerImage: process.env.RUNNER_IMAGE || "keeperhub-runner:latest",
   imagePullPolicy: process.env.IMAGE_PULL_POLICY || "Never",
   namespace: process.env.K8S_NAMESPACE || "local",
+  // Dedicated, zero-RBAC ServiceAccount for runner Job pods. The runner makes
+  // no in-cluster Kubernetes API calls, so this SA has no Role/RoleBinding and
+  // its token is never mounted (see automountServiceAccountToken below). Falls
+  // back to "default" only for local clusters where the SA is not provisioned.
+  runnerServiceAccount:
+    process.env.RUNNER_SERVICE_ACCOUNT || "keeperhub-workflow-runner",
+  // Name prefix of the External Secrets-synced K8s Secrets that the runner
+  // Job pulls high-value credentials from via secretKeyRef (so they are never
+  // written as literal values into the Job manifest). The chart materializes
+  // one Secret per credential as `<prefix>-<slug>` with a single key of the
+  // same name; this prefix is the executor Helm release fullname.
+  runnerSecretPrefix:
+    process.env.RUNNER_SECRET_PREFIX || "keeperhub-executor-common",
   jobTtlSeconds: Number(process.env.JOB_TTL_SECONDS) || 3600,
   jobActiveDeadline: Number(process.env.JOB_ACTIVE_DEADLINE) || 300,
   maxConcurrentJobs: Number(process.env.MAX_CONCURRENT_JOBS) || 1,

--- a/keeperhub-executor/k8s-job.test.ts
+++ b/keeperhub-executor/k8s-job.test.ts
@@ -1,4 +1,4 @@
-import type { V1Job } from "@kubernetes/client-node";
+import type { V1EnvVar, V1Job } from "@kubernetes/client-node";
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
 let mockCreateNamespacedJob: Mock;
@@ -30,6 +30,8 @@ vi.mock("./config", () => ({
     chainRpcConfig: '{"eth":"http://localhost:8545"}',
     etherscanApiKey: "test-etherscan-key",
     namespace: "test-ns",
+    runnerServiceAccount: "keeperhub-workflow-runner",
+    runnerSecretPrefix: "keeperhub-executor-common",
     runnerImage: "runner:latest",
     imagePullPolicy: "Never",
     jobTtlSeconds: 3600,
@@ -54,18 +56,19 @@ function getSubmittedJob(): V1Job {
   return call.body as V1Job;
 }
 
-function getJobEnvVars(job: V1Job): Array<{ name: string; value: string }> {
-  return (job.spec?.template?.spec?.containers?.[0]?.env ?? []) as Array<{
-    name: string;
-    value: string;
-  }>;
+function getJobEnvVars(job: V1Job): V1EnvVar[] {
+  return job.spec?.template?.spec?.containers?.[0]?.env ?? [];
 }
 
-function getEnvVar(
-  envVars: Array<{ name: string; value: string }>,
-  name: string
-): string | undefined {
+function getEnvVar(envVars: V1EnvVar[], name: string): string | undefined {
   return envVars.find((v) => v.name === name)?.value;
+}
+
+function getSecretRef(
+  envVars: V1EnvVar[],
+  name: string
+): { name?: string; key?: string; optional?: boolean } | undefined {
+  return envVars.find((v) => v.name === name)?.valueFrom?.secretKeyRef;
 }
 
 describe("createWorkflowJob", () => {
@@ -77,10 +80,9 @@ describe("createWorkflowJob", () => {
     delete process.env.METRICS_INGEST_TOKEN;
   });
 
-  it("forwards metrics ingest env vars when set", async () => {
+  it("forwards non-secret metrics env vars as literals when set", async () => {
     process.env.METRICS_COLLECTOR = "prometheus";
     process.env.EXECUTOR_METRICS_INGEST_URL = "http://executor:3080";
-    process.env.METRICS_INGEST_TOKEN = "secret";
 
     await createWorkflowJob({
       workflowId: "wf-1",
@@ -94,10 +96,9 @@ describe("createWorkflowJob", () => {
     expect(getEnvVar(envVars, "EXECUTOR_METRICS_INGEST_URL")).toBe(
       "http://executor:3080"
     );
-    expect(getEnvVar(envVars, "METRICS_INGEST_TOKEN")).toBe("secret");
   });
 
-  it("omits metrics ingest env vars when unset", async () => {
+  it("omits non-secret metrics literals when unset", async () => {
     await createWorkflowJob({
       workflowId: "wf-1",
       executionId: "exec-1234abcd",
@@ -106,28 +107,14 @@ describe("createWorkflowJob", () => {
     });
 
     const envVars = getJobEnvVars(getSubmittedJob());
+    expect(envVars.find((v) => v.name === "METRICS_COLLECTOR")).toBeUndefined();
     expect(
       envVars.find((v) => v.name === "EXECUTOR_METRICS_INGEST_URL")
     ).toBeUndefined();
-    expect(
-      envVars.find((v) => v.name === "METRICS_INGEST_TOKEN")
-    ).toBeUndefined();
   });
 
-  it("includes ETHERSCAN_API_KEY when configured", async () => {
-    await createWorkflowJob({
-      workflowId: "wf-1",
-      executionId: "exec-1234abcd",
-      input: { triggerType: "schedule" },
-      triggerType: "schedule",
-    });
-
-    const envVars = getJobEnvVars(getSubmittedJob());
-    expect(getEnvVar(envVars, "ETHERSCAN_API_KEY")).toBe("test-etherscan-key");
-  });
-
-  it("omits ETHERSCAN_API_KEY when not configured", async () => {
-    (CONFIG as Record<string, unknown>).etherscanApiKey = "";
+  it("injects METRICS_INGEST_TOKEN as an optional secret ref, not a literal", async () => {
+    process.env.METRICS_INGEST_TOKEN = "should-not-be-relayed";
 
     await createWorkflowJob({
       workflowId: "wf-1",
@@ -137,10 +124,15 @@ describe("createWorkflowJob", () => {
     });
 
     const envVars = getJobEnvVars(getSubmittedJob());
-    expect(envVars.find((v) => v.name === "ETHERSCAN_API_KEY")).toBeUndefined();
+    expect(getEnvVar(envVars, "METRICS_INGEST_TOKEN")).toBeUndefined();
+    expect(getSecretRef(envVars, "METRICS_INGEST_TOKEN")).toEqual({
+      name: "keeperhub-executor-common-metrics-ingest-token",
+      key: "keeperhub-executor-common-metrics-ingest-token",
+      optional: true,
+    });
   });
 
-  it("includes system env vars from runner-env", async () => {
+  it("references ETHERSCAN_API_KEY as an optional secret ref", async () => {
     await createWorkflowJob({
       workflowId: "wf-1",
       executionId: "exec-1234abcd",
@@ -149,14 +141,30 @@ describe("createWorkflowJob", () => {
     });
 
     const envVars = getJobEnvVars(getSubmittedJob());
-    expect(getEnvVar(envVars, "OPENAI_API_KEY")).toBe("sk-test");
+    expect(getEnvVar(envVars, "ETHERSCAN_API_KEY")).toBeUndefined();
+    expect(getSecretRef(envVars, "ETHERSCAN_API_KEY")).toEqual({
+      name: "keeperhub-executor-common-etherscan-api-key",
+      key: "keeperhub-executor-common-etherscan-api-key",
+      optional: true,
+    });
+  });
+
+  it("forwards non-secret system env vars from runner-env as literals", async () => {
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: {},
+      triggerType: "schedule",
+    });
+
+    const envVars = getJobEnvVars(getSubmittedJob());
     expect(getEnvVar(envVars, "SLACK_API_KEY")).toBe("xoxb-test");
   });
 
-  it("deduplicates system vars against explicit vars", async () => {
+  it("never relays secret-valued system vars as plaintext", async () => {
     (getRunnerSystemEnvVars as Mock).mockReturnValue([
       { name: "DATABASE_URL", value: "should-be-ignored" },
-      { name: "OPENAI_API_KEY", value: "sk-test" },
+      { name: "OPENAI_API_KEY", value: "should-be-ignored" },
     ]);
 
     await createWorkflowJob({
@@ -169,15 +177,16 @@ describe("createWorkflowJob", () => {
     const envVars = getJobEnvVars(getSubmittedJob());
     const dbUrls = envVars.filter((v) => v.name === "DATABASE_URL");
     expect(dbUrls).toHaveLength(1);
-    expect(dbUrls[0].value).toBe("postgres://localhost/test");
+    expect(dbUrls[0].value).toBeUndefined();
+    expect(dbUrls[0].valueFrom?.secretKeyRef?.name).toBe(
+      "keeperhub-executor-common-db-url"
+    );
+    const openai = envVars.filter((v) => v.name === "OPENAI_API_KEY");
+    expect(openai).toHaveLength(1);
+    expect(openai[0].value).toBeUndefined();
   });
 
-  it("forwards Turnkey API env vars from runner-env into the Job spec", async () => {
-    (getRunnerSystemEnvVars as Mock).mockReturnValue([
-      { name: "TURNKEY_API_PUBLIC_KEY", value: "pub-test" },
-      { name: "TURNKEY_API_PRIVATE_KEY", value: "priv-test" },
-    ]);
-
+  it("references Turnkey API keys as optional secret refs", async () => {
     await createWorkflowJob({
       workflowId: "wf-1",
       executionId: "exec-1234abcd",
@@ -186,8 +195,17 @@ describe("createWorkflowJob", () => {
     });
 
     const envVars = getJobEnvVars(getSubmittedJob());
-    expect(getEnvVar(envVars, "TURNKEY_API_PUBLIC_KEY")).toBe("pub-test");
-    expect(getEnvVar(envVars, "TURNKEY_API_PRIVATE_KEY")).toBe("priv-test");
+    expect(getSecretRef(envVars, "TURNKEY_API_PUBLIC_KEY")).toEqual({
+      name: "keeperhub-executor-common-turnkey-api-public-key",
+      key: "keeperhub-executor-common-turnkey-api-public-key",
+      optional: true,
+    });
+    expect(getSecretRef(envVars, "TURNKEY_API_PRIVATE_KEY")).toEqual({
+      name: "keeperhub-executor-common-turnkey-api-private-key",
+      key: "keeperhub-executor-common-turnkey-api-private-key",
+      optional: true,
+    });
+    expect(getEnvVar(envVars, "TURNKEY_API_PRIVATE_KEY")).toBeUndefined();
   });
 
   it("includes SCHEDULE_ID for scheduled triggers", async () => {
@@ -215,7 +233,7 @@ describe("createWorkflowJob", () => {
     expect(envVars.find((v) => v.name === "SCHEDULE_ID")).toBeUndefined();
   });
 
-  it("includes all infrastructure env vars", async () => {
+  it("passes non-secret execution context as literal env vars", async () => {
     await createWorkflowJob({
       workflowId: "wf-1",
       executionId: "exec-1234abcd",
@@ -228,15 +246,35 @@ describe("createWorkflowJob", () => {
     expect(getEnvVar(envVars, "WORKFLOW_ID")).toBe("wf-1");
     expect(getEnvVar(envVars, "EXECUTION_ID")).toBe("exec-1234abcd");
     expect(getEnvVar(envVars, "WORKFLOW_INPUT")).toBe('{"test":true}');
-    expect(getEnvVar(envVars, "DATABASE_URL")).toBe(
-      "postgres://localhost/test"
-    );
-    expect(getEnvVar(envVars, "INTEGRATION_ENCRYPTION_KEY")).toBe(
-      "test-enc-key"
-    );
-    expect(getEnvVar(envVars, "CHAIN_RPC_CONFIG")).toBe(
-      '{"eth":"http://localhost:8545"}'
-    );
+  });
+
+  it("references core credentials as required (non-optional) secret refs", async () => {
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: {},
+      triggerType: "schedule",
+    });
+
+    const envVars = getJobEnvVars(getSubmittedJob());
+
+    // No plaintext for any of the high-value credentials.
+    expect(getEnvVar(envVars, "DATABASE_URL")).toBeUndefined();
+    expect(getEnvVar(envVars, "INTEGRATION_ENCRYPTION_KEY")).toBeUndefined();
+    expect(getEnvVar(envVars, "CHAIN_RPC_CONFIG")).toBeUndefined();
+
+    expect(getSecretRef(envVars, "DATABASE_URL")).toEqual({
+      name: "keeperhub-executor-common-db-url",
+      key: "keeperhub-executor-common-db-url",
+      optional: false,
+    });
+    expect(getSecretRef(envVars, "INTEGRATION_ENCRYPTION_KEY")).toEqual({
+      name: "keeperhub-executor-common-integration-encryption-key",
+      key: "keeperhub-executor-common-integration-encryption-key",
+      optional: false,
+    });
+    // CHAIN_RPC_CONFIG is plugin-specific, so it is optional.
+    expect(getSecretRef(envVars, "CHAIN_RPC_CONFIG")?.optional).toBe(true);
   });
 
   it("force-enables SAFE_FETCH_ENFORCE on runner pods even when unset on controller", async () => {
@@ -274,5 +312,71 @@ describe("createWorkflowJob", () => {
     expect(getEnvVar(envVars, "SAFE_FETCH_ENFORCE")).toBe("true");
     const occurrences = envVars.filter((v) => v.name === "SAFE_FETCH_ENFORCE");
     expect(occurrences).toHaveLength(1);
+  });
+
+  it("runs under the dedicated SA with no mounted token", async () => {
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: {},
+      triggerType: "schedule",
+    });
+
+    const podSpec = getSubmittedJob().spec?.template?.spec;
+    expect(podSpec?.serviceAccountName).toBe("keeperhub-workflow-runner");
+    expect(podSpec?.automountServiceAccountToken).toBe(false);
+  });
+
+  it("applies a non-root pod securityContext", async () => {
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: {},
+      triggerType: "schedule",
+    });
+
+    const podSecurityContext =
+      getSubmittedJob().spec?.template?.spec?.securityContext;
+    expect(podSecurityContext?.runAsNonRoot).toBe(true);
+    expect(podSecurityContext?.runAsUser).toBe(1000);
+    expect(podSecurityContext?.runAsGroup).toBe(1000);
+    expect(podSecurityContext?.fsGroup).toBe(1000);
+    expect(podSecurityContext?.seccompProfile?.type).toBe("RuntimeDefault");
+  });
+
+  it("locks down the runner container securityContext", async () => {
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: {},
+      triggerType: "schedule",
+    });
+
+    const container = getSubmittedJob().spec?.template?.spec?.containers?.[0];
+    expect(container?.securityContext?.allowPrivilegeEscalation).toBe(false);
+    expect(container?.securityContext?.readOnlyRootFilesystem).toBe(true);
+    expect(container?.securityContext?.capabilities?.drop).toEqual(["ALL"]);
+  });
+
+  it("mounts a writable /tmp emptyDir backing TMPDIR", async () => {
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: {},
+      triggerType: "schedule",
+    });
+
+    const job = getSubmittedJob();
+    const podSpec = job.spec?.template?.spec;
+    const tmpVolume = podSpec?.volumes?.find((v) => v.name === "tmp");
+    expect(tmpVolume?.emptyDir).toBeDefined();
+
+    const tmpMount = podSpec?.containers?.[0]?.volumeMounts?.find(
+      (m) => m.name === "tmp"
+    );
+    expect(tmpMount?.mountPath).toBe("/tmp");
+
+    const envVars = getJobEnvVars(job);
+    expect(getEnvVar(envVars, "TMPDIR")).toBe("/tmp");
   });
 });

--- a/keeperhub-executor/k8s-job.ts
+++ b/keeperhub-executor/k8s-job.ts
@@ -1,10 +1,67 @@
-import { BatchV1Api, KubeConfig, type V1Job } from "@kubernetes/client-node";
+import {
+  BatchV1Api,
+  KubeConfig,
+  type V1EnvVar,
+  type V1Job,
+} from "@kubernetes/client-node";
 import { CONFIG } from "./config";
 import { getRunnerSystemEnvVars } from "./runner-env";
 
 const kc = new KubeConfig();
 kc.loadFromDefault();
 const batchApi = kc.makeApiClient(BatchV1Api);
+
+// Non-root identity for runner pods. 1000/1000 is the "node" user/group that
+// ships in the node:alpine runner image, so the app files (world-readable)
+// stay accessible while the container never runs as root.
+const RUNNER_UID = 1000;
+const RUNNER_GID = 1000;
+
+// High-value credentials reach the runner via Kubernetes Secret references
+// instead of literal env values, so plaintext never lands in the Job manifest
+// (or etcd, or `kubectl get job -o yaml`). Each entry maps a runner env var to
+// the credential slug used by the executor's External Secrets-synced Secrets;
+// secret name == key == `${CONFIG.runnerSecretPrefix}-${slug}`. The slug is the
+// SSM parameter short-name from deploy/executor/<env>/values.yaml and is NOT
+// derivable from the env var (e.g. DATABASE_URL -> db-url), so it is listed
+// explicitly. Verified against techops-staging and techops-prod (2026-06-02).
+const SECRET_ENV_SLUGS: Record<string, string> = {
+  DATABASE_URL: "db-url",
+  INTEGRATION_ENCRYPTION_KEY: "integration-encryption-key",
+  CHAIN_RPC_CONFIG: "chain-rpc-config",
+  ETHERSCAN_API_KEY: "etherscan-api-key",
+  METRICS_INGEST_TOKEN: "metrics-ingest-token",
+  OPENAI_API_KEY: "openai-api-key",
+  PIMLICO_API_KEY: "pimlico-api-key",
+  PIMLICO_BASE_URL: "pimlico-base-url",
+  SENDGRID_API_KEY: "sendgrid-api-key",
+  SIMPLE_ACCOUNT_7702_ADDRESS: "simple-account-7702-address",
+  TURNKEY_API_PRIVATE_KEY: "turnkey-api-private-key",
+  TURNKEY_API_PUBLIC_KEY: "turnkey-api-public-key",
+};
+
+// Only these are mandatory for any workflow to run (asserted by
+// workflow-runner.ts at startup). The rest are plugin-specific, so their
+// Secret refs are marked optional: a runner whose workflow does not need a
+// given credential still starts if that Secret is absent.
+const REQUIRED_SECRET_ENV = new Set([
+  "DATABASE_URL",
+  "INTEGRATION_ENCRYPTION_KEY",
+]);
+
+function secretEnvRef(name: string): V1EnvVar {
+  const secretName = `${CONFIG.runnerSecretPrefix}-${SECRET_ENV_SLUGS[name]}`;
+  return {
+    name,
+    valueFrom: {
+      secretKeyRef: {
+        name: secretName,
+        key: secretName,
+        optional: !REQUIRED_SECRET_ENV.has(name),
+      },
+    },
+  };
+}
 
 // Semaphore to limit concurrent K8s Jobs
 let activeJobs = 0;
@@ -51,16 +108,14 @@ export async function createWorkflowJob(params: {
   // security.content_scanner_hit signals never reached the alert.
   const jobName = `keeperhub-workflow-${executionId.substring(0, 8)}-${Date.now()}`;
 
-  const envVars = [
+  const envVars: V1EnvVar[] = [
     { name: "WORKFLOW_ID", value: workflowId },
     { name: "EXECUTION_ID", value: executionId },
     { name: "WORKFLOW_INPUT", value: JSON.stringify(input) },
-    { name: "DATABASE_URL", value: CONFIG.databaseUrl },
-    {
-      name: "INTEGRATION_ENCRYPTION_KEY",
-      value: CONFIG.integrationEncryptionKey,
-    },
-    { name: "CHAIN_RPC_CONFIG", value: CONFIG.chainRpcConfig },
+    // With readOnlyRootFilesystem the only writable path is the /tmp emptyDir
+    // below. tsx/esbuild and any plugin temp writes resolve through TMPDIR, so
+    // point it there to keep the runner working under the hardened context.
+    { name: "TMPDIR", value: "/tmp" },
     // SSRF guard: force-enable on every workflow runner pod regardless
     // of controller env. Hardcoded (rather than forwarded via
     // RUNNER_SYSTEM_ENV_VARS) so the runner enforces even if the
@@ -68,9 +123,8 @@ export async function createWorkflowJob(params: {
     // Flipping back to shadow mode is a deliberate code change here,
     // which is the intended posture for SSRF protection.
     { name: "SAFE_FETCH_ENFORCE", value: "true" },
-    ...(CONFIG.etherscanApiKey
-      ? [{ name: "ETHERSCAN_API_KEY", value: CONFIG.etherscanApiKey }]
-      : []),
+    // High-value credentials as Secret references, never literal values.
+    ...Object.keys(SECRET_ENV_SLUGS).map(secretEnvRef),
     ...(process.env.METRICS_COLLECTOR
       ? [{ name: "METRICS_COLLECTOR", value: process.env.METRICS_COLLECTOR }]
       : []),
@@ -82,18 +136,15 @@ export async function createWorkflowJob(params: {
           },
         ]
       : []),
-    ...(process.env.METRICS_INGEST_TOKEN
-      ? [
-          {
-            name: "METRICS_INGEST_TOKEN",
-            value: process.env.METRICS_INGEST_TOKEN,
-          },
-        ]
-      : []),
   ];
 
   const explicitNames = new Set(envVars.map((v) => v.name));
   for (const systemVar of getRunnerSystemEnvVars()) {
+    // Secret-valued system vars are injected via secretKeyRef above; never
+    // relay them as plaintext through the controller's environment.
+    if (SECRET_ENV_SLUGS[systemVar.name]) {
+      continue;
+    }
     if (!explicitNames.has(systemVar.name)) {
       envVars.push(systemVar);
     }
@@ -141,18 +192,40 @@ export async function createWorkflowJob(params: {
         },
         spec: {
           restartPolicy: "Never",
+          // Dedicated zero-RBAC ServiceAccount and no projected token: the
+          // runner makes no in-cluster Kubernetes API calls, so it should not
+          // carry credentials that widen blast radius if a step is compromised.
+          serviceAccountName: CONFIG.runnerServiceAccount,
+          automountServiceAccountToken: false,
+          securityContext: {
+            runAsNonRoot: true,
+            runAsUser: RUNNER_UID,
+            runAsGroup: RUNNER_GID,
+            // Own the /tmp emptyDir as the runtime group so the non-root user
+            // can write to it under readOnlyRootFilesystem.
+            fsGroup: RUNNER_GID,
+            seccompProfile: { type: "RuntimeDefault" },
+          },
           containers: [
             {
               name: "runner",
               image: CONFIG.runnerImage,
               imagePullPolicy: CONFIG.imagePullPolicy,
               env: envVars,
+              securityContext: {
+                allowPrivilegeEscalation: false,
+                readOnlyRootFilesystem: true,
+                capabilities: { drop: ["ALL"] },
+              },
+              volumeMounts: [{ name: "tmp", mountPath: "/tmp" }],
               resources: {
                 requests: { memory: "160Mi", cpu: "200m" },
                 limits: { memory: "320Mi", cpu: "750m" },
               },
             },
           ],
+          // Sole writable path under readOnlyRootFilesystem; backs TMPDIR.
+          volumes: [{ name: "tmp", emptyDir: {} }],
         },
       },
     },


### PR DESCRIPTION
## Problem

Workflow-runner Job pods (spawned by the executor to run each workflow) ran with no isolation hardening, widening blast radius if a workflow step is compromised:

- `serviceAccountName: default` with the SA token mounted
- empty pod/container `securityContext` (root, gid=0, writable root fs, full caps)
- high-value secrets (DATABASE_URL with RDS password, INTEGRATION_ENCRYPTION_KEY, TURNKEY_API_PRIVATE_KEY, SENDGRID_API_KEY, METRICS_INGEST_TOKEN, ...) passed as **literal env values** in the Job manifest

## Fix

The Job spec is built in code (`keeperhub-executor/k8s-job.ts`):

- **Dedicated zero-RBAC ServiceAccount** `keeperhub-workflow-runner` (no Role/RoleBinding anywhere) with `automountServiceAccountToken: false`. Manifests under `deploy/executor/<env>/runner-sa.yaml`, applied by `deploy-executor.yaml`. Mirrors the existing sandbox SA pattern.
- **Pod securityContext**: `runAsNonRoot`, `runAsUser`/`runAsGroup` 1000, `fsGroup` 1000, `seccompProfile: RuntimeDefault`.
- **Container securityContext**: `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]`. A writable `/tmp` emptyDir + `TMPDIR=/tmp` keeps tsx/esbuild working under the read-only root.
- **All 12 high-value credentials** now reach the runner via `valueFrom.secretKeyRef` against the executor's External Secrets-synced Secrets, instead of literal values. Secret-valued vars are no longer relayed as plaintext through the controller env. `DATABASE_URL` and `INTEGRATION_ENCRYPTION_KEY` are required refs; the rest are optional so a workflow that does not need a given credential still starts.

## Testing

- `pnpm test:executor` - 52 passing (rewrote secret assertions, added SA/token/securityContext/secret-ref coverage)
- `pnpm type-check`, `pnpm check` - clean
- Secret naming verified against live techops-staging and techops-prod (`keeperhub-executor-common-<slug>`, name == key)
- PR-environment validation: dedicated wiring added so a freshly spawned `keeperhub-workflow-*` pod can be inspected for non-default SA, no mounted token, runAsNonRoot + dropped caps, secret-ref env, and successful workflow execution before merge.

## Done when

A freshly spawned `workflow-*` pod shows a non-default SA, no mounted SA token, runAsNonRoot + dropped capabilities, secret-ref env; workflows still execute.