### PR TITLE
fix: resolve client IP via CF-Connecting-IP on direct session writes

### DIFF
--- a/app/api/auth/oauth-mfa-finalize/route.ts
+++ b/app/api/auth/oauth-mfa-finalize/route.ts
@@ -14,6 +14,7 @@ import {
   readPendingOauthMfaCookie,
 } from "@/lib/oauth-mfa-cookie";
 import { sanitizeNextPath } from "@/lib/sanitize-next-path";
+import { resolveClientIpFromHeaders } from "@/lib/security/login-risk";
 
 /**
  * Finishes the deferred OAuth sign-in.
@@ -119,10 +120,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   const expiresAt = new Date(Date.now() + DEFAULT_SESSION_TTL_MS);
   const sessionId = `sess_${randomBytes(16).toString("base64url")}`;
   const userAgent = request.headers.get("user-agent") ?? null;
-  const ipAddress =
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-    request.headers.get("x-real-ip") ??
-    null;
+  const ipAddress = resolveClientIpFromHeaders(request.headers);
 
   try {
     await db.insert(sessions).values({

--- a/app/api/user/totp/enroll/route.ts
+++ b/app/api/user/totp/enroll/route.ts
@@ -18,7 +18,10 @@ import {
 import {
   buildPendingSignupClearCookie,
 } from "@/lib/pending-signup-cookie";
-import { recordTrustedIpFromRequest } from "@/lib/security/login-risk";
+import {
+  recordTrustedIpFromRequest,
+  resolveClientIpFromHeaders,
+} from "@/lib/security/login-risk";
 import { verifyUserTotp } from "@/lib/security/totp-verify";
 
 type RequestBody = {
@@ -77,7 +80,6 @@ function buildSessionSetCookie(
  *     cookie returned here is the FIRST usable session for the
  *     account.
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: two converging auth shapes
 export async function POST(request: Request): Promise<NextResponse> {
   const caller = await resolveEnrollMfaCaller(request.headers);
   if (caller.kind === "anonymous") {
@@ -219,10 +221,7 @@ export async function POST(request: Request): Promise<NextResponse> {
     const expiresAt = new Date(Date.now() + DEFAULT_SESSION_TTL_MS);
     const sessionId = `sess_${randomBytes(16).toString("base64url")}`;
     const userAgent = request.headers.get("user-agent") ?? null;
-    const ipAddress =
-      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-      request.headers.get("x-real-ip") ??
-      null;
+    const ipAddress = resolveClientIpFromHeaders(request.headers);
 
     // Single transaction across the three writes so a mid-flight
     // failure cannot leave the account in a "twoFactorEnabled = true

--- a/lib/security/login-risk.ts
+++ b/lib/security/login-risk.ts
@@ -420,31 +420,46 @@ export function logIpVerify(
   console.info(`[ip-verify] ${stage}`, fields);
 }
 
+/**
+ * Resolve the raw client IP from a set of request headers using the
+ * auth system's trust model. Behind the edge proxy (staging/prod) only
+ * CF-Connecting-IP is authoritative: it is set at the edge and cannot be
+ * forged by the caller, whereas X-Forwarded-For and X-Real-IP are
+ * caller-controlled and may be rewritten by intermediate hops, so they
+ * are not a reliable source of the client IP. Outside production we fall
+ * back to the first X-Forwarded-For hop and then X-Real-IP so VPN / NAT
+ * changes during local dev still exercise the new-IP gate. Returns null
+ * when no trusted source is present rather than an unreliable address, so
+ * callers persist an honest empty value instead of a misattributed one.
+ *
+ * Shared by resolveLoginIp (ambient headers) and the session-minting
+ * routes that write sessions.ip_address directly instead of through
+ * Better Auth's getIp, so every entrypoint resolves the client IP the
+ * same way.
+ */
+export function resolveClientIpFromHeaders(
+  header: Pick<Headers, "get">
+): string | null {
+  const cfConnectingIp = header.get("cf-connecting-ip");
+  if (cfConnectingIp) {
+    return cfConnectingIp;
+  }
+  if (process.env.NODE_ENV !== "production") {
+    const xffFirst = header.get("x-forwarded-for")?.split(",")[0]?.trim();
+    if (xffFirst) {
+      return xffFirst;
+    }
+    const xRealIp = header.get("x-real-ip");
+    if (xRealIp) {
+      return xRealIp;
+    }
+  }
+  return null;
+}
+
 async function resolveLoginIp(): Promise<string | null> {
   try {
-    const header = await headers();
-    const cfConnectingIp = header.get("cf-connecting-ip");
-    if (cfConnectingIp) {
-      return cfConnectingIp;
-    }
-    // Cloudflare is the trusted source in staging/prod. In other
-    // environments we fall back to the first X-Forwarded-For hop and
-    // then to X-Real-IP so VPN / NAT changes during local dev still
-    // exercise the new-IP gate. NODE_ENV-gated because in CF-fronted
-    // environments these headers are caller-controlled and must not
-    // be trusted.
-    if (process.env.NODE_ENV !== "production") {
-      const xff = header.get("x-forwarded-for");
-      const xffFirst = xff?.split(",")[0]?.trim();
-      if (xffFirst) {
-        return xffFirst;
-      }
-      const xRealIp = header.get("x-real-ip");
-      if (xRealIp) {
-        return xRealIp;
-      }
-    }
-    return null;
+    return resolveClientIpFromHeaders(await headers());
   } catch {
     return null;
   }

--- a/tests/unit/client-ip-resolution.test.ts
+++ b/tests/unit/client-ip-resolution.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveClientIpFromHeaders } from "@/lib/security/login-risk";
+
+function headersOf(values: Record<string, string>): Pick<Headers, "get"> {
+  const map = new Map<string, string>(
+    Object.entries(values).map(([k, v]) => [k.toLowerCase(), v])
+  );
+  return { get: (name: string) => map.get(name.toLowerCase()) ?? null };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("resolveClientIpFromHeaders in production", () => {
+  it("returns CF-Connecting-IP when present", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    expect(
+      resolveClientIpFromHeaders(
+        headersOf({ "cf-connecting-ip": "203.0.113.7" })
+      )
+    ).toBe("203.0.113.7");
+  });
+
+  it("prefers CF-Connecting-IP over a spoofable X-Forwarded-For", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    expect(
+      resolveClientIpFromHeaders(
+        headersOf({
+          "cf-connecting-ip": "203.0.113.7",
+          "x-forwarded-for": "10.1.2.3",
+        })
+      )
+    ).toBe("203.0.113.7");
+  });
+
+  it("ignores an internal node IP carried in X-Forwarded-For and returns null", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    expect(
+      resolveClientIpFromHeaders(headersOf({ "x-forwarded-for": "10.1.2.3" }))
+    ).toBeNull();
+  });
+
+  it("ignores X-Real-IP and returns null when CF-Connecting-IP is absent", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    expect(
+      resolveClientIpFromHeaders(headersOf({ "x-real-ip": "10.1.2.4" }))
+    ).toBeNull();
+  });
+
+  it("returns null when no header is present", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    expect(resolveClientIpFromHeaders(headersOf({}))).toBeNull();
+  });
+});
+
+describe("resolveClientIpFromHeaders outside production", () => {
+  it("still prefers CF-Connecting-IP", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    expect(
+      resolveClientIpFromHeaders(
+        headersOf({
+          "cf-connecting-ip": "203.0.113.7",
+          "x-forwarded-for": "198.51.100.4",
+        })
+      )
+    ).toBe("203.0.113.7");
+  });
+
+  it("falls back to the first X-Forwarded-For hop, trimmed", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    expect(
+      resolveClientIpFromHeaders(
+        headersOf({ "x-forwarded-for": " 198.51.100.4 , 10.0.0.1 " })
+      )
+    ).toBe("198.51.100.4");
+  });
+
+  it("falls back to X-Real-IP when X-Forwarded-For is absent", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    expect(
+      resolveClientIpFromHeaders(headersOf({ "x-real-ip": "198.51.100.4" }))
+    ).toBe("198.51.100.4");
+  });
+
+  it("returns null when no header is present", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    expect(resolveClientIpFromHeaders(headersOf({}))).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

A subset of `sessions.ip_address` rows store an unreliable internal address instead of the real client IP, which makes IP attribution on those sessions untrustworthy.

## Root cause

The OAuth-MFA finalize and TOTP enrollment routes mint sessions directly (not through Better Auth's session writer) and derived `ip_address` from the leftmost `X-Forwarded-For` hop. `X-Forwarded-For` is caller-controlled and can be rewritten by intermediate hops, so it is not a reliable source of the client IP. Better Auth's own session writes already resolve `CF-Connecting-IP`, but these two direct-insert routes bypassed that.

## Fix

- Extract the existing CF-aware IP logic in `lib/security/login-risk.ts` into an exported `resolveClientIpFromHeaders(headers)` helper. `resolveLoginIp` now delegates to it (behavior unchanged).
- Use the helper in both direct-insert routes. In production only `CF-Connecting-IP` is trusted (set at the edge, not forgeable by the caller); outside production `X-Forwarded-For` then `X-Real-IP` remain as local-dev fallbacks. Sessions now store the attested client IP or `null`, never an unreliable address.

## Tests

- New `tests/unit/client-ip-resolution.test.ts`: covers production (CF-only; a private IP in `X-Forwarded-For` resolves to `null`) and the non-prod fallbacks.
- `pnpm check`, `pnpm type-check`, and the full `pnpm test:unit` suite pass locally.

## Notes

- The underlying ingress behavior that lets an internal address reach `X-Forwarded-For` is tracked as a separate infra follow-up. This change stops it from polluting session IP attribution.