### PR TITLE
fix(security): make new-sign-in-location email and IP gate replica-safe

### DIFF
--- a/app/api/user/verify-ip/route.ts
+++ b/app/api/user/verify-ip/route.ts
@@ -391,9 +391,9 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 
-  // Same-pod cache invalidation so the next request on this pod sees the
-  // freshly-trusted IP without waiting for the UNTRUSTED_TTL_MS window in
-  // the proxy gate. Cross-pod stale entries age out on their own.
+  // Same-pod cache invalidation: evict any stale entry so the next request on
+  // this pod reflects the fresh upsert immediately. Untrusted is not cached,
+  // so other pods just re-read the DB and see the trust right away.
   clearTrustCacheEntry(decoded.payload.userId, decoded.payload.ip);
 
   const response = NextResponse.json({

--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -183,6 +183,18 @@ env:
     type: parameterStore
     name: mcp-session-secret
     parameter_name: /eks/techops-prod/keeperhub/mcp-session-secret
+  REDIS_HOST:
+    type: parameterStore
+    name: redis-host
+    parameter_name: /eks/techops-prod/keeperhub/redis-host
+  REDIS_PORT:
+    type: parameterStore
+    name: redis-port
+    parameter_name: /eks/techops-prod/keeperhub/redis-port
+  REDIS_PASSWORD:
+    type: parameterStore
+    name: redis-password
+    parameter_name: /eks/techops-prod/keeperhub/redis-password
   DISCORD_WEBHOOK_SIGNUPS:
     type: parameterStore
     name: discord-webhook-signups

--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -186,15 +186,18 @@ env:
   REDIS_HOST:
     type: parameterStore
     name: redis-host
-    parameter_name: /eks/techops-prod/keeperhub/redis-host
+    parameter_name: /eks/techops-prod/keeperhub-events/redis-host
   REDIS_PORT:
     type: parameterStore
     name: redis-port
-    parameter_name: /eks/techops-prod/keeperhub/redis-port
+    parameter_name: /eks/techops-prod/keeperhub-events/redis-port
   REDIS_PASSWORD:
     type: parameterStore
     name: redis-password
-    parameter_name: /eks/techops-prod/keeperhub/redis-password
+    parameter_name: /eks/techops-prod/keeperhub-events/redis-password
+  REDIS_KEY_PREFIX:
+    type: kv
+    value: "prod"
   DISCORD_WEBHOOK_SIGNUPS:
     type: parameterStore
     name: discord-webhook-signups

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -184,15 +184,18 @@ env:
   REDIS_HOST:
     type: parameterStore
     name: redis-host
-    parameter_name: /eks/techops-staging/keeperhub/redis-host
+    parameter_name: /eks/techops-staging/keeperhub-events/redis-host
   REDIS_PORT:
     type: parameterStore
     name: redis-port
-    parameter_name: /eks/techops-staging/keeperhub/redis-port
+    parameter_name: /eks/techops-staging/keeperhub-events/redis-port
   REDIS_PASSWORD:
     type: parameterStore
     name: redis-password
-    parameter_name: /eks/techops-staging/keeperhub/redis-password
+    parameter_name: /eks/techops-staging/keeperhub-events/redis-password
+  REDIS_KEY_PREFIX:
+    type: kv
+    value: "staging"
   # Auth and social providers (GitHub, Google)
   NEXT_PUBLIC_AUTH_PROVIDERS:
     type: kv

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -181,6 +181,18 @@ env:
     type: parameterStore
     name: mcp-session-secret
     parameter_name: /eks/techops-staging/keeperhub/mcp-session-secret
+  REDIS_HOST:
+    type: parameterStore
+    name: redis-host
+    parameter_name: /eks/techops-staging/keeperhub/redis-host
+  REDIS_PORT:
+    type: parameterStore
+    name: redis-port
+    parameter_name: /eks/techops-staging/keeperhub/redis-port
+  REDIS_PASSWORD:
+    type: parameterStore
+    name: redis-password
+    parameter_name: /eks/techops-staging/keeperhub/redis-password
   # Auth and social providers (GitHub, Google)
   NEXT_PUBLIC_AUTH_PROVIDERS:
     type: kv

--- a/deploy/pr-environment/values.template.yaml
+++ b/deploy/pr-environment/values.template.yaml
@@ -206,15 +206,18 @@ env:
   REDIS_HOST:
     type: parameterStore
     name: redis-host
-    parameter_name: /eks/techops-staging/keeperhub/redis-host
+    parameter_name: /eks/techops-staging/keeperhub-events/redis-host
   REDIS_PORT:
     type: parameterStore
     name: redis-port
-    parameter_name: /eks/techops-staging/keeperhub/redis-port
+    parameter_name: /eks/techops-staging/keeperhub-events/redis-port
   REDIS_PASSWORD:
     type: parameterStore
     name: redis-password
-    parameter_name: /eks/techops-staging/keeperhub/redis-password
+    parameter_name: /eks/techops-staging/keeperhub-events/redis-password
+  REDIS_KEY_PREFIX:
+    type: kv
+    value: "pr-${PR_NUMBER}"
   OPENAI_API_KEY:
     type: parameterStore
     name: openai-api-key

--- a/deploy/pr-environment/values.template.yaml
+++ b/deploy/pr-environment/values.template.yaml
@@ -203,6 +203,18 @@ env:
     type: parameterStore
     name: mcp-session-secret
     parameter_name: /eks/techops-staging/keeperhub/mcp-session-secret
+  REDIS_HOST:
+    type: parameterStore
+    name: redis-host
+    parameter_name: /eks/techops-staging/keeperhub/redis-host
+  REDIS_PORT:
+    type: parameterStore
+    name: redis-port
+    parameter_name: /eks/techops-staging/keeperhub/redis-port
+  REDIS_PASSWORD:
+    type: parameterStore
+    name: redis-password
+    parameter_name: /eks/techops-staging/keeperhub/redis-password
   OPENAI_API_KEY:
     type: parameterStore
     name: openai-api-key

--- a/lib/redis-keys.ts
+++ b/lib/redis-keys.ts
@@ -1,9 +1,19 @@
 /**
  * Central registry of Redis key builders. Keep key strings here, not inlined
- * at call sites, so namespaces don't drift.
+ * at call sites, so namespaces can't drift.
  */
+
+// Per-deployment namespace. staging and every PR env share one Redis instance,
+// so keys are prefixed to keep them isolated. Not NODE_ENV: staging and PR
+// envs are both "development". Set REDIS_KEY_PREFIX per deployment.
+const KEY_PREFIX = process.env.REDIS_KEY_PREFIX ?? "local";
+
+/** Joins `parts` into a Redis key under the per-deployment namespace. */
+export function deploymentKey(...parts: string[]): string {
+  return [KEY_PREFIX, ...parts].join(":");
+}
 
 /** `ip` must be the normalized /24-or-/64 trust key (matches user_trusted_ips). */
 export function newIpNotifyClaimKey(userId: string, ip: string): string {
-  return `ip-notify:${userId}:${ip}`;
+  return deploymentKey("ip-notify", userId, ip);
 }

--- a/lib/redis-keys.ts
+++ b/lib/redis-keys.ts
@@ -1,0 +1,9 @@
+/**
+ * Central registry of Redis key builders. Keep key strings here, not inlined
+ * at call sites, so namespaces don't drift.
+ */
+
+/** `ip` must be the normalized /24-or-/64 trust key (matches user_trusted_ips). */
+export function newIpNotifyClaimKey(userId: string, ip: string): string {
+  return `ip-notify:${userId}:${ip}`;
+}

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,0 +1,61 @@
+import { Redis } from "ioredis";
+
+/**
+ * Best-effort Redis for the app tier: a cross-replica coordination layer,
+ * never a source of truth. Callers must tolerate a null client and rejected
+ * commands. Returns null when REDIS_HOST is unset so local/self-hosted
+ * environments degrade to in-process behavior instead of erroring.
+ */
+
+const globalForRedis = globalThis as unknown as {
+  keeperhubRedis?: Redis | null;
+};
+
+const ERROR_LOG_INTERVAL_MS = 60_000;
+let lastErrorLoggedAt = 0;
+
+function logRedisError(err: Error): void {
+  const now = Date.now();
+  if (now - lastErrorLoggedAt < ERROR_LOG_INTERVAL_MS) {
+    return;
+  }
+  lastErrorLoggedAt = now;
+  console.warn("[redis] client error (best-effort, ignoring)", err.message);
+}
+
+function createClient(): Redis | null {
+  const {
+    REDIS_HOST: host,
+    REDIS_PORT: port,
+    REDIS_PASSWORD: password,
+  } = process.env;
+
+  if (!(host && password)) {
+    return null;
+  }
+
+  const client = new Redis({
+    host,
+    port: Number(port) || 6379,
+    password,
+    lazyConnect: true,
+    // Fail commands fast into the caller's fallback rather than stalling a
+    // request while Redis is unreachable.
+    enableOfflineQueue: false,
+    maxRetriesPerRequest: 1,
+    connectTimeout: 1000,
+    commandTimeout: 500,
+    retryStrategy: (times: number): number => Math.min(times * 500, 5000),
+  });
+
+  // An unhandled 'error' would crash the process; swallow and throttle.
+  client.on("error", logRedisError);
+  return client;
+}
+
+export function getRedis(): Redis | null {
+  if (globalForRedis.keeperhubRedis === undefined) {
+    globalForRedis.keeperhubRedis = createClient();
+  }
+  return globalForRedis.keeperhubRedis;
+}

--- a/lib/security/login-risk.ts
+++ b/lib/security/login-risk.ts
@@ -469,19 +469,16 @@ export type RequestIpGate =
  * lookup. The cache collapses those to one DB hit per (user, ip) per
  * TTL window.
  *
- * Trusted results get a long TTL because the trust list rarely changes
- * for an active user. Untrusted gets a short TTL so that once the user
- * completes /verify-ip the next request picks up the new trust quickly
- * without requiring cross-pod invalidation; same-pod invalidation is
- * driven explicitly from /api/user/verify-ip via clearTrustCacheEntry.
- * `no_ip` is rare and stable (only fires when CF-Connecting-IP is
- * missing) so it gets the long TTL too.
+ * Only `trusted` is cached. Untrusted is deliberately not: a per-pod
+ * untrusted entry outlived the moment another replica trusted the IP via
+ * /verify-ip, re-bouncing the user. Re-reading the DB (the shared source of
+ * truth) on every untrusted request keeps replicas consistent; untrusted is
+ * rare and short-lived, so the extra lookups are negligible.
  */
 type CachedTrust = { result: RequestIpGate; expiresAt: number };
 const TRUST_CACHE = new Map<string, CachedTrust>();
 const TRUST_CACHE_LIMIT = 10_000;
 const TRUSTED_TTL_MS = 300_000;
-const UNTRUSTED_TTL_MS = 30_000;
 
 function trustCacheKey(userId: string, ip: string): string {
   return `${userId}:${ip}`;
@@ -502,10 +499,8 @@ function rememberTrust(key: string, entry: CachedTrust): void {
 
 /**
  * Drop the cached gate result for this (user, ip). Called by
- * /api/user/verify-ip after a successful upsert so the next request on
- * the same pod sees the freshly-trusted IP without waiting for the
- * untrusted TTL to expire. Cross-pod stale entries age out on their own
- * within UNTRUSTED_TTL_MS.
+ * /api/user/verify-ip after a successful upsert. Now only evicts a stale
+ * `trusted` entry; untrusted is no longer cached.
  */
 export function clearTrustCacheEntry(userId: string, ip: string): void {
   TRUST_CACHE.delete(trustCacheKey(userId, ip));
@@ -555,8 +550,9 @@ export async function gateRequestIp(userId: string): Promise<RequestIpGate> {
   } catch {
     country = null;
   }
+  // Not cached -- see TRUST_CACHE doc; a stale untrusted entry re-bounced
+  // already-verified users on multi-replica deployments.
   const result: RequestIpGate = { kind: "untrusted", ip, country };
-  rememberTrust(key, { result, expiresAt: now + UNTRUSTED_TTL_MS });
   logIpVerify("gate-untrusted", {
     userId,
     rawIp,

--- a/lib/security/new-ip-notification.ts
+++ b/lib/security/new-ip-notification.ts
@@ -1,0 +1,91 @@
+import { sendNewIpAttemptEmail } from "@/lib/email";
+import { getRedis } from "@/lib/redis";
+import { newIpNotifyClaimKey } from "@/lib/redis-keys";
+import { describeUserAgentLabel } from "@/lib/security/device-label";
+import { logIpVerify } from "@/lib/security/login-risk";
+
+/**
+ * Dedup + delivery for the courtesy email the IP gate sends the first time an
+ * authenticated request reaches us from a network not in user_trusted_ips.
+ * Redis is the sole dedup: `SET NX` is atomic, so even the ~20-request
+ * fan-out of a single page load yields exactly one send across the fleet.
+ * Fire-and-forget; never blocks the gate.
+ */
+
+// Suppress re-sends for a week; the /verify-ip redirect is independent of this.
+export const NEW_IP_NOTIFY_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+/**
+ * True when this process should send for (userId, ip): the Redis `SET NX`
+ * won, so this is the first claim on the network within the TTL. Returns
+ * false when another caller already claimed it, when no Redis is configured,
+ * or on a Redis error -- with no dedup authority we skip the courtesy email
+ * rather than risk one per request. The /verify-ip gate is unaffected either
+ * way, so security never depends on this send.
+ */
+export async function claimNewIpNotification(
+  userId: string,
+  ip: string
+): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) {
+    return false;
+  }
+  try {
+    const result = await redis.set(
+      newIpNotifyClaimKey(userId, ip),
+      "1",
+      "EX",
+      NEW_IP_NOTIFY_TTL_SECONDS,
+      "NX"
+    );
+    return result === "OK";
+  } catch (err) {
+    logIpVerify("notify-claim-error", {
+      userId,
+      error: err instanceof Error ? err.message : "unknown",
+    });
+    return false;
+  }
+}
+
+export type NewIpNotification = {
+  userId: string;
+  email: string;
+  ip: string;
+  country: string | null;
+  userAgent: string | null;
+};
+
+async function deliver(notification: NewIpNotification): Promise<void> {
+  const { userId, email, ip, country, userAgent } = notification;
+  try {
+    if (!(await claimNewIpNotification(userId, ip))) {
+      return;
+    }
+    await sendNewIpAttemptEmail({
+      email,
+      ip,
+      country,
+      device: describeUserAgentLabel(userAgent),
+      when: new Date(),
+    });
+  } catch {
+    // best-effort; underlying failures are logged in the helpers
+  }
+}
+
+/**
+ * Notify the account owner about a new sign-in network, deduped fleet-wide by
+ * the Redis claim in deliver(). Non-blocking; the gate must never wait on
+ * Redis or SendGrid.
+ */
+export function maybeNotifyNewIp(notification: NewIpNotification): void {
+  const { userId, ip } = notification;
+  if (!(userId && ip)) {
+    return;
+  }
+  deliver(notification).catch(() => {
+    // deliver() already swallows; this is the floating-promise boundary
+  });
+}

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "drizzle-orm": "^0.45.2",
     "ethers": "^6.16.0",
     "import-in-the-middle": "^2.0.6",
+    "ioredis": "5.4.2",
     "jose": "^6.2.2",
     "jotai": "^2.19.0",
     "lucide-react": "^0.577.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,7 +117,7 @@ importers:
         version: 2.8.14
       '@turnkey/ethers':
         specifier: ^1.3.27
-        version: 1.3.28(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        version: 1.3.28(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(ioredis@5.4.2)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@turnkey/sdk-server':
         specifier: ^5.2.0
         version: 5.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
@@ -172,6 +172,9 @@ importers:
       import-in-the-middle:
         specifier: ^2.0.6
         version: 2.0.6
+      ioredis:
+        specifier: 5.4.2
+        version: 5.4.2
       jose:
         specifier: ^6.2.2
         version: 6.2.2
@@ -1726,6 +1729,9 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@ioredis/commands@1.10.0':
+    resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
 
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
@@ -5732,6 +5738,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   cmdk@1.1.1:
     resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
     peerDependencies:
@@ -6835,6 +6845,10 @@ packages:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
 
+  ioredis@5.4.2:
+    resolution: {integrity: sha512-0SZXGNGZ+WzISQ67QDyZ2x0+wVxjjUndtD8oSeik/4ajifeiRufed8fCb8QW8VMyi4MXcS+UO1k/0NGhvq1PAg==}
+    engines: {node: '>=12.22.0'}
+
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
@@ -7237,6 +7251,12 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -8148,6 +8168,14 @@ packages:
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   reduce-flatten@2.0.0:
     resolution: {integrity: sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==}
     engines: {node: '>=6'}
@@ -8467,6 +8495,9 @@ packages:
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
@@ -10787,6 +10818,8 @@ snapshots:
   '@inquirer/type@4.0.4(@types/node@24.12.2)':
     optionalDependencies:
       '@types/node': 24.12.2
+
+  '@ioredis/commands@1.10.0': {}
 
   '@isaacs/cliui@9.0.0': {}
 
@@ -13828,7 +13861,7 @@ snapshots:
       '@turnkey/encoding': 0.6.0
       sha256-uint8array: 0.10.7
 
-  '@turnkey/core@1.14.1(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@turnkey/core@1.14.1(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(ioredis@5.4.2)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@turnkey/api-key-stamper': 0.6.5
       '@turnkey/crypto': 2.8.14
@@ -13838,8 +13871,8 @@ snapshots:
       '@turnkey/webauthn-stamper': 0.6.0
       '@wallet-standard/app': 1.1.0
       '@wallet-standard/base': 1.1.0
-      '@walletconnect/sign-client': 2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@walletconnect/types': 2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))
+      '@walletconnect/sign-client': 2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(ioredis@5.4.2)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/types': 2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(ioredis@5.4.2)
       cross-fetch: 3.2.0
       ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       jwt-decode: 4.0.0
@@ -13886,10 +13919,10 @@ snapshots:
       bs58: 6.0.0
       bs58check: 4.0.0
 
-  '@turnkey/ethers@1.3.28(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@turnkey/ethers@1.3.28(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(ioredis@5.4.2)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@turnkey/api-key-stamper': 0.6.5
-      '@turnkey/core': 1.14.1(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@turnkey/core': 1.14.1(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(ioredis@5.4.2)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@turnkey/http': 3.18.1
       '@turnkey/sdk-browser': 5.16.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@turnkey/sdk-server': 5.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
@@ -14266,21 +14299,21 @@ snapshots:
 
   '@wallet-standard/base@1.1.0': {}
 
-  '@walletconnect/core@2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/core@2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(ioredis@5.4.2)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      '@walletconnect/keyvaluestorage': 1.1.1(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))
+      '@walletconnect/keyvaluestorage': 1.1.1(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(ioredis@5.4.2)
       '@walletconnect/logger': 3.0.2
       '@walletconnect/relay-api': 1.0.11
       '@walletconnect/relay-auth': 1.1.0
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))
-      '@walletconnect/utils': 2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(typescript@5.9.3)(zod@4.3.6)
+      '@walletconnect/types': 2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(ioredis@5.4.2)
+      '@walletconnect/utils': 2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(ioredis@5.4.2)(typescript@5.9.3)(zod@4.3.6)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.44.0
       events: 3.3.0
@@ -14352,11 +14385,11 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@walletconnect/keyvaluestorage@1.1.1(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))':
+  '@walletconnect/keyvaluestorage@1.1.1(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(ioredis@5.4.2)':
     dependencies:
       '@walletconnect/safe-json': 1.0.2
       idb-keyval: 6.2.2
-      unstorage: 1.17.4(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(idb-keyval@6.2.2)
+      unstorage: 1.17.4(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(idb-keyval@6.2.2)(ioredis@5.4.2)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -14398,16 +14431,16 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/sign-client@2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/sign-client@2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(ioredis@5.4.2)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
-      '@walletconnect/core': 2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/core': 2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(ioredis@5.4.2)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 3.0.2
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))
-      '@walletconnect/utils': 2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(typescript@5.9.3)(zod@4.3.6)
+      '@walletconnect/types': 2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(ioredis@5.4.2)
+      '@walletconnect/utils': 2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(ioredis@5.4.2)(typescript@5.9.3)(zod@4.3.6)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -14438,12 +14471,12 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/types@2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))':
+  '@walletconnect/types@2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(ioredis@5.4.2)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/keyvaluestorage': 1.1.1(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))
+      '@walletconnect/keyvaluestorage': 1.1.1(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(ioredis@5.4.2)
       '@walletconnect/logger': 3.0.2
       events: 3.3.0
     transitivePeerDependencies:
@@ -14467,7 +14500,7 @@ snapshots:
       - ioredis
       - uploadthing
 
-  '@walletconnect/utils@2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(typescript@5.9.3)(zod@4.3.6)':
+  '@walletconnect/utils@2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(ioredis@5.4.2)(typescript@5.9.3)(zod@4.3.6)':
     dependencies:
       '@msgpack/msgpack': 3.1.3
       '@noble/ciphers': 1.3.0
@@ -14475,13 +14508,13 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))
+      '@walletconnect/keyvaluestorage': 1.1.1(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(ioredis@5.4.2)
       '@walletconnect/logger': 3.0.2
       '@walletconnect/relay-api': 1.0.11
       '@walletconnect/relay-auth': 1.1.0
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))
+      '@walletconnect/types': 2.23.8(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(ioredis@5.4.2)
       '@walletconnect/window-getters': 1.0.1
       '@walletconnect/window-metadata': 1.0.1
       blakejs: 1.2.1
@@ -15683,6 +15716,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
@@ -15964,8 +15999,7 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  denque@2.1.0:
-    optional: true
+  denque@2.1.0: {}
 
   depd@2.0.0: {}
 
@@ -16862,6 +16896,20 @@ snapshots:
 
   interpret@3.1.1: {}
 
+  ioredis@5.4.2:
+    dependencies:
+      '@ioredis/commands': 1.10.0
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3(supports-color@8.1.1)
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
@@ -17200,6 +17248,10 @@ snapshots:
       p-locate: 6.0.0
 
   lodash.camelcase@4.3.0: {}
+
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   lodash@4.18.1: {}
 
@@ -18129,6 +18181,12 @@ snapshots:
       - '@types/react'
       - redux
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   reduce-flatten@2.0.0: {}
 
   redux-thunk@3.1.0(redux@5.0.1):
@@ -18555,6 +18613,8 @@ snapshots:
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
+
+  standard-as-callback@2.1.0: {}
 
   standardwebhooks@1.0.0:
     dependencies:
@@ -18995,7 +19055,7 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  unstorage@1.17.4(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(idb-keyval@6.2.2):
+  unstorage@1.17.4(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(idb-keyval@6.2.2)(ioredis@5.4.2):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -19008,6 +19068,7 @@ snapshots:
     optionalDependencies:
       '@vercel/functions': 3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13)
       idb-keyval: 6.2.2
+      ioredis: 5.4.2
 
   untyped@2.0.0:
     dependencies:

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,12 +1,11 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
-import { sendNewIpAttemptEmail } from "@/lib/email";
-import { describeUserAgentLabel } from "@/lib/security/device-label";
-import { gateRequestIp } from "@/lib/security/login-risk";
 import {
   buildPendingIpSetCookie,
   encodePendingIpCookie,
 } from "@/lib/pending-ip-cookie";
+import { gateRequestIp } from "@/lib/security/login-risk";
+import { maybeNotifyNewIp } from "@/lib/security/new-ip-notification";
 import {
   hasSessionCookie,
   isTrustedOrigin,
@@ -298,28 +297,6 @@ async function mfaBlock(request: NextRequest): Promise<MfaResult> {
 // IP gate
 // ---------------------------------------------------------------------------
 
-/**
- * Per-pod dedup of (userId, ip) pairs we've already alerted on. Prevents
- * a single new network from generating one email per page navigation
- * while the user is mid-verification. Same shape and eviction approach
- * as the trust caches in lib/security/login-risk.ts.
- */
-const NEW_IP_NOTIFIED: Set<string> = new Set();
-const NEW_IP_NOTIFIED_LIMIT = 10_000;
-
-function rememberNotified(key: string): void {
-  if (NEW_IP_NOTIFIED.size >= NEW_IP_NOTIFIED_LIMIT) {
-    const retained = Array.from(NEW_IP_NOTIFIED).slice(
-      -Math.floor(NEW_IP_NOTIFIED_LIMIT / 2)
-    );
-    NEW_IP_NOTIFIED.clear();
-    for (const k of retained) {
-      NEW_IP_NOTIFIED.add(k);
-    }
-  }
-  NEW_IP_NOTIFIED.add(key);
-}
-
 async function ipGateBlock(
   request: NextRequest,
   user: GatedUser
@@ -345,22 +322,13 @@ async function ipGateBlock(
     return null;
   }
 
-  const notifyKey = `${user.id}:${gate.ip}`;
-  if (!NEW_IP_NOTIFIED.has(notifyKey)) {
-    rememberNotified(notifyKey);
-    const userAgent = request.headers.get("user-agent");
-    // Fire-and-forget. SendGrid failures are already logged inside
-    // sendNewIpAttemptEmail and must not block the gate response.
-    sendNewIpAttemptEmail({
-      email: user.email,
-      ip: gate.ip,
-      country: gate.country,
-      device: describeUserAgentLabel(userAgent),
-      when: new Date(),
-    }).catch(() => {
-      // Already logged inside the email helper; swallow at the boundary.
-    });
-  }
+  maybeNotifyNewIp({
+    userId: user.id,
+    email: user.email,
+    ip: gate.ip,
+    country: gate.country,
+    userAgent: request.headers.get("user-agent"),
+  });
 
   const apiPath = request.nextUrl.pathname.startsWith("/api/");
   if (apiPath) {

--- a/tests/unit/new-ip-notification.test.ts
+++ b/tests/unit/new-ip-notification.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetRedis, mockSendEmail } = vi.hoisted(() => ({
+  mockGetRedis: vi.fn(),
+  mockSendEmail: vi.fn(),
+}));
+
+vi.mock("@/lib/redis", () => ({ getRedis: mockGetRedis }));
+vi.mock("@/lib/email", () => ({ sendNewIpAttemptEmail: mockSendEmail }));
+vi.mock("@/lib/security/device-label", () => ({
+  describeUserAgentLabel: (ua: string | null) => ua ?? "Unknown device",
+}));
+// Mock only the logger we depend on so the test doesn't pull the DB client
+// (and the rest of login-risk) into the unit env.
+vi.mock("@/lib/security/login-risk", () => ({ logIpVerify: vi.fn() }));
+
+import { newIpNotifyClaimKey } from "@/lib/redis-keys";
+import {
+  claimNewIpNotification,
+  maybeNotifyNewIp,
+  NEW_IP_NOTIFY_TTL_SECONDS,
+} from "@/lib/security/new-ip-notification";
+
+type SetFn = (...args: unknown[]) => Promise<unknown>;
+function redisWithSet(set: SetFn): { set: SetFn } {
+  return { set };
+}
+
+// Each test uses a distinct userId so the module-level per-pod dedup set
+// (which persists across tests in this file) never bleeds between cases.
+let userSeq = 0;
+function freshUser(): string {
+  userSeq += 1;
+  return `user-${userSeq}`;
+}
+
+beforeEach(() => {
+  mockGetRedis.mockReset();
+  mockSendEmail.mockReset();
+  mockSendEmail.mockResolvedValue(true);
+});
+
+describe("newIpNotifyClaimKey", () => {
+  it("namespaces under ip-notify with user and normalized ip", () => {
+    expect(newIpNotifyClaimKey("u1", "1.2.3.0")).toBe("ip-notify:u1:1.2.3.0");
+  });
+});
+
+describe("claimNewIpNotification", () => {
+  it("returns false (skip) when no Redis is configured", async () => {
+    mockGetRedis.mockReturnValue(null);
+    await expect(claimNewIpNotification("u1", "1.2.3.0")).resolves.toBe(false);
+  });
+
+  it("returns true and claims with NX + EX TTL when the key was set", async () => {
+    const set = vi.fn().mockResolvedValue("OK");
+    mockGetRedis.mockReturnValue(redisWithSet(set));
+
+    await expect(claimNewIpNotification("u1", "1.2.3.0")).resolves.toBe(true);
+    expect(set).toHaveBeenCalledWith(
+      "ip-notify:u1:1.2.3.0",
+      "1",
+      "EX",
+      NEW_IP_NOTIFY_TTL_SECONDS,
+      "NX"
+    );
+  });
+
+  it("returns false (skip) when another replica already holds the key", async () => {
+    mockGetRedis.mockReturnValue(redisWithSet(vi.fn().mockResolvedValue(null)));
+    await expect(claimNewIpNotification("u1", "1.2.3.0")).resolves.toBe(false);
+  });
+
+  it("returns false (skip) when the Redis command throws", async () => {
+    mockGetRedis.mockReturnValue(
+      redisWithSet(vi.fn().mockRejectedValue(new Error("ECONNREFUSED")))
+    );
+    await expect(claimNewIpNotification("u1", "1.2.3.0")).resolves.toBe(false);
+  });
+});
+
+describe("maybeNotifyNewIp", () => {
+  it("sends once when the claim is won, with the resolved device label", async () => {
+    mockGetRedis.mockReturnValue(redisWithSet(vi.fn().mockResolvedValue("OK")));
+    const userId = freshUser();
+
+    maybeNotifyNewIp({
+      userId,
+      email: "a@b.com",
+      ip: "9.9.9.0",
+      country: "DE",
+      userAgent: "Mozilla/5.0",
+    });
+
+    await vi.waitFor(() => expect(mockSendEmail).toHaveBeenCalledTimes(1));
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "a@b.com",
+        ip: "9.9.9.0",
+        country: "DE",
+        device: "Mozilla/5.0",
+      })
+    );
+  });
+
+  it("does not send when another replica already claimed", async () => {
+    mockGetRedis.mockReturnValue(redisWithSet(vi.fn().mockResolvedValue(null)));
+
+    maybeNotifyNewIp({
+      userId: freshUser(),
+      email: "a@b.com",
+      ip: "9.9.9.0",
+      country: null,
+      userAgent: null,
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("sends once across a fan-out: only the SET NX winner delivers", async () => {
+    // SET NX is atomic in Redis: the first call sets the key ("OK"), the rest
+    // see it exists (null). The mock mirrors that so concurrent requests for
+    // the same network produce exactly one email with no local dedup.
+    const set = vi.fn().mockResolvedValueOnce("OK").mockResolvedValue(null);
+    mockGetRedis.mockReturnValue(redisWithSet(set));
+    const notification = {
+      userId: freshUser(),
+      email: "a@b.com",
+      ip: "9.9.9.0",
+      country: null,
+      userAgent: null,
+    };
+
+    maybeNotifyNewIp(notification);
+    maybeNotifyNewIp(notification);
+    maybeNotifyNewIp(notification);
+
+    await vi.waitFor(() => expect(mockSendEmail).toHaveBeenCalledTimes(1));
+    expect(set).toHaveBeenCalledTimes(3);
+  });
+
+  it("skips entirely when userId or ip is empty", async () => {
+    mockGetRedis.mockReturnValue(redisWithSet(vi.fn().mockResolvedValue("OK")));
+
+    maybeNotifyNewIp({
+      userId: "",
+      email: "a@b.com",
+      ip: "9.9.9.0",
+      country: null,
+      userAgent: null,
+    });
+    maybeNotifyNewIp({
+      userId: freshUser(),
+      email: "a@b.com",
+      ip: "",
+      country: null,
+      userAgent: null,
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/new-ip-notification.test.ts
+++ b/tests/unit/new-ip-notification.test.ts
@@ -26,14 +26,6 @@ function redisWithSet(set: SetFn): { set: SetFn } {
   return { set };
 }
 
-// Each test uses a distinct userId so the module-level per-pod dedup set
-// (which persists across tests in this file) never bleeds between cases.
-let userSeq = 0;
-function freshUser(): string {
-  userSeq += 1;
-  return `user-${userSeq}`;
-}
-
 beforeEach(() => {
   mockGetRedis.mockReset();
   mockSendEmail.mockReset();
@@ -85,10 +77,8 @@ describe("claimNewIpNotification", () => {
 describe("maybeNotifyNewIp", () => {
   it("sends once when the claim is won, with the resolved device label", async () => {
     mockGetRedis.mockReturnValue(redisWithSet(vi.fn().mockResolvedValue("OK")));
-    const userId = freshUser();
-
     maybeNotifyNewIp({
-      userId,
+      userId: "u1",
       email: "a@b.com",
       ip: "9.9.9.0",
       country: "DE",
@@ -110,7 +100,7 @@ describe("maybeNotifyNewIp", () => {
     mockGetRedis.mockReturnValue(redisWithSet(vi.fn().mockResolvedValue(null)));
 
     maybeNotifyNewIp({
-      userId: freshUser(),
+      userId: "u1",
       email: "a@b.com",
       ip: "9.9.9.0",
       country: null,
@@ -129,7 +119,7 @@ describe("maybeNotifyNewIp", () => {
     const set = vi.fn().mockResolvedValueOnce("OK").mockResolvedValue(null);
     mockGetRedis.mockReturnValue(redisWithSet(set));
     const notification = {
-      userId: freshUser(),
+      userId: "u1",
       email: "a@b.com",
       ip: "9.9.9.0",
       country: null,
@@ -155,7 +145,7 @@ describe("maybeNotifyNewIp", () => {
       userAgent: null,
     });
     maybeNotifyNewIp({
-      userId: freshUser(),
+      userId: "u1",
       email: "a@b.com",
       ip: "",
       country: null,

--- a/tests/unit/new-ip-notification.test.ts
+++ b/tests/unit/new-ip-notification.test.ts
@@ -41,8 +41,11 @@ beforeEach(() => {
 });
 
 describe("newIpNotifyClaimKey", () => {
-  it("namespaces under ip-notify with user and normalized ip", () => {
-    expect(newIpNotifyClaimKey("u1", "1.2.3.0")).toBe("ip-notify:u1:1.2.3.0");
+  it("namespaces under deployment prefix + ip-notify with user and normalized ip", () => {
+    // REDIS_KEY_PREFIX is unset in tests, so the prefix falls back to "local".
+    expect(newIpNotifyClaimKey("u1", "1.2.3.0")).toBe(
+      "local:ip-notify:u1:1.2.3.0"
+    );
   });
 });
 
@@ -58,7 +61,7 @@ describe("claimNewIpNotification", () => {
 
     await expect(claimNewIpNotification("u1", "1.2.3.0")).resolves.toBe(true);
     expect(set).toHaveBeenCalledWith(
-      "ip-notify:u1:1.2.3.0",
+      "local:ip-notify:u1:1.2.3.0",
       "1",
       "EX",
       NEW_IP_NOTIFY_TTL_SECONDS,

--- a/tests/unit/redis-keys.test.ts
+++ b/tests/unit/redis-keys.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { deploymentKey, newIpNotifyClaimKey } from "@/lib/redis-keys";
+
+describe("deploymentKey", () => {
+  it("prefixes a single part with the default 'local' namespace", () => {
+    expect(deploymentKey("a")).toBe("local:a");
+  });
+
+  it("joins multiple parts under the namespace", () => {
+    expect(deploymentKey("a", "b", "c")).toBe("local:a:b:c");
+  });
+});
+
+describe("newIpNotifyClaimKey", () => {
+  it("builds an ip-notify key through deploymentKey", () => {
+    expect(newIpNotifyClaimKey("u1", "1.2.3.0")).toBe(
+      "local:ip-notify:u1:1.2.3.0"
+    );
+  });
+});
+
+describe("REDIS_KEY_PREFIX per deployment", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("namespaces keys with the configured prefix", async () => {
+    // The prefix is read at module load, so reset + re-import after stubbing.
+    vi.stubEnv("REDIS_KEY_PREFIX", "staging");
+    vi.resetModules();
+    const mod = await import("@/lib/redis-keys");
+
+    expect(mod.deploymentKey("ip-notify", "u1", "1.2.3.0")).toBe(
+      "staging:ip-notify:u1:1.2.3.0"
+    );
+    expect(mod.newIpNotifyClaimKey("u1", "1.2.3.0")).toBe(
+      "staging:ip-notify:u1:1.2.3.0"
+    );
+  });
+
+  it("isolates two deployments sharing one Redis instance", async () => {
+    vi.stubEnv("REDIS_KEY_PREFIX", "pr-42");
+    vi.resetModules();
+    const mod = await import("@/lib/redis-keys");
+
+    // Same user + ip on a different deployment lands on a different key.
+    expect(mod.newIpNotifyClaimKey("u1", "1.2.3.0")).not.toBe(
+      "staging:ip-notify:u1:1.2.3.0"
+    );
+    expect(mod.newIpNotifyClaimKey("u1", "1.2.3.0")).toBe(
+      "pr-42:ip-notify:u1:1.2.3.0"
+    );
+  });
+});


### PR DESCRIPTION
## Problem

On a multi-replica deployment, signing in from a new network produced two "New sign-in location detected" emails and forced the email plus MFA step twice. Confirmed in prod from the `[ip-verify]` logs: both replicas processed the same sign-in with an identical normalized IP, each acting on its own in-memory state.

## Root cause

All the dedup state lived in per-pod memory:

1. The new-location notification was deduped by a per-pod set, so each replica sent its own email.
2. The IP gate cached untrusted trust results per pod, so after one replica recorded the IP as trusted via verify-ip, another replica kept serving a stale untrusted result and bounced the user back through verification.

The database (`user_trusted_ips`) was already the correct global source of truth; only the in-memory layers were inconsistent across replicas.

## Changes

- Add a best-effort ioredis client for the app tier. It returns null when `REDIS_HOST` or `REDIS_PASSWORD` is unset, never opens an unauthenticated connection, and never blocks a request.
- Move the notification dedup into a Redis `SET NX` claim with a 7 day TTL, so exactly one replica sends per network. Delivery is fire-and-forget; when Redis is unavailable the courtesy email is skipped rather than sent once per request.
- Stop caching untrusted IP gate results. Untrusted is now read from the database on every request, so any replica sees a freshly trusted IP immediately. Trusted stays cached per pod because trust only ever grows.
- Namespace Redis keys per deployment via `REDIS_KEY_PREFIX` (`staging`, `prod`, `pr-<number>`). staging and every PR environment share one Redis instance, so the prefix keeps their keyspaces isolated. A `deploymentKey` helper applies it to every key builder.
- Point `REDIS_HOST`, `REDIS_PORT`, and `REDIS_PASSWORD` at the parameters already provisioned under the keeperhub-events SSM namespace, for staging, prod, and PR environments.

## Safety

The verify-ip gate is unchanged, so security does not depend on the notification or on Redis. With no Redis configured the app falls back to its prior single-pod behaviour and login is never blocked. Trust is never stored in Redis, so a key collision could at most suppress a courtesy email, never affect a trust decision.

## Deploy

No new SSM parameters are needed: the app reuses the `redis-host`, `redis-port`, and `redis-password` parameters the event tracker already uses under `/eks/techops-staging/keeperhub-events` and `/eks/techops-prod/keeperhub-events`. The keeperhub app role must be able to read that path.

Tested: unit suite passing (including the new redis-keys and notification coverage), integration passing (two pre-existing flaky workflow-runner signal tests are unrelated to this change), executor passing.
