### PR TITLE
refactor(security): back the IP-trust gate with a shared Redis cache

### DIFF
--- a/app/api/user/verify-ip/route.ts
+++ b/app/api/user/verify-ip/route.ts
@@ -28,7 +28,7 @@ import { sanitizeNextPath } from "@/lib/sanitize-next-path";
 import {
   assessIpTrust,
   buildRiskFlagsJsonForIp,
-  clearTrustCacheEntry,
+  cacheTrustedIp,
   logIpVerify,
 } from "@/lib/security/login-risk";
 import { verifyUserTotp } from "@/lib/security/totp-verify";
@@ -391,10 +391,9 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 
-  // Same-pod cache invalidation: evict any stale entry so the next request on
-  // this pod reflects the fresh upsert immediately. Untrusted is not cached,
-  // so other pods just re-read the DB and see the trust right away.
-  clearTrustCacheEntry(decoded.payload.userId, decoded.payload.ip);
+  // Warm the shared cache so every replica's next request is a hit, not a DB
+  // read. Best-effort; the DB upsert above is the durable source of truth.
+  await cacheTrustedIp(decoded.payload.userId, decoded.payload.ip);
 
   const response = NextResponse.json({
     ok: true,

--- a/lib/redis-keys.ts
+++ b/lib/redis-keys.ts
@@ -17,3 +17,11 @@ export function deploymentKey(...parts: string[]): string {
 export function newIpNotifyClaimKey(userId: string, ip: string): string {
   return deploymentKey("ip-notify", userId, ip);
 }
+
+/**
+ * Shared cache of a trusted (user, ip). Present means the IP gate may pass
+ * without a DB read. `ip` must be the normalized /24-or-/64 trust key.
+ */
+export function trustedIpKey(userId: string, ip: string): string {
+  return deploymentKey("trust", userId, ip);
+}

--- a/lib/security/login-risk.ts
+++ b/lib/security/login-risk.ts
@@ -3,6 +3,8 @@ import { headers } from "next/headers";
 import { db } from "@/lib/db";
 import { sessions, userTrustedIps } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { getRedis } from "@/lib/redis";
+import { trustedIpKey } from "@/lib/redis-keys";
 import { normalizeIpForTrust } from "@/lib/security/ip-normalize";
 import {
   type ResolvedLocation,
@@ -462,48 +464,39 @@ export type RequestIpGate =
   | { kind: "no_ip" };
 
 /**
- * Per-pod TTL cache for gate results. A single page navigation in the
- * KeeperHub app fans out into ~20 parallel API requests, each of which
- * passes through the proxy. Without caching the gate would do one DB
- * round-trip per request, plus a redundant evaluation of every header
- * lookup. The cache collapses those to one DB hit per (user, ip) per
- * TTL window.
+ * Shared (cross-replica) cache of trusted (user, ip) pairs in Redis, fronting
+ * the user_trusted_ips table. A single page navigation fans out into ~20
+ * parallel gate checks; the cache collapses those to one DB read per (user,
+ * ip) per TTL window across the whole fleet, instead of one per pod.
  *
- * Only `trusted` is cached. Untrusted is deliberately not: a per-pod
- * untrusted entry outlived the moment another replica trusted the IP via
- * /verify-ip, re-bouncing the user. Re-reading the DB (the shared source of
- * truth) on every untrusted request keeps replicas consistent; untrusted is
- * rare and short-lived, so the extra lookups are negligible.
+ * Postgres stays the durable source of truth: on a cache miss the gate reads
+ * the DB and re-populates Redis, so a Redis flush or restart re-fills on
+ * demand and never locks anyone out. Only `trusted` is cached -- untrusted is
+ * always re-checked against the DB. Trust is monotonic, so a cached entry is
+ * never a false positive; the TTL just bounds memory and any future
+ * revocation window.
  */
-type CachedTrust = { result: RequestIpGate; expiresAt: number };
-const TRUST_CACHE = new Map<string, CachedTrust>();
-const TRUST_CACHE_LIMIT = 10_000;
-const TRUSTED_TTL_MS = 300_000;
-
-function trustCacheKey(userId: string, ip: string): string {
-  return `${userId}:${ip}`;
-}
-
-function rememberTrust(key: string, entry: CachedTrust): void {
-  if (TRUST_CACHE.size >= TRUST_CACHE_LIMIT) {
-    const retained = Array.from(TRUST_CACHE.entries()).slice(
-      -Math.floor(TRUST_CACHE_LIMIT / 2)
-    );
-    TRUST_CACHE.clear();
-    for (const [k, v] of retained) {
-      TRUST_CACHE.set(k, v);
-    }
-  }
-  TRUST_CACHE.set(key, entry);
-}
+const TRUSTED_TTL_SECONDS = 300;
 
 /**
- * Drop the cached gate result for this (user, ip). Called by
- * /api/user/verify-ip after a successful upsert. Now only evicts a stale
- * `trusted` entry; untrusted is no longer cached.
+ * Mark (user, ip) trusted in the shared cache. Called by the gate after a DB
+ * hit and by /api/user/verify-ip after a successful upsert, so every replica's
+ * next request is a cache hit. Best-effort: a missing or failing Redis is
+ * swallowed (the DB read-through still serves the correct answer).
  */
-export function clearTrustCacheEntry(userId: string, ip: string): void {
-  TRUST_CACHE.delete(trustCacheKey(userId, ip));
+export async function cacheTrustedIp(
+  userId: string,
+  ip: string
+): Promise<void> {
+  const redis = getRedis();
+  if (!redis) {
+    return;
+  }
+  try {
+    await redis.set(trustedIpKey(userId, ip), "1", "EX", TRUSTED_TTL_SECONDS);
+  } catch {
+    // best-effort cache write; the DB remains the source of truth
+  }
 }
 
 /**
@@ -525,22 +518,34 @@ export async function gateRequestIp(userId: string): Promise<RequestIpGate> {
     return result;
   }
   const ip = normalizeIpForTrust(rawIp);
-  const key = trustCacheKey(userId, ip);
-  const now = Date.now();
-  const cached = TRUST_CACHE.get(key);
-  if (cached && cached.expiresAt > now) {
-    return cached.result;
+
+  // Fast path: shared Redis cache. A hit means a prior DB read on some replica
+  // already confirmed trust; trust is monotonic so the cached answer is safe.
+  const redis = getRedis();
+  if (redis) {
+    try {
+      if ((await redis.get(trustedIpKey(userId, ip))) === "1") {
+        return { kind: "trusted" };
+      }
+    } catch {
+      // Redis unavailable -- fall through to the DB source of truth.
+    }
   }
+
+  // Source of truth: user_trusted_ips. Re-populate the cache on a hit so the
+  // next request on any replica is served from Redis.
   const [hit] = await db
     .select({ id: userTrustedIps.id })
     .from(userTrustedIps)
     .where(and(eq(userTrustedIps.userId, userId), eq(userTrustedIps.ip, ip)))
     .limit(1);
   if (hit) {
-    const result: RequestIpGate = { kind: "trusted" };
-    rememberTrust(key, { result, expiresAt: now + TRUSTED_TTL_MS });
-    return result;
+    cacheTrustedIp(userId, ip).catch(() => {
+      // cacheTrustedIp already swallows; this is the floating-promise boundary
+    });
+    return { kind: "trusted" };
   }
+
   // CF-attested country only on the hot path; the external IP-to-location
   // lookup has a 2-second timeout and isn't wanted here.
   let country: string | null = null;
@@ -550,8 +555,8 @@ export async function gateRequestIp(userId: string): Promise<RequestIpGate> {
   } catch {
     country = null;
   }
-  // Not cached -- see TRUST_CACHE doc; a stale untrusted entry re-bounced
-  // already-verified users on multi-replica deployments.
+  // Untrusted is never cached -- re-checked against the DB every request so a
+  // freshly trusted IP is honored fleet-wide on the very next request.
   const result: RequestIpGate = { kind: "untrusted", ip, country };
   logIpVerify("gate-untrusted", {
     userId,

--- a/tests/unit/gate-request-ip.test.ts
+++ b/tests/unit/gate-request-ip.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetRedis, mockHeaders, mockLimit } = vi.hoisted(() => ({
+  mockGetRedis: vi.fn(),
+  mockHeaders: vi.fn(),
+  mockLimit: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({ headers: mockHeaders }));
+vi.mock("@/lib/redis", () => ({ getRedis: mockGetRedis }));
+// db.select(...).from(...).where(...).limit(1) -> mockLimit()
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({ where: () => ({ limit: mockLimit }) }),
+    }),
+  },
+}));
+
+import { gateRequestIp } from "@/lib/security/login-risk";
+
+type RedisLike = {
+  get: (key: string) => Promise<unknown>;
+  set: (...args: unknown[]) => Promise<unknown>;
+};
+
+function headersWith(values: Record<string, string>): {
+  get: (key: string) => string | null;
+} {
+  return { get: (key: string) => values[key.toLowerCase()] ?? null };
+}
+
+// CF-Connecting-IP 9.9.9.9 normalizes (/24) to 9.9.9.0.
+const CF_HEADERS = { "cf-connecting-ip": "9.9.9.9", "cf-ipcountry": "DE" };
+const TRUST_KEY = "local:trust:u1:9.9.9.0";
+
+beforeEach(() => {
+  mockGetRedis.mockReset();
+  mockHeaders.mockReset();
+  mockLimit.mockReset();
+  mockHeaders.mockResolvedValue(headersWith(CF_HEADERS));
+});
+
+describe("gateRequestIp read-through Redis cache", () => {
+  it("returns no_ip when no client IP can be resolved (no DB, no Redis)", async () => {
+    mockHeaders.mockResolvedValue(headersWith({}));
+    mockGetRedis.mockReturnValue(null);
+
+    expect(await gateRequestIp("u1")).toEqual({ kind: "no_ip" });
+    expect(mockLimit).not.toHaveBeenCalled();
+  });
+
+  it("serves trusted from a Redis hit without touching the DB", async () => {
+    const get = vi.fn().mockResolvedValue("1");
+    mockGetRedis.mockReturnValue({ get, set: vi.fn() } as RedisLike);
+
+    expect(await gateRequestIp("u1")).toEqual({ kind: "trusted" });
+    expect(get).toHaveBeenCalledWith(TRUST_KEY);
+    expect(mockLimit).not.toHaveBeenCalled();
+  });
+
+  it("on a Redis miss reads the DB, returns trusted, and re-caches", async () => {
+    const get = vi.fn().mockResolvedValue(null);
+    const set = vi.fn().mockResolvedValue("OK");
+    mockGetRedis.mockReturnValue({ get, set } as RedisLike);
+    mockLimit.mockResolvedValue([{ id: "row-1" }]);
+
+    expect(await gateRequestIp("u1")).toEqual({ kind: "trusted" });
+    expect(mockLimit).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() =>
+      expect(set).toHaveBeenCalledWith(TRUST_KEY, "1", "EX", 300)
+    );
+  });
+
+  it("returns untrusted (with ip + country) when the DB has no row", async () => {
+    const get = vi.fn().mockResolvedValue(null);
+    mockGetRedis.mockReturnValue({ get, set: vi.fn() } as RedisLike);
+    mockLimit.mockResolvedValue([]);
+
+    expect(await gateRequestIp("u1")).toEqual({
+      kind: "untrusted",
+      ip: "9.9.9.0",
+      country: "DE",
+    });
+  });
+
+  it("falls back to the DB when Redis is not configured", async () => {
+    mockGetRedis.mockReturnValue(null);
+    mockLimit.mockResolvedValue([{ id: "row-1" }]);
+
+    expect(await gateRequestIp("u1")).toEqual({ kind: "trusted" });
+    expect(mockLimit).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the DB when the Redis read throws", async () => {
+    const get = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    mockGetRedis.mockReturnValue({ get, set: vi.fn() } as RedisLike);
+    mockLimit.mockResolvedValue([{ id: "row-1" }]);
+
+    expect(await gateRequestIp("u1")).toEqual({ kind: "trusted" });
+    expect(mockLimit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/redis-keys.test.ts
+++ b/tests/unit/redis-keys.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { deploymentKey, newIpNotifyClaimKey } from "@/lib/redis-keys";
+import {
+  deploymentKey,
+  newIpNotifyClaimKey,
+  trustedIpKey,
+} from "@/lib/redis-keys";
 
 describe("deploymentKey", () => {
   it("prefixes a single part with the default 'local' namespace", () => {
@@ -16,6 +20,12 @@ describe("newIpNotifyClaimKey", () => {
     expect(newIpNotifyClaimKey("u1", "1.2.3.0")).toBe(
       "local:ip-notify:u1:1.2.3.0"
     );
+  });
+});
+
+describe("trustedIpKey", () => {
+  it("builds a trust key through deploymentKey", () => {
+    expect(trustedIpKey("u1", "1.2.3.0")).toBe("local:trust:u1:1.2.3.0");
   });
 });
 


### PR DESCRIPTION
## Problem

The IP-trust gate cached trusted results in a per-pod in-memory `Map`. With more than one replica, each pod kept its own cache, so cross-pod state was inconsistent: a result cached on one pod was a miss on the next. We already run Redis for the new-sign-in-location dedup, so the cache belongs there, shared across the fleet.

## Change

Replace the per-pod `TRUST_CACHE` with a read-through Redis cache, keyed per deployment via `REDIS_KEY_PREFIX` (`staging`, `prod`, `pr-<number>`):

- The gate reads `GET trust:{user}:{ip}` first; a hit returns trusted with no DB read.
- On a miss it reads `user_trusted_ips` (the durable source of truth) and re-caches the result, so the next request on any replica is a hit.
- `/verify-ip` warms the cache with `SET trusted` right after the upsert, so a just-verified IP is honored fleet-wide on the next request.
- Untrusted is still never cached; it is re-checked against the DB every request.

## Safety

- Postgres stays the durable source of truth. A Redis flush, restart, or outage re-fills on demand and never locks anyone out.
- Redis is best-effort: an unconfigured or failing Redis falls straight through to Postgres, so the gate cannot fail on Redis.
- Trust is monotonic (rows are only added), so a cached entry is never a false positive; the TTL only bounds memory.

## Testing

- New `tests/unit/gate-request-ip.test.ts`: Redis hit (no DB), miss then DB then re-cache, untrusted, no-Redis fallback, Redis-error fallback, and no_ip.
- `trustedIpKey` covered in `tests/unit/redis-keys.test.ts`.
- type-check and biome clean; existing `login-risk.test.ts` unchanged and passing.
