### PR TITLE
fix: align staging keeperhub-common CPU request with prod

### DIFF
--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -129,7 +129,7 @@ resources:
     # Kept in lockstep with prod so staging is predictive of prod memory behaviour.
     memory: 4Gi
   requests:
-    cpu: 1m
+    cpu: 100m
     memory: 2Gi
 
 env:


### PR DESCRIPTION
## Summary
Staging `keeperhub-common` requested `1m` CPU while prod requests `100m`. The
Grafana alert "KeeperHub High CPU Usage (Staging)" evaluates
`cpu_usage / cpu_request > 2` per container, so a 1m request put idle pods
(~15-25m CPU) permanently at 15-25x the request and re-fired a P3 on every
rollout. Recent incidents: PD #32659 and Q1EHMYBJ0D6IAL.

This sets the staging request to `100m` to match prod.

## Usage analysis (14d, per-pod, 5m-rate)
| metric | staging (req 1m) | prod (req 100m) |
| --- | --- | --- |
| avg | 19.4m | 21.8m |
| p95 | 28.5m | 38.8m |
| p99 | 47.8m | 70.8m |
| max | 108.6m | 345.8m |

## Why 100m
- Above staging p99 (48m); covers steady-state with headroom.
- Matches prod, keeping staging predictive of prod behaviour.
- Moves the alert threshold to 2x = 200m, comfortably above staging's observed
  5m-rate max of 108m (~1.85x headroom): no false fire under current load, still
  catches a genuine runaway.

Memory (2Gi request / 4Gi limit) is intentionally lockstepped with prod and left
unchanged.

## Testing
- values.yaml validated as YAML.
- No app CI applies (no TS/build/tests touched). Takes effect on the next staging
  deploy via the `deploy-keeperhub` helm upgrade.
