### PR TITLE
docs(executor): note runner UID 1000 is coupled to the node base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -202,6 +202,11 @@ EXPOSE 3000
 CMD ["tsx", "block-dispatcher/index.ts"]
 
 # Stage 2.8: Workflow Runner stage (for executing workflows in K8s Jobs)
+# The K8s Job runs this image as a non-root user pinned to UID/GID 1000
+# (keeperhub-executor/k8s-job.ts -> RUNNER_UID/RUNNER_GID). node:*-alpine ships
+# a "node" user at 1000. If you change this base image, verify a non-root user
+# exists at UID 1000 and that the copied app files stay readable by it, or
+# update RUNNER_UID/RUNNER_GID to match the new image.
 FROM node:24-alpine AS workflow-runner
 WORKDIR /app
 RUN npm install -g pnpm@9 tsx@4

--- a/keeperhub-executor/k8s-job.ts
+++ b/keeperhub-executor/k8s-job.ts
@@ -11,9 +11,12 @@ const kc = new KubeConfig();
 kc.loadFromDefault();
 const batchApi = kc.makeApiClient(BatchV1Api);
 
-// Non-root identity for runner pods. 1000/1000 is the "node" user/group that
-// ships in the node:alpine runner image, so the app files (world-readable)
-// stay accessible while the container never runs as root.
+// Non-root identity for runner pods. Pinned to 1000/1000, the "node" user/group
+// that ships in the node:alpine runner image (see the workflow-runner stage in
+// Dockerfile), so the app files (world-readable) stay accessible while the
+// container never runs as root. Coupled to that image: if the runner base image
+// changes, confirm UID 1000 is a valid non-root user there and the app files are
+// readable by it, otherwise update RUNNER_UID/RUNNER_GID to match.
 const RUNNER_UID = 1000;
 const RUNNER_GID = 1000;
 


### PR DESCRIPTION
## What

Comment-only change. Documents the coupling between the runner base image and the hardcoded non-root UID.

The runner Job pins `runAsUser`/`runAsGroup` to **1000** (`RUNNER_UID`/`RUNNER_GID` in `keeperhub-executor/k8s-job.ts`). That works only because `node:*-alpine` ships a `node` user at UID/GID 1000 and the copied app files are world-readable. The coupling spans two files that change independently:

- the **Dockerfile** `workflow-runner` stage picks the base image
- **k8s-job.ts** hardcodes the UID

Someone swapping the base image won't necessarily look at the executor code, so this adds cross-referencing comments in both places: change the image -> verify UID 1000 is a valid non-root user there (or update `RUNNER_UID`/`RUNNER_GID`).

## Why

Follow-up to the workflow-runner pod hardening. No behavior change, no runtime impact - just prevents a future image swap from silently breaking the non-root assumption.

## Testing

- `pnpm type-check` - clean
- `pnpm check` - clean