### PR TITLE
release: promote staging to prod

### DIFF
--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -15,6 +15,7 @@ jobs:
       should-deploy-events: ${{ steps.check.outputs.should-deploy-events }}
       should-deploy-events-only: ${{ steps.check.outputs.should-deploy-events-only }}
       should-build-executor: ${{ steps.check.outputs.should-build-executor }}
+      should-deploy-collector: ${{ steps.check.outputs.should-deploy-collector }}
     steps:
       - name: Checkout code (for change detection)
         if: github.event.action == 'synchronize'
@@ -30,6 +31,7 @@ jobs:
           echo "should-deploy-events=false" >> $GITHUB_OUTPUT
           echo "should-deploy-events-only=false" >> $GITHUB_OUTPUT
           echo "should-build-executor=false" >> $GITHUB_OUTPUT
+          echo "should-deploy-collector=false" >> $GITHUB_OUTPUT
 
           HAS_DEPLOY_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'deploy-pr-environment') }}"
           HAS_TEST_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'run-e2e-tests-pr-deploy') }}"
@@ -44,6 +46,12 @@ jobs:
           # dispatchers are consumed; this label adds a PR-specific build for
           # ticket-driven validation. See KEEP-556.
           HAS_EXECUTOR_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'deploy-pr-executor') }}"
+          # Metrics-collector PR deploy is opt-in alongside deploy-pr-environment
+          # (TECH-6484), same pattern as deploy-pr-executor. Default off; when
+          # set, CI builds a PR-specific collector image and deploys it as a
+          # satellite so the PR's collector code can be exercised against the
+          # PR's DB. ServiceMonitors are off in PR envs - verify via curl.
+          HAS_METRICS_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'deploy-pr-metrics') }}"
           ACTION="${{ github.event.action }}"
           ADDED_LABEL="${{ github.event.label.name }}"
 
@@ -58,6 +66,9 @@ jobs:
               fi
               if [[ "$HAS_EXECUTOR_LABEL" == "true" ]]; then
                 echo "should-build-executor=true" >> $GITHUB_OUTPUT
+              fi
+              if [[ "$HAS_METRICS_LABEL" == "true" ]]; then
+                echo "should-deploy-collector=true" >> $GITHUB_OUTPUT
               fi
             elif [[ "$ADDED_LABEL" == "run-e2e-tests-pr-deploy" ]]; then
               echo "should-test=true" >> $GITHUB_OUTPUT
@@ -85,6 +96,12 @@ jobs:
                 if [[ "$HAS_TEST_LABEL" == "true" ]]; then
                   echo "should-test=true" >> $GITHUB_OUTPUT
                 fi
+              fi
+            elif [[ "$ADDED_LABEL" == "deploy-pr-metrics" ]]; then
+              # Metrics-only path: PR env already deployed. Build a PR collector
+              # image and deploy just that satellite (TECH-6484).
+              if [[ "$HAS_DEPLOY_LABEL" == "true" ]]; then
+                echo "should-deploy-collector=true" >> $GITHUB_OUTPUT
               fi
             fi
           elif [[ "$ACTION" == "unlabeled" ]]; then
@@ -121,6 +138,9 @@ jobs:
               fi
               if [[ "$HAS_EXECUTOR_LABEL" == "true" ]]; then
                 echo "should-build-executor=true" >> $GITHUB_OUTPUT
+              fi
+              if [[ "$HAS_METRICS_LABEL" == "true" ]]; then
+                echo "should-deploy-collector=true" >> $GITHUB_OUTPUT
               fi
             fi
             # Run tests if both labels present (even without deploy)
@@ -217,6 +237,57 @@ jobs:
             type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:cache-app
             type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:${{ matrix.image.cache_key }}
           cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.AWS_ECR_NAME }}:${{ matrix.image.cache_key }},mode=max
+
+  # Builds a PR-specific metrics-collector image when the deploy-pr-metrics
+  # label is present alongside deploy-pr-environment (TECH-6484). Pushed to the
+  # staging collector ECR with a collector-${sha_short} tag; never pushes
+  # collector-latest so concurrent staging deploys are unaffected.
+  build-collector-image:
+    needs: check-labels
+    if: needs.check-labels.outputs.should-deploy-collector == 'true'
+    runs-on: ubuntu-latest
+    environment: staging
+    env:
+      REGION: ${{ vars.TO_REGION }}
+      COLLECTOR_ECR_NAME: keeperhub-metrics-collector-staging
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.REGION }}
+
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Extract commit hash
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push collector image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: metrics-collector
+          push: true
+          provenance: false
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.COLLECTOR_ECR_NAME }}:collector-${{ steps.vars.outputs.sha_short }}
+          cache-from: |
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.COLLECTOR_ECR_NAME }}:cache
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.COLLECTOR_ECR_NAME }}:cache-pr
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.COLLECTOR_ECR_NAME }}:cache-pr,mode=max
 
   # Builds a PR-specific event-tracker image when the deploy-pr-events
   # label is present alongside deploy-pr-environment. Without it, the PR
@@ -361,7 +432,7 @@ jobs:
           cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.EXECUTOR_ECR_NAME }}:cache-pr,mode=max
 
   deploy:
-    needs: [check-labels, build-images, build-events-image, build-executor-image]
+    needs: [check-labels, build-images, build-events-image, build-executor-image, build-collector-image]
     # Cannot use the `success()` shorthand here because GHA evaluates it
     # as false whenever ANY needed job is skipped. build-events-image is
     # skipped on purpose for PRs without the deploy-pr-events label, so
@@ -374,7 +445,8 @@ jobs:
       needs.check-labels.outputs.should-deploy == 'true' &&
       needs.build-images.result == 'success' &&
       (needs.build-events-image.result == 'success' || needs.build-events-image.result == 'skipped') &&
-      (needs.build-executor-image.result == 'success' || needs.build-executor-image.result == 'skipped')
+      (needs.build-executor-image.result == 'success' || needs.build-executor-image.result == 'skipped') &&
+      (needs.build-collector-image.result == 'success' || needs.build-collector-image.result == 'skipped')
     runs-on: ubuntu-latest
     environment: staging
     env:
@@ -530,6 +602,10 @@ jobs:
           # / event triggers. The template prepends "executor-" itself, so we
           # set only the bare tag here (matches the {{IMAGE_TAG}} pattern).
           EXECUTOR_IMAGE_TAG: ${{ needs.check-labels.outputs.should-build-executor == 'true' && steps.vars.outputs.sha_short || 'latest' }}
+          # PR-specific collector image tag when deploy-pr-metrics was set
+          # (build-collector-image ran); else the collector-latest baseline.
+          # Bare tag; the template prepends "collector-". (TECH-6484)
+          COLLECTOR_IMAGE_TAG: ${{ needs.check-labels.outputs.should-deploy-collector == 'true' && steps.vars.outputs.sha_short || 'latest' }}
         run: |
           # Percent-encode DB_PASSWORD so base64 characters (+/=) don't break URL parsing
           # in the pod. Init containers previously encoded at runtime but that path was
@@ -542,6 +618,7 @@ jobs:
           envsubst < deploy/pr-environment/block-dispatcher.template.yaml > ${{ github.workspace }}/block-pr-${{ env.PR_NUMBER }}.yaml
           envsubst < deploy/pr-environment/event-tracker.template.yaml > ${{ github.workspace }}/event-pr-${{ env.PR_NUMBER }}.yaml
           envsubst < deploy/pr-environment/executor.template.yaml > ${{ github.workspace }}/executor-pr-${{ env.PR_NUMBER }}.yaml
+          envsubst < deploy/pr-environment/metrics-collector.template.yaml > ${{ github.workspace }}/metrics-pr-${{ env.PR_NUMBER }}.yaml
           envsubst < deploy/pr-environment/sandbox.template.yaml > ${{ github.workspace }}/sandbox-pr-${{ env.PR_NUMBER }}.yaml
 
       - name: Clean up stale Helm releases
@@ -563,6 +640,18 @@ jobs:
             techops-services/common \
             -f ${GITHUB_WORKSPACE}/values-pr-${PR_NUMBER}.yaml \
             --namespace "${NAMESPACE}" --timeout 10m0s --atomic --version 0.2.1
+
+      # Opt-in (deploy-pr-metrics label). Deploys the metrics-collector
+      # satellite against the PR DB so its /metrics can be curled directly
+      # (ServiceMonitors are off in PR envs). TECH-6484.
+      - name: Deploy metrics collector (PR, opt-in)
+        if: needs.check-labels.outputs.should-deploy-collector == 'true'
+        run: |
+          set -euo pipefail
+          helm upgrade --install metrics-pr-${PR_NUMBER} \
+            techops-services/common \
+            -f ${GITHUB_WORKSPACE}/metrics-pr-${PR_NUMBER}.yaml \
+            --namespace "${NAMESPACE}" --timeout 5m0s --atomic --version 0.2.1
 
       - name: Deploy satellite services (parallel)
         run: |

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -98,10 +98,17 @@ jobs:
                 fi
               fi
             elif [[ "$ADDED_LABEL" == "deploy-pr-metrics" ]]; then
-              # Metrics-only path: PR env already deployed. Build a PR collector
-              # image and deploy just that satellite (TECH-6484).
+              # Metrics path: PR env already deployed. Build a PR collector image
+              # and re-run the deploy (which now includes the collector step).
+              # should-deploy=true is required because the collector deploy step
+              # lives inside the should-deploy-gated deploy job - same pattern as
+              # the deploy-pr-executor incremental path. (TECH-6484)
               if [[ "$HAS_DEPLOY_LABEL" == "true" ]]; then
+                echo "should-deploy=true" >> $GITHUB_OUTPUT
                 echo "should-deploy-collector=true" >> $GITHUB_OUTPUT
+                if [[ "$HAS_TEST_LABEL" == "true" ]]; then
+                  echo "should-test=true" >> $GITHUB_OUTPUT
+                fi
               fi
             fi
           elif [[ "$ACTION" == "unlabeled" ]]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -202,6 +202,11 @@ EXPOSE 3000
 CMD ["tsx", "block-dispatcher/index.ts"]
 
 # Stage 2.8: Workflow Runner stage (for executing workflows in K8s Jobs)
+# The K8s Job runs this image as a non-root user pinned to UID/GID 1000
+# (keeperhub-executor/k8s-job.ts -> RUNNER_UID/RUNNER_GID). node:*-alpine ships
+# a "node" user at 1000. If you change this base image, verify a non-root user
+# exists at UID 1000 and that the copied app files stay readable by it, or
+# update RUNNER_UID/RUNNER_GID to match the new image.
 FROM node:24-alpine AS workflow-runner
 WORKDIR /app
 RUN npm install -g pnpm@9 tsx@4

--- a/app/api/auth/oauth-mfa-finalize/route.ts
+++ b/app/api/auth/oauth-mfa-finalize/route.ts
@@ -14,6 +14,7 @@ import {
   readPendingOauthMfaCookie,
 } from "@/lib/oauth-mfa-cookie";
 import { sanitizeNextPath } from "@/lib/sanitize-next-path";
+import { resolveClientIpFromHeaders } from "@/lib/security/login-risk";
 
 /**
  * Finishes the deferred OAuth sign-in.
@@ -119,10 +120,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   const expiresAt = new Date(Date.now() + DEFAULT_SESSION_TTL_MS);
   const sessionId = `sess_${randomBytes(16).toString("base64url")}`;
   const userAgent = request.headers.get("user-agent") ?? null;
-  const ipAddress =
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-    request.headers.get("x-real-ip") ??
-    null;
+  const ipAddress = resolveClientIpFromHeaders(request.headers);
 
   try {
     await db.insert(sessions).values({

--- a/app/api/metrics/db/route.ts
+++ b/app/api/metrics/db/route.ts
@@ -3,12 +3,22 @@
  *
  * Exposes only database-sourced gauge metrics. These are identical across pods,
  * so only one pod needs to be scraped for these metrics.
+ *
+ * TECH-6484: these gauges are now served by the dedicated
+ * keeperhub-metrics-collector service. When METRICS_DB_OFFLOADED is set, this
+ * route returns 404 so the heavy aggregate scan never runs on the
+ * request-serving pods (the app's db-metrics ServiceMonitor is removed too).
+ * The flag keeps the cutover reversible via config without a code revert.
  */
 
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 
 export async function GET(): Promise<NextResponse> {
+  if (process.env.METRICS_DB_OFFLOADED === "true") {
+    return new NextResponse("Not Found", { status: 404 });
+  }
+
   if (process.env.METRICS_COLLECTOR !== "prometheus") {
     return new NextResponse("Not Found", { status: 404 });
   }

--- a/app/api/user/totp/enroll/route.ts
+++ b/app/api/user/totp/enroll/route.ts
@@ -18,7 +18,10 @@ import {
 import {
   buildPendingSignupClearCookie,
 } from "@/lib/pending-signup-cookie";
-import { recordTrustedIpFromRequest } from "@/lib/security/login-risk";
+import {
+  recordTrustedIpFromRequest,
+  resolveClientIpFromHeaders,
+} from "@/lib/security/login-risk";
 import { verifyUserTotp } from "@/lib/security/totp-verify";
 
 type RequestBody = {
@@ -77,7 +80,6 @@ function buildSessionSetCookie(
  *     cookie returned here is the FIRST usable session for the
  *     account.
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: two converging auth shapes
 export async function POST(request: Request): Promise<NextResponse> {
   const caller = await resolveEnrollMfaCaller(request.headers);
   if (caller.kind === "anonymous") {
@@ -219,10 +221,7 @@ export async function POST(request: Request): Promise<NextResponse> {
     const expiresAt = new Date(Date.now() + DEFAULT_SESSION_TTL_MS);
     const sessionId = `sess_${randomBytes(16).toString("base64url")}`;
     const userAgent = request.headers.get("user-agent") ?? null;
-    const ipAddress =
-      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-      request.headers.get("x-real-ip") ??
-      null;
+    const ipAddress = resolveClientIpFromHeaders(request.headers);
 
     // Single transaction across the three writes so a mid-flight
     // failure cannot leave the account in a "twoFactorEnabled = true

--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -117,14 +117,9 @@ serviceMonitors:
       path: /api/metrics/api
       interval: 30s
       scrapeTimeout: 10s
-    - name: db-metrics
-      port: http
-      path: /api/metrics/db
-      interval: 30s
-      # 12s (not 10s): this endpoint blocks on the serialised db-metrics
-      # refresh, which is several seconds at prod scale. See KEEP-682 to
-      # measure refresh duration and revisit if it approaches this timeout.
-      scrapeTimeout: 12s
+    # db-metrics removed (TECH-6484): the DB-sourced gauges are now scraped from
+    # the dedicated keeperhub-metrics-collector single-replica service, not from
+    # the app pods. The app route is also gated off via METRICS_DB_OFFLOADED.
 
 resources:
   limits:
@@ -144,6 +139,11 @@ env:
   METRICS_COLLECTOR:
     type: kv
     value: "prometheus"
+  # TECH-6484: /api/metrics/db is served by keeperhub-metrics-collector now;
+  # gate the app route to 404 so the heavy scan never runs on these pods.
+  METRICS_DB_OFFLOADED:
+    type: kv
+    value: "true"
   RPC_PROBE_INTERVAL_MS:
     type: kv
     value: "30000"

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -117,14 +117,9 @@ serviceMonitors:
       path: /api/metrics/api
       interval: 30s
       scrapeTimeout: 10s
-    - name: db-metrics
-      port: http
-      path: /api/metrics/db
-      interval: 30s
-      # 12s (not 10s): this endpoint blocks on the serialised db-metrics
-      # refresh. Staging refresh is well under this, but kept in parity with
-      # prod to avoid config drift. See KEEP-682.
-      scrapeTimeout: 12s
+    # db-metrics removed (TECH-6484): the DB-sourced gauges are now scraped from
+    # the dedicated keeperhub-metrics-collector single-replica service, not from
+    # the app pods. The app route is also gated off via METRICS_DB_OFFLOADED.
 
 resources:
   limits:
@@ -145,6 +140,11 @@ env:
   METRICS_COLLECTOR:
     type: kv
     value: "prometheus"
+  # TECH-6484: /api/metrics/db is served by keeperhub-metrics-collector now;
+  # gate the app route to 404 so the heavy scan never runs on these pods.
+  METRICS_DB_OFFLOADED:
+    type: kv
+    value: "true"
   RPC_PROBE_INTERVAL_MS:
     type: kv
     value: "30000"

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -129,7 +129,7 @@ resources:
     # Kept in lockstep with prod so staging is predictive of prod memory behaviour.
     memory: 4Gi
   requests:
-    cpu: 1m
+    cpu: 100m
     memory: 2Gi
 
 env:

--- a/deploy/pr-environment/metrics-collector.template.yaml
+++ b/deploy/pr-environment/metrics-collector.template.yaml
@@ -1,0 +1,83 @@
+# Metrics Collector for PR environments (TECH-6484)
+#
+# Serves the DB-sourced Prometheus gauges from the PR's database, off the app
+# pods. Opt-in via the deploy-pr-metrics label: CI builds a PR-specific image
+# (collector-${sha_short}) and renders this template with
+# COLLECTOR_IMAGE_TAG=${sha_short}. ServiceMonitors are disabled in PR envs, so
+# verify by curling /metrics on the pod directly.
+#
+# Variables substituted by envsubst at deploy time:
+#   ${PR_NUMBER}, ${ECR_REGISTRY}, ${COLLECTOR_IMAGE_TAG}, ${ENCODED_DB_PASSWORD}
+
+replicaCount: 1
+
+service:
+  enabled: true
+  name: keeperhub-metrics-collector-pr-${PR_NUMBER}
+  type: ClusterIP
+  port: 9090
+  containerPort: 9090
+  tls:
+    enabled: false
+
+ingress:
+  enabled: false
+
+image:
+  repository: ${ECR_REGISTRY}/keeperhub-metrics-collector-staging
+  tag: collector-${COLLECTOR_IMAGE_TAG}
+  pullPolicy: Always
+
+deployment:
+  enabled: true
+
+serviceAccount:
+  create: false
+  name: keeperhub-pr-${PR_NUMBER}
+
+podAnnotations:
+  reloader.stakater.com/auto: "true"
+
+serviceMonitors:
+  enabled: false
+
+resources:
+  limits:
+    memory: 512Mi
+    cpu: 300m
+  requests:
+    cpu: 50m
+    memory: 128Mi
+
+command: ["/bin/sh"]
+args:
+  - "-c"
+  - |
+    echo "$(date) - [MetricsCollector] Starting..."
+    tsx keeperhub-metrics-collector/index.ts
+
+env:
+  DATABASE_URL:
+    type: kv
+    value: "postgresql://keeperhub:${ENCODED_DB_PASSWORD}@keeperhub-pr-${PR_NUMBER}-db-rw.pr-${PR_NUMBER}.svc.cluster.local:5432/keeperhub"
+  PORT:
+    type: kv
+    value: "9090"
+  METRICS_COLLECTOR:
+    type: kv
+    value: "prometheus"
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 20
+  periodSeconds: 30
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 10
+  periodSeconds: 10

--- a/deploy/pr-environment/metrics-collector.template.yaml
+++ b/deploy/pr-environment/metrics-collector.template.yaml
@@ -49,12 +49,7 @@ resources:
     cpu: 50m
     memory: 128Mi
 
-command: ["/bin/sh"]
-args:
-  - "-c"
-  - |
-    echo "$(date) - [MetricsCollector] Starting..."
-    tsx keeperhub-metrics-collector/index.ts
+# Startup comes from the Dockerfile CMD; no helm command/args override.
 
 env:
   DATABASE_URL:

--- a/keeperhub-executor/k8s-job.ts
+++ b/keeperhub-executor/k8s-job.ts
@@ -11,9 +11,12 @@ const kc = new KubeConfig();
 kc.loadFromDefault();
 const batchApi = kc.makeApiClient(BatchV1Api);
 
-// Non-root identity for runner pods. 1000/1000 is the "node" user/group that
-// ships in the node:alpine runner image, so the app files (world-readable)
-// stay accessible while the container never runs as root.
+// Non-root identity for runner pods. Pinned to 1000/1000, the "node" user/group
+// that ships in the node:alpine runner image (see the workflow-runner stage in
+// Dockerfile), so the app files (world-readable) stay accessible while the
+// container never runs as root. Coupled to that image: if the runner base image
+// changes, confirm UID 1000 is a valid non-root user there and the app files are
+// readable by it, otherwise update RUNNER_UID/RUNNER_GID to match.
 const RUNNER_UID = 1000;
 const RUNNER_GID = 1000;
 

--- a/lib/metrics/METRICS_REFERENCE.md
+++ b/lib/metrics/METRICS_REFERENCE.md
@@ -26,6 +26,8 @@ Metrics are collected from two sources depending on the collector type:
 
 > **Note:** Runtime code (executor, routes) also increments workflow metrics for console logging, but Prometheus relies solely on DB snapshots. This dual approach ensures complete data even when workflow runners exit before scrape.
 
+> **Note (TECH-6484):** The DB-sourced gauges are served by the dedicated single-replica `keeperhub-metrics-collector` service (`deploy/metrics-collector/`), not by the app pods. It reuses this module's `updateDbMetrics` / `getDbMetrics` and serves them on `/metrics`. Its ServiceMonitor scrapes the gauges deterministically from one pod. The app's `/api/metrics/db` route is gated off via `METRICS_DB_OFFLOADED` and its `db-metrics` ServiceMonitor removed, so the heavy aggregate scan no longer runs on the request-serving pods. `/api/metrics/api` (per-pod, in-memory) is unchanged.
+
 ---
 
 ## Architecture Context

--- a/lib/security/login-risk.ts
+++ b/lib/security/login-risk.ts
@@ -420,31 +420,46 @@ export function logIpVerify(
   console.info(`[ip-verify] ${stage}`, fields);
 }
 
+/**
+ * Resolve the raw client IP from a set of request headers using the
+ * auth system's trust model. Behind the edge proxy (staging/prod) only
+ * CF-Connecting-IP is authoritative: it is set at the edge and cannot be
+ * forged by the caller, whereas X-Forwarded-For and X-Real-IP are
+ * caller-controlled and may be rewritten by intermediate hops, so they
+ * are not a reliable source of the client IP. Outside production we fall
+ * back to the first X-Forwarded-For hop and then X-Real-IP so VPN / NAT
+ * changes during local dev still exercise the new-IP gate. Returns null
+ * when no trusted source is present rather than an unreliable address, so
+ * callers persist an honest empty value instead of a misattributed one.
+ *
+ * Shared by resolveLoginIp (ambient headers) and the session-minting
+ * routes that write sessions.ip_address directly instead of through
+ * Better Auth's getIp, so every entrypoint resolves the client IP the
+ * same way.
+ */
+export function resolveClientIpFromHeaders(
+  header: Pick<Headers, "get">
+): string | null {
+  const cfConnectingIp = header.get("cf-connecting-ip");
+  if (cfConnectingIp) {
+    return cfConnectingIp;
+  }
+  if (process.env.NODE_ENV !== "production") {
+    const xffFirst = header.get("x-forwarded-for")?.split(",")[0]?.trim();
+    if (xffFirst) {
+      return xffFirst;
+    }
+    const xRealIp = header.get("x-real-ip");
+    if (xRealIp) {
+      return xRealIp;
+    }
+  }
+  return null;
+}
+
 async function resolveLoginIp(): Promise<string | null> {
   try {
-    const header = await headers();
-    const cfConnectingIp = header.get("cf-connecting-ip");
-    if (cfConnectingIp) {
-      return cfConnectingIp;
-    }
-    // Cloudflare is the trusted source in staging/prod. In other
-    // environments we fall back to the first X-Forwarded-For hop and
-    // then to X-Real-IP so VPN / NAT changes during local dev still
-    // exercise the new-IP gate. NODE_ENV-gated because in CF-fronted
-    // environments these headers are caller-controlled and must not
-    // be trusted.
-    if (process.env.NODE_ENV !== "production") {
-      const xff = header.get("x-forwarded-for");
-      const xffFirst = xff?.split(",")[0]?.trim();
-      if (xffFirst) {
-        return xffFirst;
-      }
-      const xRealIp = header.get("x-real-ip");
-      if (xRealIp) {
-        return xRealIp;
-      }
-    }
-    return null;
+    return resolveClientIpFromHeaders(await headers());
   } catch {
     return null;
   }

--- a/tests/unit/client-ip-resolution.test.ts
+++ b/tests/unit/client-ip-resolution.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveClientIpFromHeaders } from "@/lib/security/login-risk";
+
+function headersOf(values: Record<string, string>): Pick<Headers, "get"> {
+  const map = new Map<string, string>(
+    Object.entries(values).map(([k, v]) => [k.toLowerCase(), v])
+  );
+  return { get: (name: string) => map.get(name.toLowerCase()) ?? null };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("resolveClientIpFromHeaders in production", () => {
+  it("returns CF-Connecting-IP when present", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    expect(
+      resolveClientIpFromHeaders(
+        headersOf({ "cf-connecting-ip": "203.0.113.7" })
+      )
+    ).toBe("203.0.113.7");
+  });
+
+  it("prefers CF-Connecting-IP over a spoofable X-Forwarded-For", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    expect(
+      resolveClientIpFromHeaders(
+        headersOf({
+          "cf-connecting-ip": "203.0.113.7",
+          "x-forwarded-for": "10.1.2.3",
+        })
+      )
+    ).toBe("203.0.113.7");
+  });
+
+  it("ignores an internal node IP carried in X-Forwarded-For and returns null", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    expect(
+      resolveClientIpFromHeaders(headersOf({ "x-forwarded-for": "10.1.2.3" }))
+    ).toBeNull();
+  });
+
+  it("ignores X-Real-IP and returns null when CF-Connecting-IP is absent", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    expect(
+      resolveClientIpFromHeaders(headersOf({ "x-real-ip": "10.1.2.4" }))
+    ).toBeNull();
+  });
+
+  it("returns null when no header is present", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    expect(resolveClientIpFromHeaders(headersOf({}))).toBeNull();
+  });
+});
+
+describe("resolveClientIpFromHeaders outside production", () => {
+  it("still prefers CF-Connecting-IP", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    expect(
+      resolveClientIpFromHeaders(
+        headersOf({
+          "cf-connecting-ip": "203.0.113.7",
+          "x-forwarded-for": "198.51.100.4",
+        })
+      )
+    ).toBe("203.0.113.7");
+  });
+
+  it("falls back to the first X-Forwarded-For hop, trimmed", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    expect(
+      resolveClientIpFromHeaders(
+        headersOf({ "x-forwarded-for": " 198.51.100.4 , 10.0.0.1 " })
+      )
+    ).toBe("198.51.100.4");
+  });
+
+  it("falls back to X-Real-IP when X-Forwarded-For is absent", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    expect(
+      resolveClientIpFromHeaders(headersOf({ "x-real-ip": "198.51.100.4" }))
+    ).toBe("198.51.100.4");
+  });
+
+  it("returns null when no header is present", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    expect(resolveClientIpFromHeaders(headersOf({}))).toBeNull();
+  });
+});


### PR DESCRIPTION
## Release: staging -> prod

Promotes the current `staging` HEAD to `prod` (10 commits, 4 PRs).

### Included
| PR | Change | Type |
|----|--------|------|
| #1442 | TECH-6484 - cut over `/api/metrics/db` to the collector + PR-env wiring | **functional** |
| #1452 | KEEP-676 - resolve client IP via `CF-Connecting-IP` on direct session writes | fix |
| #1456 | KEEP-713 - align staging `keeperhub-common` CPU request with prod | chore |
| #1457 | TECH-29 - comment noting runner UID 1000 is coupled to the node base image | docs (no runtime change) |

### Notes for the reviewer
- **The workflow-runner pod hardening (TECH-29, #1451) is already live on prod** (shipped in release #1455). This release only carries the follow-up doc comment for it.
- The one functional change here is **TECH-6484 (#1442)** - the `/api/metrics/db` collector cutover. Worth a look from that owner before merge.
- All four PRs already passed their checks on merge to `staging` and were validated there.

### Deploy
Merging this triggers the prod CI pipeline (build -> deploy) on the `prod` branch.