### PR TITLE
feat(billing): clarify monthly executions with a tooltip

### DIFF
--- a/components/billing/billing-status.tsx
+++ b/components/billing/billing-status.tsx
@@ -397,7 +397,29 @@ function ExecutionUsageBar({
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between text-sm">
-        <span className="text-muted-foreground">Monthly executions</span>
+        <span className="flex items-center gap-1 text-muted-foreground">
+          Monthly executions
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                aria-label="How monthly executions are counted"
+                className="inline-flex cursor-help items-center text-muted-foreground transition-colors hover:text-foreground"
+                type="button"
+              >
+                <Info className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              <p>
+                Counts billable executions for the current calendar month
+                (since the 1st, UTC) and resets on the 1st. This is your plan
+                quota usage, so it differs from the Analytics page, which counts
+                all executions over the time range you select there (for
+                example, the last 30 days).
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </span>
         <span className="font-medium">
           {used.toLocaleString()} /{" "}
           {isUnlimited ? "Unlimited" : limit.toLocaleString()}


### PR DESCRIPTION
## What

Adds an info tooltip next to the "Monthly executions" label on the billing page's Current Plan card.

## Why

The billing "Monthly executions" value is the current calendar-month quota usage (billable executions since the 1st, UTC, resetting on the 1st). The Analytics page instead counts all executions over the time range selected there (e.g. last 30 days). The two numbers legitimately differ, which has caused confusion. The tooltip explains the distinction inline.

## Notes

- Reuses the existing Tooltip + Info pattern already used in the same component (Gas sponsorship credits tooltip); no new imports.
- No backend or query changes; copy-only UI addition.