### PR TITLE
fix(workflow): count failures of executed nodes shared with skipped branches

### DIFF
--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -2615,6 +2615,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
                 notTakenHandle,
                 edgesBySourceHandle
               ),
+              takenTargets: handleTargets,
             });
             await executeReadyDownstream(nodeId, handleTargets, visited);
 

--- a/lib/workflow/nodes/condition/skipped-branch.ts
+++ b/lib/workflow/nodes/condition/skipped-branch.ts
@@ -8,6 +8,8 @@ import type { EdgesBySourceHandle } from "@/lib/workflow/editor/edge-handle-util
 export type ConditionDecision = {
   taken: string;
   skippedTargets: string[];
+  /** Target node IDs on the handle that was taken (these nodes execute). */
+  takenTargets?: string[];
 };
 
 /**
@@ -27,17 +29,25 @@ export function collectSkippedTargets(
 }
 
 /**
- * Aggregate all skipped targets from every condition decision
- * into a single set for finalSuccess evaluation.
+ * Aggregate not-taken targets across all condition decisions, excluding any
+ * node that another condition actually took (executed), so its failure is not
+ * masked as skipped.
  */
 export function collectAllSkippedTargets(
   conditionDecisions: Map<string, ConditionDecision>
 ): Set<string> {
   const allSkipped = new Set<string>();
+  const allTaken = new Set<string>();
   for (const decision of conditionDecisions.values()) {
     for (const target of decision.skippedTargets) {
       allSkipped.add(target);
     }
+    for (const target of decision.takenTargets ?? []) {
+      allTaken.add(target);
+    }
+  }
+  for (const target of allTaken) {
+    allSkipped.delete(target);
   }
   return allSkipped;
 }

--- a/tests/unit/skipped-branch-utils.test.ts
+++ b/tests/unit/skipped-branch-utils.test.ts
@@ -111,4 +111,22 @@ describe("collectAllSkippedTargets", () => {
     const allSkipped = collectAllSkippedTargets(decisions);
     expect(allSkipped).toEqual(new Set(["skip-a"]));
   });
+
+  it("excludes a node that another condition actually took (shared alert node)", () => {
+    // cond-1 passes: its false branch (alert) is not taken.
+    // cond-2 fails: its false branch takes the same alert node, which executes.
+    const decisions = new Map<string, ConditionDecision>([
+      [
+        "cond-1",
+        { taken: "true", skippedTargets: ["alert"], takenTargets: [] },
+      ],
+      [
+        "cond-2",
+        { taken: "false", skippedTargets: [], takenTargets: ["alert"] },
+      ],
+    ]);
+
+    const allSkipped = collectAllSkippedTargets(decisions);
+    expect(allSkipped.has("alert")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Problem

A workflow run is marked `success` even when a node actually ran and failed, when that node is the target of multiple condition branches. Concretely: several checks each route their failure (`false`) branch into one shared alert node. On a run where some checks pass and one fails, the shared node executes and fails, but the run still shows green.

## Root cause

Run status is decided by `computeFinalSuccess`, which passes a node when `node.success || skippedTargets.has(node)`. `collectAllSkippedTargets` unions the not-taken branch targets of every condition. A node that is the not-taken target of the passing checks AND the taken (executed) target of the failing check ends up in `skippedTargets`, so `computeFinalSuccess` ignores its failure.

## Fix

- `ConditionDecision` records the taken-handle targets (`takenTargets`).
- `collectAllSkippedTargets` removes any taken target from the skipped set, so a node that any branch actually executed can no longer be treated as skipped, and its failure counts toward run status.
- Genuinely dead branches (never taken by any condition) remain excluded, so no false failures are introduced.

## Tests

- New regression test in `skipped-branch-utils.test.ts` for the shared-node case.
- Existing branch-routing / branch-status / executor suites pass (119 tests), type-check clean.