### PR TITLE
feat(workflow): type-aware condition builder with safe array/object operators

### DIFF
--- a/components/workflow/condition-query-builder.tsx
+++ b/components/workflow/condition-query-builder.tsx
@@ -5,7 +5,9 @@ import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
@@ -20,7 +22,9 @@ import {
   createEmptyGroup,
   createEmptyRule,
   isUnaryOperator,
+  OPERATOR_GROUPS,
   OPERATOR_METADATA,
+  operatorsForCategory,
 } from "@/lib/workflow/nodes/condition/builder-utils";
 import { cn } from "@/lib/utils";
 
@@ -30,10 +34,13 @@ type ConditionQueryBuilderProps = {
   disabled?: boolean;
 };
 
-const OPERATOR_OPTIONS = Object.entries(OPERATOR_METADATA) as [
-  ConditionOperator,
-  (typeof OPERATOR_METADATA)[ConditionOperator],
-][];
+// Operators grouped by value type so the dropdown shows section headers
+// (General / Text / Number / Boolean / Array / Object) with their operators
+// beneath, making clear which comparisons apply to which kind of value.
+const OPERATOR_OPTION_GROUPS = OPERATOR_GROUPS.map((groupMeta) => ({
+  label: groupMeta.label,
+  operators: operatorsForCategory(groupMeta.category),
+}));
 
 function RuleRow({
   rule,
@@ -72,10 +79,15 @@ function RuleRow({
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          {OPERATOR_OPTIONS.map(([op, meta]) => (
-            <SelectItem key={op} value={op}>
-              {meta.label}
-            </SelectItem>
+          {OPERATOR_OPTION_GROUPS.map((optionGroup) => (
+            <SelectGroup key={optionGroup.label}>
+              <SelectLabel>{optionGroup.label}</SelectLabel>
+              {optionGroup.operators.map((op) => (
+                <SelectItem key={op} value={op}>
+                  {OPERATOR_METADATA[op].label}
+                </SelectItem>
+              ))}
+            </SelectGroup>
           ))}
         </SelectContent>
       </Select>

--- a/lib/workflow/editor/sanitize-nodes.ts
+++ b/lib/workflow/editor/sanitize-nodes.ts
@@ -71,6 +71,14 @@ const VALID_OPERATORS = new Set<string>([
   "exists",
   "doesNotExist",
   "matchesRegex",
+  "isTrue",
+  "isFalse",
+  "arrayIsEmpty",
+  "arrayIsNotEmpty",
+  "arrayContains",
+  "arrayLength",
+  "objectIsEmpty",
+  "objectHasKey",
 ]);
 
 /** Normalize a condition operator string to a canonical ConditionOperator value */

--- a/lib/workflow/nodes/condition/builder-types.ts
+++ b/lib/workflow/nodes/condition/builder-types.ts
@@ -14,7 +14,15 @@ export type ConditionOperator =
   | "isNotEmpty"
   | "exists"
   | "doesNotExist"
-  | "matchesRegex";
+  | "matchesRegex"
+  | "isTrue"
+  | "isFalse"
+  | "arrayIsEmpty"
+  | "arrayIsNotEmpty"
+  | "arrayContains"
+  | "arrayLength"
+  | "objectIsEmpty"
+  | "objectHasKey";
 
 export type ConditionRule = {
   id: string;

--- a/lib/workflow/nodes/condition/builder-utils.ts
+++ b/lib/workflow/nodes/condition/builder-utils.ts
@@ -6,7 +6,17 @@ import type {
 } from "./builder-types";
 import { isConditionGroup } from "./builder-types";
 
-type OperatorCategory = "comparison" | "string" | "existence" | "pattern";
+// Grouping categories drive the type-aware operator dropdown: each operator
+// belongs to one value-type group so the picker can show section headers
+// (General / Text / Number / Boolean / Array / Object) and the author can see
+// at a glance which comparisons make sense for which kind of value.
+type OperatorCategory =
+  | "general"
+  | "text"
+  | "number"
+  | "boolean"
+  | "array"
+  | "object";
 
 type OperatorMeta = {
   label: string;
@@ -15,27 +25,58 @@ type OperatorMeta = {
 };
 
 export const OPERATOR_METADATA: Record<ConditionOperator, OperatorMeta> = {
-  "==": { label: "soft equals", unary: false, category: "comparison" },
-  "===": { label: "equals", unary: false, category: "comparison" },
-  "!=": { label: "soft not equals", unary: false, category: "comparison" },
-  "!==": { label: "not equals", unary: false, category: "comparison" },
-  ">": { label: "greater than", unary: false, category: "comparison" },
+  "===": { label: "equals", unary: false, category: "general" },
+  "!==": { label: "not equals", unary: false, category: "general" },
+  "==": { label: "soft equals", unary: false, category: "general" },
+  "!=": { label: "soft not equals", unary: false, category: "general" },
+  exists: { label: "exists", unary: true, category: "general" },
+  doesNotExist: { label: "does not exist", unary: true, category: "general" },
+  contains: { label: "contains", unary: false, category: "text" },
+  startsWith: { label: "starts with", unary: false, category: "text" },
+  endsWith: { label: "ends with", unary: false, category: "text" },
+  matchesRegex: { label: "matches regex", unary: false, category: "text" },
+  isEmpty: { label: "is empty", unary: true, category: "text" },
+  isNotEmpty: { label: "is not empty", unary: true, category: "text" },
+  ">": { label: "greater than", unary: false, category: "number" },
   ">=": {
     label: "greater than or equal",
     unary: false,
-    category: "comparison",
+    category: "number",
   },
-  "<": { label: "less than", unary: false, category: "comparison" },
-  "<=": { label: "less than or equal", unary: false, category: "comparison" },
-  contains: { label: "contains", unary: false, category: "string" },
-  startsWith: { label: "starts with", unary: false, category: "string" },
-  endsWith: { label: "ends with", unary: false, category: "string" },
-  isEmpty: { label: "is empty", unary: true, category: "existence" },
-  isNotEmpty: { label: "is not empty", unary: true, category: "existence" },
-  exists: { label: "exists", unary: true, category: "existence" },
-  doesNotExist: { label: "does not exist", unary: true, category: "existence" },
-  matchesRegex: { label: "matches regex", unary: false, category: "pattern" },
+  "<": { label: "less than", unary: false, category: "number" },
+  "<=": { label: "less than or equal", unary: false, category: "number" },
+  isTrue: { label: "is true", unary: true, category: "boolean" },
+  isFalse: { label: "is false", unary: true, category: "boolean" },
+  arrayIsEmpty: { label: "is empty", unary: true, category: "array" },
+  arrayIsNotEmpty: { label: "is not empty", unary: true, category: "array" },
+  arrayContains: { label: "contains", unary: false, category: "array" },
+  arrayLength: { label: "length", unary: false, category: "array" },
+  objectIsEmpty: { label: "is empty", unary: true, category: "object" },
+  objectHasKey: { label: "has key", unary: false, category: "object" },
 } as const;
+
+// Ordered groups for the operator dropdown. Section labels match the screenshot
+// pattern (header + items beneath) so each operator reads in the context of the
+// value type it applies to.
+export const OPERATOR_GROUPS: ReadonlyArray<{
+  label: string;
+  category: OperatorCategory;
+}> = [
+  { label: "General", category: "general" },
+  { label: "Text", category: "text" },
+  { label: "Number", category: "number" },
+  { label: "Boolean", category: "boolean" },
+  { label: "Array", category: "array" },
+  { label: "Object", category: "object" },
+] as const;
+
+export function operatorsForCategory(
+  category: OperatorCategory
+): ConditionOperator[] {
+  return (Object.keys(OPERATOR_METADATA) as ConditionOperator[]).filter(
+    (op) => OPERATOR_METADATA[op].category === category
+  );
+}
 
 export function isUnaryOperator(operator: ConditionOperator): boolean {
   return OPERATOR_METADATA[operator].unary;

--- a/lib/workflow/nodes/condition/expression.ts
+++ b/lib/workflow/nodes/condition/expression.ts
@@ -20,6 +20,11 @@ const UNARY_OPERATORS: ReadonlySet<ConditionOperator> = new Set([
   "isNotEmpty",
   "exists",
   "doesNotExist",
+  "isTrue",
+  "isFalse",
+  "arrayIsEmpty",
+  "arrayIsNotEmpty",
+  "objectIsEmpty",
 ]);
 
 function wrapOperand(operand: string): string {
@@ -92,6 +97,34 @@ function ruleToExpression(rule: ConditionRule): string {
 
     case "matchesRegex":
       return `new RegExp(${wrapOperand(rule.rightOperand)}).test(String(${left}))`;
+
+    case "isTrue":
+      return `${left} === true`;
+
+    case "isFalse":
+      return `${left} === false`;
+
+    // Array operators are guarded with Array.isArray so they evaluate safely
+    // (to false) when the referenced value is not an array, instead of throwing.
+    case "arrayIsEmpty":
+      return `(Array.isArray(${left}) && ${left}.length === 0)`;
+
+    case "arrayIsNotEmpty":
+      return `(Array.isArray(${left}) && ${left}.length > 0)`;
+
+    case "arrayContains":
+      return `(Array.isArray(${left}) && ${left}.includes(${wrapOperand(rule.rightOperand)}))`;
+
+    case "arrayLength":
+      return `(Array.isArray(${left}) && ${left}.length === ${wrapOperand(rule.rightOperand)})`;
+
+    // Object operators guard against null/undefined before reading keys, so a
+    // missing reference is false rather than a thrown error.
+    case "objectIsEmpty":
+      return `(${left} !== null && ${left} !== undefined && Object.keys(${left}).length === 0)`;
+
+    case "objectHasKey":
+      return `(${left} !== null && ${left} !== undefined && Object.keys(${left}).includes(${wrapOperand(rule.rightOperand)}))`;
 
     default: {
       const _exhaustive: never = rule.operator;

--- a/lib/workflow/nodes/condition/validator.ts
+++ b/lib/workflow/nodes/condition/validator.ts
@@ -77,6 +77,11 @@ const ALLOWED_METHODS = new Set([
   "toUpperCase",
   "trim",
   "length", // Actually a property, but accessed like .length
+  // Type guards emitted by the visual builder's Array/Object operators. Both are
+  // pure, non-mutating reads on built-in globals, so they are safe to evaluate
+  // and let array/object comparisons run without throwing on non-matching types.
+  "isArray", // Array.isArray(...)
+  "keys", // Object.keys(...)
 ]);
 
 // Pattern to match method calls

--- a/tests/unit/condition-builder-utils.test.ts
+++ b/tests/unit/condition-builder-utils.test.ts
@@ -60,6 +60,20 @@ describe("condition-builder-utils", () => {
       expect(isUnaryOperator("contains")).toBe(false);
       expect(isUnaryOperator("matchesRegex")).toBe(false);
     });
+
+    it("should return true for unary boolean/array/object operators", () => {
+      expect(isUnaryOperator("isTrue")).toBe(true);
+      expect(isUnaryOperator("isFalse")).toBe(true);
+      expect(isUnaryOperator("arrayIsEmpty")).toBe(true);
+      expect(isUnaryOperator("arrayIsNotEmpty")).toBe(true);
+      expect(isUnaryOperator("objectIsEmpty")).toBe(true);
+    });
+
+    it("should return false for binary array/object operators", () => {
+      expect(isUnaryOperator("arrayContains")).toBe(false);
+      expect(isUnaryOperator("arrayLength")).toBe(false);
+      expect(isUnaryOperator("objectHasKey")).toBe(false);
+    });
   });
 
   describe("visualConditionToExpression", () => {
@@ -173,6 +187,64 @@ describe("condition-builder-utils", () => {
         const expr = visualConditionToExpression(g);
         expect(expr).toContain("new RegExp");
         expect(expr).toContain(".test(");
+      });
+    });
+
+    describe("boolean operators", () => {
+      it("should generate isTrue expression", () => {
+        const g = group("AND", [rule("{{@n:L.flag}}", "isTrue")]);
+        expect(visualConditionToExpression(g)).toBe("{{@n:L.flag}} === true");
+      });
+
+      it("should generate isFalse expression", () => {
+        const g = group("AND", [rule("{{@n:L.flag}}", "isFalse")]);
+        expect(visualConditionToExpression(g)).toBe("{{@n:L.flag}} === false");
+      });
+    });
+
+    describe("array operators", () => {
+      it("should generate guarded arrayIsEmpty expression", () => {
+        const g = group("AND", [rule("{{@n:L.items}}", "arrayIsEmpty")]);
+        expect(visualConditionToExpression(g)).toBe(
+          "(Array.isArray({{@n:L.items}}) && {{@n:L.items}}.length === 0)"
+        );
+      });
+
+      it("should generate guarded arrayIsNotEmpty expression", () => {
+        const g = group("AND", [rule("{{@n:L.items}}", "arrayIsNotEmpty")]);
+        expect(visualConditionToExpression(g)).toBe(
+          "(Array.isArray({{@n:L.items}}) && {{@n:L.items}}.length > 0)"
+        );
+      });
+
+      it("should generate guarded arrayContains expression", () => {
+        const g = group("AND", [rule("{{@n:L.items}}", "arrayContains", "5")]);
+        expect(visualConditionToExpression(g)).toBe(
+          "(Array.isArray({{@n:L.items}}) && {{@n:L.items}}.includes(5))"
+        );
+      });
+
+      it("should generate guarded arrayLength expression", () => {
+        const g = group("AND", [rule("{{@n:L.items}}", "arrayLength", "3")]);
+        expect(visualConditionToExpression(g)).toBe(
+          "(Array.isArray({{@n:L.items}}) && {{@n:L.items}}.length === 3)"
+        );
+      });
+    });
+
+    describe("object operators", () => {
+      it("should generate null-guarded objectIsEmpty expression", () => {
+        const g = group("AND", [rule("{{@n:L.obj}}", "objectIsEmpty")]);
+        expect(visualConditionToExpression(g)).toBe(
+          "({{@n:L.obj}} !== null && {{@n:L.obj}} !== undefined && Object.keys({{@n:L.obj}}).length === 0)"
+        );
+      });
+
+      it("should generate null-guarded objectHasKey expression", () => {
+        const g = group("AND", [rule("{{@n:L.obj}}", "objectHasKey", "id")]);
+        expect(visualConditionToExpression(g)).toBe(
+          '({{@n:L.obj}} !== null && {{@n:L.obj}} !== undefined && Object.keys({{@n:L.obj}}).includes("id"))'
+        );
       });
     });
 

--- a/tests/unit/condition-executor.test.ts
+++ b/tests/unit/condition-executor.test.ts
@@ -539,6 +539,137 @@ describe("condition evaluation edge cases", () => {
     });
   });
 
+  describe("typed operators via visual builder (boolean/array/object)", () => {
+    function evalRule(
+      operator: string,
+      value: unknown,
+      rightOperand = ""
+    ): boolean {
+      const config: Record<string, unknown> = {
+        conditionConfig: {
+          group: {
+            id: "g1",
+            logic: "AND",
+            rules: [
+              {
+                id: "r1",
+                leftOperand: "{{@node1:API.value}}",
+                operator,
+                rightOperand,
+              },
+            ],
+          },
+        },
+      };
+
+      const expression = resolveConditionExpression(config);
+      const outputs = { node1: { label: "API", data: { value } } };
+      return evaluateConditionExpression(expression, outputs).result;
+    }
+
+    describe("isTrue / isFalse", () => {
+      it("should match a boolean true value with isTrue", () => {
+        expect(evalRule("isTrue", true)).toBe(true);
+      });
+
+      it("should not treat a truthy string as isTrue", () => {
+        // strict `=== true`, so the string "true" does not match
+        expect(evalRule("isTrue", "true")).toBe(false);
+      });
+
+      it("should match a boolean false value with isFalse", () => {
+        expect(evalRule("isFalse", false)).toBe(true);
+      });
+
+      it("should not treat 0 as isFalse", () => {
+        expect(evalRule("isFalse", 0)).toBe(false);
+      });
+    });
+
+    describe("arrayIsEmpty / arrayIsNotEmpty", () => {
+      it("should report an empty array as empty", () => {
+        expect(evalRule("arrayIsEmpty", [])).toBe(true);
+      });
+
+      it("should report a populated array as not empty", () => {
+        expect(evalRule("arrayIsNotEmpty", [1, 2, 3])).toBe(true);
+      });
+
+      it("should evaluate arrayIsEmpty to false on a non-array (no throw)", () => {
+        // The Array.isArray guard means a string is not "an empty array"
+        expect(evalRule("arrayIsEmpty", "not an array")).toBe(false);
+      });
+
+      it("should evaluate arrayIsEmpty to false on null (no throw)", () => {
+        expect(evalRule("arrayIsEmpty", null)).toBe(false);
+      });
+
+      it("should evaluate arrayIsNotEmpty to false on a non-array (no throw)", () => {
+        expect(evalRule("arrayIsNotEmpty", 42)).toBe(false);
+      });
+    });
+
+    describe("arrayContains", () => {
+      it("should detect a present numeric element", () => {
+        expect(evalRule("arrayContains", [1, 2, 3], "2")).toBe(true);
+      });
+
+      it("should detect a present string element", () => {
+        expect(evalRule("arrayContains", ["a", "b"], "b")).toBe(true);
+      });
+
+      it("should return false when the element is absent", () => {
+        expect(evalRule("arrayContains", [1, 2, 3], "9")).toBe(false);
+      });
+
+      it("should evaluate to false on a non-array (no throw)", () => {
+        expect(evalRule("arrayContains", "abc", "a")).toBe(false);
+      });
+    });
+
+    describe("arrayLength", () => {
+      it("should match the exact length", () => {
+        expect(evalRule("arrayLength", [1, 2, 3], "3")).toBe(true);
+      });
+
+      it("should not match a different length", () => {
+        expect(evalRule("arrayLength", [1, 2], "3")).toBe(false);
+      });
+
+      it("should evaluate to false on a non-array (no throw)", () => {
+        expect(evalRule("arrayLength", "abc", "3")).toBe(false);
+      });
+    });
+
+    describe("objectIsEmpty", () => {
+      it("should report an object with no keys as empty", () => {
+        expect(evalRule("objectIsEmpty", {})).toBe(true);
+      });
+
+      it("should report an object with keys as not empty", () => {
+        expect(evalRule("objectIsEmpty", { a: 1 })).toBe(false);
+      });
+
+      it("should evaluate to false on null (no throw)", () => {
+        expect(evalRule("objectIsEmpty", null)).toBe(false);
+      });
+    });
+
+    describe("objectHasKey", () => {
+      it("should detect a present key", () => {
+        expect(evalRule("objectHasKey", { id: 1, name: "x" }, "id")).toBe(true);
+      });
+
+      it("should return false for an absent key", () => {
+        expect(evalRule("objectHasKey", { id: 1 }, "missing")).toBe(false);
+      });
+
+      it("should evaluate to false on null (no throw)", () => {
+        expect(evalRule("objectHasKey", null, "id")).toBe(false);
+      });
+    });
+  });
+
   describe("BigInt-safe comparisons for large Web3 values", () => {
     it("should detect off-by-one difference in large numbers", () => {
       const expression = "{{@node1:Contract.balance}} > 1000000000000000000";


### PR DESCRIPTION
## Problem

The condition builder's operator dropdown listed every operator in one flat list, with no notion of value type. Array comparisons were impossible to express safely: an array operand was stringified before comparison (e.g. an empty-array check generated `"(....length)" === 0`, comparing a string to a number), so it always evaluated false. Authors worked around this by hand-writing JS (`new RegExp(...)`, array literals), which the expression sandbox correctly rejects, leaving no valid path.

## Changes

- Operator dropdown is grouped by value type with section headers: General, Text, Number, Boolean, Array, Object. Each type only surfaces the comparisons that make sense for it.
- New operators: Boolean (`is true`, `is false`), Array (`is empty`, `is not empty`, `contains`, `length`), Object (`is empty`, `has key`).
- Array and object operators generate guarded expressions (`Array.isArray(...)`, null-checked `Object.keys(...)`) so they evaluate to false instead of throwing when the value is not the expected type, and never stringify a live reference.
- Expression validator whitelists the `isArray` and `keys` reads used by the guards.
- Node sanitization keeps the new operators so AI/MCP-authored conditions are not downgraded.

## Tests

- All existing condition unit tests pass (159), plus an end-to-end check (generate, validate, evaluate) confirming empty/non-empty arrays, non-array safety, objects, and booleans. Type-check clean.