### PR TITLE
fix: default HTTP Request method to POST when unset

### DIFF
--- a/components/workflow/config/action-config.tsx
+++ b/components/workflow/config/action-config.tsx
@@ -33,6 +33,10 @@ import { actionRequiresCredentials } from "@/lib/integration-helpers";
 import { ConditionQueryBuilder } from "@/components/workflow/condition-query-builder";
 import type { ConditionGroup } from "@/lib/workflow/nodes/condition/builder-types";
 import {
+  DEFAULT_HTTP_METHOD,
+  HTTP_METHODS,
+} from "@/lib/workflow/nodes/http-request/constants";
+import {
   createEmptyGroup,
   expressionToConditionGroup,
   visualConditionToExpression,
@@ -138,17 +142,17 @@ function HttpRequestFields({
         <Select
           disabled={disabled}
           onValueChange={(value) => onUpdateConfig("httpMethod", value)}
-          value={(config?.httpMethod as string) || "POST"}
+          value={(config?.httpMethod as string) || DEFAULT_HTTP_METHOD}
         >
           <SelectTrigger className="w-full" id="httpMethod">
             <SelectValue placeholder="Select method" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="GET">GET</SelectItem>
-            <SelectItem value="POST">POST</SelectItem>
-            <SelectItem value="PUT">PUT</SelectItem>
-            <SelectItem value="PATCH">PATCH</SelectItem>
-            <SelectItem value="DELETE">DELETE</SelectItem>
+            {HTTP_METHODS.map((method) => (
+              <SelectItem key={method} value={method}>
+                {method}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </div>

--- a/lib/workflow/codegen/codegen.ts
+++ b/lib/workflow/codegen/codegen.ts
@@ -1,5 +1,6 @@
 import { buildEdgesBySourceHandle } from "@/lib/workflow/editor/edge-handle-utils";
 import { resolveConditionExpression } from "@/lib/workflow/nodes/condition/resolver";
+import { DEFAULT_HTTP_METHOD } from "@/lib/workflow/nodes/http-request/constants";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 import { findActionById, flattenConfigFields } from "@/plugins/registry";
 import {
@@ -400,7 +401,7 @@ export function generateWorkflowCode(
     const config = node.data.config || {};
     const endpoint =
       (config.endpoint as string) || "https://api.example.com/endpoint";
-    const method = (config.httpMethod as string) || "POST";
+    const method = (config.httpMethod as string) || DEFAULT_HTTP_METHOD;
 
     return [
       `${indent}const ${varName} = await ${stepInfo.functionName}({`,

--- a/lib/workflow/codegen/sdk.ts
+++ b/lib/workflow/codegen/sdk.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { DEFAULT_HTTP_METHOD } from "@/lib/workflow/nodes/http-request/constants";
 import { findActionById } from "@/plugins/registry";
 import { synthesiseProtocolForSDK } from "./protocol-synthesiser";
 // System action codegen templates (not in plugin registry)
@@ -344,7 +345,7 @@ export function generateWorkflowSDKCode(
   function buildHttpParams(config: Record<string, unknown>): string[] {
     const params = [
       `url: "${config.endpoint || "https://api.example.com/endpoint"}"`,
-      `method: "${config.httpMethod || "POST"}"`,
+      `method: "${config.httpMethod || DEFAULT_HTTP_METHOD}"`,
       `headers: ${config.httpHeaders || "{}"}`,
     ];
     if (config.httpBody) {

--- a/lib/workflow/nodes/http-request/constants.ts
+++ b/lib/workflow/nodes/http-request/constants.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared HTTP Request node constants.
+ *
+ * Deliberately free of `server-only` and any Node imports so both the client
+ * config editor and the server-only step worker can import the SAME default.
+ * The editor only persists `httpMethod` when the user changes the dropdown, so
+ * the runtime needs the identical fallback to avoid silently defaulting to GET
+ * (which then rejects a configured body). Keep all three consumers -- the
+ * editor, the worker, and the SDK codegen -- pointed at these constants so the
+ * default and the option list never drift apart again.
+ */
+
+export const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
+
+export type HttpMethod = (typeof HTTP_METHODS)[number];
+
+export const DEFAULT_HTTP_METHOD: HttpMethod = "POST";

--- a/lib/workflow/nodes/http-request/perform.ts
+++ b/lib/workflow/nodes/http-request/perform.ts
@@ -16,6 +16,7 @@ import { safeFetch } from "@/lib/safe-fetch";
 import { getErrorMessage } from "@/lib/utils";
 import { extractTemplateTokens } from "@/lib/utils/template";
 import type { StepInput } from "@/lib/workflow/executor/step-handler";
+import { DEFAULT_HTTP_METHOD } from "./constants";
 
 export type HttpRequestResult =
   // KEEP-444: the success variant carries an optional `error` so a soft-failed
@@ -27,7 +28,9 @@ export type HttpRequestResult =
 
 export type HttpRequestInput = StepInput & {
   endpoint: string;
-  httpMethod: string;
+  // Optional: the visual editor only persists this when the user changes the
+  // dropdown, so it can arrive undefined. resolveHttpMethod defaults it to POST.
+  httpMethod?: string;
   httpHeaders?: string;
   httpBody?: string;
   // KEEP-444: per-node request timeout in seconds (default 5, clamped 1-30).
@@ -68,6 +71,21 @@ export function resolveTimeoutMs(timeout: unknown): number {
  */
 export function resolveFailOnError(failOnError: unknown): boolean {
   return failOnError !== false && failOnError !== "false";
+}
+
+/**
+ * Resolve the HTTP method. The visual editor only writes `httpMethod` to the
+ * node config when the user actively changes the dropdown -- leaving it on its
+ * displayed default means the field is never persisted, so `input.httpMethod`
+ * arrives undefined and fetch silently falls back to GET (which then rejects a
+ * configured body). Default the missing/empty case to POST and uppercase so the
+ * GET-body guard in parseBody matches regardless of casing. Exported for tests.
+ */
+export function resolveHttpMethod(httpMethod: unknown): string {
+  if (typeof httpMethod !== "string" || httpMethod.trim() === "") {
+    return DEFAULT_HTTP_METHOD;
+  }
+  return httpMethod.trim().toUpperCase();
 }
 
 // URLs never legitimately contain `{{`, so any token left in the endpoint
@@ -149,12 +167,13 @@ export async function httpRequest(
   }
   const { endpoint } = validation;
   const failOnError = resolveFailOnError(input.failOnError);
+  const httpMethod = resolveHttpMethod(input.httpMethod);
 
   try {
     const response = await safeFetch(endpoint, {
-      method: input.httpMethod,
+      method: httpMethod,
       headers: parseHeaders(input.httpHeaders),
-      body: parseBody(input.httpMethod, input.httpBody),
+      body: parseBody(httpMethod, input.httpBody),
       signal: AbortSignal.timeout(resolveTimeoutMs(input.timeout)),
       plugin: "http-request",
     });

--- a/tests/unit/http-request-timeout-soft-fail.test.ts
+++ b/tests/unit/http-request-timeout-soft-fail.test.ts
@@ -16,6 +16,7 @@ import { safeFetch } from "@/lib/safe-fetch";
 import {
   httpRequest,
   resolveFailOnError,
+  resolveHttpMethod,
   resolveTimeoutMs,
 } from "@/lib/workflow/nodes/http-request/perform";
 
@@ -98,6 +99,50 @@ describe("resolveFailOnError", () => {
 
   it("stays true for the string 'true'", () => {
     expect(resolveFailOnError("true")).toBe(true);
+  });
+});
+
+describe("resolveHttpMethod", () => {
+  it("defaults to POST when the editor never persisted a method", () => {
+    expect(resolveHttpMethod(undefined)).toBe("POST");
+  });
+
+  it("defaults to POST for an empty / whitespace string", () => {
+    expect(resolveHttpMethod("")).toBe("POST");
+    expect(resolveHttpMethod("   ")).toBe("POST");
+  });
+
+  it("preserves an explicitly configured method", () => {
+    expect(resolveHttpMethod("GET")).toBe("GET");
+    expect(resolveHttpMethod("DELETE")).toBe("DELETE");
+  });
+
+  it("uppercases so the GET-body guard matches regardless of casing", () => {
+    expect(resolveHttpMethod("post")).toBe("POST");
+    expect(resolveHttpMethod(" get ")).toBe("GET");
+  });
+});
+
+describe("httpRequest method resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends POST with the body when httpMethod is missing from config", async () => {
+    // KEEP-723: a node saved without httpMethod must not fall back to GET, which
+    // would drop the body or throw "GET/HEAD method cannot have body".
+    mockedSafeFetch.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, body: {} })
+    );
+
+    await httpRequest({
+      endpoint: "https://api.example.com/post",
+      httpBody: '{"a":"b"}',
+    });
+
+    const init = mockedSafeFetch.mock.calls[0][1];
+    expect(init?.method).toBe("POST");
+    expect(init?.body).toBe('{"a":"b"}');
   });
 });
 


### PR DESCRIPTION
## Problem

The HTTP Request node sent requests without an HTTP method, so POST requests failed with:

> HTTP request failed: Request with GET/HEAD method cannot have body.

The method dropdown displayed `POST` as a fallback (`value={config?.httpMethod || "POST"}`), but the `Select`'s `onValueChange` only fires when the user *actively changes* the dropdown. A user who left it on the shown default never triggered a write, so `httpMethod` was never persisted to the node config. At runtime `input.httpMethod` arrived `undefined`, fetch/undici fell back to GET, and the configured body threw. Already-saved workflows were affected too, not just newly-created ones.

## Fix

- Resolve a missing or empty method to `POST` in the worker (`resolveHttpMethod`), following the existing `resolveTimeoutMs` / `resolveFailOnError` pattern. This also repairs already-saved workflows since the default is applied at execution time.
- Route the editor fallback, the method option list, and both codegen paths through a single shared `DEFAULT_HTTP_METHOD` / `HTTP_METHODS` constant (new `lib/workflow/nodes/http-request/constants.ts`, free of `server-only` so client and server share it) so the default and option list can no longer drift.

## Tests

- `resolveHttpMethod` unit tests (missing/empty -> POST, preserves explicit method, uppercases).
- Regression test: a config without `httpMethod` but with a body sends `POST` with that body instead of falling back to GET.
- Full type-check and lint pass.