### PR TITLE
fix(billing): redirect non-owners home instead of serving a 404

### DIFF
--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -18,7 +18,7 @@ export default async function BillingRoute(): Promise<React.ReactElement> {
 
   const activeMember = await auth.api.getActiveMember({ headers: hdrs });
   if (activeMember?.role !== "owner") {
-    notFound();
+    redirect("/");
   }
 
   return (


### PR DESCRIPTION
Non-owners who navigate directly to `/billing` were served a 404, which reads as an app error. The billing menu link is already owner-gated, so non-owners only land here via a direct URL. They are now redirected to the home page instead.