### PR TITLE
fix(org-switcher): truncate long org names to one line with tooltip

### DIFF
--- a/components/organization/org-switcher.tsx
+++ b/components/organization/org-switcher.tsx
@@ -16,6 +16,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useSession } from "@/lib/auth-client";
 import {
   useOrganization,
@@ -163,7 +168,14 @@ export function OrgSwitcher() {
                         organization.id === org.id ? "opacity-100" : "opacity-0"
                       }`}
                     />
-                    {org.name}
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="min-w-0 flex-1 truncate text-left">
+                          {org.name}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent side="right">{org.name}</TooltipContent>
+                    </Tooltip>
                   </CommandItem>
                 ))}
               </CommandGroup>


### PR DESCRIPTION
Long organization names wrapped to multiple lines in the switcher dropdown, which looked broken. Each name now truncates to a single line with an ellipsis, and hovering shows a tooltip with the full name so visually similar names stay distinguishable before selecting.