### PR TITLE
fix(executor): treat missing integration credential as a user error

### DIFF
--- a/lib/credential-fetcher.ts
+++ b/lib/credential-fetcher.ts
@@ -101,6 +101,13 @@ export async function fetchCredentials(
   integrationId: string,
   principal?: IntegrationPrincipal
 ): Promise<WorkflowCredentials> {
+  // A node with no integration selected passes undefined at runtime; treat it
+  // as a missing integration instead of letting getIntegrationById(undefined)
+  // throw UNDEFINED_VALUE and surface as a system error.
+  if (!integrationId) {
+    return {};
+  }
+
   if (principal) {
     const unauthorized = await filterUnauthorizedIntegrationIds(
       [integrationId],

--- a/lib/errors/classify.ts
+++ b/lib/errors/classify.ts
@@ -142,6 +142,12 @@ const RULES: readonly Rule[] = [
     errorCategory: ErrorCategory.CONFIGURATION,
     errorType: "user",
   },
+  // User-config: integration credential not configured
+  {
+    pattern: /API key is required/i,
+    errorCategory: ErrorCategory.CONFIGURATION,
+    errorType: "user",
+  },
   // User-action: Para wallet session needs re-export
   // Must come BEFORE the generic `^Failed to initialize organization wallet` rule below.
   {

--- a/tests/unit/classify-execution-error.test.ts
+++ b/tests/unit/classify-execution-error.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyExecutionError } from "@/lib/errors/classify";
+import { ErrorCategory } from "@/lib/logging";
+
+describe("classifyExecutionError", () => {
+  it("classifies a missing integration credential as a user config error", () => {
+    const result = classifyExecutionError(
+      "Safe API key is required. Configure it in the integration settings."
+    );
+    expect(result).toEqual({
+      errorCategory: ErrorCategory.CONFIGURATION,
+      errorType: "user",
+    });
+  });
+
+  it("defaults unmatched messages to system so real engine faults still page", () => {
+    const result = classifyExecutionError("some unexpected internal failure");
+    expect(result.errorType).toBe("system");
+    expect(result.errorCategory).toBe(ErrorCategory.WORKFLOW_ENGINE);
+  });
+
+  it("classifies null/empty messages as system", () => {
+    expect(classifyExecutionError(null).errorType).toBe("system");
+    expect(classifyExecutionError("   ").errorType).toBe("system");
+  });
+});

--- a/tests/unit/credential-fetcher.test.ts
+++ b/tests/unit/credential-fetcher.test.ts
@@ -131,6 +131,19 @@ describe("mapIntegrationConfig (via fetchCredentials)", () => {
     expect(creds[envVar]).toBe("secret-value");
   });
 
+  it("returns empty creds without hitting the DB when integrationId is missing", async () => {
+    const { getIntegrationById } = await import("@/lib/db/integrations");
+    const { fetchCredentials } = await import("@/lib/credential-fetcher");
+
+    vi.mocked(getIntegrationById).mockClear();
+
+    // Must short-circuit before getIntegrationById(undefined) throws.
+    const creds = await fetchCredentials(undefined as unknown as string);
+
+    expect(creds).toEqual({});
+    expect(getIntegrationById).not.toHaveBeenCalled();
+  });
+
   it("returns empty creds for unknown integration types", async () => {
     const { getIntegrationById } = await import("@/lib/db/integrations");
     const { fetchCredentials } = await import("@/lib/credential-fetcher");


### PR DESCRIPTION
A workflow node with no integration selected passed `integrationId` as `undefined` to `fetchCredentials`, which forwarded it to `getIntegrationById`, where drizzle threw `UNDEFINED_VALUE: Undefined values are not allowed`. That is a user misconfiguration, but it surfaced as `error_type=system` and counted against the system-error SLI.

## Fix

- Guard `fetchCredentials`: an empty `integrationId` returns no credentials (matching the existing "integration not found" behavior) instead of reaching the DB layer. The step then fails through its own credential-required path with a user-facing message.
- Add a classifier rule so that failure (`... API key is required`) is labelled `error_type=user` instead of falling through to the `system` default.

## Verification

Unit tests cover the full chain: `fetchCredentials(undefined)` returns `{}` without calling `getIntegrationById`, and `classifyExecutionError` labels the resulting message as `user`/`configuration`. The Safe step already returns that message on empty credentials.