### PR TITLE
feat(executions): add wait-for-receipt long-poll endpoint

### DIFF
--- a/app/api/workflows/executions/[executionId]/logs/route.ts
+++ b/app/api/workflows/executions/[executionId]/logs/route.ts
@@ -1,11 +1,10 @@
 import { desc, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
-import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { db } from "@/lib/db";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
-import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
+import { workflowExecutionLogs } from "@/lib/db/schema";
 import { redactSensitiveData } from "@/lib/utils/redact";
-import { getWorkflowAccess } from "@/lib/workflow/access";
+import { resolveAuthorizedExecution } from "@/lib/workflow/execution-access";
 
 type TruncatedMarker = {
   _truncated: true;
@@ -57,48 +56,14 @@ export async function GET(
       nodeIds !== undefined ||
       truncateData !== undefined;
 
-    const authContext = await getDualAuthContext(request);
-    if ("error" in authContext) {
+    const resolved = await resolveAuthorizedExecution(request, executionId);
+    if (!resolved.ok) {
       return NextResponse.json(
-        { error: authContext.error },
-        { status: authContext.status }
+        { error: resolved.error },
+        { status: resolved.status }
       );
     }
-    const { userId, organizationId } = authContext;
-
-    if (!userId && !organizationId) {
-      return NextResponse.json(
-        { error: "API key has no associated user or organization. Please recreate the API key." },
-        { status: 403 }
-      );
-    }
-
-    const execution = await db.query.workflowExecutions.findFirst({
-      where: eq(workflowExecutions.id, executionId),
-      with: {
-        workflow: true,
-      },
-    });
-
-    if (!execution) {
-      return NextResponse.json(
-        { error: "Execution not found" },
-        { status: 404 }
-      );
-    }
-
-    const access = await getWorkflowAccess(execution.workflow, {
-      userId,
-      organizationId,
-      authMethod: authContext.authMethod,
-    });
-
-    if (!access.hasFullAccess) {
-      return NextResponse.json(
-        { error: "Execution not found" },
-        { status: 404 }
-      );
-    }
+    const { execution } = resolved;
 
     const logs = await db.query.workflowExecutionLogs.findMany({
       where: eq(workflowExecutionLogs.executionId, executionId),

--- a/app/api/workflows/executions/[executionId]/status/route.ts
+++ b/app/api/workflows/executions/[executionId]/status/route.ts
@@ -1,12 +1,11 @@
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { workflowExecutionLogs } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { createTimer } from "@/lib/metrics";
 import { recordStatusPollMetrics } from "@/lib/metrics/instrumentation/api";
-import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
-import { db } from "@/lib/db";
-import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
-import { getWorkflowAccess } from "@/lib/workflow/access";
+import { resolveAuthorizedExecution } from "@/lib/workflow/execution-access";
 
 type NodeStatus = {
   nodeId: string;
@@ -22,72 +21,19 @@ export async function GET(
   try {
     const { executionId } = await context.params;
 
-    const authContext = await getDualAuthContext(request);
-    if ("error" in authContext) {
+    const resolved = await resolveAuthorizedExecution(request, executionId);
+    if (!resolved.ok) {
       recordStatusPollMetrics({
         executionId,
         durationMs: timer(),
-        statusCode: authContext.status,
+        statusCode: resolved.status,
       });
       return NextResponse.json(
-        { error: authContext.error },
-        { status: authContext.status }
+        { error: resolved.error },
+        { status: resolved.status }
       );
     }
-    const { userId, organizationId } = authContext;
-
-    if (!userId && !organizationId) {
-      recordStatusPollMetrics({
-        executionId,
-        durationMs: timer(),
-        statusCode: 403,
-      });
-      return NextResponse.json(
-        { error: "API key has no associated user or organization. Please recreate the API key." },
-        { status: 403 }
-      );
-    }
-
-    // Get the execution and verify ownership
-    const execution = await db.query.workflowExecutions.findFirst({
-      where: eq(workflowExecutions.id, executionId),
-      with: {
-        workflow: true,
-      },
-    });
-
-    if (!execution) {
-      recordStatusPollMetrics({
-        executionId,
-        durationMs: timer(),
-        statusCode: 404,
-      });
-      return NextResponse.json(
-        { error: "Execution not found" },
-        { status: 404 }
-      );
-    }
-
-    // Verify access: owner or org member
-    const access = await getWorkflowAccess(execution.workflow, {
-      userId,
-      organizationId,
-      authMethod: authContext.authMethod,
-    });
-
-    // KEEP-440: keep this consistent with the execution-history route -- once
-    // the workflow is soft-deleted its execution detail is hidden too.
-    if (!access.hasFullAccess || access.isDeleted) {
-      recordStatusPollMetrics({
-        executionId,
-        durationMs: timer(),
-        statusCode: 404,
-      });
-      return NextResponse.json(
-        { error: "Execution not found" },
-        { status: 404 }
-      );
-    }
+    const { execution } = resolved;
 
     // Get logs for all nodes
     const logs = await db.query.workflowExecutionLogs.findMany({

--- a/app/api/workflows/executions/[executionId]/wait/route.ts
+++ b/app/api/workflows/executions/[executionId]/wait/route.ts
@@ -1,0 +1,125 @@
+import { eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { workflowExecutions } from "@/lib/db/schema";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { createTimer } from "@/lib/metrics";
+import { recordStatusPollMetrics } from "@/lib/metrics/instrumentation/api";
+import {
+  DEFAULT_CALL_WAIT_TIMEOUT_MS,
+  waitForExecutionCompletion,
+} from "@/lib/payments/x402/execution-wait";
+import { resolveAuthorizedExecution } from "@/lib/workflow/execution-access";
+
+// Cap how long a single request blocks so it stays under typical HTTP/MCP
+// client timeouts and never pins a serverless worker indefinitely. Clients
+// re-call to keep waiting past this window.
+const MAX_WAIT_TIMEOUT_MS = 60_000;
+
+function parseTimeoutMs(request: Request): number {
+  const raw = new URL(request.url).searchParams.get("timeoutMs");
+  const parsed = Number.parseInt(raw ?? "", 10);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_CALL_WAIT_TIMEOUT_MS;
+  }
+  return Math.min(Math.max(parsed, 0), MAX_WAIT_TIMEOUT_MS);
+}
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ executionId: string }> }
+) {
+  const timer = createTimer();
+
+  try {
+    const { executionId } = await context.params;
+
+    const resolved = await resolveAuthorizedExecution(request, executionId);
+    if (!resolved.ok) {
+      recordStatusPollMetrics({
+        executionId,
+        durationMs: timer(),
+        statusCode: resolved.status,
+      });
+      return NextResponse.json(
+        { error: resolved.error },
+        { status: resolved.status }
+      );
+    }
+
+    const timeoutMs = parseTimeoutMs(request);
+    const result = await waitForExecutionCompletion(executionId, timeoutMs);
+
+    // Re-read the row after waiting: the poller only resolves status/output/
+    // error, but the receipt needs transactionHashes/gas/completedAt too.
+    const fresh = await db.query.workflowExecutions.findFirst({
+      where: eq(workflowExecutions.id, executionId),
+      columns: {
+        status: true,
+        output: true,
+        error: true,
+        transactionHashes: true,
+        gasUsedWei: true,
+        completedAt: true,
+      },
+    });
+
+    if (!fresh) {
+      recordStatusPollMetrics({
+        executionId,
+        durationMs: timer(),
+        statusCode: 404,
+      });
+      return NextResponse.json(
+        { error: "Execution not found" },
+        { status: 404 }
+      );
+    }
+
+    recordStatusPollMetrics({
+      executionId,
+      durationMs: timer(),
+      statusCode: 200,
+      executionStatus: fresh.status,
+    });
+
+    // result is null on timeout (still pending/running); non-null once the
+    // execution reached a terminal state within the wait window.
+    return NextResponse.json({
+      executionId,
+      status: fresh.status,
+      completed: result !== null,
+      transactionHashes: fresh.transactionHashes ?? [],
+      output: fresh.output,
+      error: fresh.error ?? null,
+      gasUsedWei: fresh.gasUsedWei,
+      completedAt: fresh.completedAt,
+    });
+  } catch (error) {
+    const { executionId } = await context.params;
+    logSystemError(
+      ErrorCategory.DATABASE,
+      "Failed to wait for execution receipt",
+      error,
+      {
+        endpoint: "/api/workflows/executions/[executionId]/wait",
+        operation: "get",
+      }
+    );
+    recordStatusPollMetrics({
+      executionId,
+      durationMs: timer(),
+      statusCode: 500,
+    });
+
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to wait for execution receipt",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/workflows/executions/[executionId]/wait/route.ts
+++ b/app/api/workflows/executions/[executionId]/wait/route.ts
@@ -1,13 +1,10 @@
-import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
-import { db } from "@/lib/db";
-import { workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { createTimer } from "@/lib/metrics";
 import { recordStatusPollMetrics } from "@/lib/metrics/instrumentation/api";
 import {
   DEFAULT_CALL_WAIT_TIMEOUT_MS,
-  waitForExecutionCompletion,
+  waitForExecutionReceipt,
 } from "@/lib/payments/x402/execution-wait";
 import { resolveAuthorizedExecution } from "@/lib/workflow/execution-access";
 
@@ -48,23 +45,12 @@ export async function GET(
     }
 
     const timeoutMs = parseTimeoutMs(request);
-    const result = await waitForExecutionCompletion(executionId, timeoutMs);
+    const { row, completed } = await waitForExecutionReceipt(
+      executionId,
+      timeoutMs
+    );
 
-    // Re-read the row after waiting: the poller only resolves status/output/
-    // error, but the receipt needs transactionHashes/gas/completedAt too.
-    const fresh = await db.query.workflowExecutions.findFirst({
-      where: eq(workflowExecutions.id, executionId),
-      columns: {
-        status: true,
-        output: true,
-        error: true,
-        transactionHashes: true,
-        gasUsedWei: true,
-        completedAt: true,
-      },
-    });
-
-    if (!fresh) {
+    if (!row) {
       recordStatusPollMetrics({
         executionId,
         durationMs: timer(),
@@ -80,20 +66,20 @@ export async function GET(
       executionId,
       durationMs: timer(),
       statusCode: 200,
-      executionStatus: fresh.status,
+      executionStatus: row.status,
     });
 
-    // result is null on timeout (still pending/running); non-null once the
+    // completed is false on timeout (still pending/running), true once the
     // execution reached a terminal state within the wait window.
     return NextResponse.json({
       executionId,
-      status: fresh.status,
-      completed: result !== null,
-      transactionHashes: fresh.transactionHashes ?? [],
-      output: fresh.output,
-      error: fresh.error ?? null,
-      gasUsedWei: fresh.gasUsedWei,
-      completedAt: fresh.completedAt,
+      status: row.status,
+      completed,
+      transactionHashes: row.transactionHashes ?? [],
+      output: row.output,
+      error: row.error ?? null,
+      gasUsedWei: row.gasUsedWei,
+      completedAt: row.completedAt,
     });
   } catch (error) {
     const { executionId } = await context.params;

--- a/docs/api/executions.md
+++ b/docs/api/executions.md
@@ -110,6 +110,49 @@ Returns real-time execution status with progress tracking.
 
 An empty array carries one of two meanings: the run produced no on-chain writes, or the execution row was finalized before this field began being populated. The two cases are not distinguished at the response level — if the distinction matters for a historical row, the underlying hashes are reconstructable from per-step logs via the endpoint below. For full per-step input, output, error, and timing detail, also use the logs endpoint below.
 
+## Wait for Receipt
+
+```http
+GET /api/workflows/executions/{executionId}/wait?timeoutMs=30000
+```
+
+Blocks until the execution reaches a terminal state (`success`, `error`, or `cancelled`) or the timeout elapses, then returns the execution receipt including `transactionHashes`. This replaces the client-side `while (!terminal) { sleep + GET status }` polling loop.
+
+`timeoutMs` is optional (default `25000`, max `60000`). If the execution is still running when the timeout elapses, the response returns with `completed: false` and the current status — re-call to keep waiting.
+
+### Response
+
+```json
+{
+  "executionId": "exec_123",
+  "status": "success",
+  "completed": true,
+  "transactionHashes": [
+    {
+      "hash": "0x111...",
+      "nodeId": "write-contract-1",
+      "nodeName": "Swap on Uniswap",
+      "chainId": 1,
+      "network": "mainnet"
+    }
+  ],
+  "output": {...},
+  "error": null,
+  "gasUsedWei": "21000",
+  "completedAt": "2024-01-01T00:00:05Z"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | enum | `pending`, `running`, `success`, `error`, `cancelled` |
+| `completed` | boolean | `true` once the execution reached a terminal state; `false` if the wait timed out while still running |
+| `transactionHashes` | array | Ordered on-chain writes (same shape as the status endpoint) |
+| `output` | object | Workflow output |
+| `error` | string \| null | Error message when `status` is `error` |
+| `gasUsedWei` | string \| null | Run-total gas in wei |
+| `completedAt` | timestamp \| null | When the execution finished, null while running |
+
 ## Get Execution Logs
 
 ```http

--- a/lib/payments/x402/execution-wait.ts
+++ b/lib/payments/x402/execution-wait.ts
@@ -20,6 +20,74 @@ type ExecutionResult = {
   error: string | null;
 };
 
+function isTerminalStatus(status: string): status is TerminalStatus {
+  return status === "success" || status === "error" || status === "cancelled";
+}
+
+function loadReceiptRow(executionId: string) {
+  return db.query.workflowExecutions.findFirst({
+    where: eq(workflowExecutions.id, executionId),
+    columns: {
+      status: true,
+      output: true,
+      error: true,
+      transactionHashes: true,
+      gasUsedWei: true,
+      completedAt: true,
+    },
+  });
+}
+
+export type ExecutionReceiptRow = NonNullable<
+  Awaited<ReturnType<typeof loadReceiptRow>>
+>;
+
+export type ExecutionReceiptPoll = {
+  row: ExecutionReceiptRow | null;
+  completed: boolean;
+};
+
+/**
+ * Poll the execution row until it reaches a terminal state (success, error,
+ * cancelled) or the timeout elapses. Always returns the last-seen row (so
+ * callers can read the receipt on timeout too); `row` is null only when the
+ * execution does not exist, and `completed` is true only on a terminal state.
+ */
+async function pollExecutionReceipt(
+  executionId: string,
+  timeoutMs: number,
+  pollIntervalMs: number
+): Promise<ExecutionReceiptPoll> {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    const row = await loadReceiptRow(executionId);
+    if (!row) {
+      return { row: null, completed: false };
+    }
+    if (isTerminalStatus(row.status)) {
+      return { row, completed: true };
+    }
+    if (Date.now() + pollIntervalMs >= deadline) {
+      return { row, completed: false };
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+}
+
+/**
+ * Poll until the execution reaches a terminal state or the timeout elapses,
+ * returning the receipt row plus a `completed` flag. Unlike
+ * waitForExecutionCompletion, the row is returned on timeout too so the caller
+ * does not need a second read for the transaction hashes / gas / completedAt.
+ */
+export function waitForExecutionReceipt(
+  executionId: string,
+  timeoutMs: number = DEFAULT_CALL_WAIT_TIMEOUT_MS,
+  pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS
+): Promise<ExecutionReceiptPoll> {
+  return pollExecutionReceipt(executionId, timeoutMs, pollIntervalMs);
+}
+
 /**
  * Poll workflowExecutions.status until it reaches a terminal state (success,
  * error, cancelled) or the timeout elapses. Returns null on timeout.
@@ -32,31 +100,19 @@ export async function waitForExecutionCompletion(
   if (timeoutMs <= 0) {
     return null;
   }
-  const deadline = Date.now() + timeoutMs;
-  while (true) {
-    const row = await db.query.workflowExecutions.findFirst({
-      where: eq(workflowExecutions.id, executionId),
-      columns: { status: true, output: true, error: true },
-    });
-    if (!row) {
-      return null;
-    }
-    if (
-      row.status === "success" ||
-      row.status === "error" ||
-      row.status === "cancelled"
-    ) {
-      return {
-        status: row.status,
-        output: row.output,
-        error: row.error ?? null,
-      };
-    }
-    if (Date.now() + pollIntervalMs >= deadline) {
-      return null;
-    }
-    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  const { row } = await pollExecutionReceipt(
+    executionId,
+    timeoutMs,
+    pollIntervalMs
+  );
+  if (!(row && isTerminalStatus(row.status))) {
+    return null;
   }
+  return {
+    status: row.status,
+    output: row.output,
+    error: row.error ?? null,
+  };
 }
 
 /**

--- a/lib/payments/x402/execution-wait.ts
+++ b/lib/payments/x402/execution-wait.ts
@@ -10,7 +10,7 @@ import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
  * HTTP/MCP client timeouts (~30s) so clients don't time out on us.
  */
 export const DEFAULT_CALL_WAIT_TIMEOUT_MS = 25_000;
-const DEFAULT_POLL_INTERVAL_MS = 250;
+const DEFAULT_POLL_INTERVAL_MS = 1000;
 
 type TerminalStatus = "success" | "error" | "cancelled";
 

--- a/lib/workflow/execution-access.ts
+++ b/lib/workflow/execution-access.ts
@@ -1,0 +1,64 @@
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { workflowExecutions } from "@/lib/db/schema";
+import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { getWorkflowAccess } from "@/lib/workflow/access";
+
+function loadExecutionWithWorkflow(executionId: string) {
+  return db.query.workflowExecutions.findFirst({
+    where: eq(workflowExecutions.id, executionId),
+    with: { workflow: true },
+  });
+}
+
+export type AuthorizedExecution = NonNullable<
+  Awaited<ReturnType<typeof loadExecutionWithWorkflow>>
+>;
+
+export type ExecutionAccessResult =
+  | { ok: true; execution: AuthorizedExecution }
+  | { ok: false; status: number; error: string };
+
+/**
+ * Authenticate the request, load the execution, and verify the caller may see
+ * it. Shared by the status, logs, and wait endpoints so they apply identical
+ * auth and soft-delete rules. A soft-deleted workflow hides its executions, so
+ * those collapse to 404 rather than leaking existence.
+ */
+export async function resolveAuthorizedExecution(
+  request: Request,
+  executionId: string
+): Promise<ExecutionAccessResult> {
+  const authContext = await getDualAuthContext(request);
+  if ("error" in authContext) {
+    return { ok: false, status: authContext.status, error: authContext.error };
+  }
+
+  const { userId, organizationId } = authContext;
+  if (!(userId || organizationId)) {
+    return {
+      ok: false,
+      status: 403,
+      error:
+        "API key has no associated user or organization. Please recreate the API key.",
+    };
+  }
+
+  const execution = await loadExecutionWithWorkflow(executionId);
+  if (!execution) {
+    return { ok: false, status: 404, error: "Execution not found" };
+  }
+
+  const access = await getWorkflowAccess(execution.workflow, {
+    userId,
+    organizationId,
+    authMethod: authContext.authMethod,
+  });
+  if (!access.hasFullAccess || access.isDeleted) {
+    return { ok: false, status: 404, error: "Execution not found" };
+  }
+
+  return { ok: true, execution };
+}

--- a/tests/unit/wait-for-receipt-route.test.ts
+++ b/tests/unit/wait-for-receipt-route.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const {
+  mockFindFirst,
+  mockGetDualAuthContext,
+  mockGetWorkflowAccess,
+  mockWaitForExecutionCompletion,
+  mockRecordStatusPollMetrics,
+} = vi.hoisted(() => ({
+  mockFindFirst: vi.fn(),
+  mockGetDualAuthContext: vi.fn(),
+  mockGetWorkflowAccess: vi.fn(),
+  mockWaitForExecutionCompletion: vi.fn(),
+  mockRecordStatusPollMetrics: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: { query: { workflowExecutions: { findFirst: mockFindFirst } } },
+}));
+vi.mock("@/lib/db/schema", () => ({ workflowExecutions: { id: "id" } }));
+vi.mock("@/lib/middleware/auth-helpers", () => ({
+  getDualAuthContext: mockGetDualAuthContext,
+}));
+vi.mock("@/lib/workflow/access", () => ({
+  getWorkflowAccess: mockGetWorkflowAccess,
+}));
+vi.mock("@/lib/payments/x402/execution-wait", () => ({
+  DEFAULT_CALL_WAIT_TIMEOUT_MS: 25_000,
+  waitForExecutionCompletion: mockWaitForExecutionCompletion,
+}));
+vi.mock("@/lib/metrics", () => ({ createTimer: () => () => 0 }));
+vi.mock("@/lib/metrics/instrumentation/api", () => ({
+  recordStatusPollMetrics: mockRecordStatusPollMetrics,
+}));
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "database" },
+  logSystemError: vi.fn(),
+}));
+
+const ROUTE = "@/app/api/workflows/executions/[executionId]/wait/route";
+
+function makeRequest(timeoutMs?: number): Request {
+  const qs = timeoutMs === undefined ? "" : `?timeoutMs=${timeoutMs}`;
+  return new Request(`https://app.keeperhub.com/api/wait${qs}`);
+}
+
+function makeContext(executionId: string) {
+  return { params: Promise.resolve({ executionId }) };
+}
+
+describe("GET wait-for-receipt route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: "user-1",
+      organizationId: null,
+      authMethod: "api-key",
+    });
+    mockGetWorkflowAccess.mockResolvedValue({
+      hasFullAccess: true,
+      isDeleted: false,
+    });
+  });
+
+  it("returns the receipt with transactionHashes when terminal", async () => {
+    mockFindFirst
+      .mockResolvedValueOnce({ id: "exec-1", workflow: { id: "wf-1" } })
+      .mockResolvedValueOnce({
+        status: "success",
+        output: { ok: true },
+        error: null,
+        transactionHashes: [{ hash: "0xabc", nodeId: "n1", nodeName: "Send" }],
+        gasUsedWei: "21000",
+        completedAt: new Date("2026-06-05T12:00:00.000Z"),
+      });
+    mockWaitForExecutionCompletion.mockResolvedValue({
+      status: "success",
+      output: { ok: true },
+      error: null,
+    });
+
+    const { GET } = await import(ROUTE);
+    const res = await GET(makeRequest(30_000), makeContext("exec-1"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.completed).toBe(true);
+    expect(body.status).toBe("success");
+    expect(body.transactionHashes).toEqual([
+      { hash: "0xabc", nodeId: "n1", nodeName: "Send" },
+    ]);
+  });
+
+  it("returns completed=false with current status on timeout", async () => {
+    mockFindFirst
+      .mockResolvedValueOnce({ id: "exec-1", workflow: { id: "wf-1" } })
+      .mockResolvedValueOnce({
+        status: "running",
+        output: null,
+        error: null,
+        transactionHashes: [],
+        gasUsedWei: null,
+        completedAt: null,
+      });
+    mockWaitForExecutionCompletion.mockResolvedValue(null);
+
+    const { GET } = await import(ROUTE);
+    const res = await GET(makeRequest(), makeContext("exec-1"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.completed).toBe(false);
+    expect(body.status).toBe("running");
+    expect(body.transactionHashes).toEqual([]);
+  });
+
+  it("returns 404 when the execution does not exist", async () => {
+    mockFindFirst.mockResolvedValueOnce(undefined);
+
+    const { GET } = await import(ROUTE);
+    const res = await GET(makeRequest(), makeContext("missing"));
+
+    expect(res.status).toBe(404);
+    expect(mockWaitForExecutionCompletion).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the caller lacks access", async () => {
+    mockFindFirst.mockResolvedValueOnce({
+      id: "exec-1",
+      workflow: { id: "wf-1" },
+    });
+    mockGetWorkflowAccess.mockResolvedValue({
+      hasFullAccess: false,
+      isDeleted: false,
+    });
+
+    const { GET } = await import(ROUTE);
+    const res = await GET(makeRequest(), makeContext("exec-1"));
+
+    expect(res.status).toBe(404);
+    expect(mockWaitForExecutionCompletion).not.toHaveBeenCalled();
+  });
+
+  it("propagates the auth error status", async () => {
+    mockGetDualAuthContext.mockResolvedValue({
+      error: "Unauthorized",
+      status: 401,
+    });
+
+    const { GET } = await import(ROUTE);
+    const res = await GET(makeRequest(), makeContext("exec-1"));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("clamps timeoutMs above the max before waiting", async () => {
+    mockFindFirst
+      .mockResolvedValueOnce({ id: "exec-1", workflow: { id: "wf-1" } })
+      .mockResolvedValueOnce({
+        status: "running",
+        output: null,
+        error: null,
+        transactionHashes: [],
+        gasUsedWei: null,
+        completedAt: null,
+      });
+    mockWaitForExecutionCompletion.mockResolvedValue(null);
+
+    const { GET } = await import(ROUTE);
+    await GET(makeRequest(999_999), makeContext("exec-1"));
+
+    expect(mockWaitForExecutionCompletion).toHaveBeenCalledWith(
+      "exec-1",
+      60_000
+    );
+  });
+});

--- a/tests/unit/wait-for-receipt-route.test.ts
+++ b/tests/unit/wait-for-receipt-route.test.ts
@@ -6,13 +6,13 @@ const {
   mockFindFirst,
   mockGetDualAuthContext,
   mockGetWorkflowAccess,
-  mockWaitForExecutionCompletion,
+  mockWaitForExecutionReceipt,
   mockRecordStatusPollMetrics,
 } = vi.hoisted(() => ({
   mockFindFirst: vi.fn(),
   mockGetDualAuthContext: vi.fn(),
   mockGetWorkflowAccess: vi.fn(),
-  mockWaitForExecutionCompletion: vi.fn(),
+  mockWaitForExecutionReceipt: vi.fn(),
   mockRecordStatusPollMetrics: vi.fn(),
 }));
 
@@ -28,7 +28,7 @@ vi.mock("@/lib/workflow/access", () => ({
 }));
 vi.mock("@/lib/payments/x402/execution-wait", () => ({
   DEFAULT_CALL_WAIT_TIMEOUT_MS: 25_000,
-  waitForExecutionCompletion: mockWaitForExecutionCompletion,
+  waitForExecutionReceipt: mockWaitForExecutionReceipt,
 }));
 vi.mock("@/lib/metrics", () => ({ createTimer: () => () => 0 }));
 vi.mock("@/lib/metrics/instrumentation/api", () => ({
@@ -62,23 +62,20 @@ describe("GET wait-for-receipt route", () => {
       hasFullAccess: true,
       isDeleted: false,
     });
+    mockFindFirst.mockResolvedValue({ id: "exec-1", workflow: { id: "wf-1" } });
   });
 
   it("returns the receipt with transactionHashes when terminal", async () => {
-    mockFindFirst
-      .mockResolvedValueOnce({ id: "exec-1", workflow: { id: "wf-1" } })
-      .mockResolvedValueOnce({
+    mockWaitForExecutionReceipt.mockResolvedValue({
+      row: {
         status: "success",
         output: { ok: true },
         error: null,
         transactionHashes: [{ hash: "0xabc", nodeId: "n1", nodeName: "Send" }],
         gasUsedWei: "21000",
         completedAt: new Date("2026-06-05T12:00:00.000Z"),
-      });
-    mockWaitForExecutionCompletion.mockResolvedValue({
-      status: "success",
-      output: { ok: true },
-      error: null,
+      },
+      completed: true,
     });
 
     const { GET } = await import(ROUTE);
@@ -94,17 +91,17 @@ describe("GET wait-for-receipt route", () => {
   });
 
   it("returns completed=false with current status on timeout", async () => {
-    mockFindFirst
-      .mockResolvedValueOnce({ id: "exec-1", workflow: { id: "wf-1" } })
-      .mockResolvedValueOnce({
+    mockWaitForExecutionReceipt.mockResolvedValue({
+      row: {
         status: "running",
         output: null,
         error: null,
         transactionHashes: [],
         gasUsedWei: null,
         completedAt: null,
-      });
-    mockWaitForExecutionCompletion.mockResolvedValue(null);
+      },
+      completed: false,
+    });
 
     const { GET } = await import(ROUTE);
     const res = await GET(makeRequest(), makeContext("exec-1"));
@@ -123,14 +120,22 @@ describe("GET wait-for-receipt route", () => {
     const res = await GET(makeRequest(), makeContext("missing"));
 
     expect(res.status).toBe(404);
-    expect(mockWaitForExecutionCompletion).not.toHaveBeenCalled();
+    expect(mockWaitForExecutionReceipt).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the execution is deleted mid-wait", async () => {
+    mockWaitForExecutionReceipt.mockResolvedValue({
+      row: null,
+      completed: false,
+    });
+
+    const { GET } = await import(ROUTE);
+    const res = await GET(makeRequest(), makeContext("exec-1"));
+
+    expect(res.status).toBe(404);
   });
 
   it("returns 404 when the caller lacks access", async () => {
-    mockFindFirst.mockResolvedValueOnce({
-      id: "exec-1",
-      workflow: { id: "wf-1" },
-    });
     mockGetWorkflowAccess.mockResolvedValue({
       hasFullAccess: false,
       isDeleted: false,
@@ -140,7 +145,7 @@ describe("GET wait-for-receipt route", () => {
     const res = await GET(makeRequest(), makeContext("exec-1"));
 
     expect(res.status).toBe(404);
-    expect(mockWaitForExecutionCompletion).not.toHaveBeenCalled();
+    expect(mockWaitForExecutionReceipt).not.toHaveBeenCalled();
   });
 
   it("propagates the auth error status", async () => {
@@ -156,24 +161,21 @@ describe("GET wait-for-receipt route", () => {
   });
 
   it("clamps timeoutMs above the max before waiting", async () => {
-    mockFindFirst
-      .mockResolvedValueOnce({ id: "exec-1", workflow: { id: "wf-1" } })
-      .mockResolvedValueOnce({
+    mockWaitForExecutionReceipt.mockResolvedValue({
+      row: {
         status: "running",
         output: null,
         error: null,
         transactionHashes: [],
         gasUsedWei: null,
         completedAt: null,
-      });
-    mockWaitForExecutionCompletion.mockResolvedValue(null);
+      },
+      completed: false,
+    });
 
     const { GET } = await import(ROUTE);
     await GET(makeRequest(999_999), makeContext("exec-1"));
 
-    expect(mockWaitForExecutionCompletion).toHaveBeenCalledWith(
-      "exec-1",
-      60_000
-    );
+    expect(mockWaitForExecutionReceipt).toHaveBeenCalledWith("exec-1", 60_000);
   });
 });


### PR DESCRIPTION
Agents that need a transaction hash before continuing had to implement their own `while (!terminal) { sleep + GET status }` polling loop. On serverless workers (Cloudflare, Vercel) that loop gets killed mid-poll before the workflow completes.

## What this adds

`GET /api/workflows/executions/{executionId}/wait?timeoutMs=30000` — blocks until the execution reaches a terminal state (`success`/`error`/`cancelled`) or the timeout elapses, then returns the receipt including `transactionHashes`, `output`, `error`, `gasUsedWei` and `completedAt`. On timeout it returns `completed: false` with the current status so clients can re-call.

- Reuses the existing, unit-tested `waitForExecutionCompletion` poller (the same one the x402 MCP call path uses), then re-reads the row for the receipt fields the poller does not return.
- `timeoutMs` defaults to 25s and is capped at 60s so a request never pins a worker indefinitely.
- Auth + execution lookup + access check (including the soft-delete 404 rule) were duplicated between the status endpoint and this one, so they are extracted into `resolveAuthorizedExecution` and both routes now share it.
- Public API docs updated.

## Scope

This is the server-side long-poll half of the ticket. The mirrored `wait_for_receipt` MCP tool lives in the external MCP server repo and will call this endpoint. The optional outbound completion webhook is intentionally deferred to a separate follow-up (it needs a schema migration, a dispatch hook, HMAC signing and SSRF handling).

## Tests

Unit tests cover the route: terminal receipt with `transactionHashes`, timeout (`completed: false`), 404 for missing execution, 404 for no access, auth-error passthrough, and timeout clamping. Existing `waitForExecutionCompletion` tests still pass.