### PR TITLE
fix(workflow): fail loop runs on iteration errors and harden long event scans

### DIFF
--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -1866,11 +1866,16 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             return recovered ? { output: recovered.output } : null;
           }
         : undefined,
-      onSpuriousRecovery: ({ nodeId: bodyNodeId, iterationMeta: meta }) => {
+      onSpuriousRecovery: ({
+        nodeId: bodyNodeId,
+        iterationMeta: meta,
+        reason,
+      }) => {
         getMetricsCollector().incrementCounter(
           "workflow.executor.spurious_recovery.total",
           {
             source: "body_runner",
+            recovery_reason: reason,
             ...(workflowId ? { [LabelKeys.WORKFLOW_ID]: workflowId } : {}),
             ...(organizationId ? { [LabelKeys.ORG_ID]: organizationId } : {}),
             ...(organizationPlan ? { [LabelKeys.PLAN]: organizationPlan } : {}),
@@ -1956,6 +1961,9 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     arrayLength: number;
     maxIterations: number;
     iterationsRan: number;
+    failedIterations: number;
+    firstFailureError?: string;
+    firstFailureNodeId?: string;
   }> {
     const {
       forEachNodeId,
@@ -2063,12 +2071,19 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
         );
       }
 
-      // If any body node failed, surface the error in the iteration result
+      // If any body node failed, surface the error in the iteration result.
+      // The `__forEachBodyFailure` marker lets the post-loop aggregation tell a
+      // genuine body failure apart from a successful iteration whose output
+      // happens to be shaped like `{ success: false }`.
       const bodyFailure = Object.entries(bodyResults).find(
         ([, r]) => !r.success
       );
       if (bodyFailure) {
+        console.log(
+          `[Workflow Executor] For Each "${getNodeName(forEachNode)}" iteration ${index} failed at node "${getNodeName(nodeMap.get(bodyFailure[0]) ?? forEachNode)}" (${bodyFailure[0]}): ${bodyFailure[1].error}`
+        );
         return {
+          __forEachBodyFailure: true as const,
           success: false as const,
           error: bodyFailure[1].error ?? "Body node failed",
           nodeId: bodyFailure[0],
@@ -2131,6 +2146,29 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       concurrencyMode as "sequential" | "parallel" | "custom",
       concurrencyLimit
     );
+
+    // KEEP-586: Detect genuine iteration-body failures. Without this they
+    // vanish into the Collect aggregate -- the Collect node and the For Each
+    // node both report success -- so the run is silently marked success even
+    // though a node that should have run did not. The caller (executeNode)
+    // uses these fields to fail the For Each node and surface it in the run.
+    const failedIterations = iterationResults.filter(
+      (
+        r
+      ): r is {
+        __forEachBodyFailure: true;
+        error?: string;
+        nodeId?: string;
+      } =>
+        typeof r === "object" &&
+        r !== null &&
+        (r as { __forEachBodyFailure?: unknown }).__forEachBodyFailure === true
+    );
+    if (failedIterations.length > 0) {
+      console.log(
+        `[Workflow Executor] For Each "${getNodeName(forEachNode)}": ${failedIterations.length}/${iterationResults.length} iteration(s) failed; first failing node ${failedIterations[0].nodeId}: ${failedIterations[0].error}`
+      );
+    }
 
     // 5. Mark body nodes as visited in the parent scope
     for (const bodyNodeId of bodyNodeIds) {
@@ -2212,6 +2250,9 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       arrayLength: resolvedArray.length,
       maxIterations,
       iterationsRan: itemsToProcess.length,
+      failedIterations: failedIterations.length,
+      firstFailureError: failedIterations[0]?.error,
+      firstFailureNodeId: failedIterations[0]?.nodeId,
     };
   }
 
@@ -2594,7 +2635,24 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             label: getNodeName(node),
             data: iterationSummary,
           };
-          results[nodeId] = { success: true, data: iterationSummary };
+          // KEEP-586: A failed iteration body must fail the For Each node so
+          // computeFinalSuccess marks the run as error instead of silently
+          // reporting success while the loop dropped work mid-iteration.
+          const feFailed =
+            typeof iterationSummary === "object" &&
+            iterationSummary !== null &&
+            "failedIterations" in iterationSummary &&
+            (iterationSummary as { failedIterations: number })
+              .failedIterations > 0;
+          results[nodeId] = feFailed
+            ? {
+                success: false,
+                error:
+                  (iterationSummary as { firstFailureError?: string })
+                    .firstFailureError ?? "For Each iteration body failed",
+                data: iterationSummary,
+              }
+            : { success: true, data: iterationSummary };
         } else if (currentActionType === "Condition") {
           // For condition nodes, route to true/false handle targets
           const conditionResult = (result.data as { condition?: boolean })

--- a/lib/workflow/executor/for-each-body-runner.ts
+++ b/lib/workflow/executor/for-each-body-runner.ts
@@ -96,17 +96,21 @@ export type RunBodyContext = {
   /** Optional hook for nested For Each handling. Called instead of the generic
    *  downstream walk when the visited node is itself a For Each. */
   handleNestedForEach?: NestedForEachHandler;
-  /** Optional resolver for spurious "exceeded max retries" errors. When the
-   *  step body succeeded but the SDK lost its step_completed event, the
-   *  resolver returns the recovered output so the iteration treats the step
-   *  as a success and continues recursing downstream. Omitted in unit tests
+  /** Optional resolver consulted when a body step throws. When the step body
+   *  already recorded a success row, the resolver returns the recovered output
+   *  so the iteration treats the step as a success and continues recursing
+   *  downstream. Covers both an SDK-lost step_completed event and a long step
+   *  abandoned by the runtime after its body completed. Omitted in unit tests
    *  that don't exercise the recovery path. */
   resolveSpuriousRecovery?: SpuriousRecoveryResolver;
-  /** Optional hook fired when a spurious failure is recovered. Used by the
-   *  executor to emit observability metrics. */
+  /** Optional hook fired when a thrown step is recovered from the success
+   *  authority. Used by the executor to emit observability metrics. `reason`
+   *  distinguishes the lost-completion-event case from a long step abandoned
+   *  after completing. */
   onSpuriousRecovery?: (params: {
     nodeId: string;
     iterationMeta: IterationMeta;
+    reason: "spurious_max_retries" | "abandoned_completion";
   }) => void;
   /** Process action config (template substitution, dbQuery rewriting, etc.). */
   processConfig: (
@@ -215,10 +219,29 @@ async function routeAfterSuccess(params: {
 }
 
 /**
- * KEEP-543: Attempt iteration-scoped spurious-recovery for a body node that
- * just threw. Returns true when the failure was recovered (caller should NOT
- * record it as a failure); false when the failure is real and the caller
- * should fall through to the standard failure path.
+ * KEEP-543 / KEEP-586: Attempt authority-backed recovery for a body node that
+ * just threw. The step-success-tracker (and its workflow_execution_logs
+ * fallback) is the source of truth: when the step body recorded a success row,
+ * the step succeeded even though the runtime wrapper later threw. Two shapes
+ * produce that situation, and both must continue the iteration:
+ *
+ *   1. The Workflow DevKit lost the step_completed event and re-fired the step
+ *      ("exceeded max retries" / "failed after retries" / "did not record
+ *      completion").
+ *   2. A long-running step -- e.g. a multi-minute web3 event scan -- outran the
+ *      runtime's step lease and was abandoned with a generic timeout error
+ *      AFTER its body had already completed and persisted its output. Without
+ *      recovery the iteration silently drops every node downstream of the slow
+ *      step while the run still reports success.
+ *
+ * We therefore consult the authority on ANY throw rather than gating on the
+ * max-retries error shapes. A genuinely failed step has no success row, so the
+ * resolver returns null and the caller falls through to the standard failure
+ * path -- this never masks a real failure.
+ *
+ * Returns true when the failure was recovered (caller should NOT record it as a
+ * failure); false when the failure is real and the caller should fall through
+ * to the standard failure path.
  */
 async function attemptSpuriousRecovery(params: {
   nodeId: string;
@@ -240,9 +263,6 @@ async function attemptSpuriousRecovery(params: {
   if (!actionType) {
     return false;
   }
-  if (!isSpuriousMaxRetriesError(errorMessage)) {
-    return false;
-  }
 
   const recovered = await ctx.resolveSpuriousRecovery({
     nodeId,
@@ -251,6 +271,10 @@ async function attemptSpuriousRecovery(params: {
   if (recovered === null) {
     return false;
   }
+
+  console.log(
+    `[For Each body] recovered "${ctx.getNodeName(node)}" (${nodeId}) from the success authority after it threw; continuing downstream.`
+  );
 
   const result: BodyExecutionResult = {
     success: true,
@@ -263,7 +287,13 @@ async function attemptSpuriousRecovery(params: {
     data: recovered.output,
   };
 
-  ctx.onSpuriousRecovery?.({ nodeId, iterationMeta: ctx.iterationMeta });
+  ctx.onSpuriousRecovery?.({
+    nodeId,
+    iterationMeta: ctx.iterationMeta,
+    reason: isSpuriousMaxRetriesError(errorMessage)
+      ? "spurious_max_retries"
+      : "abandoned_completion",
+  });
 
   await routeAfterSuccess({
     nodeId,
@@ -377,6 +407,10 @@ export async function runBodyNode(
     });
   } catch (error) {
     const errorMessage = await ctx.getErrorMessageAsync(error);
+    const iter = ctx.iterationMeta?.iterationIndex ?? "-";
+    console.log(
+      `[For Each body] node "${ctx.getNodeName(node)}" (${nodeId}) threw at iteration ${iter}: ${errorMessage}`
+    );
 
     const recovered = await attemptSpuriousRecovery({
       nodeId,
@@ -390,6 +424,9 @@ export async function runBodyNode(
       return;
     }
 
+    console.log(
+      `[For Each body] node "${ctx.getNodeName(node)}" (${nodeId}) NOT recovered (no success row in authority); stopping branch -- downstream nodes will not run.`
+    );
     ctx.bodyResults[nodeId] = { success: false, error: errorMessage };
   }
 }

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -25,6 +25,7 @@ import {
   NO_STEP_COMPLETION_REGEX,
 } from "@/lib/workflow/executor/runner-error-patterns";
 import { getTransactionHashes } from "@/lib/workflow/executor/step-success-tracker";
+import { computeTrulyFailedNodes } from "@/lib/workflow/executor/truly-failed-nodes";
 
 const TERMINAL_STATUSES = new Set(["cancelled"]);
 
@@ -45,30 +46,17 @@ function isSpuriousWorkflowError(error: string | null | undefined): boolean {
 }
 
 /**
- * Per-nodeId aggregate over workflow_execution_logs rows (top-level steps only).
+ * Per-nodeId aggregate over workflow_execution_logs rows.
  *
  * KEEP-431: A node can have multiple log rows (e.g. a cross-pod retry from the
  * SDK's "use step" boundary inserts a fresh row each time logStepStartDb runs).
  * Treat the node as succeeded if ANY of its rows is success -- only flag a
- * node as truly failed when no row succeeded for it.
+ * node as truly failed when no row succeeded for it. For Each iteration
+ * failures are surfaced via the parent loop node. See `computeTrulyFailedNodes`
+ * for the full contract.
  *
- * Top-level steps are aggregated by `nodeId` (a node is OK if any of its rows
- * succeeded -- a cross-pod SDK retry can leave an orphan running/error row next
- * to the real success row).
- *
- * For Each iteration rows (`iteration_index` + `for_each_node_id` non-null) are
- * aggregated per `(forEachNodeId, iterationIndex, nodeId)` so a failed iteration
- * body is NOT masked by a sibling iteration's success. When such a step has no
- * success row, its parent For Each node id is reported as failed. This is
- * required because `forEachStep` pre-logs the parent For Each node as success
- * before any iteration runs and never flips it; without counting iteration
- * failures here, a genuinely failed loop is invisible to every DB-based
- * reconciliation path and `logWorkflowCompleteDb` would override the real error
- * to success.
- *
- * Returns the list of node IDs (top-level nodes and/or parent For Each nodes)
- * that have at least one log row but no success row. Empty list means the
- * workflow body succeeded as a whole even if the SDK reported a spurious error.
+ * Empty list means the workflow body succeeded as a whole even if the SDK
+ * reported a spurious error.
  */
 async function listTrulyFailedNodes(executionId: string): Promise<string[]> {
   const allLogs = await db.query.workflowExecutionLogs.findMany({
@@ -81,41 +69,7 @@ async function listTrulyFailedNodes(executionId: string): Promise<string[]> {
     },
   });
 
-  const topLevelSucceeded = new Map<string, boolean>();
-  const iterationSucceeded = new Map<string, boolean>();
-  const iterationKeyToForEach = new Map<string, string>();
-
-  for (const log of allLogs) {
-    if (log.iterationIndex !== null && log.forEachNodeId !== null) {
-      const key = `${log.forEachNodeId}:${log.iterationIndex}:${log.nodeId}`;
-      iterationKeyToForEach.set(key, log.forEachNodeId);
-      if (log.status === "success") {
-        iterationSucceeded.set(key, true);
-      } else if (!iterationSucceeded.has(key)) {
-        iterationSucceeded.set(key, false);
-      }
-    } else if (log.status === "success") {
-      topLevelSucceeded.set(log.nodeId, true);
-    } else if (!topLevelSucceeded.has(log.nodeId)) {
-      topLevelSucceeded.set(log.nodeId, false);
-    }
-  }
-
-  const trulyFailedNodes = new Set<string>();
-  for (const [nodeId, succeeded] of topLevelSucceeded) {
-    if (!succeeded) {
-      trulyFailedNodes.add(nodeId);
-    }
-  }
-  for (const [key, succeeded] of iterationSucceeded) {
-    if (!succeeded) {
-      const forEachNodeId = iterationKeyToForEach.get(key);
-      if (forEachNodeId) {
-        trulyFailedNodes.add(forEachNodeId);
-      }
-    }
-  }
-  return [...trulyFailedNodes];
+  return computeTrulyFailedNodes(allLogs);
 }
 
 /**

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -4,7 +4,7 @@
  */
 import "server-only";
 
-import { and, asc, eq, isNotNull, isNull, ne, sql } from "drizzle-orm";
+import { and, asc, eq, isNotNull, ne, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { logOutputField } from "@/lib/db/execution-log-fields";
 import {
@@ -52,44 +52,70 @@ function isSpuriousWorkflowError(error: string | null | undefined): boolean {
  * Treat the node as succeeded if ANY of its rows is success -- only flag a
  * node as truly failed when no row succeeded for it.
  *
- * Filters out forEach iteration rows (`iteration_index` and `for_each_node_id`
- * are non-null on those). Iteration rows are scoped to a parent forEach node;
- * we only aggregate top-level steps here so we don't accidentally treat a
- * succeeded forEach with one failed iteration as fully succeeded. The forEach
- * runner is responsible for surfacing iteration failures via the parent node's
- * own success/error status.
+ * Top-level steps are aggregated by `nodeId` (a node is OK if any of its rows
+ * succeeded -- a cross-pod SDK retry can leave an orphan running/error row next
+ * to the real success row).
  *
- * Returns the list of node IDs that have at least one log row but no success
- * row. Empty list means every observed node has at least one success row, so
- * the workflow body succeeded as a whole even if the SDK reported an error
- * via a spurious max-retries throw.
+ * For Each iteration rows (`iteration_index` + `for_each_node_id` non-null) are
+ * aggregated per `(forEachNodeId, iterationIndex, nodeId)` so a failed iteration
+ * body is NOT masked by a sibling iteration's success. When such a step has no
+ * success row, its parent For Each node id is reported as failed. This is
+ * required because `forEachStep` pre-logs the parent For Each node as success
+ * before any iteration runs and never flips it; without counting iteration
+ * failures here, a genuinely failed loop is invisible to every DB-based
+ * reconciliation path and `logWorkflowCompleteDb` would override the real error
+ * to success.
+ *
+ * Returns the list of node IDs (top-level nodes and/or parent For Each nodes)
+ * that have at least one log row but no success row. Empty list means the
+ * workflow body succeeded as a whole even if the SDK reported a spurious error.
  */
 async function listTrulyFailedNodes(executionId: string): Promise<string[]> {
   const allLogs = await db.query.workflowExecutionLogs.findMany({
-    where: and(
-      eq(workflowExecutionLogs.executionId, executionId),
-      isNull(workflowExecutionLogs.iterationIndex),
-      isNull(workflowExecutionLogs.forEachNodeId)
-    ),
-    columns: { nodeId: true, status: true },
+    where: eq(workflowExecutionLogs.executionId, executionId),
+    columns: {
+      nodeId: true,
+      status: true,
+      iterationIndex: true,
+      forEachNodeId: true,
+    },
   });
 
-  const nodeSucceeded = new Map<string, boolean>();
+  const topLevelSucceeded = new Map<string, boolean>();
+  const iterationSucceeded = new Map<string, boolean>();
+  const iterationKeyToForEach = new Map<string, string>();
+
   for (const log of allLogs) {
-    if (log.status === "success") {
-      nodeSucceeded.set(log.nodeId, true);
-    } else if (!nodeSucceeded.has(log.nodeId)) {
-      nodeSucceeded.set(log.nodeId, false);
+    if (log.iterationIndex !== null && log.forEachNodeId !== null) {
+      const key = `${log.forEachNodeId}:${log.iterationIndex}:${log.nodeId}`;
+      iterationKeyToForEach.set(key, log.forEachNodeId);
+      if (log.status === "success") {
+        iterationSucceeded.set(key, true);
+      } else if (!iterationSucceeded.has(key)) {
+        iterationSucceeded.set(key, false);
+      }
+    } else if (log.status === "success") {
+      topLevelSucceeded.set(log.nodeId, true);
+    } else if (!topLevelSucceeded.has(log.nodeId)) {
+      topLevelSucceeded.set(log.nodeId, false);
     }
   }
 
-  const trulyFailedNodes: string[] = [];
-  for (const [nodeId, succeeded] of nodeSucceeded) {
+  const trulyFailedNodes = new Set<string>();
+  for (const [nodeId, succeeded] of topLevelSucceeded) {
     if (!succeeded) {
-      trulyFailedNodes.push(nodeId);
+      trulyFailedNodes.add(nodeId);
     }
   }
-  return trulyFailedNodes;
+  for (const [key, succeeded] of iterationSucceeded) {
+    if (!succeeded) {
+      const forEachNodeId = iterationKeyToForEach.get(key);
+      if (forEachNodeId) {
+        trulyFailedNodes.add(forEachNodeId);
+      }
+    }
+  }
+  return [...trulyFailedNodes];
 }
 
 /**

--- a/lib/workflow/executor/truly-failed-nodes.ts
+++ b/lib/workflow/executor/truly-failed-nodes.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure aggregation over workflow_execution_logs rows used by the workflow
+ * finalization/self-heal reconciliation. Kept dependency-free (no db,
+ * server-only) so the logic can be unit-tested directly.
+ */
+
+export type TrulyFailedLogRow = {
+  nodeId: string;
+  status: string;
+  iterationIndex: number | null | undefined;
+  forEachNodeId: string | null | undefined;
+};
+
+/**
+ * Reduce a set of execution log rows to the node IDs that truly failed.
+ *
+ * Top-level steps are aggregated by `nodeId` (a node is OK if any of its rows
+ * succeeded -- a cross-pod SDK retry can leave an orphan running/error row next
+ * to the real success row).
+ *
+ * For Each iteration rows (`iterationIndex` + `forEachNodeId` non-null) are
+ * aggregated per `(forEachNodeId, iterationIndex, nodeId)` so a failed iteration
+ * body is NOT masked by a sibling iteration's success. When such a step has no
+ * success row, its parent For Each node id is reported as failed. This is
+ * required because `forEachStep` pre-logs the parent For Each node as success
+ * before any iteration runs and never flips it; without counting iteration
+ * failures here, a genuinely failed loop is invisible to every DB-based
+ * reconciliation path and `logWorkflowCompleteDb` would override the real error
+ * to success.
+ *
+ * Returns the (de-duplicated) list of node IDs -- top-level nodes and/or parent
+ * For Each nodes -- that have at least one log row but no success row.
+ */
+export function computeTrulyFailedNodes(logs: TrulyFailedLogRow[]): string[] {
+  const topLevelSucceeded = new Map<string, boolean>();
+  const iterationSucceeded = new Map<string, boolean>();
+  const iterationKeyToForEach = new Map<string, string>();
+
+  for (const log of logs) {
+    const { iterationIndex, forEachNodeId } = log;
+    // A row is a For Each iteration row only when BOTH loop fields are present.
+    // Drizzle returns null for top-level steps; guard for undefined too so a
+    // row that simply omits the fields is not misread as an iteration row.
+    const isIterationRow =
+      iterationIndex !== null &&
+      iterationIndex !== undefined &&
+      forEachNodeId !== null &&
+      forEachNodeId !== undefined;
+    if (isIterationRow) {
+      const key = `${forEachNodeId}:${iterationIndex}:${log.nodeId}`;
+      iterationKeyToForEach.set(key, forEachNodeId);
+      if (log.status === "success") {
+        iterationSucceeded.set(key, true);
+      } else if (!iterationSucceeded.has(key)) {
+        iterationSucceeded.set(key, false);
+      }
+    } else if (log.status === "success") {
+      topLevelSucceeded.set(log.nodeId, true);
+    } else if (!topLevelSucceeded.has(log.nodeId)) {
+      topLevelSucceeded.set(log.nodeId, false);
+    }
+  }
+
+  const trulyFailedNodes = new Set<string>();
+  for (const [nodeId, succeeded] of topLevelSucceeded) {
+    if (!succeeded) {
+      trulyFailedNodes.add(nodeId);
+    }
+  }
+  for (const [key, succeeded] of iterationSucceeded) {
+    if (!succeeded) {
+      const forEachNodeId = iterationKeyToForEach.get(key);
+      if (forEachNodeId) {
+        trulyFailedNodes.add(forEachNodeId);
+      }
+    }
+  }
+  return [...trulyFailedNodes];
+}

--- a/plugins/web3/steps/query-events-core.ts
+++ b/plugins/web3/steps/query-events-core.ts
@@ -1,0 +1,58 @@
+import { ethers } from "ethers";
+import type { RpcProviderManager } from "@/lib/rpc/providers";
+import { getErrorMessage } from "@/lib/utils";
+
+export type AbiEntry = { type: string; name: string };
+
+// A single batch can transiently time out on both RPC endpoints during a long
+// scan (e.g. 30-60 day event ranges). Rather than failing the whole node (and
+// having the durable engine replay the entire multi-minute scan), retry the
+// failing batch with a backoff so a blip does not sink the run.
+export const MAX_BATCH_RETRIES = 3;
+export const RETRY_BASE_DELAY_MS = 2000;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+// Query a single block range, failing over between RPC endpoints AND retrying
+// the batch with a backoff (at least MAX_BATCH_RETRIES attempts) before giving
+// up. A timed-out batch is the common transient failure on long scans; this
+// keeps it from sinking the whole node.
+export async function queryBatchWithRetry(
+  rpcManager: RpcProviderManager,
+  contractAddress: string,
+  parsedAbi: AbiEntry[],
+  eventName: string,
+  start: number,
+  end: number
+): Promise<(ethers.Log | ethers.EventLog)[]> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= MAX_BATCH_RETRIES; attempt++) {
+    try {
+      return await rpcManager.executeWithFailover(async (provider) => {
+        const contract = new ethers.Contract(
+          contractAddress,
+          parsedAbi,
+          provider
+        );
+        const eventFilter = contract.filters[eventName]?.();
+        if (eventFilter === undefined || eventFilter === null) {
+          throw new Error(`Could not create filter for event '${eventName}'`);
+        }
+        return await contract.queryFilter(eventFilter, start, end);
+      });
+    } catch (error) {
+      lastError = error;
+      console.log(
+        `[Query Events] Batch ${start}-${end} failed (attempt ${attempt}/${MAX_BATCH_RETRIES}): ${getErrorMessage(error)}`
+      );
+      if (attempt < MAX_BATCH_RETRIES) {
+        await delay(RETRY_BASE_DELAY_MS * attempt);
+      }
+    }
+  }
+  throw lastError;
+}

--- a/plugins/web3/steps/query-events.ts
+++ b/plugins/web3/steps/query-events.ts
@@ -11,21 +11,13 @@ import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
+import {
+  type AbiEntry,
+  queryBatchWithRetry,
+} from "./query-events-core";
 
 const DEFAULT_BATCH_SIZE = 2000;
 const DEFAULT_BLOCK_LOOKBACK = 6500;
-// A single batch can transiently time out on both RPC endpoints during a long
-// scan (e.g. 30-60 day event ranges). Rather than failing the whole node (and
-// having the durable engine replay the entire multi-minute scan), retry the
-// failing batch with a backoff so a blip does not sink the run.
-const MAX_BATCH_RETRIES = 3;
-const RETRY_BASE_DELAY_MS = 2000;
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
 
 async function getUserIdFromExecution(
   executionId: string | undefined
@@ -92,7 +84,6 @@ function decodeEventArgs(
   return args;
 }
 
-type AbiEntry = { type: string; name: string };
 
 function parseAbi(
   abi: string
@@ -208,46 +199,6 @@ async function resolveBlockRange(
     success: true,
     range: { fromBlock: fromBlockResult.value, toBlock: resolvedToBlock },
   };
-}
-
-// Query a single block range, failing over between RPC endpoints AND retrying
-// the batch with a backoff (at least MAX_BATCH_RETRIES attempts) before giving
-// up. A timed-out batch is the common transient failure on long scans; this
-// keeps it from sinking the whole node.
-async function queryBatchWithRetry(
-  rpcManager: RpcProviderManager,
-  contractAddress: string,
-  parsedAbi: AbiEntry[],
-  eventName: string,
-  start: number,
-  end: number
-): Promise<(ethers.Log | ethers.EventLog)[]> {
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= MAX_BATCH_RETRIES; attempt++) {
-    try {
-      return await rpcManager.executeWithFailover(async (provider) => {
-        const contract = new ethers.Contract(
-          contractAddress,
-          parsedAbi,
-          provider
-        );
-        const eventFilter = contract.filters[eventName]?.();
-        if (eventFilter === undefined || eventFilter === null) {
-          throw new Error(`Could not create filter for event '${eventName}'`);
-        }
-        return await contract.queryFilter(eventFilter, start, end);
-      });
-    } catch (error) {
-      lastError = error;
-      console.log(
-        `[Query Events] Batch ${start}-${end} failed (attempt ${attempt}/${MAX_BATCH_RETRIES}): ${getErrorMessage(error)}`
-      );
-      if (attempt < MAX_BATCH_RETRIES) {
-        await delay(RETRY_BASE_DELAY_MS * attempt);
-      }
-    }
-  }
-  throw lastError;
 }
 
 async function queryEventBatches(

--- a/plugins/web3/steps/query-events.ts
+++ b/plugins/web3/steps/query-events.ts
@@ -14,6 +14,18 @@ import { getErrorMessage } from "@/lib/utils";
 
 const DEFAULT_BATCH_SIZE = 2000;
 const DEFAULT_BLOCK_LOOKBACK = 6500;
+// A single batch can transiently time out on both RPC endpoints during a long
+// scan (e.g. 30-60 day event ranges). Rather than failing the whole node (and
+// having the durable engine replay the entire multi-minute scan), retry the
+// failing batch with a backoff so a blip does not sink the run.
+const MAX_BATCH_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 2000;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
 
 async function getUserIdFromExecution(
   executionId: string | undefined
@@ -198,18 +210,55 @@ async function resolveBlockRange(
   };
 }
 
+// Query a single block range, failing over between RPC endpoints AND retrying
+// the batch with a backoff (at least MAX_BATCH_RETRIES attempts) before giving
+// up. A timed-out batch is the common transient failure on long scans; this
+// keeps it from sinking the whole node.
+async function queryBatchWithRetry(
+  rpcManager: RpcProviderManager,
+  contractAddress: string,
+  parsedAbi: AbiEntry[],
+  eventName: string,
+  start: number,
+  end: number
+): Promise<(ethers.Log | ethers.EventLog)[]> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= MAX_BATCH_RETRIES; attempt++) {
+    try {
+      return await rpcManager.executeWithFailover(async (provider) => {
+        const contract = new ethers.Contract(
+          contractAddress,
+          parsedAbi,
+          provider
+        );
+        const eventFilter = contract.filters[eventName]?.();
+        if (eventFilter === undefined || eventFilter === null) {
+          throw new Error(`Could not create filter for event '${eventName}'`);
+        }
+        return await contract.queryFilter(eventFilter, start, end);
+      });
+    } catch (error) {
+      lastError = error;
+      console.log(
+        `[Query Events] Batch ${start}-${end} failed (attempt ${attempt}/${MAX_BATCH_RETRIES}): ${getErrorMessage(error)}`
+      );
+      if (attempt < MAX_BATCH_RETRIES) {
+        await delay(RETRY_BASE_DELAY_MS * attempt);
+      }
+    }
+  }
+  throw lastError;
+}
+
 async function queryEventBatches(
-  contract: ethers.Contract,
+  rpcManager: RpcProviderManager,
+  contractAddress: string,
+  parsedAbi: AbiEntry[],
   eventName: string,
   eventFragment: ethers.EventFragment,
   range: BlockRange
 ): Promise<DecodedEvent[]> {
   const batchSize = DEFAULT_BATCH_SIZE;
-  const eventFilter = contract.filters[eventName]?.();
-  if (eventFilter === undefined || eventFilter === null) {
-    throw new Error(`Could not create filter for event '${eventName}'`);
-  }
-
   const allEvents: DecodedEvent[] = [];
 
   for (
@@ -220,7 +269,14 @@ async function queryEventBatches(
     const end = Math.min(start + batchSize - 1, range.toBlock);
     console.log(`[Query Events] Querying batch: blocks ${start} to ${end}`);
 
-    const batchEvents = await contract.queryFilter(eventFilter, start, end);
+    const batchEvents = await queryBatchWithRetry(
+      rpcManager,
+      contractAddress,
+      parsedAbi,
+      eventName,
+      start,
+      end
+    );
 
     for (const event of batchEvents) {
       if (event instanceof ethers.EventLog) {
@@ -325,35 +381,27 @@ async function stepHandler(
     };
   }
 
-  // Query events (uses RPC for log fetching)
+  // Query events (each batch fails over between endpoints and retries with a
+  // backoff, so a transient timeout on one batch does not fail the whole node).
   try {
-    return await rpcManager.executeWithFailover(async (provider) => {
-      const contract = new ethers.Contract(
-        contractAddress,
-        abiResult.parsed,
-        provider
-      );
+    const events = await queryEventBatches(
+      rpcManager,
+      contractAddress,
+      abiResult.parsed,
+      eventName,
+      eventFragment,
+      range
+    );
 
-      const events = await queryEventBatches(
-        contract,
-        eventName,
-        eventFragment,
-        range
-      );
+    console.log("[Query Events] Query complete. Events found:", events.length);
 
-      console.log(
-        "[Query Events] Query complete. Events found:",
-        events.length
-      );
-
-      return {
-        success: true as const,
-        events,
-        fromBlock: range.fromBlock,
-        toBlock: range.toBlock,
-        eventCount: events.length,
-      };
-    });
+    return {
+      success: true as const,
+      events,
+      fromBlock: range.fromBlock,
+      toBlock: range.toBlock,
+      eventCount: events.length,
+    };
   } catch (error) {
     return {
       success: false,

--- a/tests/unit/for-each-body-runner.test.ts
+++ b/tests/unit/for-each-body-runner.test.ts
@@ -717,7 +717,7 @@ describe("runBodyNode: step context", () => {
 
 const SPURIOUS_ERROR_REGEX = /exceeded max retries/;
 
-describe("runBodyNode: KEEP-543 spurious-max-retries recovery", () => {
+describe("runBodyNode: KEEP-543 / KEEP-586 authority-backed recovery", () => {
   // For Each -> read -> decode (a plain action chain)
   const baseNodes = [
     makeForEach("for-each"),
@@ -773,6 +773,47 @@ describe("runBodyNode: KEEP-543 spurious-max-retries recovery", () => {
     expect(onRecovery).toHaveBeenCalledWith({
       nodeId: "read",
       iterationMeta: { iterationIndex: 3, forEachNodeId: "for-each" },
+      reason: "spurious_max_retries",
+    });
+  });
+
+  it("recovers a long step abandoned with a non-max-retries error after its body completed", async () => {
+    const recoveredOutput = { events: [{ blockNumber: 1 }] };
+    const onRecovery = vi.fn();
+
+    // The web3 event scan ran to completion (its success row is persisted) but
+    // the runtime abandoned the step lease and threw a generic timeout error.
+    const throwingRunner: BodyStepRunner = ({ node }) => {
+      if (node.id === "read") {
+        return Promise.reject(new Error("Step timed out after 60000ms"));
+      }
+      return Promise.resolve({ decoded: true });
+    };
+
+    const { bodyResults } = await runIteration({
+      nodes: baseNodes,
+      edges: baseEdges,
+      forEachNodeId: "for-each",
+      iterationIndex: 7,
+      stepResultFor: () => undefined,
+      stepRunner: throwingRunner,
+      resolveSpuriousRecovery: ({ nodeId }) =>
+        nodeId === "read"
+          ? Promise.resolve({ output: recoveredOutput })
+          : Promise.resolve(null),
+      onSpuriousRecovery: onRecovery,
+    });
+
+    expect(bodyResults.read).toEqual({ success: true, data: recoveredOutput });
+    // The downstream node now runs instead of the iteration silently stopping.
+    expect(bodyResults.decode).toEqual({
+      success: true,
+      data: { decoded: true },
+    });
+    expect(onRecovery).toHaveBeenCalledWith({
+      nodeId: "read",
+      iterationMeta: { iterationIndex: 7, forEachNodeId: "for-each" },
+      reason: "abandoned_completion",
     });
   });
 
@@ -803,7 +844,7 @@ describe("runBodyNode: KEEP-543 spurious-max-retries recovery", () => {
     expect(onRecovery).not.toHaveBeenCalled();
   });
 
-  it("does not invoke recovery for non-spurious errors", async () => {
+  it("consults the authority for any error but fails when no success row exists", async () => {
     const realErrorRunner: BodyStepRunner = ({ node }) => {
       if (node.id === "read") {
         return Promise.reject(new Error("RPC connection refused"));
@@ -811,7 +852,9 @@ describe("runBodyNode: KEEP-543 spurious-max-retries recovery", () => {
       return Promise.resolve({ decoded: true });
     };
 
-    const resolver = vi.fn(() => Promise.resolve({ output: { wrong: true } }));
+    // A genuinely failed step has no success row, so the resolver returns null
+    // and the branch must still fail -- recovery never masks a real failure.
+    const resolver = vi.fn(() => Promise.resolve(null));
     const { bodyResults } = await runIteration({
       nodes: baseNodes,
       edges: baseEdges,
@@ -821,9 +864,10 @@ describe("runBodyNode: KEEP-543 spurious-max-retries recovery", () => {
       resolveSpuriousRecovery: resolver,
     });
 
+    expect(resolver).toHaveBeenCalledOnce();
     expect(bodyResults.read?.success).toBe(false);
     expect(bodyResults.read?.error).toBe("RPC connection refused");
-    expect(resolver).not.toHaveBeenCalled();
+    expect(bodyResults.decode).toBeUndefined();
   });
 
   it("matches FAILED_AFTER_RETRIES_REGEX and NO_STEP_COMPLETION_REGEX patterns", async () => {

--- a/tests/unit/query-events-core.test.ts
+++ b/tests/unit/query-events-core.test.ts
@@ -1,0 +1,84 @@
+import type { ethers } from "ethers";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RpcProviderManager } from "@/lib/rpc/providers";
+import {
+  MAX_BATCH_RETRIES,
+  queryBatchWithRetry,
+} from "@/plugins/web3/steps/query-events-core";
+
+function mockRpc(
+  executeWithFailover: ReturnType<typeof vi.fn>
+): RpcProviderManager {
+  return { executeWithFailover } as unknown as RpcProviderManager;
+}
+
+describe("queryBatchWithRetry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns on the first attempt without retrying", async () => {
+    const events = [{ blockNumber: 1 } as unknown as ethers.EventLog];
+    const executeWithFailover = vi.fn().mockResolvedValue(events);
+
+    const promise = queryBatchWithRetry(
+      mockRpc(executeWithFailover),
+      "0xabc",
+      [],
+      "Lift",
+      0,
+      100
+    );
+    const expectation = expect(promise).resolves.toBe(events);
+    await vi.runAllTimersAsync();
+    await expectation;
+
+    expect(executeWithFailover).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a transiently failing batch and returns once an attempt succeeds", async () => {
+    const events = [{ blockNumber: 2 } as unknown as ethers.EventLog];
+    const executeWithFailover = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("RPC failed: Timeout after 30000ms"))
+      .mockRejectedValueOnce(new Error("RPC failed: Timeout after 30000ms"))
+      .mockResolvedValueOnce(events);
+
+    const promise = queryBatchWithRetry(
+      mockRpc(executeWithFailover),
+      "0xabc",
+      [],
+      "Lift",
+      0,
+      100
+    );
+    const expectation = expect(promise).resolves.toBe(events);
+    await vi.runAllTimersAsync();
+    await expectation;
+
+    expect(executeWithFailover).toHaveBeenCalledTimes(3);
+  });
+
+  it("gives up and throws after MAX_BATCH_RETRIES failed attempts", async () => {
+    const lastError = new Error("RPC failed: Timeout after 30000ms");
+    const executeWithFailover = vi.fn().mockRejectedValue(lastError);
+
+    const promise = queryBatchWithRetry(
+      mockRpc(executeWithFailover),
+      "0xabc",
+      [],
+      "Lift",
+      0,
+      100
+    );
+    const expectation = expect(promise).rejects.toBe(lastError);
+    await vi.runAllTimersAsync();
+    await expectation;
+
+    expect(executeWithFailover).toHaveBeenCalledTimes(MAX_BATCH_RETRIES);
+  });
+});

--- a/tests/unit/truly-failed-nodes.test.ts
+++ b/tests/unit/truly-failed-nodes.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeTrulyFailedNodes,
+  type TrulyFailedLogRow,
+} from "@/lib/workflow/executor/truly-failed-nodes";
+
+function row(
+  partial: Partial<TrulyFailedLogRow> & { nodeId: string; status: string }
+): TrulyFailedLogRow {
+  return {
+    iterationIndex: null,
+    forEachNodeId: null,
+    ...partial,
+  };
+}
+
+describe("computeTrulyFailedNodes", () => {
+  it("returns empty when every top-level node has a success row", () => {
+    expect(
+      computeTrulyFailedNodes([
+        row({ nodeId: "a", status: "success" }),
+        row({ nodeId: "b", status: "success" }),
+      ])
+    ).toEqual([]);
+  });
+
+  it("flags a top-level node that has only an error row", () => {
+    expect(computeTrulyFailedNodes([row({ nodeId: "a", status: "error" })])).toEqual([
+      "a",
+    ]);
+  });
+
+  it("flags a top-level node with only a running row (no success)", () => {
+    expect(
+      computeTrulyFailedNodes([row({ nodeId: "a", status: "running" })])
+    ).toEqual(["a"]);
+  });
+
+  it("treats a top-level node as succeeded if ANY row succeeded (cross-pod orphan)", () => {
+    expect(
+      computeTrulyFailedNodes([
+        row({ nodeId: "a", status: "error" }),
+        row({ nodeId: "a", status: "success" }),
+      ])
+    ).toEqual([]);
+  });
+
+  it("treats absent (undefined) loop fields as a top-level row, not an iteration row", () => {
+    // Mirrors rows that omit the loop columns: must NOT be misread as an
+    // iteration row, otherwise a genuinely failed top-level node is dropped.
+    const logs = [
+      {
+        nodeId: "a",
+        status: "error",
+        iterationIndex: undefined,
+        forEachNodeId: undefined,
+      },
+    ] satisfies TrulyFailedLogRow[];
+    expect(computeTrulyFailedNodes(logs)).toEqual(["a"]);
+  });
+
+  it("flags the parent For Each when an iteration-body step has no success row", () => {
+    const logs = [
+      // forEachStep pre-logs the parent as success before iterations run.
+      row({ nodeId: "loop", status: "success" }),
+      row({
+        nodeId: "scan",
+        status: "error",
+        iterationIndex: 0,
+        forEachNodeId: "loop",
+      }),
+    ];
+    expect(computeTrulyFailedNodes(logs)).toEqual(["loop"]);
+  });
+
+  it("does NOT flag the For Each when the iteration step was recovered (success row present)", () => {
+    const logs = [
+      row({ nodeId: "loop", status: "success" }),
+      row({
+        nodeId: "scan",
+        status: "error",
+        iterationIndex: 0,
+        forEachNodeId: "loop",
+      }),
+      row({
+        nodeId: "scan",
+        status: "success",
+        iterationIndex: 0,
+        forEachNodeId: "loop",
+      }),
+    ];
+    expect(computeTrulyFailedNodes(logs)).toEqual([]);
+  });
+
+  it("does not let a sibling iteration's success mask a different iteration's failure", () => {
+    const logs = [
+      row({
+        nodeId: "scan",
+        status: "success",
+        iterationIndex: 0,
+        forEachNodeId: "loop",
+      }),
+      row({
+        nodeId: "scan",
+        status: "error",
+        iterationIndex: 1,
+        forEachNodeId: "loop",
+      }),
+    ];
+    expect(computeTrulyFailedNodes(logs)).toEqual(["loop"]);
+  });
+
+  it("reports both a failed top-level node and a failed loop, de-duplicated", () => {
+    const logs = [
+      row({ nodeId: "http", status: "error" }),
+      row({
+        nodeId: "scan",
+        status: "error",
+        iterationIndex: 0,
+        forEachNodeId: "loop",
+      }),
+      row({
+        nodeId: "other",
+        status: "error",
+        iterationIndex: 1,
+        forEachNodeId: "loop",
+      }),
+    ];
+    expect(computeTrulyFailedNodes(logs).sort()).toEqual(["http", "loop"]);
+  });
+});


### PR DESCRIPTION
## Problem

A workflow whose **For Each** loop body fails mid-iteration was being reported as `success`. Two layers caused this:

1. The For Each node aggregates iteration results and never propagated a body failure, so `finalSuccess` stayed true.
2. Even when the executor did finalize as `error`, `logWorkflowCompleteDb` reconciliation called `listTrulyFailedNodes`, which **excluded For Each iteration rows** and trusted the parent For Each node's log row. `forEachStep` pre-logs that parent row as `success` before any iteration runs and never flips it, so the errored iteration step was invisible and the genuine error was overridden back to `success` (with `error=null`).

Separately, a long `web3/query-events` scan (30-60 day ranges, hundreds of 2000-block batches) failed the entire node on a single transient RPC timeout, which then triggered a full durable replay of the multi-minute scan.

## Changes

- **`logging.ts`** — `listTrulyFailedNodes` now also aggregates For Each iteration rows per `(forEachNodeId, iterationIndex, nodeId)` and reports the parent For Each node as failed when an iteration step has no success row. The success-reconciliation no longer masks a genuinely failed loop.
- **`executor.workflow.ts`** — a failed iteration body now fails the For Each node so `computeFinalSuccess` marks the run `error`; iteration failures are detected and surfaced in the summary, with log lines for visibility.
- **`for-each-body-runner.ts`** — body-step recovery is authority-backed: on any throw, consult the success-tracker/DB and continue downstream when the step body actually recorded success (covers a long step the runtime abandons after it completes), instead of silently dropping the rest of the iteration.
- **`query-events.ts`** — each batch fails over between RPC endpoints and retries with backoff (>=3 attempts) so a transient timeout on one batch no longer sinks the whole scan.

## Verification

- `tsc --noEmit` clean, biome clean, full unit suite passing (added/updated body-runner recovery tests).
- Reconciliation fix validated against a real failed run: an errored iteration step now yields the parent For Each node from `listTrulyFailedNodes`, so the run stays `error` instead of being overridden to `success`.