### PR TITLE
fix(workflow): ignore template refs inside code-node comments

### DIFF
--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -835,67 +835,180 @@ function formatCodeValue(value: unknown): string {
  * Handles both stored format {{@nodeId:Label.field}} and display format
  * {{Label.field}} (fallback).
  */
+// Character ranges [start, end) of `//` line comments and block comments in JS
+// source. String/template literals are tracked so a `//` or `{{...}}` inside a
+// string is NOT treated as a comment -- only genuine comments are returned.
+function computeCommentRanges(code: string): [number, number][] {
+  const ranges: [number, number][] = [];
+  const n = code.length;
+  let i = 0;
+  let stringDelim: string | null = null;
+  while (i < n) {
+    const c = code[i];
+    if (stringDelim) {
+      if (c === "\\") {
+        i += 2;
+        continue;
+      }
+      if (c === stringDelim) {
+        stringDelim = null;
+      }
+      i++;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      stringDelim = c;
+      i++;
+      continue;
+    }
+    if (c === "/" && code[i + 1] === "/") {
+      const start = i;
+      i += 2;
+      while (i < n && code[i] !== "\n") {
+        i++;
+      }
+      ranges.push([start, i]);
+      continue;
+    }
+    if (c === "/" && code[i + 1] === "*") {
+      const start = i;
+      i += 2;
+      while (i < n && !(code[i] === "*" && code[i + 1] === "/")) {
+        i++;
+      }
+      i = Math.min(i + 2, n);
+      ranges.push([start, i]);
+      continue;
+    }
+    i++;
+  }
+  return ranges;
+}
+
+function offsetInRanges(
+  offset: number,
+  ranges: [number, number][]
+): boolean {
+  return ranges.some(([start, end]) => offset >= start && offset < end);
+}
+
+function lineNumberAt(code: string, offset: number): number {
+  let line = 1;
+  const limit = Math.min(offset, code.length);
+  for (let i = 0; i < limit; i++) {
+    if (code[i] === "\n") {
+      line++;
+    }
+  }
+  return line;
+}
+
+function resolveStoredCodeRef(
+  full: string,
+  nodeId: string,
+  rest: string,
+  outputs: NodeOutputs,
+  tracker: TemplateResolutionTracker | undefined,
+  line: number
+): string {
+  const trimmedNodeId = nodeId.trim();
+  const sanitizedNodeId = trimmedNodeId.replace(/[^a-zA-Z0-9]/g, "_");
+  const output = outputs[sanitizedNodeId] ?? outputs[trimmedNodeId];
+  if (!output) {
+    recordUnresolved(tracker, {
+      token: full,
+      reason: "no-node",
+      detail: `Node "${trimmedNodeId}" has no output yet (line ${line}).`,
+    });
+    return full;
+  }
+  const { data } = output;
+  if (data === null || data === undefined) {
+    recordUnresolved(tracker, {
+      token: full,
+      reason: "no-data",
+      detail: `Node "${trimmedNodeId}" produced no data (line ${line}).`,
+    });
+    return "null";
+  }
+  const fieldPath = rest.includes(".")
+    ? rest.substring(rest.indexOf(".") + 1).trim()
+    : "";
+  const resolved = resolveFromOutputData(data, fieldPath);
+  if (resolved === undefined || resolved === null) {
+    recordUnresolved(tracker, {
+      token: full,
+      reason: "no-path",
+      detail: `Field "${fieldPath || "(whole output)"}" not found on node "${trimmedNodeId}" (line ${line}).`,
+    });
+    return "null";
+  }
+  return formatCodeValue(resolved);
+}
+
+function resolveDisplayCodeRef(
+  full: string,
+  displayRef: string,
+  outputs: NodeOutputs,
+  tracker: TemplateResolutionTracker | undefined,
+  line: number
+): string {
+  const resolved = resolveDisplayTemplate(displayRef, outputs);
+  if (resolved === undefined || resolved === null) {
+    recordUnresolved(tracker, {
+      token: full,
+      reason: "no-path",
+      detail: `Display reference "${displayRef}" did not resolve (line ${line}).`,
+    });
+    return "null";
+  }
+  return formatCodeValue(resolved);
+}
+
+// Matches a stored ref `{{@nodeId:Label.field}}` OR a display ref
+// `{{Label.field}}` in one pass so offsets align with the comment scan below.
+const CODE_TEMPLATE_PATTERN =
+  /\{\{@([^:]+):([^}]+)\}\}|\{\{([^@}][^}]*)\}\}/g;
+
 export function processCodeTemplates(
   code: string,
   outputs: NodeOutputs,
   tracker?: TemplateResolutionTracker
 ): string {
-  const storedPattern = /\{\{@([^:]+):([^}]+)\}\}/g;
-  const displayPattern = /\{\{([^@}][^}]*)\}\}/g;
+  // Refs inside comments or commented-out code are documentation, not
+  // dependencies: they must not be resolved or fail strict resolution. Scan the
+  // original code so match offsets line up with the comment ranges.
+  const commentRanges = computeCommentRanges(code);
 
-  let result = code.replace(
-    storedPattern,
-    (full, nodeId: string, rest: string) => {
-      const trimmedNodeId = nodeId.trim();
-      const sanitizedNodeId = trimmedNodeId.replace(/[^a-zA-Z0-9]/g, "_");
-      const output = outputs[sanitizedNodeId] ?? outputs[trimmedNodeId];
-      if (!output) {
-        recordUnresolved(tracker, {
-          token: full,
-          reason: "no-node",
-          detail: `Node "${trimmedNodeId}" has no output yet.`,
-        });
+  return code.replace(
+    CODE_TEMPLATE_PATTERN,
+    (
+      full: string,
+      storedNodeId: string | undefined,
+      storedRest: string | undefined,
+      displayRef: string | undefined,
+      offset: number
+    ) => {
+      if (offsetInRanges(offset, commentRanges)) {
         return full;
       }
-      const { data } = output;
-      if (data === null || data === undefined) {
-        recordUnresolved(tracker, {
-          token: full,
-          reason: "no-data",
-          detail: `Node "${trimmedNodeId}" produced no data.`,
-        });
-        return "null";
+      const line = lineNumberAt(code, offset);
+      if (storedNodeId !== undefined && storedRest !== undefined) {
+        return resolveStoredCodeRef(
+          full,
+          storedNodeId,
+          storedRest,
+          outputs,
+          tracker,
+          line
+        );
       }
-      const fieldPath = rest.includes(".")
-        ? rest.substring(rest.indexOf(".") + 1).trim()
-        : "";
-      const resolved = resolveFromOutputData(data, fieldPath);
-      if (resolved === undefined || resolved === null) {
-        recordUnresolved(tracker, {
-          token: full,
-          reason: "no-path",
-          detail: `Field "${fieldPath || "(whole output)"}" not found on node "${trimmedNodeId}".`,
-        });
-        return "null";
+      if (displayRef !== undefined) {
+        return resolveDisplayCodeRef(full, displayRef, outputs, tracker, line);
       }
-      return formatCodeValue(resolved);
+      return full;
     }
   );
-
-  result = result.replace(displayPattern, (full, displayRef: string) => {
-    const resolved = resolveDisplayTemplate(displayRef, outputs);
-    if (resolved === undefined || resolved === null) {
-      recordUnresolved(tracker, {
-        token: full,
-        reason: "no-path",
-        detail: `Display reference "${displayRef}" did not resolve.`,
-      });
-      return "null";
-    }
-    return formatCodeValue(resolved);
-  });
-
-  return result;
 }
 
 /**
@@ -1754,12 +1867,15 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       processedConfig.dbQuery = originalDbQuery;
     }
 
+    // Render the code now (so genuine unresolved refs in executable code land
+    // in the tracker), but attach it only AFTER the leftover-literal assert
+    // below. processCodeTemplates skips refs inside comments / commented-out
+    // code, so the rendered code must stay out of the generic leftover scan --
+    // otherwise a `{{...}}` left intact inside a comment would be re-flagged as
+    // an unresolved literal. The tracker is the authority for code-field refs.
+    let renderedCode: string | undefined;
     if (actionType === "code/run-code" && typeof originalCode === "string") {
-      processedConfig.code = processCodeTemplates(
-        originalCode,
-        currentOutputs,
-        tracker
-      );
+      renderedCode = processCodeTemplates(originalCode, currentOutputs, tracker);
     }
 
     // KEEP-468 hotfix: scan + assert BEFORE re-attaching condition fields.
@@ -1775,6 +1891,9 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       actionType,
     });
 
+    if (renderedCode !== undefined) {
+      processedConfig.code = renderedCode;
+    }
     if (originalCondition !== undefined) {
       processedConfig.condition = originalCondition;
     }

--- a/tests/unit/template-fail-closed.test.ts
+++ b/tests/unit/template-fail-closed.test.ts
@@ -162,6 +162,455 @@ describe("processCodeTemplates strict integration", () => {
   });
 });
 
+describe("processCodeTemplates: refs in comments are documentation, not deps", () => {
+  const codeOutputs = {
+    src: { label: "Src", data: { value: 42, addr: "0xabc" } },
+    "50CDD": {
+      label: "Check past lift events",
+      data: { events: [{ whom: "0xspell" }] },
+    },
+  };
+
+  it("ignores a ref in a // line comment", () => {
+    const tracker = createTracker();
+    const code = "// example: {{@missing:Foo.bar}}\nconst x = 1;";
+    const out = processCodeTemplates(code, codeOutputs, tracker);
+    expect(out).toBe(code);
+    expect(tracker.unresolved).toEqual([]);
+  });
+
+  it("ignores a ref in a /* */ block comment", () => {
+    const tracker = createTracker();
+    const code = "/* see {{@missing:Foo.bar}} */\nconst x = 1;";
+    const out = processCodeTemplates(code, codeOutputs, tracker);
+    expect(out).toBe(code);
+    expect(tracker.unresolved).toEqual([]);
+  });
+
+  it("ignores a ref in a /** */ JSDoc comment", () => {
+    const tracker = createTracker();
+    const code = "/**\n * @example {{@missing:Foo.bar}}\n */\nconst x = 1;";
+    const out = processCodeTemplates(code, codeOutputs, tracker);
+    expect(out).toBe(code);
+    expect(tracker.unresolved).toEqual([]);
+  });
+
+  it("ignores a ref in commented-out code", () => {
+    const tracker = createTracker();
+    const code = "// const old = {{@missing:Foo.bar}};\nconst x = 1;";
+    const out = processCodeTemplates(code, codeOutputs, tracker);
+    expect(out).toBe(code);
+    expect(tracker.unresolved).toEqual([]);
+  });
+
+  it("ignores a trailing inline // comment ref but resolves the code ref before it", () => {
+    const tracker = createTracker();
+    const code = "const x = {{@src:Src.value}}; // and {{@missing:Foo.bar}}";
+    const out = processCodeTemplates(code, codeOutputs, tracker);
+    expect(out).toBe("const x = 42; // and {{@missing:Foo.bar}}");
+    expect(tracker.unresolved).toEqual([]);
+  });
+
+  it("ignores refs spread across a multi-line block comment", () => {
+    const tracker = createTracker();
+    const code =
+      "/*\n {{@a:A.b}}\n {{@c:C.d}}\n*/\nconst x = {{@src:Src.value}};";
+    const out = processCodeTemplates(code, codeOutputs, tracker);
+    expect(out).toContain("{{@a:A.b}}");
+    expect(out).toContain("{{@c:C.d}}");
+    expect(out).toContain("const x = 42;");
+    expect(tracker.unresolved).toEqual([]);
+  });
+
+  it("resolves a ref inside a string literal (a string is not a comment)", () => {
+    const tracker = createTracker();
+    const code = 'const s = "{{@src:Src.value}}";';
+    const out = processCodeTemplates(code, codeOutputs, tracker);
+    expect(out).not.toContain("{{");
+    expect(tracker.unresolved).toEqual([]);
+  });
+
+  it("does not treat // inside a string literal as a comment", () => {
+    const tracker = createTracker();
+    const code = 'const url = "http://{{@src:Src.value}}";';
+    const out = processCodeTemplates(code, codeOutputs, tracker);
+    expect(out).not.toContain("{{");
+    expect(out).toContain("42");
+    expect(tracker.unresolved).toEqual([]);
+  });
+
+  it("still flags a genuine unresolved ref in executable code, with the line number", () => {
+    const tracker = createTracker();
+    const code = "const a = 1;\nconst b = {{@missing:Foo.bar}};";
+    processCodeTemplates(code, codeOutputs, tracker);
+    expect(tracker.unresolved).toHaveLength(1);
+    expect(tracker.unresolved[0]?.reason).toBe("no-node");
+    expect(tracker.unresolved[0]?.detail).toContain("line 2");
+  });
+
+  it("the Chief Keeper Filter case: example refs in comments do not fail the node", () => {
+    const tracker = createTracker();
+    const code = [
+      "// Use @ to insert template variables from upstream nodes",
+      "// e.g. {{QueryEvents.events}}, {{ReadContract.result}}",
+      "",
+      "const data = {{@50CDD:Check past lift events.events}};",
+      "return data.length;",
+    ].join("\n");
+    const out = processCodeTemplates(code, codeOutputs, tracker);
+    expect(tracker.unresolved).toEqual([]);
+    expect(out).toContain('const data = [{"whom":"0xspell"}];');
+    expect(out).toContain("{{QueryEvents.events}}");
+  });
+
+  // Data-driven: every comment style x both ref forms (stored + display) must
+  // be left untouched and never recorded as unresolved.
+  const COMMENT_WRAPPERS: Array<{ name: string; wrap: (ref: string) => string }> =
+    [
+      { name: "// line comment", wrap: (r) => `// ${r}\nconst x = 1;` },
+      { name: "/* block */ comment", wrap: (r) => `/* ${r} */\nconst x = 1;` },
+      {
+        name: "/** jsdoc */ comment",
+        wrap: (r) => `/**\n * @example ${r}\n */\nconst x = 1;`,
+      },
+      { name: "trailing inline // comment", wrap: (r) => `const x = 1; // ${r}` },
+      {
+        name: "commented-out code",
+        wrap: (r) => `// const old = ${r};\nconst x = 1;`,
+      },
+    ];
+  const REF_FORMS = [
+    "{{@missing:Foo.bar}}", // stored form, unknown node
+    "{{@src:Src.value}}", // stored form, KNOWN node (must still be skipped in a comment)
+    "{{QueryEvents.events}}", // display form, unknown node
+  ];
+  for (const wrapper of COMMENT_WRAPPERS) {
+    for (const ref of REF_FORMS) {
+      it(`does not resolve ${ref} inside ${wrapper.name}`, () => {
+        const tracker = createTracker();
+        const code = wrapper.wrap(ref);
+        const out = processCodeTemplates(code, codeOutputs, tracker);
+        expect(out).toContain(ref);
+        expect(out).not.toContain("42");
+        expect(tracker.unresolved).toEqual([]);
+      });
+    }
+  }
+
+  it("handles arbitrary interleaving of real code, comments, and commented-out code", () => {
+    const tracker = createTracker();
+    const code = [
+      "const a = {{@src:Src.value}};", // real -> 42
+      "// commented {{@x:X.y}} ref", // comment -> skip
+      "const b = {{@src:Src.addr}};", // real -> "0xabc"
+      "/* block {{@p:P.q}}", // block comment -> skip
+      "   still {{@r:R.s}} comment", // block comment -> skip
+      "*/",
+      "const c = {{@50CDD:Check past lift events.events}}; // trailing {{@t:T.u}}", // real + trailing skip
+      "// const old = {{@src:Src.value}};", // commented-out real-looking ref -> skip
+      "/** @example {{ReadContract.result}} */", // jsdoc display -> skip
+      "return [a, b, c];",
+    ].join("\n");
+    const out = processCodeTemplates(code, codeOutputs, tracker);
+
+    expect(tracker.unresolved).toEqual([]);
+    expect(out).toContain("const a = 42;");
+    expect(out).toContain('const b = "0xabc";');
+    expect(out).toContain('const c = [{"whom":"0xspell"}];');
+    for (const left of [
+      "{{@x:X.y}}",
+      "{{@p:P.q}}",
+      "{{@r:R.s}}",
+      "{{@t:T.u}}",
+      "// const old = {{@src:Src.value}};",
+      "{{ReadContract.result}}",
+    ]) {
+      expect(out).toContain(left);
+    }
+  });
+
+  it("resolves multiple real refs across many lines while skipping interleaved comment refs", () => {
+    const tracker = createTracker();
+    const code = [
+      "/* header {{@h:H.i}} */",
+      "const a = {{@src:Src.value}};",
+      "const b = {{@src:Src.value}}; // {{@c1:C.1}}",
+      "// {{@c2:C.2}}",
+      "const c = {{@src:Src.addr}};",
+    ].join("\n");
+    const out = processCodeTemplates(code, codeOutputs, tracker);
+    expect(tracker.unresolved).toEqual([]);
+    expect((out.match(/42/g) ?? []).length).toBe(2);
+    expect(out).toContain('"0xabc"');
+    for (const left of ["{{@h:H.i}}", "{{@c1:C.1}}", "{{@c2:C.2}}"]) {
+      expect(out).toContain(left);
+    }
+  });
+
+  it("flags every genuine unresolved ref with its line number, ignoring comment refs", () => {
+    const tracker = createTracker();
+    const code = [
+      "// comment {{@inComment:A.b}}", // line 1 - skip
+      "const a = {{@missing1:Foo.bar}};", // line 2 - flag
+      "const b = 2;", // line 3
+      "/* {{@inBlock:C.d}} */", // line 4 - skip
+      "const e = {{@missing2:Baz.qux}};", // line 5 - flag
+    ].join("\n");
+    processCodeTemplates(code, codeOutputs, tracker);
+    const details = tracker.unresolved.map((u) => u.detail ?? "");
+    expect(tracker.unresolved).toHaveLength(2);
+    expect(details.some((d) => d.includes("line 2"))).toBe(true);
+    expect(details.some((d) => d.includes("line 5"))).toBe(true);
+    expect(details.some((d) => d.includes("inComment"))).toBe(false);
+    expect(details.some((d) => d.includes("inBlock"))).toBe(false);
+  });
+
+  it("resolves a real ref on the same line right after a block comment closes", () => {
+    const tracker = createTracker();
+    const code = "/* {{@a:A.b}} */ const v = {{@src:Src.value}};";
+    const out = processCodeTemplates(code, codeOutputs, tracker);
+    expect(out).toBe("/* {{@a:A.b}} */ const v = 42;");
+    expect(tracker.unresolved).toEqual([]);
+  });
+
+  it("leaves code that is only comments untouched", () => {
+    const tracker = createTracker();
+    const code = "// {{@a:A.b}}\n/* {{@c:C.d}} */\n/** {{Display.ref}} */";
+    const out = processCodeTemplates(code, codeOutputs, tracker);
+    expect(out).toBe(code);
+    expect(tracker.unresolved).toEqual([]);
+  });
+
+  // Comment detection is structure-agnostic (it scans tokens, not syntax), so
+  // refs in comments inside any control-flow structure must be skipped while
+  // real refs in the same structure resolve. `{{@src:Src.value}}` is the one
+  // real ref (-> 42); every other token lives in a comment and must survive.
+  const structureCase = (name: string, code: string): void => {
+    it(name, () => {
+      const tracker = createTracker();
+      const out = processCodeTemplates(code, codeOutputs, tracker);
+      expect(tracker.unresolved).toEqual([]);
+      expect(out).toContain("42");
+      for (const m of code.matchAll(/\{\{[^}]+\}\}/g)) {
+        const token = m[0];
+        if (token !== "{{@src:Src.value}}") {
+          expect(out).toContain(token);
+        }
+      }
+    });
+  };
+
+  structureCase(
+    "if / else if / else",
+    [
+      "if (a) {",
+      "  // {{@c1:C.1}}",
+      "  const x = {{@src:Src.value}};",
+      "} else if (b) {",
+      "  /* {{@c2:C.2}} */",
+      "} else {",
+      "  // fallback {{@c3:C.3}}",
+      "}",
+    ].join("\n")
+  );
+
+  structureCase(
+    "switch / case",
+    [
+      "switch (k) {",
+      "  case 1: // {{@c1:C.1}}",
+      "    return {{@src:Src.value}};",
+      "  /* {{@c2:C.2}} */",
+      "  default:",
+      "    // {{@c3:C.3}}",
+      "    break;",
+      "}",
+    ].join("\n")
+  );
+
+  structureCase(
+    "for loop",
+    [
+      "for (let i = 0; i < n; i++) {",
+      "  // iterate {{@c1:C.1}}",
+      "  total += {{@src:Src.value}};",
+      "  /* {{@c2:C.2}} */",
+      "}",
+    ].join("\n")
+  );
+
+  structureCase(
+    "while loop",
+    [
+      "while (cond) {",
+      "  // {{@c1:C.1}}",
+      "  x = {{@src:Src.value}};",
+      "}",
+    ].join("\n")
+  );
+
+  structureCase(
+    "try / catch / finally",
+    [
+      "try {",
+      "  // {{@c1:C.1}}",
+      "  v = {{@src:Src.value}};",
+      "} catch (e) {",
+      "  /* {{@c2:C.2}} */",
+      "} finally {",
+      "  // {{@c3:C.3}}",
+      "}",
+    ].join("\n")
+  );
+
+  structureCase(
+    "function + arrow function bodies",
+    [
+      "function f() {",
+      "  // {{@c1:C.1}}",
+      "  return {{@src:Src.value}};",
+      "}",
+      "const g = () => {",
+      "  /* {{@c2:C.2}} */",
+      "};",
+    ].join("\n")
+  );
+
+  structureCase(
+    "nested structures (for inside if inside switch) with interleaved comments",
+    [
+      "switch (k) {",
+      "  case 1:",
+      "    if (a) {",
+      "      // {{@c1:C.1}}",
+      "      for (const it of items) {",
+      "        /* {{@c2:C.2}}",
+      "           {{@c3:C.3}} */",
+      "        acc += {{@src:Src.value}};",
+      "      }",
+      "    }",
+      "    break;",
+      "}",
+    ].join("\n")
+  );
+
+  structureCase(
+    "do / while loop",
+    [
+      "do {",
+      "  // {{@c1:C.1}}",
+      "  x = {{@src:Src.value}};",
+      "} while (cond); /* {{@c2:C.2}} */",
+    ].join("\n")
+  );
+
+  structureCase(
+    "for...of loop",
+    [
+      "for (const item of items) {",
+      "  // {{@c1:C.1}}",
+      "  sum += {{@src:Src.value}};",
+      "}",
+    ].join("\n")
+  );
+
+  structureCase(
+    "for...in loop",
+    [
+      "for (const key in obj) {",
+      "  /* {{@c1:C.1}} */",
+      "  total = {{@src:Src.value}};",
+      "}",
+    ].join("\n")
+  );
+
+  structureCase(
+    "ternary expression",
+    [
+      "const v = cond",
+      "  ? {{@src:Src.value}} // {{@c1:C.1}}",
+      "  : 0; /* {{@c2:C.2}} */",
+    ].join("\n")
+  );
+
+  structureCase(
+    "object literal",
+    [
+      "const o = {",
+      "  // {{@c1:C.1}}",
+      "  amount: {{@src:Src.value}},",
+      "  /* {{@c2:C.2}} */",
+      "};",
+    ].join("\n")
+  );
+
+  structureCase(
+    "array literal",
+    [
+      "const arr = [",
+      "  // {{@c1:C.1}}",
+      "  {{@src:Src.value}},",
+      "  /* {{@c2:C.2}} */",
+      "];",
+    ].join("\n")
+  );
+
+  structureCase(
+    "class declaration with method",
+    [
+      "class C {",
+      "  // {{@c1:C.1}}",
+      "  m() {",
+      "    /* {{@c2:C.2}} */",
+      "    return {{@src:Src.value}};",
+      "  }",
+      "}",
+    ].join("\n")
+  );
+
+  structureCase(
+    "async / await function",
+    [
+      "async function run() {",
+      "  // {{@c1:C.1}}",
+      "  await tick();",
+      "  return {{@src:Src.value}}; /* {{@c2:C.2}} */",
+      "}",
+    ].join("\n")
+  );
+
+  structureCase(
+    "generator function",
+    [
+      "function* gen() {",
+      "  // {{@c1:C.1}}",
+      "  yield {{@src:Src.value}};",
+      "}",
+    ].join("\n")
+  );
+
+  structureCase(
+    "IIFE",
+    [
+      "(function () {",
+      "  /* {{@c1:C.1}} */",
+      "  return {{@src:Src.value}};",
+      "})(); // {{@c2:C.2}}",
+    ].join("\n")
+  );
+
+  structureCase(
+    "labeled loop with break",
+    [
+      "outer: for (;;) {",
+      "  // {{@c1:C.1}}",
+      "  x = {{@src:Src.value}};",
+      "  break outer; /* {{@c2:C.2}} */",
+      "}",
+    ].join("\n")
+  );
+});
+
 describe("extractTemplateParameters strict integration", () => {
   it("records no-path when a referenced field does not resolve", () => {
     const tracker = createTracker();


### PR DESCRIPTION
## Problem

A `code/run-code` node fails strict template resolution when its `code` contains a `{{...}}` reference inside a **comment** or **commented-out code** — even though comments never execute. The resolver scans the whole code string, can't resolve e.g. the boilerplate `// e.g. {{QueryEvents.events}}, {{ReadContract.result}}`, and aborts the node with `Unresolved template reference(s) ... action was aborted`.

In a For Each body this stops the iteration the moment it reaches that node and nothing downstream runs. It surfaced concretely in a governance keeper whose `Filter` node shipped with example refs in a comment: the loop reached `Filter`, it threw, and the keeper never progressed.

## Fix

- **`processCodeTemplates`** now scans the code in a single pass and **skips any `{{...}}` whose offset falls inside a comment** — `//` line comments, `/* */` and `/** */` (JSDoc) block comments, and commented-out code. String/template literals are tracked so a `//` or `{{...}}` inside a string is still treated as real code. Refs in real code resolve exactly as before.
- **`processActionConfig`** attaches the rendered `code` *after* the leftover-literal `assertResolved`, so a `{{...}}` deliberately left intact inside a comment is not re-flagged by the generic leftover scan. The tracker remains the authority for genuine unresolved refs in executable code.
- Unresolved-ref errors now include the **line number** (`... did not resolve (line N)`), since a node can reference the same value on multiple lines.

## Tests

`tests/unit/template-fail-closed.test.ts` gains thorough coverage:
- Every comment style (`//`, `/* */`, `/** */`) × both ref forms (`{{@id:..}}` stored and `{{Label.field}}` display), including a known-node ref inside a comment (must still be skipped).
- Interleaved real code / comments / commented-out code, multi-line block comments, trailing inline comments, refs adjacent to a closing comment, and comment-only files.
- Refs inside **all common JS structures**: `if`/`else if`/`else`, `switch`/`case`, `for`, `while`, `do/while`, `for...of`, `for...in`, ternary, object/array literals, class methods, `async`/`await`, generators, IIFE, labeled loops, `try`/`catch`/`finally`, and nested combinations.
- Genuine unresolved refs in executable code still fail closed, now reporting the correct line number.

Full unit suite green; type-check and lint clean.