### PR TITLE
fix(workflow): give For Each body conditions the dead-branch grace

### DIFF
--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -1840,11 +1840,20 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
         scopedOutputs: outputs,
         stepContext,
       }) =>
+        // Pass nodeMap + executionResults so a Condition inside the loop body
+        // gets the same dead-branch grace as a top-level Condition: a reference
+        // to a graph node that never executed (e.g. a convergence node that
+        // joins two mutually-exclusive branches) resolves to `undefined`
+        // instead of throwing, letting `doesNotExist`/`=== undefined` rules
+        // evaluate. Without this the body Condition fails closed with
+        // "references node ... but no output was found".
         await executeActionStep({
           actionType,
           config: processedConfig,
           outputs,
           context: stepContext,
+          nodeMap,
+          executionResults: results,
         }),
       // KEEP-543: Same KEEP-398/431 spurious-max-retries recovery pattern as
       // the top-level node executor, scoped to the current iteration.

--- a/tests/unit/condition-executor.test.ts
+++ b/tests/unit/condition-executor.test.ts
@@ -6,6 +6,7 @@ import { evaluateConditionExpression } from "@/lib/workflow/executor/executor.wo
 import { resolveConditionExpression } from "@/lib/workflow/nodes/condition/resolver";
 
 const NO_EXPRESSION_REGEX = /no expression configured/;
+const NO_OUTPUT_FOUND_RE = /no output was found/;
 
 /**
  * Tests for KEEP-1520: Condition node losing expression at runtime
@@ -930,5 +931,49 @@ describe("condition evaluation edge cases", () => {
       const result = evaluateConditionExpression(expression, outputs);
       expect(result.result).toBe(true);
     });
+  });
+});
+
+describe("dead-branch grace: references to nodes that never executed", () => {
+  // A convergence Condition (e.g. "Already scheduled?") joins two
+  // mutually-exclusive branches and references a node from each, using
+  // doesNotExist / === undefined to handle whichever branch did not run. When
+  // nodeMap + executionResults are supplied, a reference to a graph node that
+  // never executed resolves to `undefined` instead of throwing. The For Each
+  // body must pass that context so a loop-body Condition behaves like a
+  // top-level one.
+  const deadNodeMap = new Map<string, unknown>([
+    ["dead", { id: "dead", data: { label: "Query Transaction History" } }],
+  ]);
+
+  it("resolves a reference to a non-executed graph node to undefined (no throw)", () => {
+    const expression =
+      "({{@dead:Query Transaction History.matchCount}} === null || {{@dead:Query Transaction History.matchCount}} === undefined)";
+    const result = evaluateConditionExpression(expression, {}, deadNodeMap, {});
+    expect(result.result).toBe(true);
+  });
+
+  it("evaluates a convergence condition when one referenced branch ran and the other did not", () => {
+    const expression =
+      "{{@ran:Check if already scheduled?.matchCount}} == 0 && ({{@dead:Query Transaction History.matchCount}} === null || {{@dead:Query Transaction History.matchCount}} === undefined)";
+    const outputs = {
+      ran: { label: "Check if already scheduled?", data: { matchCount: 0 } },
+    };
+    const nodeMap = new Map<string, unknown>([
+      ["ran", { id: "ran" }],
+      ["dead", { id: "dead" }],
+    ]);
+    const result = evaluateConditionExpression(expression, outputs, nodeMap, {
+      ran: { success: true },
+    });
+    expect(result.result).toBe(true);
+  });
+
+  it("throws without the dead-branch context (the pre-fix For Each body behaviour)", () => {
+    const expression =
+      "{{@dead:Query Transaction History.matchCount}} === undefined";
+    expect(() => evaluateConditionExpression(expression, {})).toThrow(
+      NO_OUTPUT_FOUND_RE
+    );
   });
 });


### PR DESCRIPTION
## Problem

A `Condition` inside a `For Each` loop that references a node on a **not-taken / dead branch** fails closed with:

```
Condition references node "..." but no output was found. The referenced node may not have executed or produced output.
```

Concrete case (Chief Keeper): on the loop write-path `Lift the spell → Check if already scheduled? → Already scheduled?`, the `Already scheduled?` condition is a convergence node that references two mutually-exclusive upstream nodes:
- `Check if already scheduled?` — runs on the loop path
- `Query Transaction History` — only runs on the main-flow branch (hat not executed), which did not run this execution

When the condition evaluates, the reference to the never-executed `Query Transaction History` throws, killing the iteration.

## Root cause

The executor already has a **dead-branch grace** ([executor.workflow.ts](lib/workflow/executor/executor.workflow.ts)): a reference to a node that exists in the graph but never executed resolves to `undefined` (so `doesNotExist` / `=== undefined` rules can evaluate) — **but only when `nodeMap` + `executionResults` are passed** to the condition step.

Top-level conditions pass that context; the **For Each body's `executeActionStep` did not**. So the same convergence condition works at the top level but throws inside a loop.

## Fix

Pass `nodeMap` + `executionResults` in the body's `executeActionStep`, identical to the top-level call. A loop-body condition now gets the same dead-branch grace.

This is safe for the parallel-join case: genuinely-parallel converging branches are gated by the fork-join convergence barrier (`convergence-barrier.ts`), so the condition only evaluates after all inputs have arrived — the grace only ever sees definitively-skipped (dead) branches, never still-pending ones.

## Tests

`tests/unit/condition-executor.test.ts`:
- a reference to a non-executed graph node resolves to `undefined` (no throw) when `nodeMap` + `executionResults` are supplied;
- a convergence condition where one referenced branch ran and the other did not evaluates correctly;
- without the context it still throws (the pre-fix For Each body behaviour).

Type-check + lint clean; full unit suite green.