### PR TITLE
fix(sandbox): re-validate SSRF on every redirect hop in sandboxed fetch

### DIFF
--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -64,6 +64,10 @@ const { BlockList, isIP } = require("node:net");
 
 const MAX_LOG_ENTRIES = 200;
 
+// Cap on redirect hops a single sandboxed fetch will follow before giving
+// up, mirroring undici's built-in maxRedirections default.
+const MAX_SANDBOX_REDIRECTS = 20;
+
 // SSRF guard: ported from lib/safe-fetch.ts. Modeled on the main-app
 // pattern but inlined here because the sandbox package is
 // zero-runtime-dep by design and the grandchild gets only node: builtins.
@@ -87,12 +91,17 @@ const MAX_LOG_ENTRIES = 200;
 // undici as a sandbox dep), so there is a small window between our
 // dns.lookup and the fetch's internal connect where the record could
 // change. NetworkPolicy is the real defense for that (tracked elsewhere).
+// Redirects: lacking the per-connect hook, the wrapped fetch uses
+// redirect:"manual" and re-runs these same checks on each 3xx Location
+// before following it, so a redirect cannot chase a public host into a
+// blocked one (IMDS, K8s apiserver, *.svc.cluster.local).
 // Testing note: the sandbox guard is not unit-tested directly because
 // this entire file is a template literal executed in a subprocess via
 // "node -e". The parallel behavior in lib/safe-fetch.ts is unit-tested
 // (tests/unit/safe-fetch.test.ts) and these CIDR / hostname denylists
 // are kept in lockstep with that file by convention.
 const ALLOWED_SCHEMES = new Set(["http:", "https:"]);
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const IPV4_MAPPED_PREFIX = "::ffff:";
 const IPV4_MAPPED_HEX_REGEX = /^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/;
 // NAT64 well-known prefix (RFC 6052): 64:ff9b::/96 — last 32 bits encode an
@@ -211,6 +220,23 @@ function stripIpv6Brackets(hostname) {
     return hostname.slice(1, -1);
   }
   return hostname;
+}
+
+// Rewrite the method/body for the next hop the way undici's follow mode
+// would: 301/302 downgrade a POST to GET, 303 downgrades any non-GET/HEAD
+// to GET, and 307/308 preserve both. Keeps manual redirect following
+// behaviourally equivalent to the network layer's own follow.
+function applyRedirectMethod(init, status) {
+  const next = Object.assign({}, init);
+  const method = (typeof next.method === "string" ? next.method : "GET").toUpperCase();
+  const downgrade =
+    ((status === 301 || status === 302) && method === "POST") ||
+    (status === 303 && method !== "GET" && method !== "HEAD");
+  if (downgrade) {
+    next.method = "GET";
+    delete next.body;
+  }
+  return next;
 }
 
 // Pre-DNS hostname denylist interpolated from lib/ssrf-blocklist.ts at
@@ -349,10 +375,71 @@ function run(input) {
       );
     }
 
-    const nextInit = Object.assign({}, init, { signal: controller.signal });
-    return fetch(resource, nextInit).finally(function clearTimer() {
-      clearTimeout(timer);
+    // Follow redirects manually so every hop is re-validated. undici's
+    // built-in follow mode would transparently chase a 3xx Location into a
+    // blocked host (IMDS, K8s apiserver, *.svc.cluster.local) because the
+    // SSRF guard above only sees the initial URL. "manual" returns the real
+    // 3xx response with a readable Location header, so we re-run the same
+    // scheme + SSRF checks before issuing the next request.
+    const baseInit = Object.assign({}, init, {
+      signal: controller.signal,
+      redirect: "manual",
     });
+
+    let currentResource = resource;
+    let currentBase = parsed;
+    let currentInit = baseInit;
+    let redirectsLeft = MAX_SANDBOX_REDIRECTS;
+
+    try {
+      while (true) {
+        const response = await fetch(currentResource, currentInit);
+        const location = REDIRECT_STATUSES.has(response.status)
+          ? response.headers.get("location")
+          : null;
+        if (location === null) {
+          return response;
+        }
+        if (redirectsLeft <= 0) {
+          throw new Error("sandbox fetch: too many redirects");
+        }
+        redirectsLeft -= 1;
+
+        let nextUrl;
+        try {
+          nextUrl = new URL(location, currentBase);
+        } catch (_e) {
+          throw new Error("sandbox fetch: invalid redirect location: " + location);
+        }
+        if (!ALLOWED_SCHEMES.has(nextUrl.protocol)) {
+          throw new Error("sandbox fetch: scheme not allowed: " + nextUrl.protocol);
+        }
+        const nextHostname = stripIpv6Brackets(nextUrl.hostname);
+        const nextCheck = await checkHostnameSsrf(nextHostname);
+        if (nextCheck.blocked) {
+          const nextIp = nextCheck.ip;
+          const nextSuffix = nextIp && nextIp !== nextHostname ? " -> " + nextIp : "";
+          throw new Error(
+            "sandbox fetch: SSRF blocked (" + nextHostname + nextSuffix + ")"
+          );
+        }
+
+        // Discard the redirect body so the underlying socket is freed.
+        if (response.body) {
+          try {
+            await response.body.cancel();
+          } catch (_e) {
+            // body may already be consumed or unsupported; ignore
+          }
+        }
+
+        currentInit = applyRedirectMethod(currentInit, response.status);
+        currentResource = nextUrl.href;
+        currentBase = nextUrl;
+      }
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   const sandbox = createContext({

--- a/tests/unit/sandbox-child-source.test.ts
+++ b/tests/unit/sandbox-child-source.test.ts
@@ -1,7 +1,9 @@
 import { spawn } from "node:child_process";
 import { readFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import { deserialize } from "node:v8";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
@@ -57,7 +59,7 @@ describe("sandbox child-source consumes lib/ssrf-blocklist.ts", () => {
 
   it("inlines the NAT64 well-known prefix tuple from the SoT", () => {
     expect(SANDBOX_CHILD_SOURCE).toContain(
-      JSON.stringify(SSRF_NAT64_PREFIX_CIDR),
+      JSON.stringify(SSRF_NAT64_PREFIX_CIDR)
     );
   });
 
@@ -90,6 +92,8 @@ describe("sandbox child-source consumes lib/ssrf-blocklist.ts", () => {
 // across "node -e") or introduce a dependency the standalone sandbox image
 // does not have. Lock the contract here so it cannot regress quietly.
 const IMPORT_STATEMENT_REGEX = /^import\s.+$/gm;
+const SCHEME_NOT_ALLOWED_REGEX = /scheme not allowed/;
+const TOO_MANY_REDIRECTS_REGEX = /too many redirects/;
 
 describe("lib/sandbox/child-source.ts only imports pure data", () => {
   it("has at most one import and it points at the SSRF blocklist JSON", async () => {
@@ -117,9 +121,7 @@ function parseChildOutput(stdout: string): SandboxOutcome {
   }
   const newlineIdx = stdout.indexOf("\n", idx);
   const end = newlineIdx === -1 ? stdout.length : newlineIdx;
-  const base64 = stdout
-    .slice(idx + SANDBOX_RESULT_SENTINEL.length, end)
-    .trim();
+  const base64 = stdout.slice(idx + SANDBOX_RESULT_SENTINEL.length, end).trim();
   try {
     return deserialize(Buffer.from(base64, "base64")) as SandboxOutcome;
   } catch (_err) {
@@ -130,9 +132,10 @@ function parseChildOutput(stdout: string): SandboxOutcome {
 async function runSandboxed(
   userCode: string,
   timeoutMs = 3000,
+  source: string = SANDBOX_CHILD_SOURCE
 ): Promise<SandboxOutcome> {
   return await new Promise<SandboxOutcome>((resolve) => {
-    const child = spawn(process.execPath, ["-e", SANDBOX_CHILD_SOURCE], {
+    const child = spawn(process.execPath, ["-e", source], {
       stdio: ["pipe", "pipe", "pipe"],
     });
     let stdout = "";
@@ -225,18 +228,196 @@ describe("sandbox grandchild SSRF guard fires on every category", () => {
     ['await fetch("http://localhost/")', "pre-DNS exact match"],
     ['await fetch("http://LOCALHOST/")', "case normalisation"],
     ['await fetch("http://localhost./")', "trailing-dot normalisation"],
-    [
-      'await fetch("http://probe.svc.cluster.local/")',
-      "*.svc.cluster.local",
-    ],
-    [
-      'await fetch("http://probe.pod.cluster.local/")',
-      "*.pod.cluster.local",
-    ],
+    ['await fetch("http://probe.svc.cluster.local/")', "*.svc.cluster.local"],
+    ['await fetch("http://probe.pod.cluster.local/")', "*.pod.cluster.local"],
     ['await fetch("http://probe.internal/")', "*.internal"],
     ['await fetch("http://probe.local/")', "*.local (mDNS / Bonjour)"],
   ])("blocks %s before DNS (%s)", async (snippet) => {
     const outcome = await runSandboxed(snippet);
     expectBlocked(outcome);
+  });
+}, 30_000);
+
+// Structural guard for the redirect re-validation wiring. undici's default
+// follow mode would chase a 3xx Location into a blocked host because the
+// SSRF guard only sees the initial URL; the wrapped fetch must instead use
+// manual redirects and re-check every hop. Lock the key tokens so the
+// behaviour cannot regress silently if the template is refactored.
+describe("sandbox grandchild re-validates redirects", () => {
+  it("uses manual redirect mode on the wrapped fetch", () => {
+    expect(SANDBOX_CHILD_SOURCE).toContain('redirect: "manual"');
+  });
+
+  it("re-runs the SSRF check on each redirect hop and caps the chain", () => {
+    expect(SANDBOX_CHILD_SOURCE).toContain("REDIRECT_STATUSES");
+    expect(SANDBOX_CHILD_SOURCE).toContain("MAX_SANDBOX_REDIRECTS");
+    expect(SANDBOX_CHILD_SOURCE).toContain("too many redirects");
+  });
+});
+
+// Behavioural coverage for the redirect loop. The real grandchild blocks
+// every locally-bindable address, so no hop of a local test server would be
+// reachable. We derive a variant of the real source with only the IPv4
+// loopback subnet removed, leaving link-local/IMDS (169.254.0.0/16), RFC1918
+// and the cluster-hostname denylist intact - exactly the redirect targets
+// the per-hop re-validation must still catch. The redirect-following code
+// under test is otherwise the unmodified production source.
+const LOOPBACK_CIDR_TUPLE = '["127.0.0.0",8]';
+const REDIRECT_TEST_SOURCE = SANDBOX_CHILD_SOURCE.replace(
+  `,${LOOPBACK_CIDR_TUPLE}`,
+  ""
+);
+
+type FetchResult = { status: number; body: string };
+
+function resultOf(outcome: SandboxOutcome): FetchResult {
+  if (!outcome.ok) {
+    throw new Error(`expected ok outcome, got: ${outcome.errorMessage}`);
+  }
+  return outcome.result as FetchResult;
+}
+
+describe("sandbox grandchild redirect following", () => {
+  let server: Server;
+  let base: string;
+
+  beforeAll(async () => {
+    server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (url.pathname === "/loop") {
+        res.writeHead(302, { Location: "/loop" });
+        res.end();
+        return;
+      }
+      if (url.pathname === "/redir") {
+        const to = url.searchParams.get("to") ?? "/ok";
+        const status = Number(url.searchParams.get("status") ?? "302");
+        res.writeHead(status, { Location: to });
+        res.end();
+        return;
+      }
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        const body = Buffer.concat(chunks).toString();
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end(`FINAL method=${req.method} body=${body}`);
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const { port } = server.address() as AddressInfo;
+    base = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  function getCode(url: string): string {
+    return `const r = await fetch(${JSON.stringify(url)}); return { status: r.status, body: await r.text() };`;
+  }
+
+  function postCode(url: string, body: string): string {
+    return `const r = await fetch(${JSON.stringify(url)}, { method: "POST", body: ${JSON.stringify(body)} }); return { status: r.status, body: await r.text() };`;
+  }
+
+  function redirTo(target: string, status = 302): string {
+    return `${base}/redir?status=${status}&to=${encodeURIComponent(target)}`;
+  }
+
+  it("sanity: the test source actually dropped the loopback block", () => {
+    expect(REDIRECT_TEST_SOURCE).not.toBe(SANDBOX_CHILD_SOURCE);
+    expect(REDIRECT_TEST_SOURCE).not.toContain(LOOPBACK_CIDR_TUPLE);
+  });
+
+  it("follows a 302 to an allowed host", async () => {
+    const outcome = await runSandboxed(
+      getCode(redirTo(`${base}/ok`)),
+      3000,
+      REDIRECT_TEST_SOURCE
+    );
+    const result = resultOf(outcome);
+    expect(result.status).toBe(200);
+    expect(result.body).toContain("FINAL method=GET");
+  });
+
+  it("follows a multi-hop redirect chain", async () => {
+    const outcome = await runSandboxed(
+      getCode(redirTo(redirTo(`${base}/ok`))),
+      3000,
+      REDIRECT_TEST_SOURCE
+    );
+    expect(resultOf(outcome).status).toBe(200);
+  });
+
+  it("blocks a redirect into IMDS link-local", async () => {
+    const outcome = await runSandboxed(
+      getCode(redirTo("http://169.254.169.254/latest/meta-data/")),
+      3000,
+      REDIRECT_TEST_SOURCE
+    );
+    expectBlocked(outcome);
+    if (!outcome.ok) {
+      expect(outcome.errorMessage).toContain("169.254.169.254");
+    }
+  });
+
+  it("blocks a redirect into a cluster hostname", async () => {
+    const outcome = await runSandboxed(
+      getCode(redirTo("http://probe.svc.cluster.local/")),
+      3000,
+      REDIRECT_TEST_SOURCE
+    );
+    expectBlocked(outcome);
+  });
+
+  it("rejects a redirect to a disallowed scheme", async () => {
+    const outcome = await runSandboxed(
+      getCode(redirTo("file:///etc/passwd")),
+      3000,
+      REDIRECT_TEST_SOURCE
+    );
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.errorMessage).toMatch(SCHEME_NOT_ALLOWED_REGEX);
+    }
+  });
+
+  it("downgrades POST to GET and drops the body on a 302", async () => {
+    const outcome = await runSandboxed(
+      postCode(redirTo(`${base}/ok`, 302), "secret-payload"),
+      3000,
+      REDIRECT_TEST_SOURCE
+    );
+    const result = resultOf(outcome);
+    expect(result.body).toContain("method=GET");
+    expect(result.body).not.toContain("secret-payload");
+  });
+
+  it("preserves POST and body across a 307", async () => {
+    const outcome = await runSandboxed(
+      postCode(redirTo(`${base}/ok`, 307), "keep-me"),
+      3000,
+      REDIRECT_TEST_SOURCE
+    );
+    const result = resultOf(outcome);
+    expect(result.body).toContain("method=POST");
+    expect(result.body).toContain("keep-me");
+  });
+
+  it("errors on an unbounded redirect loop", async () => {
+    const outcome = await runSandboxed(
+      getCode(`${base}/loop`),
+      5000,
+      REDIRECT_TEST_SOURCE
+    );
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.errorMessage).toMatch(TOO_MANY_REDIRECTS_REGEX);
+    }
   });
 }, 30_000);

--- a/tests/unit/sandbox-child-source.test.ts
+++ b/tests/unit/sandbox-child-source.test.ts
@@ -277,22 +277,23 @@ function resultOf(outcome: SandboxOutcome): FetchResult {
   return outcome.result as FetchResult;
 }
 
+// Each redirect route maps to a server-defined target. The Location is
+// never derived from the request (which CodeQL would flag as an open
+// redirect); the test picks behaviour by choosing a path, and the server
+// reflects a fixed, server-owned target for that path.
+type RedirectRoute = { status: number; location: string };
+
 describe("sandbox grandchild redirect following", () => {
   let server: Server;
   let base: string;
+  let routes: Record<string, RedirectRoute> = {};
 
   beforeAll(async () => {
     server = createServer((req, res) => {
       const url = new URL(req.url ?? "/", "http://127.0.0.1");
-      if (url.pathname === "/loop") {
-        res.writeHead(302, { Location: "/loop" });
-        res.end();
-        return;
-      }
-      if (url.pathname === "/redir") {
-        const to = url.searchParams.get("to") ?? "/ok";
-        const status = Number(url.searchParams.get("status") ?? "302");
-        res.writeHead(status, { Location: to });
+      const route = routes[url.pathname];
+      if (route) {
+        res.writeHead(route.status, { Location: route.location });
         res.end();
         return;
       }
@@ -309,6 +310,21 @@ describe("sandbox grandchild redirect following", () => {
     });
     const { port } = server.address() as AddressInfo;
     base = `http://127.0.0.1:${port}`;
+    routes = {
+      "/r/ok": { status: 302, location: `${base}/ok` },
+      "/r/ok307": { status: 307, location: `${base}/ok` },
+      "/r/chain": { status: 302, location: `${base}/r/ok` },
+      "/r/imds": {
+        status: 302,
+        location: "http://169.254.169.254/latest/meta-data/",
+      },
+      "/r/cluster": {
+        status: 302,
+        location: "http://probe.svc.cluster.local/",
+      },
+      "/r/scheme": { status: 302, location: "file:///etc/passwd" },
+      "/loop": { status: 302, location: "/loop" },
+    };
   });
 
   afterAll(async () => {
@@ -325,10 +341,6 @@ describe("sandbox grandchild redirect following", () => {
     return `const r = await fetch(${JSON.stringify(url)}, { method: "POST", body: ${JSON.stringify(body)} }); return { status: r.status, body: await r.text() };`;
   }
 
-  function redirTo(target: string, status = 302): string {
-    return `${base}/redir?status=${status}&to=${encodeURIComponent(target)}`;
-  }
-
   it("sanity: the test source actually dropped the loopback block", () => {
     expect(REDIRECT_TEST_SOURCE).not.toBe(SANDBOX_CHILD_SOURCE);
     expect(REDIRECT_TEST_SOURCE).not.toContain(LOOPBACK_CIDR_TUPLE);
@@ -336,7 +348,7 @@ describe("sandbox grandchild redirect following", () => {
 
   it("follows a 302 to an allowed host", async () => {
     const outcome = await runSandboxed(
-      getCode(redirTo(`${base}/ok`)),
+      getCode(`${base}/r/ok`),
       3000,
       REDIRECT_TEST_SOURCE
     );
@@ -347,7 +359,7 @@ describe("sandbox grandchild redirect following", () => {
 
   it("follows a multi-hop redirect chain", async () => {
     const outcome = await runSandboxed(
-      getCode(redirTo(redirTo(`${base}/ok`))),
+      getCode(`${base}/r/chain`),
       3000,
       REDIRECT_TEST_SOURCE
     );
@@ -356,7 +368,7 @@ describe("sandbox grandchild redirect following", () => {
 
   it("blocks a redirect into IMDS link-local", async () => {
     const outcome = await runSandboxed(
-      getCode(redirTo("http://169.254.169.254/latest/meta-data/")),
+      getCode(`${base}/r/imds`),
       3000,
       REDIRECT_TEST_SOURCE
     );
@@ -368,7 +380,7 @@ describe("sandbox grandchild redirect following", () => {
 
   it("blocks a redirect into a cluster hostname", async () => {
     const outcome = await runSandboxed(
-      getCode(redirTo("http://probe.svc.cluster.local/")),
+      getCode(`${base}/r/cluster`),
       3000,
       REDIRECT_TEST_SOURCE
     );
@@ -377,7 +389,7 @@ describe("sandbox grandchild redirect following", () => {
 
   it("rejects a redirect to a disallowed scheme", async () => {
     const outcome = await runSandboxed(
-      getCode(redirTo("file:///etc/passwd")),
+      getCode(`${base}/r/scheme`),
       3000,
       REDIRECT_TEST_SOURCE
     );
@@ -389,7 +401,7 @@ describe("sandbox grandchild redirect following", () => {
 
   it("downgrades POST to GET and drops the body on a 302", async () => {
     const outcome = await runSandboxed(
-      postCode(redirTo(`${base}/ok`, 302), "secret-payload"),
+      postCode(`${base}/r/ok`, "secret-payload"),
       3000,
       REDIRECT_TEST_SOURCE
     );
@@ -400,7 +412,7 @@ describe("sandbox grandchild redirect following", () => {
 
   it("preserves POST and body across a 307", async () => {
     const outcome = await runSandboxed(
-      postCode(redirTo(`${base}/ok`, 307), "keep-me"),
+      postCode(`${base}/r/ok307`, "keep-me"),
       3000,
       REDIRECT_TEST_SOURCE
     );


### PR DESCRIPTION
## Summary
`sandboxedFetch` in the Code-node sandbox checked the SSRF blocklist only on the initial URL, then let undici follow 3xx redirects transparently. A redirect from a public attacker-controlled host could chase a `302` into internal targets and return the response to the sandbox:
- AWS IMDS (`169.254.169.254`)
- K8s apiserver / `*.svc.cluster.local`
- any RFC1918 / link-local address

## Fix
Follow redirects manually with `redirect: "manual"` and re-run the same scheme + SSRF checks on every `Location` before issuing the next request:
- capped at 20 hops (matches undici's default)
- `POST -> GET` + body drop on 301/302, `303 -> GET`, `307/308` preserved
- mirrors the per-hop validation `lib/safe-fetch.ts` already does via its undici connector

## Tests
`tests/unit/sandbox-child-source.test.ts` (28 -> 39):
- structural guards on the rendered source (manual mode, hop cap, statuses)
- behavioral tests spawning the real grandchild against a local redirect server: follows allowed redirects (single + multi-hop), blocks redirects into IMDS and cluster hostnames, rejects disallowed schemes, downgrades POST->GET on 302, preserves POST on 307, errors on redirect loops

Because the production blocklist blocks every locally-bindable address, the behavioral suite derives a source variant with only the IPv4 loopback subnet removed (link-local/IMDS and cluster hostnames stay blocked) so a local hop-1 is reachable; a sanity test asserts the strip is not a no-op.