### PR TITLE
ci: resolve escape-matrix rollout to keeperhub-common

### DIFF
--- a/.github/workflows/sandbox-escape-matrix.yaml
+++ b/.github/workflows/sandbox-escape-matrix.yaml
@@ -63,7 +63,7 @@ jobs:
       REGION: ${{ vars.TO_REGION }}
       CLUSTER_NAME: ${{ vars.TO_CLUSTER_NAME }}
       NAMESPACE: keeperhub
-      KH_RELEASE_NAME: keeperhub-${{ inputs.environment || 'staging' }}
+      KH_RELEASE_NAME: keeperhub
       CANARY_SSM_PATH: /eks/techops-${{ inputs.environment || 'staging' }}/keeperhub/_sandbox_escape_canary
       APP_URL: ${{ (inputs.environment || 'staging') == 'prod' && vars.TO_PROD_URL || vars.TO_STAGING_URL }}
       TARGET_ENV: ${{ inputs.environment || 'staging' }}


### PR DESCRIPTION
## Problem

The `sandbox-escape-matrix` workflow's `Force ExternalSecrets refresh + rollout` step targets `${KH_RELEASE_NAME}-common`, with `KH_RELEASE_NAME` env-suffixed to `keeperhub-staging` / `keeperhub-prod`. No ExternalSecret/Deployment by that name exists - the main app release is `keeperhub-common` in namespace `keeperhub`. The step failed `NotFound` on both environments, so the rollout/fetch/run-suite steps never ran and the escape-matrix vitest suite (TEST-01..10) was skipped per deploy. Plant + teardown succeeded, masking that the security assertion never executed. (This surfaced after the SSM IAM grant unblocked the canary-plant step.)

## Fix

Set `KH_RELEASE_NAME: keeperhub` (drop the env suffix) so `${KH_RELEASE_NAME}-common` resolves to `keeperhub-common` - the same release name the deploy-keeperhub workflow uses for the main app. The env-specific canary SSM path and APP_URL stay keyed off the `environment` input and are unchanged. One-line change.

## Behavior note

With the name fixed, the rollout step now actually restarts the main `keeperhub-common` app (it silently no-op'd before). On staging this auto-fires after every successful `deploy-sandbox` - this is the intended plant -> roll -> test design.

## Verification

- `actionlint -shellcheck=""` (matches the maintainability CI gate): clean.
- Post-merge: trigger `sandbox-escape-matrix` via workflow_dispatch on staging and confirm the rollout step passes and the vitest suite executes.