### PR TITLE
fix(analytics): allow cancelled status filter on runs endpoint

### DIFF
--- a/app/api/analytics/runs/route.ts
+++ b/app/api/analytics/runs/route.ts
@@ -11,6 +11,7 @@ const VALID_STATUSES = new Set<NormalizedStatus>([
   "running",
   "success",
   "error",
+  "cancelled",
 ]);
 
 const VALID_SOURCES = new Set<RunSource>(["workflow", "direct"]);


### PR DESCRIPTION
The Analytics runs endpoint validated the `status` query param against a whitelist that omitted `cancelled`. Selecting the **Cancelled** status filter therefore failed validation, fell back to `undefined`, and returned every run instead of just cancelled ones.

Adds `cancelled` to `VALID_STATUSES`. The query layer already maps and filters cancelled correctly for both workflow and direct executions, so no other changes are needed. All other status filters (success, error, running, pending) and both source filters were verified to pass validation and filter correctly.