### PR TITLE
feat: add per-workflow execution error counter for alert dedup (TECH-42)

### DIFF
--- a/lib/errors/finalize-error.ts
+++ b/lib/errors/finalize-error.ts
@@ -4,7 +4,10 @@ import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { organization, workflows } from "@/lib/db/schema";
 import { classifyExecutionError } from "@/lib/errors/classify";
-import { recordWorkflowExecutionError } from "@/lib/metrics/collectors/prometheus";
+import {
+  recordWorkflowExecutionError,
+  recordWorkflowExecutionErrorByWorkflow,
+} from "@/lib/metrics/collectors/prometheus";
 import { ANONYMOUS_ORG_SLUG } from "@/lib/metrics/db-metrics";
 
 /**
@@ -39,6 +42,12 @@ export async function recordExecutionErrorFinalized(args: {
     recordWorkflowExecutionError({
       orgSlug,
       errorCategory,
+      errorType,
+    });
+
+    recordWorkflowExecutionErrorByWorkflow({
+      workflowId: args.workflowId,
+      orgSlug,
       errorType,
     });
   } catch {

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -904,6 +904,30 @@ export function recordWorkflowExecutionError(labels: {
   });
 }
 
+// Per-workflow error counter used exclusively for managed-client alert dedup.
+// Labels are kept to (workflow_id, org_slug, error_type) — no error_category —
+// so cardinality stays bounded: only workflows that actually fail contribute
+// series, and the set of actively-failing workflows at any moment is small.
+// Cardinality ceiling: ~N_failing_workflows * 2 orgs * 2 error_types ≪ 1k.
+const workflowExecutionErrorsByWorkflow = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_workflow_execution_errors_by_workflow_total",
+  "Workflow execution errors by workflow_id, for per-workflow alert dedup",
+  ["workflow_id", "org_slug", "error_type"]
+);
+
+export function recordWorkflowExecutionErrorByWorkflow(labels: {
+  workflowId: string;
+  orgSlug: string;
+  errorType: "user" | "system";
+}): void {
+  workflowExecutionErrorsByWorkflow.inc({
+    workflow_id: labels.workflowId,
+    org_slug: labels.orgSlug,
+    error_type: labels.errorType,
+  });
+}
+
 const slowQueries = getOrCreateCounter(
   apiRegistry,
   "keeperhub_db_query_slow_total",

--- a/tests/unit/execution-error-finalize.test.ts
+++ b/tests/unit/execution-error-finalize.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// Minimal drizzle-orm stub — eq() just needs to not throw.
+vi.mock("drizzle-orm", () => ({
+  eq: (a: unknown, b: unknown) => ({ a, b }),
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  organization: { slug: "organization.slug", id: "organization.id" },
+  workflows: { id: "workflows.id", organizationId: "workflows.organizationId" },
+}));
+
+vi.mock("@/lib/errors/classify", () => ({
+  classifyExecutionError: vi.fn().mockReturnValue({
+    errorCategory: "workflow_engine",
+    errorType: "system" as const,
+  }),
+}));
+
+vi.mock("@/lib/metrics/db-metrics", () => ({
+  ANONYMOUS_ORG_SLUG: "_anonymous",
+}));
+
+const mockLimit = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        leftJoin: () => ({
+          where: () => ({
+            limit: (...args: unknown[]) => mockLimit(...args),
+          }),
+        }),
+      }),
+    }),
+  },
+}));
+
+import {
+  getPrometheusMetrics,
+  recordWorkflowExecutionErrorByWorkflow,
+} from "@/lib/metrics/collectors/prometheus";
+
+import { recordExecutionErrorFinalized } from "@/lib/errors/finalize-error";
+
+describe("recordWorkflowExecutionErrorByWorkflow", () => {
+  it("increments keeperhub_workflow_execution_errors_by_workflow_total with correct labels", async () => {
+    recordWorkflowExecutionErrorByWorkflow({
+      workflowId: "wf_test_abc",
+      orgSlug: "acme",
+      errorType: "system",
+    });
+
+    const output = await getPrometheusMetrics();
+
+    expect(output).toContain(
+      "keeperhub_workflow_execution_errors_by_workflow_total"
+    );
+    expect(output).toMatch(/workflow_id="wf_test_abc"/);
+    expect(output).toMatch(/org_slug="acme"/);
+    expect(output).toMatch(/error_type="system"/);
+  });
+
+  it("accepts error_type user as well as system", async () => {
+    recordWorkflowExecutionErrorByWorkflow({
+      workflowId: "wf_user_err",
+      orgSlug: "beta-org",
+      errorType: "user",
+    });
+
+    const output = await getPrometheusMetrics();
+
+    expect(output).toMatch(/workflow_id="wf_user_err"/);
+    expect(output).toMatch(/error_type="user"/);
+  });
+});
+
+describe("recordExecutionErrorFinalized", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls both counters with the org slug resolved from the DB", async () => {
+    mockLimit.mockResolvedValue([{ slug: "acme" }]);
+
+    const prometheusMod = await import("@/lib/metrics/collectors/prometheus");
+    const recordErrorSpy = vi.spyOn(prometheusMod, "recordWorkflowExecutionError");
+    const recordByWorkflowSpy = vi.spyOn(
+      prometheusMod,
+      "recordWorkflowExecutionErrorByWorkflow"
+    );
+
+    await recordExecutionErrorFinalized({
+      workflowId: "wf_abc123",
+      errorMessage: "step execution failed",
+    });
+
+    expect(recordErrorSpy).toHaveBeenCalledWith({
+      orgSlug: "acme",
+      errorCategory: "workflow_engine",
+      errorType: "system",
+    });
+    expect(recordByWorkflowSpy).toHaveBeenCalledWith({
+      workflowId: "wf_abc123",
+      orgSlug: "acme",
+      errorType: "system",
+    });
+  });
+
+  it("falls back to ANONYMOUS_ORG_SLUG when the DB returns no matching row", async () => {
+    mockLimit.mockResolvedValue([]);
+
+    const prometheusMod = await import("@/lib/metrics/collectors/prometheus");
+    const recordErrorSpy = vi.spyOn(prometheusMod, "recordWorkflowExecutionError");
+    const recordByWorkflowSpy = vi.spyOn(
+      prometheusMod,
+      "recordWorkflowExecutionErrorByWorkflow"
+    );
+
+    await recordExecutionErrorFinalized({
+      workflowId: "wf_personal",
+      errorMessage: null,
+    });
+
+    expect(recordErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ orgSlug: "_anonymous" })
+    );
+    expect(recordByWorkflowSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ orgSlug: "_anonymous", workflowId: "wf_personal" })
+    );
+  });
+
+  it("swallows errors so a DB failure never breaks the finalize path", async () => {
+    mockLimit.mockRejectedValue(new Error("DB connection lost"));
+
+    await expect(
+      recordExecutionErrorFinalized({
+        workflowId: "wf_db_fail",
+        errorMessage: "some error",
+      })
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Adds `keeperhub_workflow_execution_errors_by_workflow_total`, a per-pod counter, incremented at execution finalization, labeled by `workflow_id`, `org_slug`, and `error_type`. Cardinality is bounded to actively-failing workflows only. Wires the new counter into `recordExecutionErrorFinalized` alongside the existing per-org counter.

This aims to help solving the alert noise described in the "Incident #32571" postmortem doc by having the workflow ID available in Grafana for alert deduplication. Another PR is required, but it depends on this one and it needs to be created in the infra repo (already on it).

Ran `pnpm test:unit` locally and the new tests passed. There was a single file with 6 failed tests but those are also failing in base branch, so I'll deal with them in another ticket if no one else is already working on them.