### PR TITLE
fix(code): ignore template refs inside comments in code step

### DIFF
--- a/plugins/code/steps/run-code.ts
+++ b/plugins/code/steps/run-code.ts
@@ -43,11 +43,53 @@ if (
   );
 }
 
-const JS_STRING_LITERAL_REGEX =
-  /"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|`(?:[^`\\]|\\.)*`/g;
-
-function stripStringLiterals(code: string): string {
-  return code.replace(JS_STRING_LITERAL_REGEX, "");
+// Remove string/template-literal bodies and `//` + block comments so the
+// template scan only sees executable code. Refs inside strings or comments are
+// data or documentation, not dependencies, and must not be flagged as
+// unresolved -- the executor deliberately leaves them in place. Mirrors the
+// string/comment-aware scanning in executor.workflow.ts.
+function stripStringsAndComments(code: string): string {
+  const out: string[] = [];
+  const n = code.length;
+  let i = 0;
+  let stringDelim: string | null = null;
+  while (i < n) {
+    const c = code[i];
+    if (stringDelim) {
+      if (c === "\\") {
+        i += 2;
+        continue;
+      }
+      if (c === stringDelim) {
+        stringDelim = null;
+      }
+      i++;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      stringDelim = c;
+      i++;
+      continue;
+    }
+    if (c === "/" && code[i + 1] === "/") {
+      i += 2;
+      while (i < n && code[i] !== "\n") {
+        i++;
+      }
+      continue;
+    }
+    if (c === "/" && code[i + 1] === "*") {
+      i += 2;
+      while (i < n && !(code[i] === "*" && code[i + 1] === "/")) {
+        i++;
+      }
+      i = Math.min(i + 2, n);
+      continue;
+    }
+    out.push(c);
+    i++;
+  }
+  return out.join("");
 }
 
 function extractLineNumber(stack: string | undefined): number | undefined {
@@ -206,7 +248,7 @@ function validateInput(input: RunCodeCoreInput): RunCodeResult | null {
   if (!code || code.trim() === "") {
     return { success: false, error: "No code provided", logs: [] };
   }
-  const unresolvedTemplates = stripStringLiterals(code).match(
+  const unresolvedTemplates = stripStringsAndComments(code).match(
     UNRESOLVED_TEMPLATE_REGEX,
   );
   if (unresolvedTemplates) {

--- a/tests/unit/code-run-code.test.ts
+++ b/tests/unit/code-run-code.test.ts
@@ -640,6 +640,28 @@ describe("code/run-code - error handling", () => {
     expect(result.error).toContain("Unresolved template variables");
   });
 
+  it("allows {{...}} inside line comments", async () => {
+    const result = await expectSuccess({
+      code: "// const x = {{Commented.result}};\nreturn 1;",
+    });
+    expect(result.result).toBe(1);
+  });
+
+  it("allows {{...}} inside block comments", async () => {
+    const result = await expectSuccess({
+      code: "/* const x = {{A.result}};\nconst y = {{B.result}}; */\nreturn 2;",
+    });
+    expect(result.result).toBe(2);
+  });
+
+  it("still detects unresolved templates outside comments", async () => {
+    const result = await expectFailure({
+      code: "/* const x = {{Commented.result}}; */\nreturn {{Outside.field}};",
+    });
+    expect(result.error).toContain("Unresolved template variables");
+    expect(result.error).not.toContain("{{Commented.result}}");
+  });
+
   it("preserves console logs even on error", async () => {
     const code = [
       'console.log("before error");',


### PR DESCRIPTION
## Summary

The code step's pre-flight validation flagged template references inside JavaScript comments as "Unresolved template variables" and failed the step, even though the executor deliberately leaves commented references untouched.

The validator only stripped string literals before scanning, not comments. This replaces the regex string-stripper with a single-pass scanner that skips both string/template-literal bodies and `//` + `/* */` comments, matching the comment-aware tokenizing the executor (`processCodeTemplates`) already uses.

## Behavior

- References inside `//` line comments no longer throw
- References inside `/* */` block comments (including multi-line) no longer throw
- References inside string literals still tolerated (unchanged)
- Real unresolvable references in executable code still fail as before

Example that now works:

```js
const a = {{Node A.result}};
/*const b = {{Node B.result}};
const c = {{Node C.result}};*/
const d = {{Node D.result}};
```

## Tests

Added unit tests covering refs inside line comments, block comments, and a mixed case where a commented ref is ignored while a real one outside still fails. Full unit suite passes.