### PR TITLE
fix: wire schedule-dispatcher through shared HMAC http-client

### DIFF
--- a/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
@@ -13,11 +13,8 @@
 
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
 import { CronExpressionParser } from "cron-parser";
-import {
-  KEEPERHUB_URL,
-  SERVICE_API_KEY,
-  SQS_QUEUE_URL,
-} from "../lib/config.js";
+import { SQS_QUEUE_URL } from "../lib/config.js";
+import { apiRequest } from "../lib/http-client.js";
 import { sqs } from "../lib/sqs-client.js";
 import type { Schedule, ScheduleMessage } from "../lib/types.js";
 
@@ -28,20 +25,9 @@ export type DispatchResult = {
 };
 
 export async function fetchSchedules(): Promise<Schedule[]> {
-  const response = await fetch(`${KEEPERHUB_URL}/api/internal/schedules`, {
-    method: "GET",
-    headers: {
-      "X-Service-Key": SERVICE_API_KEY,
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error(
-      `Failed to fetch schedules: ${response.status} ${await response.text()}`,
-    );
-  }
-
-  const data = (await response.json()) as { schedules: Schedule[] };
+  const data = await apiRequest<{ schedules: Schedule[] }>(
+    "/api/internal/schedules",
+  );
   return data.schedules;
 }
 

--- a/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
+++ b/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
@@ -648,7 +648,9 @@ describe("dispatch", () => {
       }),
     );
 
-    await expect(dispatch()).rejects.toThrow(/API GET \/api\/internal\/schedules failed: 500/);
+    await expect(dispatch()).rejects.toThrow(
+      /API GET \/api\/internal\/schedules failed: 500/,
+    );
     expect(mockedSqsSend).not.toHaveBeenCalled();
   });
 

--- a/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
+++ b/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
@@ -336,7 +336,7 @@ describe("fetchSchedules", () => {
     );
 
     await expect(fetchSchedules()).rejects.toThrow(
-      /Failed to fetch schedules: 503 service unavailable/,
+      /API GET \/api\/internal\/schedules failed: 503 service unavailable/,
     );
   });
 
@@ -352,7 +352,7 @@ describe("fetchSchedules", () => {
     await expect(fetchSchedules()).rejects.toThrow("ECONNREFUSED");
   });
 
-  it("calls fetch with the schedules path and X-Service-Key header", async () => {
+  it("calls fetch with the schedules path and HMAC headers", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ schedules: [] }),
@@ -364,9 +364,10 @@ describe("fetchSchedules", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toMatch(/\/api\/internal\/schedules$/);
-    expect(init).toMatchObject({
-      method: "GET",
-      headers: expect.objectContaining({ "X-Service-Key": expect.any(String) }),
+    expect(init.headers).toMatchObject({
+      "X-KH-Caller": "scheduler",
+      "X-KH-Timestamp": expect.stringMatching(/^\d+$/),
+      "X-KH-Signature": expect.stringMatching(/^[0-9a-f]{64}$/),
     });
   });
 });
@@ -647,7 +648,7 @@ describe("dispatch", () => {
       }),
     );
 
-    await expect(dispatch()).rejects.toThrow(/Failed to fetch schedules: 500/);
+    await expect(dispatch()).rejects.toThrow(/API GET \/api\/internal\/schedules failed: 500/);
     expect(mockedSqsSend).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

- `schedule-dispatcher/dispatch.ts` was calling `/api/internal/schedules` with raw `fetch` and an `X-Service-Key` header, bypassing the shared `lib/http-client.ts` that already signs requests with HMAC
- Swapped the raw `fetch` call for `apiRequest` from the shared client — the same path the block-dispatcher uses
- Updated unit tests: error message regex and header assertions now match the `apiRequest` contract

## Root cause

The previous PR added the `INTERNAL_SERVICE_HMAC_SECRET` startup guard to the schedule-dispatcher but did not update the `fetchSchedules` function itself to use the HMAC-signing client. The block-dispatcher was already correctly routed through `apiRequest`; the schedule-dispatcher was not.

## Verification

After staging deploy, confirm logs show `scheme=hmac, outcome=accept` for `caller=scheduler, route=/api/internal/schedules` (previously `scheme=legacy-bearer`).