### PR TITLE
feat: enable INTERNAL_AUTH_REQUIRE_HMAC on staging

### DIFF
--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -426,6 +426,9 @@ env:
     type: kv
     value: "10000"
   # Internal service API keys for service-to-service auth
+  INTERNAL_AUTH_REQUIRE_HMAC:
+    type: kv
+    value: "true"
   MCP_SERVICE_API_KEY:
     type: parameterStore
     name: mcp-service-api-key


### PR DESCRIPTION
## Summary

Flips `INTERNAL_AUTH_REQUIRE_HMAC=true` in staging, disabling the legacy bearer fallback path in internal service-to-service auth.

## Pre-conditions verified

All active producers confirmed sending HMAC prior to this change:
- scheduler (block-dispatcher): `scheme=hmac, outcome=accept, key_version=1`
- scheduler (schedule-dispatcher): `scheme=hmac, outcome=accept, key_version=1`
- events: `scheme=hmac, outcome=accept, key_version=1`

## Monitoring

Watch for 401s on internal routes in staging logs for 24h post-deploy. Any `outcome=reject` entries identify a producer that was missed.