### PR TITLE
feat: enable INTERNAL_AUTH_REQUIRE_HMAC on prod

### DIFF
--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -428,6 +428,9 @@ env:
     type: kv
     value: "10000"
   # Internal service API keys for service-to-service auth
+  INTERNAL_AUTH_REQUIRE_HMAC:
+    type: kv
+    value: "true"
   MCP_SERVICE_API_KEY:
     type: parameterStore
     name: mcp-service-api-key

--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -431,6 +431,10 @@ env:
   INTERNAL_AUTH_REQUIRE_HMAC:
     type: kv
     value: "true"
+  INTERNAL_SERVICE_HMAC_SECRET:
+    type: parameterStore
+    name: internal-service-hmac-secret
+    parameter_name: /eks/techops-prod/keeperhub/internal-service-hmac-secret
   MCP_SERVICE_API_KEY:
     type: parameterStore
     name: mcp-service-api-key

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -429,6 +429,10 @@ env:
   INTERNAL_AUTH_REQUIRE_HMAC:
     type: kv
     value: "true"
+  INTERNAL_SERVICE_HMAC_SECRET:
+    type: parameterStore
+    name: internal-service-hmac-secret
+    parameter_name: /eks/techops-staging/keeperhub/internal-service-hmac-secret
   MCP_SERVICE_API_KEY:
     type: parameterStore
     name: mcp-service-api-key


### PR DESCRIPTION
Flips the internal service auth kill-switch in production.

The prod DB has been seeded with the HMAC secret (inserted into `internal_service_hmac_secrets` via the same Node.js seed approach used for staging).

All producer services already have `INTERNAL_SERVICE_HMAC_SECRET` wired to the prod SSM param (`/eks/techops-prod/keeperhub/internal-service-hmac-secret`) — these were included in previous PRs.

The reaper CronJob already uses `INTERNAL_SERVICE_HMAC_SECRET` (also from a previous PR).

This PR contains exactly one change: adding `INTERNAL_AUTH_REQUIRE_HMAC: true` to `deploy/keeperhub/prod/values.yaml`.

After merging, monitor prod auth logs for 24h. Any `outcome=reject` on internal routes indicates a missed producer.

Cleanup PR (remove legacy bearer code) should follow after the 24h clean window.