### PR TITLE
fix(notifications): gate digest upgrade button to owners

### DIFF
--- a/components/organization/execution-digest-section.tsx
+++ b/components/organization/execution-digest-section.tsx
@@ -21,6 +21,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useFeature } from "@/hooks/use-features";
+import { isBillingEnabled } from "@/lib/billing/feature-flag";
 import { DIGEST_REQUIRES_SUBSCRIBER_ERROR } from "@/lib/notifications/digest-messages";
 
 const SCHEDULE_HINT: Record<Cadence, string> = {
@@ -47,10 +48,12 @@ type DigestSettingsResponse = {
 
 type ExecutionDigestSectionProps = {
   organizationId: string;
+  canManageBilling: boolean;
 };
 
 export function ExecutionDigestSection({
   organizationId,
+  canManageBilling,
 }: ExecutionDigestSectionProps): React.ReactElement {
   const router = useRouter();
   const { enabled: featureEnabled, loading: featureLoading } = useFeature(
@@ -149,9 +152,25 @@ export function ExecutionDigestSection({
             Get a scheduled email summary of your workflow runs: total
             executions, successes, and failures. Available on paid plans.
           </p>
-          <Button onClick={() => router.push("/billing")} size="sm">
-            Upgrade
-          </Button>
+          {isBillingEnabled() &&
+            (canManageBilling ? (
+              <Button onClick={() => router.push("/billing")} size="sm">
+                Upgrade
+              </Button>
+            ) : (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span>
+                    <Button disabled size="sm">
+                      Upgrade
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  Only organization owners can upgrade the plan.
+                </TooltipContent>
+              </Tooltip>
+            ))}
         </div>
       </div>
     );

--- a/components/organization/manage-orgs-modal.tsx
+++ b/components/organization/manage-orgs-modal.tsx
@@ -1570,7 +1570,10 @@ export function ManageOrgsModal({
 
             <TabsContent className="space-y-4" value="notifications">
               {organization && (isActiveOrgOwner || isActiveOrgAdmin) ? (
-                <ExecutionDigestSection organizationId={organization.id} />
+                <ExecutionDigestSection
+                  canManageBilling={isActiveOrgOwner}
+                  organizationId={organization.id}
+                />
               ) : (
                 <div className="py-8 text-center text-muted-foreground">
                   Only organization owners and admins can manage notifications.


### PR DESCRIPTION
## Summary

The execution digest panel in the Manage Org modal renders for both owners and admins, but its **Upgrade** button pushed to `/billing` which is gated to owners only (and 404s when `NEXT_PUBLIC_BILLING_ENABLED` is off). Admins who legitimately manage notifications clicked Upgrade and were silently redirected back to `/`, so the button appeared to do nothing.

## Changes

`ExecutionDigestSection` now receives `canManageBilling` (true for owners) and branches the upgrade CTA to match `/billing`'s actual gate:

- **Billing disabled**: no button (no upgrade path exists to point at)
- **Billing enabled, non-owner**: disabled button with tooltip "Only organization owners can upgrade the plan."
- **Billing enabled, owner**: live button to `/billing`

The disabled button is wrapped in a `span` so the Radix tooltip fires on hover (disabled elements emit no pointer events).