### PR TITLE
fix: keep email-code modal mounted across tab switch

### DIFF
--- a/components/auth/dialog.tsx
+++ b/components/auth/dialog.tsx
@@ -256,6 +256,14 @@ export const isSingleProviderSignInInitiated = () =>
 let pendingVerifyEmail: string | null = null;
 let pendingVerifyPassword: string | null = null;
 
+// True while the dialog is on a sign-in/sign-up verification step (email OTP,
+// TOTP, or signup email verify). UserMenu reads this to keep the AuthDialog
+// mounted through the Better Auth session refetch that fires when the tab
+// regains focus, so leaving to grab the code from the email tab does not drop
+// the modal.
+let authFlowInProgress = false;
+export const isAuthFlowInProgress = () => authFlowInProgress;
+
 type SingleProviderButtonProps = {
   provider: Provider;
   loadingProvider: "github" | "google" | null;
@@ -504,6 +512,15 @@ export const AuthDialog = ({
       captchaRef.current?.reset();
     }
   }, [view]);
+
+  // Mirror the active verification step into a module flag so UserMenu can
+  // keep this dialog mounted through the tab-focus session refetch instead of
+  // swapping it for a skeleton and losing the in-progress code entry.
+  useEffect(() => {
+    authFlowInProgress =
+      open &&
+      (view === "signin-email-otp" || view === "totp" || view === "verify");
+  }, [open, view]);
 
   const resetCaptcha = () => {
     setCaptchaToken("");

--- a/components/workflows/user-menu.tsx
+++ b/components/workflows/user-menu.tsx
@@ -13,6 +13,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import {
   AuthDialog,
+  isAuthFlowInProgress,
   isSingleProviderSignInInitiated,
 } from "@/components/auth/dialog";
 import { ManageOrgsModal } from "@/components/organization/manage-orgs-modal";
@@ -43,6 +44,7 @@ import { useActiveMember, useOrganization } from "@/lib/hooks/use-organization";
 export const UserMenu = (): React.ReactElement => {
   const { data: session, isPending } = useSession();
   const signInInProgress = isSingleProviderSignInInitiated();
+  const authFlowInProgress = isAuthFlowInProgress();
 
   // Check if user is anonymous
   // Better Auth anonymous plugin creates users with name "Anonymous" and temp- email
@@ -60,12 +62,14 @@ export const UserMenu = (): React.ReactElement => {
   // appears. Render a neutral avatar-shaped skeleton during that window
   // instead of flashing Sign In.
   //
-  // Two cases must keep falling through so the AuthDialog stays mounted
-  // across the brief refetch that Better Auth runs after a credential
-  // submit (otherwise the post-credential `totp` view is dropped before the
-  // user can see it): a single-provider auto-sign-in is mid-flight, or an
-  // *existing* anonymous session (session.user present) is being refetched.
-  if (isPending && !signInInProgress) {
+  // Several cases must keep falling through so the AuthDialog stays mounted
+  // across the brief refetch that Better Auth runs after a credential submit
+  // or on tab focus (otherwise the post-credential email/totp view is dropped
+  // before the user can see it): a single-provider auto-sign-in is mid-flight,
+  // the dialog is on a verification step (email OTP / TOTP / signup verify),
+  // or an *existing* anonymous session (session.user present) is being
+  // refetched.
+  if (isPending && !signInInProgress && !authFlowInProgress) {
     const anonymousSessionRefetching =
       Boolean(session?.user) && isAnonymousUser;
     if (!anonymousSessionRefetching) {


### PR DESCRIPTION
The sign-in email-code dialog is the uncontrolled `AuthDialog` owned by `UserMenu`. When the tab regains focus, Better Auth refetches the session; for a visitor with no session that refetch flips `isPending` to true, and `UserMenu` swapped the dialog for a loading skeleton, unmounting it and dropping the in-progress code entry. Leaving to grab the code from the email tab is exactly what triggered it.

Track when the dialog is on a verification step (email OTP, TOTP, or signup email verify) with a module flag, and keep `UserMenu` from unmounting the dialog while that flag is set, mirroring the existing single-provider sign-in guard.