### PR TITLE
fix: add openssl to runner image so digest cron can sign HMAC requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -287,10 +287,10 @@ ENV NEXT_TELEMETRY_DISABLED=1
 
 COPY --link --from=deps /etc/ssl/certs/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
 
-# Create non-root user and install curl (used by healthcheck and cronjob scripts)
+# Create non-root user and install curl + openssl (used by healthcheck and cronjob scripts)
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs && \
-    apk add --no-cache curl
+    apk add --no-cache curl openssl
 
 # Copy built application (source maps removed - uploaded by sentry-upload stage)
 COPY --link --from=builder /app/public ./public


### PR DESCRIPTION
The execution-digest CronJob runs `deploy/scripts/digest-cron.sh` inside the app (runner) image to call `/api/internal/execution-digest`, authenticating with an HMAC signature it computes locally with `openssl`.

## Issue

The runner stage only installs `curl`. `node:24-alpine` ships libssl but not the `openssl` CLI, so the script's two `openssl dgst` calls failed with `openssl: not found`. The signature came out empty, the request went out with empty `X-KH-Signature`/`X-KH-Timestamp` headers, and the endpoint rejected every run with `401 Missing HMAC headers`. The cron has been firing daily at 14:00 UTC and failing every time, so no execution digests have ever been delivered in production.

## Fix

Install `openssl` alongside `curl` in the runner stage so the signing computes a valid signature. One-line change; the signing logic and server verification are already correct and unchanged.

## Verification

Reproduced and verified end-to-end in a `node:24-alpine` container:

- Without `openssl`: `openssl: NOT FOUND`, matching the failing prod pod log.
- With `openssl` added: the real `digest-cron.sh` produces a 64-char signature, and the server verification algorithm (copied verbatim from `lib/internal-service-auth.ts`) accepts it, with `expected` and `provided` signatures byte-identical. Also confirmed alpine openssl 3.5.6 output parses correctly through the script's `awk`, and the pathname extraction matches the server's `url.pathname`.

The fix takes effect once a fresh prod image is built and deployed; the next scheduled run will then authenticate and send digests.