### PR TITLE
feat(org): show member 2FA status to owners and admins

### DIFF
--- a/app/api/organizations/[organizationId]/members/two-factor/route.ts
+++ b/app/api/organizations/[organizationId]/members/two-factor/route.ts
@@ -1,0 +1,111 @@
+import { and, eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { member, users } from "@/lib/db/schema";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
+import {
+  auditFromAuth,
+  type DualAuthContext,
+  getDualAuthContext,
+} from "@/lib/middleware/auth-helpers";
+
+const ADMIN_ROLES = new Set(["owner", "admin"]);
+
+type MemberTwoFactorResponse = {
+  /** Map of member user id to whether that user has TOTP enrolled. */
+  statuses: Record<string, boolean>;
+};
+
+/**
+ * GET /api/organizations/[organizationId]/members/two-factor
+ *
+ * Read-only 2FA enrollment view for org owners/admins: which members of the
+ * organization have a second factor enrolled. Drives the security-status
+ * column in the members list. The boolean comes straight from
+ * users.two_factor_enabled; no secret or code material is exposed.
+ *
+ * Authorization: the caller must be an owner or admin of the same
+ * organization. API-key callers are confined to their home org.
+ */
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ organizationId: string }> }
+): Promise<NextResponse> {
+  let authContext: DualAuthContext | null = null;
+  try {
+    const { organizationId } = await context.params;
+
+    authContext = await getDualAuthContext(request);
+    if ("error" in authContext) {
+      return NextResponse.json(
+        { error: authContext.error },
+        { status: authContext.status }
+      );
+    }
+
+    const { userId, organizationId: callerOrgId, authMethod } = authContext;
+    if (!userId) {
+      return NextResponse.json(
+        { error: "Auth context missing user. Please recreate the API key." },
+        { status: 400 }
+      );
+    }
+
+    if (authMethod === "api-key" && callerOrgId !== organizationId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const [callerMembership] = await db
+      .select({ role: member.role })
+      .from(member)
+      .where(
+        and(
+          eq(member.organizationId, organizationId),
+          eq(member.userId, userId)
+        )
+      )
+      .limit(1);
+
+    if (!(callerMembership && ADMIN_ROLES.has(callerMembership.role))) {
+      return NextResponse.json(
+        {
+          error:
+            "Only organization owners and admins can view member 2FA status",
+        },
+        { status: 403 }
+      );
+    }
+
+    const rows = await db
+      .select({
+        userId: member.userId,
+        twoFactorEnabled: users.twoFactorEnabled,
+      })
+      .from(member)
+      .innerJoin(users, eq(users.id, member.userId))
+      .where(eq(member.organizationId, organizationId));
+
+    const statuses: Record<string, boolean> = {};
+    for (const row of rows) {
+      statuses[row.userId] = row.twoFactorEnabled === true;
+    }
+
+    const body: MemberTwoFactorResponse = { statuses };
+    return NextResponse.json(body);
+  } catch (error) {
+    logSystemError(
+      ErrorCategory.DATABASE,
+      "Failed to list member 2FA status",
+      error,
+      {
+        endpoint: "/api/organizations/[organizationId]/members/two-factor",
+        operation: "list",
+        ...auditFromAuth(authContext),
+      }
+    );
+    return NextResponse.json(
+      { error: "Failed to load member 2FA status" },
+      { status: 500 }
+    );
+  }
+}

--- a/components/organization/manage-orgs-modal.tsx
+++ b/components/organization/manage-orgs-modal.tsx
@@ -9,6 +9,8 @@ import {
   Plus,
   RotateCw,
   Settings,
+  ShieldAlert,
+  ShieldCheck,
   Trash2,
   X,
 } from "lucide-react";
@@ -27,6 +29,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -186,6 +189,8 @@ type MembersListContentProps = {
   onUpdateMemberRole?: (memberId: string, role: string) => Promise<void>;
   updatingRoleMemberId?: string | null;
   organizationId?: string | null;
+  /** 2FA enrollment per member user id. Only populated for owners/admins. */
+  twoFactorStatuses?: Record<string, boolean>;
 };
 
 function MembersListContent({
@@ -204,6 +209,7 @@ function MembersListContent({
   onUpdateMemberRole,
   updatingRoleMemberId,
   organizationId,
+  twoFactorStatuses,
 }: MembersListContentProps) {
   const [pendingAction, setPendingAction] = useState<{
     type: "revoke" | "remove" | "resend" | "remove-member";
@@ -269,11 +275,30 @@ function MembersListContent({
             >
               {entry.email}
             </p>
-            <p className="text-muted-foreground text-xs">
-              {entry.role}
-              {entry.kind === "invite" &&
-                (entry.expired ? " - expired" : " - invited")}
-            </p>
+            <div className="flex items-center gap-2">
+              <p className="text-muted-foreground text-xs">
+                {entry.role}
+                {entry.kind === "invite" &&
+                  (entry.expired ? " - expired" : " - invited")}
+              </p>
+              {entry.kind === "member" &&
+                entry.userId &&
+                twoFactorStatuses?.[entry.userId] !== undefined &&
+                (twoFactorStatuses[entry.userId] ? (
+                  <Badge
+                    className="gap-1 border-keeperhub-green/30 bg-keeperhub-green/10 text-keeperhub-green"
+                    variant="outline"
+                  >
+                    <ShieldCheck />
+                    2FA on
+                  </Badge>
+                ) : (
+                  <Badge className="gap-1" variant="destructive">
+                    <ShieldAlert />
+                    No 2FA
+                  </Badge>
+                ))}
+            </div>
           </div>
           <div className="flex shrink-0 items-center gap-1">
             {entry.kind === "member" && canInvite && organizationId && (
@@ -581,6 +606,10 @@ export function ManageOrgsModal({
     };
   };
   const [members, setMembers] = useState<Member[]>([]);
+  // 2FA enrollment per member user id, fetched for owners/admins only.
+  const [twoFactorStatuses, setTwoFactorStatuses] = useState<
+    Record<string, boolean>
+  >({});
 
   // Compute user's role in the managed org from fetched members
   const currentUserMember = members.find((m) => m.userId === session?.user?.id);
@@ -709,6 +738,29 @@ export function ManageOrgsModal({
     }
   }, [organizationId, isStaleRequest]);
 
+  // Fetch per-member 2FA status. Owner/admin-gated on the server; we only
+  // call it when the caller can manage the org to avoid a guaranteed 403.
+  const fetchTwoFactorStatuses = useCallback(async () => {
+    if (!organizationId) {
+      return;
+    }
+
+    const orgIdAtStart = organizationId;
+    try {
+      const result =
+        await api.organization.memberTwoFactorStatus(organizationId);
+      if (isStaleRequest(orgIdAtStart)) {
+        return;
+      }
+      setTwoFactorStatuses(result.statuses);
+    } catch (error) {
+      console.error("Failed to fetch member 2FA status:", error);
+      if (!isStaleRequest(orgIdAtStart)) {
+        setTwoFactorStatuses({});
+      }
+    }
+  }, [organizationId, isStaleRequest]);
+
   // Fetch invitations when modal opens
   useEffect(() => {
     if (open) {
@@ -721,10 +773,19 @@ export function ManageOrgsModal({
     if (open && managedOrgId) {
       setMembers([]);
       setSentInvitations([]);
+      setTwoFactorStatuses({});
       fetchSentInvitations();
       fetchMembers();
     }
   }, [open, managedOrgId, fetchSentInvitations, fetchMembers]);
+
+  // Load 2FA status once we know the caller manages the org. canInvite is
+  // derived from the fetched members, so this runs after fetchMembers settles.
+  useEffect(() => {
+    if (open && managedOrgId && canInvite) {
+      fetchTwoFactorStatuses();
+    }
+  }, [open, managedOrgId, canInvite, fetchTwoFactorStatuses]);
 
   // Keep edit input in sync when switching orgs / name updates
   const lastManagedOrgIdForNameEditRef = useRef<string | null>(null);
@@ -1486,6 +1547,7 @@ export function ManageOrgsModal({
                         organizationId={managedOrgId}
                         removingMember={removingMember}
                         sentInvitations={sentInvitations}
+                        twoFactorStatuses={twoFactorStatuses}
                         updatingRoleMemberId={updatingRoleMemberId}
                       />
                     </div>

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -462,6 +462,12 @@ export const organizationApi = {
       method: "POST",
       body: JSON.stringify(body),
     }),
+
+  /** 2FA enrollment status per member, keyed by user id. Owner/admin only. */
+  memberTwoFactorStatus: (organizationId: string) =>
+    apiCall<{ statuses: Record<string, boolean> }>(
+      `/api/organizations/${organizationId}/members/two-factor`
+    ),
 };
 
 // Address Book API

--- a/tests/integration/organizations-members-two-factor-route.test.ts
+++ b/tests/integration/organizations-members-two-factor-route.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const URL_ORG_ID = "org-target";
+const KEY_ORG_ID = "org-key-home";
+const USER_ID = "user-1";
+
+const { mockGetDualAuthContext, mockMembershipLimit, mockStatusesWhere } =
+  vi.hoisted(() => ({
+    mockGetDualAuthContext: vi.fn(),
+    mockMembershipLimit: vi.fn(),
+    mockStatusesWhere: vi.fn(),
+  }));
+
+vi.mock("@/lib/middleware/auth-helpers", () => ({
+  getDualAuthContext: mockGetDualAuthContext,
+  UNAUTHENTICATED_AUDIT: { authMethod: "unknown" },
+  auditFromAuth: (ctx: unknown): Record<string, string> => {
+    if (ctx && typeof ctx === "object" && "error" in ctx) {
+      return { authMethod: "unknown" };
+    }
+    const c = ctx as { authMethod: string };
+    return { authMethod: c.authMethod };
+  },
+}));
+
+// The route runs two queries: the membership-role lookup ends in .limit(),
+// the statuses lookup joins users and is awaited straight off .where().
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: mockMembershipLimit })),
+        innerJoin: vi.fn(() => ({ where: mockStatusesWhere })),
+      })),
+    })),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  member: {
+    id: "id",
+    organizationId: "organization_id",
+    userId: "user_id",
+    role: "role",
+  },
+  users: { id: "id", twoFactorEnabled: "two_factor_enabled" },
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "DATABASE" },
+  logSystemError: vi.fn(),
+}));
+
+import { GET } from "@/app/api/organizations/[organizationId]/members/two-factor/route";
+
+function buildRequest(): Request {
+  return new Request(
+    `http://localhost/api/organizations/${URL_ORG_ID}/members/two-factor`
+  );
+}
+
+function buildContext(): { params: Promise<{ organizationId: string }> } {
+  return { params: Promise.resolve({ organizationId: URL_ORG_ID }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/organizations/[id]/members/two-factor", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockGetDualAuthContext.mockResolvedValue({
+      error: "Unauthorized",
+      status: 401,
+    });
+
+    const response = await GET(buildRequest(), buildContext());
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 when API key has no recorded creator", async () => {
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: null,
+      organizationId: URL_ORG_ID,
+      authMethod: "api-key",
+    });
+
+    const response = await GET(buildRequest(), buildContext());
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects API-key caller whose home org differs from URL org", async () => {
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: USER_ID,
+      organizationId: KEY_ORG_ID,
+      authMethod: "api-key",
+    });
+
+    const response = await GET(buildRequest(), buildContext());
+    expect(response.status).toBe(403);
+    expect(mockMembershipLimit).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when caller is a plain member of the org", async () => {
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: USER_ID,
+      organizationId: URL_ORG_ID,
+      authMethod: "session",
+    });
+    mockMembershipLimit.mockResolvedValue([{ role: "member" }]);
+
+    const response = await GET(buildRequest(), buildContext());
+    expect(response.status).toBe(403);
+    expect(mockStatusesWhere).not.toHaveBeenCalled();
+  });
+
+  it("returns a status map keyed by user id for an owner", async () => {
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: USER_ID,
+      organizationId: URL_ORG_ID,
+      authMethod: "session",
+    });
+    mockMembershipLimit.mockResolvedValue([{ role: "owner" }]);
+    mockStatusesWhere.mockResolvedValue([
+      { userId: "user-1", twoFactorEnabled: true },
+      { userId: "user-2", twoFactorEnabled: false },
+      { userId: "user-3", twoFactorEnabled: null },
+    ]);
+
+    const response = await GET(buildRequest(), buildContext());
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.statuses).toEqual({
+      "user-1": true,
+      "user-2": false,
+      "user-3": false,
+    });
+  });
+
+  it("permits an admin caller", async () => {
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: USER_ID,
+      organizationId: URL_ORG_ID,
+      authMethod: "session",
+    });
+    mockMembershipLimit.mockResolvedValue([{ role: "admin" }]);
+    mockStatusesWhere.mockResolvedValue([]);
+
+    const response = await GET(buildRequest(), buildContext());
+    expect(response.status).toBe(200);
+  });
+});


### PR DESCRIPTION
Org owners and admins can now see each member's two-factor enrollment status in the Manage Organizations members list, addressing the visibility half of the security request.

## What changed
- New owner/admin-gated endpoint `GET /api/organizations/[organizationId]/members/two-factor` returning per-member 2FA status keyed by user id. Better Auth's `listMembers` does not expose `two_factor_enabled`, so the route joins `users` to report it. Authorization mirrors the existing member-sessions route: dual-auth context, API keys confined to their home org, plain members get 403.
- Members list shows a green `2FA on` / red `No 2FA` badge per member. Statuses load only when the viewer can manage the org.
- Added `organizationApi.memberTwoFactorStatus` client method.
- Integration test covering auth gating and the status map shape.

## Note
Two-factor enrollment is already globally enforced for every signed-in user via the MFA proxy gate, so in practice this badge flags members in the post-invite, pre-enrollment window where `two_factor_enabled` is still false.