### PR TITLE
fix(ci): quote docs-site image tag so numeric short SHAs do not break the deploy

### DIFF
--- a/deploy/docs-site/prod/values.yaml
+++ b/deploy/docs-site/prod/values.yaml
@@ -27,7 +27,7 @@ httpBasicAuth:
 
 image:
   repository: ${ECR_REGISTRY}/keeperhub-docs-prod
-  tag: ${IMAGE_TAG}
+  tag: "${IMAGE_TAG}"
   pullPolicy: Always
 
 deployment:

--- a/deploy/docs-site/staging/values.yaml
+++ b/deploy/docs-site/staging/values.yaml
@@ -27,7 +27,7 @@ httpBasicAuth:
 
 image:
   repository: ${ECR_REGISTRY}/keeperhub-docs-staging
-  tag: ${IMAGE_TAG}
+  tag: "${IMAGE_TAG}"
   pullPolicy: Always
 
 deployment:

--- a/deploy/docs-site/techops-prod/values.yaml
+++ b/deploy/docs-site/techops-prod/values.yaml
@@ -27,7 +27,7 @@ httpBasicAuth:
 
 image:
   repository: ${ECR_REGISTRY}/keeperhub-docs-prod
-  tag: ${IMAGE_TAG}
+  tag: "${IMAGE_TAG}"
   pullPolicy: Always
 
 deployment:


### PR DESCRIPTION
## What

Quote the image tag in the docs-site Helm values (prod, staging, techops-prod):

```yaml
tag: "${IMAGE_TAG}"
```

## Why

The deploy workflow substitutes the git short SHA into `tag: ${IMAGE_TAG}`. When a short SHA is all decimal digits (no a-f chars), the bare YAML scalar is parsed as a number and re-serialised in scientific notation (e.g. `6801028` -> `6.801028e+06`), producing an invalid Docker tag and an `InvalidImageName` failure.

Other services are immune because they prefix the tag with letters (`app-`, `event-`, `executor-`, etc.). The `deploy/local` template already quotes it; this aligns the three deployed envs with it.

## Verification

Rendered all three values files with the workflow substitution and a numeric tag (`6801028`); the tag stays a quoted string in every env and yields a valid `repo:6801028` reference.
