### PR TITLE
feat(auth): add load-test bypass header for signup captcha

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,11 @@ TURNSTILE_SECRET_KEY=
 # endpoints are enabled. Production enforces unconditionally and ignores this.
 # When enforced, the X-Test-API-Key signup bypass no longer applies.
 TURNSTILE_ENFORCE=
+# Load-test bypass token for the captcha plugin. When set, a signup request
+# carrying an X-Load-Test-Captcha-Bypass header that matches this value
+# (timing-safe compared) skips captcha verification. Intended only for the
+# scheduled k6 load test against staging. Leave unset in production.
+LOAD_TEST_CAPTCHA_BYPASS_TOKEN=
 
 # Billing
 NEXT_PUBLIC_BILLING_ENABLED=false

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -160,6 +160,7 @@ jobs:
             -e SKIP_CLEANUP=true \
             -e CF_ACCESS_CLIENT_ID="${CF_ACCESS_CLIENT_ID}" \
             -e CF_ACCESS_CLIENT_SECRET="${CF_ACCESS_CLIENT_SECRET}" \
+            -e LOAD_TEST_CAPTCHA_BYPASS_TOKEN="${LOAD_TEST_CAPTCHA_BYPASS_TOKEN}" \
             -e TARGET_VUS="${{ inputs.target_vus || '25' }}" \
             -e WF_PER_VU="${{ inputs.wf_per_vu || '65' }}" \
             -e OBSERVE_SECONDS="${{ inputs.observe_seconds || '300' }}" \
@@ -179,6 +180,7 @@ jobs:
           SERVICE_KEY: ${{ secrets.SCHEDULER_SERVICE_API_KEY }}
           CF_ACCESS_CLIENT_ID: ${{ secrets.TO_CF_ACCESS_CLIENT_ID }}
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.TO_CF_ACCESS_CLIENT_SECRET }}
+          LOAD_TEST_CAPTCHA_BYPASS_TOKEN: ${{ secrets.LOAD_TEST_CAPTCHA_BYPASS_TOKEN }}
           K6_PROMETHEUS_RW_SERVER_URL: ${{ secrets.K6_PROMETHEUS_RW_SERVER_URL }}
           K6_PROMETHEUS_RW_USERNAME: ${{ secrets.K6_PROMETHEUS_RW_USERNAME }}
           K6_PROMETHEUS_RW_PASSWORD: ${{ secrets.K6_PROMETHEUS_RW_PASSWORD }}
@@ -198,6 +200,7 @@ jobs:
           TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
           CF_ACCESS_CLIENT_ID: ${{ secrets.TO_CF_ACCESS_CLIENT_ID }}
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.TO_CF_ACCESS_CLIENT_SECRET }}
+          LOAD_TEST_CAPTCHA_BYPASS_TOKEN: ${{ secrets.LOAD_TEST_CAPTCHA_BYPASS_TOKEN }}
 
       - name: Cleanup test users
         if: always()

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -456,6 +456,10 @@ env:
   ALLOW_TEST_ENDPOINTS:
     type: kv
     value: "true"
+  LOAD_TEST_CAPTCHA_BYPASS_TOKEN:
+    type: parameterStore
+    name: load-test-captcha-bypass-token
+    parameter_name: /eks/techops-staging/keeperhub/load-test-captcha-bypass-token
   KH_ADMIN_SECRET:
     type: parameterStore
     name: kh-admin-secret

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { randomUUID, timingSafeEqual } from "node:crypto";
 import { captureMessage } from "@sentry/nextjs";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
@@ -167,14 +167,53 @@ if (captchaRequired && !captchaSecretKey) {
   );
 }
 
+// Optional load-test bypass: when LOAD_TEST_CAPTCHA_BYPASS_TOKEN is set in the
+// environment, wrap the captcha plugin so a request carrying a matching
+// X-Load-Test-Captcha-Bypass header skips the upstream siteverify call. The
+// header value is compared timing-safe. Without the env var (production), the
+// wrapper is a no-op and no bypass path exists. Only the scheduled k6 load
+// test running against staging has both the env var and the matching header.
+type CaptchaPluginInstance = ReturnType<typeof captcha>;
+function withLoadTestBypass(
+  plugin: CaptchaPluginInstance
+): CaptchaPluginInstance {
+  const token = process.env.LOAD_TEST_CAPTCHA_BYPASS_TOKEN;
+  if (!token) {
+    return plugin;
+  }
+  const expected = Buffer.from(token, "utf8");
+  const originalOnRequest = plugin.onRequest;
+  return {
+    ...plugin,
+    onRequest: async (request, ctx) => {
+      const provided = request.headers.get("x-load-test-captcha-bypass");
+      if (provided) {
+        const providedBuf = Buffer.from(provided, "utf8");
+        if (
+          providedBuf.length === expected.length &&
+          timingSafeEqual(providedBuf, expected)
+        ) {
+          ctx.logger.info("captcha bypass header accepted", {
+            endpoint: request.url,
+          });
+          return undefined;
+        }
+      }
+      return await originalOnRequest(request, ctx);
+    },
+  };
+}
+
 const captchaPlugins =
   !captchaSkippedForTests && captchaSecretKey
     ? [
-        captcha({
-          provider: "cloudflare-turnstile",
-          secretKey: captchaSecretKey,
-          endpoints: ["/sign-up/email"],
-        }),
+        withLoadTestBypass(
+          captcha({
+            provider: "cloudflare-turnstile",
+            secretKey: captchaSecretKey,
+            endpoints: ["/sign-up/email"],
+          })
+        ),
       ]
     : [];
 

--- a/tests/k6/helpers/http.js
+++ b/tests/k6/helpers/http.js
@@ -4,6 +4,8 @@ const BASE_URL = __ENV.BASE_URL || "http://localhost:3000";
 const TEST_API_KEY = __ENV.TEST_API_KEY || "";
 const CF_ACCESS_CLIENT_ID = __ENV.CF_ACCESS_CLIENT_ID || "";
 const CF_ACCESS_CLIENT_SECRET = __ENV.CF_ACCESS_CLIENT_SECRET || "";
+const LOAD_TEST_CAPTCHA_BYPASS_TOKEN =
+  __ENV.LOAD_TEST_CAPTCHA_BYPASS_TOKEN || "";
 
 export function getBaseUrl() {
   return BASE_URL;
@@ -23,6 +25,10 @@ export function getCommonHeaders() {
   if (CF_ACCESS_CLIENT_ID && CF_ACCESS_CLIENT_SECRET) {
     headers["CF-Access-Client-Id"] = CF_ACCESS_CLIENT_ID;
     headers["CF-Access-Client-Secret"] = CF_ACCESS_CLIENT_SECRET;
+  }
+
+  if (LOAD_TEST_CAPTCHA_BYPASS_TOKEN) {
+    headers["X-Load-Test-Captcha-Bypass"] = LOAD_TEST_CAPTCHA_BYPASS_TOKEN;
   }
 
   return headers;

--- a/tests/k6/ramp-until-breach.sh
+++ b/tests/k6/ramp-until-breach.sh
@@ -3,7 +3,8 @@
 # until success rate drops below THRESHOLD or MAX_VUS is reached.
 #
 # Usage: ./ramp-until-breach.sh <base_url> [threshold%] [step_size] [step_duration] [max_vus]
-# Env: TEST_API_KEY, CF_ACCESS_CLIENT_ID, CF_ACCESS_CLIENT_SECRET
+# Env: TEST_API_KEY, CF_ACCESS_CLIENT_ID, CF_ACCESS_CLIENT_SECRET,
+#      LOAD_TEST_CAPTCHA_BYPASS_TOKEN
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -49,6 +50,7 @@ while [ "$current_vus" -le "$MAX_VUS" ]; do
     -e TEST_API_KEY="${TEST_API_KEY:-}" \
     -e CF_ACCESS_CLIENT_ID="${CF_ACCESS_CLIENT_ID:-}" \
     -e CF_ACCESS_CLIENT_SECRET="${CF_ACCESS_CLIENT_SECRET:-}" \
+    -e LOAD_TEST_CAPTCHA_BYPASS_TOKEN="${LOAD_TEST_CAPTCHA_BYPASS_TOKEN:-}" \
     -e K6_SCENARIO=ci \
     --no-usage-report \
     2>&1 | tee "$output_file" || tier_exit=$?

--- a/tests/unit/signup-defenses.test.ts
+++ b/tests/unit/signup-defenses.test.ts
@@ -192,6 +192,7 @@ describe("signup defenses: load-test captcha bypass", () => {
 
   it("passes through when the bypass header matches the env token", async () => {
     vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("CI", "");
     process.env.TURNSTILE_SECRET_KEY = "test-secret";
     process.env.LOAD_TEST_CAPTCHA_BYPASS_TOKEN = BYPASS_TOKEN;
     const plugin = await loadCaptchaPlugin();
@@ -209,6 +210,7 @@ describe("signup defenses: load-test captcha bypass", () => {
 
   it("delegates to the underlying captcha check when no bypass header is sent", async () => {
     vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("CI", "");
     process.env.TURNSTILE_SECRET_KEY = "test-secret";
     process.env.LOAD_TEST_CAPTCHA_BYPASS_TOKEN = BYPASS_TOKEN;
     const plugin = await loadCaptchaPlugin();
@@ -223,6 +225,7 @@ describe("signup defenses: load-test captcha bypass", () => {
 
   it("delegates when the bypass header is the same length but the wrong value", async () => {
     vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("CI", "");
     process.env.TURNSTILE_SECRET_KEY = "test-secret";
     process.env.LOAD_TEST_CAPTCHA_BYPASS_TOKEN = BYPASS_TOKEN;
     const plugin = await loadCaptchaPlugin();
@@ -241,6 +244,7 @@ describe("signup defenses: load-test captcha bypass", () => {
 
   it("delegates when the bypass header is the wrong length", async () => {
     vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("CI", "");
     process.env.TURNSTILE_SECRET_KEY = "test-secret";
     process.env.LOAD_TEST_CAPTCHA_BYPASS_TOKEN = BYPASS_TOKEN;
     const plugin = await loadCaptchaPlugin();
@@ -258,6 +262,7 @@ describe("signup defenses: load-test captcha bypass", () => {
 
   it("ignores the bypass header entirely when the env token is unset", async () => {
     vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("CI", "");
     process.env.TURNSTILE_SECRET_KEY = "test-secret";
     // LOAD_TEST_CAPTCHA_BYPASS_TOKEN intentionally left unset (production posture)
     const plugin = await loadCaptchaPlugin();

--- a/tests/unit/signup-defenses.test.ts
+++ b/tests/unit/signup-defenses.test.ts
@@ -5,9 +5,18 @@ type RateLimitRuleFn = (
   req: Request,
   defaults: RateLimitRule
 ) => Promise<RateLimitRule | false> | RateLimitRule | false;
+type CaptchaPluginCtx = {
+  logger: {
+    info: (...args: unknown[]) => void;
+    error: (...args: unknown[]) => void;
+  };
+};
 type CaptchaPluginShape = {
   id: string;
   options: { provider?: string; endpoints?: string[]; secretKey?: string };
+};
+type CaptchaPluginWithRequest = CaptchaPluginShape & {
+  onRequest: (request: Request, ctx: CaptchaPluginCtx) => Promise<unknown>;
 };
 
 const TEST_API_KEY = "kha_test_signup_defenses_key";
@@ -26,6 +35,8 @@ function clearTurnstileEnv(): void {
   delete process.env.NEXT_PHASE;
   // biome-ignore lint/performance/noDelete: same
   delete process.env.TURNSTILE_ENFORCE;
+  // biome-ignore lint/performance/noDelete: same
+  delete process.env.LOAD_TEST_CAPTCHA_BYPASS_TOKEN;
 }
 
 describe("signup defenses: captcha plugin", () => {
@@ -77,7 +88,7 @@ describe("signup defenses: captcha plugin", () => {
   it("throws at module load in production when TURNSTILE_SECRET_KEY is missing", async () => {
     vi.stubEnv("NODE_ENV", "production");
     await expect(import("@/lib/auth")).rejects.toThrow(
-      /TURNSTILE_SECRET_KEY is required in production/
+      MISSING_CAPTCHA_SECRET_ERROR
     );
   });
 
@@ -126,6 +137,139 @@ describe("signup defenses: captcha plugin", () => {
     vi.stubEnv("TURNSTILE_ENFORCE", "true");
     await expect(import("@/lib/auth")).rejects.toThrow(
       MISSING_CAPTCHA_SECRET_ERROR
+    );
+  });
+});
+
+describe("signup defenses: load-test captcha bypass", () => {
+  const BYPASS_TOKEN = "0123456789abcdef0123456789abcdef";
+  const SAME_LENGTH_WRONG = "ffffffffffffffffffffffffffffffff";
+  const SIGNUP_URL = "http://localhost:3000/api/auth/sign-up/email";
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    clearTurnstileEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    clearTurnstileEnv();
+  });
+
+  async function loadCaptchaPlugin(): Promise<CaptchaPluginWithRequest> {
+    const { auth } = await import("@/lib/auth");
+    const plugin = (auth.options.plugins ?? []).find(
+      (p) => (p as { id?: string }).id === "captcha"
+    );
+    if (!plugin) {
+      throw new Error("captcha plugin not loaded");
+    }
+    return plugin as unknown as CaptchaPluginWithRequest;
+  }
+
+  function makeRequest(headers: Record<string, string> = {}): Request {
+    return new Request(SIGNUP_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ email: "x@x.test", password: "x", name: "x" }),
+    });
+  }
+
+  function makeCtx(): CaptchaPluginCtx & {
+    logger: {
+      info: ReturnType<typeof vi.fn>;
+      error: ReturnType<typeof vi.fn>;
+    };
+  } {
+    return {
+      logger: {
+        info: vi.fn() as unknown as (...args: unknown[]) => void,
+        error: vi.fn() as unknown as (...args: unknown[]) => void,
+      },
+    } as never;
+  }
+
+  it("passes through when the bypass header matches the env token", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    process.env.TURNSTILE_SECRET_KEY = "test-secret";
+    process.env.LOAD_TEST_CAPTCHA_BYPASS_TOKEN = BYPASS_TOKEN;
+    const plugin = await loadCaptchaPlugin();
+    const ctx = makeCtx();
+    const result = await plugin.onRequest(
+      makeRequest({ "X-Load-Test-Captcha-Bypass": BYPASS_TOKEN }),
+      ctx
+    );
+    expect(result).toBeUndefined();
+    expect(ctx.logger.info).toHaveBeenCalledWith(
+      "captcha bypass header accepted",
+      expect.objectContaining({ endpoint: expect.stringContaining(SIGNUP_URL) })
+    );
+  });
+
+  it("delegates to the underlying captcha check when no bypass header is sent", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    process.env.TURNSTILE_SECRET_KEY = "test-secret";
+    process.env.LOAD_TEST_CAPTCHA_BYPASS_TOKEN = BYPASS_TOKEN;
+    const plugin = await loadCaptchaPlugin();
+    const ctx = makeCtx();
+    const result = await plugin.onRequest(makeRequest(), ctx);
+    expect(result).toBeDefined();
+    expect(ctx.logger.info).not.toHaveBeenCalledWith(
+      "captcha bypass header accepted",
+      expect.anything()
+    );
+  });
+
+  it("delegates when the bypass header is the same length but the wrong value", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    process.env.TURNSTILE_SECRET_KEY = "test-secret";
+    process.env.LOAD_TEST_CAPTCHA_BYPASS_TOKEN = BYPASS_TOKEN;
+    const plugin = await loadCaptchaPlugin();
+    expect(SAME_LENGTH_WRONG.length).toBe(BYPASS_TOKEN.length);
+    const ctx = makeCtx();
+    const result = await plugin.onRequest(
+      makeRequest({ "X-Load-Test-Captcha-Bypass": SAME_LENGTH_WRONG }),
+      ctx
+    );
+    expect(result).toBeDefined();
+    expect(ctx.logger.info).not.toHaveBeenCalledWith(
+      "captcha bypass header accepted",
+      expect.anything()
+    );
+  });
+
+  it("delegates when the bypass header is the wrong length", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    process.env.TURNSTILE_SECRET_KEY = "test-secret";
+    process.env.LOAD_TEST_CAPTCHA_BYPASS_TOKEN = BYPASS_TOKEN;
+    const plugin = await loadCaptchaPlugin();
+    const ctx = makeCtx();
+    const result = await plugin.onRequest(
+      makeRequest({ "X-Load-Test-Captcha-Bypass": "too-short" }),
+      ctx
+    );
+    expect(result).toBeDefined();
+    expect(ctx.logger.info).not.toHaveBeenCalledWith(
+      "captcha bypass header accepted",
+      expect.anything()
+    );
+  });
+
+  it("ignores the bypass header entirely when the env token is unset", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    process.env.TURNSTILE_SECRET_KEY = "test-secret";
+    // LOAD_TEST_CAPTCHA_BYPASS_TOKEN intentionally left unset (production posture)
+    const plugin = await loadCaptchaPlugin();
+    const ctx = makeCtx();
+    const result = await plugin.onRequest(
+      makeRequest({ "X-Load-Test-Captcha-Bypass": BYPASS_TOKEN }),
+      ctx
+    );
+    expect(result).toBeDefined();
+    expect(ctx.logger.info).not.toHaveBeenCalledWith(
+      "captcha bypass header accepted",
+      expect.anything()
     );
   });
 });


### PR DESCRIPTION
## Summary

The scheduled k6 load test signs up new VUs against `/api/auth/sign-up/email`, which is gated by the Turnstile captcha plugin. A headless runner cannot solve a real captcha, so every signup returns `{"code":"MISSING_RESPONSE"}` and the load test fails before doing any work.

This adds a server-side wrapper around the captcha plugin that honors an `X-Load-Test-Captcha-Bypass` header when the value matches `LOAD_TEST_CAPTCHA_BYPASS_TOKEN` from the environment (timing-safe compared via `node:crypto`). When the env var is unset the wrapper is a no-op and no bypass path exists, so production is unchanged.

## Changes

- `lib/auth.ts`: `withLoadTestBypass` wrapper around the captcha plugin's `onRequest`
- `deploy/keeperhub/staging/values.yaml`: mount `LOAD_TEST_CAPTCHA_BYPASS_TOKEN` from SSM (staging only)
- `tests/k6/helpers/http.js` + `tests/k6/ramp-until-breach.sh`: send the bypass header on every signup when the k6 env var is set
- `.github/workflows/load-test.yml`: pass the staging-env GH Actions secret to k6 in both execution and http-ramp modes
- `tests/unit/signup-defenses.test.ts`: 5 new tests (matched, same-length wrong-value, wrong-length, no header, env unset)
- `.env.example`: document the new env var to keep the env-sync maintainability check green

## Test plan

- [x] `pnpm vitest run tests/unit/signup-defenses.test.ts` - 16/16 pass (8 existing + 5 new bypass + 3 rate-limit)
- [x] `pnpm check` on changed files - 0 errors
- [x] `pnpm type-check` - no new errors from these changes
- [ ] Post-merge: dispatch the load test workflow against `staging` and confirm signup step now succeeds
