### PR TITLE
fix(tests/k6): send captcha bypass header from execution-load-test

### DIFF
--- a/tests/k6/execution-load-test.js
+++ b/tests/k6/execution-load-test.js
@@ -23,6 +23,8 @@ const TEST_API_KEY = __ENV.TEST_API_KEY || "";
 const CF_ID = __ENV.CF_ACCESS_CLIENT_ID || "";
 const CF_SECRET = __ENV.CF_ACCESS_CLIENT_SECRET || "";
 const SERVICE_KEY = __ENV.SERVICE_KEY || "";
+const LOAD_TEST_CAPTCHA_BYPASS_TOKEN =
+  __ENV.LOAD_TEST_CAPTCHA_BYPASS_TOKEN || "";
 const TARGET_VUS = parseInt(__ENV.TARGET_VUS || "20", 10);
 const OBSERVE_SECONDS = parseInt(__ENV.OBSERVE_SECONDS || "180", 10);
 const PASSWORD = "K6LoadTest!2024";
@@ -68,6 +70,7 @@ function h() {
   if (TEST_API_KEY) hd["X-Test-API-Key"] = TEST_API_KEY;
   if (CF_ID) hd["CF-Access-Client-Id"] = CF_ID;
   if (CF_SECRET) hd["CF-Access-Client-Secret"] = CF_SECRET;
+  if (LOAD_TEST_CAPTCHA_BYPASS_TOKEN) hd["X-Load-Test-Captcha-Bypass"] = LOAD_TEST_CAPTCHA_BYPASS_TOKEN;
   return hd;
 }
 function adminH() { const hd = h(); if (TEST_API_KEY) hd["Authorization"] = `Bearer ${TEST_API_KEY}`; return hd; }


### PR DESCRIPTION
## Summary

Follow-up to the load-test captcha bypass landed in PR #1502. That PR added the `X-Load-Test-Captcha-Bypass` header in `tests/k6/helpers/http.js`, which covers the http-ramp mode (it routes through `helpers/auth.js`). The scheduled **execution** mode runs `tests/k6/execution-load-test.js`, which is self-contained and has its own `h()` header builder - so it never sent the bypass header.

A manual dispatch on `staging` post-deploy reproduced this: all 25 VUs got `signup 400` and 1625 follow-on `wf create failed 401`s (65 per VU, matching `WF_PER_VU=65`).

This adds the same two-line wiring to `execution-load-test.js`: read `LOAD_TEST_CAPTCHA_BYPASS_TOKEN` from `__ENV` and attach the header in `h()` when set. The header is only sent when the staging-env GH Actions secret is populated, so prod is unchanged.

## Changes

- `tests/k6/execution-load-test.js`: read the env var, attach `X-Load-Test-Captcha-Bypass` in `h()`

## Test plan

- [x] Lint clean on the changed file
- [ ] Post-merge to `staging` + deploy: dispatch `k6 Load Test` workflow and confirm signup step succeeds (no more `signup 400` console errors)
