### PR TITLE
feat(auth): decrypt OTP in admin route and add load-test MFA bypass

### DIFF
--- a/app/api/admin/test/otp/route.staging.ts
+++ b/app/api/admin/test/otp/route.staging.ts
@@ -1,3 +1,4 @@
+import { symmetricDecrypt } from "better-auth/crypto";
 import { desc, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { authenticateAdmin, validateTestEmail } from "@/lib/admin-auth";
@@ -44,7 +45,19 @@ export async function GET(request: Request): Promise<NextResponse> {
       );
     }
 
-    const otp = result[0].value.split(":")[0];
+    // verifications.value is `${storedOTP}:${attempts}`. lib/auth.ts configures
+    // the email-otp plugin with `storeOTP: "encrypted"`, so the stored portion
+    // is xchacha20poly1305 ciphertext keyed off BETTER_AUTH_SECRET. Decrypt
+    // here so callers receive the 6-digit plaintext OTP.
+    const stored = result[0].value.split(":")[0];
+    const secret = process.env.BETTER_AUTH_SECRET;
+    if (!secret) {
+      return NextResponse.json(
+        { error: "BETTER_AUTH_SECRET not configured" },
+        { status: 500 }
+      );
+    }
+    const otp = await symmetricDecrypt({ key: secret, data: stored });
     return NextResponse.json({ otp });
   } catch (error) {
     logSystemError(ErrorCategory.DATABASE, "Admin OTP lookup failed", error, {

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import { type NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { readDeviceCookie } from "@/lib/device-cookie";
@@ -168,6 +169,30 @@ const MFA_EXEMPT_PAGE_PREFIXES: readonly string[] = [
   "/sign-up",
 ];
 
+// Optional load-test MFA bypass: when LOAD_TEST_CAPTCHA_BYPASS_TOKEN is set in
+// the environment, a request carrying X-Load-Test-Mfa-Bypass with a matching
+// value (timing-safe) skips the mandatory-MFA gate. Same env var as the
+// captcha plugin wrapper in lib/auth.ts, same rotation path, and unset in
+// production so no bypass surface exists there.
+const LOAD_TEST_BYPASS_TOKEN = process.env.LOAD_TEST_CAPTCHA_BYPASS_TOKEN;
+const LOAD_TEST_BYPASS_HEADER = "x-load-test-mfa-bypass";
+
+function hasValidLoadTestMfaBypass(request: NextRequest): boolean {
+  if (!LOAD_TEST_BYPASS_TOKEN) {
+    return false;
+  }
+  const provided = request.headers.get(LOAD_TEST_BYPASS_HEADER);
+  if (!provided) {
+    return false;
+  }
+  const providedBuf = Buffer.from(provided, "utf8");
+  const expectedBuf = Buffer.from(LOAD_TEST_BYPASS_TOKEN, "utf8");
+  if (providedBuf.length !== expectedBuf.length) {
+    return false;
+  }
+  return timingSafeEqual(providedBuf, expectedBuf);
+}
+
 function isMfaExemptPath(pathname: string): boolean {
   if (pathname.startsWith("/api/")) {
     for (const prefix of MFA_EXEMPT_API_PREFIXES) {
@@ -222,6 +247,9 @@ async function mfaBlock(request: NextRequest): Promise<MfaResult> {
   const { pathname } = request.nextUrl;
 
   if (isMfaExemptPath(pathname)) {
+    return { kind: "pass", user: null };
+  }
+  if (hasValidLoadTestMfaBypass(request)) {
     return { kind: "pass", user: null };
   }
   // No session cookie at all → no session → nothing to gate on. Route

--- a/tests/integration/admin-otp-route.test.ts
+++ b/tests/integration/admin-otp-route.test.ts
@@ -1,7 +1,13 @@
+import { symmetricEncrypt } from "better-auth/crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const TEST_KEY = "kha_test-secret-key-12345";
 const TEST_EMAIL = "test@techops.services";
+const TEST_BETTER_AUTH_SECRET = "test-better-auth-secret-32-chars!";
+
+async function encryptOtp(otp: string): Promise<string> {
+  return await symmetricEncrypt({ key: TEST_BETTER_AUTH_SECRET, data: otp });
+}
 
 let mockResult: unknown[] = [];
 let mockShouldThrow = false;
@@ -53,6 +59,7 @@ describe("GET /api/admin/test/otp", () => {
     mockResult = [];
     mockShouldThrow = false;
     process.env.TEST_API_KEY = TEST_KEY;
+    process.env.BETTER_AUTH_SECRET = TEST_BETTER_AUTH_SECRET;
     vi.stubEnv("INCLUDE_TEST_ENDPOINTS", "true");
   });
 
@@ -100,16 +107,18 @@ describe("GET /api/admin/test/otp", () => {
   });
 
   describe("OTP lookup", () => {
-    it("should return OTP when found", async () => {
-      mockResult = [{ value: "123456:2" }];
+    it("should decrypt and return the plaintext OTP when found", async () => {
+      const cipher = await encryptOtp("123456");
+      mockResult = [{ value: `${cipher}:2` }];
       const response = await GET(createRequest(TEST_EMAIL, TEST_KEY));
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.otp).toBe("123456");
     });
 
-    it("should split value on colon and return first part", async () => {
-      mockResult = [{ value: "789012:5:extra" }];
+    it("should split value on colon and decrypt the first part only", async () => {
+      const cipher = await encryptOtp("789012");
+      mockResult = [{ value: `${cipher}:5:extra` }];
       const response = await GET(createRequest(TEST_EMAIL, TEST_KEY));
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -128,6 +137,16 @@ describe("GET /api/admin/test/otp", () => {
       mockResult = [{ value: null }];
       const response = await GET(createRequest(TEST_EMAIL, TEST_KEY));
       expect(response.status).toBe(404);
+    });
+
+    it("should return 500 when BETTER_AUTH_SECRET is unset", async () => {
+      // biome-ignore lint/performance/noDelete: env var must be removed
+      delete process.env.BETTER_AUTH_SECRET;
+      mockResult = [{ value: `${await encryptOtp("123456")}:0` }];
+      const response = await GET(createRequest(TEST_EMAIL, TEST_KEY));
+      expect(response.status).toBe(500);
+      const data = await response.json();
+      expect(data.error).toBe("BETTER_AUTH_SECRET not configured");
     });
 
     it("should return 500 on database error", async () => {

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -518,6 +518,113 @@ describe("MFA gate", () => {
   });
 });
 
+describe("MFA gate: load-test bypass header", () => {
+  // The bypass token is read once at module load. The tests that follow
+  // stub it via vi.stubEnv before importing the proxy module. To exercise
+  // the bypass code paths we must import proxy.ts fresh inside each test
+  // so the module-level const picks up the stubbed value.
+  const BYPASS_TOKEN = "load-test-bypass-token-32-bytes-long!";
+  const SAME_LENGTH_WRONG = "WRONG-TOKEN-DIFFERENT-VALUE-XXXXXXXXX";
+
+  function sessionCookieHeaders(): Record<string, string> {
+    return {
+      cookie: "better-auth.session_token=tok",
+      origin: "http://localhost:3000",
+    };
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    mockGetSession.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  async function loadProxyWithBypassTokenSet(): Promise<typeof proxy> {
+    vi.stubEnv("LOAD_TEST_CAPTCHA_BYPASS_TOKEN", BYPASS_TOKEN);
+    const mod = await import("@/proxy");
+    return mod.proxy;
+  }
+
+  it("passes an authenticated API request when the bypass header matches", async () => {
+    expect(SAME_LENGTH_WRONG.length).toBe(BYPASS_TOKEN.length);
+    mockGetSession.mockResolvedValue({
+      user: { id: "u1", twoFactorEnabled: false },
+      session: { requiresMfa: false },
+    });
+    const proxyFn = await loadProxyWithBypassTokenSet();
+    const res = await proxyFn(
+      make("/api/workflows", {
+        headers: {
+          ...sessionCookieHeaders(),
+          "x-load-test-mfa-bypass": BYPASS_TOKEN,
+        },
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(mockGetSession).not.toHaveBeenCalled();
+  });
+
+  it("does not honor a same-length but wrong bypass header", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: "u1", twoFactorEnabled: false },
+      session: { requiresMfa: false },
+    });
+    const proxyFn = await loadProxyWithBypassTokenSet();
+    const res = await proxyFn(
+      make("/api/workflows", {
+        headers: {
+          ...sessionCookieHeaders(),
+          "x-load-test-mfa-bypass": SAME_LENGTH_WRONG,
+        },
+      })
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("mfa_enrollment_required");
+  });
+
+  it("does not honor a wrong-length bypass header", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: "u1", twoFactorEnabled: false },
+      session: { requiresMfa: false },
+    });
+    const proxyFn = await loadProxyWithBypassTokenSet();
+    const res = await proxyFn(
+      make("/api/workflows", {
+        headers: {
+          ...sessionCookieHeaders(),
+          "x-load-test-mfa-bypass": "too-short",
+        },
+      })
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("ignores the bypass header entirely when the env token is unset (production)", async () => {
+    // LOAD_TEST_CAPTCHA_BYPASS_TOKEN intentionally not stubbed.
+    mockGetSession.mockResolvedValue({
+      user: { id: "u1", twoFactorEnabled: false },
+      session: { requiresMfa: false },
+    });
+    const mod = await import("@/proxy");
+    const res = await mod.proxy(
+      make("/api/workflows", {
+        headers: {
+          ...sessionCookieHeaders(),
+          "x-load-test-mfa-bypass": BYPASS_TOKEN,
+        },
+      })
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("mfa_enrollment_required");
+  });
+});
+
 describe("Country gate", () => {
   // Authenticated, enrolled, MFA-verified user with an email so mfaBlock
   // returns a real user and the country gate runs.


### PR DESCRIPTION
## Summary

Two coupled fixes that unblock the scheduled k6 load test after the captcha bypass from PR #1502 got signups working. End-to-end verification of that PR against staging from a workstation surfaced two further breakages downstream of `/api/auth/sign-up/email`:

1. **Admin OTP test endpoint returned ciphertext, not the 6-digit OTP.** `lib/auth.ts` configures the email-otp plugin with `storeOTP: "encrypted"`, so the `verifications.value` stored portion is xchacha20poly1305 ciphertext keyed off `BETTER_AUTH_SECRET`. The admin route was reading `.split(":")[0]` and returning the raw ciphertext, which `/api/auth/email-otp/verify-email` then rejected as `INVALID_OTP`. Fix: decrypt via better-auth's `symmetricDecrypt` before returning.

2. **`proxy.ts` mandatory-MFA gate blocked every authenticated `/api/**` request** from the load test. k6 VUs use session cookies (not API keys), and freshly-signed-up users have `twoFactorEnabled=false`, so every request after signin hit the gate. Fix: when `LOAD_TEST_CAPTCHA_BYPASS_TOKEN` is set in the environment, recognize an `X-Load-Test-Mfa-Bypass` header whose value matches the same token (timing-safe). Same env var as the captcha plugin wrapper, same rotation path. In production (env var unset) the helper short-circuits to `false` and the gate behaves exactly as before.

## Changes

- `app/api/admin/test/otp/route.staging.ts`: decrypt the stored value with `symmetricDecrypt`, fail loudly with 500 if `BETTER_AUTH_SECRET` is unset
- `proxy.ts`: module-level `hasValidLoadTestMfaBypass` helper, called as the first check in `mfaBlock` after the existing exempt-path list
- `tests/integration/admin-otp-route.test.ts`: tests now use real `symmetricEncrypt`-produced ciphertext, plus a new case for the missing-secret path
- `tests/unit/proxy.test.ts`: 4 new cases - matching token passes, same-length wrong-value blocks, wrong-length blocks, env-unset blocks (production posture)

## Verification

- `pnpm vitest run tests/integration/admin-otp-route.test.ts tests/unit/proxy.test.ts` - 62/62 pass with `CI=true`
- `pnpm check` on changed files - 0 errors
- `pnpm type-check` - no new errors (only pre-existing unrelated `credential-map` / `step-registry` modules)
- Decrypt logic verified live against staging: a real signup -> admin-otp -> decrypt -> verify-email cycle returned `200 status:true emailVerified:true`. Signin then returned a valid session token.
- MFA bypass logic cannot be exercised end-to-end pre-deploy (proxy.ts runs in middleware); unit tests cover the four boundary cases.

## Post-merge test plan

- [ ] After staging deploy completes: re-run the workstation verify script (signup -> admin-otp -> verify -> signin -> wf-create with MFA-bypass header). 200 at wf-create proves the chain is intact.
- [ ] Dispatch `k6 Load Test` workflow against `staging` (now-merged) and confirm the run goes past the prior `signup 400` / `wf-create 401` failure modes into actual k6 iterations.
