### PR TITLE
refactor(load-test): switch k6 to pre-seeded users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,11 +87,13 @@ TURNSTILE_SECRET_KEY=
 # endpoints are enabled. Production enforces unconditionally and ignores this.
 # When enforced, the X-Test-API-Key signup bypass no longer applies.
 TURNSTILE_ENFORCE=
-# Load-test bypass token for the captcha plugin. When set, a signup request
-# carrying an X-Load-Test-Captcha-Bypass header that matches this value
-# (timing-safe compared) skips captcha verification. Intended only for the
-# scheduled k6 load test against staging. Leave unset in production.
-LOAD_TEST_CAPTCHA_BYPASS_TOKEN=
+# Load-test bypass token. When set, proxy.ts honors an X-Load-Test-Mfa-Bypass
+# header whose value matches this token (timing-safe) and skips the
+# mandatory-MFA gate. Staging only; leave unset in production.
+LOAD_TEST_BYPASS_TOKEN=
+# Password for the pre-seeded k6 load-test users (k6-loadtest-vu1..50@techops.services).
+# Used by both the seed script and the k6 test for signin. Staging only.
+LOAD_TEST_USER_PASSWORD=
 
 # Billing
 NEXT_PUBLIC_BILLING_ENABLED=false

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -160,7 +160,8 @@ jobs:
             -e SKIP_CLEANUP=true \
             -e CF_ACCESS_CLIENT_ID="${CF_ACCESS_CLIENT_ID}" \
             -e CF_ACCESS_CLIENT_SECRET="${CF_ACCESS_CLIENT_SECRET}" \
-            -e LOAD_TEST_CAPTCHA_BYPASS_TOKEN="${LOAD_TEST_CAPTCHA_BYPASS_TOKEN}" \
+            -e LOAD_TEST_BYPASS_TOKEN="${LOAD_TEST_BYPASS_TOKEN}" \
+            -e LOAD_TEST_USER_PASSWORD="${LOAD_TEST_USER_PASSWORD}" \
             -e TARGET_VUS="${{ inputs.target_vus || '25' }}" \
             -e WF_PER_VU="${{ inputs.wf_per_vu || '65' }}" \
             -e OBSERVE_SECONDS="${{ inputs.observe_seconds || '300' }}" \
@@ -180,7 +181,8 @@ jobs:
           SERVICE_KEY: ${{ secrets.SCHEDULER_SERVICE_API_KEY }}
           CF_ACCESS_CLIENT_ID: ${{ secrets.TO_CF_ACCESS_CLIENT_ID }}
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.TO_CF_ACCESS_CLIENT_SECRET }}
-          LOAD_TEST_CAPTCHA_BYPASS_TOKEN: ${{ secrets.LOAD_TEST_CAPTCHA_BYPASS_TOKEN }}
+          LOAD_TEST_BYPASS_TOKEN: ${{ secrets.LOAD_TEST_BYPASS_TOKEN }}
+          LOAD_TEST_USER_PASSWORD: ${{ secrets.LOAD_TEST_USER_PASSWORD }}
           K6_PROMETHEUS_RW_SERVER_URL: ${{ secrets.K6_PROMETHEUS_RW_SERVER_URL }}
           K6_PROMETHEUS_RW_USERNAME: ${{ secrets.K6_PROMETHEUS_RW_USERNAME }}
           K6_PROMETHEUS_RW_PASSWORD: ${{ secrets.K6_PROMETHEUS_RW_PASSWORD }}
@@ -200,7 +202,8 @@ jobs:
           TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
           CF_ACCESS_CLIENT_ID: ${{ secrets.TO_CF_ACCESS_CLIENT_ID }}
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.TO_CF_ACCESS_CLIENT_SECRET }}
-          LOAD_TEST_CAPTCHA_BYPASS_TOKEN: ${{ secrets.LOAD_TEST_CAPTCHA_BYPASS_TOKEN }}
+          LOAD_TEST_BYPASS_TOKEN: ${{ secrets.LOAD_TEST_BYPASS_TOKEN }}
+          LOAD_TEST_USER_PASSWORD: ${{ secrets.LOAD_TEST_USER_PASSWORD }}
 
       - name: Cleanup test users
         if: always()

--- a/app/api/admin/test/cleanup/route.staging.ts
+++ b/app/api/admin/test/cleanup/route.staging.ts
@@ -4,14 +4,65 @@ import { authenticateAdmin } from "@/lib/admin-auth";
 import { db } from "@/lib/db";
 import { users } from "@/lib/db/schema";
 
-const K6_EMAIL_PATTERN = "k6-%@techops.services";
-const VERIFICATION_PATTERN = "email-verification-otp-k6-%@techops.services";
+const K6_EMAIL_PATTERN = "k6-vu%@techops.services";
+const SEEDED_EMAIL_PATTERN = "k6-loadtest-vu%@techops.services";
+const VERIFICATION_PATTERN = "email-verification-otp-k6-vu%@techops.services";
 const MAX_ATTEMPTS = 10;
 
 // Allowlist for identifiers returned by information_schema.
 const IDENT_RE = /^[a-z_][a-z0-9_]*$/i;
 
 type FkRow = { table_name: string; column_name: string };
+
+type SeededCleanupCounts = {
+  workflows: number;
+  executions: number;
+};
+
+// Clean workflows + execution data owned by the pre-seeded load-test users.
+// The user/org/membership rows are intentionally preserved so the next run
+// can sign in with the same credentials.
+async function cleanupSeededUserWorkflows(): Promise<SeededCleanupCounts> {
+  const userSubquery = sql`SELECT id FROM users WHERE email LIKE ${SEEDED_EMAIL_PATTERN}`;
+  const wfSubquery = sql`SELECT id FROM workflows WHERE user_id IN (${userSubquery})`;
+
+  const wfCount = await db.execute<{ count: string }>(sql`
+    SELECT count(*)::text as count FROM workflows
+    WHERE user_id IN (${userSubquery})
+  `);
+  const execCount = await db.execute<{ count: string }>(sql`
+    SELECT count(*)::text as count FROM workflow_executions
+    WHERE workflow_id IN (${wfSubquery})
+  `);
+
+  await db
+    .execute(sql`
+    UPDATE workflows SET enabled = false WHERE user_id IN (${userSubquery})
+  `)
+    .catch(() => {});
+  await db
+    .execute(sql`
+    UPDATE workflow_executions SET status = 'cancelled'
+    WHERE status = 'running' AND workflow_id IN (${wfSubquery})
+  `)
+    .catch(() => {});
+
+  const statements = [
+    sql`DELETE FROM workflow_execution_logs WHERE execution_id IN (
+      SELECT id FROM workflow_executions WHERE workflow_id IN (${wfSubquery}))`,
+    sql`DELETE FROM workflow_executions WHERE workflow_id IN (${wfSubquery})`,
+    sql`DELETE FROM workflow_schedules WHERE workflow_id IN (${wfSubquery})`,
+    sql`DELETE FROM workflows WHERE user_id IN (${userSubquery})`,
+  ];
+  for (const stmt of statements) {
+    await db.execute(stmt).catch(() => {});
+  }
+
+  return {
+    workflows: Number(wfCount[0]?.count ?? 0),
+    executions: Number(execCount[0]?.count ?? 0),
+  };
+}
 
 // Single cleanup pass — deletes what it can, ignores lock/FK errors.
 // Returns the number of remaining test users.
@@ -139,6 +190,11 @@ export async function POST(request: Request): Promise<NextResponse> {
   }
 
   try {
+    const seededCounts =
+      body.dryRun === true
+        ? { workflows: 0, executions: 0 }
+        : await cleanupSeededUserWorkflows();
+
     const testUsers = await db
       .select({ id: users.id, email: users.email })
       .from(users)
@@ -146,7 +202,12 @@ export async function POST(request: Request): Promise<NextResponse> {
 
     if (testUsers.length === 0) {
       return NextResponse.json({
-        deleted: { users: 0, organizations: 0, workflows: 0 },
+        deleted: {
+          users: 0,
+          organizations: 0,
+          workflows: seededCounts.workflows,
+        },
+        executions: { total: seededCounts.executions },
         emails: [],
         dryRun: body.dryRun === true,
       });
@@ -253,10 +314,10 @@ export async function POST(request: Request): Promise<NextResponse> {
       deleted: {
         users: deletedUsers,
         organizations: deletedUsers,
-        workflows: deletedWorkflows,
+        workflows: deletedWorkflows + seededCounts.workflows,
       },
       executions: {
-        total: execTotal,
+        total: execTotal + seededCounts.executions,
         success: execSuccess,
         error: execError,
         successRate:

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -456,10 +456,14 @@ env:
   ALLOW_TEST_ENDPOINTS:
     type: kv
     value: "true"
-  LOAD_TEST_CAPTCHA_BYPASS_TOKEN:
+  LOAD_TEST_BYPASS_TOKEN:
     type: parameterStore
     name: load-test-captcha-bypass-token
     parameter_name: /eks/techops-staging/keeperhub/load-test-captcha-bypass-token
+  LOAD_TEST_USER_PASSWORD:
+    type: parameterStore
+    name: load-test-user-password
+    parameter_name: /eks/techops-staging/keeperhub/load-test-user-password
   KH_ADMIN_SECRET:
     type: parameterStore
     name: kh-admin-secret

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,4 +1,4 @@
-import { randomUUID, timingSafeEqual } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { captureMessage } from "@sentry/nextjs";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
@@ -167,53 +167,14 @@ if (captchaRequired && !captchaSecretKey) {
   );
 }
 
-// Optional load-test bypass: when LOAD_TEST_CAPTCHA_BYPASS_TOKEN is set in the
-// environment, wrap the captcha plugin so a request carrying a matching
-// X-Load-Test-Captcha-Bypass header skips the upstream siteverify call. The
-// header value is compared timing-safe. Without the env var (production), the
-// wrapper is a no-op and no bypass path exists. Only the scheduled k6 load
-// test running against staging has both the env var and the matching header.
-type CaptchaPluginInstance = ReturnType<typeof captcha>;
-function withLoadTestBypass(
-  plugin: CaptchaPluginInstance
-): CaptchaPluginInstance {
-  const token = process.env.LOAD_TEST_CAPTCHA_BYPASS_TOKEN;
-  if (!token) {
-    return plugin;
-  }
-  const expected = Buffer.from(token, "utf8");
-  const originalOnRequest = plugin.onRequest;
-  return {
-    ...plugin,
-    onRequest: async (request, ctx) => {
-      const provided = request.headers.get("x-load-test-captcha-bypass");
-      if (provided) {
-        const providedBuf = Buffer.from(provided, "utf8");
-        if (
-          providedBuf.length === expected.length &&
-          timingSafeEqual(providedBuf, expected)
-        ) {
-          ctx.logger.info("captcha bypass header accepted", {
-            endpoint: request.url,
-          });
-          return undefined;
-        }
-      }
-      return await originalOnRequest(request, ctx);
-    },
-  };
-}
-
 const captchaPlugins =
   !captchaSkippedForTests && captchaSecretKey
     ? [
-        withLoadTestBypass(
-          captcha({
-            provider: "cloudflare-turnstile",
-            secretKey: captchaSecretKey,
-            endpoints: ["/sign-up/email"],
-          })
-        ),
+        captcha({
+          provider: "cloudflare-turnstile",
+          secretKey: captchaSecretKey,
+          endpoints: ["/sign-up/email"],
+        }),
       ]
     : [];
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import { type NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { readDeviceCookie } from "@/lib/device-cookie";
@@ -168,6 +169,24 @@ const MFA_EXEMPT_PAGE_PREFIXES: readonly string[] = [
   "/sign-up",
 ];
 
+const LOAD_TEST_BYPASS_TOKEN = process.env.LOAD_TEST_BYPASS_TOKEN;
+
+function hasValidLoadTestMfaBypass(request: NextRequest): boolean {
+  if (!LOAD_TEST_BYPASS_TOKEN) {
+    return false;
+  }
+  const provided = request.headers.get("x-load-test-mfa-bypass");
+  if (!provided) {
+    return false;
+  }
+  const providedBuf = Buffer.from(provided, "utf8");
+  const expectedBuf = Buffer.from(LOAD_TEST_BYPASS_TOKEN, "utf8");
+  if (providedBuf.length !== expectedBuf.length) {
+    return false;
+  }
+  return timingSafeEqual(providedBuf, expectedBuf);
+}
+
 function isMfaExemptPath(pathname: string): boolean {
   if (pathname.startsWith("/api/")) {
     for (const prefix of MFA_EXEMPT_API_PREFIXES) {
@@ -222,6 +241,9 @@ async function mfaBlock(request: NextRequest): Promise<MfaResult> {
   const { pathname } = request.nextUrl;
 
   if (isMfaExemptPath(pathname)) {
+    return { kind: "pass", user: null };
+  }
+  if (hasValidLoadTestMfaBypass(request)) {
     return { kind: "pass", user: null };
   }
   // No session cookie at all → no session → nothing to gate on. Route

--- a/scripts/seed-load-test-users.ts
+++ b/scripts/seed-load-test-users.ts
@@ -34,7 +34,7 @@ async function seedUser(vuId: number, password: string): Promise<"created" | "sk
       emailVerified: true,
       createdAt: now,
       updatedAt: now,
-      twoFactorEnabled: true,
+      twoFactorEnabled: false,
     });
     await tx.insert(accounts).values({
       id: accountId,

--- a/scripts/seed-load-test-users.ts
+++ b/scripts/seed-load-test-users.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from "node:crypto";
+import { hashPassword } from "better-auth/crypto";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, member, organization, users } from "@/lib/db/schema";
+
+const COUNT = Number(process.env.SEED_COUNT ?? "50");
+const EMAIL_PREFIX = "k6-loadtest-vu";
+const EMAIL_DOMAIN = "@techops.services";
+
+async function seedUser(vuId: number, password: string): Promise<"created" | "skipped"> {
+  const email = `${EMAIL_PREFIX}${vuId}${EMAIL_DOMAIN}`;
+  const existing = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1);
+  if (existing.length > 0) {
+    return "skipped";
+  }
+
+  const userId = randomUUID();
+  const orgId = randomUUID();
+  const memberId = randomUUID();
+  const accountId = randomUUID();
+  const now = new Date();
+  const slug = `k6-loadtest-vu${vuId}-${randomUUID().slice(0, 6)}`;
+
+  await db.transaction(async (tx) => {
+    await tx.insert(users).values({
+      id: userId,
+      name: `K6 LoadTest VU${vuId}`,
+      email,
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+      twoFactorEnabled: true,
+    });
+    await tx.insert(accounts).values({
+      id: accountId,
+      accountId: email,
+      providerId: "credential",
+      userId,
+      password,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await tx.insert(organization).values({
+      id: orgId,
+      name: `K6 LoadTest VU${vuId} Org`,
+      slug,
+      createdAt: now,
+    });
+    await tx.insert(member).values({
+      id: memberId,
+      organizationId: orgId,
+      userId,
+      role: "owner",
+      createdAt: now,
+    });
+  });
+
+  return "created";
+}
+
+async function main(): Promise<void> {
+  const password = process.env.LOAD_TEST_USER_PASSWORD;
+  if (!password) {
+    throw new Error("LOAD_TEST_USER_PASSWORD env var is required");
+  }
+  const hashed = await hashPassword(password);
+
+  let created = 0;
+  let skipped = 0;
+  for (let v = 1; v <= COUNT; v++) {
+    const result = await seedUser(v, hashed);
+    if (result === "created") {
+      created++;
+    } else {
+      skipped++;
+    }
+  }
+
+  console.log(`seed-load-test-users: created=${created} skipped=${skipped} total=${COUNT}`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("seed-load-test-users failed:", err);
+  process.exit(1);
+});

--- a/tests/k6/execution-load-test.js
+++ b/tests/k6/execution-load-test.js
@@ -23,11 +23,10 @@ const TEST_API_KEY = __ENV.TEST_API_KEY || "";
 const CF_ID = __ENV.CF_ACCESS_CLIENT_ID || "";
 const CF_SECRET = __ENV.CF_ACCESS_CLIENT_SECRET || "";
 const SERVICE_KEY = __ENV.SERVICE_KEY || "";
-const LOAD_TEST_CAPTCHA_BYPASS_TOKEN =
-  __ENV.LOAD_TEST_CAPTCHA_BYPASS_TOKEN || "";
+const LOAD_TEST_BYPASS_TOKEN = __ENV.LOAD_TEST_BYPASS_TOKEN || "";
 const TARGET_VUS = parseInt(__ENV.TARGET_VUS || "20", 10);
 const OBSERVE_SECONDS = parseInt(__ENV.OBSERVE_SECONDS || "180", 10);
-const PASSWORD = "K6LoadTest!2024";
+const PASSWORD = __ENV.LOAD_TEST_USER_PASSWORD || "K6LoadTest!2024";
 const TIERS = (__ENV.TIERS || "10,12,14,16,18,20,25,30,40,50").split(",").map(Number);
 
 // Metrics — pushed to Prometheus via --out experimental-prometheus-rw
@@ -70,7 +69,7 @@ function h() {
   if (TEST_API_KEY) hd["X-Test-API-Key"] = TEST_API_KEY;
   if (CF_ID) hd["CF-Access-Client-Id"] = CF_ID;
   if (CF_SECRET) hd["CF-Access-Client-Secret"] = CF_SECRET;
-  if (LOAD_TEST_CAPTCHA_BYPASS_TOKEN) hd["X-Load-Test-Captcha-Bypass"] = LOAD_TEST_CAPTCHA_BYPASS_TOKEN;
+  if (LOAD_TEST_BYPASS_TOKEN) hd["X-Load-Test-Mfa-Bypass"] = LOAD_TEST_BYPASS_TOKEN;
   return hd;
 }
 function adminH() { const hd = h(); if (TEST_API_KEY) hd["Authorization"] = `Bearer ${TEST_API_KEY}`; return hd; }
@@ -135,31 +134,10 @@ function retryPost(url, body, max) {
 
 function authenticate() {
   const v = exec.vu.idInTest;
-
-  if (!myEmail) {
-    http.get(`${BASE_URL}/api/health`, { headers: h(), redirects: 5 });
-    myEmail = `k6-vu${v}-${Date.now()}@techops.services`;
-    const su = retryPost(`${BASE_URL}/api/auth/sign-up/email`,
-      JSON.stringify({ email: myEmail, password: PASSWORD, name: `k6-${v}` }), 5);
-    if (su.status !== 200) { console.error(`VU${v}: signup ${su.status}`); return false; }
-    sleep(1);
-
-    let otp = null;
-    for (let i = 0; i < 10; i++) {
-      const r = http.get(`${BASE_URL}/api/admin/test/otp?email=${encodeURIComponent(myEmail)}`, { headers: adminH() });
-      if (r.status === 200) { otp = JSON.parse(r.body).otp; break; }
-      sleep(1);
-    }
-    if (!otp) { console.error(`VU${v}: no OTP`); return false; }
-
-    const vr = retryPost(`${BASE_URL}/api/auth/email-otp/verify-email`,
-      JSON.stringify({ email: myEmail, otp }), 5);
-    if (vr.status !== 200) { console.error(`VU${v}: verify ${vr.status}`); return false; }
-  }
-
+  myEmail = `k6-loadtest-vu${v}@techops.services`;
   const sr = retryPost(`${BASE_URL}/api/auth/sign-in/email`,
     JSON.stringify({ email: myEmail, password: PASSWORD }), 5);
-  if (sr.status !== 200) { console.error(`VU${exec.vu.idInTest}: signin ${sr.status}`); return false; }
+  if (sr.status !== 200) { console.error(`VU${v}: signin ${sr.status}`); return false; }
   return true;
 }
 

--- a/tests/k6/helpers/auth.js
+++ b/tests/k6/helpers/auth.js
@@ -1,88 +1,15 @@
-import { check, sleep } from "k6";
-import { post, adminGet } from "./http.js";
+import { check } from "k6";
+import { post } from "./http.js";
+
+const PASSWORD = __ENV.LOAD_TEST_USER_PASSWORD || "K6LoadTest!2024";
 
 export function registerAndLogin(vuId) {
-  const timestamp = Date.now();
-  const email = `k6-vu${vuId}-${timestamp}@techops.services`;
-  const password = "K6LoadTest!2024";
-  const name = `k6-user-${vuId}`;
+  const email = `k6-loadtest-vu${vuId}@techops.services`;
 
-  // Step 1: Sign up
-  const signUpRes = post("/api/auth/sign-up/email", {
-    email,
-    password,
-    name,
-  });
-
-  const signUpOk = check(signUpRes, {
-    "signup: status 200": (r) => r.status === 200,
-  });
-
-  if (!signUpOk) {
-    console.error(
-      `Signup failed for ${email}: ${signUpRes.status} ${signUpRes.body}`
-    );
-    return null;
-  }
-
-  // Step 2: Retrieve OTP via admin endpoint (with retries)
-  let otp = null;
-  const maxRetries = 8;
-
-  for (let i = 0; i < maxRetries; i++) {
-    const otpRes = adminGet(
-      `/api/admin/test/otp?email=${encodeURIComponent(email)}`
-    );
-
-    if (otpRes.status === 200) {
-      const body = JSON.parse(otpRes.body);
-      otp = body.otp;
-      break;
-    }
-
-    if (otpRes.status !== 404) {
-      console.error(
-        `OTP retrieval error for ${email}: ${otpRes.status} ${otpRes.body}`
-      );
-      return null;
-    }
-
-    const delay = Math.min(0.5 * Math.pow(2, i), 4);
-    sleep(delay);
-  }
-
-  if (!otp) {
-    console.error(`No OTP found for ${email} after ${maxRetries} retries`);
-    return null;
-  }
-
-  // Step 3: Verify email with OTP
-  const verifyRes = post("/api/auth/email-otp/verify-email", {
-    email,
-    otp,
-  });
-
-  const verifyOk = check(verifyRes, {
-    "verify: status 200": (r) => r.status === 200,
-  });
-
-  if (!verifyOk) {
-    console.error(
-      `Email verification failed for ${email}: ${verifyRes.status} ${verifyRes.body}`
-    );
-    return null;
-  }
-
-  // Step 4: Sign in
-  const signInRes = post("/api/auth/sign-in/email", {
-    email,
-    password,
-  });
-
+  const signInRes = post("/api/auth/sign-in/email", { email, password: PASSWORD });
   const signInOk = check(signInRes, {
     "signin: status 200": (r) => r.status === 200,
   });
-
   if (!signInOk) {
     console.error(
       `Sign-in failed for ${email}: ${signInRes.status} ${signInRes.body}`
@@ -90,21 +17,11 @@ export function registerAndLogin(vuId) {
     return null;
   }
 
-  // Step 5: Create an API key for webhook testing
   let apiKey = null;
   const apiKeyRes = post("/api/api-keys", { name: `k6-test-vu${vuId}` });
-  const apiKeyOk = check(apiKeyRes, {
-    "api-key create: status 200": (r) => r.status === 200,
-  });
-
-  if (apiKeyOk) {
-    const apiKeyBody = JSON.parse(apiKeyRes.body);
-    apiKey = apiKeyBody.key;
-  } else {
-    console.error(
-      `API key creation failed for ${email}: ${apiKeyRes.status} ${apiKeyRes.body}`
-    );
+  if (apiKeyRes.status === 200) {
+    apiKey = JSON.parse(apiKeyRes.body).key;
   }
 
-  return { email, password, apiKey };
+  return { email, password: PASSWORD, apiKey };
 }

--- a/tests/k6/helpers/http.js
+++ b/tests/k6/helpers/http.js
@@ -4,8 +4,7 @@ const BASE_URL = __ENV.BASE_URL || "http://localhost:3000";
 const TEST_API_KEY = __ENV.TEST_API_KEY || "";
 const CF_ACCESS_CLIENT_ID = __ENV.CF_ACCESS_CLIENT_ID || "";
 const CF_ACCESS_CLIENT_SECRET = __ENV.CF_ACCESS_CLIENT_SECRET || "";
-const LOAD_TEST_CAPTCHA_BYPASS_TOKEN =
-  __ENV.LOAD_TEST_CAPTCHA_BYPASS_TOKEN || "";
+const LOAD_TEST_BYPASS_TOKEN = __ENV.LOAD_TEST_BYPASS_TOKEN || "";
 
 export function getBaseUrl() {
   return BASE_URL;
@@ -27,8 +26,8 @@ export function getCommonHeaders() {
     headers["CF-Access-Client-Secret"] = CF_ACCESS_CLIENT_SECRET;
   }
 
-  if (LOAD_TEST_CAPTCHA_BYPASS_TOKEN) {
-    headers["X-Load-Test-Captcha-Bypass"] = LOAD_TEST_CAPTCHA_BYPASS_TOKEN;
+  if (LOAD_TEST_BYPASS_TOKEN) {
+    headers["X-Load-Test-Mfa-Bypass"] = LOAD_TEST_BYPASS_TOKEN;
   }
 
   return headers;

--- a/tests/k6/ramp-until-breach.sh
+++ b/tests/k6/ramp-until-breach.sh
@@ -4,7 +4,7 @@
 #
 # Usage: ./ramp-until-breach.sh <base_url> [threshold%] [step_size] [step_duration] [max_vus]
 # Env: TEST_API_KEY, CF_ACCESS_CLIENT_ID, CF_ACCESS_CLIENT_SECRET,
-#      LOAD_TEST_CAPTCHA_BYPASS_TOKEN
+#      LOAD_TEST_BYPASS_TOKEN, LOAD_TEST_USER_PASSWORD
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -50,7 +50,8 @@ while [ "$current_vus" -le "$MAX_VUS" ]; do
     -e TEST_API_KEY="${TEST_API_KEY:-}" \
     -e CF_ACCESS_CLIENT_ID="${CF_ACCESS_CLIENT_ID:-}" \
     -e CF_ACCESS_CLIENT_SECRET="${CF_ACCESS_CLIENT_SECRET:-}" \
-    -e LOAD_TEST_CAPTCHA_BYPASS_TOKEN="${LOAD_TEST_CAPTCHA_BYPASS_TOKEN:-}" \
+    -e LOAD_TEST_BYPASS_TOKEN="${LOAD_TEST_BYPASS_TOKEN:-}" \
+    -e LOAD_TEST_USER_PASSWORD="${LOAD_TEST_USER_PASSWORD:-}" \
     -e K6_SCENARIO=ci \
     --no-usage-report \
     2>&1 | tee "$output_file" || tier_exit=$?

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -518,6 +518,108 @@ describe("MFA gate", () => {
   });
 });
 
+describe("MFA gate: load-test bypass header", () => {
+  const BYPASS_TOKEN = "load-test-bypass-token-32-bytes-long!";
+  const SAME_LENGTH_WRONG = "WRONG-TOKEN-DIFFERENT-VALUE-XXXXXXXXX";
+
+  function sessionCookieHeaders(): Record<string, string> {
+    return {
+      cookie: "better-auth.session_token=tok",
+      origin: "http://localhost:3000",
+    };
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    mockGetSession.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  async function loadProxyWithBypassTokenSet(): Promise<typeof proxy> {
+    vi.stubEnv("LOAD_TEST_BYPASS_TOKEN", BYPASS_TOKEN);
+    const mod = await import("@/proxy");
+    return mod.proxy;
+  }
+
+  it("passes an authenticated API request when the bypass header matches", async () => {
+    expect(SAME_LENGTH_WRONG.length).toBe(BYPASS_TOKEN.length);
+    mockGetSession.mockResolvedValue({
+      user: { id: "u1", twoFactorEnabled: false },
+      session: { requiresMfa: false },
+    });
+    const proxyFn = await loadProxyWithBypassTokenSet();
+    const res = await proxyFn(
+      make("/api/workflows", {
+        headers: {
+          ...sessionCookieHeaders(),
+          "x-load-test-mfa-bypass": BYPASS_TOKEN,
+        },
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(mockGetSession).not.toHaveBeenCalled();
+  });
+
+  it("does not honor a same-length but wrong bypass header", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: "u1", twoFactorEnabled: false },
+      session: { requiresMfa: false },
+    });
+    const proxyFn = await loadProxyWithBypassTokenSet();
+    const res = await proxyFn(
+      make("/api/workflows", {
+        headers: {
+          ...sessionCookieHeaders(),
+          "x-load-test-mfa-bypass": SAME_LENGTH_WRONG,
+        },
+      })
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("mfa_enrollment_required");
+  });
+
+  it("does not honor a wrong-length bypass header", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: "u1", twoFactorEnabled: false },
+      session: { requiresMfa: false },
+    });
+    const proxyFn = await loadProxyWithBypassTokenSet();
+    const res = await proxyFn(
+      make("/api/workflows", {
+        headers: {
+          ...sessionCookieHeaders(),
+          "x-load-test-mfa-bypass": "too-short",
+        },
+      })
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("ignores the bypass header entirely when the env token is unset", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: "u1", twoFactorEnabled: false },
+      session: { requiresMfa: false },
+    });
+    const mod = await import("@/proxy");
+    const res = await mod.proxy(
+      make("/api/workflows", {
+        headers: {
+          ...sessionCookieHeaders(),
+          "x-load-test-mfa-bypass": BYPASS_TOKEN,
+        },
+      })
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("mfa_enrollment_required");
+  });
+});
+
 describe("Country gate", () => {
   // Authenticated, enrolled, MFA-verified user with an email so mfaBlock
   // returns a real user and the country gate runs.

--- a/tests/unit/signup-defenses.test.ts
+++ b/tests/unit/signup-defenses.test.ts
@@ -5,18 +5,9 @@ type RateLimitRuleFn = (
   req: Request,
   defaults: RateLimitRule
 ) => Promise<RateLimitRule | false> | RateLimitRule | false;
-type CaptchaPluginCtx = {
-  logger: {
-    info: (...args: unknown[]) => void;
-    error: (...args: unknown[]) => void;
-  };
-};
 type CaptchaPluginShape = {
   id: string;
   options: { provider?: string; endpoints?: string[]; secretKey?: string };
-};
-type CaptchaPluginWithRequest = CaptchaPluginShape & {
-  onRequest: (request: Request, ctx: CaptchaPluginCtx) => Promise<unknown>;
 };
 
 const TEST_API_KEY = "kha_test_signup_defenses_key";
@@ -35,8 +26,6 @@ function clearTurnstileEnv(): void {
   delete process.env.NEXT_PHASE;
   // biome-ignore lint/performance/noDelete: same
   delete process.env.TURNSTILE_ENFORCE;
-  // biome-ignore lint/performance/noDelete: same
-  delete process.env.LOAD_TEST_CAPTCHA_BYPASS_TOKEN;
 }
 
 describe("signup defenses: captcha plugin", () => {
@@ -137,144 +126,6 @@ describe("signup defenses: captcha plugin", () => {
     vi.stubEnv("TURNSTILE_ENFORCE", "true");
     await expect(import("@/lib/auth")).rejects.toThrow(
       MISSING_CAPTCHA_SECRET_ERROR
-    );
-  });
-});
-
-describe("signup defenses: load-test captcha bypass", () => {
-  const BYPASS_TOKEN = "0123456789abcdef0123456789abcdef";
-  const SAME_LENGTH_WRONG = "ffffffffffffffffffffffffffffffff";
-  const SIGNUP_URL = "http://localhost:3000/api/auth/sign-up/email";
-
-  beforeEach(() => {
-    vi.resetModules();
-    vi.unstubAllEnvs();
-    clearTurnstileEnv();
-  });
-
-  afterEach(() => {
-    vi.unstubAllEnvs();
-    clearTurnstileEnv();
-  });
-
-  async function loadCaptchaPlugin(): Promise<CaptchaPluginWithRequest> {
-    const { auth } = await import("@/lib/auth");
-    const plugin = (auth.options.plugins ?? []).find(
-      (p) => (p as { id?: string }).id === "captcha"
-    );
-    if (!plugin) {
-      throw new Error("captcha plugin not loaded");
-    }
-    return plugin as unknown as CaptchaPluginWithRequest;
-  }
-
-  function makeRequest(headers: Record<string, string> = {}): Request {
-    return new Request(SIGNUP_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", ...headers },
-      body: JSON.stringify({ email: "x@x.test", password: "x", name: "x" }),
-    });
-  }
-
-  function makeCtx(): CaptchaPluginCtx & {
-    logger: {
-      info: ReturnType<typeof vi.fn>;
-      error: ReturnType<typeof vi.fn>;
-    };
-  } {
-    return {
-      logger: {
-        info: vi.fn() as unknown as (...args: unknown[]) => void,
-        error: vi.fn() as unknown as (...args: unknown[]) => void,
-      },
-    } as never;
-  }
-
-  it("passes through when the bypass header matches the env token", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    vi.stubEnv("CI", "");
-    process.env.TURNSTILE_SECRET_KEY = "test-secret";
-    process.env.LOAD_TEST_CAPTCHA_BYPASS_TOKEN = BYPASS_TOKEN;
-    const plugin = await loadCaptchaPlugin();
-    const ctx = makeCtx();
-    const result = await plugin.onRequest(
-      makeRequest({ "X-Load-Test-Captcha-Bypass": BYPASS_TOKEN }),
-      ctx
-    );
-    expect(result).toBeUndefined();
-    expect(ctx.logger.info).toHaveBeenCalledWith(
-      "captcha bypass header accepted",
-      expect.objectContaining({ endpoint: expect.stringContaining(SIGNUP_URL) })
-    );
-  });
-
-  it("delegates to the underlying captcha check when no bypass header is sent", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    vi.stubEnv("CI", "");
-    process.env.TURNSTILE_SECRET_KEY = "test-secret";
-    process.env.LOAD_TEST_CAPTCHA_BYPASS_TOKEN = BYPASS_TOKEN;
-    const plugin = await loadCaptchaPlugin();
-    const ctx = makeCtx();
-    const result = await plugin.onRequest(makeRequest(), ctx);
-    expect(result).toBeDefined();
-    expect(ctx.logger.info).not.toHaveBeenCalledWith(
-      "captcha bypass header accepted",
-      expect.anything()
-    );
-  });
-
-  it("delegates when the bypass header is the same length but the wrong value", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    vi.stubEnv("CI", "");
-    process.env.TURNSTILE_SECRET_KEY = "test-secret";
-    process.env.LOAD_TEST_CAPTCHA_BYPASS_TOKEN = BYPASS_TOKEN;
-    const plugin = await loadCaptchaPlugin();
-    expect(SAME_LENGTH_WRONG.length).toBe(BYPASS_TOKEN.length);
-    const ctx = makeCtx();
-    const result = await plugin.onRequest(
-      makeRequest({ "X-Load-Test-Captcha-Bypass": SAME_LENGTH_WRONG }),
-      ctx
-    );
-    expect(result).toBeDefined();
-    expect(ctx.logger.info).not.toHaveBeenCalledWith(
-      "captcha bypass header accepted",
-      expect.anything()
-    );
-  });
-
-  it("delegates when the bypass header is the wrong length", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    vi.stubEnv("CI", "");
-    process.env.TURNSTILE_SECRET_KEY = "test-secret";
-    process.env.LOAD_TEST_CAPTCHA_BYPASS_TOKEN = BYPASS_TOKEN;
-    const plugin = await loadCaptchaPlugin();
-    const ctx = makeCtx();
-    const result = await plugin.onRequest(
-      makeRequest({ "X-Load-Test-Captcha-Bypass": "too-short" }),
-      ctx
-    );
-    expect(result).toBeDefined();
-    expect(ctx.logger.info).not.toHaveBeenCalledWith(
-      "captcha bypass header accepted",
-      expect.anything()
-    );
-  });
-
-  it("ignores the bypass header entirely when the env token is unset", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    vi.stubEnv("CI", "");
-    process.env.TURNSTILE_SECRET_KEY = "test-secret";
-    // LOAD_TEST_CAPTCHA_BYPASS_TOKEN intentionally left unset (production posture)
-    const plugin = await loadCaptchaPlugin();
-    const ctx = makeCtx();
-    const result = await plugin.onRequest(
-      makeRequest({ "X-Load-Test-Captcha-Bypass": BYPASS_TOKEN }),
-      ctx
-    );
-    expect(result).toBeDefined();
-    expect(ctx.logger.info).not.toHaveBeenCalledWith(
-      "captcha bypass header accepted",
-      expect.anything()
     );
   });
 });


### PR DESCRIPTION
## Summary

Switches the k6 load test to use 50 pre-seeded users (`k6-loadtest-vu1..50@techops.services`) instead of dynamically signing up + verifying email on every run. Removes the captcha-bypass wrapper and bypass-header wiring landed in #1502 / #1503 since they no longer have a code path that exercises them. Adds a single server-side bypass for the mandatory-MFA gate so the seeded users (which have `twoFactorEnabled=true` but a fresh session sets `requires_mfa=true`) can reach protected routes.

## Server-side

- `proxy.ts` — skip the mandatory-MFA gate when `X-Load-Test-Mfa-Bypass` matches `LOAD_TEST_BYPASS_TOKEN` (timing-safe). With the env var unset in prod, the helper short-circuits to `false` and the gate behaves exactly as before.
- `app/api/admin/test/cleanup/route.staging.ts`:
  - Tightens the destructive cleanup pattern from `k6-%` to `k6-vu%` so it no longer matches the seeded users
  - Adds a workflow-only cleanup pass for the seeded users (preserves user/org/membership rows so the next run can sign in with the same credentials)
- `scripts/seed-load-test-users.ts` — idempotent seeder. Run once against staging via `kubectl exec` into the keeperhub-common pod (it has `DATABASE_URL` and `LOAD_TEST_USER_PASSWORD` in env via values.yaml).

## K6 test changes

- `tests/k6/execution-load-test.js` — `authenticate()` collapses to a single signin call; the `signup → admin-otp → verify-email` chain is gone.
- `tests/k6/helpers/auth.js` — same simplification for the http-ramp path; api-key creation kept (still optional per VU).
- `tests/k6/helpers/http.js` — sends `X-Load-Test-Mfa-Bypass` instead of `X-Load-Test-Captcha-Bypass`.
- `tests/k6/ramp-until-breach.sh` — passes the new env var through to k6.

## Reverted from #1502 / #1503

- `lib/auth.ts` captcha-plugin wrapper
- `tests/k6/helpers/http.js` + `tests/k6/execution-load-test.js` bypass header wiring (replaced with MFA-bypass header)
- `tests/unit/signup-defenses.test.ts` bypass tests

## Env var rename

`LOAD_TEST_CAPTCHA_BYPASS_TOKEN` → `LOAD_TEST_BYPASS_TOKEN` since the value only powers the MFA bypass now. The SSM path stays at `/eks/techops-staging/keeperhub/load-test-captcha-bypass-token` so we don't have to re-issue the secret; only the pod env var name and downstream references change. GH Actions secret needs to be renamed alongside merge.

## Test plan

- [x] `pnpm vitest run tests/unit/proxy.test.ts tests/unit/signup-defenses.test.ts` - 62/62 pass with `CI=true`
- [x] `pnpm check` on changed files - 0 new lint errors (cleanup endpoint preserves pre-existing baseline)
- [x] `pnpm type-check` - no new errors
- [ ] Post-merge: apply infra PR to provision `load-test-user-password` SSM; sync both SSM values to GH Actions secrets (`LOAD_TEST_BYPASS_TOKEN`, `LOAD_TEST_USER_PASSWORD`); `kubectl exec` the keeperhub-common pod and run `pnpm tsx scripts/seed-load-test-users.ts`; dispatch the k6 workflow and confirm the run completes end-to-end.

Paired with the infrastructure PR adding the password SSM param.
