### PR TITLE
fix(scripts/seed): give seeded orgs a pro subscription

### DIFF
--- a/scripts/seed-load-test-users.ts
+++ b/scripts/seed-load-test-users.ts
@@ -2,7 +2,13 @@ import { randomUUID } from "node:crypto";
 import { hashPassword } from "better-auth/crypto";
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { accounts, member, organization, users } from "@/lib/db/schema";
+import {
+  accounts,
+  member,
+  organization,
+  organizationSubscriptions,
+  users,
+} from "@/lib/db/schema";
 
 const COUNT = Number(process.env.SEED_COUNT ?? "50");
 const EMAIL_PREFIX = "k6-loadtest-vu";
@@ -23,6 +29,7 @@ async function seedUser(vuId: number, password: string): Promise<"created" | "sk
   const orgId = randomUUID();
   const memberId = randomUUID();
   const accountId = randomUUID();
+  const subscriptionId = randomUUID();
   const now = new Date();
   const slug = `k6-loadtest-vu${vuId}-${randomUUID().slice(0, 6)}`;
 
@@ -57,6 +64,14 @@ async function seedUser(vuId: number, password: string): Promise<"created" | "sk
       userId,
       role: "owner",
       createdAt: now,
+    });
+    await tx.insert(organizationSubscriptions).values({
+      id: subscriptionId,
+      organizationId: orgId,
+      plan: "pro",
+      status: "active",
+      createdAt: now,
+      updatedAt: now,
     });
   });
 


### PR DESCRIPTION
## Summary

Follow-up to the pre-seeded-users PR (#1505). When dispatching the k6 workflow against staging post-merge, every `/api/workflows/create` call returned **402 upgrade_required** because the seeded orgs had no `organization_subscriptions` row, so `getOrgPlan()` defaulted them to `"free"` and `enforceWorkflowFeatures` blocked any workflow containing an HTTP Request action (which the k6 test uses).

The staging users were unblocked by hand with a direct SQL insert. This PR teaches the seed script to do the same in the same transaction so the next operator (or re-seed run) doesn't have to.

## Changes

- `scripts/seed-load-test-users.ts`: insert `organization_subscriptions { plan: "pro", status: "active" }` in the same transaction as the user/org/membership rows

## Verified

- Local: seed produces 4 row types + the subscription. `pnpm check` clean.
- Staging (after the manual hand-fix that this PR encodes): k6 workflow run completed end-to-end - 1625 workflows created, 1781 manual triggers succeeded, http_req_failed=7.25%, cleanup preserved the seeded users.
