### PR TITLE
chore(deploy): enable gas sponsorship in prod

### DIFF
--- a/deploy/executor/prod/values.yaml
+++ b/deploy/executor/prod/values.yaml
@@ -147,7 +147,7 @@ env:
     value: "true"
   NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED:
     type: kv
-    value: "false"
+    value: "true"
   # Gas credit caps per plan (cents, server-only)
   GAS_CREDITS_FREE_CENTS:
     type: kv

--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -343,7 +343,7 @@ env:
     value: "true"
   NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED:
     type: kv
-    value: "false"
+    value: "true"
   # AI Prompt feature flag - disabled
   # (gates UI render in components/workflow/workflow-canvas.tsx
   #  and /api/ai/generate route)


### PR DESCRIPTION
## What

Flip `NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED` to `true` in prod on both the app and the executor deployments.

- `deploy/keeperhub/prod/values.yaml` (app: in-process executions + client bundle)
- `deploy/executor/prod/values.yaml` (executor: forwards the flag to workflow runner pods)

Staging is already `true` on both.

## Why

Builds on the runner-env forwarding fix (already merged to staging). Gas sponsorship is validated in staging: scheduled web3 writes are sponsored, and the per-org gas-credit cap guardrail is enforced. Enabling prod so prod scheduled web3 writes are sponsored as well, under the same gas-credit caps.