### PR TITLE
feat: add backup provider option to block explorer (KEEP-806)

### DIFF
--- a/drizzle/0107_backup_explorer_api.sql
+++ b/drizzle/0107_backup_explorer_api.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "explorer_configs" ADD COLUMN "backup_explorer_api_type" text;--> statement-breakpoint
+ALTER TABLE "explorer_configs" ADD COLUMN "backup_explorer_api_url" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -750,6 +750,13 @@
       "when": 1779843900013,
       "tag": "0106_keep_586_digest_multi_cadence",
       "breakpoints": true
+    },
+    {
+      "idx": 107,
+      "version": "7",
+      "when": 1779843900014,
+      "tag": "0107_backup_explorer_api",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -962,6 +962,8 @@ export const explorerConfigs = pgTable(
     explorerUrl: text("explorer_url"), // e.g., "https://etherscan.io"
     explorerApiType: text("explorer_api_type"), // "etherscan" | "blockscout" | "solscan"
     explorerApiUrl: text("explorer_api_url"), // Base URL for API calls (ABI, balance, etc.)
+    backupExplorerApiType: text("backup_explorer_api_type"), // fallback API type if primary fails
+    backupExplorerApiUrl: text("backup_explorer_api_url"), // fallback API URL if primary fails
     explorerTxPath: text("explorer_tx_path").default("/tx/{hash}"),
     explorerAddressPath: text("explorer_address_path").default(
       "/address/{address}"

--- a/lib/explorer/index.ts
+++ b/lib/explorer/index.ts
@@ -160,35 +160,19 @@ function normalizeBlockscoutTx(
   };
 }
 
-/**
- * Fetch transaction list for a contract address from the appropriate explorer
- *
- * @param config - Explorer configuration from database
- * @param contractAddress - Contract address to list transactions for
- * @param chainId - Chain ID (required for Etherscan v2)
- * @param startBlock - Start block number
- * @param endBlock - End block number
- * @param apiKey - Optional API key (required for Etherscan)
- */
-export async function fetchContractTransactions(
-  config: ExplorerConfig,
+async function fetchTransactionsFromProvider(
+  apiType: string,
+  apiUrl: string,
   contractAddress: string,
   chainId: number,
   startBlock: number,
   endBlock: number,
   apiKey?: string
 ): Promise<TransactionListResult> {
-  if (!(config.explorerApiUrl && config.explorerApiType)) {
-    return {
-      success: false,
-      error: "Explorer API not configured for this chain",
-    };
-  }
-
-  switch (config.explorerApiType) {
+  switch (apiType) {
     case "etherscan": {
       const result = await fetchEtherscanTransactions(
-        config.explorerApiUrl,
+        apiUrl,
         chainId,
         contractAddress,
         startBlock,
@@ -206,7 +190,7 @@ export async function fetchContractTransactions(
 
     case "blockscout": {
       const result = await fetchBlockscoutTransactions(
-        config.explorerApiUrl,
+        apiUrl,
         contractAddress,
         startBlock,
         endBlock
@@ -223,7 +207,69 @@ export async function fetchContractTransactions(
     default:
       return {
         success: false,
-        error: `Transaction listing not supported for explorer type: ${config.explorerApiType}`,
+        error: `Transaction listing not supported for explorer type: ${apiType}`,
       };
   }
+}
+
+/**
+ * Fetch transaction list for a contract address from the appropriate explorer.
+ * If the primary explorer API fails, falls back to the backup explorer API
+ * when one is configured on the chain's explorer config.
+ *
+ * @param config - Explorer configuration from database
+ * @param contractAddress - Contract address to list transactions for
+ * @param chainId - Chain ID (required for Etherscan v2)
+ * @param startBlock - Start block number
+ * @param endBlock - End block number
+ * @param apiKey - Optional API key (used for Etherscan primary and backup)
+ */
+export async function fetchContractTransactions(
+  config: ExplorerConfig,
+  contractAddress: string,
+  chainId: number,
+  startBlock: number,
+  endBlock: number,
+  apiKey?: string
+): Promise<TransactionListResult> {
+  if (!(config.explorerApiUrl && config.explorerApiType)) {
+    return {
+      success: false,
+      error: "Explorer API not configured for this chain",
+    };
+  }
+
+  const primaryResult = await fetchTransactionsFromProvider(
+    config.explorerApiType,
+    config.explorerApiUrl,
+    contractAddress,
+    chainId,
+    startBlock,
+    endBlock,
+    apiKey
+  );
+
+  if (primaryResult.success) {
+    return primaryResult;
+  }
+
+  if (!(config.backupExplorerApiUrl && config.backupExplorerApiType)) {
+    return primaryResult;
+  }
+
+  const backupResult = await fetchTransactionsFromProvider(
+    config.backupExplorerApiType,
+    config.backupExplorerApiUrl,
+    contractAddress,
+    chainId,
+    startBlock,
+    endBlock,
+    apiKey
+  );
+
+  if (backupResult.success) {
+    return backupResult;
+  }
+
+  return primaryResult;
 }

--- a/lib/explorer/index.ts
+++ b/lib/explorer/index.ts
@@ -212,17 +212,22 @@ async function fetchTransactionsFromProvider(
   }
 }
 
+const RETRY_BACKOFF_MS = 10_000;
+const RETRY_ROUNDS = 2;
+
 /**
  * Fetch transaction list for a contract address from the appropriate explorer.
- * If the primary explorer API fails, falls back to the backup explorer API
- * when one is configured on the chain's explorer config.
  *
- * @param config - Explorer configuration from database
- * @param contractAddress - Contract address to list transactions for
- * @param chainId - Chain ID (required for Etherscan v2)
- * @param startBlock - Start block number
- * @param endBlock - End block number
- * @param apiKey - Optional API key (used for Etherscan primary and backup)
+ * When a backup provider is configured the function runs up to RETRY_ROUNDS
+ * rounds of (primary -> backup) with a RETRY_BACKOFF_MS pause between rounds,
+ * so a transient double-failure on both providers within the same window can
+ * self-heal on the next round without the caller having to retry. Rate-limiting
+ * is the most common cause of simultaneous failures, so the backoff is
+ * intentionally long (10 s) to avoid amplifying the problem.
+ *
+ * When all attempts fail the error message surfaces both providers' last errors
+ * so callers can distinguish e.g. "primary rate-limited, backup bad key" from
+ * a uniform outage.
  */
 export async function fetchContractTransactions(
   config: ExplorerConfig,
@@ -239,37 +244,70 @@ export async function fetchContractTransactions(
     };
   }
 
-  const primaryResult = await fetchTransactionsFromProvider(
-    config.explorerApiType,
-    config.explorerApiUrl,
-    contractAddress,
-    chainId,
-    startBlock,
-    endBlock,
-    apiKey
-  );
+  const backup =
+    config.backupExplorerApiType != null && config.backupExplorerApiUrl != null
+      ? {
+          apiType: config.backupExplorerApiType,
+          apiUrl: config.backupExplorerApiUrl,
+        }
+      : null;
 
-  if (primaryResult.success) {
-    return primaryResult;
+  let lastPrimaryError: string | undefined;
+  let lastBackupError: string | undefined;
+
+  for (let round = 0; round < RETRY_ROUNDS; round++) {
+    if (round > 0) {
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, RETRY_BACKOFF_MS)
+      );
+    }
+
+    const primaryResult = await fetchTransactionsFromProvider(
+      config.explorerApiType,
+      config.explorerApiUrl,
+      contractAddress,
+      chainId,
+      startBlock,
+      endBlock,
+      apiKey
+    );
+
+    if (primaryResult.success) {
+      return primaryResult;
+    }
+
+    lastPrimaryError = primaryResult.error;
+
+    if (backup === null) {
+      continue;
+    }
+
+    const backupResult = await fetchTransactionsFromProvider(
+      backup.apiType,
+      backup.apiUrl,
+      contractAddress,
+      chainId,
+      startBlock,
+      endBlock,
+      apiKey
+    );
+
+    if (backupResult.success) {
+      return backupResult;
+    }
+
+    lastBackupError = backupResult.error;
   }
 
-  if (!(config.backupExplorerApiUrl && config.backupExplorerApiType)) {
-    return primaryResult;
+  if (lastBackupError !== undefined) {
+    return {
+      success: false,
+      error: `All explorer providers failed. Primary: ${lastPrimaryError}. Backup: ${lastBackupError}`,
+    };
   }
 
-  const backupResult = await fetchTransactionsFromProvider(
-    config.backupExplorerApiType,
-    config.backupExplorerApiUrl,
-    contractAddress,
-    chainId,
-    startBlock,
-    endBlock,
-    apiKey
-  );
-
-  if (backupResult.success) {
-    return backupResult;
-  }
-
-  return primaryResult;
+  return {
+    success: false,
+    error: lastPrimaryError ?? "Explorer request failed",
+  };
 }

--- a/tests/unit/explorer.test.ts
+++ b/tests/unit/explorer.test.ts
@@ -38,6 +38,8 @@ describe("explorer", () => {
     explorerTxPath: "/tx/{hash}",
     explorerAddressPath: "/address/{address}",
     explorerContractPath: "/address/{address}#code",
+    backupExplorerApiType: null,
+    backupExplorerApiUrl: null,
     createdAt: new Date(),
     updatedAt: new Date(),
   };
@@ -52,6 +54,8 @@ describe("explorer", () => {
     explorerTxPath: "/tx/{hash}",
     explorerAddressPath: "/address/{address}",
     explorerContractPath: "/address/{address}?tab=contract",
+    backupExplorerApiType: null,
+    backupExplorerApiUrl: null,
     createdAt: new Date(),
     updatedAt: new Date(),
   };
@@ -66,6 +70,8 @@ describe("explorer", () => {
     explorerTxPath: "/tx/{hash}",
     explorerAddressPath: "/account/{address}",
     explorerContractPath: "/account/{address}#anchorProgramIDL",
+    backupExplorerApiType: null,
+    backupExplorerApiUrl: null,
     createdAt: new Date(),
     updatedAt: new Date(),
   };

--- a/tests/unit/query-transactions-core.test.ts
+++ b/tests/unit/query-transactions-core.test.ts
@@ -1,0 +1,482 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/workflow/executor/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
+  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: {
+    VALIDATION: "validation",
+    NETWORK_RPC: "network_rpc",
+    EXTERNAL_SERVICE: "external_service",
+  },
+  logUserError: vi.fn(),
+}));
+
+const mockDbSelect = vi.fn();
+const mockFindFirst = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: (...args: unknown[]) => mockDbSelect(...args),
+    query: {
+      explorerConfigs: {
+        findFirst: (...args: unknown[]) => mockFindFirst(...args),
+      },
+    },
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: { id: "id", userId: "userId" },
+  explorerConfigs: { chainId: "chainId" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: () => ({}),
+}));
+
+const mockGetChainIdFromNetwork = vi.fn();
+vi.mock("@/lib/rpc/network-utils", () => ({
+  getChainIdFromNetwork: (...args: unknown[]) =>
+    mockGetChainIdFromNetwork(...args),
+}));
+
+const mockExecuteWithFailover = vi.fn();
+vi.mock("@/lib/rpc/provider-factory", () => ({
+  getRpcProvider: () =>
+    Promise.resolve({ executeWithFailover: mockExecuteWithFailover }),
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+import { queryTransactionsCore } from "@/plugins/web3/steps/query-transactions-core";
+
+const CONTRACT_ADDRESS = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+
+const MINIMAL_ABI = JSON.stringify([
+  {
+    type: "function",
+    name: "transfer",
+    inputs: [
+      { name: "recipient", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+]);
+
+const BASE_INPUT = {
+  network: "ethereum",
+  contractAddress: CONTRACT_ADDRESS,
+  abi: MINIMAL_ABI,
+  abiFunction: "transfer",
+  fromBlock: "100",
+  toBlock: "200",
+};
+
+function makeEtherscanTxResponse(
+  transactions: Array<{
+    hash: string;
+    from?: string;
+    to?: string;
+    input?: string;
+    blockNumber?: string;
+  }>,
+  status = "1"
+): unknown {
+  return {
+    status,
+    message: status === "1" ? "OK" : "NOTOK",
+    result: transactions.map((tx) => ({
+      hash: tx.hash,
+      from: tx.from ?? "0xsender",
+      to: tx.to ?? CONTRACT_ADDRESS,
+      value: "0",
+      input:
+        tx.input ??
+        "0xa9059cbb000000000000000000000000ab8483f64d9c6d1ecf9b849ae677dd3315835cb2000000000000000000000000000000000000000000000000000000000000000a",
+      blockNumber: tx.blockNumber ?? "150",
+      timeStamp: "1700000000",
+      isError: "0",
+      functionName: "transfer(address,uint256)",
+    })),
+  };
+}
+
+describe("queryTransactionsCore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockGetChainIdFromNetwork.mockReturnValue(1);
+    mockDbSelect.mockReturnValue({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve([]) }),
+      }),
+    });
+    mockExecuteWithFailover.mockImplementation(
+      (fn: (p: { getBlockNumber: () => Promise<number> }) => unknown) =>
+        fn({ getBlockNumber: () => Promise.resolve(200) })
+    );
+  });
+
+  describe("validation", () => {
+    it("returns error for invalid contract address", async () => {
+      const result = await queryTransactionsCore({
+        ...BASE_INPUT,
+        contractAddress: "not-an-address",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Invalid contract address");
+      }
+    });
+
+    it("returns error for invalid ABI JSON", async () => {
+      const result = await queryTransactionsCore({
+        ...BASE_INPUT,
+        abi: "not-json",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Invalid ABI JSON");
+      }
+    });
+
+    it("returns error when function not found in ABI", async () => {
+      const result = await queryTransactionsCore({
+        ...BASE_INPUT,
+        abiFunction: "nonexistentFunction",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("nonexistentFunction");
+      }
+    });
+
+    it("returns error when no explorer config found for chain", async () => {
+      mockFindFirst.mockResolvedValue(undefined);
+
+      const result = await queryTransactionsCore(BASE_INPUT);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("No explorer configuration found");
+      }
+    });
+  });
+
+  describe("successful transaction fetch", () => {
+    it("returns matched transactions when primary explorer succeeds", async () => {
+      mockFindFirst.mockResolvedValue({
+        chainId: 1,
+        chainType: "evm",
+        explorerUrl: "https://etherscan.io",
+        explorerApiType: "etherscan",
+        explorerApiUrl: "https://api.etherscan.io/v2/api",
+        explorerTxPath: "/tx/{hash}",
+        explorerAddressPath: "/address/{address}",
+        explorerContractPath: null,
+        backupExplorerApiType: null,
+        backupExplorerApiUrl: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve(makeEtherscanTxResponse([{ hash: "0xabc" }])),
+      });
+
+      const result = await queryTransactionsCore(BASE_INPUT);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.matchCount).toBe(1);
+        expect(result.transactions[0].hash).toBe("0xabc");
+        expect(result.transactions[0].functionName).toBe("transfer");
+      }
+    });
+
+    it("returns empty results when no transactions match the function", async () => {
+      mockFindFirst.mockResolvedValue({
+        chainId: 1,
+        chainType: "evm",
+        explorerUrl: "https://etherscan.io",
+        explorerApiType: "etherscan",
+        explorerApiUrl: "https://api.etherscan.io/v2/api",
+        explorerTxPath: "/tx/{hash}",
+        explorerAddressPath: "/address/{address}",
+        explorerContractPath: null,
+        backupExplorerApiType: null,
+        backupExplorerApiUrl: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            status: "0",
+            message: "No transactions found",
+            result: "No transactions found",
+          }),
+      });
+
+      const result = await queryTransactionsCore(BASE_INPUT);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.matchCount).toBe(0);
+        expect(result.transactions).toEqual([]);
+      }
+    });
+  });
+
+  describe("backup explorer fallback", () => {
+    it("falls back to backup explorer when primary fails", async () => {
+      mockFindFirst.mockResolvedValue({
+        chainId: 1,
+        chainType: "evm",
+        explorerUrl: "https://etherscan.io",
+        explorerApiType: "etherscan",
+        explorerApiUrl: "https://api.etherscan.io/v2/api",
+        explorerTxPath: "/tx/{hash}",
+        explorerAddressPath: "/address/{address}",
+        explorerContractPath: null,
+        backupExplorerApiType: "blockscout",
+        backupExplorerApiUrl: "https://backup.blockscout.io/api",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      // Primary Etherscan call fails
+      mockFetch.mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            status: "0",
+            message: "NOTOK",
+            result: "Rate limit exceeded",
+          }),
+      });
+
+      // Backup Blockscout call succeeds
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            items: [
+              {
+                hash: "0xfallback",
+                from: { hash: "0xsender" },
+                to: { hash: CONTRACT_ADDRESS },
+                value: "0",
+                raw_input:
+                  "0xa9059cbb000000000000000000000000ab8483f64d9c6d1ecf9b849ae677dd3315835cb2000000000000000000000000000000000000000000000000000000000000000a",
+                block: 150,
+                timestamp: "2024-01-01T00:00:00Z",
+                status: "ok",
+                method: "transfer",
+              },
+            ],
+            next_page_params: null,
+          }),
+      });
+
+      const result = await queryTransactionsCore(BASE_INPUT);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.matchCount).toBe(1);
+        expect(result.transactions[0].hash).toBe("0xfallback");
+      }
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns primary error when both primary and backup fail", async () => {
+      mockFindFirst.mockResolvedValue({
+        chainId: 1,
+        chainType: "evm",
+        explorerUrl: "https://etherscan.io",
+        explorerApiType: "etherscan",
+        explorerApiUrl: "https://api.etherscan.io/v2/api",
+        explorerTxPath: "/tx/{hash}",
+        explorerAddressPath: "/address/{address}",
+        explorerContractPath: null,
+        backupExplorerApiType: "etherscan",
+        backupExplorerApiUrl: "https://backup.etherscan.io/v2/api",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            status: "0",
+            message: "NOTOK",
+            result: "Rate limit exceeded",
+          }),
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            status: "0",
+            message: "NOTOK",
+            result: "Service unavailable",
+          }),
+      });
+
+      const result = await queryTransactionsCore(BASE_INPUT);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe(
+          "Rate limit exceeded. Please try again later."
+        );
+      }
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not attempt backup when primary succeeds", async () => {
+      mockFindFirst.mockResolvedValue({
+        chainId: 1,
+        chainType: "evm",
+        explorerUrl: "https://etherscan.io",
+        explorerApiType: "etherscan",
+        explorerApiUrl: "https://api.etherscan.io/v2/api",
+        explorerTxPath: "/tx/{hash}",
+        explorerAddressPath: "/address/{address}",
+        explorerContractPath: null,
+        backupExplorerApiType: "blockscout",
+        backupExplorerApiUrl: "https://backup.blockscout.io/api",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve(makeEtherscanTxResponse([{ hash: "0xprimary" }])),
+      });
+
+      const result = await queryTransactionsCore(BASE_INPUT);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.transactions[0].hash).toBe("0xprimary");
+      }
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not attempt backup when no backup is configured", async () => {
+      mockFindFirst.mockResolvedValue({
+        chainId: 1,
+        chainType: "evm",
+        explorerUrl: "https://etherscan.io",
+        explorerApiType: "etherscan",
+        explorerApiUrl: "https://api.etherscan.io/v2/api",
+        explorerTxPath: "/tx/{hash}",
+        explorerAddressPath: "/address/{address}",
+        explorerContractPath: null,
+        backupExplorerApiType: null,
+        backupExplorerApiUrl: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            status: "0",
+            message: "NOTOK",
+            result: "Rate limit exceeded",
+          }),
+      });
+
+      const result = await queryTransactionsCore(BASE_INPUT);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe(
+          "Rate limit exceeded. Please try again later."
+        );
+      }
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back when primary throws a network error", async () => {
+      mockFindFirst.mockResolvedValue({
+        chainId: 1,
+        chainType: "evm",
+        explorerUrl: "https://etherscan.io",
+        explorerApiType: "etherscan",
+        explorerApiUrl: "https://api.etherscan.io/v2/api",
+        explorerTxPath: "/tx/{hash}",
+        explorerAddressPath: "/address/{address}",
+        explorerContractPath: null,
+        backupExplorerApiType: "etherscan",
+        backupExplorerApiUrl: "https://backup.etherscan.io/v2/api",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+      mockFetch.mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve(makeEtherscanTxResponse([{ hash: "0xrecovered" }])),
+      });
+
+      const result = await queryTransactionsCore(BASE_INPUT);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.transactions[0].hash).toBe("0xrecovered");
+      }
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("block range", () => {
+    it("returns empty results when fromBlock > toBlock", async () => {
+      mockFindFirst.mockResolvedValue({
+        chainId: 1,
+        chainType: "evm",
+        explorerUrl: "https://etherscan.io",
+        explorerApiType: "etherscan",
+        explorerApiUrl: "https://api.etherscan.io/v2/api",
+        explorerTxPath: "/tx/{hash}",
+        explorerAddressPath: "/address/{address}",
+        explorerContractPath: null,
+        backupExplorerApiType: null,
+        backupExplorerApiUrl: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await queryTransactionsCore({
+        ...BASE_INPUT,
+        fromBlock: "500",
+        toBlock: "100",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.transactions).toEqual([]);
+        expect(result.matchCount).toBe(0);
+      }
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/query-transactions-core.test.ts
+++ b/tests/unit/query-transactions-core.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
@@ -244,6 +244,14 @@ describe("queryTransactionsCore", () => {
   });
 
   describe("backup explorer fallback", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it("falls back to backup explorer when primary fails", async () => {
       mockFindFirst.mockResolvedValue({
         chainId: 1,
@@ -304,7 +312,7 @@ describe("queryTransactionsCore", () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
-    it("returns primary error when both primary and backup fail", async () => {
+    it("returns combined error when both providers fail on all rounds", async () => {
       mockFindFirst.mockResolvedValue({
         chainId: 1,
         chainType: "evm",
@@ -320,6 +328,60 @@ describe("queryTransactionsCore", () => {
         updatedAt: new Date(),
       });
 
+      const rateLimitResponse = {
+        json: () =>
+          Promise.resolve({
+            status: "0",
+            message: "NOTOK",
+            result: "Rate limit exceeded",
+          }),
+      };
+      const unavailableResponse = {
+        json: () =>
+          Promise.resolve({
+            status: "0",
+            message: "NOTOK",
+            result: "Service unavailable",
+          }),
+      };
+
+      // round 1
+      mockFetch.mockResolvedValueOnce(rateLimitResponse);
+      mockFetch.mockResolvedValueOnce(unavailableResponse);
+      // round 2 (after 10s backoff)
+      mockFetch.mockResolvedValueOnce(rateLimitResponse);
+      mockFetch.mockResolvedValueOnce(unavailableResponse);
+
+      const resultPromise = queryTransactionsCore(BASE_INPUT);
+      await vi.advanceTimersByTimeAsync(10_000);
+      const result = await resultPromise;
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("All explorer providers failed");
+        expect(result.error).toContain("Primary:");
+        expect(result.error).toContain("Backup:");
+      }
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+    });
+
+    it("self-heals when both providers fail transiently then primary succeeds on retry", async () => {
+      mockFindFirst.mockResolvedValue({
+        chainId: 1,
+        chainType: "evm",
+        explorerUrl: "https://etherscan.io",
+        explorerApiType: "etherscan",
+        explorerApiUrl: "https://api.etherscan.io/v2/api",
+        explorerTxPath: "/tx/{hash}",
+        explorerAddressPath: "/address/{address}",
+        explorerContractPath: null,
+        backupExplorerApiType: "etherscan",
+        backupExplorerApiUrl: "https://backup.etherscan.io/v2/api",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      // round 1: both fail
       mockFetch.mockResolvedValueOnce({
         json: () =>
           Promise.resolve({
@@ -328,25 +390,29 @@ describe("queryTransactionsCore", () => {
             result: "Rate limit exceeded",
           }),
       });
-
       mockFetch.mockResolvedValueOnce({
         json: () =>
           Promise.resolve({
             status: "0",
             message: "NOTOK",
-            result: "Service unavailable",
+            result: "Rate limit exceeded",
           }),
       });
+      // round 2: primary recovers
+      mockFetch.mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve(makeEtherscanTxResponse([{ hash: "0xrecovered" }])),
+      });
 
-      const result = await queryTransactionsCore(BASE_INPUT);
+      const resultPromise = queryTransactionsCore(BASE_INPUT);
+      await vi.advanceTimersByTimeAsync(10_000);
+      const result = await resultPromise;
 
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error).toBe(
-          "Rate limit exceeded. Please try again later."
-        );
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.transactions[0].hash).toBe("0xrecovered");
       }
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
     });
 
     it("does not attempt backup when primary succeeds", async () => {
@@ -379,7 +445,7 @@ describe("queryTransactionsCore", () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
-    it("does not attempt backup when no backup is configured", async () => {
+    it("retries primary alone when no backup is configured", async () => {
       mockFindFirst.mockResolvedValue({
         chainId: 1,
         chainType: "evm",
@@ -395,16 +461,21 @@ describe("queryTransactionsCore", () => {
         updatedAt: new Date(),
       });
 
-      mockFetch.mockResolvedValueOnce({
+      const failResponse = {
         json: () =>
           Promise.resolve({
             status: "0",
             message: "NOTOK",
             result: "Rate limit exceeded",
           }),
-      });
+      };
+      // round 1 and round 2 both fail
+      mockFetch.mockResolvedValueOnce(failResponse);
+      mockFetch.mockResolvedValueOnce(failResponse);
 
-      const result = await queryTransactionsCore(BASE_INPUT);
+      const resultPromise = queryTransactionsCore(BASE_INPUT);
+      await vi.advanceTimersByTimeAsync(10_000);
+      const result = await resultPromise;
 
       expect(result.success).toBe(false);
       if (!result.success) {
@@ -412,7 +483,7 @@ describe("queryTransactionsCore", () => {
           "Rate limit exceeded. Please try again later."
         );
       }
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
     it("falls back when primary throws a network error", async () => {


### PR DESCRIPTION
The web3/query-transactions node calls the block explorer configured for the required chain but it has no backup; if Etherscan fails, the execution fails.

This is added as optional. If no backup is configured, the code will continue to work as before this change was introduced.

This requires a DB migration in order to add 2 new columns to `explorer_configs`. Please let me know if we need to schedule it.