### PR TITLE
refactor: remove legacy bearer internal-service auth after HMAC cutover

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,8 +48,12 @@ SENTRY_ORG=
 SENTRY_PROJECT=
 SENTRY_AUTH_TOKEN=
 
-# Internal config
-KEEPERHUB_API_KEY=
+# Internal service-to-service auth (HMAC). AGENTIC_WALLET_HMAC_KMS_KEY is the
+# 32-byte base64 AES key the app uses to encrypt/decrypt the shared signing
+# secret in the internal_service_hmac_secrets store; it must be set for internal
+# auth to work locally. INTERNAL_SERVICE_HMAC_SECRET is the signing secret and
+# has a docker-compose default, so it is optional here.
+AGENTIC_WALLET_HMAC_KMS_KEY=bG9jYWwtZGV2LWFnZW50aWMtd2FsbGV0LWhtYWMta3k=
 
 # LocalStack auth token. REQUIRED for Docker and Hybrid modes -- the compose
 # file uses the Pro image which exits 55 ("License activation failed") if this

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -674,6 +674,69 @@ jobs:
             -f ${GITHUB_WORKSPACE}/values-pr-${PR_NUMBER}.yaml \
             --namespace "${NAMESPACE}" --timeout 10m0s --atomic --version 0.2.1
 
+      # Seed the internal-service HMAC store for this PR's fresh database. The
+      # app verifies HMAC-signed internal requests (reaper, dispatchers) against
+      # a DB-backed secret store that starts empty. This runs AFTER the app
+      # deploy so external-secrets has synced the signing secret from SSM - the
+      # app's db-migration initContainer can't do it (its secretKeyRef env is
+      # fixed at container start and races ESO on first boot). A short poll
+      # guards against the secret object existing before its value lands.
+      - name: Seed internal-service HMAC store
+        env:
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+          NAMESPACE: ${{ env.NAMESPACE }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
+        run: |
+          set -euo pipefail
+          SECRET_NAME="keeperhub-pr-${PR_NUMBER}-common-internal-service-hmac-secret"
+          echo "Waiting for ${SECRET_NAME} to be populated by external-secrets..."
+          for i in $(seq 1 60); do
+            v=$(kubectl get secret "${SECRET_NAME}" -n "${NAMESPACE}" -o jsonpath="{.data.${SECRET_NAME}}" 2>/dev/null || true)
+            [ -n "${v}" ] && { echo "secret populated"; break; }
+            sleep 5
+          done
+          DB_PASSWORD=$(kubectl get secret keeperhub-pr-${PR_NUMBER}-db-credentials -n "${NAMESPACE}" -o jsonpath='{.data.password}' | base64 -d)
+          ENCODED_PASSWORD=$(DB_PASSWORD="${DB_PASSWORD}" python3 -c "import urllib.parse, os; print(urllib.parse.quote(os.environ['DB_PASSWORD'], safe=''))")
+          DB_URL="postgresql://keeperhub:${ENCODED_PASSWORD}@keeperhub-pr-${PR_NUMBER}-db-rw.${NAMESPACE}.svc.cluster.local:5432/keeperhub"
+          kubectl delete job keeperhub-pr-${PR_NUMBER}-hmac-seed -n "${NAMESPACE}" --ignore-not-found
+          kubectl apply -n "${NAMESPACE}" -f - <<EOF
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: keeperhub-pr-${PR_NUMBER}-hmac-seed
+          spec:
+            backoffLimit: 2
+            ttlSecondsAfterFinished: 600
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: hmac-seed
+                    image: ${ECR_REGISTRY}/keeperhub-staging:migrator-${IMAGE_TAG}
+                    command: ["/bin/sh", "-c"]
+                    args:
+                      - 'printf "%s" "\$INTERNAL_SERVICE_HMAC_SECRET" | pnpm tsx scripts/seed-internal-service-hmac.ts || echo "seed skipped (row already present or failed - see above)"'
+                    env:
+                      - name: DATABASE_URL
+                        value: "${DB_URL}"
+                      - name: ALLOW_REMOTE
+                        value: "1"
+                      - name: INTERNAL_SERVICE_HMAC_SECRET
+                        valueFrom:
+                          secretKeyRef:
+                            name: keeperhub-pr-${PR_NUMBER}-common-internal-service-hmac-secret
+                            key: keeperhub-pr-${PR_NUMBER}-common-internal-service-hmac-secret
+                      - name: AGENTIC_WALLET_HMAC_KMS_KEY
+                        valueFrom:
+                          secretKeyRef:
+                            name: keeperhub-pr-${PR_NUMBER}-common-agentic-wallet-hmac-kms-key
+                            key: keeperhub-pr-${PR_NUMBER}-common-agentic-wallet-hmac-kms-key
+          EOF
+          kubectl wait --for=condition=complete job/keeperhub-pr-${PR_NUMBER}-hmac-seed -n "${NAMESPACE}" --timeout=180s || true
+          echo "--- hmac-seed job logs ---"
+          kubectl logs -n "${NAMESPACE}" job/keeperhub-pr-${PR_NUMBER}-hmac-seed --tail=30 || true
+
       # Opt-in (deploy-pr-metrics label). Deploys the metrics-collector
       # satellite against the PR DB so its /metrics can be curled directly
       # (ServiceMonitors are off in PR envs). TECH-6484.

--- a/app/api/internal/execution-digest/route.ts
+++ b/app/api/internal/execution-digest/route.ts
@@ -3,7 +3,7 @@
  *
  * Sends each opted-in org a summary of its workflow executions and failures to
  * the subscribed members, for each cadence the org subscribes to. Authenticated
- * as an internal service (X-Service-Key / HMAC) and invoked by the
+ * as an internal service (HMAC) and invoked by the
  * `execution-digest` k8s CronJob, which runs daily at 14:00 UTC via
  * deploy/scripts/digest-cron.sh. Daily cadence sends every run; weekly sends
  * only on Tuesdays; monthly sends only on the 1st (reporting the previous

--- a/app/api/workflows/events/route.ts
+++ b/app/api/workflows/events/route.ts
@@ -12,9 +12,8 @@ import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
 /**
  * Internal endpoint for workers to fetch active Event-type workflows.
  * Returns only enabled workflows with Event trigger type. Authentication
- * goes through the shared authenticateInternalService helper, which accepts
- * both the new HMAC scheme and the legacy X-Internal-Token / X-Service-Key
- * bearers during the dual-accept rollout window.
+ * goes through the shared authenticateInternalService helper, which verifies
+ * the request's HMAC signature.
  */
 export async function GET(request: Request) {
   try {

--- a/deploy/event-tracker/prod/values.yaml
+++ b/deploy/event-tracker/prod/values.yaml
@@ -46,10 +46,6 @@ env:
   KEEPERHUB_API_URL:
     type: kv
     value: "http://keeperhub-common:3000"
-  KEEPERHUB_API_KEY:
-    type: parameterStore
-    name: keeperhub-api-key
-    parameter_name: /eks/techops-prod/keeperhub-events/keeperhub-api-key
   INTERNAL_SERVICE_HMAC_SECRET:
     type: parameterStore
     name: internal-service-hmac-secret

--- a/deploy/event-tracker/staging/values.yaml
+++ b/deploy/event-tracker/staging/values.yaml
@@ -46,10 +46,6 @@ env:
   KEEPERHUB_API_URL:
     type: kv
     value: "http://keeperhub-common:3000"
-  KEEPERHUB_API_KEY:
-    type: parameterStore
-    name: keeperhub-api-key
-    parameter_name: /eks/techops-staging/keeperhub-events/keeperhub-api-key
   INTERNAL_SERVICE_HMAC_SECRET:
     type: parameterStore
     name: internal-service-hmac-secret

--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -427,30 +427,11 @@ env:
   GAS_CREDITS_ENTERPRISE_CENTS:
     type: kv
     value: "10000"
-  # Internal service API keys for service-to-service auth
-  INTERNAL_AUTH_REQUIRE_HMAC:
-    type: kv
-    value: "true"
+  # Internal service-to-service auth (HMAC)
   INTERNAL_SERVICE_HMAC_SECRET:
     type: parameterStore
     name: internal-service-hmac-secret
     parameter_name: /eks/techops-prod/keeperhub/internal-service-hmac-secret
-  MCP_SERVICE_API_KEY:
-    type: parameterStore
-    name: mcp-service-api-key
-    parameter_name: /eks/techops-prod/keeperhub-mcp/keeperhub-api-key
-  EVENTS_SERVICE_API_KEY:
-    type: parameterStore
-    name: events-service-api-key
-    parameter_name: /eks/techops-prod/keeperhub-events/keeperhub-api-key
-  SCHEDULER_SERVICE_API_KEY:
-    type: parameterStore
-    name: scheduler-service-api-key
-    parameter_name: /eks/techops-prod/keeperhub-scheduler/keeperhub-api-key
-  HUB_SERVICE_API_KEY:
-    type: parameterStore
-    name: hub-service-api-key
-    parameter_name: /eks/techops-prod/keeperhub-hub/keeperhub-api-key
   TEST_API_KEY:
     type: parameterStore
     name: test-api-key

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -425,30 +425,11 @@ env:
   GAS_CREDITS_ENTERPRISE_CENTS:
     type: kv
     value: "10000"
-  # Internal service API keys for service-to-service auth
-  INTERNAL_AUTH_REQUIRE_HMAC:
-    type: kv
-    value: "true"
+  # Internal service-to-service auth (HMAC)
   INTERNAL_SERVICE_HMAC_SECRET:
     type: parameterStore
     name: internal-service-hmac-secret
     parameter_name: /eks/techops-staging/keeperhub/internal-service-hmac-secret
-  MCP_SERVICE_API_KEY:
-    type: parameterStore
-    name: mcp-service-api-key
-    parameter_name: /eks/techops-staging/keeperhub-mcp/keeperhub-api-key
-  EVENTS_SERVICE_API_KEY:
-    type: parameterStore
-    name: events-service-api-key
-    parameter_name: /eks/techops-staging/keeperhub-events/keeperhub-api-key
-  SCHEDULER_SERVICE_API_KEY:
-    type: parameterStore
-    name: scheduler-service-api-key
-    parameter_name: /eks/techops-staging/keeperhub-scheduler/keeperhub-api-key
-  HUB_SERVICE_API_KEY:
-    type: parameterStore
-    name: hub-service-api-key
-    parameter_name: /eks/techops-staging/keeperhub-hub/keeperhub-api-key
   TEST_API_KEY:
     type: parameterStore
     name: test-api-key

--- a/deploy/local/hybrid/deploy.sh
+++ b/deploy/local/hybrid/deploy.sh
@@ -142,7 +142,7 @@ data:
   SQS_QUEUE_URL: "http://host.minikube.internal:4566/000000000000/keeperhub-workflow-queue"
   DATABASE_URL: "postgresql://postgres:postgres@host.minikube.internal:5433/__DB_NAME__"
   KEEPERHUB_API_URL: "http://host.minikube.internal:3000"
-  KEEPERHUB_API_KEY: "local-scheduler-key-for-dev"
+  INTERNAL_SERVICE_HMAC_SECRET: "bG9jYWwtZGV2LWludGVybmFsLXNlcnZpY2UtaG1hYzA="
   RUNNER_IMAGE: "keeperhub-runner:latest"
   IMAGE_PULL_POLICY: "Never"
   K8S_NAMESPACE: "local"

--- a/deploy/local/schedule-trigger.yaml
+++ b/deploy/local/schedule-trigger.yaml
@@ -38,7 +38,7 @@ data:
   SQS_QUEUE_URL: "http://localstack:4566/000000000000/keeperhub-workflow-queue"
   DATABASE_URL: "postgresql://local:local@postgresql:5432/keeperhub"
   KEEPERHUB_API_URL: "http://keeperhub-common:3000"
-  KEEPERHUB_API_KEY: "local-scheduler-key-for-dev"
+  INTERNAL_SERVICE_HMAC_SECRET: "bG9jYWwtZGV2LWludGVybmFsLXNlcnZpY2UtaG1hYzA="
   RUNNER_IMAGE: "keeperhub-runner:latest"
   IMAGE_PULL_POLICY: "Never"
   K8S_NAMESPACE: "local"

--- a/deploy/local/values-keeperhub.template.yaml
+++ b/deploy/local/values-keeperhub.template.yaml
@@ -104,16 +104,12 @@ env:
   NEXT_PUBLIC_API_URL:
     type: kv
     value: "https://workflow.keeperhub.local"
-  # Internal service API keys (must match scheduler-env ConfigMap)
-  SCHEDULER_SERVICE_API_KEY:
+  # Internal service-to-service auth (HMAC). Must match the secret seeded into
+  # the local app's internal_service_hmac_secrets store and the value used by
+  # the dispatchers/runner below.
+  INTERNAL_SERVICE_HMAC_SECRET:
     type: kv
-    value: "local-scheduler-key-for-dev"
-  MCP_SERVICE_API_KEY:
-    type: kv
-    value: "local-mcp-key-for-dev"
-  EVENTS_SERVICE_API_KEY:
-    type: kv
-    value: "local-events-key-for-dev"
+    value: "bG9jYWwtZGV2LWludGVybmFsLXNlcnZpY2UtaG1hYzA="
 
 livenessProbe:
   initialDelaySeconds: 120
@@ -145,9 +141,9 @@ cronjob:
         - "/app/deploy/scripts/digest-cron.sh"
         - "http://keeperhub:3000/api/internal/execution-digest"
       env:
-        SCHEDULER_SERVICE_API_KEY:
+        INTERNAL_SERVICE_HMAC_SECRET:
           type: kv
-          value: "local-scheduler-key-for-dev"
+          value: "bG9jYWwtZGV2LWludGVybmFsLXNlcnZpY2UtaG1hYzA="
       resources:
         requests:
           memory: "32Mi"

--- a/deploy/local/values-keeperhub.template.yaml
+++ b/deploy/local/values-keeperhub.template.yaml
@@ -22,6 +22,30 @@ ingress:
 
 deployment:
   enabled: true
+  # NEEDS LIVE TEST - not yet validated against a real minikube deploy.
+  # Pushes the schema to the local Postgres and seeds the shared internal-service
+  # HMAC secret so the app can verify HMAC-signed requests from the local
+  # dispatchers. Both lines tolerate failure so the initContainer never blocks
+  # app startup (worst case the store stays unseeded, same as before).
+  initContainers:
+    - name: db-migrate-seed
+      image: "keeperhub:${IMAGE_TAG}"
+      imagePullPolicy: Never
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          pnpm db:push || echo "db:push skipped"
+          printf '%s' "$INTERNAL_SERVICE_HMAC_SECRET" | ALLOW_REMOTE=1 pnpm tsx scripts/seed-internal-service-hmac.ts || echo "internal-service HMAC seed skipped (row already present or seed unavailable)"
+      env:
+        DATABASE_URL:
+          type: kv
+          value: "postgresql://local:local@postgresql.local.svc.cluster.local:5432/keeperhub"
+        INTERNAL_SERVICE_HMAC_SECRET:
+          type: kv
+          value: "bG9jYWwtZGV2LWludGVybmFsLXNlcnZpY2UtaG1hYzA="
+        AGENTIC_WALLET_HMAC_KMS_KEY:
+          type: kv
+          value: "bG9jYWwtZGV2LWFnZW50aWMtd2FsbGV0LWhtYWMta3k="
 
 serviceAccount:
   create: true
@@ -110,6 +134,11 @@ env:
   INTERNAL_SERVICE_HMAC_SECRET:
     type: kv
     value: "bG9jYWwtZGV2LWludGVybmFsLXNlcnZpY2UtaG1hYzA="
+  # 32-byte base64 AES key the app uses to encrypt/decrypt the HMAC signing
+  # secret in its internal_service_hmac_secrets store (needed to verify).
+  AGENTIC_WALLET_HMAC_KMS_KEY:
+    type: kv
+    value: "bG9jYWwtZGV2LWFnZW50aWMtd2FsbGV0LWhtYWMta3k="
 
 livenessProbe:
   initialDelaySeconds: 120

--- a/deploy/pr-environment/block-dispatcher.template.yaml
+++ b/deploy/pr-environment/block-dispatcher.template.yaml
@@ -53,10 +53,10 @@ env:
   KEEPERHUB_API_URL:
     type: kv
     value: "http://keeperhub-pr-${PR_NUMBER}-common:3000"
-  KEEPERHUB_API_KEY:
+  INTERNAL_SERVICE_HMAC_SECRET:
     type: parameterStore
-    name: scheduler-service-api-key
-    parameter_name: /eks/techops-staging/keeperhub-scheduler/keeperhub-api-key
+    name: internal-service-hmac-secret
+    parameter_name: /eks/techops-staging/keeperhub/internal-service-hmac-secret
   AWS_REGION:
     type: kv
     value: "us-east-1"

--- a/deploy/pr-environment/event-tracker.template.yaml
+++ b/deploy/pr-environment/event-tracker.template.yaml
@@ -54,10 +54,10 @@ env:
   KEEPERHUB_API_URL:
     type: kv
     value: "http://keeperhub-pr-${PR_NUMBER}-common:3000"
-  KEEPERHUB_API_KEY:
+  INTERNAL_SERVICE_HMAC_SECRET:
     type: parameterStore
-    name: events-service-api-key
-    parameter_name: /eks/techops-staging/keeperhub-events/keeperhub-api-key
+    name: internal-service-hmac-secret
+    parameter_name: /eks/techops-staging/keeperhub/internal-service-hmac-secret
   REDIS_HOST:
     type: kv
     value: "redis.pr-${PR_NUMBER}.svc.cluster.local"

--- a/deploy/pr-environment/executor.template.yaml
+++ b/deploy/pr-environment/executor.template.yaml
@@ -68,10 +68,10 @@ env:
   KEEPERHUB_API_URL:
     type: kv
     value: "http://keeperhub-pr-${PR_NUMBER}-common:3000"
-  KEEPERHUB_API_KEY:
+  INTERNAL_SERVICE_HMAC_SECRET:
     type: parameterStore
-    name: scheduler-service-api-key
-    parameter_name: /eks/techops-staging/keeperhub-scheduler/keeperhub-api-key
+    name: internal-service-hmac-secret
+    parameter_name: /eks/techops-staging/keeperhub/internal-service-hmac-secret
   AWS_REGION:
     type: kv
     value: "us-east-1"

--- a/deploy/pr-environment/scheduler-dispatcher.template.yaml
+++ b/deploy/pr-environment/scheduler-dispatcher.template.yaml
@@ -53,10 +53,10 @@ env:
   KEEPERHUB_API_URL:
     type: kv
     value: "http://keeperhub-pr-${PR_NUMBER}-common:3000"
-  KEEPERHUB_API_KEY:
+  INTERNAL_SERVICE_HMAC_SECRET:
     type: parameterStore
-    name: scheduler-service-api-key
-    parameter_name: /eks/techops-staging/keeperhub-scheduler/keeperhub-api-key
+    name: internal-service-hmac-secret
+    parameter_name: /eks/techops-staging/keeperhub/internal-service-hmac-secret
   AWS_REGION:
     type: kv
     value: "us-east-1"

--- a/deploy/pr-environment/values.template.yaml
+++ b/deploy/pr-environment/values.template.yaml
@@ -66,9 +66,23 @@ deployment:
           pnpm db:migrate
           echo "Seeding chains and tokens..."
           pnpm db:seed
+          echo "Seeding internal-service HMAC secret (shared signing key)..."
+          printf '%s' "$INTERNAL_SERVICE_HMAC_SECRET" | ALLOW_REMOTE=1 pnpm tsx scripts/seed-internal-service-hmac.ts || echo "internal-service HMAC seed skipped (row already present or seed unavailable)"
           echo "Migrations and seeding completed successfully"
       env:
         <<: *shared_env
+        # Seeds the internal-service HMAC store on a fresh PR-env database so
+        # the app can verify HMAC-signed internal requests. The secret is the
+        # same value the producers sign with; the KMS key envelope-encrypts it
+        # at rest. The seed line tolerates failure so it never blocks startup.
+        INTERNAL_SERVICE_HMAC_SECRET:
+          type: parameterStore
+          name: internal-service-hmac-secret
+          parameter_name: /eks/techops-staging/keeperhub/internal-service-hmac-secret
+        AGENTIC_WALLET_HMAC_KMS_KEY:
+          type: parameterStore
+          name: agentic-wallet-hmac-kms-key
+          parameter_name: /eks/techops-staging/keeperhub/agentic-wallet-hmac-kms-key
         TURNKEY_API_PUBLIC_KEY:
           type: parameterStore
           name: turnkey-api-public-key

--- a/deploy/pr-environment/values.template.yaml
+++ b/deploy/pr-environment/values.template.yaml
@@ -350,22 +350,10 @@ env:
     type: parameterStore
     name: stripe-price-enterprise-yearly
     parameter_name: /eks/techops-staging/keeperhub/stripe-price-enterprise-yearly
-  MCP_SERVICE_API_KEY:
+  INTERNAL_SERVICE_HMAC_SECRET:
     type: parameterStore
-    name: mcp-service-api-key
-    parameter_name: /eks/techops-staging/keeperhub-mcp/keeperhub-api-key
-  EVENTS_SERVICE_API_KEY:
-    type: parameterStore
-    name: events-service-api-key
-    parameter_name: /eks/techops-staging/keeperhub-events/keeperhub-api-key
-  SCHEDULER_SERVICE_API_KEY:
-    type: parameterStore
-    name: scheduler-service-api-key
-    parameter_name: /eks/techops-staging/keeperhub-scheduler/keeperhub-api-key
-  HUB_SERVICE_API_KEY:
-    type: parameterStore
-    name: hub-service-api-key
-    parameter_name: /eks/techops-staging/keeperhub-hub/keeperhub-api-key
+    name: internal-service-hmac-secret
+    parameter_name: /eks/techops-staging/keeperhub/internal-service-hmac-secret
   AGENTIC_WALLET_HMAC_KMS_KEY:
     type: parameterStore
     name: agentic-wallet-hmac-kms-key
@@ -457,10 +445,10 @@ cronjob:
         - "/app/deploy/scripts/reaper.sh"
         - "http://keeperhub-pr-${PR_NUMBER}-common:3000/api/internal/reaper"
       env:
-        SCHEDULER_SERVICE_API_KEY:
+        INTERNAL_SERVICE_HMAC_SECRET:
           type: parameterStore
-          name: scheduler-service-api-key
-          parameter_name: /eks/techops-staging/keeperhub-scheduler/keeperhub-api-key
+          name: internal-service-hmac-secret
+          parameter_name: /eks/techops-staging/keeperhub/internal-service-hmac-secret
       resources:
         requests:
           memory: "32Mi"

--- a/deploy/pr-environment/values.template.yaml
+++ b/deploy/pr-environment/values.template.yaml
@@ -66,23 +66,9 @@ deployment:
           pnpm db:migrate
           echo "Seeding chains and tokens..."
           pnpm db:seed
-          echo "Seeding internal-service HMAC secret (shared signing key)..."
-          printf '%s' "$INTERNAL_SERVICE_HMAC_SECRET" | ALLOW_REMOTE=1 pnpm tsx scripts/seed-internal-service-hmac.ts || echo "internal-service HMAC seed skipped (row already present or seed unavailable)"
           echo "Migrations and seeding completed successfully"
       env:
         <<: *shared_env
-        # Seeds the internal-service HMAC store on a fresh PR-env database so
-        # the app can verify HMAC-signed internal requests. The secret is the
-        # same value the producers sign with; the KMS key envelope-encrypts it
-        # at rest. The seed line tolerates failure so it never blocks startup.
-        INTERNAL_SERVICE_HMAC_SECRET:
-          type: parameterStore
-          name: internal-service-hmac-secret
-          parameter_name: /eks/techops-staging/keeperhub/internal-service-hmac-secret
-        AGENTIC_WALLET_HMAC_KMS_KEY:
-          type: parameterStore
-          name: agentic-wallet-hmac-kms-key
-          parameter_name: /eks/techops-staging/keeperhub/agentic-wallet-hmac-kms-key
         TURNKEY_API_PUBLIC_KEY:
           type: parameterStore
           name: turnkey-api-public-key

--- a/deploy/scheduler/prod/block-dispatcher-values.yaml
+++ b/deploy/scheduler/prod/block-dispatcher-values.yaml
@@ -69,10 +69,6 @@ env:
   KEEPERHUB_API_URL:
     type: kv
     value: "http://keeperhub-common:3000"
-  KEEPERHUB_API_KEY:
-    type: parameterStore
-    name: scheduler-service-api-key
-    parameter_name: /eks/techops-prod/keeperhub-scheduler/keeperhub-api-key
   INTERNAL_SERVICE_HMAC_SECRET:
     type: parameterStore
     name: internal-service-hmac-secret

--- a/deploy/scheduler/prod/dispatcher-values.yaml
+++ b/deploy/scheduler/prod/dispatcher-values.yaml
@@ -57,10 +57,6 @@ env:
   KEEPERHUB_API_URL:
     type: kv
     value: "http://keeperhub-common:3000"
-  KEEPERHUB_API_KEY:
-    type: parameterStore
-    name: scheduler-service-api-key
-    parameter_name: /eks/techops-prod/keeperhub-scheduler/keeperhub-api-key
   INTERNAL_SERVICE_HMAC_SECRET:
     type: parameterStore
     name: internal-service-hmac-secret

--- a/deploy/scheduler/staging/block-dispatcher-values.yaml
+++ b/deploy/scheduler/staging/block-dispatcher-values.yaml
@@ -69,10 +69,6 @@ env:
   KEEPERHUB_API_URL:
     type: kv
     value: "http://keeperhub-common:3000"
-  KEEPERHUB_API_KEY:
-    type: parameterStore
-    name: scheduler-service-api-key
-    parameter_name: /eks/techops-staging/keeperhub-scheduler/keeperhub-api-key
   INTERNAL_SERVICE_HMAC_SECRET:
     type: parameterStore
     name: internal-service-hmac-secret

--- a/deploy/scheduler/staging/dispatcher-values.yaml
+++ b/deploy/scheduler/staging/dispatcher-values.yaml
@@ -57,10 +57,6 @@ env:
   KEEPERHUB_API_URL:
     type: kv
     value: "http://keeperhub-common:3000"
-  KEEPERHUB_API_KEY:
-    type: parameterStore
-    name: scheduler-service-api-key
-    parameter_name: /eks/techops-staging/keeperhub-scheduler/keeperhub-api-key
   INTERNAL_SERVICE_HMAC_SECRET:
     type: parameterStore
     name: internal-service-hmac-secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,9 +72,6 @@ x-env-sqs: &env_sqs
   SQS_QUEUE_URL: http://host.minikube.internal:4566/000000000000/keeperhub-workflow-queue
 
 x-env-service-keys: &env_service_keys
-  SCHEDULER_SERVICE_API_KEY: local-scheduler-key-for-dev
-  MCP_SERVICE_API_KEY: local-mcp-key-for-dev
-  EVENTS_SERVICE_API_KEY: local-events-key-for-dev
   # Shared HMAC signing secret for internal service-to-service auth. Local-dev
   # default (base64 of 32 bytes); the hmac-seed service inserts this same value
   # into the internal_service_hmac_secrets store so signed requests verify.
@@ -156,7 +153,6 @@ services:
     environment:
       <<: [*env_db_connection, *env_aws, *env_sqs]
       NODE_ENV: production
-      KEEPERHUB_API_KEY: ${KEEPERHUB_API_KEY:-}
     depends_on:
       db:
         condition: service_healthy
@@ -205,7 +201,6 @@ services:
     environment:
       <<: [*env_db_connection, *env_aws, *env_sqs, *env_service_keys]
       HOSTNAME: "0.0.0.0"
-      KEEPERHUB_API_KEY: ${KEEPERHUB_API_KEY:-some-random-api-key}
       # 6GB heap leaves headroom on top of the 8GB container cap for
       # Turbopack's bundler, which crashes a 3GB heap on cold compile.
       NODE_OPTIONS: "--max-old-space-size=6144"
@@ -291,7 +286,7 @@ services:
       AWS_ENDPOINT_URL: http://localstack:4566
       SQS_QUEUE_URL: http://localstack:4566/000000000000/keeperhub-workflow-queue
       KEEPERHUB_API_URL: http://app-dev:3000
-      KEEPERHUB_API_KEY: ${KEEPERHUB_API_KEY:-local-scheduler-key-for-dev}
+      INTERNAL_SERVICE_HMAC_SECRET: ${INTERNAL_SERVICE_HMAC_SECRET:-bG9jYWwtZGV2LWludGVybmFsLXNlcnZpY2UtaG1hYzA=}
     depends_on:
       db:
         condition: service_healthy
@@ -333,6 +328,7 @@ services:
       AWS_SECRET_ACCESS_KEY: test
       AWS_ENDPOINT_URL: http://localstack:4566
       SQS_QUEUE_URL: http://localstack:4566/000000000000/keeperhub-workflow-queue
+      INTERNAL_SERVICE_HMAC_SECRET: ${INTERNAL_SERVICE_HMAC_SECRET:-bG9jYWwtZGV2LWludGVybmFsLXNlcnZpY2UtaG1hYzA=}
       INTEGRATION_ENCRYPTION_KEY: ${INTEGRATION_ENCRYPTION_KEY:-0000000000000000000000000000000000000000000000000000000000000000}
       HEALTH_PORT: "3080"
       TURNKEY_API_PUBLIC_KEY: ${TURNKEY_API_PUBLIC_KEY:-}
@@ -454,7 +450,7 @@ services:
     environment:
       WATCH_MODE: "true"
       KEEPERHUB_API_URL: http://keeperhub:3000
-      KEEPERHUB_API_KEY: ${KEEPERHUB_API_KEY:-local-events-key-for-dev}
+      INTERNAL_SERVICE_HMAC_SECRET: ${INTERNAL_SERVICE_HMAC_SECRET:-bG9jYWwtZGV2LWludGVybmFsLXNlcnZpY2UtaG1hYzA=}
       REDIS_HOST: redis
       REDIS_PORT: 6379
       JWT_TOKEN_USERNAME: ${JWT_TOKEN_USERNAME:-}
@@ -492,7 +488,7 @@ services:
     working_dir: /app
     environment:
       KEEPERHUB_API_URL: http://app-dev:3000
-      KEEPERHUB_API_KEY: ${KEEPERHUB_API_KEY:-local-scheduler-key-for-dev}
+      INTERNAL_SERVICE_HMAC_SECRET: ${INTERNAL_SERVICE_HMAC_SECRET:-bG9jYWwtZGV2LWludGVybmFsLXNlcnZpY2UtaG1hYzA=}
       AWS_REGION: us-east-1
       AWS_ACCESS_KEY_ID: test
       AWS_SECRET_ACCESS_KEY: test
@@ -735,7 +731,7 @@ services:
       - keeperhub_test_node_modules:/app/node_modules
     environment:
       KEEPERHUB_API_URL: http://test-app:3000
-      KEEPERHUB_API_KEY: ${KEEPERHUB_API_KEY:-local-scheduler-key-for-dev}
+      INTERNAL_SERVICE_HMAC_SECRET: ${INTERNAL_SERVICE_HMAC_SECRET:-bG9jYWwtZGV2LWludGVybmFsLXNlcnZpY2UtaG1hYzA=}
       AWS_ENDPOINT_URL: http://test-localstack:4566
       AWS_REGION: us-east-1
       AWS_ACCESS_KEY_ID: test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,10 @@ x-env-service-keys: &env_service_keys
   SCHEDULER_SERVICE_API_KEY: local-scheduler-key-for-dev
   MCP_SERVICE_API_KEY: local-mcp-key-for-dev
   EVENTS_SERVICE_API_KEY: local-events-key-for-dev
+  # Shared HMAC signing secret for internal service-to-service auth. Local-dev
+  # default (base64 of 32 bytes); the hmac-seed service inserts this same value
+  # into the internal_service_hmac_secrets store so signed requests verify.
+  INTERNAL_SERVICE_HMAC_SECRET: ${INTERNAL_SERVICE_HMAC_SECRET:-bG9jYWwtZGV2LWludGVybmFsLXNlcnZpY2UtaG1hYzA=}
 
 # -----------------------------------------------------------------------------
 # Services
@@ -345,27 +349,62 @@ services:
       - dev
 
   # ===========================================================================
+  # Internal-service HMAC secret seeder (one-shot)
+  # Ensures the schema exists (idempotent db:push) and inserts the shared HMAC
+  # signing secret under caller "*shared*" so locally-signed internal requests
+  # (reaper, execution-digest, executor, scheduler) verify against the app's
+  # DB-backed secret store. Re-runs are a no-op (duplicate insert is ignored).
+  # ===========================================================================
+  hmac-seed:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: dev
+    env_file:
+      - .env
+    environment:
+      <<: *env_db_connection
+      INTERNAL_SERVICE_HMAC_SECRET: ${INTERNAL_SERVICE_HMAC_SECRET:-bG9jYWwtZGV2LWludGVybmFsLXNlcnZpY2UtaG1hYzA=}
+    volumes:
+      - .:/app
+      - /app/node_modules
+    depends_on:
+      db:
+        condition: service_healthy
+    command: >
+      sh -c "pnpm db:push;
+      printf '%s' \"$$INTERNAL_SERVICE_HMAC_SECRET\" |
+      pnpm tsx scripts/seed-internal-service-hmac.ts || true"
+    profiles:
+      - dev
+      - minikube
+
+  # ===========================================================================
   # Reaper (stale execution cleanup)
   # Runs every 10 minutes to mark stuck workflow executions as timed out
   # ===========================================================================
   reaper:
-    image: curlimages/curl:latest
+    image: alpine:3.20
     container_name: keeperhub-reaper
     restart: unless-stopped
     environment:
-      SCHEDULER_SERVICE_API_KEY: ${KEEPERHUB_API_KEY:-local-scheduler-key-for-dev}
+      INTERNAL_SERVICE_HMAC_SECRET: ${INTERNAL_SERVICE_HMAC_SECRET:-bG9jYWwtZGV2LWludGVybmFsLXNlcnZpY2UtaG1hYzA=}
+    volumes:
+      - ./deploy/scripts:/scripts:ro
     depends_on:
       app-dev:
         condition: service_started
+      hmac-seed:
+        condition: service_completed_successfully
     command: |
-      sh -c 'while true; do
-        echo "[Reaper] Running at $$(date)"
-        curl -sS -f -H "X-Service-Key: $$SCHEDULER_SERVICE_API_KEY" \
-          http://app-dev:3000/api/internal/reaper || echo "[Reaper] Failed"
-        echo ""
-        echo "[Reaper] Sleeping 600s..."
-        sleep 600
-      done'
+      sh -c 'apk add --no-cache curl openssl >/dev/null;
+        while true; do
+          echo "[Reaper] Running at $$(date)"
+          sh /scripts/reaper.sh http://app-dev:3000/api/internal/reaper || echo "[Reaper] Failed"
+          echo ""
+          echo "[Reaper] Sleeping 600s..."
+          sleep 600
+        done'
     profiles:
       - dev
       - minikube
@@ -377,23 +416,27 @@ services:
   # than the real schedule only affects how soon a due digest is sent.
   # ===========================================================================
   execution-digest:
-    image: curlimages/curl:latest
+    image: alpine:3.20
     container_name: keeperhub-execution-digest
     restart: unless-stopped
     environment:
-      SCHEDULER_SERVICE_API_KEY: ${KEEPERHUB_API_KEY:-local-scheduler-key-for-dev}
+      INTERNAL_SERVICE_HMAC_SECRET: ${INTERNAL_SERVICE_HMAC_SECRET:-bG9jYWwtZGV2LWludGVybmFsLXNlcnZpY2UtaG1hYzA=}
+    volumes:
+      - ./deploy/scripts:/scripts:ro
     depends_on:
       app-dev:
         condition: service_started
+      hmac-seed:
+        condition: service_completed_successfully
     command: |
-      sh -c 'while true; do
-        echo "[ExecutionDigest] Running at $$(date)"
-        curl -sS -f -H "X-Service-Key: $$SCHEDULER_SERVICE_API_KEY" \
-          http://app-dev:3000/api/internal/execution-digest || echo "[ExecutionDigest] Failed"
-        echo ""
-        echo "[ExecutionDigest] Sleeping 3600s..."
-        sleep 3600
-      done'
+      sh -c 'apk add --no-cache curl openssl >/dev/null;
+        while true; do
+          echo "[ExecutionDigest] Running at $$(date)"
+          sh /scripts/digest-cron.sh http://app-dev:3000/api/internal/execution-digest || echo "[ExecutionDigest] Failed"
+          echo ""
+          echo "[ExecutionDigest] Sleeping 3600s..."
+          sleep 3600
+        done'
     profiles:
       - dev
       - minikube

--- a/keeperhub-events/.env.example
+++ b/keeperhub-events/.env.example
@@ -9,8 +9,8 @@
 # from within Docker containers (instead of localhost)
 KEEPERHUB_API_URL=http://host.docker.internal:3000
 
-# API key for authenticating with KeeperHub API
-KEEPERHUB_API_KEY=local-events-key-for-dev
+# Shared HMAC secret for signing internal service-to-service requests
+INTERNAL_SERVICE_HMAC_SECRET=bG9jYWwtZGV2LWludGVybmFsLXNlcnZpY2UtaG1hYzA=
 
 JWT_TOKEN_USERNAME=your-jwt-username
 JWT_TOKEN_PASSWORD=your-jwt-password

--- a/keeperhub-events/README.md
+++ b/keeperhub-events/README.md
@@ -61,7 +61,7 @@ The system is designed to run in multiple deployment modes: local development, D
    ```bash
    # Required variables:
    KEEPERHUB_API_URL=https://api.keeperhub.example.com
-   KEEPERHUB_API_KEY=your-api-key
+   INTERNAL_SERVICE_HMAC_SECRET=your-internal-service-hmac-secret
    JWT_TOKEN_USERNAME=your-username
    JWT_TOKEN_PASSWORD=your-password
    ETHERSCAN_API_KEY=your-etherscan-key

--- a/keeperhub-events/event-tracker/lib/config/environment.ts
+++ b/keeperhub-events/event-tracker/lib/config/environment.ts
@@ -1,5 +1,4 @@
 export const KEEPERHUB_API_URL: string = process.env.KEEPERHUB_API_URL || "";
-export const KEEPERHUB_API_KEY: string = process.env.KEEPERHUB_API_KEY || "";
 export const REDIS_HOST: string = process.env.REDIS_HOST || "localhost";
 export const REDIS_PORT: number = Number(process.env.REDIS_PORT) || 6379;
 export const REDIS_PASSWORD: string = process.env.REDIS_PASSWORD || "";

--- a/keeperhub-events/event-tracker/tests/integration/event-to-sqs-inproc-config-change.test.ts
+++ b/keeperhub-events/event-tracker/tests/integration/event-to-sqs-inproc-config-change.test.ts
@@ -159,7 +159,6 @@ describe.skipIf(SKIP_INFRA_TESTS)(
       });
 
       process.env.KEEPERHUB_API_URL = mockApi.url;
-      process.env.KEEPERHUB_API_KEY = "test-key";
       process.env.SQS_QUEUE_URL = queueUrl;
       process.env.AWS_ENDPOINT_URL = AWS_ENDPOINT;
       process.env.AWS_REGION = "us-east-1";

--- a/keeperhub-events/event-tracker/tests/integration/event-to-sqs-inproc-multi.test.ts
+++ b/keeperhub-events/event-tracker/tests/integration/event-to-sqs-inproc-multi.test.ts
@@ -148,7 +148,6 @@ describe.skipIf(SKIP_INFRA_TESTS)(
       });
 
       process.env.KEEPERHUB_API_URL = mockApi.url;
-      process.env.KEEPERHUB_API_KEY = "test-key";
       process.env.SQS_QUEUE_URL = queueUrl;
       process.env.AWS_ENDPOINT_URL = AWS_ENDPOINT;
       process.env.AWS_REGION = "us-east-1";

--- a/keeperhub-events/event-tracker/tests/integration/event-to-sqs-inproc.test.ts
+++ b/keeperhub-events/event-tracker/tests/integration/event-to-sqs-inproc.test.ts
@@ -141,7 +141,6 @@ describe.skipIf(SKIP_INFRA_TESTS)(
       });
 
       process.env.KEEPERHUB_API_URL = mockApi.url;
-      process.env.KEEPERHUB_API_KEY = "test-key";
       process.env.SQS_QUEUE_URL = queueUrl;
       process.env.AWS_ENDPOINT_URL = AWS_ENDPOINT;
       process.env.AWS_REGION = "us-east-1";

--- a/keeperhub-events/event-tracker/tests/integration/shutdown-signal.test.ts
+++ b/keeperhub-events/event-tracker/tests/integration/shutdown-signal.test.ts
@@ -87,7 +87,6 @@ describe.skipIf(SKIP_INFRA_TESTS)(
         env: {
           ...process.env,
           KEEPERHUB_API_URL: mockApi.url,
-          KEEPERHUB_API_KEY: "test-key",
           INTERNAL_SERVICE_HMAC_SECRET:
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
           SQS_QUEUE_URL: `${AWS_ENDPOINT}/000000000000/dummy-shutdown-test`,

--- a/keeperhub-executor/api-execute.test.ts
+++ b/keeperhub-executor/api-execute.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("./config", () => ({
   CONFIG: {
     keeperhubApiUrl: "https://api.test.local",
-    keeperhubApiKey: "test-service-key",
   },
 }));
 

--- a/keeperhub-executor/config.ts
+++ b/keeperhub-executor/config.ts
@@ -34,7 +34,6 @@ export const CONFIG = {
   maxConcurrentJobs: Number(process.env.MAX_CONCURRENT_JOBS) || 1,
 
   keeperhubApiUrl: process.env.KEEPERHUB_API_URL || "http://localhost:3000",
-  keeperhubApiKey: process.env.KEEPERHUB_API_KEY || "",
 
   healthPort: Number(process.env.HEALTH_PORT) || 3080,
   integrationEncryptionKey: process.env.INTEGRATION_ENCRYPTION_KEY || "",

--- a/keeperhub-scheduler/.env.example
+++ b/keeperhub-scheduler/.env.example
@@ -12,7 +12,7 @@
 # KeeperHub API Connection (all services)
 # -----------------------------------------------------------------------------
 KEEPERHUB_API_URL=http://localhost:3000
-KEEPERHUB_API_KEY=local-scheduler-key-for-dev
+INTERNAL_SERVICE_HMAC_SECRET=bG9jYWwtZGV2LWludGVybmFsLXNlcnZpY2UtaG1hYzA=
 
 # -----------------------------------------------------------------------------
 # AWS / SQS (all services)

--- a/keeperhub-scheduler/README.md
+++ b/keeperhub-scheduler/README.md
@@ -77,7 +77,7 @@ Polls SQS for workflow triggers and executes them.
 | Variable | Description | Used By |
 |----------|-------------|---------|
 | `KEEPERHUB_API_URL` | KeeperHub API base URL | All |
-| `KEEPERHUB_API_KEY` | Internal service API key | All |
+| `INTERNAL_SERVICE_HMAC_SECRET` | Shared HMAC secret for signing internal requests | All |
 | `AWS_REGION` | AWS region | All |
 | `SQS_QUEUE_URL` | SQS queue URL for workflow triggers | All |
 | `HEALTH_PORT` | HTTP health check port (defaults: 3060 schedule-dispatcher, 3050 block-dispatcher) | All |
@@ -121,7 +121,7 @@ To connect to real services, set the environment variables:
 
 ```bash
 export KEEPERHUB_API_URL=http://your-api-url
-export KEEPERHUB_API_KEY=your-api-key
+export INTERNAL_SERVICE_HMAC_SECRET=your-internal-service-hmac-secret
 export AWS_REGION=us-east-1
 export SQS_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789/your-queue
 ```
@@ -141,7 +141,7 @@ Run a container with required environment variables:
 
 ```bash
 docker run -e KEEPERHUB_API_URL=http://host.docker.internal:3000 \
-           -e KEEPERHUB_API_KEY=your-key \
+           -e INTERNAL_SERVICE_HMAC_SECRET=your-internal-service-hmac-secret \
            -e AWS_REGION=us-east-1 \
            -e SQS_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789/your-queue \
            -p 3000:3000 \

--- a/keeperhub-scheduler/block-dispatcher/index.ts
+++ b/keeperhub-scheduler/block-dispatcher/index.ts
@@ -9,7 +9,7 @@
  *
  * Environment variables:
  *   KEEPERHUB_API_URL      - KeeperHub API URL (default: http://localhost:3000)
- *   KEEPERHUB_API_KEY      - Service API key for X-Service-Key authentication
+ *   INTERNAL_SERVICE_HMAC_SECRET - HMAC signing secret for internal service auth
  *   RECONCILE_INTERVAL_MS  - How often to refetch workflows (default: 30000)
  *   SQS_QUEUE_URL          - SQS queue URL
  *   AWS_REGION             - AWS region

--- a/keeperhub-scheduler/lib/config.ts
+++ b/keeperhub-scheduler/lib/config.ts
@@ -4,7 +4,6 @@
 
 export const KEEPERHUB_URL =
   process.env.KEEPERHUB_API_URL || "http://localhost:3000";
-export const SERVICE_API_KEY = process.env.KEEPERHUB_API_KEY || "";
 
 export const AWS_REGION = process.env.AWS_REGION || "us-east-1";
 export const AWS_ENDPOINT_URL = process.env.AWS_ENDPOINT_URL;

--- a/keeperhub-scheduler/schedule-dispatcher/index.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/index.ts
@@ -9,7 +9,7 @@
  *
  * Environment variables:
  *   KEEPERHUB_API_URL - KeeperHub API URL (default: http://localhost:3000)
- *   KEEPERHUB_API_KEY - Service API key for authentication
+ *   INTERNAL_SERVICE_HMAC_SECRET - HMAC signing secret for internal service auth
  *   AWS_ENDPOINT_URL - LocalStack endpoint (default: http://localhost:4566)
  *   SQS_QUEUE_URL - SQS queue URL (default: LocalStack queue)
  *   HEALTH_PORT - Health check server port (default: 3060)

--- a/lib/internal-service-auth.ts
+++ b/lib/internal-service-auth.ts
@@ -1,41 +1,28 @@
 /**
  * @security Internal service-to-service authentication.
  *
- * Two schemes are accepted during the dual-accept rollout window:
- *
- * 1. HMAC (preferred). Producer signs the request with a shared secret stored
- *    encrypted-at-rest in internal_service_hmac_secrets. Headers:
+ * HMAC scheme. Producer signs the request with a shared secret stored
+ * encrypted-at-rest in internal_service_hmac_secrets. Headers:
  *      X-KH-Caller     identity claim (one of InternalCaller)
  *      X-KH-Timestamp  unix seconds, validated within +/- 300 s
  *      X-KH-Signature  64-char lowercase hex
  *      X-KH-Key-Version (optional) pins secret selection to a specific row
  *
- *    Signing string format (caller bound into the signed bytes so a forged
- *    header cannot route to another caller's audit row):
+ * Signing string format (caller bound into the signed bytes so a forged
+ * header cannot route to another caller's audit row):
  *      signingString = `${method}\n${pathname}\n${caller}\n${sha256_hex(body)}\n${timestamp}`
  *      signature     = hex(hmac_sha256(secret, signingString))
  *
- *    Replay within the 300-second window is INTENTIONALLY accepted. Matches
- *    the agentic-wallet HMAC precedent: a server-side nonce cache is
- *    defense-in-depth with measurable latency cost; the upstream attack model
- *    (env-var leak detected via audit log) is closed faster by short rotation
- *    than by single-use enforcement. Revisit if a future review requires it.
+ * Replay within the 300-second window is INTENTIONALLY accepted. Matches
+ * the agentic-wallet HMAC precedent: a server-side nonce cache is
+ * defense-in-depth with measurable latency cost; the upstream attack model
+ * (env-var leak detected via audit log) is closed faster by short rotation
+ * than by single-use enforcement. Revisit if a future review requires it.
  *
- *    For v1 every producer shares one signing secret stored at
- *    caller = LEGACY_SHARED_SECRET_KEY. A future per-caller split is a single
- *    INSERT plus per-client env update; the verifier path needs no change
- *    beyond replacing the constant with `claimedCaller`.
- *
- * 2. Legacy bearer (sunset). The pre-existing X-Service-Key / X-Internal-Token
- *    headers compared against the per-service env vars with timingSafeEqual.
- *    Accepted only when INTERNAL_AUTH_REQUIRE_HMAC is not "true" and no HMAC
- *    headers were sent. A captured bearer replays cross-endpoint trivially;
- *    that is the threat the HMAC scheme closes.
- *
- * Header-presence-commits-to-scheme: if any HMAC header is present the
- * verifier runs the HMAC path with NO fallback to the legacy bearer. This
- * prevents an attacker who knows the legacy bearer from appending a junk
- * signature to slip through the looser path.
+ * For v1 every producer shares one signing secret stored at
+ * caller = SHARED_SECRET_KEY. A future per-caller split is a single
+ * INSERT plus per-client env update; the verifier path needs no change
+ * beyond replacing the constant with `claimedCaller`.
  *
  * Never log secret material, signatures, or timestamps in error paths.
  */
@@ -67,7 +54,7 @@ const INTERNAL_CALLERS: ReadonlySet<InternalCaller> = new Set([
  * in v1. Distinct from any InternalCaller value so a future per-caller split
  * (one row per producer) does not collide with this row.
  */
-const LEGACY_SHARED_SECRET_KEY = "*shared*";
+const SHARED_SECRET_KEY = "*shared*";
 
 const REPLAY_WINDOW_SECONDS = 300;
 const SIGNATURE_HEX_LENGTH = 64;
@@ -76,7 +63,7 @@ export type InternalServiceAuthResult =
   | {
       authenticated: true;
       caller: InternalCaller;
-      scheme: "hmac" | "legacy-bearer";
+      scheme: "hmac";
       keyVersion?: number;
     }
   | { authenticated: false; error: string; status: number };
@@ -107,25 +94,9 @@ async function runAuthentication(
     request.headers.get("X-KH-Signature") !== null ||
     request.headers.get("X-KH-Caller") !== null ||
     request.headers.get("X-KH-Timestamp") !== null;
-  const enforceHmacOnly = process.env.INTERNAL_AUTH_REQUIRE_HMAC === "true";
 
   if (hasHmac) {
     return await verifyHmac(request, rawBody ?? "");
-  }
-
-  if (enforceHmacOnly) {
-    return {
-      authenticated: false,
-      error: "HMAC authentication required",
-      status: 401,
-    };
-  }
-
-  const hasLegacy =
-    request.headers.get("X-Service-Key") !== null ||
-    request.headers.get("X-Internal-Token") !== null;
-  if (hasLegacy) {
-    return verifyLegacyBearer(request);
   }
 
   return {
@@ -179,21 +150,13 @@ function emitAuditEvent(
   });
 }
 
-function pickAttemptedScheme(
-  request: Request
-): "hmac" | "legacy-bearer" | "none" {
+function pickAttemptedScheme(request: Request): "hmac" | "none" {
   if (
     request.headers.get("X-KH-Signature") !== null ||
     request.headers.get("X-KH-Caller") !== null ||
     request.headers.get("X-KH-Timestamp") !== null
   ) {
     return "hmac";
-  }
-  if (
-    request.headers.get("X-Service-Key") !== null ||
-    request.headers.get("X-Internal-Token") !== null
-  ) {
-    return "legacy-bearer";
   }
   return "none";
 }
@@ -271,14 +234,14 @@ async function verifyHmac(
   }
 
   // v1: every producer shares one signing secret stored under
-  // LEGACY_SHARED_SECRET_KEY. Future per-caller split replaces this constant
+  // SHARED_SECRET_KEY. Future per-caller split replaces this constant
   // with `caller` so the secret lookup tracks producer identity.
-  const secretKey = LEGACY_SHARED_SECRET_KEY;
+  const secretKey = SHARED_SECRET_KEY;
 
   // Without a pinned version, try every active secret (newest first, then any
   // still-within-grace older versions) so the 24-hour rotation window
-  // actually lets legacy consumers verify while picking up the new secret.
-  // With a pinned version, only that one row is tried.
+  // actually lets in-flight consumers verify against the previous secret
+  // while they pick up the new one. With a pinned version, only that row is tried.
   const candidates =
     pinnedVersion === undefined
       ? await listActiveHmacSecrets(secretKey)
@@ -324,60 +287,6 @@ async function verifyHmac(
   return {
     authenticated: false,
     error: "Invalid signature",
-    status: 401,
-  };
-}
-
-function secureCompare(a: string, b: string): boolean {
-  if (a.length !== b.length) {
-    return false;
-  }
-  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
-}
-
-function verifyLegacyBearer(request: Request): InternalServiceAuthResult {
-  // Either header carries a bearer in the legacy scheme; accept both so the
-  // /api/workflows/events consolidation does not require a separate code
-  // path. The verifier behavior is identical regardless of which header
-  // delivered the bearer.
-  const bearer =
-    request.headers.get("X-Service-Key") ??
-    request.headers.get("X-Internal-Token");
-
-  if (!bearer) {
-    return {
-      authenticated: false,
-      error: "Missing bearer header",
-      status: 401,
-    };
-  }
-
-  // Read env vars at call time so vi.stubEnv() works in tests and so a value
-  // change does not require a process restart.
-  const serviceKeys: Record<InternalCaller, string | undefined> = {
-    executor: process.env.KEEPERHUB_API_KEY,
-    mcp: process.env.MCP_SERVICE_API_KEY,
-    events: process.env.EVENTS_SERVICE_API_KEY,
-    scheduler: process.env.SCHEDULER_SERVICE_API_KEY,
-    hub: process.env.HUB_SERVICE_API_KEY,
-  };
-
-  for (const [caller, expectedKey] of Object.entries(serviceKeys) as [
-    InternalCaller,
-    string | undefined,
-  ][]) {
-    if (expectedKey && secureCompare(bearer, expectedKey)) {
-      return {
-        authenticated: true,
-        caller,
-        scheme: "legacy-bearer",
-      };
-    }
-  }
-
-  return {
-    authenticated: false,
-    error: "Invalid service key",
     status: 401,
   };
 }

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -435,7 +435,7 @@ export function logSystemWarn(
  */
 export function logInternalAuthEvent(fields: {
   outcome: "accept" | "reject";
-  scheme: "hmac" | "legacy-bearer" | "none";
+  scheme: "hmac" | "none";
   caller: string;
   route: string;
   method: string;

--- a/load-tests.md
+++ b/load-tests.md
@@ -18,7 +18,7 @@ Replicates the real production workload: scheduled workflows triggered by the ac
 - `scheduler-dispatcher` polls `/api/internal/schedules` every 60 seconds
 - Evaluates cron expressions, enqueues matching workflows to SQS
 - `scheduler-executor` polls SQS, calls `POST /api/workflow/{id}/execute`
-- Manual workflows triggered by k6 via `X-Service-Key` every 60 seconds
+- Manual workflows triggered by k6 via an HMAC-signed internal request every 60 seconds
 
 **Observation:** 3-minute window per tier, then collect execution results from API.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -80,8 +80,16 @@ The API also supports protocol-level featuring (e.g. featured workflows on a pro
 To feature a single workflow without editing the script:
 
 ```bash
-curl -X POST "https://app.keeperhub.com/api/hub/featured" \
+# The endpoint authenticates with an HMAC signature (X-KH-* headers), so sign
+# the request the same way feature-workflows.sh does.
+URL="https://app.keeperhub.com/api/hub/featured"
+BODY='{"workflowId": "<id>", "featured": true, "category": "Getting Started", "featuredOrder": 1}'
+TS=$(date +%s)
+BODY_DIGEST=$(printf '%s' "$BODY" | openssl dgst -sha256 | awk '{print $2}')
+SIG=$(printf '%s\n%s\n%s\n%s\n%s' POST /api/hub/featured hub "$BODY_DIGEST" "$TS" \
+  | openssl dgst -sha256 -hmac "$INTERNAL_SERVICE_HMAC_SECRET" | awk '{print $2}')
+curl -X POST "$URL" \
   -H "Content-Type: application/json" \
-  -H "X-Service-Key: $HUB_SERVICE_API_KEY" \
-  -d '{"workflowId": "<id>", "featured": true, "category": "Getting Started", "featuredOrder": 1}'
+  -H "X-KH-Caller: hub" -H "X-KH-Timestamp: $TS" -H "X-KH-Signature: $SIG" \
+  -d "$BODY"
 ```

--- a/scripts/seed-internal-service-hmac.ts
+++ b/scripts/seed-internal-service-hmac.ts
@@ -81,9 +81,15 @@ async function main(): Promise<void> {
   );
 }
 
-main().catch((error: unknown) => {
-  process.stderr.write(
-    `${error instanceof Error ? error.message : String(error)}\n`
-  );
-  process.exit(1);
-});
+main()
+  .then(() => {
+    // Exit explicitly: the DB client keeps an open connection that would
+    // otherwise keep the process (and a one-shot seed Job pod) alive forever.
+    process.exit(0);
+  })
+  .catch((error: unknown) => {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`
+    );
+    process.exit(1);
+  });

--- a/scripts/seed-internal-service-hmac.ts
+++ b/scripts/seed-internal-service-hmac.ts
@@ -22,7 +22,11 @@
 
 import { insertHmacSecret } from "@/lib/internal-service-hmac-store";
 
-const LOCAL_HOST_PATTERN = /^postgres(ql)?:\/\/[^@]+@(localhost|127\.0\.0\.1):/;
+// Allow the docker-compose service hostnames (db/postgres) in addition to
+// loopback, so the seed can run from inside the local dev stack. Mirrors the
+// host allowlist used by the dev-login bootstrap scripts.
+const LOCAL_HOST_PATTERN =
+  /^postgres(ql)?:\/\/[^@]+@(localhost|127\.0\.0\.1|db|postgres):/;
 
 function parseArgs(argv: string[]): { caller: string; version: number } {
   let caller = "*shared*";

--- a/specs/KEEP-1164-workflow-templates.md
+++ b/specs/KEEP-1164-workflow-templates.md
@@ -38,9 +38,9 @@ Note: `description` already exists on the workflow table.
 
 **Route:** `POST /keeperhub/api/hub/featured`
 
-**Authentication:** Internal service key via `X-Service-Key` header
+**Authentication:** Internal service HMAC signature via `X-KH-Caller` / `X-KH-Timestamp` / `X-KH-Signature` headers
 
-**Environment Variable:** `HUB_SERVICE_API_KEY`
+**Environment Variable:** `INTERNAL_SERVICE_HMAC_SECRET`
 
 **Request Body:**
 ```typescript
@@ -70,7 +70,7 @@ Note: `description` already exists on the workflow table.
 ```bash
 curl -X POST https://app.keeperhub.com/api/hub/featured \
   -H "Content-Type: application/json" \
-  -H "X-Service-Key: $HUB_SERVICE_API_KEY" \
+  -H "X-KH-Caller: hub" -H "X-KH-Timestamp: $TS" -H "X-KH-Signature: $SIG" \
   -d '{
     "workflowId": "abc123",
     "category": "Web3",
@@ -100,10 +100,12 @@ const SERVICE_KEYS: Record<InternalServiceName, string | undefined> = {
 ```
 
 **Authentication flow:**
-1. Request includes `X-Service-Key: <secret>` header
-2. Server loops through registered services and compares keys
-3. Uses timing-safe comparison (`crypto.timingSafeEqual`) to prevent timing attacks
-4. Returns `{ authenticated: true, service: "hub" }` on success
+1. Request includes `X-KH-Caller` / `X-KH-Timestamp` / `X-KH-Signature` headers, where the
+   signature is `hmac_sha256(secret, "POST\n/api/hub/featured\nhub\nsha256(body)\ntimestamp")`
+2. Server verifies the timestamp is within the replay window and recomputes the signature
+   using the shared secret from the `internal_service_hmac_secrets` store
+3. Uses timing-safe comparison (`crypto.timingSafeEqual`) on the signature bytes
+4. Returns `{ authenticated: true, caller: "hub" }` on success
 
 **Endpoint authorization:**
 ```typescript

--- a/tests/e2e/postgres-world.test.ts
+++ b/tests/e2e/postgres-world.test.ts
@@ -12,6 +12,9 @@
  * - WORKFLOW_POSTGRES_URL or DATABASE_URL pointing to the database
  * - workflow-postgres-setup already run against the database
  * - App running at KEEPERHUB_URL (default: http://localhost:3000)
+ * - INTERNAL_SERVICE_HMAC_SECRET set to the same value seeded into the running
+ *   app's internal_service_hmac_secrets store under caller "*shared*" (see
+ *   scripts/seed-internal-service-hmac.ts) so the signed requests below verify.
  *
  * Run with: pnpm vitest tests/e2e/postgres-world.test.ts
  */
@@ -28,14 +31,15 @@ import {
   workflows,
 } from "@/lib/db/schema";
 import { PERSISTENT_TEST_USER_EMAIL } from "../utils/db";
+import { signInternalServiceHeaders } from "../utils/internal-service-auth";
 
 const DATABASE_URL =
   process.env.DATABASE_URL ||
   "postgresql://postgres:postgres@localhost:5433/keeperhub";
 
 const KEEPERHUB_URL = process.env.KEEPERHUB_URL || "http://localhost:3000";
-const SERVICE_KEY =
-  process.env.SCHEDULER_SERVICE_API_KEY || "local-scheduler-key-for-dev";
+const INTERNAL_SERVICE_HMAC_SECRET =
+  process.env.INTERNAL_SERVICE_HMAC_SECRET || "";
 
 // Requires workflow + pgboss schemas. Run `pnpm db:setup-workflow` to create them.
 const shouldSkip =
@@ -197,17 +201,22 @@ describe.skipIf(shouldSkip || !hasPgboss)("Postgres World E2E", () => {
       it("should execute a workflow and persist run in workflow schema", {
         timeout: 35_000,
       }, async () => {
-        const response = await fetch(
-          `${KEEPERHUB_URL}/api/workflow/${testWorkflowId}/execute`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              "X-Service-Key": SERVICE_KEY,
-            },
-            body: JSON.stringify({ input: {} }),
-          }
-        );
+        const url = `${KEEPERHUB_URL}/api/workflow/${testWorkflowId}/execute`;
+        const requestBody = JSON.stringify({ input: {} });
+        const response = await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...signInternalServiceHeaders({
+              method: "POST",
+              url,
+              caller: "executor",
+              secret: INTERNAL_SERVICE_HMAC_SECRET,
+              body: requestBody,
+            }),
+          },
+          body: requestBody,
+        });
 
         expect(response.status).toBe(200);
         const body = (await response.json()) as {
@@ -250,17 +259,22 @@ describe.skipIf(shouldSkip || !hasPgboss)("Postgres World E2E", () => {
       it("should record steps in workflow.workflow_steps", {
         timeout: 35_000,
       }, async () => {
-        const response = await fetch(
-          `${KEEPERHUB_URL}/api/workflow/${testWorkflowId}/execute`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              "X-Service-Key": SERVICE_KEY,
-            },
-            body: JSON.stringify({ input: {} }),
-          }
-        );
+        const url = `${KEEPERHUB_URL}/api/workflow/${testWorkflowId}/execute`;
+        const requestBody = JSON.stringify({ input: {} });
+        const response = await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...signInternalServiceHeaders({
+              method: "POST",
+              url,
+              caller: "executor",
+              secret: INTERNAL_SERVICE_HMAC_SECRET,
+              body: requestBody,
+            }),
+          },
+          body: requestBody,
+        });
 
         expect(response.status).toBe(200);
 

--- a/tests/e2e/vitest/scheduler-lifecycle-filter.test.ts
+++ b/tests/e2e/vitest/scheduler-lifecycle-filter.test.ts
@@ -10,10 +10,27 @@ import {
   workflowSchedules,
   workflows,
 } from "../../../lib/db/schema";
+import { signInternalServiceHeaders } from "../../utils/internal-service-auth";
 
 // tests/setup.ts globally mocks @/lib/db with a stub query builder. This suite
 // drives the real route against a real database, so restore the genuine module.
 vi.unmock("@/lib/db");
+
+// The route authenticates via HMAC, verified against the internal_service_hmac
+// secret store. Mock the store so the suite stays self-contained (no seeded DB
+// row), and sign requests with the same fixed secret.
+const { HMAC_SECRET } = vi.hoisted(() => ({
+  HMAC_SECRET: "test-scheduler-lifecycle-hmac-secret",
+}));
+vi.mock("@/lib/internal-service-hmac-store", () => ({
+  listActiveHmacSecrets: vi.fn(() =>
+    Promise.resolve([{ secret: HMAC_SECRET, keyVersion: 1 }])
+  ),
+  lookupHmacSecret: vi.fn(() =>
+    Promise.resolve({ secret: HMAC_SECRET, keyVersion: 1 })
+  ),
+  insertHmacSecret: vi.fn(),
+}));
 
 // Proves the scheduler select only returns due workflows that are actually
 // runnable: enabled, not soft-deleted, not deactivated, and owned by an ACTIVE
@@ -29,11 +46,6 @@ vi.unmock("@/lib/db");
 const SKIP =
   !process.env.DATABASE_URL || process.env.SKIP_INFRA_TESTS === "true";
 const DATABASE_URL = process.env.DATABASE_URL ?? "";
-const SERVICE_KEY = "test-scheduler-lifecycle-key";
-
-// The route reads service keys from the environment at import time, so this
-// must be set before the dynamic import in beforeAll.
-process.env.SCHEDULER_SERVICE_API_KEY = SERVICE_KEY;
 
 const PREFIX = "test_keep611_lifecycle_";
 
@@ -124,9 +136,15 @@ describe.skipIf(SKIP)("scheduler lifecycle filtering", () => {
   }
 
   async function fetchScheduledWorkflowIds(): Promise<Set<string>> {
+    const url = "http://localhost/api/internal/schedules";
     const response = await GET(
-      new Request("http://localhost/api/internal/schedules", {
-        headers: { "X-Service-Key": SERVICE_KEY },
+      new Request(url, {
+        headers: signInternalServiceHeaders({
+          method: "GET",
+          url,
+          caller: "scheduler",
+          secret: HMAC_SECRET,
+        }),
       })
     );
     expect(response.status).toBe(200);

--- a/tests/integration/reaper-route.test.ts
+++ b/tests/integration/reaper-route.test.ts
@@ -100,7 +100,7 @@ import { authenticateInternalService } from "@/lib/internal-service-auth";
 
 function createRequest(): Request {
   return new Request("http://localhost:3000/api/internal/reaper", {
-    headers: { "X-Service-Key": "test-key" },
+    headers: { "X-KH-Caller": "scheduler" },
   });
 }
 

--- a/tests/integration/wallet-unlock-route.test.ts
+++ b/tests/integration/wallet-unlock-route.test.ts
@@ -74,7 +74,7 @@ function createRequest(body: unknown): Request {
   return new Request("http://localhost:3000/api/internal/wallet-unlock", {
     method: "POST",
     headers: {
-      "X-Service-Key": "test-key",
+      "X-KH-Caller": "scheduler",
       "Content-Type": "application/json",
     },
     body: typeof body === "string" ? body : JSON.stringify(body),

--- a/tests/k6/execution-load-test.js
+++ b/tests/k6/execution-load-test.js
@@ -2,7 +2,7 @@
 //
 // Each VU creates workflows in tiers (configurable via TIERS env).
 // ~75% Schedule (triggered by real scheduler-dispatcher every minute)
-// ~25% Manual (triggered by k6 via service key every ~60s)
+// ~25% Manual (triggered by k6 via HMAC-signed internal request every ~60s)
 //
 // Execution counting uses the /api/admin/test/stats endpoint which
 // queries the DB directly — no per-VU counting, no session-dependent
@@ -10,10 +10,11 @@
 //
 // k6 run execution-load-test.js \
 //   -e BASE_URL=https://app-staging.keeperhub.com \
-//   -e TEST_API_KEY=placeholder -e SERVICE_KEY=<key> \
+//   -e TEST_API_KEY=placeholder -e INTERNAL_SERVICE_HMAC_SECRET=<secret> \
 //   -e CF_ACCESS_CLIENT_ID=... -e CF_ACCESS_CLIENT_SECRET=...
 
 import http from "k6/http";
+import crypto from "k6/crypto";
 import { sleep } from "k6";
 import { Counter, Gauge } from "k6/metrics";
 import exec from "k6/execution";
@@ -22,7 +23,9 @@ const BASE_URL = __ENV.BASE_URL || "http://localhost:3000";
 const TEST_API_KEY = __ENV.TEST_API_KEY || "";
 const CF_ID = __ENV.CF_ACCESS_CLIENT_ID || "";
 const CF_SECRET = __ENV.CF_ACCESS_CLIENT_SECRET || "";
-const SERVICE_KEY = __ENV.SERVICE_KEY || "";
+const INTERNAL_SERVICE_HMAC_SECRET =
+  __ENV.INTERNAL_SERVICE_HMAC_SECRET || __ENV.SERVICE_KEY || "";
+const HMAC_CALLER = __ENV.HMAC_CALLER || "executor";
 const LOAD_TEST_BYPASS_TOKEN = __ENV.LOAD_TEST_BYPASS_TOKEN || "";
 const TARGET_VUS = parseInt(__ENV.TARGET_VUS || "20", 10);
 const OBSERVE_SECONDS = parseInt(__ENV.OBSERVE_SECONDS || "180", 10);
@@ -73,7 +76,21 @@ function h() {
   return hd;
 }
 function adminH() { const hd = h(); if (TEST_API_KEY) hd["Authorization"] = `Bearer ${TEST_API_KEY}`; return hd; }
-function serviceH() { const hd = h(); if (SERVICE_KEY) hd["X-Service-Key"] = SERVICE_KEY; return hd; }
+// Sign an internal service-to-service request with HMAC, matching the verifier
+// in lib/internal-service-auth.ts:
+//   signingString = method\npath\ncaller\nsha256_hex(body)\ntimestamp
+function serviceH(method, path, body) {
+  const hd = h();
+  if (INTERNAL_SERVICE_HMAC_SECRET) {
+    const ts = Math.floor(Date.now() / 1000).toString();
+    const bodyDigest = crypto.sha256(body || "", "hex");
+    const signingString = `${method}\n${path}\n${HMAC_CALLER}\n${bodyDigest}\n${ts}`;
+    hd["X-KH-Caller"] = HMAC_CALLER;
+    hd["X-KH-Timestamp"] = ts;
+    hd["X-KH-Signature"] = crypto.hmac("sha256", INTERNAL_SERVICE_HMAC_SECRET, signingString, "hex");
+  }
+  return hd;
+}
 
 // Workflow node builders
 function act(id, x, y) {
@@ -178,7 +195,9 @@ function createWorkflows(count) {
 
 function triggerManuals() {
   for (const wfId of manualWfIds) {
-    const r = http.post(`${BASE_URL}/api/workflow/${wfId}/execute`, JSON.stringify({}), { headers: serviceH() });
+    const path = `/api/workflow/${wfId}/execute`;
+    const body = JSON.stringify({});
+    const r = http.post(`${BASE_URL}${path}`, body, { headers: serviceH("POST", path, body) });
     if (r.status === 200 || r.status === 201) manualTriggerOk.add(1);
     else manualTriggerFail.add(1);
   }

--- a/tests/unit/internal-service-auth.test.ts
+++ b/tests/unit/internal-service-auth.test.ts
@@ -382,58 +382,6 @@ describe("authenticateInternalService - HMAC scheme", () => {
       error: "No active signing secret",
     });
   });
-});
-
-describe("authenticateInternalService - legacy bearer scheme", () => {
-  beforeEach(() => {
-    mockLookup.mockReset();
-    mockListActive.mockReset();
-    vi.unstubAllEnvs();
-    vi.stubEnv("SCHEDULER_SERVICE_API_KEY", "legacy-scheduler-key");
-  });
-
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
-  it("accepts the legacy X-Service-Key when matched against env var", async () => {
-    const { authenticateInternalService } = await import(
-      "@/lib/internal-service-auth"
-    );
-    const request = buildRequest({
-      method: "GET",
-      pathname: "/api/internal/schedules",
-      headers: { "X-Service-Key": "legacy-scheduler-key" },
-    });
-
-    const result = await authenticateInternalService(request);
-
-    expect(result).toMatchObject({
-      authenticated: true,
-      caller: "scheduler",
-      scheme: "legacy-bearer",
-    });
-  });
-
-  it("accepts the X-Internal-Token header against the same env var set", async () => {
-    const { authenticateInternalService } = await import(
-      "@/lib/internal-service-auth"
-    );
-    vi.stubEnv("EVENTS_SERVICE_API_KEY", "legacy-events-key");
-    const request = buildRequest({
-      method: "GET",
-      pathname: "/api/workflows/events",
-      headers: { "X-Internal-Token": "legacy-events-key" },
-    });
-
-    const result = await authenticateInternalService(request);
-
-    expect(result).toMatchObject({
-      authenticated: true,
-      caller: "events",
-      scheme: "legacy-bearer",
-    });
-  });
 
   it("rejects when no auth headers are present at all", async () => {
     const { authenticateInternalService } = await import(
@@ -449,52 +397,6 @@ describe("authenticateInternalService - legacy bearer scheme", () => {
     expect(result).toMatchObject({
       authenticated: false,
       error: "Missing auth headers",
-    });
-  });
-
-  it("does NOT fall back to legacy bearer when HMAC headers are present and verification fails", async () => {
-    const { authenticateInternalService } = await import(
-      "@/lib/internal-service-auth"
-    );
-    activeSecrets.length = 0;
-    activeSecrets.push({ secret: SHARED_SECRET, keyVersion: 1 });
-    mockListActive.mockImplementation(async () => activeSecrets.slice());
-
-    // Valid legacy header, but bogus HMAC headers. The presence of an HMAC
-    // signature commits to the HMAC path, so the legacy header MUST NOT
-    // rescue the request.
-    const request = buildRequest({
-      method: "GET",
-      pathname: "/api/internal/schedules",
-      headers: {
-        "X-Service-Key": "legacy-scheduler-key",
-        "X-KH-Caller": "scheduler",
-        "X-KH-Timestamp": String(Math.floor(Date.now() / 1000)),
-        "X-KH-Signature": "0".repeat(64),
-      },
-    });
-
-    const result = await authenticateInternalService(request);
-
-    expect(result.authenticated).toBe(false);
-  });
-
-  it("rejects all legacy bearers when INTERNAL_AUTH_REQUIRE_HMAC=true", async () => {
-    vi.stubEnv("INTERNAL_AUTH_REQUIRE_HMAC", "true");
-    const { authenticateInternalService } = await import(
-      "@/lib/internal-service-auth"
-    );
-    const request = buildRequest({
-      method: "GET",
-      pathname: "/api/internal/schedules",
-      headers: { "X-Service-Key": "legacy-scheduler-key" },
-    });
-
-    const result = await authenticateInternalService(request);
-
-    expect(result).toMatchObject({
-      authenticated: false,
-      error: "HMAC authentication required",
     });
   });
 });

--- a/tests/utils/internal-service-auth.ts
+++ b/tests/utils/internal-service-auth.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared helper to sign internal service-to-service requests for tests.
+ *
+ * Mirrors the canonical signing string used by the verifier
+ * (lib/internal-service-auth.ts) and the producers
+ * (e.g. keeperhub-executor/api-execute.ts):
+ *   `${method}\n${pathname}\n${caller}\n${sha256_hex(body)}\n${timestamp}`
+ *   signature = hex(hmac_sha256(secret, signingString))
+ *
+ * `caller` must be a valid InternalCaller; for v1 every producer shares one
+ * signing secret, so any caller verifies against the same `secret`.
+ */
+
+import { createHash, createHmac } from "node:crypto";
+
+export function signInternalServiceHeaders(opts: {
+  method: string;
+  url: string;
+  caller: string;
+  secret: string;
+  body?: string;
+  timestamp?: string;
+}): Record<string, string> {
+  const body = opts.body ?? "";
+  const pathname = new URL(opts.url).pathname;
+  const timestamp = opts.timestamp ?? String(Math.floor(Date.now() / 1000));
+  const bodyDigest = createHash("sha256").update(body).digest("hex");
+  const signingString = `${opts.method}\n${pathname}\n${opts.caller}\n${bodyDigest}\n${timestamp}`;
+  const signature = createHmac("sha256", opts.secret)
+    .update(signingString)
+    .digest("hex");
+  return {
+    "X-KH-Caller": opts.caller,
+    "X-KH-Timestamp": timestamp,
+    "X-KH-Signature": signature,
+  };
+}


### PR DESCRIPTION
## What

Finish the internal service-to-service HMAC cutover by removing the legacy
bearer scheme from the code **and** the deploy/runtime wiring that still
referenced it, and make the HMAC path work in every environment (prod, staging,
PR envs, and local).

`authenticateInternalService` now accepts the HMAC scheme only; the legacy
`X-Service-Key` / `X-Internal-Token` bearer and the `INTERNAL_AUTH_REQUIRE_HMAC`
enforcement flag are gone.

## Why

The HMAC scheme (request-bound signature, timestamp window, DB-backed rotatable
secret store) shipped alongside the legacy bearer in a dual-accept window, and
that cutover is complete: all internal producers sign HMAC outbound, nothing
sends the legacy headers, and the legacy keys were no longer provisioned. This
removes the dead code and the now-unused legacy key wiring, and closes the gaps
that left HMAC non-functional outside prod/staging.

## Changes

**Code**
- `lib/internal-service-auth.ts`: delete `verifyLegacyBearer` / `secureCompare`,
  the enforce flag, and the legacy branch; narrow result `scheme` to `"hmac"`;
  rename the shared-secret sentinel to `SHARED_SECRET_KEY`.
- `lib/logging.ts`: narrow the audit `scheme` type to `"hmac" | "none"`.
- Remove the now-dead `KEEPERHUB_API_KEY` reads from the executor and
  event-tracker config (they sign HMAC and never used it), plus the unused
  `SERVICE_API_KEY` producer export.
- Tests: drop the legacy-bearer unit suite; add a shared
  `tests/utils/internal-service-auth` signing helper; migrate the
  scheduler-lifecycle and postgres-world e2e suites to HMAC signing.

**Deploy manifests (prod/staging)**
- Remove `INTERNAL_AUTH_REQUIRE_HMAC` and the legacy `*_SERVICE_API_KEY` /
  producer `KEEPERHUB_API_KEY` `parameterStore` references from the keeperhub,
  scheduler and event-tracker values. These point at the SSM params that
  infrastructure #267 deletes, so they must stop being referenced first to
  avoid external-secrets sync failures.

**PR-env and local HMAC wiring**
- Wire `INTERNAL_SERVICE_HMAC_SECRET` into the PR-env app, reaper cronjob and
  all dispatchers/executor/event-tracker; same for the local manifests.
- Seed the DB-backed secret store on a fresh PR-env via a post-app-deploy step
  in `deploy-pr-environment.yaml` (a one-shot migrator-image Job). The app's
  db-migration initContainer can't seed: its `secretKeyRef` env is fixed at
  container start and loses the race with external-secrets on first boot.
- Local minikube keeps an init-container seed (it uses kv literals, so no
  external-secrets race) and documents `AGENTIC_WALLET_HMAC_KMS_KEY`.

**docker-compose (local dev)**
- The earlier consumer migration missed the dispatcher, block-dispatcher,
  executor and event-tracker dev services - they had no signing secret and
  would 401. Give every producer `INTERNAL_SERVICE_HMAC_SECRET`, drop the dead
  legacy keys, and document `AGENTIC_WALLET_HMAC_KMS_KEY` in `.env.example`.

## Verification

- `pnpm type-check`: passes. CI `lint` / `typecheck` / `test-unit` jobs: green.
- Affected unit suites (verifier + executor) pass locally.
- Local end-to-end against Postgres: db push -> seed (envelope-encrypt) ->
  store decrypt round-trip -> producer-signed HMAC matches verifier. PASS.
- **Live PR environment**: the post-deploy seed Job seeds the store and the
  reaper's signed `/api/internal/reaper` call returns **HTTP 200** (was 401
  "No active signing secret" before the seed wiring).

## Deploy sequencing (important)

1. Merge + **deploy this PR** (the deploy manifests stop referencing the legacy
   SSM params; the still-injected values become harmless).
2. **Then** apply infrastructure #267, which deletes those SSM params.

Applying #267 before this deploys would break external-secrets sync for the
keeperhub/scheduler/event-tracker releases.

## Notes

- Local minikube seeding is wired but not yet exercised against a real minikube
  deploy (the PR-env path is live-validated above).
- Pre-existing repo-wide lint findings are unaffected by these changes.

## Related PRs

Builds on the internal-service-auth HMAC cutover:
- #1405 - harden internal service auth with HMAC (original design)
- #1489 - migrate internal service auth to HMAC-SHA256
- #1490 - wire schedule-dispatcher through shared HMAC http-client
- #1491 - enable HMAC-only on staging
- #1492 - enable HMAC-only on prod

Infrastructure follow-up (removes the now-unused legacy bearer SSM parameters):
- techops-services/infrastructure#267
