### PR TITLE
fix: self-heal gas-credit allocation on mid-period plan change

### DIFF
--- a/lib/billing/gas-credits.ts
+++ b/lib/billing/gas-credits.ts
@@ -81,9 +81,11 @@ type GasCreditCheckResult =
 /**
  * Resolve the gas credit allocation for an org in the current billing period.
  *
- * On first call per period, snapshots the current env-driven cap to the DB.
- * Subsequent calls in the same period return the persisted value, ensuring
- * mid-period env changes don't affect existing orgs.
+ * Snapshots the current env-driven cap to the DB. The snapshot self-heals
+ * upward: if the org's derived cap has increased since the row was written
+ * (plan upgrade, override raise, or env increase), the allocation is raised to
+ * the new cap. It is never reduced within a period, so mid-period env decreases
+ * and plan downgrades don't claw back credits an org is already relying on.
  */
 async function resolveAllocation(
   organizationId: string,
@@ -91,21 +93,6 @@ async function resolveAllocation(
   periodStart: Date,
   overrides?: Partial<PlanLimits> | null
 ): Promise<number> {
-  const existing = await db
-    .select({ allocatedCents: gasCreditAllocations.allocatedCents })
-    .from(gasCreditAllocations)
-    .where(
-      and(
-        eq(gasCreditAllocations.organizationId, organizationId),
-        eq(gasCreditAllocations.periodStart, periodStart)
-      )
-    )
-    .limit(1);
-
-  if (existing[0] !== undefined) {
-    return existing[0].allocatedCents;
-  }
-
   const capCents = getGasCreditCapCents(planName, overrides);
 
   await db
@@ -115,9 +102,16 @@ async function resolveAllocation(
       periodStart,
       allocatedCents: capCents,
     })
-    .onConflictDoNothing();
+    .onConflictDoUpdate({
+      target: [
+        gasCreditAllocations.organizationId,
+        gasCreditAllocations.periodStart,
+      ],
+      set: { allocatedCents: capCents },
+      setWhere: sql`${gasCreditAllocations.allocatedCents} < ${capCents}`,
+    });
 
-  const inserted = await db
+  const row = await db
     .select({ allocatedCents: gasCreditAllocations.allocatedCents })
     .from(gasCreditAllocations)
     .where(
@@ -128,7 +122,7 @@ async function resolveAllocation(
     )
     .limit(1);
 
-  return inserted[0]?.allocatedCents ?? capCents;
+  return row[0]?.allocatedCents ?? capCents;
 }
 
 /**

--- a/tests/unit/gas-credits.test.ts
+++ b/tests/unit/gas-credits.test.ts
@@ -20,20 +20,25 @@ vi.mock("@/lib/web3/chainlink-feeds", () => ({
   },
 }));
 
-const mockInsertValues = vi.fn().mockResolvedValue(undefined);
+const mockOnConflictDoNothing = vi.fn().mockResolvedValue(undefined);
+const mockOnConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+const mockSelectLimit = vi.fn().mockResolvedValue([]);
 
 vi.mock("@/lib/db", () => ({
   db: {
     select: vi.fn(() => ({
       from: vi.fn(() => ({
         where: vi.fn(() => ({
-          limit: vi.fn().mockResolvedValue([]),
+          limit: (...args: unknown[]) => mockSelectLimit(...args),
         })),
       })),
     })),
     insert: vi.fn(() => ({
       values: vi.fn(() => ({
-        onConflictDoNothing: (...args: unknown[]) => mockInsertValues(...args),
+        onConflictDoNothing: (...args: unknown[]) =>
+          mockOnConflictDoNothing(...args),
+        onConflictDoUpdate: (...args: unknown[]) =>
+          mockOnConflictDoUpdate(...args),
       })),
     })),
   },
@@ -91,11 +96,14 @@ import {
   getGasCreditCaps,
   recordGasUsage,
 } from "@/lib/billing/gas-credits";
+import type { PlanLimits } from "@/lib/billing/plans";
 import { getOrgSubscription } from "@/lib/billing/plans-server";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockInsertValues.mockResolvedValue(undefined);
+  mockOnConflictDoNothing.mockResolvedValue(undefined);
+  mockOnConflictDoUpdate.mockResolvedValue(undefined);
+  mockSelectLimit.mockResolvedValue([]);
   mockReadContract.mockReset();
   process.env.GAS_CREDITS_FREE_CENTS = undefined;
   process.env.GAS_CREDITS_PRO_CENTS = undefined;
@@ -152,7 +160,7 @@ describe("recordGasUsage", () => {
       ethPriceUsd: 2000,
     });
 
-    expect(mockInsertValues).toHaveBeenCalledOnce();
+    expect(mockOnConflictDoNothing).toHaveBeenCalledOnce();
   });
 });
 
@@ -259,5 +267,49 @@ describe("getGasCreditBalance", () => {
 
     expect(balance.totalCents).toBe(7777);
     expect(balance.remainingCents).toBe(7777);
+  });
+});
+
+describe("gas credit allocation self-heal", () => {
+  const mockSubscription = (
+    plan: string,
+    overrides: Partial<PlanLimits> | null
+  ): void => {
+    vi.mocked(getOrgSubscription).mockResolvedValue({
+      plan,
+      planOverrides: overrides,
+      currentPeriodStart: new Date(),
+    } as unknown as Awaited<ReturnType<typeof getOrgSubscription>>);
+  };
+
+  it("upserts the period allocation with a raise-only guard at the derived cap", async () => {
+    mockSubscription("enterprise", { gasCreditsCents: 7777 });
+
+    await getGasCreditBalance("org_heal");
+
+    expect(mockOnConflictDoUpdate).toHaveBeenCalledOnce();
+    const [arg] = mockOnConflictDoUpdate.mock.calls[0] as [
+      {
+        target: unknown[];
+        set: { allocatedCents: number };
+        setWhere: unknown;
+      },
+    ];
+    expect(arg.set.allocatedCents).toBe(7777);
+    expect(arg.target).toHaveLength(2);
+    // The raise-only predicate (allocated_cents < cap) is enforced in SQL via
+    // setWhere; this asserts the guard is wired, not the DB-side comparison.
+    expect(arg.setWhere).toBeDefined();
+  });
+
+  it("returns the persisted allocation rather than a lower derived cap (no mid-period clawback)", async () => {
+    // A higher allocation is already snapshotted for this period...
+    mockSelectLimit.mockResolvedValue([{ allocatedCents: 10_000 }]);
+    // ...while the org now resolves to a lower plan cap (free default = 500).
+    mockSubscription("free", null);
+
+    const balance = await getGasCreditBalance("org_downgrade");
+
+    expect(balance.totalCents).toBe(10_000);
   });
 });


### PR DESCRIPTION
## Problem

Gas-credit allocations (`gas_credit_allocations`) are snapshotted once per billing period on the first balance read and were never re-derived. When an org's plan or `plan_overrides` changed mid-period, the allocation kept the cap from whatever plan it had when the row was first written.

This surfaced in production: an org upgraded free -> enterprise mid-cycle stayed funded at the free-tier cap for the rest of the period, because the upgrade path updates the subscription but never refreshes the allocation, and enterprise orgs are provisioned by direct DB edit (no code path to hook a refresh into).

## Fix

`resolveAllocation` now re-derives the cap on every read and raises the stored allocation to it via `onConflictDoUpdate` guarded by `setWhere (allocated_cents < cap)`.

- Self-healing on read: covers provider-driven upgrades and manual enterprise provisioning alike, and corrects existing stale rows on their next balance check. No migration or backfill script required.
- Runs inside `checkGasCredits -> getGasCreditBalance -> resolveAllocation`, so an upgraded org gets the correct cap the moment it next attempts a sponsored transaction.
- No schema change.

## Decision: raise-only

Mid-cycle downgrades intentionally do NOT reduce the current period's allocation. The snapshot only ever increases within a period, to avoid clawing back credits an org is already relying on. The next period naturally re-derives from current plan state.

### Alternatives considered
- Event-driven refresh in the webhook/checkout upgrade handlers - rejected: misses manual enterprise provisioning and adds surface across three call sites.
- One-time backfill script - unnecessary: self-heal corrects stale rows on next read.

## Tests

`tests/unit/gas-credits.test.ts`:
- asserts the allocation is upserted with a raise-only guard at the derived cap
- asserts the balance returns the persisted (higher) allocation rather than a lower freshly-derived cap (no mid-period clawback)

Note: the repo's vitest suite mocks the DB layer, so the raise-only SQL predicate (`setWhere`) is validated by Postgres at runtime, not in unit tests. Recommend a staging sanity check: upgrade an org, confirm the gas balance reflects the new cap without a period rollover.