### PR TITLE
fix: org-scope workflow database connections

### DIFF
--- a/components/ui/integration-selector.tsx
+++ b/components/ui/integration-selector.tsx
@@ -79,14 +79,21 @@ export function IntegrationSelector({
     }
   }, [integrationsVersion, loadIntegrations]);
 
+  // Auto-select a connection ONLY for a node that has none yet. Never change a
+  // binding that is already set: a previously pinned connection that is missing
+  // from the freshly-loaded list (deleted, or not in the active org) must not be
+  // silently rebound to a different one, since that change autosaves and can
+  // repoint a running workflow at the wrong database.
   useEffect(() => {
-    if (integrations.length > 0 && !disabled) {
-      const currentExists = value && integrations.some((i) => i.id === value);
-      if (!currentExists) {
-        onChange(integrations[0].id);
-      }
+    if (integrations.length > 0 && !disabled && !value) {
+      onChange(integrations[0].id);
     }
   }, [integrations, value, disabled, onChange]);
+
+  const selectedMissing =
+    Boolean(value) &&
+    integrations.length > 0 &&
+    !integrations.some((i) => i.id === value);
 
   const handleNewIntegrationCreated = useCallback(
     async (integrationId: string) => {
@@ -146,6 +153,15 @@ export function IntegrationSelector({
     SYSTEM_INTEGRATION_LABELS[integrationType] ||
     integrationType;
 
+  const missingSelectionWarning = selectedMissing ? (
+    <div className="flex items-center gap-2 rounded-md border border-orange-500/50 bg-orange-500/10 px-3 py-1.5 text-orange-600 text-sm dark:text-orange-400">
+      <AlertTriangle className="size-4 shrink-0" />
+      <span className="flex-1 text-left">
+        Selected {integrationLabel} connection is unavailable - choose one below
+      </span>
+    </div>
+  ) : null;
+
   if (integrations.length === 0) {
     return (
       <Button
@@ -166,31 +182,47 @@ export function IntegrationSelector({
   if (integrations.length === 1) {
     const integration = integrations[0];
     const displayName = integration.name || `${integrationLabel} API Key`;
+    const isSelected = value === integration.id;
 
     return (
-      <div
-        className={cn(
-          "flex h-9 w-full items-center gap-2 rounded-md border px-3 text-sm",
-          disabled && "cursor-not-allowed opacity-50"
-        )}
-      >
-        <Check className="size-4 shrink-0 text-green-600" />
-        <span className="flex-1 truncate">{displayName}</span>
-        <Button
-          className="size-6 shrink-0"
-          disabled={disabled}
-          onClick={() => openEditConnectionOverlay(integration)}
-          size="icon"
-          variant="ghost"
+      <div className="flex flex-col gap-1">
+        {missingSelectionWarning}
+        <div
+          className={cn(
+            "flex h-9 w-full items-center gap-2 rounded-md border px-3 text-sm",
+            disabled && "cursor-not-allowed opacity-50"
+          )}
         >
-          <Pencil className="size-3" />
-        </Button>
+          <button
+            className="flex flex-1 items-center gap-2 truncate text-left"
+            disabled={disabled}
+            onClick={() => onChange(integration.id)}
+            type="button"
+          >
+            {isSelected ? (
+              <Check className="size-4 shrink-0 text-green-600" />
+            ) : (
+              <Circle className="size-4 shrink-0 text-muted-foreground" />
+            )}
+            <span className="flex-1 truncate">{displayName}</span>
+          </button>
+          <Button
+            className="size-6 shrink-0"
+            disabled={disabled}
+            onClick={() => openEditConnectionOverlay(integration)}
+            size="icon"
+            variant="ghost"
+          >
+            <Pencil className="size-3" />
+          </Button>
+        </div>
       </div>
     );
   }
 
   return (
     <div className="flex flex-col gap-1">
+      {missingSelectionWarning}
       {integrations.map((integration) => {
         const isSelected = value === integration.id;
         const displayName = integration.name || `${integrationLabel} API Key`;

--- a/lib/credential-fetcher.ts
+++ b/lib/credential-fetcher.ts
@@ -9,7 +9,7 @@
  *
  * Pattern:
  * - Step input: { integrationId: "abc123", ...otherParams }  ← Safe to log
- * - Step fetches: credentials = await fetchCredentials(integrationId)  ← Not logged
+ * - Step fetches: credentials = await fetchCredentials(integrationId, principal)  ← Not logged
  * - Step uses: apiClient.call(credentials.apiKey)  ← In memory only
  * - Step returns: { result: data }  ← Safe to log (no credentials)
  */
@@ -84,22 +84,21 @@ function mapIntegrationConfig(
 /**
  * Fetch credentials for an integration by ID.
  *
- * When `principal` is provided, the fetch is authorized against it (owner /
- * organization visibility / specific_members grant) before any credential is
- * decrypted, and returns no credentials if the principal is not authorized.
- * This is runtime defense-in-depth: execution entry points already authorize
- * the effective principal before dispatch, but only the owner-context
- * (ownerId/organizationId) is available once a run is in flight, so steps pass
- * that here to fail closed if a referenced id ever escapes the pre-execution
- * check. Omitting `principal` preserves the prior unauthenticated behaviour.
+ * The fetch is authorized against `principal` (organization visibility /
+ * specific_members grant) before any credential is decrypted, returning no
+ * credentials if the principal is not authorized. This is the runtime guard
+ * that stops a step from resolving a connection belonging to another org if a
+ * referenced id ever escapes the pre-execution / save-time checks. `principal`
+ * is required so every step fails closed; steps source it from
+ * `input._context` (the run's owner context).
  *
  * @param integrationId - The ID of the integration to fetch credentials for
- * @param principal - Optional owner-context principal to authorize against
+ * @param principal - Owner-context principal to authorize against
  * @returns WorkflowCredentials object with the integration's credentials
  */
 export async function fetchCredentials(
   integrationId: string,
-  principal?: IntegrationPrincipal
+  principal: IntegrationPrincipal
 ): Promise<WorkflowCredentials> {
   // A node with no integration selected passes undefined at runtime; treat it
   // as a missing integration instead of letting getIntegrationById(undefined)
@@ -108,14 +107,12 @@ export async function fetchCredentials(
     return {};
   }
 
-  if (principal) {
-    const unauthorized = await filterUnauthorizedIntegrationIds(
-      [integrationId],
-      principal
-    );
-    if (unauthorized.length > 0) {
-      return {};
-    }
+  const unauthorized = await filterUnauthorizedIntegrationIds(
+    [integrationId],
+    principal
+  );
+  if (unauthorized.length > 0) {
+    return {};
   }
 
   const integration = await getIntegrationById(integrationId);
@@ -131,7 +128,7 @@ export async function fetchCredentials(
  */
 export function fetchIntegrationCredentials(
   integrationId: string,
-  principal?: IntegrationPrincipal
+  principal: IntegrationPrincipal
 ): Promise<WorkflowCredentials> {
   return fetchCredentials(integrationId, principal);
 }

--- a/lib/db/integrations.ts
+++ b/lib/db/integrations.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { toChecksumAddress } from "@/lib/address-utils";
 import { filterUnauthorizedIntegrationIds } from "@/lib/integrations/authorization";
 import {
@@ -198,9 +198,13 @@ export async function getIntegrations(
   type?: IntegrationType,
   organizationId?: string | null
 ): Promise<DecryptedIntegration[]> {
+  // No active org -> personal scope only. Constrain to integrations the user
+  // created that are NOT org-scoped (organizationId IS NULL); without this the
+  // fallback returns every connection the user ever created in ANY org, which
+  // leaks cross-org connections into the workflow connection picker.
   const conditions = organizationId
     ? [eq(integrations.organizationId, organizationId)]
-    : [eq(integrations.createdBy, userId)];
+    : [eq(integrations.createdBy, userId), isNull(integrations.organizationId)];
 
   if (type) {
     conditions.push(eq(integrations.type, type));
@@ -227,7 +231,10 @@ export async function getIntegrations(
         eq(organizationWallets.isActive, true)
       )
     )
-    .where(and(...conditions));
+    .where(and(...conditions))
+    // Deterministic order so list consumers (e.g. the connection picker) see a
+    // stable "first" row instead of unordered, insertion-dependent results.
+    .orderBy(integrations.createdAt, integrations.id);
 
   return results.map((row) => ({
     id: row.id,

--- a/lib/workflow/store.ts
+++ b/lib/workflow/store.ts
@@ -1,6 +1,7 @@
 import type { Edge, EdgeChange, Node, NodeChange } from "@xyflow/react";
 import { applyEdgeChanges, applyNodeChanges } from "@xyflow/react";
 import { atom } from "jotai";
+import { toast } from "sonner";
 import { api } from "@/lib/api-client";
 import { computeAutoLayout } from "@/lib/workflow/editor/auto-layout";
 import { buildExecutionLogsMap } from "@/lib/workflow/editor/template-helpers";
@@ -197,7 +198,11 @@ export const autosaveAtom = atom(
         // Clear the unsaved changes indicator after successful save
         set(hasUnsavedChangesAtom, false);
       } catch (error) {
+        // Leave hasUnsavedChangesAtom set (only cleared on success) and tell the
+        // user: a rejected save - e.g. the server refusing an out-of-org
+        // connection reference - must not fail silently.
         console.warn("Autosave failed:", error);
+        toast.error("Couldn't save workflow changes. Please try again.");
       } finally {
         await new Promise((resolve) => setTimeout(resolve, 800));
         set(isSavingAtom, false);

--- a/plugins/AGENTS.md
+++ b/plugins/AGENTS.md
@@ -201,7 +201,9 @@ export async function doSomethingStep(
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, {
+        organizationId: input._context?.organizationId ?? null,
+      })
     : {};
 
   return withStepLogging(input, () => stepHandler(input, credentials));
@@ -487,7 +489,9 @@ Some plugins may work without credentials (using defaults or public APIs):
 
 ```typescript
 const credentials = input.integrationId
-  ? await fetchCredentials(input.integrationId)
+  ? await fetchCredentials(input.integrationId, {
+      organizationId: input._context?.organizationId ?? null,
+    })
   : {};  // Empty object if no integrationId
 
 // Handle missing credentials gracefully

--- a/plugins/_template/steps/action.ts.txt
+++ b/plugins/_template/steps/action.ts.txt
@@ -100,7 +100,7 @@ export async function [actionName]Step(
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
     : {};
 
   return withStepLogging(input, () => stepHandler(input, credentials));

--- a/plugins/blockscout/steps/get-address-balance.ts
+++ b/plugins/blockscout/steps/get-address-balance.ts
@@ -70,7 +70,7 @@ export async function getAddressBalanceStep(
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
     : {};
 
   return withPluginMetrics(

--- a/plugins/blockscout/steps/get-address-counters.ts
+++ b/plugins/blockscout/steps/get-address-counters.ts
@@ -71,7 +71,7 @@ export async function getAddressCountersStep(
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
     : {};
 
   return withPluginMetrics(

--- a/plugins/blockscout/steps/get-address-info.ts
+++ b/plugins/blockscout/steps/get-address-info.ts
@@ -101,7 +101,7 @@ export async function getAddressInfoStep(
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
     : {};
 
   return withPluginMetrics(

--- a/plugins/blockscout/steps/get-token-info.ts
+++ b/plugins/blockscout/steps/get-token-info.ts
@@ -81,7 +81,7 @@ export async function getTokenInfoStep(
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
     : {};
 
   return withPluginMetrics(

--- a/plugins/blockscout/steps/get-transaction.ts
+++ b/plugins/blockscout/steps/get-transaction.ts
@@ -85,7 +85,7 @@ export async function getTransactionStep(
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
     : {};
 
   return withPluginMetrics(

--- a/plugins/clerk/steps/create-user.ts
+++ b/plugins/clerk/steps/create-user.ts
@@ -125,7 +125,7 @@ export async function clerkCreateUserStep(
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
     : {};
 
   return withStepLogging(input, () => stepHandler(input, credentials));

--- a/plugins/clerk/steps/delete-user.ts
+++ b/plugins/clerk/steps/delete-user.ts
@@ -89,7 +89,7 @@ export async function clerkDeleteUserStep(
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
     : {};
 
   return withStepLogging(input, () => stepHandler(input, credentials));

--- a/plugins/clerk/steps/get-user.ts
+++ b/plugins/clerk/steps/get-user.ts
@@ -86,7 +86,7 @@ export async function clerkGetUserStep(
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
     : {};
 
   return withStepLogging(input, () => stepHandler(input, credentials));

--- a/plugins/clerk/steps/update-user.ts
+++ b/plugins/clerk/steps/update-user.ts
@@ -122,7 +122,7 @@ export async function clerkUpdateUserStep(
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
     : {};
 
   return withStepLogging(input, () => stepHandler(input, credentials));

--- a/plugins/discord/steps/send-message.ts
+++ b/plugins/discord/steps/send-message.ts
@@ -179,7 +179,7 @@ export async function sendDiscordMessageStep(
 ): Promise<SendDiscordMessageResult> {
   "use step";
 
-  const credentials = await fetchCredentials(input.integrationId);
+  const credentials = await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null });
 
   return withPluginMetrics(
     {

--- a/plugins/linear/steps/find-issues.ts
+++ b/plugins/linear/steps/find-issues.ts
@@ -179,7 +179,7 @@ export async function findIssuesStep(
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
     : {};
 
   return withStepLogging(input, () => stepHandler(input, credentials));

--- a/plugins/resend/steps/send-email.ts
+++ b/plugins/resend/steps/send-email.ts
@@ -121,7 +121,7 @@ export async function sendEmailStep(
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
     : {};
 
   const coreInput: SendEmailCoreInput = {

--- a/plugins/safe/steps/get-pending-transactions.ts
+++ b/plugins/safe/steps/get-pending-transactions.ts
@@ -282,7 +282,7 @@ export async function getPendingTransactionsStep(
 ): Promise<GetPendingTransactionsResult> {
   "use step";
 
-  const credentials = await fetchCredentials(input.integrationId);
+  const credentials = await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null });
 
   return withPluginMetrics(
     {

--- a/plugins/sendgrid/steps/send-email.ts
+++ b/plugins/sendgrid/steps/send-email.ts
@@ -169,7 +169,7 @@ export async function sendEmailStep(
   }
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
     : {};
 
   // Always use KeeperHub API key

--- a/plugins/slack/steps/send-slack-message.ts
+++ b/plugins/slack/steps/send-slack-message.ts
@@ -98,7 +98,7 @@ export async function sendSlackMessageStep(
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
     : {};
 
   return withStepLogging(input, () => stepHandler(input, credentials));

--- a/plugins/telegram/steps/send-message.ts
+++ b/plugins/telegram/steps/send-message.ts
@@ -244,7 +244,7 @@ export async function sendTelegramMessageStep(
 ): Promise<SendTelegramMessageResult> {
   "use step";
 
-  const credentials = await fetchCredentials(input.integrationId);
+  const credentials = await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null });
 
   return withPluginMetrics(
     {

--- a/plugins/v0/steps/create-chat.ts
+++ b/plugins/v0/steps/create-chat.ts
@@ -68,7 +68,7 @@ export async function createChatStep(
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
     : {};
 
   return withStepLogging(input, () => stepHandler(input, credentials));

--- a/plugins/v0/steps/send-message.ts
+++ b/plugins/v0/steps/send-message.ts
@@ -67,7 +67,7 @@ export async function sendMessageStep(
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
     : {};
 
   return withStepLogging(input, () => stepHandler(input, credentials));

--- a/plugins/webflow/steps/get-site.ts
+++ b/plugins/webflow/steps/get-site.ts
@@ -126,7 +126,7 @@ export async function getSiteStep(
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
     : {};
 
   return withStepLogging(input, () => stepHandler(input, credentials));

--- a/plugins/webflow/steps/list-sites.ts
+++ b/plugins/webflow/steps/list-sites.ts
@@ -110,7 +110,7 @@ export async function listSitesStep(
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
     : {};
 
   return withStepLogging(input, () => stepHandler(input, credentials));

--- a/plugins/webflow/steps/publish-site.ts
+++ b/plugins/webflow/steps/publish-site.ts
@@ -132,7 +132,7 @@ export async function publishSiteStep(
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId)
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
     : {};
 
   return withStepLogging(input, () => stepHandler(input, credentials));

--- a/scripts/audit-cross-org-connections.ts
+++ b/scripts/audit-cross-org-connections.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env tsx
+
+/**
+ * Read-only audit: find workflows bound to a Connection (integration) that
+ * belongs to a different organization than the workflow itself.
+ *
+ * Background: before the org-scoped picker / runtime guards landed, a workflow
+ * node could be (and at least one was) silently rebound to another org's
+ * database connection. This script reports any currently-corrupted bindings so
+ * they can be repaired manually. It NEVER writes - repointing a workflow to the
+ * correct connection is an explicit, reviewed action done separately.
+ *
+ * A binding is flagged when the referenced integration's organizationId does
+ * not equal the workflow's organizationId. Deleted/unknown integration ids are
+ * reported separately (informational - a stale reference is not a leak).
+ *
+ * Usage:
+ *   npx tsx scripts/audit-cross-org-connections.ts
+ */
+
+import { inArray } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import * as schema from "../lib/db/schema";
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+  console.error("DATABASE_URL is required");
+  process.exit(1);
+}
+
+const client = postgres(connectionString);
+const db = drizzle(client, { schema });
+
+type WorkflowNode = {
+  id?: string;
+  data?: { config?: { integrationId?: unknown } };
+};
+
+function integrationIdsOf(nodes: WorkflowNode[]): string[] {
+  const ids: string[] = [];
+  for (const node of nodes) {
+    const id = node?.data?.config?.integrationId;
+    if (typeof id === "string" && id.length > 0) {
+      ids.push(id);
+    }
+  }
+  return [...new Set(ids)];
+}
+
+async function main(): Promise<void> {
+  const workflows = await db
+    .select({
+      id: schema.workflows.id,
+      name: schema.workflows.name,
+      organizationId: schema.workflows.organizationId,
+      nodes: schema.workflows.nodes,
+    })
+    .from(schema.workflows);
+
+  // Gather every referenced integration id across all workflows, then resolve
+  // their owning org in a single query.
+  const allIds = new Set<string>();
+  for (const wf of workflows) {
+    for (const id of integrationIdsOf((wf.nodes ?? []) as WorkflowNode[])) {
+      allIds.add(id);
+    }
+  }
+
+  const orgByIntegrationId = new Map<string, string | null>();
+  if (allIds.size > 0) {
+    const rows = await db
+      .select({
+        id: schema.integrations.id,
+        organizationId: schema.integrations.organizationId,
+      })
+      .from(schema.integrations)
+      .where(inArray(schema.integrations.id, [...allIds]));
+    for (const row of rows) {
+      orgByIntegrationId.set(row.id, row.organizationId);
+    }
+  }
+
+  const crossOrg: string[] = [];
+  const missing: string[] = [];
+
+  for (const wf of workflows) {
+    for (const id of integrationIdsOf((wf.nodes ?? []) as WorkflowNode[])) {
+      if (!orgByIntegrationId.has(id)) {
+        missing.push(
+          `  workflow ${wf.id} ("${wf.name}", org ${wf.organizationId}) -> connection ${id} [not found / deleted]`
+        );
+        continue;
+      }
+      const integrationOrg = orgByIntegrationId.get(id) ?? null;
+      if (integrationOrg !== wf.organizationId) {
+        crossOrg.push(
+          `  workflow ${wf.id} ("${wf.name}", org ${wf.organizationId}) -> connection ${id} (org ${integrationOrg ?? "personal/null"})`
+        );
+      }
+    }
+  }
+
+  console.log(`Scanned ${workflows.length} workflows.\n`);
+
+  console.log(`Cross-org connection bindings: ${crossOrg.length}`);
+  if (crossOrg.length > 0) {
+    console.log(crossOrg.join("\n"));
+  }
+
+  console.log(`\nStale (deleted) connection references: ${missing.length}`);
+  if (missing.length > 0) {
+    console.log(missing.join("\n"));
+  }
+
+  await client.end();
+  // Non-zero exit when leaks are present so the script is CI-usable as a gate.
+  process.exit(crossOrg.length > 0 ? 1 : 0);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/unit/credential-fetcher.test.ts
+++ b/tests/unit/credential-fetcher.test.ts
@@ -21,6 +21,11 @@ vi.mock("server-only", () => ({}));
 vi.mock("@/lib/db/integrations", () => ({
   getIntegrationById: vi.fn(),
 }));
+vi.mock("@/lib/integrations/authorization", () => ({
+  filterUnauthorizedIntegrationIds: vi.fn().mockResolvedValue([]),
+}));
+
+const ORG_PRINCIPAL = { organizationId: "org_1" };
 
 type ExpectedMapping = {
   type: string;
@@ -127,7 +132,7 @@ describe("mapIntegrationConfig (via fetchCredentials)", () => {
       config: { [configKey]: "secret-value" },
     } as Awaited<ReturnType<typeof getIntegrationById>>);
 
-    const creds = await fetchCredentials("int_test");
+    const creds = await fetchCredentials("int_test", ORG_PRINCIPAL);
     expect(creds[envVar]).toBe("secret-value");
   });
 
@@ -138,7 +143,10 @@ describe("mapIntegrationConfig (via fetchCredentials)", () => {
     vi.mocked(getIntegrationById).mockClear();
 
     // Must short-circuit before getIntegrationById(undefined) throws.
-    const creds = await fetchCredentials(undefined as unknown as string);
+    const creds = await fetchCredentials(
+      undefined as unknown as string,
+      ORG_PRINCIPAL
+    );
 
     expect(creds).toEqual({});
     expect(getIntegrationById).not.toHaveBeenCalled();
@@ -154,7 +162,26 @@ describe("mapIntegrationConfig (via fetchCredentials)", () => {
       config: { someKey: "someValue" },
     } as unknown as Awaited<ReturnType<typeof getIntegrationById>>);
 
-    const creds = await fetchCredentials("int_test");
+    const creds = await fetchCredentials("int_test", ORG_PRINCIPAL);
     expect(creds).toEqual({});
+  });
+
+  it("returns no creds and skips the DB when the principal is not authorized for the integration (cross-org)", async () => {
+    const { getIntegrationById } = await import("@/lib/db/integrations");
+    const { filterUnauthorizedIntegrationIds } = await import(
+      "@/lib/integrations/authorization"
+    );
+    const { fetchCredentials } = await import("@/lib/credential-fetcher");
+
+    vi.mocked(getIntegrationById).mockClear();
+    // The integration belongs to another org -> authorization marks it invalid.
+    vi.mocked(filterUnauthorizedIntegrationIds).mockResolvedValueOnce([
+      "int_other_org",
+    ]);
+
+    const creds = await fetchCredentials("int_other_org", ORG_PRINCIPAL);
+
+    expect(creds).toEqual({});
+    expect(getIntegrationById).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/get-integrations-scope.test.ts
+++ b/tests/unit/get-integrations-scope.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Scope regression tests for getIntegrations (the connection picker's list
+ * query). A session with no active organization must NOT see other orgs'
+ * connections: the personal fallback has to be constrained to integrations the
+ * user created that are not org-scoped (organizationId IS NULL). Results must
+ * also be deterministically ordered so the picker's "first" connection is
+ * stable across requests.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const h = vi.hoisted(() => {
+  const orderBy = vi.fn(() => Promise.resolve([]));
+  const where = vi.fn(() => ({ orderBy }));
+  const leftJoin = vi.fn(() => ({ where }));
+  const from = vi.fn(() => ({ leftJoin }));
+  const select = vi.fn(() => ({ from }));
+  const eq = vi.fn((col: unknown, val: unknown) => ({ op: "eq", col, val }));
+  const isNull = vi.fn((col: unknown) => ({ op: "isNull", col }));
+  const and = vi.fn((...conditions: unknown[]) => ({ op: "and", conditions }));
+  return { orderBy, where, leftJoin, from, select, eq, isNull, and };
+});
+
+vi.mock("drizzle-orm", () => ({ eq: h.eq, and: h.and, isNull: h.isNull }));
+
+vi.mock("@/lib/db", () => ({ db: { select: h.select } }));
+
+vi.mock("@/lib/db/schema", () => ({
+  integrations: {
+    id: "id",
+    createdBy: "created_by",
+    organizationId: "organization_id",
+    name: "name",
+    type: "type",
+    config: "config",
+    isManaged: "is_managed",
+    createdAt: "created_at",
+    updatedAt: "updated_at",
+  },
+}));
+
+vi.mock("@/lib/db/schema-extensions", () => ({
+  // Distinct token from integrations.organizationId so the leftJoin's
+  // eq(walletOrgId, integrationOrgId) cannot be confused with the WHERE clause.
+  organizationWallets: {
+    organizationId: "wallet_organization_id",
+    walletAddress: "wallet_address",
+    isActive: "is_active",
+  },
+}));
+
+// Module-load-time imports unrelated to getIntegrations.
+vi.mock("@/lib/integrations/authorization", () => ({
+  filterUnauthorizedIntegrationIds: vi.fn(),
+}));
+vi.mock("@/lib/web3/wallet-helpers", () => ({
+  getOrganizationWallet: vi.fn(),
+  organizationHasWallet: vi.fn(),
+}));
+vi.mock("@/plugins/registry", () => ({
+  findActionById: vi.fn(),
+  getIntegration: vi.fn(),
+}));
+vi.mock("@/lib/address-utils", () => ({
+  toChecksumAddress: (addr: string) => addr,
+}));
+
+describe("getIntegrations scope", () => {
+  beforeEach(() => {
+    h.eq.mockClear();
+    h.isNull.mockClear();
+    h.and.mockClear();
+    h.orderBy.mockClear();
+  });
+
+  it("constrains the no-org fallback to personal (organizationId IS NULL) rows", async () => {
+    const { getIntegrations } = await import("@/lib/db/integrations");
+
+    await getIntegrations("user_1", undefined, null);
+
+    // Personal fallback: createdBy = user AND organizationId IS NULL.
+    expect(h.eq).toHaveBeenCalledWith("created_by", "user_1");
+    expect(h.isNull).toHaveBeenCalledWith("organization_id");
+    // Must NOT scope by an org equality in the no-org path (the join uses the
+    // distinct wallet_organization_id token, so this only matches a WHERE eq).
+    expect(h.eq).not.toHaveBeenCalledWith("organization_id", expect.anything());
+    expect(h.orderBy).toHaveBeenCalled();
+  });
+
+  it("scopes by org and never falls back to createdBy when an org is active", async () => {
+    const { getIntegrations } = await import("@/lib/db/integrations");
+
+    await getIntegrations("user_1", undefined, "org_1");
+
+    expect(h.eq).toHaveBeenCalledWith("organization_id", "org_1");
+    expect(h.eq).not.toHaveBeenCalledWith("created_by", "user_1");
+    expect(h.isNull).not.toHaveBeenCalled();
+    expect(h.orderBy).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/integrations-address-field.test.ts
+++ b/tests/unit/integrations-address-field.test.ts
@@ -51,7 +51,9 @@ vi.mock("@/lib/db", () => ({
     select: vi.fn(() => ({
       from: vi.fn(() => ({
         leftJoin: vi.fn(() => ({
-          where: (...args: unknown[]) => mockJoinWhere(...args),
+          where: (...args: unknown[]) => ({
+            orderBy: () => mockJoinWhere(...args),
+          }),
         })),
       })),
     })),


### PR DESCRIPTION
## Problem

Workflow Postgres Connection integrations were not consistently organization-scoped:

- The connection picker's personal fallback filtered by creator only, so a session with no active organization listed connections from every org the user had created in.
- Opening a workflow whose bound connection was missing from the freshly-loaded list silently rebound it to a different connection and autosaved that change, which could repoint a running workflow at the wrong database.
- Most plugin steps fetched credentials at runtime without an authorization principal, so a cross-org connection id could still resolve credentials.

## Changes

- `getIntegrations`: constrain the no-org personal fallback to `organizationId IS NULL` and add deterministic ordering, so the picker never lists cross-org connections and the first row is stable.
- Connection selector: only auto-select when no connection is set; when a saved connection is missing from the list, show an unavailable warning and leave the binding untouched instead of silently rebinding (and autosaving) it.
- `credential-fetcher`: require an organization principal and thread it through every plugin step, so a cross-org integration id fails closed at runtime.
- Workflow store: surface autosave failures via a toast instead of swallowing them.
- Add a read-only audit script that reports workflows bound to out-of-organization connections.

Server-side save-time validation that rejects out-of-org connection references already exists; this closes the remaining picker-visibility, silent-rebind, and runtime credential-fetch gaps.

## Testing

- `pnpm type-check`: passes.
- `pnpm test:unit`: passes. Added cross-org credential-rejection and no-org `getIntegrations` scoping tests; updated existing integration tests for the new query shape and signature.
- Manual: with two orgs each owning a connection, confirm the picker shows only the active org's connections, and that opening a workflow whose connection was removed shows the warning without rebinding or autosaving.
