### PR TITLE
feat: email user when their account is deactivated

### DIFF
--- a/app/api/admin/users/[userId]/deactivate/route.ts
+++ b/app/api/admin/users/[userId]/deactivate/route.ts
@@ -2,8 +2,21 @@ import { and, eq, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { organizationApiKeys, sessions, users } from "@/lib/db/schema";
+import { sendAccountDeactivatedEmail } from "@/lib/email";
 import { authenticateKhAdmin } from "@/lib/kh-admin-auth";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+
+// The body is optional; callers (raita-bot auto-block, on-call tooling) may
+// POST nothing at all. notifyUser defaults to true so a deactivated user is
+// told their account was disabled and how to reach us.
+async function parseNotifyUser(request: Request): Promise<boolean> {
+  try {
+    const body = (await request.json()) as { notifyUser?: unknown };
+    return body?.notifyUser !== false;
+  } catch {
+    return true;
+  }
+}
 
 export async function POST(
   request: Request,
@@ -15,13 +28,19 @@ export async function POST(
   }
 
   const { userId } = await context.params;
+  const notifyUser = await parseNotifyUser(request);
 
   try {
     const now = new Date();
 
     const result = await db.transaction(async (tx) => {
       const [existing] = await tx
-        .select({ id: users.id, deactivatedAt: users.deactivatedAt })
+        .select({
+          id: users.id,
+          name: users.name,
+          email: users.email,
+          deactivatedAt: users.deactivatedAt,
+        })
         .from(users)
         .where(eq(users.id, userId))
         .limit(1);
@@ -57,7 +76,12 @@ export async function POST(
       //   cascade_org_deactivation_on_owner (0099): deactivates orgs where user
       //     was the sole active owner
 
-      return { userId, deactivatedAt: now };
+      return {
+        userId,
+        name: existing.name,
+        email: existing.email,
+        deactivatedAt: now,
+      };
     });
 
     if ("conflict" in result) {
@@ -67,7 +91,28 @@ export async function POST(
       return NextResponse.json({ error: "User is already deactivated" }, { status: 409 });
     }
 
-    return NextResponse.json(result);
+    // Best-effort notification, fired after the transaction commits. A failed
+    // send must not fail the deactivation -- the account is already disabled.
+    if (notifyUser && result.email) {
+      try {
+        await sendAccountDeactivatedEmail({
+          email: result.email,
+          name: result.name,
+        });
+      } catch (emailError) {
+        logSystemError(
+          ErrorCategory.EXTERNAL_SERVICE,
+          "[Admin] Failed to send deactivation email",
+          emailError,
+          { userId }
+        );
+      }
+    }
+
+    return NextResponse.json({
+      userId: result.userId,
+      deactivatedAt: result.deactivatedAt,
+    });
   } catch (error) {
     logSystemError(ErrorCategory.DATABASE, "[Admin] Failed to deactivate user", error, {
       userId,

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -905,3 +905,117 @@ ${socialText}
     attachments: getDigestSocialAttachments(),
   });
 }
+
+type AccountDeactivatedData = {
+  email: string;
+  // The user's display name (the single `name` column). May be null/empty for
+  // OAuth-only or anonymous accounts, in which case we fall back to a neutral
+  // greeting.
+  name?: string | null;
+};
+
+/**
+ * Notify a user that their account was suspended for security review after
+ * automated systems flagged activity. Intentionally vague about what was
+ * detected -- we do not want to hand an attacker a description of our
+ * detection. The social channels in the shared footer (Discord, Telegram,
+ * etc.) are how a wrongly-suspended user can reach us.
+ */
+export async function sendAccountDeactivatedEmail(
+  data: AccountDeactivatedData
+): Promise<boolean> {
+  const { email, name } = data;
+
+  const logoUrl =
+    "https://raw.githubusercontent.com/KeeperHub/keeperhub/staging/public/keeperhub_logo_email.png";
+
+  const subject = "Your KeeperHub account access has been suspended";
+
+  const trimmedName = name?.trim();
+  const greetingText = trimmedName ? `Hi ${trimmedName},` : "Hi,";
+  const greetingHtml = trimmedName ? `Hi ${escapeHtml(trimmedName)},` : "Hi,";
+
+  // Shared social footer (same set the execution-digest email uses); contact
+  // channels live here rather than in the body.
+  const socialText = DIGEST_SOCIAL_LINKS.map((s) => `${s.name}: ${s.url}`).join(
+    "\n"
+  );
+
+  const text = `
+${greetingText}
+
+Our automated security systems have temporarily suspended access to your KeeperHub account after detecting activity that requires additional review. Our team is already conducting a review. During this time, you will not be able to sign in or run workflows.
+
+This review helps us maintain the security and integrity of the KeeperHub platform and protect our users. Your data remains safe, secure, and unchanged throughout this process. All workflows, configurations, and account data are preserved and will remain available once access is restored.
+
+If you believe this action was taken in error or would like additional information, please contact our support team. We will review your case and assist you as quickly as possible.
+
+Thank you for your understanding and cooperation.
+
+Kind regards,
+KeeperHub Team
+
+---
+KeeperHub - Blockchain Workflow Automation
+${socialText}
+`.trim();
+
+  const html = `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 30px; border-radius: 12px 12px 0 0; text-align: center;">
+    <img src="${logoUrl}" alt="KeeperHub" style="max-width: 200px; height: auto;" />
+  </div>
+
+  <div style="background: #ffffff; padding: 30px; border: 1px solid #e5e5e5; border-top: none; border-radius: 0 0 12px 12px;">
+    <p>${greetingHtml}</p>
+
+    <p>Our automated security systems have temporarily suspended access to your KeeperHub account after detecting activity that requires additional review. Our team is already conducting a review. During this time, you will not be able to sign in or run workflows.</p>
+
+    <p>This review helps us maintain the security and integrity of the KeeperHub platform and protect our users. Your data remains safe, secure, and unchanged throughout this process. All workflows, configurations, and account data are preserved and will remain available once access is restored.</p>
+
+    <p>If you believe this action was taken in error or would like additional information, please contact our support team. We will review your case and assist you as quickly as possible.</p>
+
+    <p style="margin-bottom: 0;">Thank you for your understanding and cooperation.</p>
+    <p style="margin-top: 8px;">Kind regards,<br>KeeperHub Team</p>
+  </div>
+
+  <div style="text-align: center; padding: 24px 20px; color: #999; font-size: 12px;">
+    <table role="presentation" align="center" style="margin:0 auto 12px;"><tr>${DIGEST_SOCIAL_LINKS.map(
+      (s) =>
+        `<td style="padding:0 8px;"><a href="${s.url}" target="_blank" rel="noopener"><img src="cid:${s.icon}" alt="${s.name}" width="20" height="20" style="display:block;" /></a></td>`
+    ).join("")}</tr></table>
+    <p style="margin: 0;">KeeperHub - Blockchain Workflow Automation</p>
+  </div>
+</body>
+</html>
+`.trim();
+
+  const success = await sendEmail({
+    to: email,
+    subject,
+    text,
+    html,
+    attachments: getDigestSocialAttachments(),
+  });
+
+  if (success) {
+    console.log(`[Email] Account suspension notice sent to ${email}`);
+  } else if (!isTestEnv) {
+    logUserError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      `[Email] Failed to send suspension notice to ${email}`,
+      new Error("Failed to send account suspension email"),
+      {
+        service: "sendgrid",
+      }
+    );
+  }
+
+  return success;
+}

--- a/tests/integration/admin-user-deactivate.test.ts
+++ b/tests/integration/admin-user-deactivate.test.ts
@@ -2,8 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const TEST_SECRET = "kha_test-admin-secret-12345";
 const TEST_USER_ID = "user-abc123";
+const TEST_EMAIL = "blocked@example.com";
+const TEST_NAME = "Blocked User";
 
-type MockUser = { id: string; deactivatedAt: Date | null } | undefined;
+type MockUser =
+  | { id: string; name: string | null; email: string; deactivatedAt: Date | null }
+  | undefined;
 
 let mockUserForSelect: MockUser = undefined;
 let mockShouldThrow = false;
@@ -38,24 +42,39 @@ vi.mock("@/lib/db", () => {
 });
 
 vi.mock("@/lib/db/schema", () => ({
-  users: { id: "id", deactivatedAt: "deactivated_at", updatedAt: "updated_at" },
+  users: {
+    id: "id",
+    name: "name",
+    email: "email",
+    deactivatedAt: "deactivated_at",
+    updatedAt: "updated_at",
+  },
   sessions: { userId: "user_id" },
   organizationApiKeys: { createdBy: "created_by", revokedAt: "revoked_at" },
 }));
 
 vi.mock("@/lib/logging", () => ({
-  ErrorCategory: { DATABASE: "database" },
+  ErrorCategory: { DATABASE: "database", EXTERNAL_SERVICE: "external_service" },
   logSystemError: vi.fn(),
+}));
+
+const sendAccountDeactivatedEmail = vi.fn(
+  (_data: { email: string; name?: string | null }) => Promise.resolve(true)
+);
+vi.mock("@/lib/email", () => ({
+  sendAccountDeactivatedEmail: (data: { email: string; name?: string | null }) =>
+    sendAccountDeactivatedEmail(data),
 }));
 
 import { POST } from "@/app/api/admin/users/[userId]/deactivate/route";
 
-function makeRequest(token?: string): Request {
+function makeRequest(token?: string, body?: unknown): Request {
   const headers: Record<string, string> = {};
   if (token) headers.Authorization = `Bearer ${token}`;
   return new Request("http://localhost/api/admin/users/user-abc123/deactivate", {
     method: "POST",
     headers,
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
   });
 }
 
@@ -97,13 +116,90 @@ describe("POST /api/admin/users/:userId/deactivate", () => {
 
   describe("happy path", () => {
     it("deactivates the user and returns userId and deactivatedAt", async () => {
-      mockUserForSelect = { id: TEST_USER_ID, deactivatedAt: null };
+      mockUserForSelect = {
+        id: TEST_USER_ID,
+        name: TEST_NAME,
+        email: TEST_EMAIL,
+        deactivatedAt: null,
+      };
 
       const res = await POST(makeRequest(TEST_SECRET), makeContext());
       expect(res.status).toBe(200);
       const data = await res.json();
       expect(data.userId).toBe(TEST_USER_ID);
       expect(data.deactivatedAt).toBeDefined();
+      expect(data.email).toBeUndefined();
+    });
+  });
+
+  describe("deactivation email", () => {
+    it("emails the user once on a successful deactivation", async () => {
+      mockUserForSelect = {
+        id: TEST_USER_ID,
+        name: TEST_NAME,
+        email: TEST_EMAIL,
+        deactivatedAt: null,
+      };
+
+      const res = await POST(makeRequest(TEST_SECRET), makeContext());
+      expect(res.status).toBe(200);
+      expect(sendAccountDeactivatedEmail).toHaveBeenCalledTimes(1);
+      expect(sendAccountDeactivatedEmail).toHaveBeenCalledWith({
+        email: TEST_EMAIL,
+        name: TEST_NAME,
+      });
+    });
+
+    it("does not email when notifyUser is false", async () => {
+      mockUserForSelect = {
+        id: TEST_USER_ID,
+        name: TEST_NAME,
+        email: TEST_EMAIL,
+        deactivatedAt: null,
+      };
+
+      const res = await POST(
+        makeRequest(TEST_SECRET, { notifyUser: false }),
+        makeContext()
+      );
+      expect(res.status).toBe(200);
+      expect(sendAccountDeactivatedEmail).not.toHaveBeenCalled();
+    });
+
+    it("does not email on a 404", async () => {
+      mockUserForSelect = undefined;
+      const res = await POST(makeRequest(TEST_SECRET), makeContext());
+      expect(res.status).toBe(404);
+      expect(sendAccountDeactivatedEmail).not.toHaveBeenCalled();
+    });
+
+    it("does not email on a 409", async () => {
+      mockUserForSelect = {
+        id: TEST_USER_ID,
+        name: TEST_NAME,
+        email: TEST_EMAIL,
+        deactivatedAt: new Date(),
+      };
+      const res = await POST(makeRequest(TEST_SECRET), makeContext());
+      expect(res.status).toBe(409);
+      expect(sendAccountDeactivatedEmail).not.toHaveBeenCalled();
+    });
+
+    it("still returns 200 when the email send throws", async () => {
+      mockUserForSelect = {
+        id: TEST_USER_ID,
+        name: TEST_NAME,
+        email: TEST_EMAIL,
+        deactivatedAt: null,
+      };
+      sendAccountDeactivatedEmail.mockRejectedValueOnce(
+        new Error("sendgrid down")
+      );
+
+      const res = await POST(makeRequest(TEST_SECRET), makeContext());
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.userId).toBe(TEST_USER_ID);
     });
   });
 
@@ -118,7 +214,12 @@ describe("POST /api/admin/users/:userId/deactivate", () => {
     });
 
     it("returns 409 when user is already deactivated", async () => {
-      mockUserForSelect = { id: TEST_USER_ID, deactivatedAt: new Date() };
+      mockUserForSelect = {
+        id: TEST_USER_ID,
+        name: TEST_NAME,
+        email: TEST_EMAIL,
+        deactivatedAt: new Date(),
+      };
 
       const res = await POST(makeRequest(TEST_SECRET), makeContext());
       expect(res.status).toBe(409);


### PR DESCRIPTION
## What

Adds a transactional email so a user whose account is deactivated by an admin is told what happened and how to reach us.

- New `sendAccountDeactivatedEmail` in `lib/email.ts`, mirroring the existing invitation/OTP email helpers. The content states the account was deactivated after suspicious activity was detected and lists the public support channels (email, Discord, Telegram). It deliberately does not describe what was detected.
- The admin user deactivate route sends it after the transaction commits, only on a successful deactivation (not on 404 or 409).
- Best-effort: an email failure is logged and the deactivation still returns 200.
- Suppressible per call via an optional `{ "notifyUser": false }` request body (default true) for silent admin operations. The response shape is unchanged.

## Tests

Extended `tests/integration/admin-user-deactivate.test.ts`: email sent once on success, not sent on 404/409 or when `notifyUser` is false, and the deactivation still returns 200 when the email send throws. 12/12 passing locally.
