### PR TITLE
fix(mfa): remove plaintext TOTP code and PII from debug diagnostics

### DIFF
--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { hashSessionToken } from "@/lib/auth-session-token-hash";
 import { db } from "@/lib/db";
-import { sessions, twoFactor, users } from "@/lib/db/schema";
+import { sessions, users } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError, logSystemWarn } from "@/lib/logging";
 import {
   buildPendingOauthMfaSetCookie,
@@ -221,24 +221,6 @@ async function interceptOauthCallback(
   //     mints the real session inside the enroll route once the user
   //     finishes the wizard. No usable session exists until that.
   if (user.twoFactorEnabled === true) {
-    // [mfa-debug] KEEP-471 OAuth/TOTP investigation: confirm the session
-    // user the cookie points at actually owns a two_factor secret row.
-    // A mismatch (twoFactorEnabled=true but no/other secret) explains a
-    // correct authenticator code being rejected at oauth-mfa-finalize.
-    // Remove once root-caused.
-    const [tfDebug] = await db
-      .select({ secretUserId: twoFactor.userId })
-      .from(twoFactor)
-      .where(eq(twoFactor.userId, user.id))
-      .limit(1);
-    // biome-ignore lint/suspicious/noConsole: temporary KEEP-471 diagnostic
-    console.info("[mfa-debug] oauth verify-mfa path", {
-      provider,
-      resolvedUserId: user.id,
-      email: user.email,
-      twoFactorEnabled: user.twoFactorEnabled,
-      twoFactorRowFound: Boolean(tfDebug),
-    });
     const pendingValue = encodePendingOauthMfaCookie(
       {
         userId: user.id,

--- a/lib/mfa/dual-factor.ts
+++ b/lib/mfa/dual-factor.ts
@@ -144,7 +144,9 @@ export async function requireDualFactor(
 
     // Replace any in-flight OTP for the same (user, action) so the
     // most recent code is the only one accepted.
-    await db.delete(verifications).where(eq(verifications.identifier, identifier));
+    await db
+      .delete(verifications)
+      .where(eq(verifications.identifier, identifier));
     await db.insert(verifications).values({
       id: generateId(),
       identifier,
@@ -188,13 +190,6 @@ export async function requireDualFactor(
     .where(eq(twoFactorTable.userId, userId))
     .limit(1);
   if (!tfRow) {
-    // [mfa-debug] KEEP-471 OAuth/TOTP investigation: the userId carried
-    // into this gate has no two_factor row. Remove once root-caused.
-    // biome-ignore lint/suspicious/noConsole: temporary KEEP-471 diagnostic
-    console.warn("[mfa-debug] no two_factor row for userId", {
-      action,
-      userId,
-    });
     return {
       ok: false,
       status: 401,
@@ -203,14 +198,6 @@ export async function requireDualFactor(
     };
   }
   const totpOk = await verifyUserTotp(tfRow.secret, totpCode, serverSecret);
-  // [mfa-debug] KEEP-471 OAuth/TOTP investigation. Remove once root-caused.
-  // biome-ignore lint/suspicious/noConsole: temporary KEEP-471 diagnostic
-  console.info("[mfa-debug] totp check", {
-    action,
-    userId,
-    providedTotp: totpCode,
-    totpOk,
-  });
   if (!totpOk) {
     return {
       ok: false,

--- a/tests/unit/dual-factor.test.ts
+++ b/tests/unit/dual-factor.test.ts
@@ -217,6 +217,48 @@ describe("requireDualFactor", () => {
     });
   });
 
+  // F-003: the dual-factor gate must never write the user's live TOTP
+  // code to logs. A leaked code is replayable inside its time window and
+  // is a secrets-in-logs compliance violation.
+  it("never logs the plaintext TOTP code", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {
+      // swallow log output during the assertion
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+      // swallow log output during the assertion
+    });
+    const totp = totpForNow(TOTP_SECRET);
+    const encSecret = await symmetricEncrypt({
+      key: SERVER_SECRET,
+      data: TOTP_SECRET,
+    });
+    const encEmailOtp = await symmetricEncrypt({
+      key: SERVER_SECRET,
+      data: "123456",
+    });
+    mockSelect
+      .mockReturnValueOnce(selectChain([{ secret: encSecret }]))
+      .mockReturnValueOnce(
+        selectChain([{ id: "verif_1", value: encEmailOtp }])
+      );
+
+    await requireDualFactor({
+      userId: "user_log",
+      email: "user@example.com",
+      action: "oauth_signin",
+      code: totp,
+      emailOtp: "123456",
+      headers: new Headers(),
+    });
+
+    const logged = [...infoSpy.mock.calls, ...warnSpy.mock.calls]
+      .map((c) => JSON.stringify(c))
+      .join(" ");
+    expect(logged).not.toContain(totp);
+    infoSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
   it("mints and emails an OTP and returns factors_required when codes are missing", async () => {
     const result = await requireDualFactor({
       userId: "user_5",


### PR DESCRIPTION
## Finding F-003 (HIGH, confidence 0.9) -- sensitive data in logs

`requireDualFactor` logged the user-submitted TOTP code in plaintext (`providedTotp: totpCode`) on every dual-factor verify, alongside `userId`/`action`. TOTP codes are valid for ~90s (+/-1 window) with no replay detection, so anyone with log read access could replay a captured code against any dual-factor-gated endpoint.

## Fix

Remove the three temporary `[mfa-debug]` diagnostics (tagged "remove once root-caused"; the investigation they served already has a landed fix):
- `lib/mfa/dual-factor.ts`: the `totp check` log leaking `providedTotp`, plus the sibling `no two_factor row` log.
- `app/api/auth/[...all]/route.ts`: the OAuth-MFA debug block that logged `email` (PII) and ran an extra `two_factor` SELECT per login; drops the now-unused `twoFactor` table import.

Permanent non-secret traces (`[oauth-callback] pending_oauth_mfa_path`) are preserved. Pure logging removal -- no control-flow change.

## Verification

- New regression test in `tests/unit/dual-factor.test.ts` asserts the plaintext code is never passed to `console.*` during a verify -- confirmed to FAIL when the leak line is reintroduced.
- `tsc --noEmit` clean for changed files; `ultracite check` clean; dual-factor unit suite green.
- Independent review: APPROVE -- grep across `lib/mfa`, `app/api/auth`, `app/api/user`, `lib/security` finds no remaining log sink referencing a TOTP/OTP code or secret.
