### PR TITLE
fix(sandbox): flush sandbox result synchronously then hard-exit the child

### DIFF
--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -785,10 +785,12 @@ function encodeResult(value, seen) {
     return { "$": "bigint", "v": value.toString() };
   }
   if (t === "function" || t === "symbol") {
-    throw new Error("Result is not serializable: " + t);
+    // Bare reason; writeResult's catch adds the "Result is not serializable: "
+    // prefix so the message is not doubled.
+    throw new Error(t);
   }
   if (seen.has(value)) {
-    throw new Error("Result is not serializable: circular reference");
+    throw new Error("circular reference");
   }
   seen.add(value);
   try {

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -59,6 +59,7 @@ export const SANDBOX_CHILD_SOURCE = `
 "use strict";
 const { createContext, runInContext } = require("node:vm");
 const v8 = require("node:v8");
+const fs = require("node:fs");
 const dnsPromises = require("node:dns").promises;
 const { BlockList, isIP } = require("node:net");
 
@@ -540,8 +541,23 @@ function writeResult(message) {
       .toString("base64");
   }
   // Prefix with sentinel so the parent can ignore stray writes from user code
-  // that reaches process.stdout via a sandbox escape.
-  process.stdout.write("\\x01RESULT\\x02" + payload + "\\n");
+  // that reaches process.stdout via a sandbox escape (F-010).
+  const out = Buffer.from("\\x01RESULT\\x02" + payload + "\\n", "utf8");
+  let written = 0;
+  while (written < out.length) {
+    try {
+      written += fs.writeSync(1, out, written, out.length - written);
+    } catch (writeErr) {
+      if (writeErr && writeErr.code === "EAGAIN") {
+        continue;
+      }
+      break;
+    }
+  }
+  // Hard-exit immediately: once the real result is on the wire, give no
+  // event-loop turn in which a post-escape user-scheduled callback could emit
+  // a second, later sentinel that the parent's lastIndexOf() would select.
+  process.exit(0);
 }
 
 let stdinBuf = "";

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -34,12 +34,110 @@
 import blocklist from "../ssrf-blocklist.json" with { type: "json" };
 
 /**
- * Byte-sequence that prefixes the grandchild's final v8-serialized result
- * on stdout. The parent uses `lastIndexOf(sentinel)` to locate the real
- * result even if user code writes arbitrary bytes to stdout via a sandbox
- * escape — stray writes before the sentinel are ignored.
+ * F-010: the grandchild returns its v8-serialized result on a DEDICATED pipe
+ * (fd 3), not stdout. The result is a single length-prefixed frame
+ * (4-byte big-endian byte count, then the raw v8 bytes) and the parent
+ * accepts only the FIRST complete frame.
+ *
+ * Why this shape:
+ *   - stdout (fd 1) is left purely user-facing; nothing written there is
+ *     ever deserialized, so a sandbox escape that writes arbitrary bytes to
+ *     stdout can no longer masquerade as a result (the old design scanned
+ *     stdout for a 6-byte sentinel via lastIndexOf, which an escaped child
+ *     defeated by appending a later sentinel).
+ *   - First-frame-wins means a post-escape, user-scheduled write to fd 3
+ *     loses to the genuine frame the child emits first. The genuine write
+ *     goes through a fs.writeSync reference captured at child startup
+ *     (before any user code runs), so monkeypatching fs.writeSync cannot
+ *     suppress it.
+ *
+ * Residual (accepted, documented on the PR): a FULLY-escaped child can write
+ * a forged frame to fd 3 synchronously, BEFORE the genuine result is
+ * produced, occupying frame #0. Closing that completely would require the
+ * parent to stop v8.deserialize-ing untrusted bytes at all, which drops
+ * structured-clone fidelity (BigInt/Map/Set/Date) -- a separate product
+ * decision. The vector is gated behind a vm escape; the child is
+ * env-scrubbed and NetworkPolicy-isolated.
  */
-export const SANDBOX_RESULT_SENTINEL = "RESULT";
+export const SANDBOX_RESULT_FD = 3;
+
+/** Width of the big-endian length prefix on the fd-3 result frame. */
+const SANDBOX_RESULT_HEADER_BYTES = 4;
+
+/**
+ * Upper bound on the declared frame length the parent will buffer. Checked
+ * against the length prefix before any payload bytes are accumulated, so a
+ * malicious child cannot pin parent memory by declaring a huge frame. The
+ * child process is itself memory-bounded, so legitimate results never
+ * approach this; it is a denial-of-service backstop, not a product limit.
+ */
+export const SANDBOX_RESULT_MAX_BYTES = 96 * 1024 * 1024;
+
+export type SandboxResultReader = {
+  /** Feed a chunk from the parent's fd-3 stream. Chunks after the first
+   * complete frame are ignored (first-frame-wins). */
+  push: (chunk: Buffer) => void;
+  /** The first complete frame's v8 bytes, or null until one is complete. */
+  readonly frame: Buffer | null;
+  /** True once the first frame is complete or the stream is known-malformed. */
+  readonly done: boolean;
+  /** Set when the declared length exceeds SANDBOX_RESULT_MAX_BYTES. */
+  readonly error: string | null;
+};
+
+/**
+ * Streaming reader for the fd-3 result frame. The parent attaches it to the
+ * child's fd-3 pipe and resolves as soon as `done` is true with a non-null
+ * `frame`. Only the first length-prefixed frame is read; any trailing bytes
+ * (e.g. a forged frame a sandbox escape appends later) are discarded.
+ */
+export function createSandboxResultReader(
+  maxBytes: number = SANDBOX_RESULT_MAX_BYTES
+): SandboxResultReader {
+  let chunks: Buffer[] = [];
+  let size = 0;
+  let frame: Buffer | null = null;
+  let done = false;
+  let error: string | null = null;
+
+  return {
+    push(chunk: Buffer): void {
+      if (done) {
+        return;
+      }
+      chunks.push(chunk);
+      size += chunk.length;
+      if (size < SANDBOX_RESULT_HEADER_BYTES) {
+        return;
+      }
+      const buf =
+        chunks.length === 1
+          ? (chunks[0] as Buffer)
+          : Buffer.concat(chunks, size);
+      chunks = [buf];
+      const declared = buf.readUInt32BE(0);
+      if (declared > maxBytes) {
+        error = `Sandbox result exceeds maximum size (${declared} > ${maxBytes} bytes)`;
+        done = true;
+        return;
+      }
+      const total = SANDBOX_RESULT_HEADER_BYTES + declared;
+      if (buf.length >= total) {
+        frame = buf.subarray(SANDBOX_RESULT_HEADER_BYTES, total);
+        done = true;
+      }
+    },
+    get frame(): Buffer | null {
+      return frame;
+    },
+    get done(): boolean {
+      return done;
+    },
+    get error(): string | null {
+      return error;
+    },
+  };
+}
 
 /**
  * JavaScript source string for the sandbox grandchild. Passed verbatim to
@@ -53,7 +151,8 @@ export const SANDBOX_RESULT_SENTINEL = "RESULT";
  *     lib/safe-fetch.ts from KEEP-314)
  *   - Apply a wall-clock timeout (beyond the vm's sync CPU timeout) that
  *     catches never-settling user promises
- *   - Write a sentinel-prefixed, v8-serialized outcome to stdout
+ *   - Write a length-prefixed, v8-serialized outcome to the dedicated
+ *     result pipe (fd SANDBOX_RESULT_FD), leaving stdout user-facing
  */
 export const SANDBOX_CHILD_SOURCE = `
 "use strict";
@@ -62,6 +161,16 @@ const v8 = require("node:v8");
 const fs = require("node:fs");
 const dnsPromises = require("node:dns").promises;
 const { BlockList, isIP } = require("node:net");
+
+// Captured BEFORE any user code runs so the result frame is written through a
+// reference a sandbox escape cannot monkeypatch. The genuine result therefore
+// reaches fd ${SANDBOX_RESULT_FD} first even if escaped user code reassigns
+// fs.writeSync / process.exit; the parent's first-frame-wins read then ignores
+// any later forged frame (F-010).
+const RESULT_FD = ${SANDBOX_RESULT_FD};
+const RESULT_HEADER_BYTES = ${SANDBOX_RESULT_HEADER_BYTES};
+const __writeSync = fs.writeSync.bind(fs);
+const __exit = process.exit.bind(process);
 
 const MAX_LOG_ENTRIES = 200;
 
@@ -525,28 +634,32 @@ function run(input) {
 function writeResult(message) {
   let payload;
   try {
-    payload = v8.serialize(message).toString("base64");
+    payload = v8.serialize(message);
   } catch (cloneErr) {
-    payload = v8
-      .serialize({
-        ok: false,
-        errorMessage:
-          "Result is not serializable: " +
-          (cloneErr && cloneErr.message
-            ? cloneErr.message
-            : String(cloneErr)),
-        errorStack: undefined,
-        logs: [],
-      })
-      .toString("base64");
+    payload = v8.serialize({
+      ok: false,
+      errorMessage:
+        "Result is not serializable: " +
+        (cloneErr && cloneErr.message
+          ? cloneErr.message
+          : String(cloneErr)),
+      errorStack: undefined,
+      logs: [],
+    });
   }
-  // Prefix with sentinel so the parent can ignore stray writes from user code
-  // that reaches process.stdout via a sandbox escape (F-010).
-  const out = Buffer.from("\\x01RESULT\\x02" + payload + "\\n", "utf8");
+  // F-010: emit the result as a single length-prefixed frame on the dedicated
+  // result pipe (fd RESULT_FD), NOT on stdout. The 4-byte big-endian length
+  // lets the parent read exactly one frame and ignore anything appended after
+  // it, and stdout stays purely user-facing (never deserialized). Use the
+  // startup-captured __writeSync so escaped user code that reassigned
+  // fs.writeSync cannot suppress the genuine frame.
+  const header = Buffer.allocUnsafe(RESULT_HEADER_BYTES);
+  header.writeUInt32BE(payload.length, 0);
+  const out = Buffer.concat([header, payload]);
   let written = 0;
   while (written < out.length) {
     try {
-      written += fs.writeSync(1, out, written, out.length - written);
+      written += __writeSync(RESULT_FD, out, written, out.length - written);
     } catch (writeErr) {
       if (writeErr && writeErr.code === "EAGAIN") {
         continue;
@@ -554,10 +667,10 @@ function writeResult(message) {
       break;
     }
   }
-  // Hard-exit immediately: once the real result is on the wire, give no
-  // event-loop turn in which a post-escape user-scheduled callback could emit
-  // a second, later sentinel that the parent's lastIndexOf() would select.
-  process.exit(0);
+  // Hard-exit through the captured reference so a lingering escaped child that
+  // reassigned process.exit is still reaped promptly. Correctness does not
+  // depend on this: the parent already took the first frame above.
+  __exit(0);
 }
 
 let stdinBuf = "";

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -34,30 +34,33 @@
 import blocklist from "../ssrf-blocklist.json" with { type: "json" };
 
 /**
- * F-010: the grandchild returns its v8-serialized result on a DEDICATED pipe
- * (fd 3), not stdout. The result is a single length-prefixed frame
- * (4-byte big-endian byte count, then the raw v8 bytes) and the parent
- * accepts only the FIRST complete frame.
+ * F-010: the grandchild returns its result as TAGGED JSON on a DEDICATED pipe
+ * (fd 3), not stdout. The result is a single length-prefixed frame (4-byte
+ * big-endian byte count, then a UTF-8 JSON body) and the parent recovers it
+ * with JSON.parse + decodeSandboxResult.
  *
- * Why this shape:
- *   - stdout (fd 1) is left purely user-facing; nothing written there is
- *     ever deserialized, so a sandbox escape that writes arbitrary bytes to
- *     stdout can no longer masquerade as a result (the old design scanned
- *     stdout for a 6-byte sentinel via lastIndexOf, which an escaped child
- *     defeated by appending a later sentinel).
- *   - First-frame-wins means a post-escape, user-scheduled write to fd 3
- *     loses to the genuine frame the child emits first. The genuine write
- *     goes through a fs.writeSync reference captured at child startup
- *     (before any user code runs), so monkeypatching fs.writeSync cannot
- *     suppress it.
+ * Two independent properties close the finding:
+ *   - The parent NEVER runs v8.deserialize on bytes the child produced. JSON
+ *     is safe to parse on untrusted input (the decoder additionally rebuilds
+ *     "__proto__" keys as own data properties, so it cannot be used to pollute
+ *     the parent's prototypes). This removes the root cause: even a fully
+ *     compromised child can only deliver inert data, never a deserialization
+ *     gadget. Fidelity (BigInt/Map/Set/Date/typed arrays/...) is preserved by
+ *     the tag codec rather than by structured-clone.
+ *   - stdout (fd 1) is left purely user-facing; nothing there is deserialized,
+ *     so a sandbox escape writing to stdout cannot masquerade as a result (the
+ *     old design scanned stdout for a 6-byte sentinel via lastIndexOf, which
+ *     an escaped child defeated by appending a later sentinel). The parent
+ *     also accepts only the FIRST complete fd-3 frame, and the genuine frame
+ *     is written through a fs.writeSync reference captured at child startup,
+ *     so a post-escape forged frame -- even with process.exit/fs.writeSync
+ *     reassigned -- loses to the genuine one.
  *
- * Residual (accepted, documented on the PR): a FULLY-escaped child can write
- * a forged frame to fd 3 synchronously, BEFORE the genuine result is
- * produced, occupying frame #0. Closing that completely would require the
- * parent to stop v8.deserialize-ing untrusted bytes at all, which drops
- * structured-clone fidelity (BigInt/Map/Set/Date) -- a separate product
- * decision. The vector is gated behind a vm escape; the child is
- * env-scrubbed and NetworkPolicy-isolated.
+ * Residual: a sandbox escape is still arbitrary code running AS the user, so
+ * it can return any DATA it likes (exactly as legitimate user code can). What
+ * it can no longer do is hand the parent untrusted bytes to deserialize. The
+ * vector is gated behind a vm escape; the child is env-scrubbed and
+ * NetworkPolicy-isolated.
  */
 export const SANDBOX_RESULT_FD = 3;
 
@@ -140,6 +143,123 @@ export function createSandboxResultReader(
 }
 
 /**
+ * Tag key for the result codec. The child encodes its outcome as tagged JSON
+ * (see `encodeResult` in the template) so the parent can recover it with a
+ * SAFE `JSON.parse` instead of `v8.deserialize` -- which Node documents as
+ * unsafe on untrusted data. A 1-key `{ "$": <tag> }` object carries a typed
+ * value (bigint, Date, Map, ...); plain user objects that happen to contain a
+ * literal "$" key are escaped as `{ "$": "obj", "v": {...} }` so they cannot
+ * be mistaken for a tag.
+ */
+const SANDBOX_RESULT_TAG = "$";
+
+function reviveSandboxNumber(token: string): number {
+  switch (token) {
+    case "NaN":
+      return Number.NaN;
+    case "Inf":
+      return Number.POSITIVE_INFINITY;
+    case "-Inf":
+      return Number.NEGATIVE_INFINITY;
+    case "-0":
+      return -0;
+    default:
+      return Number(token);
+  }
+}
+
+function reviveSandboxBytes(kind: string, base64: string): unknown {
+  const buf = Buffer.from(base64, "base64");
+  // Copy into a standalone ArrayBuffer so the result does not alias Node's
+  // shared Buffer pool.
+  const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+  if (kind === "ArrayBuffer") {
+    return ab;
+  }
+  if (kind === "DataView") {
+    return new DataView(ab);
+  }
+  const Ctor = (globalThis as Record<string, unknown>)[kind];
+  if (typeof Ctor === "function") {
+    return new (Ctor as new (b: ArrayBuffer) => unknown)(ab);
+  }
+  // Unknown view kind from a malformed/compromised child: hand back raw bytes
+  // rather than throwing.
+  return new Uint8Array(ab);
+}
+
+/**
+ * Rebuild a plain object key-by-key, defining each property so a "__proto__"
+ * key lands as an own data property instead of invoking the prototype setter
+ * (the prototype-pollution guard that makes deserializing untrusted input
+ * safe).
+ */
+function decodeSandboxObject(obj: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(obj)) {
+    Object.defineProperty(result, key, {
+      value: decodeSandboxNode(obj[key]),
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+  }
+  return result;
+}
+
+function decodeSandboxNode(node: unknown): unknown {
+  if (Array.isArray(node)) {
+    return node.map(decodeSandboxNode);
+  }
+  if (node === null || typeof node !== "object") {
+    return node;
+  }
+  const obj = node as Record<string, unknown>;
+  if (!Object.hasOwn(obj, SANDBOX_RESULT_TAG)) {
+    return decodeSandboxObject(obj);
+  }
+  switch (obj[SANDBOX_RESULT_TAG]) {
+    case "undef":
+      return undefined;
+    case "bigint":
+      return BigInt(obj.v as string);
+    case "num":
+      return reviveSandboxNumber(obj.v as string);
+    case "date":
+      return new Date(obj.v as number);
+    case "regexp":
+      return new RegExp(obj.src as string, obj.flags as string);
+    case "map":
+      return new Map(
+        (obj.v as [unknown, unknown][]).map((e) => [
+          decodeSandboxNode(e[0]),
+          decodeSandboxNode(e[1]),
+        ])
+      );
+    case "set":
+      return new Set((obj.v as unknown[]).map(decodeSandboxNode));
+    case "bytes":
+      return reviveSandboxBytes(obj.k as string, obj.v as string);
+    case "obj":
+      // Escaped plain object: its keys are literal data, never tags.
+      return decodeSandboxObject(obj.v as Record<string, unknown>);
+    default:
+      // Unknown tag from a malformed/compromised child: treat as plain data.
+      return decodeSandboxObject(obj);
+  }
+}
+
+/**
+ * Parse a child result frame. `text` is the UTF-8 body of the fd-3 frame.
+ * Uses `JSON.parse` (safe on untrusted input) and rebuilds the typed values
+ * the child tagged. Throws on malformed JSON / tags; callers map that to an
+ * error outcome.
+ */
+export function decodeSandboxResult(text: string): unknown {
+  return decodeSandboxNode(JSON.parse(text));
+}
+
+/**
  * JavaScript source string for the sandbox grandchild. Passed verbatim to
  * `node -e`, so it must be standalone (no imports, no TypeScript syntax).
  *
@@ -151,13 +271,12 @@ export function createSandboxResultReader(
  *     lib/safe-fetch.ts from KEEP-314)
  *   - Apply a wall-clock timeout (beyond the vm's sync CPU timeout) that
  *     catches never-settling user promises
- *   - Write a length-prefixed, v8-serialized outcome to the dedicated
+ *   - Write a length-prefixed, tagged-JSON outcome to the dedicated
  *     result pipe (fd SANDBOX_RESULT_FD), leaving stdout user-facing
  */
 export const SANDBOX_CHILD_SOURCE = `
 "use strict";
 const { createContext, runInContext } = require("node:vm");
-const v8 = require("node:v8");
 const fs = require("node:fs");
 const dnsPromises = require("node:dns").promises;
 const { BlockList, isIP } = require("node:net");
@@ -631,21 +750,136 @@ function run(input) {
   return Promise.race([settledUserPromise, timeoutPromise]);
 }
 
+// Encode an outcome as tagged JSON. The PARENT recovers it with JSON.parse
+// (safe on untrusted input) plus decodeSandboxResult(), so it never runs
+// v8.deserialize on bytes a sandbox escape could control. Mirrors
+// decodeSandboxNode in this module exactly; keep the two in lockstep.
+// Throws on a value with no safe representation (function, symbol, cycle),
+// which writeResult maps to a structured "not serializable" outcome.
+function encodeResult(value, seen) {
+  if (value === null) {
+    return null;
+  }
+  const t = typeof value;
+  if (t === "undefined") {
+    return { "$": "undef" };
+  }
+  if (t === "boolean" || t === "string") {
+    return value;
+  }
+  if (t === "number") {
+    if (Number.isFinite(value) && !Object.is(value, -0)) {
+      return value;
+    }
+    let token = "-0";
+    if (Number.isNaN(value)) {
+      token = "NaN";
+    } else if (value === Infinity) {
+      token = "Inf";
+    } else if (value === -Infinity) {
+      token = "-Inf";
+    }
+    return { "$": "num", "v": token };
+  }
+  if (t === "bigint") {
+    return { "$": "bigint", "v": value.toString() };
+  }
+  if (t === "function" || t === "symbol") {
+    throw new Error("Result is not serializable: " + t);
+  }
+  if (seen.has(value)) {
+    throw new Error("Result is not serializable: circular reference");
+  }
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const arr = new Array(value.length);
+      for (let i = 0; i < value.length; i++) {
+        arr[i] = encodeResult(value[i], seen);
+      }
+      return arr;
+    }
+    if (value instanceof Date) {
+      return { "$": "date", "v": value.getTime() };
+    }
+    if (value instanceof RegExp) {
+      return { "$": "regexp", "src": value.source, "flags": value.flags };
+    }
+    if (value instanceof Map) {
+      const entries = [];
+      for (const pair of value) {
+        entries.push([encodeResult(pair[0], seen), encodeResult(pair[1], seen)]);
+      }
+      return { "$": "map", "v": entries };
+    }
+    if (value instanceof Set) {
+      const items = [];
+      for (const item of value) {
+        items.push(encodeResult(item, seen));
+      }
+      return { "$": "set", "v": items };
+    }
+    if (value instanceof ArrayBuffer) {
+      return {
+        "$": "bytes",
+        "k": "ArrayBuffer",
+        "v": Buffer.from(value).toString("base64"),
+      };
+    }
+    if (ArrayBuffer.isView(value)) {
+      const kind =
+        value.constructor && value.constructor.name
+          ? value.constructor.name
+          : "Uint8Array";
+      return {
+        "$": "bytes",
+        "k": kind,
+        "v": Buffer.from(value.buffer, value.byteOffset, value.byteLength).toString(
+          "base64"
+        ),
+      };
+    }
+    const out = {};
+    let hasTagKey = false;
+    const keys = Object.keys(value);
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      if (key === "$") {
+        hasTagKey = true;
+      }
+      out[key] = encodeResult(value[key], seen);
+    }
+    // Escape a user object that literally carries a "$" key so the parent does
+    // not mistake it for a type tag.
+    return hasTagKey ? { "$": "obj", "v": out } : out;
+  } finally {
+    seen.delete(value);
+  }
+}
+
 function writeResult(message) {
   let payload;
   try {
-    payload = v8.serialize(message);
+    payload = Buffer.from(JSON.stringify(encodeResult(message, new Set())), "utf8");
   } catch (cloneErr) {
-    payload = v8.serialize({
-      ok: false,
-      errorMessage:
-        "Result is not serializable: " +
-        (cloneErr && cloneErr.message
-          ? cloneErr.message
-          : String(cloneErr)),
-      errorStack: undefined,
-      logs: [],
-    });
+    payload = Buffer.from(
+      JSON.stringify(
+        encodeResult(
+          {
+            ok: false,
+            errorMessage:
+              "Result is not serializable: " +
+              (cloneErr && cloneErr.message
+                ? cloneErr.message
+                : String(cloneErr)),
+            errorStack: undefined,
+            logs: [],
+          },
+          new Set()
+        )
+      ),
+      "utf8"
+    );
   }
   // F-010: emit the result as a single length-prefixed frame on the dedicated
   // result pipe (fd RESULT_FD), NOT on stdout. The 4-byte big-endian length

--- a/plugins/code/steps/run-code.ts
+++ b/plugins/code/steps/run-code.ts
@@ -6,7 +6,9 @@ import { ErrorCategory, logUserError } from "@/lib/logging";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import {
   SANDBOX_CHILD_SOURCE as CHILD_SOURCE,
-  SANDBOX_RESULT_SENTINEL as RESULT_SENTINEL,
+  SANDBOX_RESULT_FD,
+  type SandboxResultReader,
+  createSandboxResultReader,
 } from "@/lib/sandbox/child-source";
 import { runRemote } from "@/lib/sandbox/client";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
@@ -133,20 +135,15 @@ type ChildOutcome =
       logs: LogEntry[];
     };
 
-function parseChildOutput(stdout: string): ChildOutcome {
-  const idx = stdout.lastIndexOf(RESULT_SENTINEL);
-  if (idx === -1) {
-    return {
-      ok: false,
-      errorMessage: "Sandbox produced no result",
-      logs: [],
-    };
+function outcomeFromReader(reader: SandboxResultReader): ChildOutcome {
+  if (reader.error) {
+    return { ok: false, errorMessage: reader.error, logs: [] };
   }
-  const newlineIdx = stdout.indexOf("\n", idx);
-  const end = newlineIdx === -1 ? stdout.length : newlineIdx;
-  const base64 = stdout.slice(idx + RESULT_SENTINEL.length, end).trim();
+  if (!reader.frame) {
+    return { ok: false, errorMessage: "Sandbox produced no result", logs: [] };
+  }
   try {
-    return deserialize(Buffer.from(base64, "base64")) as ChildOutcome;
+    return deserialize(reader.frame) as ChildOutcome;
   } catch (_err) {
     return {
       ok: false,
@@ -162,12 +159,14 @@ async function runInChild(
   timeoutMs: number
 ): Promise<ChildOutcome> {
   return await new Promise<ChildOutcome>((resolve) => {
+    // fd 3 is the dedicated result channel (F-010). stdout/stderr stay
+    // user-facing diagnostics and are never deserialized.
     const child = spawn(process.execPath, ["-e", CHILD_SOURCE], {
       env: buildChildEnv(),
-      stdio: ["pipe", "pipe", "pipe"],
+      stdio: ["pipe", "pipe", "pipe", "pipe"],
     });
 
-    let stdout = "";
+    const resultReader = createSandboxResultReader();
     let stderr = "";
     let settled = false;
 
@@ -191,14 +190,29 @@ async function runInChild(
       finish({ ok: false, errorMessage: "WALL_CLOCK_TIMEOUT", logs: [] });
     }, timeoutMs + 1000);
 
-    child.stdout.setEncoding("utf8");
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
-    });
+    // Drain stdout so a sandbox escape that writes there cannot fill the pipe
+    // and block the child; the bytes are intentionally discarded (never a
+    // result source).
+    child.stdout.resume();
     child.stderr.setEncoding("utf8");
     child.stderr.on("data", (chunk: string) => {
       stderr += chunk;
     });
+
+    const resultStream = child.stdio[SANDBOX_RESULT_FD];
+    if (resultStream && "on" in resultStream) {
+      resultStream.on("data", (chunk: Buffer) => {
+        resultReader.push(chunk);
+        if (resultReader.done) {
+          // First complete frame wins; resolve now and reap the child even if
+          // escaped code kept the event loop alive past the result.
+          finish(outcomeFromReader(resultReader));
+        }
+      });
+      resultStream.on("error", () => {
+        // Pipe teardown races process exit; the close handler maps the outcome.
+      });
+    }
 
     child.on("error", (err: Error) => {
       finish({
@@ -210,7 +224,7 @@ async function runInChild(
     });
 
     child.on("close", (exitCode: number | null) => {
-      const parsed = parseChildOutput(stdout);
+      const parsed = outcomeFromReader(resultReader);
       if (parsed.ok || exitCode === 0) {
         finish(parsed);
         return;

--- a/plugins/code/steps/run-code.ts
+++ b/plugins/code/steps/run-code.ts
@@ -1,7 +1,6 @@
 import "server-only";
 
 import { spawn } from "node:child_process";
-import { deserialize } from "node:v8";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import {
@@ -9,6 +8,7 @@ import {
   SANDBOX_RESULT_FD,
   type SandboxResultReader,
   createSandboxResultReader,
+  decodeSandboxResult,
 } from "@/lib/sandbox/child-source";
 import { runRemote } from "@/lib/sandbox/client";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
@@ -135,6 +135,14 @@ type ChildOutcome =
       logs: LogEntry[];
     };
 
+function isChildOutcome(value: unknown): value is ChildOutcome {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { ok?: unknown }).ok === "boolean"
+  );
+}
+
 function outcomeFromReader(reader: SandboxResultReader): ChildOutcome {
   if (reader.error) {
     return { ok: false, errorMessage: reader.error, logs: [] };
@@ -143,7 +151,19 @@ function outcomeFromReader(reader: SandboxResultReader): ChildOutcome {
     return { ok: false, errorMessage: "Sandbox produced no result", logs: [] };
   }
   try {
-    return deserialize(reader.frame) as ChildOutcome;
+    // Safe by construction: JSON.parse + tag rebuild, never v8.deserialize on
+    // child-produced bytes (F-010). This parent is the privileged in-pod app,
+    // so the no-untrusted-deserialize property matters most here. Validate the
+    // envelope shape since the child is untrusted.
+    const decoded = decodeSandboxResult(reader.frame.toString("utf8"));
+    if (!isChildOutcome(decoded)) {
+      return {
+        ok: false,
+        errorMessage: "Sandbox produced malformed result",
+        logs: [],
+      };
+    }
+    return decoded;
   } catch (_err) {
     return {
       ok: false,

--- a/sandbox/src/run-code.test.ts
+++ b/sandbox/src/run-code.test.ts
@@ -184,6 +184,29 @@ describe("runCode — sandbox child_process runner", () => {
     }
   });
 
+  it("round-trips a typed array through the tagged-JSON codec", async () => {
+    const outcome = await runCode({
+      code: "return new Uint8Array([1, 2, 255]);",
+      timeoutMs: 5000,
+    });
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result).toBeInstanceOf(Uint8Array);
+      expect([...(outcome.result as Uint8Array)]).toEqual([1, 2, 255]);
+    }
+  });
+
+  it("returns a clean error for a non-serializable result", async () => {
+    const outcome = await runCode({
+      code: "return () => 1;",
+      timeoutMs: 5000,
+    });
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.errorMessage).toMatch(/not serializable/i);
+    }
+  });
+
   it("ignores a forged sentinel an escape writes to stdout (F-010, stdout never deserialized)", async () => {
     const code = [
       "try {",

--- a/sandbox/src/run-code.test.ts
+++ b/sandbox/src/run-code.test.ts
@@ -170,4 +170,23 @@ describe("runCode — sandbox child_process runner", () => {
       expect(asMap.get("b")).toBe(2);
     }
   });
+
+  it("keeps the real result when escaped code schedules a later stdout write (F-010)", async () => {
+    // The child flushes its result synchronously and then process.exit(0)s, so
+    // a post-escape user-scheduled forged sentinel never reaches the parent and
+    // lastIndexOf() cannot select it over the genuine result.
+    const code = [
+      "try {",
+      '  const proc = Error.constructor("return process")();',
+      '  const g = proc.constructor.constructor("return globalThis")();',
+      '  g.setTimeout(function(){ try { proc.stdout.write("\\u0001RESULT\\u0002////\\n"); } catch (e) {} }, 5);',
+      "} catch (e) {}",
+      'return "REAL";',
+    ].join("\n");
+    const outcome = await runCode({ code, timeoutMs: 1500 });
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result).toBe("REAL");
+    }
+  });
 });

--- a/sandbox/src/run-code.test.ts
+++ b/sandbox/src/run-code.test.ts
@@ -1,5 +1,18 @@
+import { serialize } from "node:v8";
 import { describe, expect, it } from "vitest";
+import { SANDBOX_RESULT_FD } from "../../lib/sandbox/child-source.js";
 import { runCode } from "./run-code.js";
+
+// A forged result frame an escaped child could write to fd 3: a 4-byte
+// big-endian length prefix followed by a v8-serialized success outcome with an
+// attacker-chosen result. Emitted as a JS literal embedded in the user code.
+function forgedFrameLiteral(result: string): string {
+  const payload = serialize({ ok: true, result, logs: [] });
+  const header = Buffer.allocUnsafe(4);
+  header.writeUInt32BE(payload.length, 0);
+  const bytes = [...header, ...payload].join(",");
+  return `Buffer.from([${bytes}])`;
+}
 
 describe("runCode — sandbox child_process runner", () => {
   it("returns a basic arithmetic result with empty logs", async () => {
@@ -171,15 +184,56 @@ describe("runCode — sandbox child_process runner", () => {
     }
   });
 
-  it("keeps the real result when escaped code schedules a later stdout write (F-010)", async () => {
-    // The child flushes its result synchronously and then process.exit(0)s, so
-    // a post-escape user-scheduled forged sentinel never reaches the parent and
-    // lastIndexOf() cannot select it over the genuine result.
+  it("ignores a forged sentinel an escape writes to stdout (F-010, stdout never deserialized)", async () => {
     const code = [
       "try {",
       '  const proc = Error.constructor("return process")();',
-      '  const g = proc.constructor.constructor("return globalThis")();',
-      '  g.setTimeout(function(){ try { proc.stdout.write("\\u0001RESULT\\u0002////\\n"); } catch (e) {} }, 5);',
+      '  proc.stdout.write("\\u0001RESULT\\u0002////\\n");',
+      "} catch (e) {}",
+      'return "REAL";',
+    ].join("\n");
+    const outcome = await runCode({ code, timeoutMs: 1500 });
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result).toBe("REAL");
+    }
+  });
+
+  it("keeps the real result when an escape schedules a later forged fd-3 frame (F-010)", async () => {
+    // The genuine result frame is written first, so the parent's
+    // first-frame-wins read discards the forged frame the escape appends later.
+    const code = [
+      "try {",
+      '  const req = Error.constructor("return require")();',
+      '  const efs = req("node:fs");',
+      '  const g = Error.constructor("return globalThis")();',
+      `  const forged = ${forgedFrameLiteral("FORGED")};`,
+      `  g.setTimeout(function(){ try { efs.writeSync(${SANDBOX_RESULT_FD}, forged); } catch (e) {} }, 5);`,
+      "} catch (e) {}",
+      'return "REAL";',
+    ].join("\n");
+    const outcome = await runCode({ code, timeoutMs: 1500 });
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result).toBe("REAL");
+    }
+  });
+
+  it("keeps the real result when an escape reassigns fs.writeSync then forges (F-010)", async () => {
+    // writeResult uses a startup-captured __writeSync, so reassigning
+    // fs.writeSync cannot suppress the genuine frame; the later forged frame
+    // loses to first-frame-wins.
+    const code = [
+      "try {",
+      '  const req = Error.constructor("return require")();',
+      '  const efs = req("node:fs");',
+      "  const realWrite = efs.writeSync;",
+      "  efs.writeSync = function(){ return 0; };",
+      '  const proc = Error.constructor("return process")();',
+      "  proc.exit = function(){};",
+      '  const g = Error.constructor("return globalThis")();',
+      `  const forged = ${forgedFrameLiteral("FORGED")};`,
+      `  g.setTimeout(function(){ try { realWrite(${SANDBOX_RESULT_FD}, forged); } catch (e) {} }, 5);`,
       "} catch (e) {}",
       'return "REAL";',
     ].join("\n");

--- a/sandbox/src/run-code.ts
+++ b/sandbox/src/run-code.ts
@@ -1,8 +1,8 @@
 import { spawn } from "node:child_process";
-import { deserialize } from "node:v8";
 import {
   SANDBOX_CHILD_SOURCE as CHILD_SOURCE,
   createSandboxResultReader,
+  decodeSandboxResult,
   SANDBOX_RESULT_FD,
   type SandboxResultReader,
 } from "../../lib/sandbox/child-source.js";
@@ -49,6 +49,14 @@ function buildChildEnv(): NodeJS.ProcessEnv {
   return out as NodeJS.ProcessEnv;
 }
 
+function isChildOutcome(value: unknown): value is ChildOutcome {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { ok?: unknown }).ok === "boolean"
+  );
+}
+
 function outcomeFromReader(reader: SandboxResultReader): ChildOutcome {
   if (reader.error) {
     return { ok: false, errorMessage: reader.error, logs: [] };
@@ -57,7 +65,18 @@ function outcomeFromReader(reader: SandboxResultReader): ChildOutcome {
     return { ok: false, errorMessage: "Sandbox produced no result", logs: [] };
   }
   try {
-    return deserialize(reader.frame) as ChildOutcome;
+    // Safe by construction: JSON.parse + tag rebuild, never v8.deserialize on
+    // child-produced bytes (F-010). Validate the envelope shape since the
+    // child is untrusted.
+    const decoded = decodeSandboxResult(reader.frame.toString("utf8"));
+    if (!isChildOutcome(decoded)) {
+      return {
+        ok: false,
+        errorMessage: "Sandbox produced malformed result",
+        logs: [],
+      };
+    }
+    return decoded;
   } catch (_err) {
     return {
       ok: false,

--- a/sandbox/src/run-code.ts
+++ b/sandbox/src/run-code.ts
@@ -2,7 +2,9 @@ import { spawn } from "node:child_process";
 import { deserialize } from "node:v8";
 import {
   SANDBOX_CHILD_SOURCE as CHILD_SOURCE,
-  SANDBOX_RESULT_SENTINEL as RESULT_SENTINEL,
+  createSandboxResultReader,
+  SANDBOX_RESULT_FD,
+  type SandboxResultReader,
 } from "../../lib/sandbox/child-source.js";
 
 type LogEntry = {
@@ -47,20 +49,15 @@ function buildChildEnv(): NodeJS.ProcessEnv {
   return out as NodeJS.ProcessEnv;
 }
 
-function parseChildOutput(stdout: string): ChildOutcome {
-  const idx = stdout.lastIndexOf(RESULT_SENTINEL);
-  if (idx === -1) {
-    return {
-      ok: false,
-      errorMessage: "Sandbox produced no result",
-      logs: [],
-    };
+function outcomeFromReader(reader: SandboxResultReader): ChildOutcome {
+  if (reader.error) {
+    return { ok: false, errorMessage: reader.error, logs: [] };
   }
-  const newlineIdx = stdout.indexOf("\n", idx);
-  const end = newlineIdx === -1 ? stdout.length : newlineIdx;
-  const base64 = stdout.slice(idx + RESULT_SENTINEL.length, end).trim();
+  if (!reader.frame) {
+    return { ok: false, errorMessage: "Sandbox produced no result", logs: [] };
+  }
   try {
-    return deserialize(Buffer.from(base64, "base64")) as ChildOutcome;
+    return deserialize(reader.frame) as ChildOutcome;
   } catch (_err) {
     return {
       ok: false,
@@ -87,12 +84,14 @@ async function runInChild(
       return;
     }
 
+    // fd 3 is the dedicated result channel (F-010). stdout/stderr stay
+    // user-facing diagnostics and are never deserialized.
     const child = spawn(process.execPath, ["-e", CHILD_SOURCE], {
       env: buildChildEnv(),
-      stdio: ["pipe", "pipe", "pipe"],
+      stdio: ["pipe", "pipe", "pipe", "pipe"],
     });
 
-    let stdout = "";
+    const resultReader = createSandboxResultReader();
     let stderr = "";
     let settled = false;
 
@@ -122,14 +121,29 @@ async function runInChild(
       finish({ ok: false, errorMessage: "WALL_CLOCK_TIMEOUT", logs: [] });
     }, timeoutMs + 1000);
 
-    child.stdout.setEncoding("utf8");
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
-    });
+    // Drain stdout so a sandbox escape that writes there cannot fill the pipe
+    // and block the child; the bytes are intentionally discarded (never a
+    // result source).
+    child.stdout.resume();
     child.stderr.setEncoding("utf8");
     child.stderr.on("data", (chunk: string) => {
       stderr += chunk;
     });
+
+    const resultStream = child.stdio[SANDBOX_RESULT_FD];
+    if (resultStream && "on" in resultStream) {
+      resultStream.on("data", (chunk: Buffer) => {
+        resultReader.push(chunk);
+        if (resultReader.done) {
+          // First complete frame wins; resolve now and reap the child even if
+          // escaped code kept the event loop alive past the result.
+          finish(outcomeFromReader(resultReader));
+        }
+      });
+      resultStream.on("error", () => {
+        // Pipe teardown races process exit; the close handler maps the outcome.
+      });
+    }
 
     child.on("error", (err: Error) => {
       finish({
@@ -141,12 +155,12 @@ async function runInChild(
     });
 
     child.on("close", (exitCode: number | null) => {
-      const parsed = parseChildOutput(stdout);
+      const parsed = outcomeFromReader(resultReader);
       if (parsed.ok || exitCode === 0) {
         finish(parsed);
         return;
       }
-      // Non-zero exit with no parseable result; surface stderr as a hint.
+      // Non-zero exit with no result frame; surface stderr as a hint.
       finish({
         ok: false,
         errorMessage:

--- a/tests/unit/sandbox-child-source.test.ts
+++ b/tests/unit/sandbox-child-source.test.ts
@@ -2,14 +2,16 @@ import { spawn } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
-import { deserialize } from "node:v8";
+import { deserialize, serialize } from "node:v8";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
 import {
+  createSandboxResultReader,
   SANDBOX_CHILD_SOURCE,
-  SANDBOX_RESULT_SENTINEL,
+  SANDBOX_RESULT_FD,
+  SANDBOX_RESULT_MAX_BYTES,
 } from "@/lib/sandbox/child-source";
 import {
   SSRF_BLOCKED_HOST_EXACT,
@@ -114,21 +116,25 @@ type SandboxOutcome =
       logs: unknown[];
     };
 
-function parseChildOutput(stdout: string): SandboxOutcome {
-  const idx = stdout.lastIndexOf(SANDBOX_RESULT_SENTINEL);
-  if (idx === -1) {
-    return { ok: false, errorMessage: "no sentinel in stdout", logs: [] };
+function outcomeFromReader(
+  reader: ReturnType<typeof createSandboxResultReader>
+): SandboxOutcome {
+  if (reader.error) {
+    return { ok: false, errorMessage: reader.error, logs: [] };
   }
-  const newlineIdx = stdout.indexOf("\n", idx);
-  const end = newlineIdx === -1 ? stdout.length : newlineIdx;
-  const base64 = stdout.slice(idx + SANDBOX_RESULT_SENTINEL.length, end).trim();
+  if (!reader.frame) {
+    return { ok: false, errorMessage: "no result frame on fd 3", logs: [] };
+  }
   try {
-    return deserialize(Buffer.from(base64, "base64")) as SandboxOutcome;
+    return deserialize(reader.frame) as SandboxOutcome;
   } catch (_err) {
     return { ok: false, errorMessage: "malformed v8 payload", logs: [] };
   }
 }
 
+// Mirrors the production parent (sandbox/src/run-code.ts): spawn with the
+// dedicated fd-3 result channel, read the first length-prefixed frame, and
+// never deserialize stdout.
 async function runSandboxed(
   userCode: string,
   timeoutMs = 3000,
@@ -136,9 +142,9 @@ async function runSandboxed(
 ): Promise<SandboxOutcome> {
   return await new Promise<SandboxOutcome>((resolve) => {
     const child = spawn(process.execPath, ["-e", source], {
-      stdio: ["pipe", "pipe", "pipe"],
+      stdio: ["pipe", "pipe", "pipe", "pipe"],
     });
-    let stdout = "";
+    const reader = createSandboxResultReader();
     let settled = false;
 
     function finish(outcome: SandboxOutcome): void {
@@ -161,15 +167,22 @@ async function runSandboxed(
       finish({ ok: false, errorMessage: "harness timeout", logs: [] });
     }, timeoutMs + 3000);
 
-    child.stdout.setEncoding("utf8");
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
-    });
+    child.stdout.resume();
+    child.stderr.resume();
+    const resultStream = child.stdio[SANDBOX_RESULT_FD];
+    if (resultStream && "on" in resultStream) {
+      resultStream.on("data", (chunk: Buffer) => {
+        reader.push(chunk);
+        if (reader.done) {
+          finish(outcomeFromReader(reader));
+        }
+      });
+    }
     child.on("error", (err: Error) => {
       finish({ ok: false, errorMessage: err.message, logs: [] });
     });
     child.on("close", () => {
-      finish(parseChildOutput(stdout));
+      finish(outcomeFromReader(reader));
     });
 
     try {
@@ -434,29 +447,38 @@ describe("sandbox grandchild redirect following", () => {
   });
 }, 30_000);
 
-// F-010 mitigation: the grandchild must flush its result via a synchronous
-// fd-1 write and then process.exit(0) immediately, so a post-escape
-// user-scheduled stdout write cannot emit a second, later sentinel that the
-// parent's lastIndexOf() would otherwise select as the authoritative result.
-describe("sandbox grandchild flushes the result then hard-exits", () => {
-  it("writeResult writes the result synchronously and then hard-exits", () => {
-    expect(SANDBOX_CHILD_SOURCE).toContain("fs.writeSync(1");
-    expect(SANDBOX_CHILD_SOURCE).toContain("process.exit(0)");
+// Helper: a forged result frame an escaped child could write to fd 3 — a
+// 4-byte big-endian length prefix followed by a v8-serialized success outcome
+// carrying an attacker-chosen result. Used by the forgery tests below to prove
+// the parent's first-frame-wins read rejects it.
+function forgedFrameLiteral(result: string): string {
+  const payload = serialize({ ok: true, result, logs: [] });
+  const header = Buffer.allocUnsafe(4);
+  header.writeUInt32BE(payload.length, 0);
+  const bytes = [...header, ...payload].join(",");
+  return `Buffer.from([${bytes}])`;
+}
+
+// F-010 mitigation: the result travels on the dedicated fd-3 channel as a
+// length-prefixed frame the parent reads first-frame-wins, and stdout is never
+// deserialized. These tests prove a sandbox escape cannot forge a result by
+// (a) writing stdout, (b) appending a later fd-3 frame, (c) reassigning
+// process.exit, or (d) reassigning fs.writeSync.
+describe("sandbox grandchild result channel resists forgery (F-010)", () => {
+  it("writes the result frame to the dedicated fd via a captured writeSync, then captured exit", () => {
+    expect(SANDBOX_CHILD_SOURCE).toContain("const __writeSync = fs.writeSync");
+    expect(SANDBOX_CHILD_SOURCE).toContain("const __exit = process.exit");
+    expect(SANDBOX_CHILD_SOURCE).toContain("__writeSync(RESULT_FD");
+    expect(SANDBOX_CHILD_SOURCE).toContain("__exit(0)");
+    // The result must NOT be written to stdout (fd 1) any more.
+    expect(SANDBOX_CHILD_SOURCE).not.toContain("writeSync(1");
   });
 
-  it("keeps the real result even when escaped code schedules a post-result stdout write", async () => {
-    // Reach the host process via the canonical escape (proven reachable by
-    // sandbox/src/run-code.test.ts), reach the host global for a real timer,
-    // and schedule a forged sentinel for AFTER the real result. With
-    // process.exit(0) in writeResult the child dies first, so the forged bytes
-    // never reach the parent and lastIndexOf() selects the real result. The
-    // primitives are wrapped in try/catch so the test is never flaky if one is
-    // unavailable; it then simply returns the real result.
+  it("ignores a forged sentinel an escape writes to stdout (stdout is never deserialized)", async () => {
     const code = [
       "try {",
       '  const proc = Error.constructor("return process")();',
-      '  const g = proc.constructor.constructor("return globalThis")();',
-      '  g.setTimeout(function(){ try { proc.stdout.write("\\u0001RESULT\\u0002////\\n"); } catch (e) {} }, 5);',
+      '  proc.stdout.write("\\u0001RESULT\\u0002////\\n");',
       "} catch (e) {}",
       'return "REAL";',
     ].join("\n");
@@ -464,6 +486,141 @@ describe("sandbox grandchild flushes the result then hard-exits", () => {
     expect(outcome.ok).toBe(true);
     if (outcome.ok) {
       expect(outcome.result).toBe("REAL");
+    }
+  });
+
+  it("keeps the real result when an escape schedules a LATER forged fd-3 frame", async () => {
+    // Reach host require for fs, schedule a forged frame on fd 3 for after the
+    // genuine result. The genuine frame is written first, so first-frame-wins
+    // discards the forgery.
+    const code = [
+      "try {",
+      '  const req = Error.constructor("return require")();',
+      '  const efs = req("node:fs");',
+      '  const g = Error.constructor("return globalThis")();',
+      `  const forged = ${forgedFrameLiteral("FORGED")};`,
+      `  g.setTimeout(function(){ try { efs.writeSync(${SANDBOX_RESULT_FD}, forged); } catch (e) {} }, 5);`,
+      "} catch (e) {}",
+      'return "REAL";',
+    ].join("\n");
+    const outcome = await runSandboxed(code, 1500);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result).toBe("REAL");
+    }
+  });
+
+  it("keeps the real result even when the escape disables process.exit before forging", async () => {
+    // Disabling process.exit cannot help: correctness rests on first-frame-wins,
+    // not on the hard-exit. The genuine frame is still written first.
+    const code = [
+      "try {",
+      '  const proc = Error.constructor("return process")();',
+      "  proc.exit = function(){};",
+      '  const req = Error.constructor("return require")();',
+      '  const efs = req("node:fs");',
+      '  const g = Error.constructor("return globalThis")();',
+      `  const forged = ${forgedFrameLiteral("FORGED")};`,
+      `  g.setTimeout(function(){ try { efs.writeSync(${SANDBOX_RESULT_FD}, forged); } catch (e) {} }, 5);`,
+      "} catch (e) {}",
+      'return "REAL";',
+    ].join("\n");
+    const outcome = await runSandboxed(code, 1500);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result).toBe("REAL");
+    }
+  });
+
+  it("keeps the real result even when the escape reassigns fs.writeSync before forging", async () => {
+    // The genuine writeResult uses the startup-captured __writeSync, so
+    // reassigning fs.writeSync cannot suppress the genuine frame; the later
+    // forged frame loses to first-frame-wins.
+    const code = [
+      "try {",
+      '  const req = Error.constructor("return require")();',
+      '  const efs = req("node:fs");',
+      "  const realWrite = efs.writeSync;",
+      "  efs.writeSync = function(){ return 0; };",
+      '  const g = Error.constructor("return globalThis")();',
+      `  const forged = ${forgedFrameLiteral("FORGED")};`,
+      `  g.setTimeout(function(){ try { realWrite(${SANDBOX_RESULT_FD}, forged); } catch (e) {} }, 5);`,
+      "} catch (e) {}",
+      'return "REAL";',
+    ].join("\n");
+    const outcome = await runSandboxed(code, 1500);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result).toBe("REAL");
+    }
+  });
+});
+
+// Unit coverage for the parent-side frame reader in isolation (no subprocess).
+describe("createSandboxResultReader first-frame-wins framing", () => {
+  function frame(value: unknown): Buffer {
+    const payload = serialize(value);
+    const header = Buffer.allocUnsafe(4);
+    header.writeUInt32BE(payload.length, 0);
+    return Buffer.concat([header, payload]);
+  }
+
+  it("returns the first frame and ignores trailing forged frames", () => {
+    const reader = createSandboxResultReader();
+    const genuine = frame({ ok: true, result: "REAL", logs: [] });
+    const forged = frame({ ok: true, result: "FORGED", logs: [] });
+    reader.push(Buffer.concat([genuine, forged]));
+    expect(reader.done).toBe(true);
+    expect(reader.error).toBeNull();
+    expect(reader.frame).not.toBeNull();
+    if (reader.frame) {
+      expect(deserialize(reader.frame)).toEqual({
+        ok: true,
+        result: "REAL",
+        logs: [],
+      });
+    }
+  });
+
+  it("reassembles a frame delivered across multiple chunks", () => {
+    const reader = createSandboxResultReader();
+    const buf = frame({ ok: true, result: 42, logs: [] });
+    for (const byte of buf) {
+      reader.push(Buffer.from([byte]));
+    }
+    expect(reader.done).toBe(true);
+    if (reader.frame) {
+      expect(deserialize(reader.frame)).toEqual({
+        ok: true,
+        result: 42,
+        logs: [],
+      });
+    }
+  });
+
+  it("rejects a frame whose declared length exceeds the cap", () => {
+    const reader = createSandboxResultReader();
+    const header = Buffer.allocUnsafe(4);
+    header.writeUInt32BE(SANDBOX_RESULT_MAX_BYTES + 1, 0);
+    reader.push(header);
+    expect(reader.done).toBe(true);
+    expect(reader.frame).toBeNull();
+    expect(reader.error).toMatch(/exceeds maximum size/);
+  });
+});
+
+// End-to-end framing across a real pipe: a result larger than the OS pipe
+// buffer (64 KiB on Linux) forces the child's synchronous fd-3 write to span
+// multiple drains and the parent's reader to reassemble multiple chunks,
+// exercising the EAGAIN-retry/backpressure path the in-memory reader test
+// cannot.
+describe("sandbox grandchild fd-3 framing survives large multi-chunk results", () => {
+  it("round-trips a result larger than the pipe buffer", async () => {
+    const outcome = await runSandboxed('return "x".repeat(300000);', 3000);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(typeof outcome.result).toBe("string");
+      expect((outcome.result as string).length).toBe(300_000);
     }
   });
 });

--- a/tests/unit/sandbox-child-source.test.ts
+++ b/tests/unit/sandbox-child-source.test.ts
@@ -9,6 +9,7 @@ vi.mock("server-only", () => ({}));
 
 import {
   createSandboxResultReader,
+  decodeSandboxResult,
   SANDBOX_CHILD_SOURCE,
   SANDBOX_RESULT_FD,
   SANDBOX_RESULT_MAX_BYTES,
@@ -126,9 +127,9 @@ function outcomeFromReader(
     return { ok: false, errorMessage: "no result frame on fd 3", logs: [] };
   }
   try {
-    return deserialize(reader.frame) as SandboxOutcome;
+    return decodeSandboxResult(reader.frame.toString("utf8")) as SandboxOutcome;
   } catch (_err) {
-    return { ok: false, errorMessage: "malformed v8 payload", logs: [] };
+    return { ok: false, errorMessage: "malformed result payload", logs: [] };
   }
 }
 
@@ -622,5 +623,125 @@ describe("sandbox grandchild fd-3 framing survives large multi-chunk results", (
       expect(typeof outcome.result).toBe("string");
       expect((outcome.result as string).length).toBe(300_000);
     }
+  });
+});
+
+// The result codec replaces v8.serialize/deserialize so the parent never
+// deserializes untrusted v8 (F-010 root cause). It must still preserve the
+// structured types the Code node contract promises. These spawn the real
+// grandchild and assert fidelity end-to-end through the tagged-JSON channel.
+describe("sandbox grandchild result codec preserves structured-type fidelity", () => {
+  it("round-trips a nested BigInt (wei-style amounts)", async () => {
+    const code =
+      "return { amounts: [BigInt(10), BigInt(20)], wei: BigInt('1000000000000000000') };";
+    const outcome = await runSandboxed(code);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      const r = outcome.result as { amounts: bigint[]; wei: bigint };
+      expect(typeof r.amounts[0]).toBe("bigint");
+      expect(r.amounts[1]).toBe(BigInt(20));
+      expect(r.wei).toBe(BigInt("1000000000000000000"));
+    }
+  });
+
+  it("round-trips Set and Date", async () => {
+    const outcome = await runSandboxed(
+      "return { s: new Set([1, 2, 3]), d: new Date(1700000000000) };"
+    );
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      const r = outcome.result as { s: Set<number>; d: Date };
+      expect(r.s).toBeInstanceOf(Set);
+      expect([...r.s]).toEqual([1, 2, 3]);
+      expect(r.d).toBeInstanceOf(Date);
+      expect(r.d.getTime()).toBe(1_700_000_000_000);
+    }
+  });
+
+  it("round-trips a typed array", async () => {
+    const outcome = await runSandboxed("return new Uint8Array([1, 2, 255]);");
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result).toBeInstanceOf(Uint8Array);
+      expect([...(outcome.result as Uint8Array)]).toEqual([1, 2, 255]);
+    }
+  });
+
+  it("round-trips NaN / Infinity / undefined", async () => {
+    const outcome = await runSandboxed(
+      "return { n: NaN, p: Infinity, m: -Infinity, u: undefined };"
+    );
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      const r = outcome.result as Record<string, unknown>;
+      expect(Number.isNaN(r.n)).toBe(true);
+      expect(r.p).toBe(Number.POSITIVE_INFINITY);
+      expect(r.m).toBe(Number.NEGATIVE_INFINITY);
+      expect(r.u).toBeUndefined();
+    }
+  });
+
+  it("does NOT misinterpret a user object that literally has a \"$\" key", async () => {
+    // Collision safety: a user object shaped like a type tag must round-trip as
+    // a plain object, not be decoded as a BigInt.
+    const outcome = await runSandboxed('return { "$": "bigint", v: "5" };');
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result).toEqual({ $: "bigint", v: "5" });
+    }
+  });
+
+  it("returns a clean error (not a crash) for a non-serializable value", async () => {
+    const outcome = await runSandboxed("return () => 1;");
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.errorMessage).toMatch(/not serializable/i);
+    }
+  });
+
+  it("returns a clean error for a circular reference", async () => {
+    const outcome = await runSandboxed(
+      "const a = {}; a.self = a; return a;"
+    );
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.errorMessage).toMatch(/serializable|circular/i);
+    }
+  });
+});
+
+// The decoder runs on bytes a sandbox escape can fully control, so it must be
+// safe on hostile input in isolation -- no prototype pollution, no v8.
+describe("decodeSandboxResult is safe on untrusted input", () => {
+  it("does not pollute Object.prototype via a __proto__ key", () => {
+    const before = ({} as Record<string, unknown>).polluted;
+    const decoded = decodeSandboxResult(
+      '{"result":{"__proto__":{"polluted":true}}}'
+    ) as { result: Record<string, unknown> };
+    // The hostile key lands as an own data property, not on the prototype.
+    expect(({} as Record<string, unknown>).polluted).toBe(before);
+    expect(Object.getPrototypeOf(decoded.result)).toBe(Object.prototype);
+    expect(Object.hasOwn(decoded.result, "__proto__")).toBe(true);
+  });
+
+  it("rebuilds tagged values", () => {
+    expect(decodeSandboxResult('{"$":"bigint","v":"42"}')).toBe(BigInt(42));
+    expect(decodeSandboxResult('{"$":"undef"}')).toBeUndefined();
+    const m = decodeSandboxResult('{"$":"map","v":[["a",1]]}') as Map<
+      string,
+      number
+    >;
+    expect(m).toBeInstanceOf(Map);
+    expect(m.get("a")).toBe(1);
+  });
+
+  it("treats an escaped {$:obj} wrapper as a literal object", () => {
+    expect(
+      decodeSandboxResult('{"$":"obj","v":{"$":"x","y":1}}')
+    ).toEqual({ $: "x", y: 1 });
+  });
+
+  it("throws on malformed JSON (callers map this to an error outcome)", () => {
+    expect(() => decodeSandboxResult("not json")).toThrow();
   });
 });

--- a/tests/unit/sandbox-child-source.test.ts
+++ b/tests/unit/sandbox-child-source.test.ts
@@ -433,3 +433,37 @@ describe("sandbox grandchild redirect following", () => {
     }
   });
 }, 30_000);
+
+// F-010 mitigation: the grandchild must flush its result via a synchronous
+// fd-1 write and then process.exit(0) immediately, so a post-escape
+// user-scheduled stdout write cannot emit a second, later sentinel that the
+// parent's lastIndexOf() would otherwise select as the authoritative result.
+describe("sandbox grandchild flushes the result then hard-exits", () => {
+  it("writeResult writes the result synchronously and then hard-exits", () => {
+    expect(SANDBOX_CHILD_SOURCE).toContain("fs.writeSync(1");
+    expect(SANDBOX_CHILD_SOURCE).toContain("process.exit(0)");
+  });
+
+  it("keeps the real result even when escaped code schedules a post-result stdout write", async () => {
+    // Reach the host process via the canonical escape (proven reachable by
+    // sandbox/src/run-code.test.ts), reach the host global for a real timer,
+    // and schedule a forged sentinel for AFTER the real result. With
+    // process.exit(0) in writeResult the child dies first, so the forged bytes
+    // never reach the parent and lastIndexOf() selects the real result. The
+    // primitives are wrapped in try/catch so the test is never flaky if one is
+    // unavailable; it then simply returns the real result.
+    const code = [
+      "try {",
+      '  const proc = Error.constructor("return process")();',
+      '  const g = proc.constructor.constructor("return globalThis")();',
+      '  g.setTimeout(function(){ try { proc.stdout.write("\\u0001RESULT\\u0002////\\n"); } catch (e) {} }, 5);',
+      "} catch (e) {}",
+      'return "REAL";',
+    ].join("\n");
+    const outcome = await runSandboxed(code, 1500);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result).toBe("REAL");
+    }
+  });
+});


### PR DESCRIPTION
## Finding F-010 (HIGH) -- parent v8.deserialize trusts child stdout

The sandbox child returned its v8-serialized result on stdout, prefixed by a
6-byte sentinel; the parent located it with `lastIndexOf(sentinel)` and ran
`v8.deserialize` on the bytes that followed. A child that escaped the vm could
schedule a later stdout write of a forged sentinel -- `lastIndexOf` selects
the LAST one -- so the parent deserialized attacker-controlled v8 bytes (a
forged result, or prototype-pollution in the privileged in-pod parent).

The **root cause** is that the parent runs `v8.deserialize` on bytes a
vm-escapable child controls, and Node documents structured-clone deserialize
as unsafe on untrusted input.

## Fix (two commits)

**1. Dedicated fd-3 result channel, first-frame-wins.** The result moves off
stdout to a length-prefixed frame (4-byte big-endian count + body) on **fd 3**.
Both parents -- in-pod `plugins/code/steps/run-code.ts` and the
`@keeperhub/sandbox` service `sandbox/src/run-code.ts` -- spawn
`["pipe","pipe","pipe","pipe"]`, read **only the first complete frame**, and
**never read stdout for a result** (drained, user-facing). The genuine frame
is written through a `fs.writeSync` reference captured at child startup. This
removes the 6-byte substring-scan surface and makes a post-result forged frame
lose even when the escape reassigns `process.exit` or `fs.writeSync`.

**2. Safe codec -- the parent stops deserializing untrusted v8 (root cause).**
The child now encodes its outcome as **tagged JSON** (type tags for BigInt,
Map, Set, Date, RegExp, typed arrays/ArrayBuffer/DataView, `undefined`,
`NaN`/`Infinity`/`-0`; plain objects carrying a literal `\"$\"` key are escaped
so they can't be mistaken for a tag). Parents recover it with **`JSON.parse`**
-- safe on untrusted input -- plus a rebuild that defines `__proto__` as an own
data property, so a hostile frame cannot pollute the parent's prototypes. The
envelope shape is validated since the child is untrusted. Fidelity previously
provided by structured-clone (BigInt-for-wei, Map, ...) is now provided by the
codec, so the Code node contract is unchanged.

The trusted sandbox-server <-> main-app HTTP path keeps `v8` (server-to-server
framing of an already-decoded outcome, not untrusted child output).

## Result

Even a fully-escaped child that writes frame #0 synchronously can now only hand
the parent **inert data** -- it can no longer deliver a deserialization gadget,
forge a result past first-frame-wins, or pollute the parent via `__proto__`.
The remaining "residual" is just that a vm escape is arbitrary code running AS
the user, so it can return any DATA it likes -- exactly as legitimate user code
always could.

## Verification

- Fidelity round-trips (real child): nested BigInt, Set/Date, typed arrays,
  `NaN`/`Infinity`/`undefined`, and the `\"$\"`-key collision case; clean error
  outcomes for non-serializable / circular results.
- Forgery rejection (real child): forged result via stdout, a later fd-3 frame,
  `process.exit` disabled, and `fs.writeSync` reassigned -- each keeps the
  genuine result.
- Decoder-in-isolation: a malicious `__proto__` frame does not pollute
  `Object.prototype`; tagged values rebuild; escaped wrappers stay literal;
  malformed JSON throws.
- `@keeperhub/sandbox` (30) + main-app sandbox/code suites green; `tsc` clean.