### PR TITLE
fix(execute): derive node-execution gating from merged config to close reserved-field bypass

### DIFF
--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -272,9 +272,22 @@ async function executeNode(
   data: NodeExecuteRequest,
   resolved: ResolvedAction,
   apiKeyCtx: ApiKeyContext,
-  preCreatedExecutionId?: string
+  preCreatedExecutionId?: string,
+  resolvedRefs?: { network?: string; integrationId?: string }
 ): Promise<NextResponse> {
-  const { config, integrationId, network, retry } = data;
+  const { config, retry } = data;
+  const network = resolvedRefs?.network;
+  const integrationId = resolvedRefs?.integrationId;
+
+  // Drop caller-supplied gating keys so the step only sees the values the
+  // route resolved and gated on. web3Connection is intentionally preserved;
+  // it stays org-ownership-verified downstream in lib/safe/signer-resolver.ts.
+  const {
+    network: _ignoredNetwork,
+    integrationId: _ignoredIntegrationId,
+    _context: _ignoredContext,
+    ...safeConfig
+  } = config;
 
   let executionId: string;
   if (preCreatedExecutionId) {
@@ -282,7 +295,7 @@ async function executeNode(
   } else {
     const redactedInput = redactInput({
       actionType: data.actionType,
-      ...config,
+      ...safeConfig,
     });
     const created = await createExecution({
       organizationId: apiKeyCtx.organizationId,
@@ -297,7 +310,7 @@ async function executeNode(
   await markRunning(executionId);
 
   const stepInput = {
-    ...config,
+    ...safeConfig,
     ...(integrationId ? { integrationId } : {}),
     ...(network ? { network } : {}),
     _context: {
@@ -399,7 +412,21 @@ export async function POST(request: Request): Promise<NextResponse> {
     return NextResponse.json({ error: validation.error }, { status: 400 });
   }
 
-  const { actionType, integrationId, network } = validation.data;
+  const { actionType, config, integrationId, network } = validation.data;
+
+  // Gating keys can ride inside caller config; merge them in so ownership,
+  // wallet, and spending-cap checks cannot be bypassed by nesting them there.
+  const configNetwork =
+    typeof config.network === "string" && config.network.trim() !== ""
+      ? config.network
+      : undefined;
+  const configIntegrationId =
+    typeof config.integrationId === "string" &&
+    config.integrationId.trim() !== ""
+      ? config.integrationId
+      : undefined;
+  const effectiveNetwork = network ?? configNetwork;
+  const effectiveIntegrationId = integrationId ?? configIntegrationId;
 
   const resolved = resolveAction(actionType);
   if (!resolved) {
@@ -409,9 +436,9 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 
-  if (integrationId) {
+  if (effectiveIntegrationId) {
     const owned = await verifyIntegrationOwnership(
-      integrationId,
+      effectiveIntegrationId,
       apiKeyCtx.organizationId
     );
     if (!owned) {
@@ -425,7 +452,12 @@ export async function POST(request: Request): Promise<NextResponse> {
     }
   }
 
-  if (network) {
+  const resolvedRefs = {
+    network: effectiveNetwork,
+    integrationId: effectiveIntegrationId,
+  };
+
+  if (effectiveNetwork) {
     const walletError = await requireWallet(apiKeyCtx.organizationId);
     if (walletError) {
       return walletError;
@@ -439,7 +471,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       organizationId: apiKeyCtx.organizationId,
       apiKeyId: apiKeyCtx.apiKeyId,
       type: resolved.actionType,
-      network,
+      network: effectiveNetwork,
       input: redactedInput,
     });
     if (!reserve.allowed) {
@@ -450,9 +482,16 @@ export async function POST(request: Request): Promise<NextResponse> {
       validation.data,
       resolved,
       apiKeyCtx,
-      reserve.executionId
+      reserve.executionId,
+      resolvedRefs
     );
   }
 
-  return await executeNode(validation.data, resolved, apiKeyCtx);
+  return await executeNode(
+    validation.data,
+    resolved,
+    apiKeyCtx,
+    undefined,
+    resolvedRefs
+  );
 }

--- a/tests/integration/execute-node-reserved-fields.test.ts
+++ b/tests/integration/execute-node-reserved-fields.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks -- available to vi.mock factories which run before any imports
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  validateApiKey: vi.fn(),
+  checkRateLimit: vi.fn(),
+  enforceExecutionLimit: vi.fn(),
+  enterApiExecuteErrorContext: vi.fn(),
+  checkAndReserveExecution: vi.fn(),
+  requireWallet: vi.fn(),
+  createExecution: vi.fn(),
+  markRunning: vi.fn(),
+  completeExecution: vi.fn(),
+  failExecution: vi.fn(),
+  setRetryCount: vi.fn(),
+  redactInput: vi.fn(),
+  resolveAction: vi.fn(),
+  stepFn: vi.fn(),
+  ownershipResult: [] as unknown[],
+  capturedInput: undefined as Record<string, unknown> | undefined,
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/app/api/execute/_lib/auth", () => ({
+  validateApiKey: mocks.validateApiKey,
+}));
+
+vi.mock("@/app/api/execute/_lib/rate-limit", () => ({
+  checkRateLimit: mocks.checkRateLimit,
+}));
+
+vi.mock("@/lib/billing/execution-guard", () => ({
+  enforceExecutionLimit: mocks.enforceExecutionLimit,
+}));
+
+vi.mock("@/lib/db/org-helpers", () => ({
+  enterApiExecuteErrorContext: mocks.enterApiExecuteErrorContext,
+}));
+
+vi.mock("@/app/api/execute/_lib/spending-cap", () => ({
+  checkAndReserveExecution: mocks.checkAndReserveExecution,
+}));
+
+vi.mock("@/app/api/execute/_lib/wallet-check", () => ({
+  requireWallet: mocks.requireWallet,
+}));
+
+vi.mock("@/app/api/execute/_lib/execution-service", () => ({
+  createExecution: mocks.createExecution,
+  markRunning: mocks.markRunning,
+  completeExecution: mocks.completeExecution,
+  failExecution: mocks.failExecution,
+  setRetryCount: mocks.setRetryCount,
+  redactInput: mocks.redactInput,
+}));
+
+vi.mock("@/app/api/execute/_lib/action-resolver", () => ({
+  resolveAction: mocks.resolveAction,
+}));
+
+vi.mock("@/lib/utils", () => ({
+  getErrorMessage: (err: unknown) =>
+    err instanceof Error ? err.message : String(err),
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  integrations: { id: "id", organizationId: "organizationId" },
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve(mocks.ownershipResult)),
+        })),
+      })),
+    })),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Route import (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+import { POST as nodePOST } from "@/app/api/execute/node/route";
+
+// ---------------------------------------------------------------------------
+// Fixtures + helpers
+// ---------------------------------------------------------------------------
+
+const AUTH_CONTEXT = { organizationId: "org_a", apiKeyId: "kh_1" };
+const AUTH_HEADER = { Authorization: "Bearer kh_test123" };
+
+function postRequest(body: unknown): Request {
+  return new Request("http://localhost:3000/api/execute/node", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...AUTH_HEADER },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.ownershipResult = [];
+  mocks.capturedInput = undefined;
+
+  mocks.validateApiKey.mockResolvedValue(AUTH_CONTEXT);
+  mocks.checkRateLimit.mockReturnValue({ allowed: true });
+  mocks.enforceExecutionLimit.mockResolvedValue({ blocked: false });
+  mocks.enterApiExecuteErrorContext.mockResolvedValue(undefined);
+  mocks.requireWallet.mockResolvedValue(null);
+  mocks.checkAndReserveExecution.mockResolvedValue({
+    allowed: true,
+    executionId: "ex1",
+  });
+  mocks.createExecution.mockResolvedValue({ executionId: "ex1" });
+  mocks.markRunning.mockResolvedValue(undefined);
+  mocks.completeExecution.mockResolvedValue(undefined);
+  mocks.failExecution.mockResolvedValue(undefined);
+  mocks.setRetryCount.mockResolvedValue(undefined);
+  mocks.redactInput.mockImplementation(
+    (input: Record<string, unknown>) => input
+  );
+
+  mocks.stepFn.mockImplementation((input: Record<string, unknown>) => {
+    mocks.capturedInput = input;
+    return Promise.resolve({ success: true });
+  });
+
+  mocks.resolveAction.mockImplementation((actionType: string) => ({
+    actionType,
+    label: "Test Action",
+    importer: {
+      importer: () => Promise.resolve({ step: mocks.stepFn }),
+      stepFunction: "step",
+    },
+    isPluginAction: true,
+  }));
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /api/execute/node reserved-field gating", () => {
+  it("rejects a foreign integrationId smuggled inside config with 403", async () => {
+    mocks.ownershipResult = [];
+
+    const response = await nodePOST(
+      postRequest({
+        actionType: "discord/send-message",
+        config: { integrationId: "int_foreign", message: "hi" },
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expect(mocks.checkAndReserveExecution).not.toHaveBeenCalled();
+    expect(mocks.stepFn).not.toHaveBeenCalled();
+  });
+
+  it("gates a network smuggled inside config through wallet + spending cap", async () => {
+    const response = await nodePOST(
+      postRequest({
+        actionType: "web3/write-contract",
+        config: { network: "1", contractAddress: "0xabc" },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.requireWallet).toHaveBeenCalledTimes(1);
+    expect(mocks.checkAndReserveExecution).toHaveBeenCalledTimes(1);
+    expect(mocks.checkAndReserveExecution).toHaveBeenCalledWith(
+      expect.objectContaining({ network: "1" })
+    );
+    expect(mocks.capturedInput?.network).toBe("1");
+    expect(
+      (mocks.capturedInput?._context as { organizationId: string })
+        .organizationId
+    ).toBe("org_a");
+  });
+
+  it("ignores a caller-supplied _context and always sets the trusted org", async () => {
+    const response = await nodePOST(
+      postRequest({
+        actionType: "web3/write-contract",
+        config: { network: "1", _context: { organizationId: "evil" } },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(
+      (mocks.capturedInput?._context as { organizationId: string })
+        .organizationId
+    ).toBe("org_a");
+  });
+
+  it("passes an owned top-level integrationId through to the step", async () => {
+    mocks.ownershipResult = [{ id: "int_mine" }];
+
+    const response = await nodePOST(
+      postRequest({
+        actionType: "discord/send-message",
+        integrationId: "int_mine",
+        config: { message: "hi" },
+      })
+    );
+
+    expect([200, 202]).toContain(response.status);
+    expect(mocks.capturedInput?.integrationId).toBe("int_mine");
+  });
+});


### PR DESCRIPTION
## Finding A-02 (HIGH, confidence 0.7, funds at risk)

`/api/execute/node` checked security-relevant fields (`network`, `integrationId`) only at the top level but spread the caller's free-form `config` object verbatim into the step input. By nesting `config.network` / `config.integrationId` (and omitting the top-level field), any holder of an org API key or OAuth token could:
- skip `requireWallet` + `checkAndReserveExecution` (daily spend-cap) while still broadcasting a signed transaction -- repeatable fund movement; and
- skip `verifyIntegrationOwnership`, then have a plugin step decrypt and use another org's integration credentials (cross-tenant confused-deputy).

## Fix

- Derive `effectiveNetwork = network ?? config.network` and `effectiveIntegrationId = integrationId ?? config.integrationId`, and run `verifyIntegrationOwnership`, `requireWallet`, and `checkAndReserveExecution` on the merged values.
- `executeNode` strips reserved keys (`network`, `integrationId`, `_context`) out of the caller `config` and re-applies only the route-resolved trusted values plus a trusted `_context`. `web3Connection` is preserved (already org-verified downstream in the signer resolver). Legit top-level callers produce a byte-identical step input.

## Verification

- New `tests/integration/execute-node-reserved-fields.test.ts` -- the two load-bearing security cases (foreign `config.integrationId` -> 403; `config.network` -> wallet + cap gating) confirmed to FAIL on the reverted unfixed route; 39 tests green.
- Live (local dev server): `kh_` key with a nested `config.integrationId` (no top-level) -> **403 "Integration not found or does not belong to this organization"** (ownership is now enforced on the merged id).
- `tsc` + `ultracite` clean. Independent review: APPROVE.

## Note

Broader defense-in-depth (passing the org `principal` to `fetchCredentials` in ~20 plugin steps so the credential layer fails closed) is tracked separately; this route-level fix closes the finding's vector. It touches the same file as the A-03 fix (a scope guard near the top of the handler) -- the two will need a trivial merge resolution depending on order.
