### PR TITLE
fix(mfa): require step-up to rotate an already-enrolled TOTP secret

### DIFF
--- a/app/api/user/totp/enroll/route.ts
+++ b/app/api/user/totp/enroll/route.ts
@@ -3,6 +3,7 @@ import { generateRandomString, symmetricEncrypt } from "better-auth/crypto";
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
+import { readAllSetCookies } from "@/lib/auth-cookie-chain";
 import {
   hashSessionToken,
   signSessionCookieValue,
@@ -55,6 +56,41 @@ function buildSessionSetCookie(signedValue: string, ttlMs: number): string {
   return `${cookieName}=${encodeURIComponent(signedValue)}; Path=/; HttpOnly;${secureSegment} SameSite=Lax; Max-Age=${maxAge}`;
 }
 
+const SESSION_COOKIE_NAMES = [
+  "better-auth.session_token",
+  "__Secure-better-auth.session_token",
+] as const;
+
+/**
+ * Read the raw session token Better Auth wrote into one of the
+ * Set-Cookie headers returned by verifyTOTP. Better Auth signs the
+ * cookie via hono's setSignedCookie, so the cookie value is
+ * `<rawToken>.<base64HmacSignature>`. We strip the signature suffix
+ * because `sessions.token` stores `hashSessionToken(rawToken)` and we
+ * need the raw token to reproduce that hash so the requires_mfa clear
+ * can be scoped to the just-rotated session only.
+ */
+function extractNewSessionToken(setCookies: readonly string[]): string | null {
+  for (const raw of setCookies) {
+    const firstPair = raw.split(";")[0]?.trim();
+    if (!firstPair) {
+      continue;
+    }
+    const eqIdx = firstPair.indexOf("=");
+    if (eqIdx <= 0) {
+      continue;
+    }
+    const name = firstPair.slice(0, eqIdx);
+    const value = firstPair.slice(eqIdx + 1);
+    if ((SESSION_COOKIE_NAMES as readonly string[]).includes(name)) {
+      const decoded = decodeURIComponent(value);
+      const dotIdx = decoded.lastIndexOf(".");
+      return dotIdx > 0 ? decoded.slice(0, dotIdx) : decoded;
+    }
+  }
+  return null;
+}
+
 /**
  * POST /api/user/totp/enroll
  *
@@ -63,9 +99,10 @@ function buildSessionSetCookie(signedValue: string, ttlMs: number): string {
  *   - Sessioned caller: existing user upgrading from no-MFA to TOTP.
  *     Better Auth's verifyTOTP path is used so its session rotation
  *     + flip of users.two_factor_enabled = true are atomic with the
- *     plugin's own state. We also clear requires_mfa on every session
- *     this user holds, because the freshest possible TOTP proof is
- *     the one we just verified.
+ *     plugin's own state. We clear requires_mfa only on the session we
+ *     just rotated through verifyTOTP, not on every session the user
+ *     holds: a parallel session (e.g. a stolen cookie under step-up
+ *     quarantine) must stay quarantined until it proves its own factor.
  *
  *   - Pending-signup caller: brand-new credential or OAuth user who
  *     carries only the signed pending_signup_mfa cookie, no session.
@@ -137,10 +174,33 @@ export async function POST(request: Request): Promise<NextResponse> {
         .update(twoFactorTable)
         .set({ backupCodes: encryptedBackupCodes })
         .where(eq(twoFactorTable.userId, userId));
-      await db
-        .update(sessions)
-        .set({ requiresMfa: false, mfaVerifiedAt: new Date() })
-        .where(eq(sessions.userId, userId));
+      const newRawToken = extractNewSessionToken(
+        readAllSetCookies(verifyHeaders)
+      );
+      if (newRawToken) {
+        await db
+          .update(sessions)
+          .set({ requiresMfa: false, mfaVerifiedAt: new Date() })
+          .where(eq(sessions.token, hashSessionToken(newRawToken)));
+      } else {
+        // No rotated session cookie to scope to; fall back to the
+        // caller's current session rather than every session (which
+        // would lift step-up quarantine on a parallel stolen session).
+        const current = await auth.api.getSession({ headers: request.headers });
+        if (current?.session?.id) {
+          await db
+            .update(sessions)
+            .set({ requiresMfa: false, mfaVerifiedAt: new Date() })
+            .where(eq(sessions.id, current.session.id));
+        } else {
+          logSystemError(
+            ErrorCategory.AUTH,
+            "[TOTP Enroll] Could not scope requires_mfa clear to a session",
+            new Error("no session token or id available"),
+            { endpoint: "/api/user/totp/enroll", user_id: userId }
+          );
+        }
+      }
       const responseBody: EnrollResponse = { backupCodes };
       const response = NextResponse.json(responseBody);
       for (const [name, value] of verifyHeaders.entries()) {

--- a/app/api/user/totp/setup/route.ts
+++ b/app/api/user/totp/setup/route.ts
@@ -1,10 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { generateRandomString, symmetricEncrypt } from "better-auth/crypto";
+import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { twoFactor as twoFactorTable } from "@/lib/db/schema";
+import { twoFactor as twoFactorTable, users } from "@/lib/db/schema";
 import { resolveEnrollMfaCaller } from "@/lib/enroll-mfa-caller";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { requireDualFactor } from "@/lib/mfa/dual-factor";
 
 const ISSUER = "KeeperHub";
 const SECRET_LENGTH = 32;
@@ -14,6 +16,8 @@ const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
 
 type SetupRequest = {
   name?: string;
+  code?: string;
+  emailOtp?: string;
 };
 
 type SetupResponse = {
@@ -98,7 +102,12 @@ function buildTotpUri(secret: string, account: string): string {
  * coupled to the user actually proving they can read the QR.
  *
  * Calling this endpoint a second time replaces any existing
- * enrollment; it is the supported way to rotate a lost authenticator.
+ * enrollment. Once the account is fully enrolled
+ * (users.two_factor_enabled = true with a two_factor row), that
+ * rotation overwrites the live secret and wipes backup codes, so it is
+ * gated behind requireDualFactor (authenticator + email OTP) exactly
+ * like /disable. First-time and pending-signup enrollment, which have
+ * no active second factor to protect yet, mint without that proof.
  */
 export async function POST(request: Request): Promise<NextResponse> {
   const caller = await resolveEnrollMfaCaller(request.headers);
@@ -142,6 +151,40 @@ export async function POST(request: Request): Promise<NextResponse> {
   const name =
     sanitizeName(body.name) ??
     `Authenticator (${new Date().toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })})`;
+
+  // Re-running /setup on an already-enrolled account overwrites the
+  // TOTP secret and wipes backup codes. That is a security-floor
+  // mutation as impactful as /disable, so it must carry the same
+  // dual-factor proof. First-time and pending-signup enroll (no active
+  // second factor yet) are still allowed to mint without proof.
+  const [userRow] = await db
+    .select({ twoFactorEnabled: users.twoFactorEnabled })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  const [existingFactor] = await db
+    .select({ id: twoFactorTable.id })
+    .from(twoFactorTable)
+    .where(eq(twoFactorTable.userId, userId))
+    .limit(1);
+  const alreadyEnrolled =
+    userRow?.twoFactorEnabled === true && Boolean(existingFactor);
+  if (alreadyEnrolled) {
+    const dual = await requireDualFactor({
+      userId,
+      email: userEmail,
+      action: "totp_setup",
+      code: typeof body.code === "string" ? body.code.trim() : "",
+      emailOtp: typeof body.emailOtp === "string" ? body.emailOtp.trim() : "",
+      headers: request.headers,
+    });
+    if (!dual.ok) {
+      return NextResponse.json(
+        { error: dual.error, code: dual.code },
+        { status: dual.status }
+      );
+    }
+  }
 
   try {
     const totpSecret = generateRandomString(SECRET_LENGTH);

--- a/tests/integration/totp-enroll-route.test.ts
+++ b/tests/integration/totp-enroll-route.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const USER_ID = "user-1";
+const USER_EMAIL = "user@techops.services";
+
+const {
+  mockResolveCaller,
+  mockVerifyTOTP,
+  mockGetSession,
+  mockHashSessionToken,
+  updateCalls,
+} = vi.hoisted(() => ({
+  mockResolveCaller: vi.fn(),
+  mockVerifyTOTP: vi.fn(),
+  mockGetSession: vi.fn(),
+  mockHashSessionToken: vi.fn((token: string) => `hashed:${token}`),
+  updateCalls: [] as Array<{
+    table: unknown;
+    value: unknown;
+    where: { column: unknown; value: unknown };
+  }>,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: (column: unknown, value: unknown) => ({ column, value }),
+}));
+
+vi.mock("@/lib/enroll-mfa-caller", () => ({
+  resolveEnrollMfaCaller: mockResolveCaller,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: { api: { verifyTOTP: mockVerifyTOTP, getSession: mockGetSession } },
+}));
+
+vi.mock("@/lib/auth-session-token-hash", () => ({
+  hashSessionToken: mockHashSessionToken,
+  signSessionCookieValue: vi.fn(() => "signed-cookie-value"),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    update: vi.fn((table: unknown) => ({
+      set: vi.fn((value: unknown) => ({
+        where: vi.fn((where: { column: unknown; value: unknown }) => {
+          updateCalls.push({ table, value, where });
+          return Promise.resolve(undefined);
+        }),
+      })),
+    })),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  sessions: {
+    id: "sessions.id",
+    token: "sessions.token",
+    userId: "sessions.userId",
+  },
+  twoFactor: {
+    userId: "twoFactor.userId",
+    secret: "twoFactor.secret",
+    backupCodes: "twoFactor.backupCodes",
+  },
+  users: { id: "users.id", twoFactorEnabled: "users.twoFactorEnabled" },
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { AUTH: "AUTH", CONFIGURATION: "CONFIGURATION" },
+  logSystemError: vi.fn(),
+}));
+
+// Not exercised by the session path, but imported at module load.
+vi.mock("@/lib/pending-signup-cookie", () => ({
+  buildPendingSignupClearCookie: vi.fn(() => "pending-clear"),
+}));
+vi.mock("@/lib/security/device-trust", () => ({
+  resolveSigninDevice: vi.fn(async () => null),
+}));
+vi.mock("@/lib/security/login-risk", () => ({
+  recordTrustedCountryFromRequest: vi.fn(async () => undefined),
+  resolveClientIpFromHeaders: vi.fn(() => null),
+}));
+vi.mock("@/lib/security/totp-verify", () => ({
+  verifyUserTotp: vi.fn(async () => true),
+}));
+vi.mock("@/lib/mfa/dual-factor-rate-limit", () => ({
+  checkDualFactorRateLimit: vi.fn(() => ({ allowed: true })),
+  resetDualFactor: vi.fn(),
+}));
+
+import { POST } from "@/app/api/user/totp/enroll/route";
+
+function buildRequest(): Request {
+  return new Request("http://localhost/api/user/totp/enroll", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ code: "123456" }),
+  });
+}
+
+function headersWithSessionCookie(cookie: string): Headers {
+  const headers = new Headers();
+  headers.append("set-cookie", cookie);
+  return headers;
+}
+
+function isSessionsUpdate(call: { where: { column: unknown } }): boolean {
+  return (
+    call.where.column === "sessions.token" ||
+    call.where.column === "sessions.id" ||
+    call.where.column === "sessions.userId"
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updateCalls.length = 0;
+  process.env.BETTER_AUTH_SECRET = "test-better-auth-secret-1234567890";
+  mockResolveCaller.mockResolvedValue({
+    kind: "session",
+    userId: USER_ID,
+    email: USER_EMAIL,
+  });
+});
+
+describe("POST /api/user/totp/enroll (session path requires_mfa scope)", () => {
+  it("clears requires_mfa scoped to the rotated session token, not every session of the user", async () => {
+    mockVerifyTOTP.mockResolvedValue({
+      headers: headersWithSessionCookie(
+        "better-auth.session_token=rawtok123.sigABC; Path=/; HttpOnly"
+      ),
+    });
+
+    const response = await POST(buildRequest());
+
+    expect(response.status).toBe(200);
+
+    const sessionUpdates = updateCalls.filter(isSessionsUpdate);
+    // Exactly one session update, and it targets the token hash.
+    expect(sessionUpdates).toHaveLength(1);
+    expect(sessionUpdates[0].where.column).toBe("sessions.token");
+    expect(sessionUpdates[0].where.value).toBe("hashed:rawtok123");
+
+    // The broad where(userId) clear must never run.
+    const broadClears = updateCalls.filter(
+      (call) => call.where.column === "sessions.userId"
+    );
+    expect(broadClears).toHaveLength(0);
+    expect(mockGetSession).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the caller's current session id when no rotated cookie is present", async () => {
+    mockVerifyTOTP.mockResolvedValue({ headers: new Headers() });
+    mockGetSession.mockResolvedValue({ session: { id: "sess-xyz" } });
+
+    const response = await POST(buildRequest());
+
+    expect(response.status).toBe(200);
+
+    const sessionUpdates = updateCalls.filter(isSessionsUpdate);
+    expect(sessionUpdates).toHaveLength(1);
+    expect(sessionUpdates[0].where.column).toBe("sessions.id");
+    expect(sessionUpdates[0].where.value).toBe("sess-xyz");
+
+    const broadClears = updateCalls.filter(
+      (call) => call.where.column === "sessions.userId"
+    );
+    expect(broadClears).toHaveLength(0);
+  });
+});

--- a/tests/integration/totp-setup-route.test.ts
+++ b/tests/integration/totp-setup-route.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const USER_ID = "user-1";
+const USER_EMAIL = "user@techops.services";
+
+const { mockResolveCaller, mockRequireDualFactor, state, insertCalls } =
+  vi.hoisted(() => ({
+    mockResolveCaller: vi.fn(),
+    mockRequireDualFactor: vi.fn(),
+    state: {
+      userRow: undefined as { twoFactorEnabled: boolean } | undefined,
+      factorRow: undefined as { id: string } | undefined,
+    },
+    insertCalls: [] as Array<{ table: unknown; values: unknown }>,
+  }));
+
+vi.mock("@/lib/enroll-mfa-caller", () => ({
+  resolveEnrollMfaCaller: mockResolveCaller,
+}));
+
+vi.mock("@/lib/mfa/dual-factor", () => ({
+  requireDualFactor: mockRequireDualFactor,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn((table: unknown) => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => {
+            const isUsers =
+              (table as { twoFactorEnabled?: unknown }).twoFactorEnabled !==
+              undefined;
+            if (isUsers) {
+              return Promise.resolve(state.userRow ? [state.userRow] : []);
+            }
+            return Promise.resolve(state.factorRow ? [state.factorRow] : []);
+          }),
+        })),
+      })),
+    })),
+    insert: vi.fn((table: unknown) => ({
+      values: vi.fn((values: unknown) => ({
+        onConflictDoUpdate: vi.fn(() => {
+          insertCalls.push({ table, values });
+          return Promise.resolve(undefined);
+        }),
+      })),
+    })),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  users: { id: "users.id", twoFactorEnabled: "users.twoFactorEnabled" },
+  twoFactor: {
+    id: "twoFactor.id",
+    userId: "twoFactor.userId",
+    secret: "twoFactor.secret",
+    backupCodes: "twoFactor.backupCodes",
+    name: "twoFactor.name",
+    enrolledAt: "twoFactor.enrolledAt",
+  },
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { AUTH: "AUTH", CONFIGURATION: "CONFIGURATION" },
+  logSystemError: vi.fn(),
+}));
+
+import { POST } from "@/app/api/user/totp/setup/route";
+
+function buildRequest(body: unknown): Request {
+  return new Request("http://localhost/api/user/totp/setup", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  insertCalls.length = 0;
+  state.userRow = undefined;
+  state.factorRow = undefined;
+  process.env.BETTER_AUTH_SECRET = "test-better-auth-secret-1234567890";
+  mockResolveCaller.mockResolvedValue({
+    kind: "session",
+    userId: USER_ID,
+    email: USER_EMAIL,
+  });
+});
+
+describe("POST /api/user/totp/setup", () => {
+  it("mints without a dual-factor gate for a first-time enroll (no row, not enabled)", async () => {
+    state.userRow = { twoFactorEnabled: false };
+    state.factorRow = undefined;
+
+    const response = await POST(buildRequest({}));
+
+    expect(response.status).toBe(200);
+    const data = (await response.json()) as {
+      totpUri: string;
+      manualEntryKey: string;
+    };
+    expect(typeof data.totpUri).toBe("string");
+    expect(data.totpUri.startsWith("otpauth://totp/")).toBe(true);
+    expect(typeof data.manualEntryKey).toBe("string");
+    expect(mockRequireDualFactor).not.toHaveBeenCalled();
+    expect(insertCalls).toHaveLength(1);
+  });
+
+  it("mints without a gate for a pending-signup caller", async () => {
+    mockResolveCaller.mockResolvedValue({
+      kind: "pending-signup",
+      userId: USER_ID,
+      email: USER_EMAIL,
+      redirect: "/",
+    });
+    state.userRow = { twoFactorEnabled: false };
+    state.factorRow = undefined;
+
+    const response = await POST(buildRequest({}));
+
+    expect(response.status).toBe(200);
+    expect(mockRequireDualFactor).not.toHaveBeenCalled();
+    expect(insertCalls).toHaveLength(1);
+  });
+
+  it("allows a pending-enrollment re-run (row exists but not yet enabled) without a gate", async () => {
+    state.userRow = { twoFactorEnabled: false };
+    state.factorRow = { id: "tf-1" };
+
+    const response = await POST(buildRequest({}));
+
+    expect(response.status).toBe(200);
+    expect(mockRequireDualFactor).not.toHaveBeenCalled();
+    expect(insertCalls).toHaveLength(1);
+  });
+
+  it("gates an already-enrolled rotation and does NOT overwrite when dual-factor is required", async () => {
+    state.userRow = { twoFactorEnabled: true };
+    state.factorRow = { id: "tf-1" };
+    mockRequireDualFactor.mockResolvedValue({
+      ok: false,
+      status: 401,
+      error: "Enter the codes",
+      code: "factors_required",
+    });
+
+    const response = await POST(buildRequest({}));
+
+    expect(response.status).toBe(401);
+    const data = (await response.json()) as { code: string };
+    expect(data.code).toBe("factors_required");
+    expect(mockRequireDualFactor).toHaveBeenCalledTimes(1);
+    expect(mockRequireDualFactor).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "totp_setup", userId: USER_ID })
+    );
+    // The secret must NOT have been overwritten when proof is missing.
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("proceeds with the rotation once dual-factor succeeds", async () => {
+    state.userRow = { twoFactorEnabled: true };
+    state.factorRow = { id: "tf-1" };
+    mockRequireDualFactor.mockResolvedValue({ ok: true });
+
+    const response = await POST(
+      buildRequest({ code: "123456", emailOtp: "654321" })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockRequireDualFactor).toHaveBeenCalledTimes(1);
+    expect(insertCalls).toHaveLength(1);
+  });
+
+  it("rejects an anonymous caller without touching the gate or the upsert", async () => {
+    mockResolveCaller.mockResolvedValue({
+      kind: "anonymous",
+      reason: "no_auth",
+    });
+
+    const response = await POST(buildRequest({}));
+
+    expect(response.status).toBe(401);
+    expect(mockRequireDualFactor).not.toHaveBeenCalled();
+    expect(insertCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Finding F-009 (HIGH, confidence 0.8) -- MFA bypass / account takeover

`POST /api/user/totp/setup` overwrote the TOTP secret and wiped backup codes for any caller with a valid session cookie, with no step-up gate -- whereas `/totp/disable` correctly requires dual-factor. A stolen session (even one still in pre-step-up `requires_mfa` state, which the proxy exempts for `/totp/`) could mint a new secret, enroll it, and -- because `/totp/enroll` cleared `requires_mfa` on every session of the user -- obtain a fully MFA-verified session while locking the victim out of their authenticator.

## Fix

- Gate `/totp/setup` behind `requireDualFactor` when the account is already fully enrolled (`users.twoFactorEnabled === true` AND a `two_factor` row exists), computed from DB state, not request input. First-time and pending-signup enrollment still mint without proof, preserving the existing UI flows.
- Scope the `/totp/enroll` session-path `requires_mfa` clear to the just-rotated session (by session token hash) instead of `where(userId = ...)`, with a safe current-session fallback -- so a parallel quarantined/stolen session stays quarantined.

## Verification

- New integration tests (setup: gated path asserts `insertCalls === 0`, i.e. no secret overwrite; enroll: clear is scoped to the verified session, not all sessions) -- confirmed non-tautological; 8/8 green.
- `tsc` + `ultracite` clean. Independent review: APPROVE. (F-009's gate precondition -- an enrolled secret -- does not exist for the seeded dev user, so this is verified by the integration tests rather than a live gate trip.)

## Follow-ups (pre-existing, noted)

- With both `/setup` and `/disable` gated, recovery of a genuinely lost authenticator relies on backup codes / support -- intended, but worth confirming the recovery path.
- `/totp/backup-codes` regeneration remains ungated (a lesser code-wipe DoS) -- out of scope here, worth a separate look.
