### PR TITLE
fix(oauth): enforce token scope at REST execute and workflow-mutation sinks

### DIFF
--- a/app/api/ai/generate/route.ts
+++ b/app/api/ai/generate/route.ts
@@ -4,9 +4,11 @@ import type { LanguageModelV2 } from "@ai-sdk/provider";
 import { streamText } from "ai";
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { createTimer, getMetricsCollector } from "@/lib/metrics";
 import { MetricNames } from "@/lib/metrics/types";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 import { generateAIActionPrompts } from "@/plugins/registry";
 import {
   checkAiGenerateRateLimit,
@@ -342,6 +344,11 @@ export async function POST(request: Request) {
         { error: authContext.error },
         { status: authContext.status }
       );
+    }
+
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
 
     const rateLimit = checkAiGenerateRateLimit(

--- a/app/api/execute/[...slug]/route.ts
+++ b/app/api/execute/[...slug]/route.ts
@@ -4,6 +4,8 @@ import "@/protocols";
 import { NextResponse } from "next/server";
 import { resolveAbi } from "@/lib/abi/cache";
 import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import { requireScope } from "@/lib/middleware/require-scope";
 import { getProtocol } from "@/lib/protocol-registry";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { PLUGIN_STEP_IMPORTERS } from "@/lib/step-registry";
@@ -205,6 +207,11 @@ export async function POST(
   const apiKeyCtx = await validateApiKey(request);
   if (!apiKeyCtx) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE);
+  if (scopeError) {
+    return scopeError;
   }
 
   // Enter ALS error context so plugin step errors carry org labels

--- a/app/api/execute/[executionId]/status/route.ts
+++ b/app/api/execute/[executionId]/status/route.ts
@@ -4,6 +4,8 @@ import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { directExecutions } from "@/lib/db/schema";
+import { SCOPE_MCP_READ } from "@/lib/mcp/oauth-scopes";
+import { requireScope } from "@/lib/middleware/require-scope";
 import { validateApiKey } from "../../_lib/auth";
 import { checkRateLimit } from "../../_lib/rate-limit";
 import type { ExecutionStatusResponse } from "../../_lib/types";
@@ -15,6 +17,11 @@ export async function GET(
   const apiKeyCtx = await validateApiKey(request);
   if (!apiKeyCtx) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_READ);
+  if (scopeError) {
+    return scopeError;
   }
 
   const rateLimit = checkRateLimit(apiKeyCtx.apiKeyId);

--- a/app/api/execute/_lib/auth.ts
+++ b/app/api/execute/_lib/auth.ts
@@ -6,6 +6,7 @@ import { authenticateOAuthToken } from "@/lib/mcp/oauth-auth";
 export type ApiKeyContext = {
   organizationId: string;
   apiKeyId: string;
+  scope?: string;
 };
 
 /**
@@ -21,6 +22,7 @@ export async function validateApiKey(
     return {
       organizationId: oauthResult.organizationId,
       apiKeyId: `oauth:${oauthResult.userId ?? "unknown"}`,
+      scope: oauthResult.scope,
     };
   }
 

--- a/app/api/execute/check-and-execute/route.ts
+++ b/app/api/execute/check-and-execute/route.ts
@@ -5,6 +5,8 @@ import { resolveAbi } from "@/lib/abi/cache";
 import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import { simulateContractCall } from "@/lib/execute/simulate";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import { requireScope } from "@/lib/middleware/require-scope";
 import { getErrorMessage } from "@/lib/utils";
 import { readContractCore } from "@/plugins/web3/steps/read-contract-core";
 import { writeContractCore } from "@/plugins/web3/steps/write-contract-core";
@@ -170,6 +172,11 @@ export async function POST(request: Request): Promise<NextResponse> {
   const apiKeyCtx = await validateApiKey(request);
   if (!apiKeyCtx) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE);
+  if (scopeError) {
+    return scopeError;
   }
 
   // Enter ALS error context so plugin step errors carry org labels

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -6,6 +6,8 @@ import { type AbiItem, findAbiFunction } from "@/lib/abi/utils";
 import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import { simulateContractCall } from "@/lib/execute/simulate";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import { requireScope } from "@/lib/middleware/require-scope";
 import { getErrorMessage } from "@/lib/utils";
 import { readContractCore } from "@/plugins/web3/steps/read-contract-core";
 import { writeContractCore } from "@/plugins/web3/steps/write-contract-core";
@@ -172,6 +174,11 @@ export async function POST(request: Request): Promise<NextResponse> {
   const apiKeyCtx = await validateApiKey(request);
   if (!apiKeyCtx) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE);
+  if (scopeError) {
+    return scopeError;
   }
 
   // Enter ALS error context so plugin step errors carry org labels

--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -6,6 +6,8 @@ import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { db } from "@/lib/db";
 import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import { integrations } from "@/lib/db/schema";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import { requireScope } from "@/lib/middleware/require-scope";
 import { getErrorMessage } from "@/lib/utils";
 import type { ResolvedAction } from "../_lib/action-resolver";
 import { resolveAction } from "../_lib/action-resolver";
@@ -369,6 +371,11 @@ export async function POST(request: Request): Promise<NextResponse> {
   const apiKeyCtx = await validateApiKey(request);
   if (!apiKeyCtx) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE);
+  if (scopeError) {
+    return scopeError;
   }
 
   // Enter ALS error context so plugin step errors carry org labels

--- a/app/api/execute/swap/route.ts
+++ b/app/api/execute/swap/route.ts
@@ -1,12 +1,19 @@
 import "server-only";
 
 import { NextResponse } from "next/server";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import { requireScope } from "@/lib/middleware/require-scope";
 import { validateApiKey } from "../_lib/auth";
 
 export async function POST(request: Request): Promise<NextResponse> {
   const apiKeyCtx = await validateApiKey(request);
   if (!apiKeyCtx) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE);
+  if (scopeError) {
+    return scopeError;
   }
 
   return NextResponse.json({ message: "Coming soon" }, { status: 501 });

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -7,6 +7,8 @@ import {
   simulateNativeTransfer,
   simulateTokenTransfer,
 } from "@/lib/execute/simulate";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import { requireScope } from "@/lib/middleware/require-scope";
 import { transferFundsCore } from "@/plugins/web3/steps/transfer-funds-core";
 import { transferTokenCore } from "@/plugins/web3/steps/transfer-token-core";
 import { validateApiKey } from "../_lib/auth";
@@ -27,6 +29,11 @@ export async function POST(request: Request): Promise<NextResponse> {
   const apiKeyCtx = await validateApiKey(request);
   if (!apiKeyCtx) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE);
+  if (scopeError) {
+    return scopeError;
   }
 
   // Enter ALS error context so plugin step errors carry org labels

--- a/app/api/mcp/workflows/[slug]/listing/route.ts
+++ b/app/api/mcp/workflows/[slug]/listing/route.ts
@@ -8,8 +8,10 @@ import {
   unlistWorkflow,
   updateWorkflowListing,
 } from "@/lib/mcp/listing";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { checkIpRateLimit, getClientIp } from "@/lib/mcp/rate-limit";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 import { sanitizeDescription } from "@/lib/sanitize-description";
 
 const LISTING_RATE_LIMIT = 60;
@@ -146,6 +148,11 @@ export async function POST(
     );
   }
 
+  const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+  if (scopeError) {
+    return scopeError;
+  }
+
   const { organizationId } = authContext;
   if (!organizationId) {
     return NextResponse.json(
@@ -202,6 +209,11 @@ export async function PATCH(
       { error: authContext.error },
       { status: authContext.status }
     );
+  }
+
+  const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+  if (scopeError) {
+    return scopeError;
   }
 
   const { organizationId } = authContext;
@@ -263,6 +275,11 @@ export async function DELETE(
       { error: authContext.error },
       { status: authContext.status }
     );
+  }
+
+  const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+  if (scopeError) {
+    return scopeError;
   }
 
   const { organizationId } = authContext;

--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -5,7 +5,9 @@ import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { authenticateInternalService } from "@/lib/internal-service-auth";
 import { getMetricsCollector } from "@/lib/metrics";
 import { LabelKeys, MetricNames } from "@/lib/metrics/types";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 import { checkConcurrencyLimit } from "@/app/api/execute/_lib/concurrency-limit";
 import { db } from "@/lib/db";
 import { withBackstopCapture } from "@/lib/security/backstop-capture";
@@ -79,6 +81,11 @@ export async function POST(
           { error: authContext.error },
           { status: authContext.status }
         );
+      }
+
+      const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+      if (scopeError) {
+        return scopeError;
       }
 
       workflow = await db.query.workflows.findFirst({

--- a/app/api/workflows/[workflowId]/duplicate/route.ts
+++ b/app/api/workflows/[workflowId]/duplicate/route.ts
@@ -2,7 +2,9 @@ import { and, eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
 import { extractActionTypeNodes } from "@/lib/features";
@@ -123,6 +125,11 @@ export async function POST(
         { error: authContext.error },
         { status: authContext.status }
       );
+    }
+
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
 
     const { userId, organizationId } = authContext;

--- a/app/api/workflows/[workflowId]/executions/route.ts
+++ b/app/api/workflows/[workflowId]/executions/route.ts
@@ -1,7 +1,9 @@
 import { desc, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 import { db } from "@/lib/db";
 import { workflowExecutions, workflows } from "@/lib/db/schema";
 import { getWorkflowAccess } from "@/lib/workflow/access";
@@ -105,6 +107,12 @@ export async function DELETE(
         { status: authContext.status }
       );
     }
+
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
+    }
+
     const { userId, organizationId } = authContext;
 
     // Verify workflow access (owner or org member)

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -2,7 +2,9 @@ import { eq, sql } from "drizzle-orm";
 import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { extractActionTypeNodes } from "@/lib/features";
@@ -308,6 +310,11 @@ export async function PATCH(
         { error: authContext.error },
         { status: authContext.status }
       );
+    }
+
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
 
     const { userId, organizationId } = authContext;
@@ -688,6 +695,12 @@ export async function DELETE(
         { status: authContext.status }
       );
     }
+
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
+    }
+
     const { userId, organizationId } = authContext;
 
     const { hasAccess } = await validateWorkflowAccess(

--- a/app/api/workflows/create/route.ts
+++ b/app/api/workflows/create/route.ts
@@ -2,7 +2,9 @@ import { and, eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { projects, tags, workflows } from "@/lib/db/schema";
@@ -85,6 +87,11 @@ export async function POST(request: Request) {
         { error: authContext.error },
         { status: authContext.status }
       );
+    }
+
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
 
     const { userId, organizationId } = authContext;

--- a/app/api/workflows/import/route.ts
+++ b/app/api/workflows/import/route.ts
@@ -8,6 +8,7 @@ import { extractActionTypeNodes } from "@/lib/features";
 import { enforceWorkflowFeatures } from "@/lib/features/route-guard";
 import { isAnonymousUser } from "@/lib/is-anonymous";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { getMetricsCollector } from "@/lib/metrics";
 import { MetricNames } from "@/lib/metrics/types";
 import {
@@ -15,6 +16,7 @@ import {
   auditFromAuth,
   getDualAuthContext,
 } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 import { generateId } from "@/lib/utils/id";
 import {
   stripIntegrationsFromImportNodes,
@@ -59,6 +61,11 @@ export async function POST(request: Request): Promise<NextResponse> {
         { error: authContext.error },
         { status: authContext.status }
       );
+    }
+
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
 
     const { userId, organizationId } = authContext;

--- a/lib/mcp/oauth-scopes.ts
+++ b/lib/mcp/oauth-scopes.ts
@@ -137,3 +137,29 @@ export function getRequiredScopeForTool(toolName: string): OAuthScope {
   }
   return SCOPE_MCP_ADMIN;
 }
+
+const SCOPE_RANK: Record<OAuthScope, number> = {
+  [SCOPE_MCP_READ]: 1,
+  [SCOPE_MCP_WRITE]: 2,
+  [SCOPE_MCP_ADMIN]: 3,
+};
+
+/**
+ * True when `grantedScope` satisfies the `required` scope level.
+ * `undefined` means no scope restriction (kh_ API key / cookie session /
+ * internal service) and always passes -- those callers are intentionally
+ * full-access. An empty or all-invalid scope string fails for every level
+ * (matches isToolAllowed("") === false). Only OAuth Bearer tokens are gated.
+ */
+export function scopeSatisfies(
+  grantedScope: string | undefined,
+  required: OAuthScope
+): boolean {
+  if (grantedScope === undefined) {
+    return true;
+  }
+  const requiredRank = SCOPE_RANK[required];
+  return parseScopes(grantedScope).some(
+    (s) => isScopeValid(s) && SCOPE_RANK[s as OAuthScope] >= requiredRank
+  );
+}

--- a/lib/middleware/auth-helpers.ts
+++ b/lib/middleware/auth-helpers.ts
@@ -139,6 +139,7 @@ export type DualAuthContext =
       organizationId: string | null;
       authMethod: AuthMethod;
       apiKeyId: string | null;
+      scope?: string;
     }
   | { error: string; status: number; code?: "mfa_required" };
 
@@ -209,9 +210,11 @@ export function auditFromAuth(
  * These tokens are issued by the MCP OAuth flow and forwarded
  * by the MCP server when calling downstream API endpoints.
  */
-async function resolveOAuthToken(
-  request: Request
-): Promise<{ userId: string | null; organizationId: string | null } | null> {
+async function resolveOAuthToken(request: Request): Promise<{
+  userId: string | null;
+  organizationId: string | null;
+  scope?: string;
+} | null> {
   const result = await authenticateOAuthToken(request);
   if (!result.authenticated) {
     return null;
@@ -219,6 +222,7 @@ async function resolveOAuthToken(
   return {
     userId: result.userId ?? null,
     organizationId: result.organizationId ?? null,
+    scope: result.scope,
   };
 }
 

--- a/lib/middleware/require-scope.ts
+++ b/lib/middleware/require-scope.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { type OAuthScope, scopeSatisfies } from "@/lib/mcp/oauth-scopes";
+
+/**
+ * A-03: enforce OAuth token scope at the REST sinks that MCP tools forward to.
+ * OAuth tokens carry a scope (mcp:read|write|admin) the MCP tool wrapper
+ * checks, but the REST routes those tools call dropped it and ran any
+ * authenticated token. `grantedScope === undefined` means a non-OAuth caller
+ * (kh_ key / cookie session / internal service) which is intentionally
+ * full-access. Returns a 403 envelope (RFC 6750 3.1) when denied, null when
+ * allowed.
+ */
+export function requireScope(
+  grantedScope: string | undefined,
+  required: OAuthScope
+): NextResponse | null {
+  if (scopeSatisfies(grantedScope, required)) {
+    return null;
+  }
+  return NextResponse.json(
+    {
+      error: "insufficient_scope",
+      message: `This endpoint requires the \`${required}\` OAuth scope. The current token has \`${grantedScope || "(none)"}\`.`,
+      required_scope: required,
+      granted_scope: grantedScope ?? "",
+    },
+    { status: 403 }
+  );
+}

--- a/tests/integration/execute-scope-enforcement.test.ts
+++ b/tests/integration/execute-scope-enforcement.test.ts
@@ -1,0 +1,231 @@
+/**
+ * A-03: OAuth token scope is enforced at the REST sinks that MCP tools forward
+ * to. A token scoped mcp:read only (blocked by the MCP tool wrapper on write
+ * tools) must also be rejected when posted directly to the underlying REST
+ * route. A non-OAuth caller (scope undefined: kh_ key / session / internal)
+ * keeps full access.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  validateApiKey: vi.fn(),
+  checkRateLimit: vi.fn(),
+  checkAndReserveExecution: vi.fn(),
+  markRunning: vi.fn(),
+  completeExecution: vi.fn(),
+  failExecution: vi.fn(),
+  redactInput: vi.fn(),
+  transferFundsCore: vi.fn(),
+  transferTokenCore: vi.fn(),
+  getDualAuthContext: vi.fn(),
+  validateWorkflowIntegrations: vi.fn(),
+  insert: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/app/api/execute/_lib/auth", () => ({
+  validateApiKey: mocks.validateApiKey,
+}));
+
+vi.mock("@/app/api/execute/_lib/rate-limit", () => ({
+  checkRateLimit: mocks.checkRateLimit,
+}));
+
+vi.mock("@/app/api/execute/_lib/spending-cap", () => ({
+  checkAndReserveExecution: mocks.checkAndReserveExecution,
+}));
+
+vi.mock("@/app/api/execute/_lib/execution-service", () => ({
+  markRunning: mocks.markRunning,
+  completeExecution: mocks.completeExecution,
+  failExecution: mocks.failExecution,
+  redactInput: mocks.redactInput,
+}));
+
+vi.mock("@/plugins/web3/steps/transfer-funds-core", () => ({
+  transferFundsCore: mocks.transferFundsCore,
+}));
+
+vi.mock("@/plugins/web3/steps/transfer-token-core", () => ({
+  transferTokenCore: mocks.transferTokenCore,
+}));
+
+vi.mock("@/app/api/execute/_lib/wallet-check", () => ({
+  requireWallet: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/billing/execution-guard", () => ({
+  enforceExecutionLimit: vi
+    .fn()
+    .mockResolvedValue({ blocked: false, limitResult: null }),
+  EXECUTION_LIMIT_ERROR: "Monthly execution limit exceeded",
+  EXECUTION_DEBT_ERROR: "Executions suspended due to unpaid overage invoice.",
+}));
+
+vi.mock("@/lib/middleware/auth-helpers", () => ({
+  getDualAuthContext: mocks.getDualAuthContext,
+}));
+
+vi.mock("@/lib/db/integrations", () => ({
+  validateWorkflowIntegrations: mocks.validateWorkflowIntegrations,
+}));
+
+vi.mock("@/lib/features/route-guard", () => ({
+  enforceWorkflowFeatures: vi.fn().mockResolvedValue({ blocked: false }),
+  FEATURE_UPGRADE_REQUIRED_ERROR:
+    "This workflow uses features that require a paid plan.",
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "DATABASE" },
+  logSystemError: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    insert: mocks.insert,
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([])) })),
+      })),
+    })),
+    query: { workflows: { findFirst: vi.fn() } },
+  },
+}));
+
+import { POST as transferPOST } from "@/app/api/execute/transfer/route";
+import { POST as createPOST } from "@/app/api/workflows/create/route";
+
+function transferRequest(body: unknown): Request {
+  return new Request("http://localhost:3000/api/execute/transfer", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function createRequest(body: Record<string, unknown>): Request {
+  return new Request("http://localhost:3000/api/workflows/create", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const VALID_TRANSFER = {
+  network: "ethereum",
+  recipientAddress: "0x1234567890123456789012345678901234567890",
+  amount: "1.0",
+};
+
+describe("A-03 scope enforcement — POST /api/execute/transfer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.checkRateLimit.mockReturnValue({ allowed: true });
+    mocks.checkAndReserveExecution.mockResolvedValue({
+      allowed: true,
+      executionId: "exec_1",
+    });
+    mocks.redactInput.mockImplementation((input: unknown) => input);
+    mocks.markRunning.mockResolvedValue(undefined);
+    mocks.completeExecution.mockResolvedValue(undefined);
+    mocks.transferFundsCore.mockResolvedValue({
+      success: true,
+      transactionHash: "0xhash",
+      transactionLink: "https://example.com/0xhash",
+    });
+  });
+
+  it("rejects a read-only OAuth token with 403 insufficient_scope", async () => {
+    mocks.validateApiKey.mockResolvedValue({
+      organizationId: "org_1",
+      apiKeyId: "oauth:u",
+      scope: "mcp:read",
+    });
+
+    const response = await transferPOST(transferRequest(VALID_TRANSFER));
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toBe("insufficient_scope");
+    expect(body.required_scope).toBe("mcp:write");
+  });
+
+  it("allows a caller with no scope (kh_ key / undefined) past the guard", async () => {
+    mocks.validateApiKey.mockResolvedValue({
+      organizationId: "org_1",
+      apiKeyId: "key_test",
+    });
+
+    const response = await transferPOST(transferRequest(VALID_TRANSFER));
+
+    expect(response.status).not.toBe(403);
+  });
+
+  it("allows a read+write OAuth token past the guard", async () => {
+    mocks.validateApiKey.mockResolvedValue({
+      organizationId: "org_1",
+      apiKeyId: "oauth:u",
+      scope: "mcp:read mcp:write",
+    });
+
+    const response = await transferPOST(transferRequest(VALID_TRANSFER));
+
+    expect(response.status).not.toBe(403);
+  });
+});
+
+describe("A-03 scope enforcement — POST /api/workflows/create", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.validateWorkflowIntegrations.mockResolvedValue({ valid: true });
+  });
+
+  const invalidWorkflowBody = {
+    name: "Scope test workflow",
+    nodes: [
+      {
+        id: "node-1",
+        type: "action",
+        data: {
+          type: "action",
+          config: { actionType: "discord/send-message", Message: "hello" },
+        },
+      },
+    ],
+    edges: [],
+  };
+
+  it("rejects a read-only OAuth token with 403 insufficient_scope", async () => {
+    mocks.getDualAuthContext.mockResolvedValue({
+      userId: "user_1",
+      organizationId: "org_1",
+      authMethod: "oauth",
+      apiKeyId: null,
+      scope: "mcp:read",
+    });
+
+    const response = await createPOST(createRequest(invalidWorkflowBody));
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toBe("insufficient_scope");
+    expect(body.required_scope).toBe("mcp:write");
+  });
+
+  it("allows a session caller (scope undefined) past the guard", async () => {
+    mocks.getDualAuthContext.mockResolvedValue({
+      userId: "user_1",
+      organizationId: "org_1",
+      authMethod: "session",
+      apiKeyId: null,
+    });
+
+    const response = await createPOST(createRequest(invalidWorkflowBody));
+
+    const body = await response.json();
+    expect(response.status).not.toBe(403);
+    expect(body.error).not.toBe("insufficient_scope");
+  });
+});

--- a/tests/integration/execute-scope-enforcement.test.ts
+++ b/tests/integration/execute-scope-enforcement.test.ts
@@ -94,8 +94,18 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
+vi.mock("@/lib/auth", () => ({
+  auth: { api: { getSession: vi.fn() } },
+}));
+
+vi.mock("@/lib/workflow/access", () => ({
+  getWorkflowAccess: vi.fn(),
+}));
+
 import { POST as transferPOST } from "@/app/api/execute/transfer/route";
+import { DELETE as executionsDELETE } from "@/app/api/workflows/[workflowId]/executions/route";
 import { POST as createPOST } from "@/app/api/workflows/create/route";
+import { POST as importPOST } from "@/app/api/workflows/import/route";
 
 function transferRequest(body: unknown): Request {
   return new Request("http://localhost:3000/api/execute/transfer", {
@@ -227,5 +237,97 @@ describe("A-03 scope enforcement — POST /api/workflows/create", () => {
     const body = await response.json();
     expect(response.status).not.toBe(403);
     expect(body.error).not.toBe("insufficient_scope");
+  });
+});
+
+function importRequest(body: unknown): Request {
+  return new Request("http://localhost:3000/api/workflows/import", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("A-03 scope enforcement — POST /api/workflows/import", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects a read-only OAuth token with 403 insufficient_scope", async () => {
+    mocks.getDualAuthContext.mockResolvedValue({
+      userId: "user_1",
+      organizationId: "org_1",
+      authMethod: "oauth",
+      apiKeyId: null,
+      scope: "mcp:read",
+    });
+
+    const response = await importPOST(importRequest({ version: 1 }));
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toBe("insufficient_scope");
+    expect(body.required_scope).toBe("mcp:write");
+  });
+
+  it("allows a non-OAuth caller (scope undefined) past the guard", async () => {
+    mocks.getDualAuthContext.mockResolvedValue({
+      userId: "user_1",
+      organizationId: "org_1",
+      authMethod: "api_key",
+      apiKeyId: "key_test",
+    });
+
+    const response = await importPOST(importRequest({ version: 1 }));
+
+    const body = await response.json();
+    expect(response.status).not.toBe(403);
+    expect(body.error).not.toBe("insufficient_scope");
+  });
+});
+
+function executionsDeleteRequest(): Request {
+  return new Request("http://localhost:3000/api/workflows/wf_1/executions", {
+    method: "DELETE",
+  });
+}
+
+describe("A-03 scope enforcement — DELETE /api/workflows/[workflowId]/executions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects a read-only OAuth token with 403 insufficient_scope", async () => {
+    mocks.getDualAuthContext.mockResolvedValue({
+      userId: "user_1",
+      organizationId: "org_1",
+      authMethod: "oauth",
+      apiKeyId: null,
+      scope: "mcp:read",
+    });
+
+    const response = await executionsDELETE(executionsDeleteRequest(), {
+      params: Promise.resolve({ workflowId: "wf_1" }),
+    });
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toBe("insufficient_scope");
+    expect(body.required_scope).toBe("mcp:write");
+  });
+
+  it("allows a non-OAuth caller (scope undefined) past the guard", async () => {
+    mocks.getDualAuthContext.mockResolvedValue({
+      userId: "user_1",
+      organizationId: "org_1",
+      authMethod: "api_key",
+      apiKeyId: "key_test",
+    });
+
+    const response = await executionsDELETE(executionsDeleteRequest(), {
+      params: Promise.resolve({ workflowId: "wf_1" }),
+    });
+
+    expect(response.status).not.toBe(403);
   });
 });

--- a/tests/unit/dual-auth-context.test.ts
+++ b/tests/unit/dual-auth-context.test.ts
@@ -112,6 +112,25 @@ describe("getDualAuthContext", () => {
       expect(mockAuthenticateApiKey).not.toHaveBeenCalled();
       expect(mockGetSession).not.toHaveBeenCalled();
     });
+
+    it("propagates the OAuth token scope onto the context", async () => {
+      mockAuthenticateOAuthToken.mockResolvedValue({
+        authenticated: true,
+        userId: "user_oauth",
+        organizationId: "org_oauth",
+        scope: "mcp:read",
+      });
+
+      const result = await getDualAuthContext(makeRequest());
+
+      expect(result).toMatchObject({
+        userId: "user_oauth",
+        organizationId: "org_oauth",
+        authMethod: "oauth",
+        apiKeyId: null,
+        scope: "mcp:read",
+      });
+    });
   });
 
   describe("API key authentication", () => {

--- a/tests/unit/oauth-scopes.test.ts
+++ b/tests/unit/oauth-scopes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isToolAllowed } from "@/lib/mcp/oauth-scopes";
+import { isToolAllowed, scopeSatisfies } from "@/lib/mcp/oauth-scopes";
 
 describe("oauth-scopes — prepare_test_pin_data (TESTWF-06)", () => {
   it("mcp:read allows prepare_test_pin_data", () => {
@@ -20,5 +20,43 @@ describe("oauth-scopes — prepare_test_pin_data (TESTWF-06)", () => {
 
   it("unknown scope denies prepare_test_pin_data", () => {
     expect(isToolAllowed("prepare_test_pin_data", "bogus:scope")).toBe(false);
+  });
+});
+
+describe("oauth-scopes — scopeSatisfies (A-03)", () => {
+  it("undefined granted scope passes every level (non-OAuth full access)", () => {
+    expect(scopeSatisfies(undefined, "mcp:read")).toBe(true);
+    expect(scopeSatisfies(undefined, "mcp:write")).toBe(true);
+    expect(scopeSatisfies(undefined, "mcp:admin")).toBe(true);
+  });
+
+  it("mcp:read satisfies read but not write or admin", () => {
+    expect(scopeSatisfies("mcp:read", "mcp:read")).toBe(true);
+    expect(scopeSatisfies("mcp:read", "mcp:write")).toBe(false);
+    expect(scopeSatisfies("mcp:read", "mcp:admin")).toBe(false);
+  });
+
+  it("mcp:write satisfies read and write but not admin", () => {
+    expect(scopeSatisfies("mcp:write", "mcp:read")).toBe(true);
+    expect(scopeSatisfies("mcp:write", "mcp:write")).toBe(true);
+    expect(scopeSatisfies("mcp:write", "mcp:admin")).toBe(false);
+  });
+
+  it("mcp:admin satisfies every level", () => {
+    expect(scopeSatisfies("mcp:admin", "mcp:read")).toBe(true);
+    expect(scopeSatisfies("mcp:admin", "mcp:write")).toBe(true);
+    expect(scopeSatisfies("mcp:admin", "mcp:admin")).toBe(true);
+  });
+
+  it("a space-separated grant passes when any token has sufficient rank", () => {
+    expect(scopeSatisfies("mcp:read mcp:write", "mcp:write")).toBe(true);
+    expect(scopeSatisfies("mcp:read mcp:write", "mcp:admin")).toBe(false);
+  });
+
+  it("empty or all-invalid grant fails every level", () => {
+    expect(scopeSatisfies("", "mcp:read")).toBe(false);
+    expect(scopeSatisfies("bogus:x", "mcp:read")).toBe(false);
+    expect(scopeSatisfies("bogus:x", "mcp:write")).toBe(false);
+    expect(scopeSatisfies("bogus:x", "mcp:admin")).toBe(false);
   });
 });

--- a/tests/unit/require-scope.test.ts
+++ b/tests/unit/require-scope.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { requireScope } from "@/lib/middleware/require-scope";
+
+describe("requireScope (A-03)", () => {
+  it("returns null for an undefined scope (non-OAuth full access)", () => {
+    expect(requireScope(undefined, "mcp:write")).toBeNull();
+  });
+
+  it("returns null when the granted scope satisfies the requirement", () => {
+    expect(requireScope("mcp:write", "mcp:write")).toBeNull();
+    expect(requireScope("mcp:admin", "mcp:write")).toBeNull();
+    expect(requireScope("mcp:read", "mcp:read")).toBeNull();
+  });
+
+  it("returns a 403 insufficient_scope envelope when under-scoped", async () => {
+    const response = requireScope("mcp:read", "mcp:write");
+
+    expect(response).not.toBeNull();
+    expect(response?.status).toBe(403);
+
+    const body = await response?.json();
+    expect(body).toMatchObject({
+      error: "insufficient_scope",
+      required_scope: "mcp:write",
+      granted_scope: "mcp:read",
+    });
+  });
+
+  it("reports an empty granted scope as the empty string in the envelope", async () => {
+    const response = requireScope("", "mcp:write");
+
+    expect(response?.status).toBe(403);
+    const body = await response?.json();
+    expect(body.granted_scope).toBe("");
+  });
+});


### PR DESCRIPTION
## Finding A-03 (HIGH, confidence 0.7, funds at risk)

OAuth token scope (`mcp:read` / `mcp:write` / `mcp:admin`) was enforced only inside the MCP tool wrapper. The REST endpoints those tools call -- reachable directly with the same Bearer token -- dropped scope entirely. A user who granted an agent **read-only** access could have that token `POST /api/execute/transfer` and drain the org wallet. The consent-screen scope boundary was cosmetic for everything except the MCP tool list.

## Fix

- Surface the token scope from `validateApiKey` and `getDualAuthContext` (OAuth branch only).
- New pure `scopeSatisfies(grantedScope, required)` + a shared `requireScope(...)` guard that returns a 403 `insufficient_scope` envelope. `undefined` scope = no restriction, so `kh_` API keys and cookie sessions remain full-access (the documented contract).
- Gate every fund/state-changing sink on `mcp:write` (the status read sink on `mcp:read`): execute `transfer`/`contract-call`/`check-and-execute`/`swap`/`node`/`[...slug]`/`status`; workflows `create`, `[id]` PATCH+DELETE, `duplicate`; workflow `execute` (external dual-auth branch only -- internal service dispatch stays open); `ai/generate`; mcp listing POST/PATCH/DELETE. The public x402 `call` route and public GET endpoints are intentionally left open.

## Verification

- Unit (`scopeSatisfies`, `requireScope`, dual-auth scope) + integration (`execute-scope-enforcement`) -- confirmed non-tautological; 130 plan-named + 79 regression tests green.
- Live (real auth chain on a local dev server): read token -> `/api/execute/transfer` and `/api/workflows/create` -> **403 `insufficient_scope`**; read+write token -> 400 (proceeds); **`kh_` key -> 400, not 403 (full access preserved)**; read token -> status GET -> 404 (read scope sufficient).
- `tsc` + `ultracite` clean. Independent review: APPROVE.

## Backward-compat / follow-ups

- `kh_` API keys and UI cookie sessions carry no scope -> full access (verified live). The internal-service execute branch is untouched.
- The `workflows/import` route and non-status read sinks are left ungated by design here -- noted for a parity follow-up. There are currently no `mcp:admin`-only sinks.
