### PR TITLE
fix(workflow): evaluate condition expressions with a safe AST interpreter

### DIFF
--- a/lib/workflow/codegen/codegen.ts
+++ b/lib/workflow/codegen/codegen.ts
@@ -1,5 +1,6 @@
 import { buildEdgesBySourceHandle } from "@/lib/workflow/editor/edge-handle-utils";
 import { resolveConditionExpression } from "@/lib/workflow/nodes/condition/resolver";
+import { isSafeConditionExpression } from "@/lib/workflow/nodes/condition/safe-eval";
 import { DEFAULT_HTTP_METHOD } from "@/lib/workflow/nodes/http-request/constants";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 import { findActionById, flattenConfigFields } from "@/plugins/registry";
@@ -888,6 +889,14 @@ export function generateWorkflowCode(
       let convertedCondition: string;
       if (condition) {
         convertedCondition = convertConditionToJS(condition);
+        const isDisplayableCondition =
+          convertedCondition.includes("{{") ||
+          isSafeConditionExpression(convertedCondition);
+        if (!isDisplayableCondition) {
+          const errorMsg = `Condition node "${node.data.label || node.id}" contains unsupported syntax`;
+          validationErrors.push(errorMsg);
+          convertedCondition = `false /* ERROR: ${errorMsg} */`;
+        }
       } else {
         const errorMsg = `Condition node "${node.data.label || node.id}" has no condition expression configured`;
         validationErrors.push(errorMsg);
@@ -1009,6 +1018,14 @@ export function generateWorkflowCode(
       let convertedCondition: string;
       if (condition) {
         convertedCondition = convertConditionToJS(condition);
+        const isDisplayableCondition =
+          convertedCondition.includes("{{") ||
+          isSafeConditionExpression(convertedCondition);
+        if (!isDisplayableCondition) {
+          const errorMsg = `Condition node "${node.data.label || nodeId}" contains unsupported syntax`;
+          validationErrors.push(errorMsg);
+          convertedCondition = `false /* ERROR: ${errorMsg} */`;
+        }
       } else {
         const errorMsg = `Condition node "${node.data.label || nodeId}" has no condition expression configured`;
         validationErrors.push(errorMsg);

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -73,6 +73,7 @@ import {
   type TemplateResolutionTracker,
 } from "@/lib/workflow/executor/template-resolution";
 import { resolveConditionExpression } from "@/lib/workflow/nodes/condition/resolver";
+import { safeEvaluateCondition } from "@/lib/workflow/nodes/condition/safe-eval";
 import {
   type ConditionDecision,
   collectAllSkippedTargets,
@@ -323,11 +324,13 @@ type ConditionEvalResult = {
 };
 
 /**
- * Evaluate condition expression with template variable replacement
- * Uses Function constructor to evaluate user-defined conditions dynamically
+ * Evaluate condition expression with template variable replacement.
  *
- * Security: Expressions are validated before evaluation to prevent code injection.
- * Only comparison operators, logical operators, and whitelisted methods are allowed.
+ * Security (A-01): The transformed expression is evaluated by a safe AST
+ * interpreter (safeEvaluateCondition) that never constructs functions and
+ * never reaches host globals. It can only read the resolved __v/__b values and
+ * apply an allowlisted set of operators and methods. Expressions are still
+ * validated upfront for clear user-facing error messages.
  */
 // Exported for testing - KEEP-1284
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: KEEP-1284 validation requires comprehensive error checking
@@ -420,16 +423,10 @@ export function evaluateConditionExpression(
         evalContext = converted.evalContext;
       }
 
-      const varNames = Object.keys(evalContext);
-      const varValues = Object.values(evalContext);
-
-      // Safe to evaluate - expression has been validated
-      // Only contains: variables (__v0, __v1), operators, literals, and whitelisted methods
-      const evalFunc = new Function(
-        ...varNames,
-        `return (${transformedExpression});`
-      );
-      const result = evalFunc(...varValues);
+      // Safe AST interpreter (no new Function / no host access) for A-01.
+      // Only reads the resolved __v/__b values and applies allowlisted
+      // operators and methods.
+      const result = safeEvaluateCondition(transformedExpression, evalContext);
       return { result: Boolean(result), resolvedValues };
     } catch (error) {
       // KEEP-1284: Re-throw errors about missing data - these should not be silently swallowed

--- a/lib/workflow/nodes/condition/safe-eval.ts
+++ b/lib/workflow/nodes/condition/safe-eval.ts
@@ -1,0 +1,820 @@
+/**
+ * Safe condition expression evaluator (A-01 hardening).
+ *
+ * Replaces the previous `new Function(...)` evaluation of user-authored
+ * Condition expressions with a self-contained tokenizer, Pratt parser, and a
+ * strictly allowlisted tree-walking interpreter. The interpreter never
+ * constructs functions and never reaches host globals, so a condition string
+ * can only read the already-resolved `__vN`/`__bN` values and apply a fixed
+ * set of operators and methods.
+ *
+ * Supported grammar (identical to what the validator/visual-builder emit):
+ * - Literals: numbers, strings, true, false, null, undefined
+ * - Comparison: === !== == != > < >= <=
+ * - Arithmetic: + - * / % **
+ * - Logical: && || ! (with short-circuit)
+ * - Unary: ! - + typeof
+ * - Ternary: test ? a : b
+ * - Member access: obj.prop, obj["key"], obj[0], .length
+ * - Calls: String(...), Array.isArray(...), Object.keys(...), and the
+ *   allowlisted instance methods (includes/startsWith/endsWith/toString/
+ *   toLowerCase/toUpperCase/trim)
+ *
+ * Everything else (arbitrary identifiers, array/object literals, prototype
+ * access, and any other call target) throws.
+ */
+
+const HEX_RE = /^[0-9a-fA-F]+$/;
+const WHITESPACE_RE = /\s/;
+
+const ALLOWED_METHODS = new Set([
+  "includes",
+  "startsWith",
+  "endsWith",
+  "toString",
+  "toLowerCase",
+  "toUpperCase",
+  "trim",
+]);
+
+const ALLOWED_UNARY = new Set(["!", "-", "+", "typeof"]);
+
+const BLOCKED_PROPS = new Set(["constructor", "__proto__", "prototype"]);
+
+const ALLOWED_GLOBALS: Record<string, (...args: unknown[]) => unknown> = {
+  String: (...args) => String(args[0]),
+};
+
+const ALLOWED_STATIC: Record<string, (...args: unknown[]) => unknown> = {
+  "Array.isArray": (...args) => Array.isArray(args[0]),
+  "Object.keys": (...args) => Object.keys(args[0] as object),
+};
+
+// Left binding powers for the precedence-climbing parser. Higher binds tighter.
+const BINARY_BP: Record<string, number> = {
+  "||": 3,
+  "&&": 4,
+  "==": 9,
+  "!=": 9,
+  "===": 9,
+  "!==": 9,
+  "<": 10,
+  "<=": 10,
+  ">": 10,
+  ">=": 10,
+  "+": 12,
+  "-": 12,
+  "*": 13,
+  "/": 13,
+  "%": 13,
+  "**": 14,
+};
+
+const RIGHT_ASSOCIATIVE = new Set(["**"]);
+const LOGICAL_OPERATORS = new Set(["&&", "||"]);
+
+const MULTI_CHAR_PUNCTUATORS = [
+  "===",
+  "!==",
+  "**",
+  "==",
+  "!=",
+  "<=",
+  ">=",
+  "&&",
+  "||",
+];
+
+const SINGLE_CHAR_PUNCTUATORS = new Set([
+  "!",
+  "<",
+  ">",
+  "+",
+  "-",
+  "*",
+  "/",
+  "%",
+  "(",
+  ")",
+  "[",
+  "]",
+  ".",
+  "?",
+  ":",
+  ",",
+]);
+
+type LiteralNode = { type: "Literal"; value: unknown };
+type IdentifierNode = { type: "Identifier"; name: string };
+type UnaryNode = {
+  type: "UnaryExpression";
+  operator: string;
+  argument: AstNode;
+};
+type BinaryNode = {
+  type: "BinaryExpression";
+  operator: string;
+  left: AstNode;
+  right: AstNode;
+};
+type LogicalNode = {
+  type: "LogicalExpression";
+  operator: string;
+  left: AstNode;
+  right: AstNode;
+};
+type ConditionalNode = {
+  type: "ConditionalExpression";
+  test: AstNode;
+  consequent: AstNode;
+  alternate: AstNode;
+};
+type MemberNode = {
+  type: "MemberExpression";
+  object: AstNode;
+  property: AstNode;
+  computed: boolean;
+};
+type CallNode = {
+  type: "CallExpression";
+  callee: AstNode;
+  arguments: AstNode[];
+};
+
+type AstNode =
+  | LiteralNode
+  | IdentifierNode
+  | UnaryNode
+  | BinaryNode
+  | LogicalNode
+  | ConditionalNode
+  | MemberNode
+  | CallNode;
+
+type Token = { type: "num" | "str" | "ident" | "punct"; value: string };
+
+function isIdentifierStart(ch: string): boolean {
+  return (
+    (ch >= "a" && ch <= "z") ||
+    (ch >= "A" && ch <= "Z") ||
+    ch === "_" ||
+    ch === "$"
+  );
+}
+
+function isIdentifierPart(ch: string): boolean {
+  return isIdentifierStart(ch) || (ch >= "0" && ch <= "9");
+}
+
+function isDigit(ch: string): boolean {
+  return ch >= "0" && ch <= "9";
+}
+
+function decodeHexEscape(
+  src: string,
+  backslashIndex: number,
+  count: number
+): { value: string; next: number } {
+  const hex = src.slice(backslashIndex + 2, backslashIndex + 2 + count);
+  if (hex.length < count || !HEX_RE.test(hex)) {
+    throw new Error("Invalid escape sequence in string literal");
+  }
+  return {
+    value: String.fromCodePoint(Number.parseInt(hex, 16)),
+    next: backslashIndex + 2 + count,
+  };
+}
+
+function decodeUnicodeEscape(
+  src: string,
+  backslashIndex: number
+): { value: string; next: number } {
+  const afterU = backslashIndex + 2;
+  if (src[afterU] === "{") {
+    const end = src.indexOf("}", afterU);
+    if (end === -1) {
+      throw new Error("Invalid escape sequence in string literal");
+    }
+    const hex = src.slice(afterU + 1, end);
+    if (hex.length === 0 || !HEX_RE.test(hex)) {
+      throw new Error("Invalid escape sequence in string literal");
+    }
+    return {
+      value: String.fromCodePoint(Number.parseInt(hex, 16)),
+      next: end + 1,
+    };
+  }
+  return decodeHexEscape(src, backslashIndex, 4);
+}
+
+const SIMPLE_ESCAPES: Record<string, string> = {
+  n: "\n",
+  t: "\t",
+  r: "\r",
+  b: "\b",
+  f: "\f",
+  v: "\v",
+  "0": "\0",
+};
+
+function decodeEscape(
+  src: string,
+  backslashIndex: number
+): { value: string; next: number } {
+  const esc = src[backslashIndex + 1];
+  if (esc === undefined) {
+    throw new Error("Unterminated string literal");
+  }
+  if (esc === "x") {
+    return decodeHexEscape(src, backslashIndex, 2);
+  }
+  if (esc === "u") {
+    return decodeUnicodeEscape(src, backslashIndex);
+  }
+  const simple = SIMPLE_ESCAPES[esc];
+  if (simple !== undefined) {
+    return { value: simple, next: backslashIndex + 2 };
+  }
+  return { value: esc, next: backslashIndex + 2 };
+}
+
+function scanString(
+  src: string,
+  start: number
+): { value: string; next: number } {
+  const quote = src[start];
+  let i = start + 1;
+  let out = "";
+  while (i < src.length) {
+    const ch = src[i];
+    if (ch === "\\") {
+      const decoded = decodeEscape(src, i);
+      out += decoded.value;
+      i = decoded.next;
+      continue;
+    }
+    if (ch === quote) {
+      return { value: out, next: i + 1 };
+    }
+    out += ch;
+    i += 1;
+  }
+  throw new Error("Unterminated string literal");
+}
+
+function scanNumber(
+  src: string,
+  start: number
+): { value: string; next: number } {
+  let i = start;
+  while (i < src.length && isDigit(src[i])) {
+    i += 1;
+  }
+  if (src[i] === "." && isDigit(src[i + 1] ?? "")) {
+    i += 1;
+    while (i < src.length && isDigit(src[i])) {
+      i += 1;
+    }
+  }
+  return { value: src.slice(start, i), next: i };
+}
+
+function scanPunctuator(
+  src: string,
+  start: number
+): { value: string; next: number } {
+  for (const punct of MULTI_CHAR_PUNCTUATORS) {
+    if (src.startsWith(punct, start)) {
+      return { value: punct, next: start + punct.length };
+    }
+  }
+  const ch = src[start];
+  if (SINGLE_CHAR_PUNCTUATORS.has(ch)) {
+    return { value: ch, next: start + 1 };
+  }
+  throw new Error(`Invalid character "${ch}" in condition`);
+}
+
+function tokenize(src: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  while (i < src.length) {
+    const ch = src[i];
+    if (WHITESPACE_RE.test(ch)) {
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      const scanned = scanString(src, i);
+      tokens.push({ type: "str", value: scanned.value });
+      i = scanned.next;
+      continue;
+    }
+    if (isDigit(ch)) {
+      const scanned = scanNumber(src, i);
+      tokens.push({ type: "num", value: scanned.value });
+      i = scanned.next;
+      continue;
+    }
+    if (isIdentifierStart(ch)) {
+      let j = i + 1;
+      while (j < src.length && isIdentifierPart(src[j])) {
+        j += 1;
+      }
+      tokens.push({ type: "ident", value: src.slice(i, j) });
+      i = j;
+      continue;
+    }
+    const scanned = scanPunctuator(src, i);
+    tokens.push({ type: "punct", value: scanned.value });
+    i = scanned.next;
+  }
+  return tokens;
+}
+
+function literalFromIdentifier(name: string): AstNode {
+  switch (name) {
+    case "true":
+      return { type: "Literal", value: true };
+    case "false":
+      return { type: "Literal", value: false };
+    case "null":
+      return { type: "Literal", value: null };
+    case "undefined":
+      return { type: "Literal", value: undefined };
+    default:
+      return { type: "Identifier", name };
+  }
+}
+
+function parse(expression: string): AstNode {
+  const tokens = tokenize(expression);
+  let pos = 0;
+
+  function peek(): Token | undefined {
+    return tokens[pos];
+  }
+
+  function next(): Token | undefined {
+    const token = tokens[pos];
+    pos += 1;
+    return token;
+  }
+
+  function expectPunct(value: string): void {
+    const token = next();
+    if (token?.type !== "punct" || token.value !== value) {
+      throw new Error(`Expected "${value}" in condition`);
+    }
+  }
+
+  function parseArguments(): AstNode[] {
+    const args: AstNode[] = [];
+    if (peek()?.value === ")") {
+      next();
+      return args;
+    }
+    while (true) {
+      args.push(parseConditional());
+      const token = next();
+      if (token?.value === ")") {
+        return args;
+      }
+      if (token?.value !== ",") {
+        throw new Error("Malformed argument list in condition");
+      }
+    }
+  }
+
+  function parsePrimary(): AstNode {
+    const token = next();
+    if (!token) {
+      throw new Error("Unexpected end of condition expression");
+    }
+    if (token.type === "num") {
+      return { type: "Literal", value: Number(token.value) };
+    }
+    if (token.type === "str") {
+      return { type: "Literal", value: token.value };
+    }
+    if (token.type === "ident") {
+      return literalFromIdentifier(token.value);
+    }
+    if (token.value === "(") {
+      const expr = parseConditional();
+      expectPunct(")");
+      return expr;
+    }
+    throw new Error(`Unexpected token "${token.value}" in condition`);
+  }
+
+  function parseCallMember(): AstNode {
+    let node = parsePrimary();
+    while (true) {
+      const token = peek();
+      if (token?.type !== "punct") {
+        return node;
+      }
+      if (token.value === ".") {
+        next();
+        const prop = next();
+        if (prop?.type !== "ident") {
+          throw new Error("Expected property name after '.' in condition");
+        }
+        node = {
+          type: "MemberExpression",
+          object: node,
+          property: { type: "Identifier", name: prop.value },
+          computed: false,
+        };
+      } else if (token.value === "[") {
+        next();
+        const property = parseConditional();
+        expectPunct("]");
+        node = {
+          type: "MemberExpression",
+          object: node,
+          property,
+          computed: true,
+        };
+      } else if (token.value === "(") {
+        next();
+        node = {
+          type: "CallExpression",
+          callee: node,
+          arguments: parseArguments(),
+        };
+      } else {
+        return node;
+      }
+    }
+  }
+
+  function parseUnary(): AstNode {
+    const token = peek();
+    const isUnaryPunct =
+      token?.type === "punct" &&
+      (token.value === "!" || token.value === "-" || token.value === "+");
+    const isTypeof = token?.type === "ident" && token.value === "typeof";
+    if (token && (isUnaryPunct || isTypeof)) {
+      next();
+      return {
+        type: "UnaryExpression",
+        operator: token.value,
+        argument: parseUnary(),
+      };
+    }
+    return parseCallMember();
+  }
+
+  function parseBinary(minBp: number): AstNode {
+    let left = parseUnary();
+    while (true) {
+      const token = peek();
+      if (token?.type !== "punct") {
+        return left;
+      }
+      const bp = BINARY_BP[token.value];
+      if (bp === undefined || bp < minBp) {
+        return left;
+      }
+      next();
+      const nextMin = RIGHT_ASSOCIATIVE.has(token.value) ? bp : bp + 1;
+      const right = parseBinary(nextMin);
+      left = LOGICAL_OPERATORS.has(token.value)
+        ? { type: "LogicalExpression", operator: token.value, left, right }
+        : { type: "BinaryExpression", operator: token.value, left, right };
+    }
+  }
+
+  function parseConditional(): AstNode {
+    const test = parseBinary(0);
+    if (peek()?.value === "?") {
+      next();
+      const consequent = parseConditional();
+      expectPunct(":");
+      const alternate = parseConditional();
+      return { type: "ConditionalExpression", test, consequent, alternate };
+    }
+    return test;
+  }
+
+  const ast = parseConditional();
+  if (pos < tokens.length) {
+    throw new Error(`Unexpected token "${tokens[pos].value}" in condition`);
+  }
+  return ast;
+}
+
+function applyBinary(operator: string, left: unknown, right: unknown): unknown {
+  switch (operator) {
+    case "===":
+      return left === right;
+    case "!==":
+      return left !== right;
+    case "==":
+      // biome-ignore lint/suspicious/noDoubleEquals: condition grammar intentionally supports loose == for cross-type comparisons
+      return left == right;
+    case "!=":
+      // biome-ignore lint/suspicious/noDoubleEquals: condition grammar intentionally supports loose != for cross-type comparisons
+      return left != right;
+    case ">":
+      return (left as number) > (right as number);
+    case "<":
+      return (left as number) < (right as number);
+    case ">=":
+      return (left as number) >= (right as number);
+    case "<=":
+      return (left as number) <= (right as number);
+    case "+":
+      return (left as number) + (right as number);
+    case "-":
+      return (left as number) - (right as number);
+    case "*":
+      return (left as number) * (right as number);
+    case "/":
+      return (left as number) / (right as number);
+    case "%":
+      return (left as number) % (right as number);
+    case "**":
+      return (left as number) ** (right as number);
+    default:
+      throw new Error(`Operator not allowed in condition: ${operator}`);
+  }
+}
+
+function applyUnary(operator: string, argument: unknown): unknown {
+  switch (operator) {
+    case "!":
+      return !argument;
+    case "-":
+      return -(argument as number);
+    case "+":
+      return +(argument as number);
+    case "typeof":
+      return typeof argument;
+    default:
+      throw new Error(`Unary operator not allowed in condition: ${operator}`);
+  }
+}
+
+function callMethod(
+  receiver: unknown,
+  method: string,
+  args: unknown[]
+): unknown {
+  if (typeof receiver === "string") {
+    const fn = (String.prototype as unknown as Record<string, unknown>)[
+      method
+    ] as (...a: unknown[]) => unknown;
+    return fn.apply(receiver, args);
+  }
+  if (Array.isArray(receiver)) {
+    const fn = (Array.prototype as unknown as Record<string, unknown>)[
+      method
+    ] as (...a: unknown[]) => unknown;
+    return fn.apply(receiver, args);
+  }
+  const target =
+    receiver === null || receiver === undefined
+      ? undefined
+      : (receiver as Record<string, unknown>)[method];
+  if (typeof target !== "function") {
+    throw new Error(`Method "${method}" is not callable in condition`);
+  }
+  return (target as (...a: unknown[]) => unknown).apply(receiver, args);
+}
+
+function evalIdentifier(name: string, ctx: Record<string, unknown>): unknown {
+  if (Object.hasOwn(ctx, name)) {
+    return ctx[name];
+  }
+  throw new Error(`Unknown identifier "${name}" in condition`);
+}
+
+function memberKey(
+  node: MemberNode,
+  ctx: Record<string, unknown>
+): string | number {
+  if (node.computed) {
+    const key = evalNode(node.property, ctx);
+    if (typeof key !== "string" && typeof key !== "number") {
+      throw new Error("Computed member key must be a string or number");
+    }
+    if (typeof key === "string" && BLOCKED_PROPS.has(key)) {
+      throw new Error(`Property access not allowed in condition: ${key}`);
+    }
+    return key;
+  }
+  if (node.property.type !== "Identifier") {
+    throw new Error("Invalid member expression in condition");
+  }
+  const name = node.property.name;
+  if (BLOCKED_PROPS.has(name)) {
+    throw new Error(`Property access not allowed in condition: ${name}`);
+  }
+  return name;
+}
+
+function evalMember(node: MemberNode, ctx: Record<string, unknown>): unknown {
+  const key = memberKey(node, ctx);
+  const object = evalNode(node.object, ctx);
+  if (object === null || object === undefined) {
+    throw new Error(
+      `Cannot read property "${String(key)}" of ${String(object)}`
+    );
+  }
+  return (object as Record<string | number, unknown>)[key];
+}
+
+function evalCall(node: CallNode, ctx: Record<string, unknown>): unknown {
+  const callee = node.callee;
+  if (callee.type === "Identifier") {
+    const fn = ALLOWED_GLOBALS[callee.name];
+    if (!fn) {
+      throw new Error(`Function "${callee.name}" is not allowed in condition`);
+    }
+    return fn(...node.arguments.map((arg) => evalNode(arg, ctx)));
+  }
+  if (callee.type === "MemberExpression" && !callee.computed) {
+    if (callee.property.type !== "Identifier") {
+      throw new Error("Invalid call expression in condition");
+    }
+    const method = callee.property.name;
+    if (
+      callee.object.type === "Identifier" &&
+      !Object.hasOwn(ctx, callee.object.name)
+    ) {
+      const staticFn = ALLOWED_STATIC[`${callee.object.name}.${method}`];
+      if (!staticFn) {
+        throw new Error(
+          `Function "${callee.object.name}.${method}" is not allowed in condition`
+        );
+      }
+      return staticFn(...node.arguments.map((arg) => evalNode(arg, ctx)));
+    }
+    if (BLOCKED_PROPS.has(method) || !ALLOWED_METHODS.has(method)) {
+      throw new Error(`Method "${method}" is not allowed in condition`);
+    }
+    const receiver = evalNode(callee.object, ctx);
+    return callMethod(
+      receiver,
+      method,
+      node.arguments.map((arg) => evalNode(arg, ctx))
+    );
+  }
+  throw new Error("Unsupported call expression in condition");
+}
+
+function evalNode(node: AstNode, ctx: Record<string, unknown>): unknown {
+  switch (node.type) {
+    case "Literal":
+      return node.value;
+    case "Identifier":
+      return evalIdentifier(node.name, ctx);
+    case "UnaryExpression":
+      return applyUnary(node.operator, evalNode(node.argument, ctx));
+    case "BinaryExpression":
+      return applyBinary(
+        node.operator,
+        evalNode(node.left, ctx),
+        evalNode(node.right, ctx)
+      );
+    case "LogicalExpression": {
+      const left = evalNode(node.left, ctx);
+      if (node.operator === "&&") {
+        return left ? evalNode(node.right, ctx) : left;
+      }
+      return left ? left : evalNode(node.right, ctx);
+    }
+    case "ConditionalExpression":
+      return evalNode(node.test, ctx)
+        ? evalNode(node.consequent, ctx)
+        : evalNode(node.alternate, ctx);
+    case "MemberExpression":
+      return evalMember(node, ctx);
+    default:
+      return evalCall(node, ctx);
+  }
+}
+
+function walkAllowlist(node: AstNode): void {
+  switch (node.type) {
+    case "Literal":
+    case "Identifier":
+      return;
+    case "UnaryExpression":
+      if (!ALLOWED_UNARY.has(node.operator)) {
+        throw new Error(`Unary operator not allowed: ${node.operator}`);
+      }
+      walkAllowlist(node.argument);
+      return;
+    case "BinaryExpression":
+      if (BINARY_BP[node.operator] === undefined) {
+        throw new Error(`Operator not allowed: ${node.operator}`);
+      }
+      walkAllowlist(node.left);
+      walkAllowlist(node.right);
+      return;
+    case "LogicalExpression":
+      if (!LOGICAL_OPERATORS.has(node.operator)) {
+        throw new Error(`Operator not allowed: ${node.operator}`);
+      }
+      walkAllowlist(node.left);
+      walkAllowlist(node.right);
+      return;
+    case "ConditionalExpression":
+      walkAllowlist(node.test);
+      walkAllowlist(node.consequent);
+      walkAllowlist(node.alternate);
+      return;
+    case "MemberExpression":
+      walkMember(node);
+      return;
+    default:
+      walkCall(node);
+  }
+}
+
+function walkMember(node: MemberNode): void {
+  if (
+    !node.computed &&
+    node.property.type === "Identifier" &&
+    BLOCKED_PROPS.has(node.property.name)
+  ) {
+    throw new Error(`Property access not allowed: ${node.property.name}`);
+  }
+  if (
+    node.computed &&
+    node.property.type === "Literal" &&
+    typeof node.property.value === "string" &&
+    BLOCKED_PROPS.has(node.property.value)
+  ) {
+    throw new Error(`Property access not allowed: ${node.property.value}`);
+  }
+  walkAllowlist(node.object);
+  if (node.computed) {
+    walkAllowlist(node.property);
+  }
+}
+
+function walkCall(node: CallNode): void {
+  const callee = node.callee;
+  if (callee.type === "Identifier") {
+    if (!Object.hasOwn(ALLOWED_GLOBALS, callee.name)) {
+      throw new Error(`Function "${callee.name}" is not allowed`);
+    }
+  } else if (callee.type === "MemberExpression" && !callee.computed) {
+    if (callee.property.type !== "Identifier") {
+      throw new Error("Invalid call expression");
+    }
+    const method = callee.property.name;
+    const isStatic =
+      callee.object.type === "Identifier" &&
+      Object.hasOwn(ALLOWED_STATIC, `${callee.object.name}.${method}`);
+    if (!isStatic) {
+      if (BLOCKED_PROPS.has(method) || !ALLOWED_METHODS.has(method)) {
+        throw new Error(`Method "${method}" is not allowed`);
+      }
+      walkAllowlist(callee.object);
+    }
+  } else {
+    throw new Error("Unsupported call expression");
+  }
+  for (const arg of node.arguments) {
+    walkAllowlist(arg);
+  }
+}
+
+/**
+ * Parse and evaluate a transformed condition expression against the resolved
+ * `__vN`/`__bN` context. Throws on any disallowed syntax or unknown identifier.
+ */
+export function safeEvaluateCondition(
+  expression: string,
+  context: Record<string, unknown>
+): unknown {
+  let ast: AstNode;
+  try {
+    ast = parse(expression);
+  } catch (error) {
+    throw new Error(
+      `Condition parse error: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+  return evalNode(ast, context);
+}
+
+/**
+ * Static (non-evaluating) check that an expression only uses the allowlisted
+ * grammar. Used by the code generator to neutralize injected/invalid
+ * expressions in displayed/exported source.
+ */
+export function isSafeConditionExpression(expression: string): boolean {
+  try {
+    walkAllowlist(parse(expression));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/unit/condition-executor.test.ts
+++ b/tests/unit/condition-executor.test.ts
@@ -7,6 +7,7 @@ import { resolveConditionExpression } from "@/lib/workflow/nodes/condition/resol
 
 const NO_EXPRESSION_REGEX = /no expression configured/;
 const NO_OUTPUT_FOUND_RE = /no output was found/;
+const FAILED_TO_EVALUATE_RE = /Failed to evaluate condition expression/;
 
 /**
  * Tests for KEEP-1520: Condition node losing expression at runtime
@@ -975,5 +976,30 @@ describe("dead-branch grace: references to nodes that never executed", () => {
     expect(() => evaluateConditionExpression(expression, {})).toThrow(
       NO_OUTPUT_FOUND_RE
     );
+  });
+});
+
+describe("A-01: condition expressions cannot execute arbitrary code", () => {
+  it("rejects a bare global call that the regex validator lets through (SSRF vector)", () => {
+    // `fetch(...)` passes the legacy regex blocklist (no blocked keyword, not a
+    // `.method(` call) but must never reach a real fetch under the AST interpreter.
+    expect(() =>
+      evaluateConditionExpression('fetch("http://127.0.0.1/")', {})
+    ).toThrow(FAILED_TO_EVALUATE_RE);
+  });
+
+  it("rejects unicode-escaped constructor access (RCE vector)", () => {
+    expect(() =>
+      evaluateConditionExpression('"x"["\\u0063onstructor"]', {})
+    ).toThrow(FAILED_TO_EVALUATE_RE);
+  });
+
+  it("rejects the full constructor-of-constructor RCE chain", () => {
+    expect(() =>
+      evaluateConditionExpression(
+        '"x"["\\u0063onstructor"]["\\u0063onstructor"]("return 1")()',
+        {}
+      )
+    ).toThrow(FAILED_TO_EVALUATE_RE);
   });
 });

--- a/tests/unit/condition-safe-eval.test.ts
+++ b/tests/unit/condition-safe-eval.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isSafeConditionExpression,
+  safeEvaluateCondition,
+} from "@/lib/workflow/nodes/condition/safe-eval";
+
+const FAILS_RE =
+  /not allowed|Unknown identifier|parse error|Property access|Unsupported|callable|Computed member/;
+
+describe("safeEvaluateCondition - semantics", () => {
+  describe("equality and comparison", () => {
+    it("evaluates strict equality on context values", () => {
+      expect(safeEvaluateCondition("__v0 === 5", { __v0: 5 })).toBe(true);
+      expect(safeEvaluateCondition("__v0 === 5", { __v0: 6 })).toBe(false);
+    });
+
+    it("distinguishes loose == from strict === across types", () => {
+      expect(safeEvaluateCondition('"0" == 0', {})).toBe(true);
+      expect(safeEvaluateCondition('"0" === 0', {})).toBe(false);
+      expect(safeEvaluateCondition('"0" != 0', {})).toBe(false);
+      expect(safeEvaluateCondition('"0" !== 0', {})).toBe(true);
+    });
+
+    it("evaluates relational operators", () => {
+      expect(safeEvaluateCondition("__v0 > 10", { __v0: 11 })).toBe(true);
+      expect(safeEvaluateCondition("__v0 >= 10", { __v0: 10 })).toBe(true);
+      expect(safeEvaluateCondition("__v0 < 10", { __v0: 9 })).toBe(true);
+      expect(safeEvaluateCondition("__v0 <= 10", { __v0: 11 })).toBe(false);
+    });
+
+    it("evaluates arithmetic including exponentiation precedence", () => {
+      expect(safeEvaluateCondition("2 + 3 * 4", {})).toBe(14);
+      expect(safeEvaluateCondition("8 === 2 ** 3", {})).toBe(true);
+      expect(safeEvaluateCondition("10 % 3", {})).toBe(1);
+      expect(safeEvaluateCondition("(2 + 3) * 4", {})).toBe(20);
+    });
+  });
+
+  describe("logical, unary, and ternary", () => {
+    it("short-circuits && and || without evaluating the dead side", () => {
+      // missingVar is an unknown identifier; it must not be evaluated.
+      expect(safeEvaluateCondition("false && missingVar", {})).toBe(false);
+      expect(safeEvaluateCondition("true || missingVar", {})).toBe(true);
+    });
+
+    it("evaluates && and || results", () => {
+      expect(
+        safeEvaluateCondition("__v0 && __v1", { __v0: true, __v1: 7 })
+      ).toBe(7);
+      expect(
+        safeEvaluateCondition("__v0 || __v1", { __v0: 0, __v1: "x" })
+      ).toBe("x");
+    });
+
+    it("evaluates unary operators", () => {
+      expect(safeEvaluateCondition("!false", {})).toBe(true);
+      expect(safeEvaluateCondition("-__v0 === -5", { __v0: 5 })).toBe(true);
+      expect(safeEvaluateCondition("+__v0", { __v0: "3" })).toBe(3);
+      expect(safeEvaluateCondition("typeof __v0", { __v0: "x" })).toBe(
+        "string"
+      );
+    });
+
+    it("evaluates ternary expressions", () => {
+      expect(
+        safeEvaluateCondition("__v0 ? __v1 : __v2", {
+          __v0: true,
+          __v1: "yes",
+          __v2: "no",
+        })
+      ).toBe("yes");
+      expect(
+        safeEvaluateCondition("__v0 ? __v1 : __v2", {
+          __v0: false,
+          __v1: "yes",
+          __v2: "no",
+        })
+      ).toBe("no");
+    });
+  });
+
+  describe("member access", () => {
+    it("reads nested members", () => {
+      expect(
+        safeEvaluateCondition("__v0.a.b === 1", { __v0: { a: { b: 1 } } })
+      ).toBe(true);
+    });
+
+    it("reads computed members by index and string key", () => {
+      expect(safeEvaluateCondition("__v0[0]", { __v0: [42] })).toBe(42);
+      expect(
+        safeEvaluateCondition('__v0["k"] === "v"', { __v0: { k: "v" } })
+      ).toBe(true);
+    });
+
+    it("reads .length", () => {
+      expect(
+        safeEvaluateCondition("__v0.length === 3", { __v0: [1, 2, 3] })
+      ).toBe(true);
+    });
+  });
+
+  describe("allowlisted calls", () => {
+    it("supports String() and string methods", () => {
+      expect(
+        safeEvaluateCondition('String(__v0).includes("00")', { __v0: 1002 })
+      ).toBe(true);
+      expect(
+        safeEvaluateCondition('String(__v0).startsWith("ab")', { __v0: "abc" })
+      ).toBe(true);
+      expect(
+        safeEvaluateCondition('String(__v0).endsWith("bc")', { __v0: "abc" })
+      ).toBe(true);
+      expect(
+        safeEvaluateCondition("String(__v0).toLowerCase()", { __v0: "AB" })
+      ).toBe("ab");
+      expect(
+        safeEvaluateCondition("String(__v0).trim()", { __v0: "  x  " })
+      ).toBe("x");
+    });
+
+    it("supports Array.isArray and array methods", () => {
+      expect(safeEvaluateCondition("Array.isArray(__v0)", { __v0: [] })).toBe(
+        true
+      );
+      expect(safeEvaluateCondition("Array.isArray(__v0)", { __v0: 1 })).toBe(
+        false
+      );
+      expect(
+        safeEvaluateCondition("__v0.includes(2)", { __v0: [1, 2, 3] })
+      ).toBe(true);
+    });
+
+    it("supports Object.keys with chained access", () => {
+      expect(
+        safeEvaluateCondition("Object.keys(__v0).length === 0", { __v0: {} })
+      ).toBe(true);
+      expect(
+        safeEvaluateCondition('Object.keys(__v0).includes("id")', {
+          __v0: { id: 1 },
+        })
+      ).toBe(true);
+    });
+  });
+
+  describe("visual-builder operator expansions", () => {
+    it("isEmpty / isNotEmpty", () => {
+      const isEmpty = '(__v0 === null || __v0 === undefined || __v0 === "")';
+      expect(safeEvaluateCondition(isEmpty, { __v0: "" })).toBe(true);
+      expect(safeEvaluateCondition(isEmpty, { __v0: "x" })).toBe(false);
+      const isNotEmpty = '(__v0 !== null && __v0 !== undefined && __v0 !== "")';
+      expect(safeEvaluateCondition(isNotEmpty, { __v0: "x" })).toBe(true);
+    });
+
+    it("exists / doesNotExist", () => {
+      const exists = "(__v0 !== null && __v0 !== undefined)";
+      expect(safeEvaluateCondition(exists, { __v0: 0 })).toBe(true);
+      const doesNotExist = "(__v0 === null || __v0 === undefined)";
+      expect(safeEvaluateCondition(doesNotExist, { __v0: null })).toBe(true);
+    });
+  });
+
+  describe("BigInt context", () => {
+    it("compares BigInt context values exactly", () => {
+      expect(
+        safeEvaluateCondition("__v0 > __b0", {
+          __v0: BigInt("2000000000000000000"),
+          __b0: BigInt("1000000000000000000"),
+        })
+      ).toBe(true);
+    });
+
+    it("stringifies a BigInt receiver for includes()", () => {
+      expect(
+        safeEvaluateCondition('String(__v0).includes("000")', {
+          __v0: BigInt("2000000000000000000"),
+        })
+      ).toBe(true);
+    });
+  });
+});
+
+describe("safeEvaluateCondition - security (must throw)", () => {
+  const cases: Array<{
+    name: string;
+    expr: string;
+    ctx: Record<string, unknown>;
+  }> = [
+    { name: "global fetch call", expr: 'fetch("http://x")', ctx: {} },
+    {
+      name: "computed constructor access",
+      expr: '__v0["constructor"]',
+      ctx: { __v0: {} },
+    },
+    {
+      name: "unicode-escaped constructor access",
+      expr: '__v0["\\u0063onstructor"]',
+      ctx: { __v0: {} },
+    },
+    { name: "constructor on a literal", expr: "(1).constructor", ctx: {} },
+    { name: "__proto__ access", expr: "__v0.__proto__", ctx: { __v0: {} } },
+    { name: "prototype access", expr: "__v0.prototype", ctx: { __v0: {} } },
+    { name: "array literal", expr: "[1,2,3]", ctx: {} },
+    {
+      name: "non-allowlisted method",
+      expr: "__v0.toFixed(2)",
+      ctx: { __v0: 1.234 },
+    },
+    { name: "globalThis identifier", expr: "globalThis", ctx: {} },
+    { name: "process.env access", expr: "process.env", ctx: {} },
+    { name: "setTimeout call", expr: "setTimeout(1, 1)", ctx: {} },
+    {
+      name: "constructor-of-constructor RCE chain",
+      expr: '__v0["\\u0063onstructor"]["\\u0063onstructor"]("return 1")()',
+      ctx: { __v0: {} },
+    },
+  ];
+
+  for (const { name, expr, ctx } of cases) {
+    it(`throws for ${name}`, () => {
+      expect(() => safeEvaluateCondition(expr, ctx)).toThrow(FAILS_RE);
+    });
+  }
+
+  it("does not invoke a global even if it exists in the host", () => {
+    let called = false;
+    const original = (globalThis as Record<string, unknown>).__keep787Probe;
+    (globalThis as Record<string, unknown>).__keep787Probe = () => {
+      called = true;
+    };
+    try {
+      expect(() => safeEvaluateCondition("__keep787Probe()", {})).toThrow();
+    } finally {
+      (globalThis as Record<string, unknown>).__keep787Probe = original;
+    }
+    expect(called).toBe(false);
+  });
+});
+
+describe("isSafeConditionExpression", () => {
+  it("accepts allowlisted expressions (including generated var refs)", () => {
+    expect(isSafeConditionExpression("true === true")).toBe(true);
+    expect(isSafeConditionExpression("httpRequestResult.status === 200")).toBe(
+      true
+    );
+    expect(
+      isSafeConditionExpression(
+        "(Array.isArray(itemsResult) && itemsResult.length > 0)"
+      )
+    ).toBe(true);
+    expect(isSafeConditionExpression('String(bodyResult).includes("ok")')).toBe(
+      true
+    );
+  });
+
+  it("rejects injected or invalid expressions", () => {
+    expect(isSafeConditionExpression('fetch("http://x")')).toBe(false);
+    expect(isSafeConditionExpression('result["constructor"]')).toBe(false);
+    expect(isSafeConditionExpression("[1,2,3]")).toBe(false);
+    expect(isSafeConditionExpression("result.toFixed(2)")).toBe(false);
+    expect(isSafeConditionExpression("{{@unresolved:Label.field}}")).toBe(
+      false
+    );
+  });
+});


### PR DESCRIPTION
## Finding A-01 (CRITICAL, confidence 0.9, funds at risk) -- in-process RCE

Workflow Condition nodes were evaluated with `new Function(...)` directly in the live Next.js server process (no vm/sandbox), gated only by a bypassable regex blocklist. Verified payloads achieved both SSRF/exfil (`fetch('http://169.254.169.254/...')`, bypassing the egress guard every other outbound path is forced through) and full RCE (`__v0["\x63onstructor"]["\x63onstructor"]("...")()`) inside the fund-custody signing process that holds the Turnkey/Safe signer credentials, `DATABASE_URL`, and encryption keys -- the exact TTP of the prior SEV-1.

## Fix

- New `lib/workflow/nodes/condition/safe-eval.ts`: a self-contained tokenizer + Pratt parser + strict allowlisted tree-walking interpreter. No `new Function`, no host globals, no member access on `constructor`/`__proto__`/`prototype` (dot or computed), string escapes decoded before the allowlist check, calls limited to `String()` / `Array.isArray` / `Object.keys` plus 7 prototype-pinned string/array methods, and call receivers can only be resolved data (never functions). **No new dependency** (hand-rolled), so nothing new has to load in the Workflow runtime.
- `executor.workflow.ts` calls `safeEvaluateCondition` in place of `new Function`; the existing validate/transform/BigInt pipeline and user-facing error messages are preserved.
- The codegen export site (`convertConditionToJS`) is guarded with `isSafeConditionExpression`, emitting a safe `false /* ... */` fallback for out-of-grammar expressions (this path affects displayed/exported code only, not execution).

## Verification

- 33 new + 180 existing condition tests green: full semantics coverage (operators, `==` vs `===`, BigInt comparisons, member/computed/ternary/short-circuit, allowlisted string methods) AND security (`fetch(...)`, `["constructor"]`, unicode-escape constructor chain, `__proto__`, array literals, non-allowlisted methods all throw). The executor-level injection cases throw on the new path and would have executed on the old one -- non-tautological.
- `tsc --noEmit` clean (including the two `String.prototype`/`Array.prototype` cast type errors flagged in review, now fixed); `ultracite check` clean on the new files. Independent review: APPROVE (after the cast fix).

## Decisions / follow-ups

- The `matchesRegex` Condition operator keeps its current "rejected at runtime" behavior (it already failed under the old validator); making it work safely is a separate, bounded scope.
- The AST interpreter is intentionally stricter than the old permissive regex + `new Function` path -- it rejects exactly the bypass vectors. A staging audit of stored Condition expressions is advised before rollout to confirm no legitimate production condition uses syntax outside the enumerated allowlist.
