### PR TITLE
fix: patch chain monitor (TECH-45)

### DIFF
--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -1047,6 +1047,13 @@ export class ChainMonitor {
       await probeProvider.destroy().catch(() => {
         // ignore cleanup errors
       });
+      // Must set currentUrlIndex before handleDisconnect so reconnectWithBackoff
+      // lands on primary. Without it, maybeFlipUrlPreference() returns early
+      // (silentReconnects is 0 because the fallback is healthy), and connect()
+      // silently stays on fallback while the metric records a flip that never
+      // actually happens — causing the URL Flipped alert to re-fire every probe
+      // interval.
+      this.currentUrlIndex = 0;
       metrics.recordUrlFlip(this.chainName, "to_primary");
       metrics.recordWsClose(this.chainName, "primary_probe_recovered");
       this.handleDisconnect();

--- a/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
+++ b/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
@@ -894,17 +894,12 @@ describe("ChainMonitor", () => {
       // At least one new provider was created (the probe), and the active
       // provider should now be primary again.
       expect(providerInstances.length).toBeGreaterThan(startCount);
-      // Latest connected provider should be primary
-      const lastConnectedUrl = monitor.isAlive()
-        ? "wss://primary.test"
-        : "(monitor not alive)";
-      // Find the most recent provider matching the primary URL — that is the
-      // one we are now connected on.
-      const primaryProviders = providerInstances.filter(
-        (p) => p.url === "wss://primary.test",
-      );
-      expect(primaryProviders.length).toBeGreaterThanOrEqual(2);
-      expect(lastConnectedUrl).toBe("wss://primary.test");
+      // The monitor must have reconnected to primary, not stayed on fallback.
+      // This is the assertion that catches the probePrimary bug: previously,
+      // currentUrlIndex was never reset to 0, so reconnectWithBackoff always
+      // landed back on the fallback URL.
+      expect(latestProvider().url).toBe("wss://primary.test");
+      expect(monitor.isAlive()).toBe(true);
     });
 
     it("recycles the socket after SOCKET_MAX_AGE_MS elapses", async () => {


### PR DESCRIPTION
## Problem

When the block dispatcher's primary-recovery probe confirmed the primary WSS was reachable, it recorded a `url_flip_total{direction="to_primary"}` metric increment and triggered a reconnect — but never reset `currentUrlIndex` to `0`. The reconnect loop's `maybeFlipUrlPreference()` returned early (no silent reconnects to justify a flip since the fallback was delivering blocks normally), so `connect()` used `currentUrlIndex = 1` and reconnected to the fallback URL. The monitor stayed on the fallback indefinitely while the metric reported a successful switch to primary every probe interval (5 min), re-firing the "Block Dispatcher URL Flipped" alert on a continuous loop. This was confirmed in prod logs: `Primary recovered, switching back from fallback` appeared every 5 minutes, each time followed immediately by `Connected to fallback WSS`.

The test covering this path was also broken: it set `lastConnectedUrl = "wss://primary.test"` unconditionally whenever `monitor.isAlive()` was true, so it never verified the actual URL in use and could not catch the regression.

## Fix

- `probePrimary()`: set `this.currentUrlIndex = 0` before calling `handleDisconnect()` so the subsequent `reconnectWithBackoff` → `connect()` call lands on the primary URL.
- Test: replace the misleading `lastConnectedUrl` variable with a direct `expect(latestProvider().url).toBe("wss://primary.test")` assertion.

## Testing

All 106 scheduler unit and integration tests pass, including the now-meaningful `probes primary when on fallback and swaps back when primary recovers` assertion.