### PR TITLE
fix(oauth): re-check org membership in MCP token auth and refresh grant

### DIFF
--- a/app/api/oauth/token/route.ts
+++ b/app/api/oauth/token/route.ts
@@ -11,6 +11,7 @@ import {
   storeRefreshToken,
 } from "@/lib/mcp/oauth-store";
 import { checkIpRateLimit, getClientIp } from "@/lib/mcp/rate-limit";
+import { isUserMemberOfOrganization } from "@/lib/workflow/access";
 
 export const dynamic = "force-dynamic";
 
@@ -133,6 +134,14 @@ async function handleRefreshToken(params: URLSearchParams): Promise<Response> {
   // survive deactivation by repeatedly cycling itself.
   if (await isUserDeactivated(entry.userId)) {
     return jsonError("User account is deactivated", 401);
+  }
+
+  // Re-check org membership before re-issuing. A refresh token outlives any
+  // single access token, so without this a user removed from (or who left)
+  // the org could keep cycling the refresh token into fresh org-scoped
+  // access tokens indefinitely.
+  if (!(await isUserMemberOfOrganization(entry.userId, entry.organizationId))) {
+    return jsonError("User is no longer a member of this organization", 401);
   }
 
   const newRefreshToken = randomBytes(32).toString("hex");

--- a/app/api/organizations/[organizationId]/leave/route.ts
+++ b/app/api/organizations/[organizationId]/leave/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { hashSessionToken } from "@/lib/auth-session-token-hash";
 import { db } from "@/lib/db";
-import { member, sessions } from "@/lib/db/schema";
+import { mcpOauthRefreshTokens, member, sessions } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { getActiveOrgId } from "@/lib/middleware/org-context";
 
@@ -124,6 +124,18 @@ export async function POST(
         // IMMEDIATE constraint within the transaction.
         await tx.delete(member).where(eq(member.id, currentMember.id));
 
+        // Revoke this user's MCP OAuth refresh tokens for the org they are
+        // leaving so their long-lived tokens cannot be cycled into fresh
+        // org-scoped access after they no longer belong to it.
+        await tx
+          .delete(mcpOauthRefreshTokens)
+          .where(
+            and(
+              eq(mcpOauthRefreshTokens.userId, session.user.id),
+              eq(mcpOauthRefreshTokens.organizationId, organizationId)
+            )
+          );
+
         await tx
           .update(member)
           .set({ role: "owner" })
@@ -141,6 +153,18 @@ export async function POST(
       }
 
       await tx.delete(member).where(eq(member.id, currentMember.id));
+
+      // Revoke this user's MCP OAuth refresh tokens for the org they are
+      // leaving so their long-lived tokens cannot be cycled into fresh
+      // org-scoped access after they no longer belong to it.
+      await tx
+        .delete(mcpOauthRefreshTokens)
+        .where(
+          and(
+            eq(mcpOauthRefreshTokens.userId, session.user.id),
+            eq(mcpOauthRefreshTokens.organizationId, organizationId)
+          )
+        );
 
       if (getActiveOrgId(session) === organizationId) {
         await tx

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -40,6 +40,7 @@ import {
   integrations,
   invitationRelations,
   invitation as invitationTable,
+  mcpOauthRefreshTokens,
   memberRelations,
   member as memberTable,
   organizationRelations,
@@ -372,6 +373,22 @@ const plugins = [
 
       async afterAcceptInvitation() {
         await Promise.resolve();
+      },
+
+      // A-04: admin-initiated removal goes through better-auth's removeMember
+      // (no custom route), so revoke the removed member's renewable MCP OAuth
+      // refresh tokens for this org here. Access is already refused at use
+      // time by the membership re-check; this clears the dormant 30-day
+      // credential so it cannot linger. Mirrors the leave-route cascade.
+      async afterRemoveMember(data) {
+        await db
+          .delete(mcpOauthRefreshTokens)
+          .where(
+            and(
+              eq(mcpOauthRefreshTokens.userId, data.user.id),
+              eq(mcpOauthRefreshTokens.organizationId, data.organization.id)
+            )
+          );
       },
     },
   }),

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -24,6 +24,7 @@ import { DISPOSABLE_EMAIL_REJECTION_MESSAGE } from "@/lib/auth-disposable-emails
 import { isFreshSignup } from "@/lib/auth-notification-guard";
 import { sendInvitationEmail, sendVerificationOTP } from "@/lib/email";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { revokeRefreshTokensForUserOrg } from "@/lib/mcp/oauth-store";
 import {
   assessCountryTrust,
   assessLoginRisk,
@@ -40,7 +41,6 @@ import {
   integrations,
   invitationRelations,
   invitation as invitationTable,
-  mcpOauthRefreshTokens,
   memberRelations,
   member as memberTable,
   organizationRelations,
@@ -381,14 +381,7 @@ const plugins = [
       // time by the membership re-check; this clears the dormant 30-day
       // credential so it cannot linger. Mirrors the leave-route cascade.
       async afterRemoveMember(data) {
-        await db
-          .delete(mcpOauthRefreshTokens)
-          .where(
-            and(
-              eq(mcpOauthRefreshTokens.userId, data.user.id),
-              eq(mcpOauthRefreshTokens.organizationId, data.organization.id)
-            )
-          );
+        await revokeRefreshTokensForUserOrg(data.user.id, data.organization.id);
       },
     },
   }),

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -381,7 +381,27 @@ const plugins = [
       // time by the membership re-check; this clears the dormant 30-day
       // credential so it cannot linger. Mirrors the leave-route cascade.
       async afterRemoveMember(data) {
-        await revokeRefreshTokensForUserOrg(data.user.id, data.organization.id);
+        // Best-effort: better-auth calls this after the member row is already
+        // deleted and outside any transaction, and access is already refused
+        // at use time by the membership re-check. A failure to clear the
+        // dormant refresh tokens must not throw back and fail the removal
+        // request itself - log and move on; the rows are inert.
+        try {
+          await revokeRefreshTokensForUserOrg(
+            data.user.id,
+            data.organization.id
+          );
+        } catch (err) {
+          logSystemError(
+            ErrorCategory.AUTH,
+            "[Org] Failed to revoke MCP OAuth refresh tokens after member removal",
+            err,
+            {
+              userId: data.user.id,
+              organizationId: data.organization.id,
+            }
+          );
+        }
       },
     },
   }),

--- a/lib/mcp/oauth-auth.ts
+++ b/lib/mcp/oauth-auth.ts
@@ -183,6 +183,12 @@ export async function authenticateOAuthToken(
   // minted, not that they still belong to the org it is scoped to. Re-check
   // current membership on every use so a token keeps no authority after the
   // user is removed from (or leaves) the organization.
+  //
+  // Note: isUserMemberOfOrganization joins on users.deactivatedAt IS NULL, so
+  // this check also rejects a deactivated user. The explicit deactivation
+  // guard above is therefore retained for its security telemetry (the Sentry
+  // captureMessage / console.warn), not for access control - it surfaces the
+  // anomaly that this membership check would otherwise reject silently.
   if (!payload.sub) {
     return {
       authenticated: false,

--- a/lib/mcp/oauth-auth.ts
+++ b/lib/mcp/oauth-auth.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 import { jwtVerify, SignJWT } from "jose";
 import { db } from "@/lib/db";
 import { users } from "@/lib/db/schema";
+import { isUserMemberOfOrganization } from "@/lib/workflow/access";
 
 export type OAuthTokenPayload = {
   sub: string;
@@ -176,6 +177,27 @@ export async function authenticateOAuthToken(
         statusCode: 401,
       };
     }
+  }
+
+  // A long-lived access token only proves who the user was when it was
+  // minted, not that they still belong to the org it is scoped to. Re-check
+  // current membership on every use so a token keeps no authority after the
+  // user is removed from (or leaves) the organization.
+  if (!payload.sub) {
+    return {
+      authenticated: false,
+      error: "OAuth token missing subject claim",
+      statusCode: 401,
+    };
+  }
+
+  const isMember = await isUserMemberOfOrganization(payload.sub, payload.org);
+  if (!isMember) {
+    return {
+      authenticated: false,
+      error: "User is no longer a member of this organization",
+      statusCode: 401,
+    };
   }
 
   return {

--- a/lib/mcp/oauth-auth.ts
+++ b/lib/mcp/oauth-auth.ts
@@ -134,49 +134,58 @@ export async function authenticateOAuthToken(
     };
   }
 
+  // Both downstream checks key off the subject, so reject a subject-less token
+  // up front; this lets the deactivation and membership lookups treat
+  // payload.sub as a present value rather than re-guarding it.
+  if (!payload.sub) {
+    return {
+      authenticated: false,
+      error: "OAuth token missing subject claim",
+      statusCode: 401,
+    };
+  }
+
   // Reject tokens issued to a now-deactivated user. JWTs are valid for 1
   // hour after creation; without this check, a user deactivated within that
   // window could keep authenticating against MCP endpoints until the token
   // organically expired. This mirrors the deactivation guard in
   // authenticateApiKey -- both auth paths must close the same gap.
-  if (payload.sub) {
-    const user = await db.query.users.findFirst({
-      where: eq(users.id, payload.sub),
-      columns: { deactivatedAt: true },
-    });
-    if (user?.deactivatedAt) {
-      // KEEP-612: fourth deactivated-login surface (alongside better-auth
-      // session/account hooks and api-key auth). A deactivated user with a
-      // still-valid MCP OAuth JWT hitting MCP endpoints is exactly the
-      // anomaly the detection layer wants surfaced. Best-effort; never
-      // blocks the 401.
-      try {
-        captureMessage("security.deactivated_login_attempt", {
-          level: "warning",
-          tags: {
-            security: "deactivated_login_attempt",
-            surface: "mcp_oauth",
-          },
-          user: { id: payload.sub },
-          extra: { organizationId: payload.org },
-        });
-      } catch {
-        // swallow; observability must not affect the auth response
-      }
-      console.warn(
-        JSON.stringify({
-          event: "security.deactivated_login_attempt",
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, payload.sub),
+    columns: { deactivatedAt: true },
+  });
+  if (user?.deactivatedAt) {
+    // KEEP-612: fourth deactivated-login surface (alongside better-auth
+    // session/account hooks and api-key auth). A deactivated user with a
+    // still-valid MCP OAuth JWT hitting MCP endpoints is exactly the
+    // anomaly the detection layer wants surfaced. Best-effort; never
+    // blocks the 401.
+    try {
+      captureMessage("security.deactivated_login_attempt", {
+        level: "warning",
+        tags: {
+          security: "deactivated_login_attempt",
           surface: "mcp_oauth",
-          userId: payload.sub,
-          organizationId: payload.org,
-        })
-      );
-      return {
-        authenticated: false,
-        error: "User account is deactivated",
-        statusCode: 401,
-      };
+        },
+        user: { id: payload.sub },
+        extra: { organizationId: payload.org },
+      });
+    } catch {
+      // swallow; observability must not affect the auth response
     }
+    console.warn(
+      JSON.stringify({
+        event: "security.deactivated_login_attempt",
+        surface: "mcp_oauth",
+        userId: payload.sub,
+        organizationId: payload.org,
+      })
+    );
+    return {
+      authenticated: false,
+      error: "User account is deactivated",
+      statusCode: 401,
+    };
   }
 
   // A long-lived access token only proves who the user was when it was
@@ -189,14 +198,6 @@ export async function authenticateOAuthToken(
   // guard above is therefore retained for its security telemetry (the Sentry
   // captureMessage / console.warn), not for access control - it surfaces the
   // anomaly that this membership check would otherwise reject silently.
-  if (!payload.sub) {
-    return {
-      authenticated: false,
-      error: "OAuth token missing subject claim",
-      statusCode: 401,
-    };
-  }
-
   const isMember = await isUserMemberOfOrganization(payload.sub, payload.org);
   if (!isMember) {
     return {

--- a/lib/mcp/oauth-store.ts
+++ b/lib/mcp/oauth-store.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { eq, lt } from "drizzle-orm";
+import { and, eq, lt } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
   mcpOauthAuthCodes,
@@ -191,6 +191,25 @@ export async function deleteRefreshToken(token: string): Promise<void> {
   await db
     .delete(mcpOauthRefreshTokens)
     .where(eq(mcpOauthRefreshTokens.tokenHash, tokenHash));
+}
+
+/**
+ * Revoke every MCP OAuth refresh token a user holds for a given organization.
+ * Used when a user leaves or is removed from an org so their renewable 30-day
+ * credential cannot be cycled into fresh org-scoped access once membership ends.
+ */
+export async function revokeRefreshTokensForUserOrg(
+  userId: string,
+  organizationId: string
+): Promise<void> {
+  await db
+    .delete(mcpOauthRefreshTokens)
+    .where(
+      and(
+        eq(mcpOauthRefreshTokens.userId, userId),
+        eq(mcpOauthRefreshTokens.organizationId, organizationId)
+      )
+    );
 }
 
 export { AUTH_CODE_TTL_MS, REFRESH_TOKEN_TTL_MS };

--- a/tests/integration/leave-route-revokes-oauth.test.ts
+++ b/tests/integration/leave-route-revokes-oauth.test.ts
@@ -12,6 +12,8 @@ const { mockGetSession, mockGetActiveOrgId, selectState, txDeleteCalls } =
     selectState: {
       currentMember: [] as unknown[],
       ownerCount: [] as unknown[],
+      newOwner: [] as unknown[],
+      limitCalls: 0,
     },
     txDeleteCalls: [] as Array<{ table: unknown; whereArg: unknown }>,
   }));
@@ -58,10 +60,18 @@ const txStub = {
   select: vi.fn(() => ({
     from: vi.fn(() => ({
       where: vi.fn(() =>
-        // The owner-count query awaits .where() directly; the member-role
-        // query chains .limit() off it. Serve both shapes from one stub.
+        // The owner-count query awaits .where() directly; the member-role and
+        // new-owner lookups chain .limit() off it. Serve all shapes from one
+        // stub: the first .limit() is the current-member lookup, the second
+        // (sole-owner path only) is the new-owner lookup.
         Object.assign(Promise.resolve(selectState.ownerCount), {
-          limit: vi.fn(() => Promise.resolve(selectState.currentMember)),
+          limit: vi.fn(() => {
+            const isFirstLimit = selectState.limitCalls === 0;
+            selectState.limitCalls += 1;
+            return Promise.resolve(
+              isFirstLimit ? selectState.currentMember : selectState.newOwner
+            );
+          }),
         })
       ),
     })),
@@ -107,6 +117,8 @@ beforeEach(() => {
   txDeleteCalls.length = 0;
   selectState.currentMember = [];
   selectState.ownerCount = [];
+  selectState.newOwner = [];
+  selectState.limitCalls = 0;
   mockGetActiveOrgId.mockReturnValue(null);
 });
 
@@ -120,6 +132,46 @@ describe("POST /api/organizations/[id]/leave -- OAuth refresh token revocation",
     selectState.ownerCount = [{ id: "owner-other" }];
 
     const response = await POST(buildRequest({}), buildContext());
+
+    expect(response.status).toBe(200);
+
+    const oauthDelete = txDeleteCalls.find((call) => {
+      const where = call.whereArg as AndCondition;
+      return (
+        where?.op === "and" &&
+        where.conditions.some((c) => c.column === "mcp.userId")
+      );
+    });
+
+    expect(oauthDelete).toBeDefined();
+    const conditions = (oauthDelete?.whereArg as AndCondition).conditions;
+    expect(conditions).toContainEqual({
+      op: "eq",
+      column: "mcp.userId",
+      value: USER_ID,
+    });
+    expect(conditions).toContainEqual({
+      op: "eq",
+      column: "mcp.organizationId",
+      value: ORG_ID,
+    });
+  });
+
+  it("deletes the leaving user's MCP OAuth refresh tokens on the sole-owner path", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: USER_ID },
+      session: { token: "raw-token" },
+    });
+    // Caller is the only owner, so the route requires a successor and takes the
+    // ownership-transfer branch before removing the member.
+    selectState.currentMember = [{ id: "member-1", role: "owner" }];
+    selectState.ownerCount = [{ id: "member-1" }];
+    selectState.newOwner = [{ id: "member-2" }];
+
+    const response = await POST(
+      buildRequest({ newOwnerMemberId: "member-2" }),
+      buildContext()
+    );
 
     expect(response.status).toBe(200);
 

--- a/tests/integration/leave-route-revokes-oauth.test.ts
+++ b/tests/integration/leave-route-revokes-oauth.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const USER_ID = "user-1";
+const ORG_ID = "org-1";
+
+const { mockGetSession, mockGetActiveOrgId, selectState, txDeleteCalls } =
+  vi.hoisted(() => ({
+    mockGetSession: vi.fn(),
+    mockGetActiveOrgId: vi.fn(),
+    selectState: {
+      currentMember: [] as unknown[],
+      ownerCount: [] as unknown[],
+    },
+    txDeleteCalls: [] as Array<{ table: unknown; whereArg: unknown }>,
+  }));
+
+vi.mock("@/lib/auth", () => ({
+  auth: { api: { getSession: mockGetSession } },
+}));
+
+vi.mock("@/lib/auth-session-token-hash", () => ({
+  hashSessionToken: (token: string): string => `hashed:${token}`,
+}));
+
+vi.mock("@/lib/middleware/org-context", () => ({
+  getActiveOrgId: mockGetActiveOrgId,
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "DATABASE" },
+  logSystemError: vi.fn(),
+}));
+
+// Capture the structured filter objects so the test can assert exactly which
+// rows the route targets.
+vi.mock("drizzle-orm", () => ({
+  and: (...conditions: unknown[]) => ({ op: "and", conditions }),
+  eq: (column: unknown, value: unknown) => ({ op: "eq", column, value }),
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  member: {
+    id: "member.id",
+    organizationId: "member.organizationId",
+    userId: "member.userId",
+    role: "member.role",
+  },
+  sessions: { token: "sessions.token" },
+  mcpOauthRefreshTokens: {
+    userId: "mcp.userId",
+    organizationId: "mcp.organizationId",
+  },
+}));
+
+const txStub = {
+  select: vi.fn(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(() =>
+        // The owner-count query awaits .where() directly; the member-role
+        // query chains .limit() off it. Serve both shapes from one stub.
+        Object.assign(Promise.resolve(selectState.ownerCount), {
+          limit: vi.fn(() => Promise.resolve(selectState.currentMember)),
+        })
+      ),
+    })),
+  })),
+  delete: vi.fn((table: unknown) => ({
+    where: vi.fn((whereArg: unknown) => {
+      txDeleteCalls.push({ table, whereArg });
+      return Promise.resolve(undefined);
+    }),
+  })),
+  update: vi.fn(() => ({
+    set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+  })),
+};
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    transaction: vi.fn(async (cb: (tx: typeof txStub) => Promise<unknown>) => {
+      return await cb(txStub);
+    }),
+  },
+}));
+
+import { POST } from "@/app/api/organizations/[organizationId]/leave/route";
+
+function buildRequest(body: unknown): Request {
+  return new Request(`http://localhost/api/organizations/${ORG_ID}/leave`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function buildContext(): { params: Promise<{ organizationId: string }> } {
+  return { params: Promise.resolve({ organizationId: ORG_ID }) };
+}
+
+type EqCondition = { op: "eq"; column: string; value: unknown };
+type AndCondition = { op: "and"; conditions: EqCondition[] };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  txDeleteCalls.length = 0;
+  selectState.currentMember = [];
+  selectState.ownerCount = [];
+  mockGetActiveOrgId.mockReturnValue(null);
+});
+
+describe("POST /api/organizations/[id]/leave -- OAuth refresh token revocation", () => {
+  it("deletes the leaving user's MCP OAuth refresh tokens for the org", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: USER_ID },
+      session: { token: "raw-token" },
+    });
+    selectState.currentMember = [{ id: "member-1", role: "member" }];
+    selectState.ownerCount = [{ id: "owner-other" }];
+
+    const response = await POST(buildRequest({}), buildContext());
+
+    expect(response.status).toBe(200);
+
+    const oauthDelete = txDeleteCalls.find((call) => {
+      const where = call.whereArg as AndCondition;
+      return (
+        where?.op === "and" &&
+        where.conditions.some((c) => c.column === "mcp.userId")
+      );
+    });
+
+    expect(oauthDelete).toBeDefined();
+    const conditions = (oauthDelete?.whereArg as AndCondition).conditions;
+    expect(conditions).toContainEqual({
+      op: "eq",
+      column: "mcp.userId",
+      value: USER_ID,
+    });
+    expect(conditions).toContainEqual({
+      op: "eq",
+      column: "mcp.organizationId",
+      value: ORG_ID,
+    });
+  });
+});

--- a/tests/integration/oauth-token-route-deactivated.test.ts
+++ b/tests/integration/oauth-token-route-deactivated.test.ts
@@ -11,6 +11,7 @@ const {
   mockDeleteRefreshToken,
   mockStoreRefreshToken,
   mockCreateAccessToken,
+  mockIsMember,
 } = vi.hoisted(() => ({
   mockUsersFindFirst: vi.fn(),
   mockGetAuthCode: vi.fn(),
@@ -20,6 +21,7 @@ const {
   mockDeleteRefreshToken: vi.fn(),
   mockStoreRefreshToken: vi.fn(),
   mockCreateAccessToken: vi.fn(),
+  mockIsMember: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -30,6 +32,10 @@ vi.mock("@/lib/db/schema", () => ({ users: { id: "id" } }));
 
 vi.mock("@/lib/mcp/oauth-auth", () => ({
   createAccessToken: mockCreateAccessToken,
+}));
+
+vi.mock("@/lib/workflow/access", () => ({
+  isUserMemberOfOrganization: mockIsMember,
 }));
 
 vi.mock("@/lib/mcp/oauth-store", () => ({
@@ -80,6 +86,9 @@ function stubActiveOAuthClient(): void {
 beforeEach(() => {
   vi.clearAllMocks();
   mockCreateAccessToken.mockResolvedValue("access-token-stub");
+  // Default to a current member so deactivation-focused cases are unaffected;
+  // membership-focused cases override this explicitly.
+  mockIsMember.mockResolvedValue(true);
 });
 
 describe("POST /api/oauth/token -- authorization_code grant", () => {
@@ -154,6 +163,7 @@ describe("POST /api/oauth/token -- refresh_token grant", () => {
       scope: "read",
     });
     mockUsersFindFirst.mockResolvedValue({ deactivatedAt: null });
+    mockIsMember.mockResolvedValue(true);
 
     const response = await postForm({
       grant_type: "refresh_token",
@@ -165,6 +175,35 @@ describe("POST /api/oauth/token -- refresh_token grant", () => {
     expect(mockDeleteRefreshToken).toHaveBeenCalledWith("refresh-1");
     expect(mockStoreRefreshToken).toHaveBeenCalledTimes(1);
     expect(mockCreateAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects refresh_token exchange when no longer an org member", async () => {
+    // The user was removed from (or left) the org after the refresh token was
+    // issued. The presented token is still rotated out, but no fresh
+    // org-scoped credential is minted in its place.
+    stubActiveOAuthClient();
+    mockGetRefreshToken.mockResolvedValue({
+      userId: TEST_USER_ID,
+      organizationId: TEST_ORG_ID,
+      clientId: TEST_CLIENT_ID,
+      scope: "read",
+    });
+    mockUsersFindFirst.mockResolvedValue({ deactivatedAt: null });
+    mockIsMember.mockResolvedValue(false);
+
+    const response = await postForm({
+      grant_type: "refresh_token",
+      refresh_token: "refresh-1",
+      client_id: TEST_CLIENT_ID,
+    });
+
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error?: string };
+    expect(body.error).toBe("User is no longer a member of this organization");
+    expect(mockIsMember).toHaveBeenCalledWith(TEST_USER_ID, TEST_ORG_ID);
+    expect(mockDeleteRefreshToken).toHaveBeenCalledWith("refresh-1");
+    expect(mockStoreRefreshToken).not.toHaveBeenCalled();
+    expect(mockCreateAccessToken).not.toHaveBeenCalled();
   });
 
   it("rejects refresh_token exchange for a deactivated user", async () => {

--- a/tests/unit/oauth-auth-deactivated.test.ts
+++ b/tests/unit/oauth-auth-deactivated.test.ts
@@ -13,6 +13,13 @@ vi.mock("@/lib/db", () => ({
 
 vi.mock("@/lib/db/schema", () => ({ users: { id: "id" } }));
 
+// authenticateOAuthToken now also re-checks org membership; the active-user
+// case must look like a current member so the deactivation behaviour under
+// test is exercised in isolation.
+vi.mock("@/lib/workflow/access", () => ({
+  isUserMemberOfOrganization: vi.fn().mockResolvedValue(true),
+}));
+
 vi.mock("@sentry/nextjs", () => ({
   captureMessage: (message: string, context: unknown): void => {
     mockCaptureMessage(message, context);

--- a/tests/unit/oauth-auth-membership.test.ts
+++ b/tests/unit/oauth-auth-membership.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { mockUsersFindFirst, mockIsMember } = vi.hoisted(() => ({
+  mockUsersFindFirst: vi.fn(),
+  mockIsMember: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: { query: { users: { findFirst: mockUsersFindFirst } } },
+}));
+
+vi.mock("@/lib/db/schema", () => ({ users: { id: "id" } }));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureMessage: vi.fn(),
+}));
+
+vi.mock("@/lib/workflow/access", () => ({
+  isUserMemberOfOrganization: mockIsMember,
+}));
+
+const TEST_SECRET = "test-secret-32-bytes-long-enough-for-hs256";
+process.env.OAUTH_JWT_SECRET = TEST_SECRET;
+
+import {
+  authenticateOAuthToken,
+  createAccessToken,
+} from "@/lib/mcp/oauth-auth";
+
+function buildRequestWithToken(token: string): Request {
+  return new Request("http://localhost/api/anything", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: the token subject is an active (non-deactivated) user so the
+  // membership re-check is the only gate under test.
+  mockUsersFindFirst.mockResolvedValue({ deactivatedAt: null });
+});
+
+describe("authenticateOAuthToken -- org membership re-check", () => {
+  it("rejects a token whose subject is no longer a member of the org", async () => {
+    const token = await createAccessToken({
+      sub: "user-1",
+      org: "org-1",
+      scope: "read",
+    });
+    mockIsMember.mockResolvedValue(false);
+
+    const result = await authenticateOAuthToken(buildRequestWithToken(token));
+
+    expect(result.authenticated).toBe(false);
+    expect(result.statusCode).toBe(401);
+    expect(result.error).toBe(
+      "User is no longer a member of this organization"
+    );
+    expect(mockIsMember).toHaveBeenCalledWith("user-1", "org-1");
+  });
+
+  it("authenticates a token whose subject is a current member", async () => {
+    const token = await createAccessToken({
+      sub: "user-1",
+      org: "org-1",
+      scope: "read",
+    });
+    mockIsMember.mockResolvedValue(true);
+
+    const result = await authenticateOAuthToken(buildRequestWithToken(token));
+
+    expect(result.authenticated).toBe(true);
+    expect(result.userId).toBe("user-1");
+    expect(result.organizationId).toBe("org-1");
+    expect(result.scope).toBe("read");
+  });
+});

--- a/tests/unit/oauth-store-revoke.test.ts
+++ b/tests/unit/oauth-store-revoke.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const USER_ID = "user-1";
+const ORG_ID = "org-1";
+
+const { deleteCalls } = vi.hoisted(() => ({
+  deleteCalls: [] as Array<{ table: unknown; whereArg: unknown }>,
+}));
+
+// Capture the structured filter objects so the test can assert exactly which
+// rows the helper targets.
+vi.mock("drizzle-orm", () => ({
+  and: (...conditions: unknown[]) => ({ op: "and", conditions }),
+  eq: (column: unknown, value: unknown) => ({ op: "eq", column, value }),
+  lt: (column: unknown, value: unknown) => ({ op: "lt", column, value }),
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  mcpOauthAuthCodes: {},
+  mcpOauthClients: {},
+  mcpOauthRefreshTokens: {
+    userId: "mcp.userId",
+    organizationId: "mcp.organizationId",
+    tokenHash: "mcp.tokenHash",
+  },
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    delete: vi.fn((table: unknown) => ({
+      where: vi.fn((whereArg: unknown) => {
+        deleteCalls.push({ table, whereArg });
+        return Promise.resolve(undefined);
+      }),
+    })),
+  },
+}));
+
+import { revokeRefreshTokensForUserOrg } from "@/lib/mcp/oauth-store";
+
+type EqCondition = { op: "eq"; column: string; value: unknown };
+type AndCondition = { op: "and"; conditions: EqCondition[] };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  deleteCalls.length = 0;
+});
+
+describe("revokeRefreshTokensForUserOrg", () => {
+  it("deletes the refresh tokens scoped to the given user and org", async () => {
+    await revokeRefreshTokensForUserOrg(USER_ID, ORG_ID);
+
+    expect(deleteCalls).toHaveLength(1);
+    const where = deleteCalls[0]?.whereArg as AndCondition;
+    expect(where.op).toBe("and");
+    expect(where.conditions).toContainEqual({
+      op: "eq",
+      column: "mcp.userId",
+      value: USER_ID,
+    });
+    expect(where.conditions).toContainEqual({
+      op: "eq",
+      column: "mcp.organizationId",
+      value: ORG_ID,
+    });
+  });
+});


### PR DESCRIPTION
## What this fixes

Finding A-04. The OAuth/MCP token auth layer verified the caller was not deactivated but never re-checked that they are still a **member** of the org in the token's `org` claim. A member removed from an org but whose account stays active kept full OAuth/MCP access for up to 1h per access token, and the refresh grant re-minted a fresh 1h access token plus a fresh 30-day refresh token after only a deactivation check — making the persistence indefinitely self-renewing.

The asymmetry was real: the API-key path already rejects a creator who is no longer a member, and execution-time integration access re-checks membership — but the OAuth auth layer did not.

## Change

- `lib/mcp/oauth-auth.ts` — `authenticateOAuthToken` now requires a non-empty subject and calls `isUserMemberOfOrganization(sub, org)`, returning 401 if the caller is no longer a member. This gates every OAuth/MCP surface (all four callers funnel through it).
- `app/api/oauth/token/route.ts` — `handleRefreshToken` re-checks membership after rotating (deleting) the presented refresh token and before minting a new pair, so a removed member cannot cycle the refresh token.
- `app/api/organizations/[organizationId]/leave/route.ts` — revokes the leaving user's `mcpOauthRefreshTokens` for the org inside the existing member-delete transaction (both the sole-owner and regular-member paths), for hygiene / defense-in-depth.

Reuses the existing `isUserMemberOfOrganization` helper; no import cycle; one extra indexed query per OAuth request.

## Tests

- `tests/unit/oauth-auth-membership.test.ts` — rejects a non-member token (401); authenticates a current member.
- `tests/integration/oauth-token-route-deactivated.test.ts` — refresh exchange rejected for a non-member (presented token still invalidated; no new pair minted).
- `tests/integration/leave-route-revokes-oauth.test.ts` — leave deletes the user's OAuth refresh tokens scoped to user + org.

All fail on the pre-fix tree and pass after.

## Scope / follow-ups (not in this PR)

- Admin-initiated `removeMember` (Better Auth plugin) does not cascade-revoke refresh tokens; the auth-layer and refresh re-checks already neutralize access, so the stale rows are inert (DB hygiene). Tracked separately.
- The analytics SSE stream re-validates org membership only at connect, not during its sub-5-minute poll loop (session-auth surface, read-only aggregate). Tracked separately.
- The `authorization_code` grant could also re-check membership at mint for symmetry (non-exploitable today; caught at use-time).
