### PR TITLE
fix(auth): remove unused better-auth bearer plugin to close MFA and IP gate bypass

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -5,9 +5,6 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { APIError } from "better-auth/api";
 import {
   anonymous,
-  // start custom keeperhub code //
-  bearer,
-  // end keeperhub code //
   captcha,
   deviceAuthorization,
   emailOTP,
@@ -181,7 +178,6 @@ const captchaPlugins =
 // Build plugins array conditionally
 const plugins = [
   // start custom keeperhub code //
-  bearer(),
   deviceAuthorization({
     expiresIn: "15m",
     interval: "5s",

--- a/tests/unit/auth-plugins.test.ts
+++ b/tests/unit/auth-plugins.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// lib/auth pulls in lib/redis (via login-risk) which imports ioredis. Stub it
+// so the module graph resolves without a live Redis: this test only inspects
+// the statically-constructed plugin list, not any runtime Redis behaviour.
+vi.mock("ioredis", () => ({ Redis: class {} }));
+
+// Better Auth plugins expose a stable string `id`. The registered list lives
+// on the constructed auth object at `auth.options.plugins`.
+type PluginShape = { id: string };
+
+function registeredPluginIds(plugins: unknown[]): string[] {
+  return plugins.map((p) => (p as PluginShape).id);
+}
+
+describe("auth plugin registration", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("does not register the better-auth bearer plugin", async () => {
+    vi.stubEnv("NODE_ENV", "test");
+    const { auth } = await import("@/lib/auth");
+    const ids = registeredPluginIds(auth.options.plugins ?? []);
+    expect(ids.some((id) => id === "bearer")).toBe(false);
+  });
+
+  it("still registers deviceAuthorization and twoFactor (surgical-removal guard)", async () => {
+    vi.stubEnv("NODE_ENV", "test");
+    const { auth } = await import("@/lib/auth");
+    const ids = registeredPluginIds(auth.options.plugins ?? []);
+    expect(ids.some((id) => id === "device-authorization")).toBe(true);
+    expect(ids.some((id) => id === "two-factor")).toBe(true);
+  });
+});


### PR DESCRIPTION
## What this fixes

Finding F-021. The Better Auth `bearer()` plugin let a caller authenticate with `Authorization: Bearer <session-token>` and no cookie. The proxy's CSRF, mandatory-MFA, and IP-trust gates all key off `hasSessionCookie()`, which inspects only the `Cookie` header — so a bearer-only request short-circuited every gate. That is exactly the "stolen session token replayed from a new network" threat the IP/MFA gates are designed to stop. The plugin's after-hook also exposed the raw session token via the JS-readable `set-auth-token` response header on sign-in.

## Why removal, not gating

A multi-repo investigation found `bearer()` was unused speculative scaffolding (added alongside `deviceAuthorization` for a CLI-auth feature whose client half was never built): no first-party client uses it, and the three real bearer-shaped credentials — `kh_` API keys, OAuth-JWT, and `wfb_` webhook tokens — all have independent auth paths that do not route through it. The CLI authenticates with `kh_` keys; the MCP client uses an API key; `@keeperhub/wallet` uses a cookie. Removing the plugin affects none of them.

## Change

- `lib/auth.ts` — removed the `bearer()` plugin and its import. `deviceAuthorization`, `twoFactor`, and all other plugins are unchanged.

## Tests

- `tests/unit/auth-plugins.test.ts` — asserts no plugin with id `bearer` is registered, and that `device-authorization` and `two-factor` remain (surgical-removal guard). Verified to fail on the pre-fix tree (bearer present) and pass after.

Regression suites `trusted-origins` and `dual-auth-context` remain green (51 tests).

## Follow-up (not in this PR)

- Several sensitive routes that call `getSession` directly rely on the proxy for the MFA/IP gate; adding per-route step-up / IP defense-in-depth is worth tracking.
