### PR TITLE
fix(auth): invalidate sessions on password reset and change

### DIFF
--- a/app/api/user/forgot-password/route.ts
+++ b/app/api/user/forgot-password/route.ts
@@ -1,6 +1,6 @@
 import { randomInt, timingSafeEqual } from "node:crypto";
 import { symmetricDecrypt, symmetricEncrypt } from "better-auth/crypto";
-import { and, eq, gt, isNull } from "drizzle-orm";
+import { and, eq, gt } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import {
@@ -9,7 +9,6 @@ import {
   deviceCode,
   mcpOauthAuthCodes,
   mcpOauthRefreshTokens,
-  organizationApiKeys,
   sessions,
   twoFactor as twoFactorTable,
   users,
@@ -368,20 +367,26 @@ async function handleReset(
   }
 
   // Hash the new password, drop the consumed reset code, and revoke every
-  // credential this user holds in a single transaction. A reset is a recovery
+  // user-scoped credential in a single transaction. A reset is a recovery
   // path the user may be invoking precisely because they lost control of the
   // account, so nothing minted before the reset may survive it. Sessions alone
   // are not enough: API keys, MCP refresh tokens, auth codes, and device codes
   // each authenticate standalone with no password or session, so a stolen one
-  // would outlive the reset. This mirrors the cascade that runs on user
-  // deactivation (drizzle/0085), the other compromise-revocation path. The
-  // reset flow itself mints no session, so the user signs in fresh.
+  // would outlive the reset. The reset flow itself mints no session, so the
+  // user signs in fresh.
+  //
+  // Organization API keys are deliberately NOT revoked here. They are
+  // org-owned, not user-owned (created_by records provenance, not ownership),
+  // and minting one already requires admin/owner role plus dual-factor, so a
+  // password reset is the wrong lever: it would take down the org's running
+  // automation on a routine, usually-benign event. Genuine account compromise
+  // is handled by account deactivation, whose cascade (drizzle/0085) revokes
+  // org keys; an exfiltrated key is revoked per-key via /api/keys/[keyId].
   const hashedPassword = await hashPassword(newPassword);
-  const revokedAt = new Date();
   await db.transaction(async (tx) => {
     await tx
       .update(accounts)
-      .set({ password: hashedPassword, updatedAt: revokedAt })
+      .set({ password: hashedPassword, updatedAt: new Date() })
       .where(eq(accounts.id, credentialAccount.id));
 
     await tx.delete(verifications).where(eq(verifications.id, verification.id));
@@ -395,15 +400,6 @@ async function handleReset(
       .delete(mcpOauthAuthCodes)
       .where(eq(mcpOauthAuthCodes.userId, user.id));
     await tx.delete(deviceCode).where(eq(deviceCode.userId, user.id));
-    await tx
-      .update(organizationApiKeys)
-      .set({ revokedAt })
-      .where(
-        and(
-          eq(organizationApiKeys.createdBy, user.id),
-          isNull(organizationApiKeys.revokedAt)
-        )
-      );
   });
 
   return NextResponse.json({

--- a/app/api/user/forgot-password/route.ts
+++ b/app/api/user/forgot-password/route.ts
@@ -5,6 +5,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import {
   accounts,
+  sessions,
   twoFactor as twoFactorTable,
   users,
   verifications,
@@ -361,15 +362,23 @@ async function handleReset(
     }
   }
 
-  // Hash and update password
+  // Hash the new password, drop the consumed reset code, and revoke
+  // every session for this user in a single transaction. A reset is a
+  // recovery path the user may be invoking precisely because they lost
+  // control of the account, so any session minted before the reset must
+  // not survive it. The reset flow itself mints no session, so all of
+  // them are cleared and the user signs in fresh.
   const hashedPassword = await hashPassword(newPassword);
-  await db
-    .update(accounts)
-    .set({ password: hashedPassword, updatedAt: new Date() })
-    .where(eq(accounts.id, credentialAccount.id));
+  await db.transaction(async (tx) => {
+    await tx
+      .update(accounts)
+      .set({ password: hashedPassword, updatedAt: new Date() })
+      .where(eq(accounts.id, credentialAccount.id));
 
-  // Delete used verification
-  await db.delete(verifications).where(eq(verifications.id, verification.id));
+    await tx.delete(verifications).where(eq(verifications.id, verification.id));
+
+    await tx.delete(sessions).where(eq(sessions.userId, user.id));
+  });
 
   return NextResponse.json({
     success: true,

--- a/app/api/user/forgot-password/route.ts
+++ b/app/api/user/forgot-password/route.ts
@@ -1,10 +1,15 @@
 import { randomInt, timingSafeEqual } from "node:crypto";
 import { symmetricDecrypt, symmetricEncrypt } from "better-auth/crypto";
-import { and, eq, gt } from "drizzle-orm";
+import { and, eq, gt, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import {
   accounts,
+  apiKeys,
+  deviceCode,
+  mcpOauthAuthCodes,
+  mcpOauthRefreshTokens,
+  organizationApiKeys,
   sessions,
   twoFactor as twoFactorTable,
   users,
@@ -362,22 +367,43 @@ async function handleReset(
     }
   }
 
-  // Hash the new password, drop the consumed reset code, and revoke
-  // every session for this user in a single transaction. A reset is a
-  // recovery path the user may be invoking precisely because they lost
-  // control of the account, so any session minted before the reset must
-  // not survive it. The reset flow itself mints no session, so all of
-  // them are cleared and the user signs in fresh.
+  // Hash the new password, drop the consumed reset code, and revoke every
+  // credential this user holds in a single transaction. A reset is a recovery
+  // path the user may be invoking precisely because they lost control of the
+  // account, so nothing minted before the reset may survive it. Sessions alone
+  // are not enough: API keys, MCP refresh tokens, auth codes, and device codes
+  // each authenticate standalone with no password or session, so a stolen one
+  // would outlive the reset. This mirrors the cascade that runs on user
+  // deactivation (drizzle/0085), the other compromise-revocation path. The
+  // reset flow itself mints no session, so the user signs in fresh.
   const hashedPassword = await hashPassword(newPassword);
+  const revokedAt = new Date();
   await db.transaction(async (tx) => {
     await tx
       .update(accounts)
-      .set({ password: hashedPassword, updatedAt: new Date() })
+      .set({ password: hashedPassword, updatedAt: revokedAt })
       .where(eq(accounts.id, credentialAccount.id));
 
     await tx.delete(verifications).where(eq(verifications.id, verification.id));
 
     await tx.delete(sessions).where(eq(sessions.userId, user.id));
+    await tx.delete(apiKeys).where(eq(apiKeys.userId, user.id));
+    await tx
+      .delete(mcpOauthRefreshTokens)
+      .where(eq(mcpOauthRefreshTokens.userId, user.id));
+    await tx
+      .delete(mcpOauthAuthCodes)
+      .where(eq(mcpOauthAuthCodes.userId, user.id));
+    await tx.delete(deviceCode).where(eq(deviceCode.userId, user.id));
+    await tx
+      .update(organizationApiKeys)
+      .set({ revokedAt })
+      .where(
+        and(
+          eq(organizationApiKeys.createdBy, user.id),
+          isNull(organizationApiKeys.revokedAt)
+        )
+      );
   });
 
   return NextResponse.json({

--- a/app/api/user/password/route.ts
+++ b/app/api/user/password/route.ts
@@ -1,8 +1,8 @@
-import { eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { accounts } from "@/lib/db/schema";
+import { accounts, sessions } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { requireDualFactor } from "@/lib/mfa/dual-factor";
 import { hashPassword, verifyPassword } from "@/lib/password";
@@ -112,12 +112,31 @@ export async function POST(request: Request): Promise<NextResponse> {
       );
     }
 
-    // Hash and update new password
+    // Rotate the password and invalidate every other session in a single
+    // transaction so a mid-write failure cannot leave the new password set
+    // while a previously phished or stolen cookie outlives the change. The
+    // session the caller just re-authenticated from is preserved (the ne()
+    // guard) so they stay signed in on the device they made the change from;
+    // if its id is unavailable we fail secure and drop every session.
     const hashedPassword = await hashPassword(newPassword);
-    await db
-      .update(accounts)
-      .set({ password: hashedPassword, updatedAt: new Date() })
-      .where(eq(accounts.id, credentialAccount.id));
+    const currentSessionId = (session.session as { id?: string } | undefined)
+      ?.id;
+    await db.transaction(async (tx) => {
+      await tx
+        .update(accounts)
+        .set({ password: hashedPassword, updatedAt: new Date() })
+        .where(eq(accounts.id, credentialAccount.id));
+      await tx
+        .delete(sessions)
+        .where(
+          currentSessionId
+            ? and(
+                eq(sessions.userId, session.user.id),
+                ne(sessions.id, currentSessionId)
+              )
+            : eq(sessions.userId, session.user.id)
+        );
+    });
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/tests/e2e/vitest/forgot-password-reset-revocation.test.ts
+++ b/tests/e2e/vitest/forgot-password-reset-revocation.test.ts
@@ -1,0 +1,303 @@
+import { randomUUID } from "node:crypto";
+import { symmetricEncrypt } from "better-auth/crypto";
+import { eq, sql } from "drizzle-orm";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+// This spec drives the real reset handler against a real Postgres so it proves
+// the credential rows are actually gone after a reset, not merely that a delete
+// was issued (which the mocked tests/integration spec already covers). Only the
+// non-DB collaborators are stubbed; @/lib/db is restored to the real
+// postgres-backed singleton (tests/setup.ts globally replaces it with an
+// in-memory stub).
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { AUTH: "AUTH", CONFIGURATION: "CONFIGURATION" },
+  logSystemError: vi.fn(),
+}));
+vi.mock("@/lib/email", () => ({
+  sendOAuthPasswordResetEmail: vi.fn(),
+  sendVerificationOTP: vi.fn(),
+}));
+vi.mock("@/lib/security/trusted-proxies", () => ({
+  resolveTrustedClientIp: vi.fn(() => "203.0.113.10"),
+}));
+vi.mock("@/lib/db", async () => await vi.importActual("@/lib/db"));
+
+import { POST } from "@/app/api/user/forgot-password/route";
+import { db } from "@/lib/db";
+import {
+  accounts,
+  apiKeys,
+  deviceCode,
+  mcpOauthAuthCodes,
+  mcpOauthRefreshTokens,
+  organization,
+  organizationApiKeys,
+  sessions,
+  users,
+  verifications,
+} from "@/lib/db/schema";
+
+const SKIP = process.env.SKIP_INFRA_TESTS === "true";
+const SECRET = "test-better-auth-secret-0123456789abcdef";
+const OTP = "123456";
+const NEW_PASSWORD = "new-password-123";
+
+function future(minutes: number): Date {
+  return new Date(Date.now() + minutes * 60_000);
+}
+
+type Seeded = {
+  userId: string;
+  orgId: string;
+  email: string;
+  accountId: string;
+  verificationId: string;
+};
+
+async function seedUserWithCredentials(): Promise<Seeded> {
+  const suffix = randomUUID();
+  const userId = `u-${suffix}`;
+  const orgId = `o-${suffix}`;
+  const email = `reset-${suffix}@example.test`;
+  const accountId = `acc-${suffix}`;
+  const verificationId = `ver-${suffix}`;
+  const now = new Date();
+
+  await db.insert(users).values({
+    id: userId,
+    email,
+    emailVerified: true,
+    twoFactorEnabled: false,
+    createdAt: now,
+    updatedAt: now,
+  });
+  await db.insert(organization).values({
+    id: orgId,
+    name: `Org ${suffix}`,
+    slug: `slug-${suffix}`,
+    createdAt: now,
+  });
+  await db.insert(accounts).values({
+    id: accountId,
+    accountId: userId,
+    providerId: "credential",
+    userId,
+    password: "pre-reset-hash",
+    createdAt: now,
+    updatedAt: now,
+  });
+  // Encrypted reset code matching the handler's `${ciphertext}:0` format.
+  const value = `${await symmetricEncrypt({ key: SECRET, data: OTP })}:0`;
+  await db.insert(verifications).values({
+    id: verificationId,
+    identifier: email,
+    value,
+    expiresAt: future(5),
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  // One row in every user-scoped credential class the reset must revoke.
+  await db.insert(sessions).values({
+    id: `sess-${suffix}`,
+    token: `tok-${suffix}`,
+    userId,
+    expiresAt: future(60),
+    createdAt: now,
+    updatedAt: now,
+  });
+  await db.insert(apiKeys).values({
+    id: `ak-${suffix}`,
+    userId,
+    keyHash: `akhash-${suffix}`,
+    keyPrefix: "wfb_test",
+    createdAt: now,
+  });
+  await db.insert(mcpOauthRefreshTokens).values({
+    id: `mr-${suffix}`,
+    tokenHash: `mrhash-${suffix}`,
+    clientId: "test-client",
+    userId,
+    organizationId: orgId,
+    scope: "read",
+    expiresAt: future(60),
+  });
+  await db.insert(mcpOauthAuthCodes).values({
+    id: `mc-${suffix}`,
+    code: `code-${suffix}`,
+    clientId: "test-client",
+    redirectUri: "https://example.test/cb",
+    scope: "read",
+    userId,
+    organizationId: orgId,
+    codeChallenge: "challenge",
+    codeChallengeMethod: "S256",
+    expiresAt: future(60),
+  });
+  await db.insert(deviceCode).values({
+    id: `dc-${suffix}`,
+    deviceCode: `devc-${suffix}`,
+    userCode: `uc-${suffix}`,
+    userId,
+    status: "pending",
+    expiresAt: future(60),
+  });
+  // Org-owned key created by this user: must survive the reset.
+  await db.insert(organizationApiKeys).values({
+    id: `oak-${suffix}`,
+    organizationId: orgId,
+    name: "team-integration",
+    keyHash: `oakhash-${suffix}`,
+    keyPrefix: "kh_test",
+    createdBy: userId,
+    createdAt: now,
+  });
+
+  return { userId, orgId, email, accountId, verificationId };
+}
+
+async function rowCount(
+  table: typeof sessions | typeof apiKeys | typeof deviceCode,
+  userId: string
+): Promise<number> {
+  const rows = await db
+    .select({ id: table.id })
+    .from(table)
+    .where(eq(table.userId, userId));
+  return rows.length;
+}
+
+function resetRequest(email: string): Request {
+  return new Request("http://localhost/api/user/forgot-password", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      action: "reset",
+      email,
+      otp: OTP,
+      newPassword: NEW_PASSWORD,
+    }),
+  });
+}
+
+const cleanup: Seeded[] = [];
+
+async function purge(s: Seeded): Promise<void> {
+  await db
+    .delete(organizationApiKeys)
+    .where(eq(organizationApiKeys.organizationId, s.orgId));
+  await db
+    .delete(mcpOauthAuthCodes)
+    .where(eq(mcpOauthAuthCodes.userId, s.userId));
+  await db
+    .delete(mcpOauthRefreshTokens)
+    .where(eq(mcpOauthRefreshTokens.userId, s.userId));
+  await db.delete(deviceCode).where(eq(deviceCode.userId, s.userId));
+  await db.delete(apiKeys).where(eq(apiKeys.userId, s.userId));
+  await db.delete(sessions).where(eq(sessions.userId, s.userId));
+  await db.delete(accounts).where(eq(accounts.userId, s.userId));
+  await db.delete(verifications).where(eq(verifications.identifier, s.email));
+  await db.delete(organization).where(eq(organization.id, s.orgId));
+  await db.delete(users).where(eq(users.id, s.userId));
+}
+
+describe.skipIf(SKIP)(
+  "POST /api/user/forgot-password reset (real Postgres)",
+  () => {
+    beforeAll(async () => {
+      process.env.BETTER_AUTH_SECRET = SECRET;
+      try {
+        await db.execute(sql`select 1`);
+      } catch (error) {
+        throw new Error(
+          `This spec needs a migrated Postgres at DATABASE_URL. Set SKIP_INFRA_TESTS=true to skip. Cause: ${String(error)}`
+        );
+      }
+    });
+
+    afterEach(async () => {
+      while (cleanup.length > 0) {
+        const s = cleanup.pop();
+        if (s) {
+          await purge(s);
+        }
+      }
+    });
+
+    it("revokes every user-scoped credential and keeps org keys", async () => {
+      const s = await seedUserWithCredentials();
+      cleanup.push(s);
+
+      const response = await POST(resetRequest(s.email));
+      expect(response.status).toBe(200);
+
+      // Password was rotated to a fresh hash.
+      const [account] = await db
+        .select({ password: accounts.password })
+        .from(accounts)
+        .where(eq(accounts.id, s.accountId));
+      expect(account?.password).toBeTruthy();
+      expect(account?.password).not.toBe("pre-reset-hash");
+
+      // Every user-scoped credential row is gone.
+      expect(await rowCount(sessions, s.userId)).toBe(0);
+      expect(await rowCount(apiKeys, s.userId)).toBe(0);
+      expect(await rowCount(deviceCode, s.userId)).toBe(0);
+      const mcpRefresh = await db
+        .select({ id: mcpOauthRefreshTokens.id })
+        .from(mcpOauthRefreshTokens)
+        .where(eq(mcpOauthRefreshTokens.userId, s.userId));
+      expect(mcpRefresh).toHaveLength(0);
+      const mcpCodes = await db
+        .select({ id: mcpOauthAuthCodes.id })
+        .from(mcpOauthAuthCodes)
+        .where(eq(mcpOauthAuthCodes.userId, s.userId));
+      expect(mcpCodes).toHaveLength(0);
+
+      // The consumed reset code is deleted.
+      const leftoverVerification = await db
+        .select({ id: verifications.id })
+        .from(verifications)
+        .where(eq(verifications.id, s.verificationId));
+      expect(leftoverVerification).toHaveLength(0);
+
+      // The org-owned API key is untouched: present and not revoked.
+      const [orgKey] = await db
+        .select({ revokedAt: organizationApiKeys.revokedAt })
+        .from(organizationApiKeys)
+        .where(eq(organizationApiKeys.createdBy, s.userId));
+      expect(orgKey).toBeDefined();
+      expect(orgKey?.revokedAt).toBeNull();
+    });
+
+    it("leaves all credentials intact when the OTP is wrong", async () => {
+      const s = await seedUserWithCredentials();
+      cleanup.push(s);
+
+      const badRequest = new Request(
+        "http://localhost/api/user/forgot-password",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            action: "reset",
+            email: s.email,
+            otp: "000000",
+            newPassword: NEW_PASSWORD,
+          }),
+        }
+      );
+      const response = await POST(badRequest);
+      expect(response.status).toBe(400);
+
+      expect(await rowCount(sessions, s.userId)).toBe(1);
+      expect(await rowCount(apiKeys, s.userId)).toBe(1);
+      const [account] = await db
+        .select({ password: accounts.password })
+        .from(accounts)
+        .where(eq(accounts.id, s.accountId));
+      expect(account?.password).toBe("pre-reset-hash");
+    });
+  }
+);

--- a/tests/integration/user-forgot-password-route.test.ts
+++ b/tests/integration/user-forgot-password-route.test.ts
@@ -19,7 +19,6 @@ const {
   mockEq,
   mockAnd,
   mockGt,
-  mockIsNull,
   txUpdateCalls,
   txDeleteCalls,
 } = vi.hoisted(() => ({
@@ -37,7 +36,6 @@ const {
   mockGt: vi.fn((column: unknown, value: unknown) => ({
     __gt: [column, value],
   })),
-  mockIsNull: vi.fn((column: unknown) => ({ __isNull: column })),
   txUpdateCalls: [] as Array<{ table: unknown; value: unknown }>,
   txDeleteCalls: [] as Array<{ table: unknown }>,
 }));
@@ -46,7 +44,6 @@ vi.mock("drizzle-orm", () => ({
   and: mockAnd,
   eq: mockEq,
   gt: mockGt,
-  isNull: mockIsNull,
 }));
 
 vi.mock("better-auth/crypto", () => ({
@@ -134,7 +131,6 @@ import {
   deviceCode as deviceCodeToken,
   mcpOauthAuthCodes as mcpOauthAuthCodesToken,
   mcpOauthRefreshTokens as mcpOauthRefreshTokensToken,
-  organizationApiKeys as organizationApiKeysToken,
   sessions as sessionsToken,
 } from "@/lib/db/schema";
 
@@ -184,10 +180,10 @@ describe("POST /api/user/forgot-password (reset)", () => {
 
     expect(response.status).toBe(200);
 
-    // The reset revokes every credential the user holds, not just sessions:
-    // the transaction deletes the consumed verification row plus sessions,
-    // api keys, MCP refresh tokens, MCP auth codes, and device codes, and
-    // updates the account password plus revokes the user's org api keys.
+    // The reset revokes every user-scoped credential, not just sessions: the
+    // transaction deletes the consumed verification row plus sessions, api
+    // keys, MCP refresh tokens, MCP auth codes, and device codes, each keyed
+    // on the user id.
     expect(mockTransaction).toHaveBeenCalledTimes(1);
     expect(txDeleteCalls).toHaveLength(6);
     const deletedTables = txDeleteCalls.map((call) => call.table);
@@ -205,21 +201,16 @@ describe("POST /api/user/forgot-password (reset)", () => {
     expect(mockEq).toHaveBeenCalledWith("mcpOauthAuthCodes.userId", USER_ID);
     expect(mockEq).toHaveBeenCalledWith("deviceCode.userId", USER_ID);
 
-    // Org api keys are soft-revoked (revokedAt set) for keys this user
-    // created that are not already revoked, not hard-deleted.
-    expect(txUpdateCalls).toHaveLength(2);
-    const orgKeyUpdate = txUpdateCalls.find(
-      (call) => call.table === organizationApiKeysToken
-    );
-    expect(orgKeyUpdate).toBeDefined();
+    // The only update is the account password rotation. Organization api keys
+    // are org-owned and are deliberately not touched by a user password reset.
+    expect(txUpdateCalls).toHaveLength(1);
     expect(
-      (orgKeyUpdate?.value as { revokedAt?: Date }).revokedAt
-    ).toBeInstanceOf(Date);
-    expect(mockEq).toHaveBeenCalledWith(
+      (txUpdateCalls[0].value as { password?: string }).password
+    ).toBeDefined();
+    expect(mockEq).not.toHaveBeenCalledWith(
       "organizationApiKeys.createdBy",
       USER_ID
     );
-    expect(mockIsNull).toHaveBeenCalledWith("organizationApiKeys.revokedAt");
   });
 
   it("does not touch sessions when the OTP is invalid or expired", async () => {

--- a/tests/integration/user-forgot-password-route.test.ts
+++ b/tests/integration/user-forgot-password-route.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const USER_ID = "user-1";
+const USER_EMAIL = "user@example.com";
+const CREDENTIAL_ACCOUNT_ID = "acct-credential";
+const VERIFICATION_ID = "verification-1";
+const VALID_OTP = "123456";
+
+const {
+  mockVerificationsFindFirst,
+  mockUsersFindFirst,
+  mockAccountsFindFirst,
+  mockTransaction,
+  mockHashPassword,
+  mockSymmetricDecrypt,
+  mockSymmetricEncrypt,
+  mockEq,
+  mockAnd,
+  mockGt,
+  txUpdateCalls,
+  txDeleteCalls,
+} = vi.hoisted(() => ({
+  mockVerificationsFindFirst: vi.fn(),
+  mockUsersFindFirst: vi.fn(),
+  mockAccountsFindFirst: vi.fn(),
+  mockTransaction: vi.fn(),
+  mockHashPassword: vi.fn(),
+  mockSymmetricDecrypt: vi.fn(),
+  mockSymmetricEncrypt: vi.fn(),
+  mockEq: vi.fn((column: unknown, value: unknown) => ({
+    __eq: [column, value],
+  })),
+  mockAnd: vi.fn((...args: unknown[]) => ({ __and: args })),
+  mockGt: vi.fn((column: unknown, value: unknown) => ({
+    __gt: [column, value],
+  })),
+  txUpdateCalls: [] as Array<{ table: unknown; value: unknown }>,
+  txDeleteCalls: [] as Array<{ table: unknown }>,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: mockAnd,
+  eq: mockEq,
+  gt: mockGt,
+}));
+
+vi.mock("better-auth/crypto", () => ({
+  symmetricDecrypt: mockSymmetricDecrypt,
+  symmetricEncrypt: mockSymmetricEncrypt,
+}));
+
+const txStub = {
+  update: vi.fn((table: unknown) => ({
+    set: vi.fn((value: unknown) => {
+      txUpdateCalls.push({ table, value });
+      return { where: vi.fn().mockResolvedValue(undefined) };
+    }),
+  })),
+  delete: vi.fn((table: unknown) => {
+    txDeleteCalls.push({ table });
+    return { where: vi.fn().mockResolvedValue(undefined) };
+  }),
+};
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      verifications: { findFirst: mockVerificationsFindFirst },
+      users: { findFirst: mockUsersFindFirst },
+      accounts: { findFirst: mockAccountsFindFirst },
+    },
+    transaction: mockTransaction,
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  accounts: {
+    id: "accounts.id",
+    userId: "accounts.userId",
+    providerId: "accounts.providerId",
+  },
+  sessions: { id: "sessions.id", userId: "sessions.userId" },
+  twoFactor: { userId: "twoFactor.userId", secret: "twoFactor.secret" },
+  users: { id: "users.id", email: "users.email" },
+  verifications: {
+    id: "verifications.id",
+    identifier: "verifications.identifier",
+    expiresAt: "verifications.expiresAt",
+  },
+}));
+
+vi.mock("@/lib/email", () => ({
+  sendOAuthPasswordResetEmail: vi.fn().mockResolvedValue(undefined),
+  sendVerificationOTP: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { AUTH: "AUTH", CONFIGURATION: "CONFIGURATION" },
+  logSystemError: vi.fn(),
+}));
+
+vi.mock("@/lib/password", () => ({
+  hashPassword: mockHashPassword,
+}));
+
+vi.mock("@/lib/security/totp-verify", () => ({
+  verifyUserTotp: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/lib/security/trusted-proxies", () => ({
+  resolveTrustedClientIp: vi.fn(() => "203.0.113.10"),
+}));
+
+vi.mock("@/lib/utils/id", () => ({
+  generateId: vi.fn(() => "generated-id"),
+}));
+
+import { POST } from "@/app/api/user/forgot-password/route";
+import { sessions as sessionsToken } from "@/lib/db/schema";
+
+function buildResetRequest(body: unknown): Request {
+  return new Request("http://localhost/api/user/forgot-password", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  txUpdateCalls.length = 0;
+  txDeleteCalls.length = 0;
+  process.env.BETTER_AUTH_SECRET = "test-secret";
+  mockHashPassword.mockResolvedValue("new-stored-hash");
+  mockSymmetricDecrypt.mockResolvedValue(VALID_OTP);
+  mockTransaction.mockImplementation(
+    async (cb: (tx: typeof txStub) => Promise<unknown>) => {
+      await cb(txStub);
+    }
+  );
+});
+
+describe("POST /api/user/forgot-password (reset)", () => {
+  it("deletes all of the user's sessions after a successful reset", async () => {
+    mockVerificationsFindFirst.mockResolvedValue({
+      id: VERIFICATION_ID,
+      value: "ciphertext:0",
+    });
+    mockUsersFindFirst.mockResolvedValue({
+      id: USER_ID,
+      email: USER_EMAIL,
+      twoFactorEnabled: false,
+    });
+    mockAccountsFindFirst.mockResolvedValue({ id: CREDENTIAL_ACCOUNT_ID });
+
+    const response = await POST(
+      buildResetRequest({
+        action: "reset",
+        email: USER_EMAIL,
+        otp: VALID_OTP,
+        newPassword: "new-password-1",
+      })
+    );
+
+    expect(response.status).toBe(200);
+
+    // Transaction performed the account update plus two deletes
+    // (consumed verification row + every session for the user).
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+    expect(txUpdateCalls).toHaveLength(1);
+    expect(txDeleteCalls).toHaveLength(2);
+    expect(txDeleteCalls.some((call) => call.table === sessionsToken)).toBe(
+      true
+    );
+    expect(mockEq).toHaveBeenCalledWith("sessions.userId", USER_ID);
+  });
+
+  it("does not touch sessions when the OTP is invalid or expired", async () => {
+    mockVerificationsFindFirst.mockResolvedValue(undefined);
+
+    const response = await POST(
+      buildResetRequest({
+        action: "reset",
+        email: USER_EMAIL,
+        otp: "000000",
+        newPassword: "new-password-1",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockTransaction).not.toHaveBeenCalled();
+    expect(txDeleteCalls).toHaveLength(0);
+  });
+});

--- a/tests/integration/user-forgot-password-route.test.ts
+++ b/tests/integration/user-forgot-password-route.test.ts
@@ -19,6 +19,7 @@ const {
   mockEq,
   mockAnd,
   mockGt,
+  mockIsNull,
   txUpdateCalls,
   txDeleteCalls,
 } = vi.hoisted(() => ({
@@ -36,6 +37,7 @@ const {
   mockGt: vi.fn((column: unknown, value: unknown) => ({
     __gt: [column, value],
   })),
+  mockIsNull: vi.fn((column: unknown) => ({ __isNull: column })),
   txUpdateCalls: [] as Array<{ table: unknown; value: unknown }>,
   txDeleteCalls: [] as Array<{ table: unknown }>,
 }));
@@ -44,6 +46,7 @@ vi.mock("drizzle-orm", () => ({
   and: mockAnd,
   eq: mockEq,
   gt: mockGt,
+  isNull: mockIsNull,
 }));
 
 vi.mock("better-auth/crypto", () => ({
@@ -80,6 +83,14 @@ vi.mock("@/lib/db/schema", () => ({
     id: "accounts.id",
     userId: "accounts.userId",
     providerId: "accounts.providerId",
+  },
+  apiKeys: { userId: "apiKeys.userId" },
+  deviceCode: { userId: "deviceCode.userId" },
+  mcpOauthAuthCodes: { userId: "mcpOauthAuthCodes.userId" },
+  mcpOauthRefreshTokens: { userId: "mcpOauthRefreshTokens.userId" },
+  organizationApiKeys: {
+    createdBy: "organizationApiKeys.createdBy",
+    revokedAt: "organizationApiKeys.revokedAt",
   },
   sessions: { id: "sessions.id", userId: "sessions.userId" },
   twoFactor: { userId: "twoFactor.userId", secret: "twoFactor.secret" },
@@ -118,7 +129,14 @@ vi.mock("@/lib/utils/id", () => ({
 }));
 
 import { POST } from "@/app/api/user/forgot-password/route";
-import { sessions as sessionsToken } from "@/lib/db/schema";
+import {
+  apiKeys as apiKeysToken,
+  deviceCode as deviceCodeToken,
+  mcpOauthAuthCodes as mcpOauthAuthCodesToken,
+  mcpOauthRefreshTokens as mcpOauthRefreshTokensToken,
+  organizationApiKeys as organizationApiKeysToken,
+  sessions as sessionsToken,
+} from "@/lib/db/schema";
 
 function buildResetRequest(body: unknown): Request {
   return new Request("http://localhost/api/user/forgot-password", {
@@ -166,15 +184,42 @@ describe("POST /api/user/forgot-password (reset)", () => {
 
     expect(response.status).toBe(200);
 
-    // Transaction performed the account update plus two deletes
-    // (consumed verification row + every session for the user).
+    // The reset revokes every credential the user holds, not just sessions:
+    // the transaction deletes the consumed verification row plus sessions,
+    // api keys, MCP refresh tokens, MCP auth codes, and device codes, and
+    // updates the account password plus revokes the user's org api keys.
     expect(mockTransaction).toHaveBeenCalledTimes(1);
-    expect(txUpdateCalls).toHaveLength(1);
-    expect(txDeleteCalls).toHaveLength(2);
-    expect(txDeleteCalls.some((call) => call.table === sessionsToken)).toBe(
-      true
-    );
+    expect(txDeleteCalls).toHaveLength(6);
+    const deletedTables = txDeleteCalls.map((call) => call.table);
+    expect(deletedTables).toContain(sessionsToken);
+    expect(deletedTables).toContain(apiKeysToken);
+    expect(deletedTables).toContain(mcpOauthRefreshTokensToken);
+    expect(deletedTables).toContain(mcpOauthAuthCodesToken);
+    expect(deletedTables).toContain(deviceCodeToken);
     expect(mockEq).toHaveBeenCalledWith("sessions.userId", USER_ID);
+    expect(mockEq).toHaveBeenCalledWith("apiKeys.userId", USER_ID);
+    expect(mockEq).toHaveBeenCalledWith(
+      "mcpOauthRefreshTokens.userId",
+      USER_ID
+    );
+    expect(mockEq).toHaveBeenCalledWith("mcpOauthAuthCodes.userId", USER_ID);
+    expect(mockEq).toHaveBeenCalledWith("deviceCode.userId", USER_ID);
+
+    // Org api keys are soft-revoked (revokedAt set) for keys this user
+    // created that are not already revoked, not hard-deleted.
+    expect(txUpdateCalls).toHaveLength(2);
+    const orgKeyUpdate = txUpdateCalls.find(
+      (call) => call.table === organizationApiKeysToken
+    );
+    expect(orgKeyUpdate).toBeDefined();
+    expect(
+      (orgKeyUpdate?.value as { revokedAt?: Date }).revokedAt
+    ).toBeInstanceOf(Date);
+    expect(mockEq).toHaveBeenCalledWith(
+      "organizationApiKeys.createdBy",
+      USER_ID
+    );
+    expect(mockIsNull).toHaveBeenCalledWith("organizationApiKeys.revokedAt");
   });
 
   it("does not touch sessions when the OTP is invalid or expired", async () => {

--- a/tests/integration/user-password-route.test.ts
+++ b/tests/integration/user-password-route.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const USER_ID = "user-1";
+const USER_EMAIL = "user@example.com";
+const CURRENT_SESSION_ID = "session-current";
+const CREDENTIAL_ACCOUNT_ID = "acct-credential";
+
+const {
+  mockGetSession,
+  mockRequireDualFactor,
+  mockVerifyPassword,
+  mockHashPassword,
+  mockAnd,
+  mockEq,
+  mockNe,
+  selectResult,
+  updateCalls,
+  deleteCalls,
+} = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockRequireDualFactor: vi.fn(),
+  mockVerifyPassword: vi.fn(),
+  mockHashPassword: vi.fn(),
+  mockAnd: vi.fn((...args: unknown[]) => ({ __and: args })),
+  mockEq: vi.fn((column: unknown, value: unknown) => ({
+    __eq: [column, value],
+  })),
+  mockNe: vi.fn((column: unknown, value: unknown) => ({
+    __ne: [column, value],
+  })),
+  selectResult: { current: [] as unknown[] },
+  updateCalls: [] as Array<{ table: unknown; value: unknown }>,
+  deleteCalls: [] as Array<{ table: unknown }>,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: mockAnd,
+  eq: mockEq,
+  ne: mockNe,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: { api: { getSession: mockGetSession } },
+}));
+
+vi.mock("@/lib/mfa/dual-factor", () => ({
+  requireDualFactor: mockRequireDualFactor,
+}));
+
+vi.mock("@/lib/password", () => ({
+  verifyPassword: mockVerifyPassword,
+  hashPassword: mockHashPassword,
+}));
+
+vi.mock("@/lib/db", () => {
+  const dbMock = {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => Promise.resolve(selectResult.current)),
+      })),
+    })),
+    update: vi.fn((table: unknown) => ({
+      set: vi.fn((value: unknown) => {
+        updateCalls.push({ table, value });
+        return { where: vi.fn().mockResolvedValue(undefined) };
+      }),
+    })),
+    delete: vi.fn((table: unknown) => {
+      deleteCalls.push({ table });
+      return { where: vi.fn().mockResolvedValue(undefined) };
+    }),
+    // The password change wraps its update + session-delete in a
+    // transaction; run the callback with the same mocked builder so the
+    // update/delete call trackers still observe the writes.
+    transaction: vi.fn((cb: (tx: unknown) => Promise<unknown>) => cb(dbMock)),
+  };
+  return { db: dbMock };
+});
+
+vi.mock("@/lib/db/schema", () => ({
+  accounts: {
+    id: "accounts.id",
+    userId: "accounts.userId",
+    providerId: "accounts.providerId",
+    password: "accounts.password",
+  },
+  sessions: { id: "sessions.id", userId: "sessions.userId" },
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { AUTH: "AUTH" },
+  logSystemError: vi.fn(),
+}));
+
+import { POST } from "@/app/api/user/password/route";
+import { sessions as sessionsToken } from "@/lib/db/schema";
+
+function buildRequest(body: unknown): Request {
+  return new Request("http://localhost/api/user/password", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function buildSession() {
+  mockGetSession.mockResolvedValue({
+    user: { id: USER_ID, email: USER_EMAIL },
+    session: { id: CURRENT_SESSION_ID },
+  });
+}
+
+function credentialAccountRows(): unknown[] {
+  return [
+    {
+      id: CREDENTIAL_ACCOUNT_ID,
+      providerId: "credential",
+      password: "stored-hash",
+    },
+  ];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectResult.current = [];
+  updateCalls.length = 0;
+  deleteCalls.length = 0;
+  mockRequireDualFactor.mockResolvedValue({ ok: true });
+  mockVerifyPassword.mockResolvedValue(true);
+  mockHashPassword.mockResolvedValue("new-stored-hash");
+});
+
+describe("POST /api/user/password", () => {
+  it("revokes every session except the current one on success", async () => {
+    buildSession();
+    selectResult.current = credentialAccountRows();
+
+    const response = await POST(
+      buildRequest({
+        currentPassword: "old-password",
+        newPassword: "new-password-1",
+        code: "111111",
+        emailOtp: "222222",
+      })
+    );
+
+    expect(response.status).toBe(200);
+
+    // Exactly one delete, against the sessions table.
+    expect(deleteCalls).toHaveLength(1);
+    expect(deleteCalls[0].table).toBe(sessionsToken);
+
+    // Scoped to this user, excluding the caller's current session.
+    expect(mockEq).toHaveBeenCalledWith("sessions.userId", USER_ID);
+    expect(mockNe).toHaveBeenCalledWith("sessions.id", CURRENT_SESSION_ID);
+  });
+
+  it("does not delete sessions when the current password is wrong", async () => {
+    buildSession();
+    selectResult.current = credentialAccountRows();
+    mockVerifyPassword.mockResolvedValue(false);
+
+    const response = await POST(
+      buildRequest({
+        currentPassword: "wrong-password",
+        newPassword: "new-password-1",
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(deleteCalls).toHaveLength(0);
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  it("does not delete sessions when the dual-factor challenge fails", async () => {
+    buildSession();
+    selectResult.current = credentialAccountRows();
+    mockRequireDualFactor.mockResolvedValue({
+      ok: false,
+      error: "Two-factor required",
+      code: "mfa_required",
+      status: 401,
+    });
+
+    const response = await POST(
+      buildRequest({
+        currentPassword: "old-password",
+        newPassword: "new-password-1",
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(deleteCalls).toHaveLength(0);
+    expect(updateCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What this fixes

Finding F-005. The password reset and password change paths rotated `accounts.password` but never deleted existing `sessions` rows, so a previously phished or stolen session cookie survived a password rotation — defeating the victim's "lock the attacker out" action. The deactivation route already used the correct pattern; it was simply never applied to the password paths.

## Change

- `app/api/user/password/route.ts` (change) — after rotating the password, deletes every **other** session for the user (`ne(sessions.id, currentSessionId)`) so the caller stays signed in on their current device. The rotation and revocation run in a single transaction so a mid-write failure cannot leave the password changed with old sessions alive; it falls secure (drops all sessions) if the current session id is unavailable.
- `app/api/user/forgot-password/route.ts` (reset) — deletes **all** sessions for the user (the reset flow mints none), wrapped with the password update and verification-row delete in one transaction.

## Tests

- `tests/integration/user-password-route.test.ts` — revokes every session except the current one on success; no session delete when the current password is wrong or dual-factor fails.
- `tests/integration/user-forgot-password-route.test.ts` — deletes all sessions after a successful reset; none on invalid/expired OTP.

All fail on the pre-fix tree and pass after.

## Scope

Password rotation does not revoke org API keys (that remains limited to account deactivation).
