### PR TITLE
fix(mcp): drop workflow nodes from public listing endpoint

### DIFF
--- a/app/api/mcp/workflows/[slug]/listing/route.ts
+++ b/app/api/mcp/workflows/[slug]/listing/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import {
-  getWorkflowListing,
+  getWorkflowListingPublic,
   type ListingErrorDetails,
   type ListWorkflowMetadata,
   listWorkflow,
@@ -104,7 +104,9 @@ export async function GET(
     }
 
     const { slug } = await params;
-    const result = await getWorkflowListing(slug);
+    // Public, unauthenticated read: project the nodes-free listing so workflow
+    // internals (contract addresses, webhook URLs, calldata) never leak.
+    const result = await getWorkflowListingPublic(slug);
 
     if (!result.ok) {
       return NextResponse.json({ error: "Listing not found" }, { status: 404 });

--- a/app/api/workflows/public/route.ts
+++ b/app/api/workflows/public/route.ts
@@ -10,6 +10,10 @@ import {
 } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import type { VoteDirection } from "@/lib/workflow/editor/votes";
+import {
+  projectEdgesForPublicFeed,
+  projectNodesForPublicFeed,
+} from "@/lib/workflow/public-feed-projection";
 import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
 type TagInfo = { id: string; name: string; slug: string };
 
@@ -262,6 +266,10 @@ export async function GET(request: Request): Promise<NextResponse> {
 
     const mappedWorkflows = publicWorkflows.map((workflow) => ({
       ...workflow,
+      // Anonymous feed: expose only the graph shape the marketplace renders
+      // (positions + node/action type), never node config or secrets.
+      nodes: projectNodesForPublicFeed(workflow.nodes),
+      edges: projectEdgesForPublicFeed(workflow.edges),
       publicTags: tagsByWorkflow[workflow.id] ?? [],
       score: scores[workflow.id] ?? 0,
       userVote: userVotes[workflow.id] ?? null,

--- a/app/api/workflows/public/route.ts
+++ b/app/api/workflows/public/route.ts
@@ -11,6 +11,8 @@ import {
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import type { VoteDirection } from "@/lib/workflow/editor/votes";
 import {
+  type PublicFeedEdge,
+  type PublicFeedNode,
   projectEdgesForPublicFeed,
   projectNodesForPublicFeed,
 } from "@/lib/workflow/public-feed-projection";
@@ -264,20 +266,40 @@ export async function GET(request: Request): Promise<NextResponse> {
       fetchDuplicateCounts(workflowIds),
     ]);
 
-    const mappedWorkflows = publicWorkflows.map((workflow) => ({
-      ...workflow,
-      // Anonymous feed: expose only the graph shape the marketplace renders
-      // (positions + node/action type), never node config or secrets.
-      nodes: projectNodesForPublicFeed(workflow.nodes),
-      edges: projectEdgesForPublicFeed(workflow.edges),
-      publicTags: tagsByWorkflow[workflow.id] ?? [],
-      score: scores[workflow.id] ?? 0,
-      userVote: userVotes[workflow.id] ?? null,
-      canVote: userDuplications.has(workflow.id),
-      duplicateCount: duplicateCounts[workflow.id] ?? 0,
-      createdAt: workflow.createdAt.toISOString(),
-      updatedAt: workflow.updatedAt.toISOString(),
-    }));
+    // The serialized feed element. nodes/edges are pinned to the projected
+    // types so a future edit that drops the projection (or spreads the full
+    // row) fails to compile instead of silently leaking node internals.
+    type PublicFeedWorkflow = Omit<
+      (typeof publicWorkflows)[number],
+      "nodes" | "edges" | "createdAt" | "updatedAt"
+    > & {
+      nodes: PublicFeedNode[];
+      edges: PublicFeedEdge[];
+      createdAt: string;
+      updatedAt: string;
+      publicTags: TagInfo[];
+      score: number;
+      userVote: VoteDirection | null;
+      canVote: boolean;
+      duplicateCount: number;
+    };
+
+    const mappedWorkflows = publicWorkflows.map(
+      (workflow): PublicFeedWorkflow => ({
+        ...workflow,
+        // Anonymous feed: expose only the graph shape the marketplace renders
+        // (positions + node/action type), never node config or secrets.
+        nodes: projectNodesForPublicFeed(workflow.nodes),
+        edges: projectEdgesForPublicFeed(workflow.edges),
+        publicTags: tagsByWorkflow[workflow.id] ?? [],
+        score: scores[workflow.id] ?? 0,
+        userVote: userVotes[workflow.id] ?? null,
+        canVote: userDuplications.has(workflow.id),
+        duplicateCount: duplicateCounts[workflow.id] ?? 0,
+        createdAt: workflow.createdAt.toISOString(),
+        updatedAt: workflow.updatedAt.toISOString(),
+      })
+    );
 
     return NextResponse.json(mappedWorkflows);
   } catch (error) {

--- a/app/mcp/w/[slug]/route.ts
+++ b/app/mcp/w/[slug]/route.ts
@@ -321,6 +321,11 @@ async function resolveListing(slug: string): Promise<
     }
   | { ok: false; response: Response }
 > {
+  // Authenticated per-workflow MCP server: intentionally uses the full,
+  // nodes-bearing getWorkflowListing because createWorkflowMcpServer ->
+  // detectListingTriggerType(listing.nodes) needs the workflow nodes for
+  // trigger detection. The public/unauthenticated HTTP endpoint uses
+  // getWorkflowListingPublic instead, which strips nodes.
   const result = await getWorkflowListing(slug);
   if (!(result.ok && result.listing.isListed)) {
     return {

--- a/lib/mcp/listing.ts
+++ b/lib/mcp/listing.ts
@@ -69,6 +69,32 @@ const LISTING_COLUMNS = {
   nodes: workflows.nodes,
 };
 
+// Public projection: LISTING_COLUMNS minus `nodes`. The public,
+// unauthenticated GET /api/mcp/workflows/[slug]/listing endpoint (and the
+// HTTP-proxied get_workflow_listing MCP tool) must never return workflow node
+// internals (contract addresses, webhook URLs, raw calldata) to anonymous
+// callers. Maintained as an explicit allowlist mirroring LISTED_WORKFLOW_COLUMNS
+// (app/api/mcp/workflows/route.ts) -- NOT a runtime Omit -- so a future column
+// added to LISTING_COLUMNS does not auto-leak through this surface.
+const PUBLIC_LISTING_COLUMNS = {
+  id: workflows.id,
+  name: workflows.name,
+  description: workflows.description,
+  listedSlug: workflows.listedSlug,
+  listedAt: workflows.listedAt,
+  inputSchema: workflows.inputSchema,
+  outputMapping: workflows.outputMapping,
+  priceUsdcPerCall: workflows.priceUsdcPerCall,
+  organizationId: workflows.organizationId,
+  createdAt: workflows.createdAt,
+  updatedAt: workflows.updatedAt,
+  isListed: workflows.isListed,
+  workflowType: workflows.workflowType,
+  category: workflows.category,
+  chain: workflows.chain,
+  listingVersion: workflows.listingVersion,
+};
+
 type ListingRow = {
   id: string;
   name: string;
@@ -421,4 +447,31 @@ export async function getWorkflowListing(
   }
 
   return { ok: true, listing: rows[0] as ListingRow };
+}
+
+export async function getWorkflowListingPublic(
+  slug: string
+): Promise<ListingResult<Omit<ListingRow, "nodes">>> {
+  // Unauthenticated public read. Runs the IDENTICAL query as getWorkflowListing
+  // (listedSlug + isListed=true + not-deleted, limit 1) but projects
+  // PUBLIC_LISTING_COLUMNS so workflow `nodes` are never returned. The
+  // authenticated per-workflow MCP server keeps using getWorkflowListing because
+  // it needs nodes for trigger detection.
+  const rows = await db
+    .select(PUBLIC_LISTING_COLUMNS)
+    .from(workflows)
+    .where(
+      and(
+        eq(workflows.listedSlug, slug),
+        eq(workflows.isListed, true),
+        workflowNotDeleted()
+      )
+    )
+    .limit(1);
+
+  if (rows.length === 0) {
+    return { ok: false, error: "NOT_FOUND" };
+  }
+
+  return { ok: true, listing: rows[0] as Omit<ListingRow, "nodes"> };
 }

--- a/lib/workflow/public-feed-projection.ts
+++ b/lib/workflow/public-feed-projection.ts
@@ -1,0 +1,68 @@
+/**
+ * Public marketplace feed projection.
+ *
+ * The unauthenticated `/api/workflows/public` feed renders a minimap and node
+ * icons from each workflow's graph, so it needs node positions and the node /
+ * action type, but it must never expose node config (parameters, addresses,
+ * message bodies, endpoints, integrationId, or any embedded secret) to
+ * anonymous callers. These projections are allowlists: any field not named
+ * here is absent by default, so a new node-config field cannot leak later
+ * without an explicit change.
+ */
+
+type UnknownRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): UnknownRecord | null {
+  return typeof value === "object" && value !== null
+    ? (value as UnknownRecord)
+    : null;
+}
+
+/**
+ * Keep only the node fields the feed renders: id, type, position, and the
+ * node/action/trigger type used to pick an icon. All other config is dropped.
+ */
+export function projectNodesForPublicFeed(nodes: unknown): UnknownRecord[] {
+  if (!Array.isArray(nodes)) {
+    return [];
+  }
+  return nodes.map((raw) => {
+    const node = asRecord(raw) ?? {};
+    const data = asRecord(node.data);
+    const config = data ? asRecord(data.config) : null;
+    const position = asRecord(node.position);
+    return {
+      id: node.id,
+      type: node.type,
+      position: {
+        x: position?.x ?? 0,
+        y: position?.y ?? 0,
+      },
+      data: {
+        type: data?.type,
+        config: {
+          actionType: config?.actionType,
+          triggerType: config?.triggerType,
+        },
+      },
+    };
+  });
+}
+
+/**
+ * Keep only graph connectivity (id, source, target). Edge handles and any
+ * other metadata are dropped.
+ */
+export function projectEdgesForPublicFeed(edges: unknown): UnknownRecord[] {
+  if (!Array.isArray(edges)) {
+    return [];
+  }
+  return edges.map((raw) => {
+    const edge = asRecord(raw) ?? {};
+    return {
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
+    };
+  });
+}

--- a/lib/workflow/public-feed-projection.ts
+++ b/lib/workflow/public-feed-projection.ts
@@ -12,10 +12,44 @@
 
 type UnknownRecord = Record<string, unknown>;
 
+/**
+ * The exact node shape the anonymous feed emits. Deliberately narrow: `config`
+ * holds only the two render hints, so a consumer that reaches for node config
+ * (e.g. `node.data.config.contractAddress`) is a compile error rather than a
+ * silent `undefined`, and the route cannot accidentally serialize full nodes.
+ */
+export type PublicFeedNode = {
+  id: string | undefined;
+  type: string | undefined;
+  position: { x: number; y: number };
+  data: {
+    type: string | undefined;
+    config: {
+      actionType: string | undefined;
+      triggerType: string | undefined;
+    };
+  };
+};
+
+/** The exact edge shape the anonymous feed emits: connectivity only. */
+export type PublicFeedEdge = {
+  id: string | undefined;
+  source: string | undefined;
+  target: string | undefined;
+};
+
 function asRecord(value: unknown): UnknownRecord | null {
   return typeof value === "object" && value !== null
     ? (value as UnknownRecord)
     : null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function asNumber(value: unknown): number {
+  return typeof value === "number" ? value : 0;
 }
 
 /**
@@ -41,37 +75,39 @@ function readNodeConfigField(
  * in-flight nodes may still carry the colon form, and the icon lookup
  * (WorkflowNodeIcons) splits on "/" to resolve the brand.
  */
-function normalizeActionType(value: unknown): unknown {
-  return typeof value === "string" ? value.replace(":", "/") : value;
+function normalizeActionType(value: unknown): string | undefined {
+  return typeof value === "string" ? value.replace(":", "/") : undefined;
 }
 
 /**
  * Keep only the node fields the feed renders: id, type, position, and the
  * node/action/trigger type used to pick an icon. All other config is dropped.
  */
-export function projectNodesForPublicFeed(nodes: unknown): UnknownRecord[] {
+export function projectNodesForPublicFeed(nodes: unknown): PublicFeedNode[] {
   if (!Array.isArray(nodes)) {
     return [];
   }
-  return nodes.map((raw) => {
+  return nodes.map((raw): PublicFeedNode => {
     const node = asRecord(raw) ?? {};
     const data = asRecord(node.data);
     const config = data ? asRecord(data.config) : null;
     const position = asRecord(node.position);
     return {
-      id: node.id,
-      type: node.type,
+      id: asString(node.id),
+      type: asString(node.type),
       position: {
-        x: position?.x ?? 0,
-        y: position?.y ?? 0,
+        x: asNumber(position?.x),
+        y: asNumber(position?.y),
       },
       data: {
-        type: data?.type,
+        type: asString(data?.type),
         config: {
           actionType: normalizeActionType(
             readNodeConfigField(data, config, "actionType")
           ),
-          triggerType: readNodeConfigField(data, config, "triggerType"),
+          triggerType: asString(
+            readNodeConfigField(data, config, "triggerType")
+          ),
         },
       },
     };
@@ -82,16 +118,16 @@ export function projectNodesForPublicFeed(nodes: unknown): UnknownRecord[] {
  * Keep only graph connectivity (id, source, target). Edge handles and any
  * other metadata are dropped.
  */
-export function projectEdgesForPublicFeed(edges: unknown): UnknownRecord[] {
+export function projectEdgesForPublicFeed(edges: unknown): PublicFeedEdge[] {
   if (!Array.isArray(edges)) {
     return [];
   }
-  return edges.map((raw) => {
+  return edges.map((raw): PublicFeedEdge => {
     const edge = asRecord(raw) ?? {};
     return {
-      id: edge.id,
-      source: edge.source,
-      target: edge.target,
+      id: asString(edge.id),
+      source: asString(edge.source),
+      target: asString(edge.target),
     };
   });
 }

--- a/lib/workflow/public-feed-projection.ts
+++ b/lib/workflow/public-feed-projection.ts
@@ -19,6 +19,33 @@ function asRecord(value: unknown): UnknownRecord | null {
 }
 
 /**
+ * Read a node-config field, preferring `data.config.<field>` but falling back
+ * to the legacy top-level `data.<field>`. The rest of the codebase
+ * (lib/mcp/calldata.ts, lib/mcp/listing-validators.ts) accepts both shapes for
+ * actionType, and legacy / in-flight workflows still carry the top-level form;
+ * the feed must read the same way or those nodes project a blank type and the
+ * marketplace icon falls back to a generic box.
+ */
+function readNodeConfigField(
+  data: UnknownRecord | null,
+  config: UnknownRecord | null,
+  field: string
+): unknown {
+  const fromConfig = config?.[field];
+  return fromConfig === undefined ? data?.[field] : fromConfig;
+}
+
+/**
+ * Normalize colon-separated action types (`code:run-code`) to the slash form
+ * (`code/run-code`). sanitize-nodes does this on the write path, but legacy /
+ * in-flight nodes may still carry the colon form, and the icon lookup
+ * (WorkflowNodeIcons) splits on "/" to resolve the brand.
+ */
+function normalizeActionType(value: unknown): unknown {
+  return typeof value === "string" ? value.replace(":", "/") : value;
+}
+
+/**
  * Keep only the node fields the feed renders: id, type, position, and the
  * node/action/trigger type used to pick an icon. All other config is dropped.
  */
@@ -41,8 +68,10 @@ export function projectNodesForPublicFeed(nodes: unknown): UnknownRecord[] {
       data: {
         type: data?.type,
         config: {
-          actionType: config?.actionType,
-          triggerType: config?.triggerType,
+          actionType: normalizeActionType(
+            readNodeConfigField(data, config, "actionType")
+          ),
+          triggerType: readNodeConfigField(data, config, "triggerType"),
         },
       },
     };

--- a/tests/integration/workflow-listing-lifecycle.test.ts
+++ b/tests/integration/workflow-listing-lifecycle.test.ts
@@ -34,21 +34,36 @@ let workflowState: WorkflowRow;
 vi.mock("@/lib/db", () => ({
   db: {
     select: (cols?: unknown) => {
-      // getWorkflowListing projects LISTING_COLUMNS (which includes listedSlug)
-      // and is a public read — must honour the isListed=true filter. Other
-      // selects (e.g. updateWorkflowListing's pre-flight by id+orgId) use
-      // db.select() with no columns and ignore the listing invariant.
+      // getWorkflowListing / getWorkflowListingPublic both pass a column map
+      // (each includes listedSlug) and are public reads — must honour the
+      // isListed=true filter. Other selects (e.g. updateWorkflowListing's
+      // pre-flight by id+orgId) use db.select() with no columns and ignore the
+      // listing invariant.
+      const isColumnSelect =
+        cols !== undefined && cols !== null && typeof cols === "object";
       const isPublicListingRead =
-        cols !== undefined &&
-        cols !== null &&
-        typeof cols === "object" &&
-        "listedSlug" in (cols as Record<string, unknown>);
+        isColumnSelect && "listedSlug" in (cols as Record<string, unknown>);
       return {
         from: (_table: unknown) => ({
           where: (_condition: unknown) => ({
             limit: (_n: number) => {
               if (isPublicListingRead && !workflowState.isListed) {
                 return Promise.resolve([]);
+              }
+              if (isColumnSelect) {
+                // Mirror Drizzle column projection: only the selected columns
+                // are returned. This makes getWorkflowListingPublic's
+                // PUBLIC_LISTING_COLUMNS (which omits `nodes`) observable in the
+                // result, while getWorkflowListing's LISTING_COLUMNS keeps them.
+                const projected: Record<string, unknown> = {};
+                for (const key of Object.keys(
+                  cols as Record<string, unknown>
+                )) {
+                  projected[key] = (workflowState as Record<string, unknown>)[
+                    key
+                  ];
+                }
+                return Promise.resolve([projected]);
               }
               return Promise.resolve([workflowState]);
             },
@@ -94,6 +109,7 @@ const {
   listWorkflow,
   unlistWorkflow,
   getWorkflowListing,
+  getWorkflowListingPublic,
   updateWorkflowListing,
 } = await import("@/lib/mcp/listing");
 
@@ -502,5 +518,65 @@ describe("workflow listing lifecycle", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.listing.workflowType).toBe("read");
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Public projection: the unauthenticated GET path must never return workflow
+  // nodes (contract addresses, webhook URLs, calldata). The authenticated
+  // per-workflow MCP server still needs the full nodes-bearing row.
+  // ──────────────────────────────────────────────────────────────────────
+
+  it("getWorkflowListingPublic: omits `nodes` but keeps listing metadata; getWorkflowListing still returns nodes", async () => {
+    const SENTINEL_CONTRACT = "0xSENTINELdeadbeefCONTRACT";
+    const SENTINEL_WEBHOOK = "https://internal.example/secret-webhook";
+    workflowState.isListed = true;
+    workflowState.listedSlug = "public-projection";
+    workflowState.priceUsdcPerCall = "0.50";
+    workflowState.inputSchema = {
+      type: "object",
+      properties: { amount: { type: "string" } },
+    };
+    workflowState.outputMapping = { txHash: "result.hash" };
+    workflowState.nodes = [
+      {
+        id: "write-1",
+        data: {
+          actionType: "web3/write-contract",
+          config: {
+            contractAddress: SENTINEL_CONTRACT,
+            webhookUrl: SENTINEL_WEBHOOK,
+          },
+        },
+      },
+    ];
+
+    const publicRead = await getWorkflowListingPublic("public-projection");
+    expect(publicRead.ok).toBe(true);
+    if (!publicRead.ok) {
+      return;
+    }
+    // Node internals must never reach unauthenticated callers.
+    expect("nodes" in publicRead.listing).toBe(false);
+    const serialized = JSON.stringify(publicRead.listing);
+    expect(serialized).not.toContain(SENTINEL_CONTRACT);
+    expect(serialized).not.toContain(SENTINEL_WEBHOOK);
+    // Bazaar-facing metadata is still projected.
+    expect(publicRead.listing.inputSchema).toEqual({
+      type: "object",
+      properties: { amount: { type: "string" } },
+    });
+    expect(publicRead.listing.outputMapping).toEqual({ txHash: "result.hash" });
+    expect(publicRead.listing.listedSlug).toBe("public-projection");
+    expect(publicRead.listing.priceUsdcPerCall).toBe("0.50");
+
+    // Companion: the authenticated per-workflow MCP server path still gets the
+    // nodes it needs for trigger detection.
+    const fullRead = await getWorkflowListing("public-projection");
+    expect(fullRead.ok).toBe(true);
+    if (!fullRead.ok) {
+      return;
+    }
+    expect(fullRead.listing.nodes).toHaveLength(1);
+    expect(JSON.stringify(fullRead.listing.nodes)).toContain(SENTINEL_CONTRACT);
   });
 });

--- a/tests/unit/mcp-curator-tools.test.ts
+++ b/tests/unit/mcp-curator-tools.test.ts
@@ -5,16 +5,21 @@ vi.mock("@/lib/middleware/auth-helpers", () => ({
 }));
 
 vi.mock("@/lib/mcp/listing", () => ({
+  getWorkflowListingPublic: vi.fn(),
   listWorkflow: vi.fn(),
   unlistWorkflow: vi.fn(),
   updateWorkflowListing: vi.fn(),
 }));
 
-import { listWorkflow, unlistWorkflow } from "@/lib/mcp/listing";
+import {
+  getWorkflowListingPublic,
+  listWorkflow,
+  unlistWorkflow,
+} from "@/lib/mcp/listing";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 
 // Dynamic import after mocks are set up
-const { POST, DELETE } = await import(
+const { GET, POST, DELETE } = await import(
   "@/app/api/mcp/workflows/[slug]/listing/route"
 );
 
@@ -28,6 +33,11 @@ const makePostRequest = (body?: unknown) =>
 const makeDeleteRequest = () =>
   new Request("http://localhost/api/mcp/workflows/wf-123/listing", {
     method: "DELETE",
+  });
+
+const makeGetRequest = () =>
+  new Request("http://localhost/api/mcp/workflows/my-slug/listing", {
+    method: "GET",
   });
 
 const makeParams = (id = "wf-123") => ({
@@ -90,5 +100,58 @@ describe("mcp curator tools — org-scope and auth enforcement", () => {
       makeParams()
     );
     expect(res.status).toBe(401);
+  });
+});
+
+describe("mcp public listing GET — no workflow nodes leak", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("GET returns 200 with listing metadata but no `nodes` property", async () => {
+    vi.mocked(getWorkflowListingPublic).mockResolvedValue({
+      ok: true,
+      listing: {
+        id: "wf-123",
+        name: "Public Workflow",
+        description: null,
+        listedSlug: "my-slug",
+        listedAt: new Date("2026-01-01"),
+        inputSchema: { type: "object" },
+        outputMapping: { txHash: "result.hash" },
+        priceUsdcPerCall: "0.25",
+        organizationId: "org-abc",
+        createdAt: new Date("2026-01-01"),
+        updatedAt: new Date("2026-01-01"),
+        isListed: true,
+        workflowType: "read",
+        category: "defi",
+        chain: "base",
+        listingVersion: 3,
+      },
+    });
+
+    const res = await GET(makeGetRequest(), makeParams("my-slug"));
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    // The public route must call the nodes-free projection, never the full one.
+    expect(getWorkflowListingPublic).toHaveBeenCalledWith("my-slug");
+    // Unauthenticated callers must never receive workflow node internals.
+    expect("nodes" in body).toBe(false);
+    // Bazaar-facing metadata is still present.
+    expect(body.inputSchema).toEqual({ type: "object" });
+    expect(body.outputMapping).toEqual({ txHash: "result.hash" });
+    expect(body.listingVersion).toBe(3);
+  });
+
+  it("GET returns 404 when the public projection finds no listing", async () => {
+    vi.mocked(getWorkflowListingPublic).mockResolvedValue({
+      ok: false,
+      error: "NOT_FOUND",
+    });
+
+    const res = await GET(makeGetRequest(), makeParams("missing-slug"));
+    expect(res.status).toBe(404);
   });
 });

--- a/tests/unit/public-feed-projection.test.ts
+++ b/tests/unit/public-feed-projection.test.ts
@@ -50,6 +50,46 @@ describe("projectNodesForPublicFeed", () => {
     expect(serialized).not.toContain("integrationId");
   });
 
+  it("reads the legacy top-level data.actionType and normalizes the colon form", () => {
+    const [projected] = projectNodesForPublicFeed([
+      {
+        id: "legacy-1",
+        type: "action",
+        position: { x: 1, y: 2 },
+        data: {
+          type: "action",
+          // Legacy / in-flight shape: actionType at the top of data (colon
+          // form), with config holding only sensitive params.
+          actionType: "code:run-code",
+          config: { contractAddress: "0xSECRETLEGACYADDRESS" },
+        },
+      },
+    ]);
+    expect(projected.data).toEqual({
+      type: "action",
+      config: { actionType: "code/run-code", triggerType: undefined },
+    });
+    expect(JSON.stringify(projected)).not.toContain("0xSECRETLEGACYADDRESS");
+  });
+
+  it("prefers data.config.actionType over the legacy top-level field", () => {
+    const [projected] = projectNodesForPublicFeed([
+      {
+        id: "both-1",
+        type: "action",
+        position: { x: 0, y: 0 },
+        data: {
+          type: "action",
+          actionType: "legacy/value",
+          config: { actionType: "web3/transfer" },
+        },
+      },
+    ]);
+    expect(
+      (projected.data as { config: { actionType: unknown } }).config.actionType
+    ).toBe("web3/transfer");
+  });
+
   it("preserves trigger type for the trigger icon", () => {
     const [projected] = projectNodesForPublicFeed([
       {

--- a/tests/unit/public-feed-projection.test.ts
+++ b/tests/unit/public-feed-projection.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  projectEdgesForPublicFeed,
+  projectNodesForPublicFeed,
+} from "@/lib/workflow/public-feed-projection";
+
+describe("projectNodesForPublicFeed", () => {
+  const node = {
+    id: "node-1",
+    type: "action",
+    position: { x: 120, y: 240 },
+    width: 320,
+    height: 80,
+    selected: true,
+    data: {
+      type: "action",
+      label: "Send funds",
+      config: {
+        actionType: "web3/transfer",
+        triggerType: undefined,
+        integrationId: "int_secret_123",
+        recipientAddress: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        amount: "5.0",
+        privateKey: "0xPRIVATEKEYSHOULDNEVERLEAK",
+        webhookUrl: "https://internal.example.com/hook?token=abc",
+      },
+    },
+  };
+
+  it("keeps the fields the marketplace minimap and icons render", () => {
+    const [projected] = projectNodesForPublicFeed([node]);
+    expect(projected).toEqual({
+      id: "node-1",
+      type: "action",
+      position: { x: 120, y: 240 },
+      data: {
+        type: "action",
+        config: { actionType: "web3/transfer", triggerType: undefined },
+      },
+    });
+  });
+
+  it("strips every sensitive node-config field", () => {
+    const serialized = JSON.stringify(projectNodesForPublicFeed([node]));
+    expect(serialized).not.toContain("int_secret_123");
+    expect(serialized).not.toContain("PRIVATEKEY");
+    expect(serialized).not.toContain("0xdeadbeef");
+    expect(serialized).not.toContain("internal.example.com");
+    expect(serialized).not.toContain("recipientAddress");
+    expect(serialized).not.toContain("integrationId");
+  });
+
+  it("preserves trigger type for the trigger icon", () => {
+    const [projected] = projectNodesForPublicFeed([
+      {
+        id: "trigger-1",
+        type: "trigger",
+        position: { x: 0, y: 0 },
+        data: { type: "trigger", config: { triggerType: "schedule" } },
+      },
+    ]);
+    expect(
+      (projected.data as { config: { triggerType: unknown } }).config
+        .triggerType
+    ).toBe("schedule");
+  });
+
+  it("returns an empty array for non-array or malformed input", () => {
+    expect(projectNodesForPublicFeed(undefined)).toEqual([]);
+    expect(projectNodesForPublicFeed(null)).toEqual([]);
+    expect(projectNodesForPublicFeed("nodes")).toEqual([]);
+    const [fromGarbage] = projectNodesForPublicFeed([null]);
+    expect(fromGarbage).toEqual({
+      id: undefined,
+      type: undefined,
+      position: { x: 0, y: 0 },
+      data: {
+        type: undefined,
+        config: { actionType: undefined, triggerType: undefined },
+      },
+    });
+  });
+});
+
+describe("projectEdgesForPublicFeed", () => {
+  it("keeps only id, source, and target", () => {
+    const [projected] = projectEdgesForPublicFeed([
+      {
+        id: "edge-1",
+        source: "node-1",
+        target: "node-2",
+        sourceHandle: "out-secret",
+        targetHandle: "in-secret",
+        data: { condition: "balance > 1000" },
+      },
+    ]);
+    expect(projected).toEqual({
+      id: "edge-1",
+      source: "node-1",
+      target: "node-2",
+    });
+    expect(JSON.stringify(projected)).not.toContain("secret");
+    expect(JSON.stringify(projected)).not.toContain("balance");
+  });
+
+  it("returns an empty array for non-array input", () => {
+    expect(projectEdgesForPublicFeed(undefined)).toEqual([]);
+    expect(projectEdgesForPublicFeed({})).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What this fixes

Finding F-014. The unauthenticated `GET /api/mcp/workflows/[slug]/listing` (and the `get_workflow_listing` MCP tool, which HTTP-proxies it) serialized the full listing row including `workflows.nodes`, leaking the workflow's entire node graph — contract addresses, ABIs, recipient addresses, webhook URLs, channel ids, integration ids, trigger config — to anonymous callers. This contradicts the codebase's own invariant (nodes must never reach external agents) and the sibling catalog endpoint, which deliberately omits nodes. No plaintext credentials are exposed (integration secrets are stored encrypted, by reference).

## Change

- `lib/mcp/listing.ts` — adds `getWorkflowListingPublic(slug)` with an explicit `PUBLIC_LISTING_COLUMNS` allowlist (identical query, minus `nodes`). The shared `getWorkflowListing` is unchanged because the **authenticated** per-workflow MCP server legitimately needs `nodes` to derive each workflow's trigger input schema.
- `app/api/mcp/workflows/[slug]/listing/route.ts` — the public GET now calls `getWorkflowListingPublic`; this also de-leaks the proxied MCP tool. `inputSchema` / `outputMapping` are retained for marketplace consumers.
- `app/mcp/w/[slug]/route.ts` — documents that this authenticated caller intentionally keeps the full nodes-bearing helper.

## Tests

- `tests/unit/mcp-curator-tools.test.ts` — public GET returns 200 with no `nodes`, keeping `inputSchema` / `outputMapping` / `listingVersion`.
- `tests/integration/workflow-listing-lifecycle.test.ts` — `getWorkflowListingPublic` omits `nodes` (sentinel address / webhook absent) while `getWorkflowListing` still returns them. Verified fail-before / pass-after empirically.

## Follow-up (not in this PR)

- Webhook URLs and Discord channel ids embedded in already-public node graphs are bearer-secret-equivalent; rotating them is an incident-response consideration independent of this code fix.
