### PR TITLE
fix: show phantom workflow runs as pending on analytics

### DIFF
--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -35,7 +35,10 @@ import type {
  * direct_executions uses: pending | running | completed | failed
  * We normalize to: pending | running | success | error
  */
-function normalizeStatus(status: string, source: RunSource): NormalizedStatus {
+export function normalizeStatus(
+  status: string,
+  source: RunSource
+): NormalizedStatus {
   if (source === "direct") {
     if (status === "completed") {
       return "success";
@@ -46,6 +49,11 @@ function normalizeStatus(status: string, source: RunSource): NormalizedStatus {
   }
   if (status === "cancelled") {
     return "cancelled";
+  }
+  // Phantom rows are runs that were enqueued but never picked up; they have no
+  // user-facing status of their own and surface as pending everywhere in the UI.
+  if (status === "phantom") {
+    return "pending";
   }
   return status as NormalizedStatus;
 }
@@ -59,6 +67,18 @@ function directDbStatuses(status: NormalizedStatus): string[] {
   }
   if (status === "error") {
     return ["failed"];
+  }
+  return [status];
+}
+
+/**
+ * Map a normalized status to the workflow_executions DB status values.
+ * Phantom maps to pending for display, so the pending filter must also match
+ * phantom rows to keep the badge and filter consistent.
+ */
+export function workflowDbStatuses(status: NormalizedStatus): string[] {
+  if (status === "pending") {
+    return ["pending", "phantom"];
   }
   return [status];
 }
@@ -817,7 +837,7 @@ async function fetchWorkflowRuns(
   ];
 
   if (status) {
-    const dbStatuses = [status];
+    const dbStatuses = workflowDbStatuses(status);
     conditions.push(
       sql`${workflowExecutions.status} IN (${sql.join(
         dbStatuses.map((s) => sql`${s}`),
@@ -1020,7 +1040,7 @@ async function getWorkflowRunsTotal(
     conditions.push(eq(workflows.projectId, projectId));
   }
   if (status) {
-    const dbStatuses = [status];
+    const dbStatuses = workflowDbStatuses(status);
     conditions.push(
       sql`${workflowExecutions.status} IN (${sql.join(
         dbStatuses.map((s) => sql`${s}`),

--- a/tests/unit/analytics-status-normalize.test.ts
+++ b/tests/unit/analytics-status-normalize.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+// queries.ts is a server-only module that also pulls in the db client; stub
+// both so the pure status helpers can be imported under vitest without
+// resolving the server-only marker or opening a DB connection.
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/db", () => ({ db: {} }));
+
+import { normalizeStatus, workflowDbStatuses } from "@/lib/analytics/queries";
+
+describe("normalizeStatus", () => {
+  it("maps phantom workflow runs to pending", () => {
+    expect(normalizeStatus("phantom", "workflow")).toBe("pending");
+  });
+
+  it("passes through the standard workflow statuses unchanged", () => {
+    expect(normalizeStatus("pending", "workflow")).toBe("pending");
+    expect(normalizeStatus("running", "workflow")).toBe("running");
+    expect(normalizeStatus("success", "workflow")).toBe("success");
+    expect(normalizeStatus("error", "workflow")).toBe("error");
+    expect(normalizeStatus("cancelled", "workflow")).toBe("cancelled");
+  });
+
+  it("maps direct completed/failed onto success/error", () => {
+    expect(normalizeStatus("completed", "direct")).toBe("success");
+    expect(normalizeStatus("failed", "direct")).toBe("error");
+  });
+});
+
+describe("workflowDbStatuses", () => {
+  it("expands the pending filter to also match phantom rows", () => {
+    expect(workflowDbStatuses("pending")).toEqual(["pending", "phantom"]);
+  });
+
+  it("leaves other statuses as a single-value filter", () => {
+    expect(workflowDbStatuses("success")).toEqual(["success"]);
+    expect(workflowDbStatuses("error")).toEqual(["error"]);
+    expect(workflowDbStatuses("running")).toEqual(["running"]);
+    expect(workflowDbStatuses("cancelled")).toEqual(["cancelled"]);
+  });
+});


### PR DESCRIPTION
## Summary

Phantom executions (runs that were enqueued but never picked up) leaked their raw `phantom` status into the analytics layer, rendering an unstyled "Phantom" badge in the runs table. `phantom` has no user-facing status of its own and should appear as `pending` everywhere in the UI.

## Changes

- `normalizeStatus` now maps `phantom` to `pending`, so the analytics runs-table badge renders a styled "Pending" instead of an unstyled "Phantom".
- New `workflowDbStatuses` helper (mirrors the existing `directDbStatuses`) expands the workflow "Pending" filter to `status IN ('pending','phantom')`, wired into both the runs list and its count query so the badge, filter, and pagination total stay consistent.
- Both helpers are exported and covered by a focused unit test.

KPI cards needed no change: they count total minus explicit success/error/cancelled, so phantom already fell into the implicit pending remainder. The per-workflow runs panel already routed phantom through its default (Pending) case.

## Test plan

- [x] Unit: `normalizeStatus` maps phantom to pending and passes other statuses through; `workflowDbStatuses` expands pending to include phantom (5 cases)
- [x] Type-check clean for the changed files
- [x] Lint clean (biome) for the changed files