### PR TITLE
fix: add verified column to two_factor for Better Auth TOTP sign-in

### DIFF
--- a/drizzle/0109_two_factor_verified.sql
+++ b/drizzle/0109_two_factor_verified.sql
@@ -1,0 +1,10 @@
+-- Add the `verified` column Better Auth's two-factor plugin expects on the
+-- two_factor table. Its verify-totp path updates this field to true when it is
+-- not already strictly true; without the column the drizzle adapter strips the
+-- update, producing an empty SET that Postgres rejects and breaking every
+-- fresh TOTP sign-in.
+--
+-- NOT NULL DEFAULT true backfills existing enrolled rows to true in the same
+-- statement, so the plugin reads verified = true and skips the write entirely.
+
+ALTER TABLE "two_factor" ADD COLUMN "verified" boolean DEFAULT true NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -764,6 +764,13 @@
       "when": 1781225584552,
       "tag": "0108_keep_693_execution_error_code",
       "breakpoints": true
+    },
+    {
+      "idx": 109,
+      "version": "7",
+      "when": 1781274021440,
+      "tag": "0109_two_factor_verified",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -192,6 +192,14 @@ export const twoFactor = pgTable(
     backupCodes: text("backup_codes"),
     name: text("name"),
     enrolledAt: timestamp("enrolled_at").notNull().defaultNow(),
+    // Better Auth's two-factor plugin expects a `verified` field on this
+    // model. Its verify-totp path reads the row and, when `verified` is
+    // not strictly true, issues an UPDATE setting it to true. Without the
+    // column the drizzle adapter strips that field, producing an empty
+    // SET that Postgres rejects and breaking every fresh TOTP sign-in.
+    // Defaults to true so rows enrolled through our own routes are treated
+    // as verified and the plugin skips the write entirely.
+    verified: boolean("verified").notNull().default(true),
   },
   (table) => [index("idx_two_factor_user_id").on(table.userId)]
 );


### PR DESCRIPTION
## Problem

Fresh TOTP sign-in fails at the session-minting step with `{"error":"Sign-in failed at session step","code":"session_failed"}` (HTTP 500). It hits every fresh TOTP login: logout, session expiry, new device, or after an admin deactivate/reactivate that wipes sessions. Enrollment is unaffected because it uses our own routes.

## Root cause

The strict sign-in route verifies all three factors in-app, then borrows Better Auth only to mint the session cookie (`signInEmail` then `verifyTOTP`). In better-auth 1.6.11 the two-factor plugin declares a `verified` field on the `two_factor` model, and its verify-totp path runs:

```
if (twoFactor.verified !== true) {
  adapter.update({ model: "twoFactor", update: { verified: true }, where: id })
}
```

Our `two_factor` table and Drizzle schema have no `verified` column, so the read returns `undefined`, the branch is entered, and the Drizzle adapter strips the unknown field. That leaves an empty `SET`:

```
update "two_factor" set  where "two_factor"."id" = $1 returning ...
```

which Postgres rejects with `syntax error at or near "where"`. Confirmed via lockfile that both staging and prod run better-auth 1.6.11, and the column is absent on both DBs, so prod is affected too.

## Fix

Add `verified boolean NOT NULL DEFAULT true` to the `two_factor` Drizzle schema and migration `0109`. `ADD COLUMN ... DEFAULT true NOT NULL` backfills existing enrolled rows in the same statement, so the plugin reads `verified = true` and skips the write entirely. This matches Better Auth's own documented two-factor schema, so it stays correct for any future plugin behavior. No change to the verification logic or session flow.

## Verification

- `db:setup-workflow` + `db:migrate` against a fresh Postgres 16: applies through `0109`; resulting column is `boolean NOT NULL DEFAULT true`, migration registered in the journal table.
- `pnpm type-check`: clean.
- `pnpm test:unit`: 6132 tests pass.
- Read-only prod DB check: `two_factor` has no `verified` column (impact confirmed).

## Note for reviewers

The repo's Drizzle snapshot chain under `drizzle/meta/` is incomplete (snapshots for recent migrations were never committed and the 0081-0089 chain collides), so `drizzle-kit generate` errors on a pristine checkout, independent of this change. This migration was therefore hand-authored to match how recent migrations (0090-0108) were added, and validated with `db:migrate`. The `migrate-check` snapshot-drift step may flag this pre-existing state. Worth a separate cleanup of the snapshot history.