### PR TITLE
fix(oauth): gate remaining OAuth-reachable mutation routes on mcp:write scope

### DIFF
--- a/app/api/address-book/[entryId]/route.ts
+++ b/app/api/address-book/[entryId]/route.ts
@@ -5,7 +5,9 @@ import { normalizeAddressForStorage } from "@/lib/address-utils";
 import { db } from "@/lib/db";
 import { addressBookEntry } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 
 // Helper: Get existing entry and validate it belongs to organization
 async function getExistingEntry(entryId: string, activeOrgId: string) {
@@ -87,6 +89,10 @@ export async function PATCH(
         { status: authCtx.status }
       );
     }
+    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
+    }
     const { organizationId: activeOrgId } = authCtx;
 
     // Get existing entry
@@ -162,6 +168,10 @@ export async function DELETE(
         { error: authCtx.error },
         { status: authCtx.status }
       );
+    }
+    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
     const { organizationId: activeOrgId } = authCtx;
 

--- a/app/api/address-book/route.ts
+++ b/app/api/address-book/route.ts
@@ -5,10 +5,12 @@ import { normalizeAddressForStorage } from "@/lib/address-utils";
 import { db } from "@/lib/db";
 import { addressBookEntry, users } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import {
   resolveCreatorContext,
   resolveOrganizationId,
 } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 
 // GET - List all address book entries for the current organization
 export async function GET(request: Request) {
@@ -87,6 +89,10 @@ export async function POST(request: Request) {
         { error: authCtx.error },
         { status: authCtx.status }
       );
+    }
+    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
     const { organizationId: activeOrgId, userId } = authCtx;
 

--- a/app/api/gas/estimate/route.ts
+++ b/app/api/gas/estimate/route.ts
@@ -2,7 +2,7 @@ import { ethers } from "ethers";
 import { NextResponse } from "next/server";
 import { apiError } from "@/lib/api-error";
 import ERC20_ABI from "@/lib/contracts/abis/erc20.json";
-import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import { SCOPE_MCP_READ } from "@/lib/mcp/oauth-scopes";
 import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
 import { requireScope } from "@/lib/middleware/require-scope";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
@@ -190,7 +190,7 @@ async function validateRequest(request: Request): Promise<
     );
   }
 
-  const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE);
+  const scopeError = requireScope(authCtx.scope, SCOPE_MCP_READ);
   if (scopeError) {
     return scopeError;
   }

--- a/app/api/gas/estimate/route.ts
+++ b/app/api/gas/estimate/route.ts
@@ -2,7 +2,9 @@ import { ethers } from "ethers";
 import { NextResponse } from "next/server";
 import { apiError } from "@/lib/api-error";
 import ERC20_ABI from "@/lib/contracts/abis/erc20.json";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import { getChainGasDefaults } from "@/lib/web3/gas-defaults";
 import { getOrganizationWalletAddress } from "@/lib/web3/wallet-helpers";
@@ -187,6 +189,12 @@ async function validateRequest(request: Request): Promise<
       { status: authCtx.status }
     );
   }
+
+  const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE);
+  if (scopeError) {
+    return scopeError;
+  }
+
   const activeOrgId = authCtx.organizationId;
 
   const body = (await request.json().catch(() => ({}))) as Partial<{

--- a/app/api/integrations/[integrationId]/route.ts
+++ b/app/api/integrations/[integrationId]/route.ts
@@ -10,7 +10,9 @@ import {
 } from "@/lib/db/integrations";
 import { organizationWallets } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 import type { IntegrationConfig } from "@/lib/types/integration";
 
 export type GetIntegrationResponse = {
@@ -131,6 +133,11 @@ export async function PUT(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
+    }
+
     const body: UpdateIntegrationRequest = await request.json();
 
     // Fetch existing integration so updateIntegration can merge database
@@ -216,6 +223,11 @@ export async function DELETE(
 
     if (!(userId || organizationId)) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
 
     const success = await deleteIntegration(

--- a/app/api/integrations/[integrationId]/test/route.ts
+++ b/app/api/integrations/[integrationId]/test/route.ts
@@ -4,7 +4,9 @@ import {
   mergeDatabaseConfig,
 } from "@/lib/db/integrations";
 import { handleDatabaseTest, handlePluginTest } from "@/lib/db/test-connection";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 import type { IntegrationConfig } from "@/lib/types/integration";
 
 export type { TestConnectionResult } from "@/lib/db/test-connection";
@@ -40,6 +42,12 @@ export async function POST(
         { status: authContext.status }
       );
     }
+
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
+    }
+
     const { userId, organizationId } = authContext;
 
     const { integrationId } = await params;

--- a/app/api/integrations/route.ts
+++ b/app/api/integrations/route.ts
@@ -6,7 +6,9 @@ import {
 } from "@/lib/db/integrations";
 import { ApiErrorCodes, apiError } from "@/lib/errors/api-envelope";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 import type {
   IntegrationConfig,
   IntegrationType,
@@ -156,6 +158,11 @@ export async function POST(request: Request) {
         hint: "Provide a valid `Authorization: Bearer <token>` header.",
         requestHeaders: request.headers,
       });
+    }
+
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
 
     if (!authContext.userId) {

--- a/app/api/integrations/test/route.ts
+++ b/app/api/integrations/test/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { handleDatabaseTest, handlePluginTest } from "@/lib/db/test-connection";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 import type {
   IntegrationConfig,
   IntegrationType,
@@ -25,6 +27,11 @@ export async function POST(request: Request): Promise<NextResponse> {
         { error: authContext.error },
         { status: authContext.status }
       );
+    }
+
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
 
     const body: TestConnectionRequest = await request.json();

--- a/app/api/keys/[keyId]/route.ts
+++ b/app/api/keys/[keyId]/route.ts
@@ -4,9 +4,11 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { organizationApiKeys } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { requireDualFactor } from "@/lib/mfa/dual-factor";
 import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
 import { requireAdminOrOwnerWithMfa } from "@/lib/middleware/owner-mfa-guard";
+import { requireScope } from "@/lib/middleware/require-scope";
 
 // DELETE - Revoke an API key
 export async function DELETE(
@@ -21,6 +23,14 @@ export async function DELETE(
         { error: authCtx.error },
         { status: authCtx.status }
       );
+    }
+    // Defense-in-depth: this route is not OAuth-reachable today (the session +
+    // admin/owner + dual-factor gates below reject a Bearer OAuth token), but
+    // gate on write scope anyway so the A-03 class stays closed if that ordering
+    // is ever refactored. Mirrors the sibling resolveOrganizationId mutations.
+    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
     const { organizationId: activeOrgId } = authCtx;
 

--- a/app/api/organizations/[organizationId]/execution-digest/route.ts
+++ b/app/api/organizations/[organizationId]/execution-digest/route.ts
@@ -8,7 +8,9 @@ import {
 } from "@/lib/db/schema";
 import { isFeatureEnabledForOrg } from "@/lib/features/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 import {
   DIGEST_REQUIRES_CADENCE_ERROR,
   DIGEST_REQUIRES_SUBSCRIBER_ERROR,
@@ -21,7 +23,7 @@ import {
 
 const FEATURE_ID = "notifications.execution-digest" as const;
 
-type ManagerOk = { ok: true; userId: string };
+type ManagerOk = { ok: true; userId: string; scope?: string };
 type ManagerErr = { ok: false; status: number; error: string };
 
 // Owners and admins may view/manage the digest settings (matches who manages
@@ -58,7 +60,7 @@ async function requireOrgManager(
   ) {
     return { ok: false, status: 403, error: "Forbidden" };
   }
-  return { ok: true, userId };
+  return { ok: true, userId, scope: authContext.scope };
 }
 
 async function loadSettings(organizationId: string) {
@@ -159,6 +161,11 @@ export async function PUT(
         { error: manager.error },
         { status: manager.status }
       );
+    }
+
+    const scopeError = requireScope(manager.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
 
     if (!(await isFeatureEnabledForOrg(FEATURE_ID, organizationId))) {

--- a/app/api/organizations/[organizationId]/route.ts
+++ b/app/api/organizations/[organizationId]/route.ts
@@ -3,11 +3,13 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { member, organization } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import {
   auditFromAuth,
   type DualAuthContext,
   getDualAuthContext,
 } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 
 type UpdateOrganizationNameRequest = {
   name?: string;
@@ -27,6 +29,11 @@ export async function PATCH(
         { error: authContext.error },
         { status: authContext.status }
       );
+    }
+
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
 
     const { userId, organizationId: callerOrgId, authMethod } = authContext;

--- a/app/api/projects/[projectId]/route.ts
+++ b/app/api/projects/[projectId]/route.ts
@@ -3,7 +3,9 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { projects } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 
 export async function PATCH(
   request: Request,
@@ -18,6 +20,11 @@ export async function PATCH(
         { error: authResult.error },
         { status: authResult.status }
       );
+    }
+
+    const scopeError = requireScope(authResult.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
 
     const { organizationId } = authResult;
@@ -97,6 +104,11 @@ export async function DELETE(
         { error: authResult.error },
         { status: authResult.status }
       );
+    }
+
+    const scopeError = requireScope(authResult.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
 
     const { organizationId } = authResult;

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -3,10 +3,12 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { projects, workflows } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import {
   resolveCreatorContext,
   resolveOrganizationId,
 } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 import { COLOR_PALETTE } from "@/lib/palette";
 
 export async function GET(request: Request) {
@@ -76,6 +78,11 @@ export async function POST(request: Request) {
         { status: resolved.status }
       );
     }
+    const scopeError = requireScope(resolved.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
+    }
+
     const { organizationId, userId: creatorUserId } = resolved;
 
     const body = await request.json().catch(() => ({}));

--- a/app/api/tags/[tagId]/route.ts
+++ b/app/api/tags/[tagId]/route.ts
@@ -3,7 +3,9 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { tags } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 
 export async function PATCH(
   request: Request,
@@ -18,6 +20,11 @@ export async function PATCH(
         { error: authResult.error },
         { status: authResult.status }
       );
+    }
+
+    const scopeError = requireScope(authResult.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
 
     const { organizationId } = authResult;
@@ -91,6 +98,11 @@ export async function DELETE(
         { error: authResult.error },
         { status: authResult.status }
       );
+    }
+
+    const scopeError = requireScope(authResult.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
 
     const { organizationId } = authResult;

--- a/app/api/tags/route.ts
+++ b/app/api/tags/route.ts
@@ -3,10 +3,12 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { tags, workflows } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import {
   resolveCreatorContext,
   resolveOrganizationId,
 } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 
 export async function GET(request: Request): Promise<NextResponse> {
   try {
@@ -68,6 +70,10 @@ export async function POST(request: Request): Promise<NextResponse> {
         { error: resolved.error },
         { status: resolved.status }
       );
+    }
+    const scopeError = requireScope(resolved.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
     const { organizationId, userId: creatorUserId } = resolved;
 

--- a/app/api/user/wallet/tokens/route.ts
+++ b/app/api/user/wallet/tokens/route.ts
@@ -8,7 +8,9 @@ import { db } from "@/lib/db";
 import { chains, organizationTokens, supportedTokens } from "@/lib/db/schema";
 import { safeWallets } from "@/lib/db/schema-extensions";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import { organizationHasWallet } from "@/lib/web3/wallet-helpers";
 
@@ -107,6 +109,12 @@ export async function POST(request: Request) {
         { status: authCtx.status }
       );
     }
+
+    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
+    }
+
     const { organizationId: activeOrgId } = authCtx;
 
     // Check if organization has a wallet
@@ -292,6 +300,12 @@ export async function DELETE(request: Request) {
         { status: authCtx.status }
       );
     }
+
+    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
+    }
+
     const { organizationId: activeOrgId } = authCtx;
 
     const body = await request.json();

--- a/app/api/web3/fetch-abi/route.ts
+++ b/app/api/web3/fetch-abi/route.ts
@@ -8,7 +8,7 @@ import { explorerConfigs } from "@/lib/db/schema";
 import { fetchEtherscanSourceCode } from "@/lib/explorer/etherscan";
 import { detectProxyViaRpc } from "@/lib/explorer/proxy-detection";
 import { ErrorCategory, logUserError } from "@/lib/logging";
-import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import { SCOPE_MCP_READ } from "@/lib/mcp/oauth-scopes";
 import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
 import { requireScope } from "@/lib/middleware/require-scope";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
@@ -1296,7 +1296,7 @@ export async function POST(request: Request) {
       );
     }
 
-    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_READ);
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/web3/fetch-abi/route.ts
+++ b/app/api/web3/fetch-abi/route.ts
@@ -8,7 +8,9 @@ import { explorerConfigs } from "@/lib/db/schema";
 import { fetchEtherscanSourceCode } from "@/lib/explorer/etherscan";
 import { detectProxyViaRpc } from "@/lib/explorer/proxy-detection";
 import { ErrorCategory, logUserError } from "@/lib/logging";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
 
@@ -1292,6 +1294,11 @@ export async function POST(request: Request) {
         { error: authCtx.error },
         { status: authCtx.status }
       );
+    }
+
+    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
 
     // Parse request body

--- a/lib/mcp/oauth-auth.ts
+++ b/lib/mcp/oauth-auth.ts
@@ -63,6 +63,13 @@ function isOAuthTokenPayload(value: unknown): value is OAuthTokenPayload {
   return (
     typeof p.sub === "string" &&
     typeof p.org === "string" &&
+    // Load-bearing for REST scope enforcement (A-03): rejecting a token whose
+    // `scope` claim is absent or non-string guarantees an authenticated OAuth
+    // caller ALWAYS carries a string scope. The requireScope() guards at every
+    // /api mutation sink treat scope=undefined as full access (api-key/session
+    // callers); if a scope-less OAuth token were accepted here, ctx.scope would
+    // be undefined at those sinks and silently regain write access. Do not relax
+    // without also re-deriving the REST scope model (see oauth-auth-scope-required.test.ts).
     typeof p.scope === "string" &&
     typeof p.iat === "number" &&
     typeof p.exp === "number"

--- a/lib/middleware/auth-helpers.ts
+++ b/lib/middleware/auth-helpers.ts
@@ -318,6 +318,9 @@ export type OrganizationAuthContext =
       organizationId: string;
       authMethod: AuthMethod;
       apiKeyId: string | null;
+      // OAuth token scope (mcp:read|write|admin). Undefined for api-key/session
+      // callers, which scopeSatisfies() treats as full access.
+      scope?: string;
     }
   | { error: string; status: number };
 
@@ -335,6 +338,7 @@ export async function resolveOrganizationId(
       organizationId: oauthAuth.organizationId,
       authMethod: "oauth",
       apiKeyId: null,
+      scope: oauthAuth.scope,
     };
   }
 
@@ -391,6 +395,9 @@ export async function resolveCreatorContext(request: Request): Promise<
       userId: string;
       authMethod: AuthMethod;
       apiKeyId: string | null;
+      // OAuth token scope (mcp:read|write|admin). Undefined for api-key/session
+      // callers, which scopeSatisfies() treats as full access.
+      scope?: string;
     }
   | { error: string; status: number }
 > {
@@ -400,7 +407,8 @@ export async function resolveCreatorContext(request: Request): Promise<
       oauthAuth.organizationId,
       oauthAuth.userId,
       "oauth",
-      null
+      null,
+      oauthAuth.scope
     );
   }
 
@@ -448,13 +456,15 @@ function validateCreatorFields(
   organizationId: string | null | undefined,
   userId: string | null | undefined,
   authMethod: AuthMethod,
-  apiKeyId: string | null
+  apiKeyId: string | null,
+  scope?: string
 ):
   | {
       organizationId: string;
       userId: string;
       authMethod: AuthMethod;
       apiKeyId: string | null;
+      scope?: string;
     }
   | { error: string; status: number } {
   if (!organizationId) {
@@ -466,5 +476,5 @@ function validateCreatorFields(
       status: 400,
     };
   }
-  return { organizationId, userId, authMethod, apiKeyId };
+  return { organizationId, userId, authMethod, apiKeyId, scope };
 }

--- a/tests/unit/oauth-auth-scope-required.test.ts
+++ b/tests/unit/oauth-auth-scope-required.test.ts
@@ -1,0 +1,93 @@
+import { SignJWT } from "jose";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { mockUsersFindFirst, mockIsMember } = vi.hoisted(() => ({
+  mockUsersFindFirst: vi.fn(),
+  mockIsMember: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: { query: { users: { findFirst: mockUsersFindFirst } } },
+}));
+
+vi.mock("@/lib/db/schema", () => ({ users: { id: "id" } }));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureMessage: vi.fn(),
+}));
+
+vi.mock("@/lib/workflow/access", () => ({
+  isUserMemberOfOrganization: mockIsMember,
+}));
+
+const TEST_SECRET = "test-secret-32-bytes-long-enough-for-hs256";
+process.env.OAUTH_JWT_SECRET = TEST_SECRET;
+
+import {
+  authenticateOAuthToken,
+  createAccessToken,
+} from "@/lib/mcp/oauth-auth";
+
+function buildRequestWithToken(token: string): Request {
+  return new Request("http://localhost/api/anything", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+async function signRaw(claims: Record<string, unknown>): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  return await new SignJWT(claims)
+    .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+    .setIssuedAt(now)
+    .setExpirationTime(now + 3600)
+    .sign(new TextEncoder().encode(TEST_SECRET));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Subject is an active member so the scope claim is the only gate under test.
+  mockUsersFindFirst.mockResolvedValue({ deactivatedAt: null });
+  mockIsMember.mockResolvedValue(true);
+});
+
+// A-03 linchpin. The REST scope guards (requireScope at every /api mutation
+// sink) treat scope=undefined as full access for api-key/session callers. That
+// is only safe because an authenticated OAuth token ALWAYS carries a string
+// scope, guaranteed solely by isOAuthTokenPayload rejecting a scope-less
+// payload. If that check is ever relaxed, ctx.scope would be undefined at the
+// REST sinks and an mcp:read (or scope-less) token would regain write access
+// across every gated route at once. These tests pin the invariant.
+describe("authenticateOAuthToken -- scope claim is mandatory (A-03 linchpin)", () => {
+  it("rejects a validly-signed token whose scope claim is omitted", async () => {
+    const token = await signRaw({ sub: "user-1", org: "org-1" });
+
+    const result = await authenticateOAuthToken(buildRequestWithToken(token));
+
+    expect(result.authenticated).toBe(false);
+    expect(result.statusCode).toBe(401);
+  });
+
+  it("rejects a token whose scope claim is a non-string", async () => {
+    const token = await signRaw({ sub: "user-1", org: "org-1", scope: 123 });
+
+    const result = await authenticateOAuthToken(buildRequestWithToken(token));
+
+    expect(result.authenticated).toBe(false);
+    expect(result.statusCode).toBe(401);
+  });
+
+  it("authenticates a token that carries a string scope and surfaces it", async () => {
+    const token = await createAccessToken({
+      sub: "user-1",
+      org: "org-1",
+      scope: "mcp:read",
+    });
+
+    const result = await authenticateOAuthToken(buildRequestWithToken(token));
+
+    expect(result.authenticated).toBe(true);
+    expect(result.scope).toBe("mcp:read");
+  });
+});

--- a/tests/unit/oauth-scope-route-gate.test.ts
+++ b/tests/unit/oauth-scope-route-gate.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Leg 2 of the A-03 test plan: drive the REAL route handlers with REAL minted
+// OAuth tokens and assert only the scope-gate outcome (403 insufficient_scope
+// or not). Downstream DB/RPC work is irrelevant to the gate, so the heavy deps
+// are stubbed -- a thrown error or a 500 past the gate both count as "passed
+// the gate". This exercises authenticateOAuthToken -> the three dual-auth
+// helper families -> requireScope -> each route's chosen scope constant.
+
+vi.mock("server-only", () => ({}));
+
+const { mockUsersFindFirst, mockIsMember } = vi.hoisted(() => ({
+  mockUsersFindFirst: vi.fn(),
+  mockIsMember: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: new Proxy(
+    { query: { users: { findFirst: mockUsersFindFirst } } } as Record<
+      string,
+      unknown
+    >,
+    {
+      get(target, prop: string) {
+        if (prop in target) {
+          return target[prop];
+        }
+        // Any select/insert/update/delete reached past the gate just throws;
+        // the handler's try/catch turns it into a non-403 response.
+        return () => {
+          throw new Error("db unavailable in scope-gate test");
+        };
+      },
+    }
+  ),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+  captureEvent: vi.fn(),
+  withScope: vi.fn(),
+}));
+vi.mock("@/lib/workflow/access", () => ({
+  isUserMemberOfOrganization: mockIsMember,
+}));
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: vi.fn().mockResolvedValue(null),
+      getActiveMember: vi.fn().mockResolvedValue(null),
+      getFullOrganization: vi.fn().mockResolvedValue(null),
+    },
+  },
+}));
+vi.mock("@/lib/api-key-auth", () => ({
+  authenticateApiKey: vi.fn().mockResolvedValue({ authenticated: false }),
+}));
+
+const TEST_SECRET = "test-secret-32-bytes-long-enough-for-hs256";
+process.env.OAUTH_JWT_SECRET = TEST_SECRET;
+
+const { createAccessToken } = await import("@/lib/mcp/oauth-auth");
+const { POST: gasEstimatePost } = await import("@/app/api/gas/estimate/route");
+const { POST: fetchAbiPost } = await import("@/app/api/web3/fetch-abi/route");
+const { POST: tagsPost } = await import("@/app/api/tags/route");
+const { PATCH: tagPatch } = await import("@/app/api/tags/[tagId]/route");
+const { POST: integrationsPost } = await import("@/app/api/integrations/route");
+
+type Handler = (request: Request, context?: unknown) => Promise<Response>;
+
+async function tokenFor(scope: string): Promise<string> {
+  return await createAccessToken({ sub: "user-1", org: "org-1", scope });
+}
+
+async function gate(
+  handler: Handler,
+  scope: string
+): Promise<"blocked" | "passed"> {
+  const token = await tokenFor(scope);
+  const request = new Request("http://localhost/api/x", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({}),
+  });
+  let response: Response;
+  try {
+    response = await handler(request, { params: Promise.resolve({ tagId: "t1" }) });
+  } catch {
+    // Threw in downstream code => execution got past the scope gate.
+    return "passed";
+  }
+  let body: { error?: string } = {};
+  try {
+    body = (await response.json()) as { error?: string };
+  } catch {
+    // non-JSON body => not the insufficient_scope envelope
+  }
+  if (response.status === 403 && body.error === "insufficient_scope") {
+    return "blocked";
+  }
+  return "passed";
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Active member so authentication resolves; the scope claim is the only gate.
+  mockUsersFindFirst.mockResolvedValue({ deactivatedAt: null });
+  mockIsMember.mockResolvedValue(true);
+});
+
+describe("A-03 leg 2: OAuth scope gate at the REST sinks", () => {
+  describe("read-gated routes (require mcp:read after 656f6dea)", () => {
+    it("gas/estimate POST admits an mcp:read token", async () => {
+      expect(await gate(gasEstimatePost, "mcp:read")).toBe("passed");
+    });
+
+    it("web3/fetch-abi POST admits an mcp:read token", async () => {
+      expect(await gate(fetchAbiPost, "mcp:read")).toBe("passed");
+    });
+
+    it("gas/estimate POST still blocks an invalid-scope token", async () => {
+      expect(await gate(gasEstimatePost, "garbage")).toBe("blocked");
+    });
+  });
+
+  describe("write-gated routes (require mcp:write), per helper family", () => {
+    it("resolveCreatorContext: tags POST blocks mcp:read, admits mcp:write", async () => {
+      expect(await gate(tagsPost, "mcp:read")).toBe("blocked");
+      expect(await gate(tagsPost, "mcp:write")).toBe("passed");
+    });
+
+    it("getDualAuthContext: integrations POST blocks mcp:read, admits mcp:write", async () => {
+      expect(await gate(integrationsPost, "mcp:read")).toBe("blocked");
+      expect(await gate(integrationsPost, "mcp:write")).toBe("passed");
+    });
+
+    it("resolveOrganizationId: tags/[tagId] PATCH blocks mcp:read, admits mcp:write", async () => {
+      expect(await gate(tagPatch as Handler, "mcp:read")).toBe("blocked");
+      expect(await gate(tagPatch as Handler, "mcp:write")).toBe("passed");
+    });
+
+    it("admits an mcp:admin token (rank covers write)", async () => {
+      expect(await gate(tagsPost, "mcp:admin")).toBe("passed");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

OAuth access tokens carry an `mcp:read | mcp:write | mcp:admin` scope, and the consent screen presents it as a real permission boundary. But scope was enforced only at the MCP tool wrapper — the REST routes those tools call are reachable directly with the same Bearer token. A prior pass gated `/api/execute/*` and the workflow-mutation routes, but every other OAuth-reachable mutation was still ungated, so an `mcp:read` token could create/overwrite/delete integration credentials, mutate wallet token sets, address-book entries, projects, tags, and org settings.

Root cause: `resolveOrganizationId` and `resolveCreatorContext` dropped the token scope from their return shape, so routes built on them structurally could not gate on it.

## What changed

- Surface `scope` through `resolveOrganizationId` and `resolveCreatorContext` (OAuth callers carry the token scope; api-key and cookie-session callers leave it `undefined`, which `scopeSatisfies` treats as full access — so the dashboard and `kh_` API keys are unaffected).
- Apply the existing `requireScope(scope, SCOPE_MCP_WRITE)` guard to the remaining state-changing handlers:
  - integrations create / update / delete / test (credential CRUD)
  - user wallet-token add / remove
  - address-book and tag create / update / delete
  - project create / update / delete
  - organization settings update + execution-digest update
  - web3 ABI fetch and gas estimate (outbound RPC/explorer work)
  - `keys/[keyId]` revoke as defense-in-depth (already session+MFA-gated, so not OAuth-reachable today, but kept consistent so a future refactor can't reopen it)
- Document the load-bearing invariant in `oauth-auth.ts` (an authenticated OAuth token always carries a string scope; if that check is relaxed, `scope=undefined` at the REST sinks would silently grant write) and pin it with a regression test.

A re-derivation over every mutation route under `app/api/**` confirms no other OAuth-reachable mutation remains ungated.

## Verification

- `pnpm type-check`: clean.
- New unit test `oauth-auth-scope-required.test.ts` (scope-claim mandatory): 3/3 pass.
- Local dev server, adversarial matrix across all three auth-helper categories and POST/PATCH/DELETE: an `mcp:read` token is rejected with `403 insufficient_scope` at every gated route, while `mcp:write` tokens, `kh_` API keys, cookie sessions, and all `GET` reads are unaffected (negative controls).
