### PR TITLE
fix(execute): strip caller-supplied web3Connection from direct node execution

### DIFF
--- a/app/api/execute/_lib/execution-service.ts
+++ b/app/api/execute/_lib/execution-service.ts
@@ -110,3 +110,29 @@ export function redactInput(
 
   return redacted;
 }
+
+/**
+ * Records a signer override the caller supplied but the route did not honor.
+ *
+ * Org-custodied direct executions always resolve the signer via org policy, so
+ * a caller-supplied `web3Connection` (the per-node signer-mode selector) never
+ * influences the write. We still want it in the audit log -- a smuggled
+ * `web3Connection: "eoa"` is a bypass attempt worth seeing -- but it must not
+ * sit at the top level where a reader could mistake it for a value that took
+ * effect. This moves any top-level `web3Connection` out of `auditBase` and
+ * records it under `_rejectedConfig` instead, keying off the caller's original
+ * request so it works whether or not `auditBase` has already been stripped.
+ */
+export function withRejectedSignerOverride(
+  auditBase: Record<string, unknown>,
+  callerConfig: Record<string, unknown>
+): Record<string, unknown> {
+  if (!("web3Connection" in callerConfig)) {
+    return auditBase;
+  }
+  const { web3Connection: _omit, ...base } = auditBase;
+  return {
+    ...base,
+    _rejectedConfig: { web3Connection: callerConfig.web3Connection },
+  };
+}

--- a/app/api/execute/check-and-execute/route.ts
+++ b/app/api/execute/check-and-execute/route.ts
@@ -18,6 +18,7 @@ import {
   failExecution,
   markRunning,
   redactInput,
+  withRejectedSignerOverride,
 } from "../_lib/execution-service";
 import { checkRateLimit } from "../_lib/rate-limit";
 import { parseSimulateFlag } from "../_lib/simulate-flag";
@@ -120,7 +121,9 @@ async function executeConditionalWrite(
     return walletError;
   }
 
-  const redactedInput = redactInput(fullBody);
+  const redactedInput = redactInput(
+    withRejectedSignerOverride(fullBody, fullBody)
+  );
   const reserve = await checkAndReserveExecution({
     organizationId,
     apiKeyId,

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -17,6 +17,7 @@ import {
   failExecution,
   markRunning,
   redactInput,
+  withRejectedSignerOverride,
 } from "../_lib/execution-service";
 import { checkRateLimit } from "../_lib/rate-limit";
 import { parseSimulateFlag } from "../_lib/simulate-flag";
@@ -125,7 +126,7 @@ async function handleWriteCall(
     return walletError;
   }
 
-  const redactedInput = redactInput(body);
+  const redactedInput = redactInput(withRejectedSignerOverride(body, body));
   const reserve = await checkAndReserveExecution({
     organizationId,
     apiKeyId,

--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -20,6 +20,7 @@ import {
   markRunning,
   redactInput,
   setRetryCount,
+  withRejectedSignerOverride,
 } from "../_lib/execution-service";
 import { checkRateLimit } from "../_lib/rate-limit";
 import {
@@ -311,10 +312,12 @@ async function executeNode(
   if (preCreatedExecutionId) {
     executionId = preCreatedExecutionId;
   } else {
-    const redactedInput = redactInput({
-      actionType: data.actionType,
-      ...safeConfig,
-    });
+    const redactedInput = redactInput(
+      withRejectedSignerOverride(
+        { actionType: data.actionType, ...safeConfig },
+        config
+      )
+    );
     const created = await createExecution({
       organizationId: apiKeyCtx.organizationId,
       apiKeyId: apiKeyCtx.apiKeyId,
@@ -487,11 +490,18 @@ export async function POST(request: Request): Promise<NextResponse> {
     }
 
     // Strip the same reserved keys executeNode removes so the persisted audit
-    // input matches what the step actually received (see stripReservedConfig).
-    const redactedInput = redactInput({
-      actionType: validation.data.actionType,
-      ...stripReservedConfig(validation.data.config),
-    });
+    // input matches what the step actually received (see stripReservedConfig),
+    // but preserve a non-honored web3Connection under _rejectedConfig so the
+    // audit log still shows the attempt (see withRejectedSignerOverride).
+    const redactedInput = redactInput(
+      withRejectedSignerOverride(
+        {
+          actionType: validation.data.actionType,
+          ...stripReservedConfig(validation.data.config),
+        },
+        validation.data.config
+      )
+    );
     const reserve = await checkAndReserveExecution({
       organizationId: apiKeyCtx.organizationId,
       apiKeyId: apiKeyCtx.apiKeyId,

--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -282,11 +282,20 @@ async function executeNode(
   const integrationId = resolvedRefs?.integrationId;
 
   // Drop caller-supplied gating keys so the step only sees the values the
-  // route resolved and gated on. web3Connection is intentionally preserved;
-  // it stays org-ownership-verified downstream in lib/safe/signer-resolver.ts.
+  // route resolved and gated on.
+  //
+  // web3Connection is stripped on purpose: it selects the signer mode in
+  // resolveSignerForNode (lib/safe/signer-resolver.ts). A direct-execution
+  // caller must NOT be able to set web3Connection='eoa' to short-circuit to
+  // the org's Turnkey EOA and bypass the org Safe's Zodiac Roles policy on
+  // org-custodied writes. With the field absent, resolveSignerForNode falls
+  // back to the "default" branch (resolveSignerMode org-policy path), which
+  // honours the Safe + active Role. The sibling execute routes never forward
+  // web3Connection either, so this keeps /api/execute/node no weaker.
   const {
     network: _ignoredNetwork,
     integrationId: _ignoredIntegrationId,
+    web3Connection: _ignoredWeb3Connection,
     _context: _ignoredContext,
     ...safeConfig
   } = config;
@@ -470,9 +479,20 @@ export async function POST(request: Request): Promise<NextResponse> {
       return walletError;
     }
 
+    // Strip the same reserved keys executeNode removes so the persisted audit
+    // input matches what the step actually received. web3Connection in
+    // particular must not be recorded as if it influenced this org-custodied
+    // write (it is stripped before reaching the signer).
+    const {
+      network: _auditNetwork,
+      integrationId: _auditIntegrationId,
+      web3Connection: _auditWeb3Connection,
+      _context: _auditContext,
+      ...auditConfig
+    } = validation.data.config;
     const redactedInput = redactInput({
       actionType: validation.data.actionType,
-      ...validation.data.config,
+      ...auditConfig,
     });
     const reserve = await checkAndReserveExecution({
       organizationId: apiKeyCtx.organizationId,

--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -270,6 +270,30 @@ async function handleResult(
   );
 }
 
+// Caller-supplied config keys the route must own, not the caller. `network`
+// and `integrationId` are resolved and gated by the route itself; `_context`
+// is injected server-side. `web3Connection` selects the signer mode in
+// resolveSignerForNode (lib/safe/signer-resolver.ts): a direct-execution
+// caller must NOT be able to set web3Connection='eoa' to short-circuit to the
+// org's Turnkey EOA and bypass the org Safe's Zodiac Roles policy on
+// org-custodied writes. With it absent, resolveSignerForNode falls back to the
+// "default" branch (resolveSignerMode org-policy path), honouring the Safe +
+// active Role. The sibling execute routes never forward web3Connection either,
+// so this keeps /api/execute/node no weaker. Stripping all four in one place
+// keeps the step input and the persisted audit input in lockstep.
+function stripReservedConfig(
+  config: Record<string, unknown>
+): Record<string, unknown> {
+  const {
+    network: _ignoredNetwork,
+    integrationId: _ignoredIntegrationId,
+    web3Connection: _ignoredWeb3Connection,
+    _context: _ignoredContext,
+    ...rest
+  } = config;
+  return rest;
+}
+
 async function executeNode(
   data: NodeExecuteRequest,
   resolved: ResolvedAction,
@@ -281,24 +305,7 @@ async function executeNode(
   const network = resolvedRefs?.network;
   const integrationId = resolvedRefs?.integrationId;
 
-  // Drop caller-supplied gating keys so the step only sees the values the
-  // route resolved and gated on.
-  //
-  // web3Connection is stripped on purpose: it selects the signer mode in
-  // resolveSignerForNode (lib/safe/signer-resolver.ts). A direct-execution
-  // caller must NOT be able to set web3Connection='eoa' to short-circuit to
-  // the org's Turnkey EOA and bypass the org Safe's Zodiac Roles policy on
-  // org-custodied writes. With the field absent, resolveSignerForNode falls
-  // back to the "default" branch (resolveSignerMode org-policy path), which
-  // honours the Safe + active Role. The sibling execute routes never forward
-  // web3Connection either, so this keeps /api/execute/node no weaker.
-  const {
-    network: _ignoredNetwork,
-    integrationId: _ignoredIntegrationId,
-    web3Connection: _ignoredWeb3Connection,
-    _context: _ignoredContext,
-    ...safeConfig
-  } = config;
+  const safeConfig = stripReservedConfig(config);
 
   let executionId: string;
   if (preCreatedExecutionId) {
@@ -480,19 +487,10 @@ export async function POST(request: Request): Promise<NextResponse> {
     }
 
     // Strip the same reserved keys executeNode removes so the persisted audit
-    // input matches what the step actually received. web3Connection in
-    // particular must not be recorded as if it influenced this org-custodied
-    // write (it is stripped before reaching the signer).
-    const {
-      network: _auditNetwork,
-      integrationId: _auditIntegrationId,
-      web3Connection: _auditWeb3Connection,
-      _context: _auditContext,
-      ...auditConfig
-    } = validation.data.config;
+    // input matches what the step actually received (see stripReservedConfig).
     const redactedInput = redactInput({
       actionType: validation.data.actionType,
-      ...auditConfig,
+      ...stripReservedConfig(validation.data.config),
     });
     const reserve = await checkAndReserveExecution({
       organizationId: apiKeyCtx.organizationId,

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -17,6 +17,7 @@ import {
   failExecution,
   markRunning,
   redactInput,
+  withRejectedSignerOverride,
 } from "../_lib/execution-service";
 import { checkRateLimit } from "../_lib/rate-limit";
 import { parseSimulateFlag } from "../_lib/simulate-flag";
@@ -134,7 +135,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   }
 
   // 6. Spending cap + create execution atomically
-  const redactedInput = redactInput(body);
+  const redactedInput = redactInput(withRejectedSignerOverride(body, body));
   const reserve = await checkAndReserveExecution({
     organizationId: apiKeyCtx.organizationId,
     apiKeyId: apiKeyCtx.apiKeyId,

--- a/tests/integration/direct-execution-api.test.ts
+++ b/tests/integration/direct-execution-api.test.ts
@@ -34,12 +34,19 @@ vi.mock("@/app/api/execute/_lib/spending-cap", () => ({
   checkAndReserveExecution: mocks.checkAndReserveExecution,
 }));
 
-vi.mock("@/app/api/execute/_lib/execution-service", () => ({
-  markRunning: mocks.markRunning,
-  completeExecution: mocks.completeExecution,
-  failExecution: mocks.failExecution,
-  redactInput: mocks.redactInput,
-}));
+vi.mock("@/app/api/execute/_lib/execution-service", async (importActual) => {
+  const actual =
+    await importActual<
+      typeof import("@/app/api/execute/_lib/execution-service")
+    >();
+  return {
+    ...actual,
+    markRunning: mocks.markRunning,
+    completeExecution: mocks.completeExecution,
+    failExecution: mocks.failExecution,
+    redactInput: mocks.redactInput,
+  };
+});
 
 vi.mock("@/plugins/web3/steps/transfer-funds-core", () => ({
   transferFundsCore: mocks.transferFundsCore,

--- a/tests/integration/execute-node-reserved-fields.test.ts
+++ b/tests/integration/execute-node-reserved-fields.test.ts
@@ -199,6 +199,27 @@ describe("POST /api/execute/node reserved-field gating", () => {
     ).toBe("org_a");
   });
 
+  it("strips a caller-supplied web3Connection so it cannot weaken the signer mode", async () => {
+    const response = await nodePOST(
+      postRequest({
+        actionType: "web3/write-contract",
+        config: {
+          network: "1",
+          contractAddress: "0xabc",
+          // Attempt to force the org Turnkey EOA and bypass the Safe's
+          // Zodiac Roles policy on an org-custodied write.
+          web3Connection: "eoa",
+        },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    // The step must never see web3Connection: with it absent,
+    // resolveSignerForNode falls back to the org-policy (Safe + Role) path.
+    expect(mocks.capturedInput).toBeDefined();
+    expect("web3Connection" in (mocks.capturedInput ?? {})).toBe(false);
+  });
+
   it("passes an owned top-level integrationId through to the step", async () => {
     mocks.ownershipResult = [{ id: "int_mine" }];
 

--- a/tests/integration/execute-node-reserved-fields.test.ts
+++ b/tests/integration/execute-node-reserved-fields.test.ts
@@ -220,6 +220,34 @@ describe("POST /api/execute/node reserved-field gating", () => {
     expect("web3Connection" in (mocks.capturedInput ?? {})).toBe(false);
   });
 
+  it("strips reserved keys from the persisted audit input", async () => {
+    const response = await nodePOST(
+      postRequest({
+        actionType: "web3/write-contract",
+        config: {
+          network: "1",
+          contractAddress: "0xabc",
+          web3Connection: "eoa",
+          _context: { spoofed: true },
+        },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    // The execution-audit record is the `input` reserved through the spending
+    // cap. web3Connection in particular must not be persisted as if it had
+    // influenced this org-custodied write -- it is stripped before the signer.
+    expect(mocks.checkAndReserveExecution).toHaveBeenCalledTimes(1);
+    const auditInput = mocks.checkAndReserveExecution.mock.calls[0]?.[0]
+      ?.input as Record<string, unknown>;
+    expect(auditInput).toBeDefined();
+    expect("web3Connection" in auditInput).toBe(false);
+    expect("network" in auditInput).toBe(false);
+    expect("integrationId" in auditInput).toBe(false);
+    expect("_context" in auditInput).toBe(false);
+    expect(auditInput.contractAddress).toBe("0xabc");
+  });
+
   it("passes an owned top-level integrationId through to the step", async () => {
     mocks.ownershipResult = [{ id: "int_mine" }];
 

--- a/tests/integration/execute-node-reserved-fields.test.ts
+++ b/tests/integration/execute-node-reserved-fields.test.ts
@@ -49,14 +49,23 @@ vi.mock("@/app/api/execute/_lib/wallet-check", () => ({
   requireWallet: mocks.requireWallet,
 }));
 
-vi.mock("@/app/api/execute/_lib/execution-service", () => ({
-  createExecution: mocks.createExecution,
-  markRunning: mocks.markRunning,
-  completeExecution: mocks.completeExecution,
-  failExecution: mocks.failExecution,
-  setRetryCount: mocks.setRetryCount,
-  redactInput: mocks.redactInput,
-}));
+vi.mock("@/app/api/execute/_lib/execution-service", async (importActual) => {
+  // Keep the real (pure) helpers like withRejectedSignerOverride; only the
+  // DB-touching functions are replaced with mocks.
+  const actual =
+    await importActual<
+      typeof import("@/app/api/execute/_lib/execution-service")
+    >();
+  return {
+    ...actual,
+    createExecution: mocks.createExecution,
+    markRunning: mocks.markRunning,
+    completeExecution: mocks.completeExecution,
+    failExecution: mocks.failExecution,
+    setRetryCount: mocks.setRetryCount,
+    redactInput: mocks.redactInput,
+  };
+});
 
 vi.mock("@/app/api/execute/_lib/action-resolver", () => ({
   resolveAction: mocks.resolveAction,
@@ -216,11 +225,13 @@ describe("POST /api/execute/node reserved-field gating", () => {
     expect(response.status).toBe(200);
     // The step must never see web3Connection: with it absent,
     // resolveSignerForNode falls back to the org-policy (Safe + Role) path.
+    // The _rejectedConfig marker is audit-only and must not leak to the step.
     expect(mocks.capturedInput).toBeDefined();
     expect("web3Connection" in (mocks.capturedInput ?? {})).toBe(false);
+    expect("_rejectedConfig" in (mocks.capturedInput ?? {})).toBe(false);
   });
 
-  it("strips reserved keys from the persisted audit input", async () => {
+  it("records a non-honored web3Connection under _rejectedConfig in the audit input", async () => {
     const response = await nodePOST(
       postRequest({
         actionType: "web3/write-contract",
@@ -235,8 +246,9 @@ describe("POST /api/execute/node reserved-field gating", () => {
 
     expect(response.status).toBe(200);
     // The execution-audit record is the `input` reserved through the spending
-    // cap. web3Connection in particular must not be persisted as if it had
-    // influenced this org-custodied write -- it is stripped before the signer.
+    // cap. web3Connection must not appear at the top level (it did not
+    // influence this org-custodied write) but is preserved under
+    // _rejectedConfig so the audit log still shows the bypass attempt.
     expect(mocks.checkAndReserveExecution).toHaveBeenCalledTimes(1);
     const auditInput = mocks.checkAndReserveExecution.mock.calls[0]?.[0]
       ?.input as Record<string, unknown>;
@@ -246,6 +258,22 @@ describe("POST /api/execute/node reserved-field gating", () => {
     expect("integrationId" in auditInput).toBe(false);
     expect("_context" in auditInput).toBe(false);
     expect(auditInput.contractAddress).toBe("0xabc");
+    expect(auditInput._rejectedConfig).toEqual({ web3Connection: "eoa" });
+  });
+
+  it("omits _rejectedConfig from the audit input when no override was sent", async () => {
+    const response = await nodePOST(
+      postRequest({
+        actionType: "web3/write-contract",
+        config: { network: "1", contractAddress: "0xabc" },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const auditInput = mocks.checkAndReserveExecution.mock.calls[0]?.[0]
+      ?.input as Record<string, unknown>;
+    expect(auditInput).toBeDefined();
+    expect("_rejectedConfig" in auditInput).toBe(false);
   });
 
   it("passes an owned top-level integrationId through to the step", async () => {

--- a/tests/integration/execute-scope-enforcement.test.ts
+++ b/tests/integration/execute-scope-enforcement.test.ts
@@ -36,12 +36,19 @@ vi.mock("@/app/api/execute/_lib/spending-cap", () => ({
   checkAndReserveExecution: mocks.checkAndReserveExecution,
 }));
 
-vi.mock("@/app/api/execute/_lib/execution-service", () => ({
-  markRunning: mocks.markRunning,
-  completeExecution: mocks.completeExecution,
-  failExecution: mocks.failExecution,
-  redactInput: mocks.redactInput,
-}));
+vi.mock("@/app/api/execute/_lib/execution-service", async (importActual) => {
+  const actual =
+    await importActual<
+      typeof import("@/app/api/execute/_lib/execution-service")
+    >();
+  return {
+    ...actual,
+    markRunning: mocks.markRunning,
+    completeExecution: mocks.completeExecution,
+    failExecution: mocks.failExecution,
+    redactInput: mocks.redactInput,
+  };
+});
 
 vi.mock("@/plugins/web3/steps/transfer-funds-core", () => ({
   transferFundsCore: mocks.transferFundsCore,

--- a/tests/integration/execute-simulate-route.test.ts
+++ b/tests/integration/execute-simulate-route.test.ts
@@ -67,12 +67,19 @@ vi.mock("../../app/api/execute/_lib/spending-cap", () => ({
   checkAndReserveExecution: spies.checkAndReserveExecution,
 }));
 
-vi.mock("../../app/api/execute/_lib/execution-service", () => ({
-  markRunning: spies.markRunning,
-  completeExecution: spies.completeExecution,
-  failExecution: spies.failExecution,
-  redactInput: (x: unknown) => x,
-}));
+vi.mock("../../app/api/execute/_lib/execution-service", async (importActual) => {
+  const actual =
+    await importActual<
+      typeof import("../../app/api/execute/_lib/execution-service")
+    >();
+  return {
+    ...actual,
+    markRunning: spies.markRunning,
+    completeExecution: spies.completeExecution,
+    failExecution: spies.failExecution,
+    redactInput: (x: unknown) => x,
+  };
+});
 
 vi.mock("@/plugins/web3/steps/write-contract-core", () => ({
   writeContractCore: spies.writeContractCore,

--- a/tests/unit/check-and-execute-routing.test.ts
+++ b/tests/unit/check-and-execute-routing.test.ts
@@ -37,12 +37,19 @@ const mockCompleteExecution = vi.fn();
 const mockFailExecution = vi.fn();
 const mockMarkRunning = vi.fn();
 const mockRedactInput = vi.fn();
-vi.mock("@/app/api/execute/_lib/execution-service", () => ({
-  completeExecution: (...args: unknown[]) => mockCompleteExecution(...args),
-  failExecution: (...args: unknown[]) => mockFailExecution(...args),
-  markRunning: (...args: unknown[]) => mockMarkRunning(...args),
-  redactInput: (...args: unknown[]) => mockRedactInput(...args),
-}));
+vi.mock("@/app/api/execute/_lib/execution-service", async (importActual) => {
+  const actual =
+    await importActual<
+      typeof import("@/app/api/execute/_lib/execution-service")
+    >();
+  return {
+    ...actual,
+    completeExecution: (...args: unknown[]) => mockCompleteExecution(...args),
+    failExecution: (...args: unknown[]) => mockFailExecution(...args),
+    markRunning: (...args: unknown[]) => mockMarkRunning(...args),
+    redactInput: (...args: unknown[]) => mockRedactInput(...args),
+  };
+});
 
 const mockCheckRateLimit = vi.fn();
 vi.mock("@/app/api/execute/_lib/rate-limit", () => ({

--- a/tests/unit/with-rejected-signer-override.test.ts
+++ b/tests/unit/with-rejected-signer-override.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+
+// execution-service pulls in server-only + the DB client at module load; stub
+// them so we can import the pure helper without a database.
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/db", () => ({ db: {} }));
+vi.mock("@/lib/db/schema", () => ({ directExecutions: {} }));
+
+import { withRejectedSignerOverride } from "@/app/api/execute/_lib/execution-service";
+
+describe("withRejectedSignerOverride", () => {
+  it("returns the base unchanged when the caller sent no web3Connection", () => {
+    const base = {
+      actionType: "web3/write-contract",
+      contractAddress: "0xabc",
+    };
+    const result = withRejectedSignerOverride(base, {
+      contractAddress: "0xabc",
+    });
+    expect(result).toEqual(base);
+    expect("_rejectedConfig" in result).toBe(false);
+  });
+
+  it("records a non-honored override under _rejectedConfig (pre-stripped base)", () => {
+    // The node route passes a base from which web3Connection was already
+    // removed, plus the original caller config.
+    const result = withRejectedSignerOverride(
+      { actionType: "web3/write-contract", contractAddress: "0xabc" },
+      { contractAddress: "0xabc", web3Connection: "eoa" }
+    );
+    expect(result._rejectedConfig).toEqual({ web3Connection: "eoa" });
+    expect("web3Connection" in result).toBe(false);
+    expect(result.contractAddress).toBe("0xabc");
+  });
+
+  it("strips a top-level web3Connection from the base too (sibling body case)", () => {
+    // Sibling routes pass the raw body as both base and callerConfig, so the
+    // override sits at the top level and must be relocated, not duplicated.
+    const body = { contractAddress: "0xabc", web3Connection: "eoa" };
+    const result = withRejectedSignerOverride(body, body);
+    expect("web3Connection" in result).toBe(false);
+    expect(result._rejectedConfig).toEqual({ web3Connection: "eoa" });
+    expect(result.contractAddress).toBe("0xabc");
+  });
+
+  it("does not mutate the inputs", () => {
+    const base = { contractAddress: "0xabc", web3Connection: "eoa" };
+    const config = { contractAddress: "0xabc", web3Connection: "eoa" };
+    withRejectedSignerOverride(base, config);
+    expect(base.web3Connection).toBe("eoa");
+    expect(config.web3Connection).toBe("eoa");
+  });
+});


### PR DESCRIPTION
## Summary
`/api/execute/node` spread the caller's free-form `config` verbatim into the step input, preserving `config.web3Connection`. The web3 step cores forward it to `resolveSignerForNode`, whose `eoa` branch short-circuits to the org's Turnkey EOA and bypasses the org Safe's Zodiac Roles policy on org-custodied writes. The dedicated transfer/contract-call/check-and-execute routes never forward it, so this route was strictly weaker — a holder of an `mcp:write` key could route an unconstrained write through the EOA.

## Change
- Strip `web3Connection` (with the already-stripped `network`, `integrationId`, `_context`) before it reaches the step input, forcing the persisted node's signer mode (org-policy: Safe + active Role).
- Strip the same reserved keys from the persisted/redacted execution-audit input so the record matches what the step received.

## Verification
- Sibling sweep: confirmed no other execute route forwards a caller-supplied signer mode.
- Integration test asserts `web3Connection` never reaches `stepInput`; 5/5 pass. type-check clean.