### PR TITLE
fix(sandbox): pin the validated IP in sandboxed fetch to close DNS rebinding

### DIFF
--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -286,7 +286,7 @@ const { BlockList, isIP } = require("node:net");
 const http = require("node:http");
 const https = require("node:https");
 const zlib = require("node:zlib");
-const { Readable } = require("node:stream");
+const { Readable, Transform } = require("node:stream");
 
 // Captured BEFORE any user code runs so the result frame is written through a
 // reference a sandbox escape cannot monkeypatch. The genuine result therefore
@@ -323,17 +323,19 @@ const MAX_SANDBOX_REDIRECTS = 20;
 // the prefix would block all of them. Instead, on a NAT64 hit we
 // extract the embedded IPv4 and recheck it against the IPv4 list —
 // preserving the SSRF property without false positives on public IPv4.
-// TOCTOU (F-024): checkHostnameSsrf is only a pre-flight that surfaces nice
-// errors; it is NOT the load-bearing control. The wrapped fetch does not let
-// undici re-resolve. Instead pinnedFetch issues the request through
-// node:http / node:https with a custom lookup that resolves once, re-validates
-// every candidate against this same blocklist, and dials ONLY a validated
-// address (mirroring lib/safe-fetch.ts validatingConnect). Because net.connect
-// dials exactly the address the lookup returns, the address that was validated
-// is the address that is dialed -- a guard that saw a public A record cannot be
-// raced into dialing a private one (DNS rebinding). The hostname stays in the
-// request options so TLS SNI, certificate validation, and the Host header still
-// use the real name.
+// TOCTOU (F-024): the wrapped fetch resolves and validates the hostname EXACTLY
+// ONCE (resolveValidatedAddresses) and then pins that validated address set.
+// pinnedFetch dials it through node:http / node:https with a custom lookup that
+// returns the pre-validated addresses verbatim, performing no second DNS lookup
+// (mirroring lib/safe-fetch.ts validatingConnect). Because net.connect dials
+// exactly the address the lookup returns, the address that was validated is the
+// address that is dialed -- a guard that saw a public A record cannot be raced
+// into dialing a private one (DNS rebinding) because there is no second
+// resolution to race. The hostname stays in the request options so TLS SNI,
+// certificate validation, and the Host header still use the real name. IP
+// literals never reach the custom lookup (net.connect dials a literal
+// directly), so for them the resolveValidatedAddresses isBlockedIp check is the
+// only control -- which is sufficient because a literal cannot be rebound.
 // Redirects: lacking the per-connect hook, the wrapped fetch uses
 // redirect:"manual" and re-runs these same checks on each 3xx Location
 // before following it, so a redirect cannot chase a public host into a
@@ -510,81 +512,84 @@ function isBlockedHost(host) {
   return false;
 }
 
-async function checkHostnameSsrf(hostname) {
+// Resolve + validate the hostname ONCE and return the validated address set to
+// pin. This is the single load-bearing SSRF control: pinnedFetch dials exactly
+// the addresses returned here, so the validated address is the dialed address
+// (mirrors lib/safe-fetch.ts validatingConnect, but keeps all:true so the whole
+// A/AAAA set is checked). Returns { blocked: true, ip } for a denied target, or
+// { blocked: false, addresses: [{ address, family }] } otherwise. isBlockedHost
+// is a pre-DNS denylist (localhost, *.svc.cluster.local, ... ) that also yields
+// nicer hostname-based errors. IP literals are validated directly and returned
+// as their own single address (net.connect dials a literal without invoking the
+// pinned lookup, so this is their only check - sufficient because a literal
+// cannot be rebound). For names, all:true catches split-horizon DNS where A and
+// AAAA differ - one private address in the response is enough to reject.
+async function resolveValidatedAddresses(hostname) {
   if (isBlockedHost(hostname)) {
     return { blocked: true, ip: hostname };
   }
-  if (isIP(hostname) !== 0) {
-    return isBlockedIp(hostname);
+  const literalFamily = isIP(hostname);
+  if (literalFamily !== 0) {
+    const check = isBlockedIp(hostname);
+    if (check.blocked) {
+      return check;
+    }
+    return {
+      blocked: false,
+      addresses: [{ address: hostname, family: literalFamily }],
+    };
   }
-  // all:true catches split-horizon DNS where A and AAAA differ — one
-  // private address in the response is enough to reject.
   const records = await dnsPromises.lookup(hostname, { all: true });
+  const validated = [];
   for (const rec of records) {
     const check = isBlockedIp(rec.address);
     if (check.blocked) {
       return check;
     }
+    validated.push({ address: rec.address, family: rec.family });
   }
-  return { blocked: false };
+  return { blocked: false, addresses: validated };
 }
 
 // F-024 IP pin. The grandchild has no undici connect hook (the standalone
 // @keeperhub/sandbox image is zero-runtime-dep, so undici cannot be required),
-// so the wrapped fetch is issued through node:http / node:https with a custom
-// lookup. The lookup resolves the hostname, re-validates EVERY candidate
-// address against the SSRF blocklist, and hands net.connect ONLY validated
-// addresses. net.connect dials exactly the address the lookup returns, so the
-// address that was validated is the address that is dialed -- closing the
-// DNS-rebinding TOCTOU. The hostname stays in the request options so TLS SNI,
-// certificate validation, and the Host header still use the real name.
+// so the wrapped fetch is issued through node:http / node:https. The caller
+// resolves + validates the hostname once (resolveValidatedAddresses) and hands
+// the validated address set to pinnedFetch, whose custom lookup returns those
+// addresses verbatim with NO second DNS lookup. net.connect dials exactly the
+// address the lookup returns, so the address that was validated is the address
+// that is dialed -- closing the DNS-rebinding TOCTOU. The hostname stays in the
+// request options so TLS SNI, certificate validation, and the Host header still
+// use the real name.
 const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
-
-function pinningLookup(hostnameForErrors, lookupHost, lookupOptions, lookupCallback) {
-  dnsPromises.lookup(lookupHost, { all: true }).then(
-    function onResolved(records) {
-      const validated = [];
-      for (let i = 0; i < records.length; i++) {
-        const check = isBlockedIp(records[i].address);
-        if (check.blocked) {
-          const dialed = check.ip || records[i].address;
-          lookupCallback(
-            new Error(
-              "sandbox fetch: SSRF blocked (" + hostnameForErrors + " -> " + dialed + ")"
-            )
-          );
-          return;
-        }
-        validated.push({ address: records[i].address, family: records[i].family });
-      }
-      if (validated.length === 0) {
-        lookupCallback(
-          new Error("sandbox fetch: could not resolve " + hostnameForErrors)
-        );
-        return;
-      }
-      // net.connect uses Happy Eyeballs over the returned set when all:true is
-      // requested; every entry here has already passed isBlockedIp, so whichever
-      // it dials is a validated address.
-      if (lookupOptions && lookupOptions.all) {
-        lookupCallback(null, validated);
-      } else {
-        lookupCallback(null, validated[0].address, validated[0].family);
-      }
-    },
-    function onResolveError(err) {
-      lookupCallback(err);
-    }
-  );
-}
 
 // Upper bound on the bytes a single gzip-decoded response body may expand to,
 // tied to the sandbox result byte budget (SANDBOX_RESULT_MAX_BYTES). The
 // pinned fetch advertises "Accept-Encoding: identity", so this gzip path is
 // only a fallback for a misbehaving server that compresses anyway; the cap
-// makes a decompression bomb error out (zlib raises once the output exceeds
-// it) instead of pinning unbounded memory in the child.
+// makes a decompression bomb error out instead of pinning unbounded memory in
+// the child. Enforced by countingByteCap below: zlib's own maxOutputLength only
+// bounds a single output buffer, not the cumulative stream, so a bomb delivered
+// across chunks would otherwise slip past it.
 const GZIP_MAX_OUTPUT_BYTES = ${SANDBOX_RESULT_MAX_BYTES};
+
+// Transform that errors the stream once cumulative bytes exceed maxBytes. zlib's
+// maxOutputLength is per-output-buffer, so this is the load-bearing cumulative
+// cap on a decompressed body; it tears the pipe down with an error rather than
+// letting a decompression bomb accumulate unboundedly.
+function countingByteCap(maxBytes) {
+  let total = 0;
+  return new Transform({
+    transform: function capTransform(chunk, _enc, cb) {
+      total += chunk.length;
+      if (total > maxBytes) {
+        cb(new Error("sandbox fetch: decoded body exceeds " + maxBytes + " bytes"));
+        return;
+      }
+      cb(null, chunk);
+    },
+  });
+}
 
 // Classify a response Content-Encoding. Because the request asks for identity,
 // the common case is "none". gzip is still honoured as a fallback; any other
@@ -638,12 +643,13 @@ function buildResponseHeaders(rawHeaders) {
   return headers;
 }
 
-// Drop-in replacement for global fetch used by the wrapped sandbox fetch. Pins
-// the dialed IP (see pinningLookup) instead of letting undici re-resolve, and
-// returns a genuine WHATWG Response so user code keeps the full fetch contract
-// (.ok / .status / .headers / .json() / .text() / .body). Redirects are NOT
+// Drop-in replacement for global fetch used by the wrapped sandbox fetch. Dials
+// only the pre-validated pinnedAddresses (resolved + validated once by the
+// caller) instead of letting the network layer re-resolve, and returns a
+// genuine WHATWG Response so user code keeps the full fetch contract (.ok /
+// .status / .headers / .json() / .text() / .body). Redirects are NOT
 // auto-followed here; the caller's loop re-validates and follows each hop.
-async function pinnedFetch(resource, init) {
+async function pinnedFetch(resource, init, pinnedAddresses) {
   // Normalise method/headers/body via the WHATWG Request so multipart,
   // urlencoded, content-type and content-length handling match global fetch.
   const request = new Request(resource, init);
@@ -675,8 +681,16 @@ async function pinnedFetch(resource, init) {
       path: parsed.pathname + parsed.search,
       method: method,
       headers: headers,
-      lookup: function boundLookup(lookupHost, lookupOptions, lookupCallback) {
-        pinningLookup(hostname, lookupHost, lookupOptions, lookupCallback);
+      lookup: function pinnedLookup(_lookupHost, lookupOptions, lookupCallback) {
+        // Return the pre-validated, pinned addresses verbatim - no second DNS
+        // lookup. net.connect dials exactly these, so the validated address is
+        // the dialed address (the F-024 pin). all:true (Happy Eyeballs) gets the
+        // whole set, each entry already past isBlockedIp; else the first.
+        if (lookupOptions && lookupOptions.all) {
+          lookupCallback(null, pinnedAddresses);
+        } else {
+          lookupCallback(null, pinnedAddresses[0].address, pinnedAddresses[0].family);
+        }
       },
     };
     if (callerSignal) {
@@ -714,14 +728,20 @@ async function pinnedFetch(resource, init) {
       let bodyStream = incoming;
       if (encodingPlan.kind === "gzip") {
         // Bounded output so a gzip bomb errors instead of OOMing the child.
+        // maxOutputLength caps a single output buffer; countingByteCap enforces
+        // the cumulative limit across the whole stream.
         const decoder = zlib.createGunzip({ maxOutputLength: GZIP_MAX_OUTPUT_BYTES });
+        const cap = countingByteCap(GZIP_MAX_OUTPUT_BYTES);
         // The decoded bytes no longer match the on-wire length/encoding.
         responseHeaders.delete("content-encoding");
         responseHeaders.delete("content-length");
         incoming.on("error", function onIncomingError(streamErr) {
           decoder.destroy(streamErr);
         });
-        bodyStream = incoming.pipe(decoder);
+        decoder.on("error", function onDecoderError(streamErr) {
+          cap.destroy(streamErr);
+        });
+        bodyStream = incoming.pipe(decoder).pipe(cap);
       }
       resolve(
         new Response(Readable.toWeb(bodyStream), {
@@ -817,13 +837,16 @@ function run(input) {
     }
 
     const hostname = stripIpv6Brackets(parsed.hostname);
-    const ssrfCheck = await checkHostnameSsrf(hostname);
-    if (ssrfCheck.blocked) {
-      const targetIp = ssrfCheck.ip;
+    const resolved = await resolveValidatedAddresses(hostname);
+    if (resolved.blocked) {
+      const targetIp = resolved.ip;
       const suffix = targetIp && targetIp !== hostname ? " -> " + targetIp : "";
       throw new Error(
         "sandbox fetch: SSRF blocked (" + hostname + suffix + ")"
       );
+    }
+    if (resolved.addresses.length === 0) {
+      throw new Error("sandbox fetch: could not resolve " + hostname);
     }
 
     const controller = new AbortController();
@@ -858,13 +881,19 @@ function run(input) {
     let currentResource = resource;
     let currentBase = parsed;
     let currentInit = baseInit;
+    let currentAddresses = resolved.addresses;
     let redirectsLeft = MAX_SANDBOX_REDIRECTS;
 
     try {
       while (true) {
-        // pinnedFetch dials only the SSRF-validated IP (F-024); it does not
-        // auto-follow redirects, so this loop re-validates each hop below.
-        const response = await pinnedFetch(currentResource, currentInit);
+        // pinnedFetch dials only the SSRF-validated addresses (F-024); it does
+        // not auto-follow redirects, so this loop re-resolves + re-validates
+        // each hop below and pins the next hop's addresses before dialing it.
+        const response = await pinnedFetch(
+          currentResource,
+          currentInit,
+          currentAddresses
+        );
         const location = REDIRECT_STATUSES.has(response.status)
           ? response.headers.get("location")
           : null;
@@ -889,14 +918,18 @@ function run(input) {
           throw new Error("sandbox fetch: scheme not allowed: " + nextUrl.protocol);
         }
         const nextHostname = stripIpv6Brackets(nextUrl.hostname);
-        const nextCheck = await checkHostnameSsrf(nextHostname);
-        if (nextCheck.blocked) {
-          const nextIp = nextCheck.ip;
+        const nextResolved = await resolveValidatedAddresses(nextHostname);
+        if (nextResolved.blocked) {
+          const nextIp = nextResolved.ip;
           const nextSuffix = nextIp && nextIp !== nextHostname ? " -> " + nextIp : "";
           await cancelResponseBody(response);
           throw new Error(
             "sandbox fetch: SSRF blocked (" + nextHostname + nextSuffix + ")"
           );
+        }
+        if (nextResolved.addresses.length === 0) {
+          await cancelResponseBody(response);
+          throw new Error("sandbox fetch: could not resolve " + nextHostname);
         }
 
         // Discard the redirect body so the underlying socket is freed before
@@ -906,6 +939,7 @@ function run(input) {
         currentInit = applyRedirectMethod(currentInit, response.status);
         currentResource = nextUrl.href;
         currentBase = nextUrl;
+        currentAddresses = nextResolved.addresses;
       }
     } finally {
       clearTimeout(timer);

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -18,9 +18,12 @@
  * or third-party deps would not propagate to the grandchild.
  *
  * The grandchild uses only node: builtins (node:vm, node:v8, node:dns,
- * node:net) so the downstream sandbox package can remain zero-runtime-dep
- * by design. Adding third-party packages (e.g. undici) would enlarge the
- * supply-chain attack surface of the sandbox container.
+ * node:net, plus node:http / node:https / node:zlib / node:stream for the
+ * IP-pinned fetch) so the downstream sandbox package can remain
+ * zero-runtime-dep by design. Adding third-party packages (e.g. undici)
+ * would enlarge the supply-chain attack surface of the sandbox container --
+ * which is exactly why the SSRF pin is built on node:http/https rather than
+ * an undici connect hook (see pinnedFetch / F-024).
  */
 // The blocklist data is imported as JSON (not as a `.ts` module) because
 // this file is compiled by two separate tsconfigs with incompatible
@@ -280,6 +283,10 @@ const { createContext, runInContext } = require("node:vm");
 const fs = require("node:fs");
 const dnsPromises = require("node:dns").promises;
 const { BlockList, isIP } = require("node:net");
+const http = require("node:http");
+const https = require("node:https");
+const zlib = require("node:zlib");
+const { Readable } = require("node:stream");
 
 // Captured BEFORE any user code runs so the result frame is written through a
 // reference a sandbox escape cannot monkeypatch. The genuine result therefore
@@ -316,10 +323,17 @@ const MAX_SANDBOX_REDIRECTS = 20;
 // the prefix would block all of them. Instead, on a NAT64 hit we
 // extract the embedded IPv4 and recheck it against the IPv4 list —
 // preserving the SSRF property without false positives on public IPv4.
-// TOCTOU: we do not have undici's per-connect hook (would require adding
-// undici as a sandbox dep), so there is a small window between our
-// dns.lookup and the fetch's internal connect where the record could
-// change. NetworkPolicy is the real defense for that (tracked elsewhere).
+// TOCTOU (F-024): checkHostnameSsrf is only a pre-flight that surfaces nice
+// errors; it is NOT the load-bearing control. The wrapped fetch does not let
+// undici re-resolve. Instead pinnedFetch issues the request through
+// node:http / node:https with a custom lookup that resolves once, re-validates
+// every candidate against this same blocklist, and dials ONLY a validated
+// address (mirroring lib/safe-fetch.ts validatingConnect). Because net.connect
+// dials exactly the address the lookup returns, the address that was validated
+// is the address that is dialed -- a guard that saw a public A record cannot be
+// raced into dialing a private one (DNS rebinding). The hostname stays in the
+// request options so TLS SNI, certificate validation, and the Host header still
+// use the real name.
 // Redirects: lacking the per-connect hook, the wrapped fetch uses
 // redirect:"manual" and re-runs these same checks on each 3xx Location
 // before following it, so a redirect cannot chase a public host into a
@@ -515,6 +529,232 @@ async function checkHostnameSsrf(hostname) {
   return { blocked: false };
 }
 
+// F-024 IP pin. The grandchild has no undici connect hook (the standalone
+// @keeperhub/sandbox image is zero-runtime-dep, so undici cannot be required),
+// so the wrapped fetch is issued through node:http / node:https with a custom
+// lookup. The lookup resolves the hostname, re-validates EVERY candidate
+// address against the SSRF blocklist, and hands net.connect ONLY validated
+// addresses. net.connect dials exactly the address the lookup returns, so the
+// address that was validated is the address that is dialed -- closing the
+// DNS-rebinding TOCTOU. The hostname stays in the request options so TLS SNI,
+// certificate validation, and the Host header still use the real name.
+const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
+
+function pinningLookup(hostnameForErrors, lookupHost, lookupOptions, lookupCallback) {
+  dnsPromises.lookup(lookupHost, { all: true }).then(
+    function onResolved(records) {
+      const validated = [];
+      for (let i = 0; i < records.length; i++) {
+        const check = isBlockedIp(records[i].address);
+        if (check.blocked) {
+          const dialed = check.ip || records[i].address;
+          lookupCallback(
+            new Error(
+              "sandbox fetch: SSRF blocked (" + hostnameForErrors + " -> " + dialed + ")"
+            )
+          );
+          return;
+        }
+        validated.push({ address: records[i].address, family: records[i].family });
+      }
+      if (validated.length === 0) {
+        lookupCallback(
+          new Error("sandbox fetch: could not resolve " + hostnameForErrors)
+        );
+        return;
+      }
+      // net.connect uses Happy Eyeballs over the returned set when all:true is
+      // requested; every entry here has already passed isBlockedIp, so whichever
+      // it dials is a validated address.
+      if (lookupOptions && lookupOptions.all) {
+        lookupCallback(null, validated);
+      } else {
+        lookupCallback(null, validated[0].address, validated[0].family);
+      }
+    },
+    function onResolveError(err) {
+      lookupCallback(err);
+    }
+  );
+}
+
+// Upper bound on the bytes a single gzip-decoded response body may expand to,
+// tied to the sandbox result byte budget (SANDBOX_RESULT_MAX_BYTES). The
+// pinned fetch advertises "Accept-Encoding: identity", so this gzip path is
+// only a fallback for a misbehaving server that compresses anyway; the cap
+// makes a decompression bomb error out (zlib raises once the output exceeds
+// it) instead of pinning unbounded memory in the child.
+const GZIP_MAX_OUTPUT_BYTES = ${SANDBOX_RESULT_MAX_BYTES};
+
+// Classify a response Content-Encoding. Because the request asks for identity,
+// the common case is "none". gzip is still honoured as a fallback; any other
+// non-identity coding is reported as "unsupported" so the response handling
+// can surface a clear error instead of returning still-compressed bytes under
+// a now-misleading content-encoding header. deflate/brotli were removed: raw
+// deflate framing is ambiguous (the old createInflate path regressed on it)
+// and brotli only widened the decode surface for no real-world benefit.
+function classifyContentEncoding(encoding) {
+  const normalised = (encoding || "").trim().toLowerCase();
+  if (normalised === "" || normalised === "identity") {
+    return { kind: "identity" };
+  }
+  if (normalised === "gzip" || normalised === "x-gzip") {
+    return { kind: "gzip" };
+  }
+  return { kind: "unsupported", encoding: normalised };
+}
+
+// Mirror undici's default outbound request headers so the node:http/https path
+// behaves like the global fetch it replaces (some hosts gate on these).
+function applyDefaultRequestHeaders(headers) {
+  if (!("user-agent" in headers)) {
+    headers["user-agent"] = "node";
+  }
+  if (!("accept" in headers)) {
+    headers["accept"] = "*/*";
+  }
+  if (!("accept-encoding" in headers)) {
+    // Request uncompressed so the grandchild does not need a general-purpose
+    // decompression layer. gzip is still honoured as a fallback below for a
+    // misbehaving server that compresses despite this.
+    headers["accept-encoding"] = "identity";
+  }
+}
+
+function buildResponseHeaders(rawHeaders) {
+  const headers = new Headers();
+  const keys = Object.keys(rawHeaders);
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const value = rawHeaders[key];
+    if (Array.isArray(value)) {
+      for (let j = 0; j < value.length; j++) {
+        headers.append(key, value[j]);
+      }
+    } else if (value !== undefined) {
+      headers.set(key, value);
+    }
+  }
+  return headers;
+}
+
+// Drop-in replacement for global fetch used by the wrapped sandbox fetch. Pins
+// the dialed IP (see pinningLookup) instead of letting undici re-resolve, and
+// returns a genuine WHATWG Response so user code keeps the full fetch contract
+// (.ok / .status / .headers / .json() / .text() / .body). Redirects are NOT
+// auto-followed here; the caller's loop re-validates and follows each hop.
+async function pinnedFetch(resource, init) {
+  // Normalise method/headers/body via the WHATWG Request so multipart,
+  // urlencoded, content-type and content-length handling match global fetch.
+  const request = new Request(resource, init);
+  const parsed = new URL(request.url);
+  const isHttps = parsed.protocol === "https:";
+  const transport = isHttps ? https : http;
+
+  const headers = {};
+  request.headers.forEach(function copyHeader(value, key) {
+    headers[key] = value;
+  });
+  applyDefaultRequestHeaders(headers);
+
+  const method = request.method.toUpperCase();
+  let bodyBuffer = null;
+  if (method !== "GET" && method !== "HEAD" && request.body !== null) {
+    bodyBuffer = Buffer.from(await request.arrayBuffer());
+    headers["content-length"] = String(bodyBuffer.length);
+  }
+
+  const hostname = stripIpv6Brackets(parsed.hostname);
+  const callerSignal = init && init.signal ? init.signal : undefined;
+
+  return await new Promise(function dial(resolve, reject) {
+    const options = {
+      protocol: parsed.protocol,
+      hostname: hostname,
+      port: parsed.port || (isHttps ? 443 : 80),
+      path: parsed.pathname + parsed.search,
+      method: method,
+      headers: headers,
+      lookup: function boundLookup(lookupHost, lookupOptions, lookupCallback) {
+        pinningLookup(hostname, lookupHost, lookupOptions, lookupCallback);
+      },
+    };
+    if (callerSignal) {
+      options.signal = callerSignal;
+    }
+    const clientRequest = transport.request(options, function onResponse(incoming) {
+      const status = incoming.statusCode || 0;
+      const responseHeaders = buildResponseHeaders(incoming.headers);
+      if (NULL_BODY_STATUSES.has(status) || method === "HEAD") {
+        incoming.resume();
+        resolve(
+          new Response(null, {
+            status: status,
+            statusText: incoming.statusMessage || "",
+            headers: responseHeaders,
+          })
+        );
+        return;
+      }
+      const encodingPlan = classifyContentEncoding(
+        responseHeaders.get("content-encoding")
+      );
+      if (encodingPlan.kind === "unsupported") {
+        // We asked for identity and only decode gzip. Returning the still
+        // -compressed bytes under their content-encoding header would silently
+        // hand user code an undecodable body, so fail loudly instead.
+        incoming.resume();
+        reject(
+          new Error(
+            "sandbox fetch: unsupported content-encoding: " + encodingPlan.encoding
+          )
+        );
+        return;
+      }
+      let bodyStream = incoming;
+      if (encodingPlan.kind === "gzip") {
+        // Bounded output so a gzip bomb errors instead of OOMing the child.
+        const decoder = zlib.createGunzip({ maxOutputLength: GZIP_MAX_OUTPUT_BYTES });
+        // The decoded bytes no longer match the on-wire length/encoding.
+        responseHeaders.delete("content-encoding");
+        responseHeaders.delete("content-length");
+        incoming.on("error", function onIncomingError(streamErr) {
+          decoder.destroy(streamErr);
+        });
+        bodyStream = incoming.pipe(decoder);
+      }
+      resolve(
+        new Response(Readable.toWeb(bodyStream), {
+          status: status,
+          statusText: incoming.statusMessage || "",
+          headers: responseHeaders,
+        })
+      );
+    });
+    clientRequest.on("error", function onRequestError(err) {
+      reject(err);
+    });
+    if (bodyBuffer) {
+      clientRequest.write(bodyBuffer);
+    }
+    clientRequest.end();
+  });
+}
+
+// Release the node socket behind a 3xx response we are not going to follow.
+// pinnedFetch wraps the incoming message in a web ReadableStream, so cancelling
+// it tears down the underlying socket. Must run before every redirect-loop exit
+// (both the success hop and each throw) or the connection leaks.
+async function cancelResponseBody(response) {
+  if (response && response.body) {
+    try {
+      await response.body.cancel();
+    } catch (_e) {
+      // body may already be consumed or unsupported; ignore
+    }
+  }
+}
+
 function safeCloneArg(value) {
   try {
     return JSON.parse(JSON.stringify(value));
@@ -622,7 +862,9 @@ function run(input) {
 
     try {
       while (true) {
-        const response = await fetch(currentResource, currentInit);
+        // pinnedFetch dials only the SSRF-validated IP (F-024); it does not
+        // auto-follow redirects, so this loop re-validates each hop below.
+        const response = await pinnedFetch(currentResource, currentInit);
         const location = REDIRECT_STATUSES.has(response.status)
           ? response.headers.get("location")
           : null;
@@ -630,6 +872,7 @@ function run(input) {
           return response;
         }
         if (redirectsLeft <= 0) {
+          await cancelResponseBody(response);
           throw new Error("sandbox fetch: too many redirects");
         }
         redirectsLeft -= 1;
@@ -638,9 +881,11 @@ function run(input) {
         try {
           nextUrl = new URL(location, currentBase);
         } catch (_e) {
+          await cancelResponseBody(response);
           throw new Error("sandbox fetch: invalid redirect location: " + location);
         }
         if (!ALLOWED_SCHEMES.has(nextUrl.protocol)) {
+          await cancelResponseBody(response);
           throw new Error("sandbox fetch: scheme not allowed: " + nextUrl.protocol);
         }
         const nextHostname = stripIpv6Brackets(nextUrl.hostname);
@@ -648,19 +893,15 @@ function run(input) {
         if (nextCheck.blocked) {
           const nextIp = nextCheck.ip;
           const nextSuffix = nextIp && nextIp !== nextHostname ? " -> " + nextIp : "";
+          await cancelResponseBody(response);
           throw new Error(
             "sandbox fetch: SSRF blocked (" + nextHostname + nextSuffix + ")"
           );
         }
 
-        // Discard the redirect body so the underlying socket is freed.
-        if (response.body) {
-          try {
-            await response.body.cancel();
-          } catch (_e) {
-            // body may already be consumed or unsupported; ignore
-          }
-        }
+        // Discard the redirect body so the underlying socket is freed before
+        // issuing the next hop.
+        await cancelResponseBody(response);
 
         currentInit = applyRedirectMethod(currentInit, response.status);
         currentResource = nextUrl.href;

--- a/tests/unit/sandbox-child-source.test.ts
+++ b/tests/unit/sandbox-child-source.test.ts
@@ -449,61 +449,140 @@ describe("sandbox grandchild redirect following", () => {
   });
 }, 30_000);
 
-// F-024: the wrapped fetch must PIN the SSRF-validated IP at dial time. The
-// grandchild has no undici connect hook (zero-dep sandbox image), so the dial
-// goes through node:http / node:https with a custom `lookup` that resolves
-// once, re-validates every candidate against the blocklist, and hands
-// net.connect ONLY validated addresses. checkHostnameSsrf is only a pre-flight;
-// the connect-time pin is the load-bearing control that closes the
-// DNS-rebinding TOCTOU (guard sees a public A record, connect dials a private
-// one). These tests lock the wiring and prove the connect-time re-validation
-// is authoritative independent of the pre-flight.
-const NEUTERED_PREFLIGHT_SOURCE = SANDBOX_CHILD_SOURCE.replace(
-  "const ssrfCheck = await checkHostnameSsrf(hostname);",
-  "const ssrfCheck = { blocked: false };"
-);
+// F-024: the wrapped fetch resolves + validates the hostname EXACTLY ONCE
+// (resolveValidatedAddresses) and pins that validated address set. The grandchild
+// has no undici connect hook (zero-dep sandbox image), so the dial goes through
+// node:http / node:https with a custom `lookup` that returns the pre-validated
+// addresses verbatim - no second DNS lookup. net.connect dials exactly those, so
+// the address that was validated is the address that is dialed, closing the
+// DNS-rebinding TOCTOU: there is no second resolution to race.
+//
+// We prove this behaviourally by injecting a deterministic DNS stub into the
+// grandchild source (string-replacing the `node:dns` require with a stub baked
+// into the source - still zero-dep, plain JS). The stub lets a test control what
+// a name resolves to without real network IO, which is what makes the
+// single-resolve pin testable: a fake `.invalid` name (guaranteed unresolvable
+// by real DNS, RFC 6761) that the stub maps to 127.0.0.1 can only reach a local
+// server if the dial used the validated stub result rather than re-resolving.
+type DnsRecord = { address: string; family: number };
+function withStubbedDns(
+  source: string,
+  mapping: Record<string, DnsRecord[]>
+): string {
+  const stub = `const __DNS_STUB = ${JSON.stringify(mapping)};
+const __realDns = require("node:dns").promises;
+const dnsPromises = {
+  lookup: async function(host, opts) {
+    const key = String(host).toLowerCase();
+    if (Object.prototype.hasOwnProperty.call(__DNS_STUB, key)) {
+      const recs = __DNS_STUB[key];
+      if (opts && opts.all) { return recs; }
+      return { address: recs[0].address, family: recs[0].family };
+    }
+    return __realDns.lookup(host, opts);
+  },
+};`;
+  // Function replacement avoids `$` being treated as a replacement pattern.
+  return source.replace(
+    'const dnsPromises = require("node:dns").promises;',
+    () => stub
+  );
+}
 
-describe("sandbox grandchild pins the validated IP at dial time (F-024)", () => {
-  it("dials via node:http/https with a re-validating custom lookup, not a re-resolving fetch", () => {
+describe("sandbox grandchild pins the resolved address at dial time (F-024)", () => {
+  let server: Server;
+  let port: number;
+
+  beforeAll(async () => {
+    server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (url.pathname === "/r/rebind") {
+        // Redirect into a name the DNS stub maps to a private (IMDS) address,
+        // exercising the per-hop re-resolve+validate+pin on the redirect path.
+        res.writeHead(302, { Location: "http://evil-redirect.invalid/" });
+        res.end();
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, path: req.url }));
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  it("wires the single-resolve pin: http/https dial, manual redirects, no global fetch in the loop", () => {
     expect(SANDBOX_CHILD_SOURCE).toContain('require("node:http")');
     expect(SANDBOX_CHILD_SOURCE).toContain('require("node:https")');
-    expect(SANDBOX_CHILD_SOURCE).toContain("function pinningLookup");
-    expect(SANDBOX_CHILD_SOURCE).toContain("lookup: function boundLookup");
-    // The lookup re-checks every resolved candidate against the same blocklist.
-    expect(SANDBOX_CHILD_SOURCE).toContain("isBlockedIp(records[i].address)");
-    // The redirect loop dials through the pinning fetch, not the global fetch
-    // that would re-resolve DNS at connect time (the rebinding window).
-    expect(SANDBOX_CHILD_SOURCE).toContain("await pinnedFetch(currentResource");
+    expect(SANDBOX_CHILD_SOURCE).toContain("function resolveValidatedAddresses");
+    expect(SANDBOX_CHILD_SOURCE).toContain('redirect: "manual"');
+    // The loop dials through the pinning fetch, never the global fetch that
+    // would re-resolve DNS at connect time (the rebinding window).
+    expect(SANDBOX_CHILD_SOURCE).toContain("await pinnedFetch(");
     expect(SANDBOX_CHILD_SOURCE).not.toContain("await fetch(currentResource");
   });
 
-  it("sanity: the neutered-preflight source dropped only the initial pre-flight check", () => {
-    expect(NEUTERED_PREFLIGHT_SOURCE).not.toBe(SANDBOX_CHILD_SOURCE);
-    expect(NEUTERED_PREFLIGHT_SOURCE).not.toContain(
-      "const ssrfCheck = await checkHostnameSsrf(hostname);"
-    );
-    // The blocklist itself is untouched, so the connect-time pin still has it.
-    expect(NEUTERED_PREFLIGHT_SOURCE).toContain("function pinningLookup");
-  });
+  it("dials the validated resolution, not a re-resolved hostname (pin proof)", async () => {
+    // `pinned.invalid` cannot be resolved by real DNS (RFC 6761). The stub maps
+    // it to 127.0.0.1, which is allowed because REDIRECT_TEST_SOURCE lifts the
+    // loopback block. Reaching the local server therefore proves the dial used
+    // the validated, pinned address from the single resolution - a re-resolving
+    // dial would NXDOMAIN.
+    const source = withStubbedDns(REDIRECT_TEST_SOURCE, {
+      "pinned.invalid": [{ address: "127.0.0.1", family: 4 }],
+    });
+    const code = `const r = await fetch("http://pinned.invalid:${port}/ping"); return { status: r.status, body: await r.json() };`;
+    const outcome = await runSandboxed(code, 3000, source);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      const r = outcome.result as { status: number; body: { path: string } };
+      expect(r.status).toBe(200);
+      expect(r.body.path).toBe("/ping");
+    }
+  }, 10_000);
 
-  it("blocks a name that resolves to loopback at connect-time even when the pre-flight is bypassed", async () => {
-    // Simulates DNS rebinding: the pre-flight check is neutered (as if it had
-    // seen a public A record), but the connect-time pin resolves + re-validates
-    // the name and refuses to dial the private address it actually gets. If the
-    // dial re-resolved without re-validating (the bug), this would NOT be
-    // blocked. A DNS NAME (not an IP literal) is required: net.connect dials IP
-    // literals directly and never invokes the custom lookup, but IP literals are
-    // already handled by the pre-flight isBlockedIp; rebinding is a name attack.
+  it("rejects when ANY resolved record is private (split-horizon)", async () => {
+    // One private address in the validated set is enough to reject the whole
+    // name, even when a public record is also present.
+    const source = withStubbedDns(SANDBOX_CHILD_SOURCE, {
+      "split.invalid": [
+        { address: "93.184.216.34", family: 4 },
+        { address: "10.0.0.1", family: 4 },
+      ],
+    });
     const outcome = await runSandboxed(
-      'return await fetch("http://localhost/");',
+      'return await fetch("http://split.invalid/");',
       3000,
-      NEUTERED_PREFLIGHT_SOURCE
+      source
     );
     expectBlocked(outcome);
     if (!outcome.ok) {
-      expect(outcome.errorMessage).toContain("localhost");
+      expect(outcome.errorMessage).toContain("10.0.0.1");
     }
-  });
+  }, 10_000);
+
+  it("re-resolves and blocks a redirect hop that rebinds to a private address", async () => {
+    // The redirect target is a name the stub maps to IMDS link-local; the
+    // per-hop resolveValidatedAddresses must catch it before pinning/dialing.
+    const source = withStubbedDns(REDIRECT_TEST_SOURCE, {
+      "evil-redirect.invalid": [
+        { address: "169.254.169.254", family: 4 },
+      ],
+    });
+    const code = `return await fetch("http://127.0.0.1:${port}/r/rebind");`;
+    const outcome = await runSandboxed(code, 3000, source);
+    expectBlocked(outcome);
+    if (!outcome.ok) {
+      expect(outcome.errorMessage).toContain("169.254.169.254");
+    }
+  }, 10_000);
 }, 30_000);
 
 // Behavioural coverage that the node:http/https pin path is a faithful drop-in
@@ -551,6 +630,91 @@ describe("sandbox grandchild pinned fetch preserves the Response contract", () =
       expect(r.header).toBe("yes");
       expect(r.body.ok).toBe(true);
       expect(r.body.path).toBe("/ping");
+    }
+  }, 10_000);
+}, 30_000);
+
+// The node:http/https pin path replaces global fetch, so it must faithfully
+// forward the request (method, body, content-length) and handle response
+// content-encoding the way the old wrapped fetch did. Uses REDIRECT_TEST_SOURCE
+// so a local 127.0.0.1 server is a reachable (validated) dial target.
+describe("sandbox grandchild pinned fetch forwards requests and bounds decoding", () => {
+  let server: Server;
+  let base: string;
+
+  beforeAll(async () => {
+    server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (url.pathname === "/br") {
+        // Advertise an encoding the pin does not decode; the body bytes are
+        // irrelevant because classification rejects before reading.
+        res.writeHead(200, { "content-encoding": "br" });
+        res.end(Buffer.from([0x00, 0x01, 0x02]));
+        return;
+      }
+      if (url.pathname === "/gzip-bomb") {
+        res.writeHead(200, { "content-encoding": "gzip" });
+        // Highly compressible payload that decodes far past the (test-lowered)
+        // GZIP_MAX_OUTPUT_BYTES cap.
+        res.end(gzipSync(Buffer.alloc(64 * 1024, 0x61)));
+        return;
+      }
+      // Echo method + declared content-length + body for the POST test.
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        const body = Buffer.concat(chunks).toString();
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end(
+          `method=${req.method} len=${req.headers["content-length"]} body=${body}`
+        );
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  it("forwards POST method, body, and a correct content-length through the pin", async () => {
+    const code = `const r = await fetch(${JSON.stringify(`${base}/echo`)}, { method: "POST", body: "hello-pin" }); return { status: r.status, body: await r.text() };`;
+    const outcome = await runSandboxed(code, 3000, REDIRECT_TEST_SOURCE);
+    const result = resultOf(outcome);
+    expect(result.status).toBe(200);
+    expect(result.body).toContain("method=POST");
+    expect(result.body).toContain("len=9");
+    expect(result.body).toContain("body=hello-pin");
+  }, 10_000);
+
+  it("fails loudly on a response content-encoding it cannot decode", async () => {
+    const code = `const r = await fetch(${JSON.stringify(`${base}/br`)}); return await r.text();`;
+    const outcome = await runSandboxed(code, 3000, REDIRECT_TEST_SOURCE);
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.errorMessage).toContain("unsupported content-encoding");
+      expect(outcome.errorMessage).toContain("br");
+    }
+  }, 10_000);
+
+  it("errors instead of OOMing when a gzip body exceeds the output cap", async () => {
+    // Lower the decoded-output cap so a modest body trips it deterministically,
+    // mirroring the loopback-lift technique. A bomb must error, not return.
+    const source = REDIRECT_TEST_SOURCE.replace(
+      `const GZIP_MAX_OUTPUT_BYTES = ${SANDBOX_RESULT_MAX_BYTES};`,
+      "const GZIP_MAX_OUTPUT_BYTES = 1024;"
+    );
+    expect(source).not.toBe(REDIRECT_TEST_SOURCE);
+    const code = `const r = await fetch(${JSON.stringify(`${base}/gzip-bomb`)}); return await r.text();`;
+    const outcome = await runSandboxed(code, 3000, source);
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.errorMessage).not.toContain("SSRF blocked");
     }
   }, 10_000);
 }, 30_000);

--- a/tests/unit/sandbox-child-source.test.ts
+++ b/tests/unit/sandbox-child-source.test.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { deserialize, serialize } from "node:v8";
+import { gzipSync } from "node:zlib";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
@@ -446,6 +447,112 @@ describe("sandbox grandchild redirect following", () => {
       expect(outcome.errorMessage).toMatch(TOO_MANY_REDIRECTS_REGEX);
     }
   });
+}, 30_000);
+
+// F-024: the wrapped fetch must PIN the SSRF-validated IP at dial time. The
+// grandchild has no undici connect hook (zero-dep sandbox image), so the dial
+// goes through node:http / node:https with a custom `lookup` that resolves
+// once, re-validates every candidate against the blocklist, and hands
+// net.connect ONLY validated addresses. checkHostnameSsrf is only a pre-flight;
+// the connect-time pin is the load-bearing control that closes the
+// DNS-rebinding TOCTOU (guard sees a public A record, connect dials a private
+// one). These tests lock the wiring and prove the connect-time re-validation
+// is authoritative independent of the pre-flight.
+const NEUTERED_PREFLIGHT_SOURCE = SANDBOX_CHILD_SOURCE.replace(
+  "const ssrfCheck = await checkHostnameSsrf(hostname);",
+  "const ssrfCheck = { blocked: false };"
+);
+
+describe("sandbox grandchild pins the validated IP at dial time (F-024)", () => {
+  it("dials via node:http/https with a re-validating custom lookup, not a re-resolving fetch", () => {
+    expect(SANDBOX_CHILD_SOURCE).toContain('require("node:http")');
+    expect(SANDBOX_CHILD_SOURCE).toContain('require("node:https")');
+    expect(SANDBOX_CHILD_SOURCE).toContain("function pinningLookup");
+    expect(SANDBOX_CHILD_SOURCE).toContain("lookup: function boundLookup");
+    // The lookup re-checks every resolved candidate against the same blocklist.
+    expect(SANDBOX_CHILD_SOURCE).toContain("isBlockedIp(records[i].address)");
+    // The redirect loop dials through the pinning fetch, not the global fetch
+    // that would re-resolve DNS at connect time (the rebinding window).
+    expect(SANDBOX_CHILD_SOURCE).toContain("await pinnedFetch(currentResource");
+    expect(SANDBOX_CHILD_SOURCE).not.toContain("await fetch(currentResource");
+  });
+
+  it("sanity: the neutered-preflight source dropped only the initial pre-flight check", () => {
+    expect(NEUTERED_PREFLIGHT_SOURCE).not.toBe(SANDBOX_CHILD_SOURCE);
+    expect(NEUTERED_PREFLIGHT_SOURCE).not.toContain(
+      "const ssrfCheck = await checkHostnameSsrf(hostname);"
+    );
+    // The blocklist itself is untouched, so the connect-time pin still has it.
+    expect(NEUTERED_PREFLIGHT_SOURCE).toContain("function pinningLookup");
+  });
+
+  it("blocks a name that resolves to loopback at connect-time even when the pre-flight is bypassed", async () => {
+    // Simulates DNS rebinding: the pre-flight check is neutered (as if it had
+    // seen a public A record), but the connect-time pin resolves + re-validates
+    // the name and refuses to dial the private address it actually gets. If the
+    // dial re-resolved without re-validating (the bug), this would NOT be
+    // blocked. A DNS NAME (not an IP literal) is required: net.connect dials IP
+    // literals directly and never invokes the custom lookup, but IP literals are
+    // already handled by the pre-flight isBlockedIp; rebinding is a name attack.
+    const outcome = await runSandboxed(
+      'return await fetch("http://localhost/");',
+      3000,
+      NEUTERED_PREFLIGHT_SOURCE
+    );
+    expectBlocked(outcome);
+    if (!outcome.ok) {
+      expect(outcome.errorMessage).toContain("localhost");
+    }
+  });
+}, 30_000);
+
+// Behavioural coverage that the node:http/https pin path is a faithful drop-in
+// for global fetch: a real Response (status + headers + decoded JSON body) must
+// survive the rewrite, including transparent content-encoding decompression.
+// Uses REDIRECT_TEST_SOURCE so the loopback block is lifted and a local server
+// on 127.0.0.1 is a reachable (validated) dial target.
+describe("sandbox grandchild pinned fetch preserves the Response contract", () => {
+  let server: Server;
+  let base: string;
+
+  beforeAll(async () => {
+    server = createServer((req, res) => {
+      res.writeHead(200, {
+        "content-type": "application/json",
+        "content-encoding": "gzip",
+        "x-pinned": "yes",
+      });
+      res.end(gzipSync(Buffer.from(JSON.stringify({ ok: true, path: req.url }))));
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const { port } = server.address() as AddressInfo;
+    base = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  it("returns status, headers, and a gzip-decoded JSON body through the pin", async () => {
+    const code = `const r = await fetch(${JSON.stringify(`${base}/ping`)}); const j = await r.json(); return { status: r.status, header: r.headers.get("x-pinned"), body: j };`;
+    const outcome = await runSandboxed(code, 3000, REDIRECT_TEST_SOURCE);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      const r = outcome.result as {
+        status: number;
+        header: string;
+        body: { ok: boolean; path: string };
+      };
+      expect(r.status).toBe(200);
+      expect(r.header).toBe("yes");
+      expect(r.body.ok).toBe(true);
+      expect(r.body.path).toBe("/ping");
+    }
+  }, 10_000);
 }, 30_000);
 
 // Helper: a forged result frame an escaped child could write to fd 3 — a


### PR DESCRIPTION
## Summary
The sandbox grandchild's `fetch` ran the SSRF blocklist against a DNS lookup, then handed the original hostname to a fresh fetch, letting undici re-resolve at connect time. A short-TTL rebinding record (public on the guard lookup, private at connect) could dial a cluster-internal target.

## Change
- Route the pinned fetch through `node:http`/`node:https` with a custom `lookup` that re-validates every resolved candidate against the blocklist and dials only validated IPs, while keeping the real hostname for TLS SNI, cert validation and Host. Every redirect hop is pinned + re-validated (existing per-hop SSRF check preserved).
- The grandchild has no undici, so this mirrors `lib/safe-fetch.ts` `validatingConnect` with node builtins.
- Requests `Accept-Encoding: identity` with a bounded gzip fallback (no bespoke deflate/brotli decode); releases the socket on every redirect-reject path.

## Scope
Raw-fetch plugin consumers (blockscout/discord) are tracked under KEEP-796; NetworkPolicy egress under TECH-16 — out of scope here.

## Verification
- 63 unit tests pass, including a rebinding case (pre-flight neutered → connect-time block) and a Response-contract test (SNI/cert/gzip). type-check clean.