### PR TITLE
fix(ssrf): always-on public-URL assertion for user-controlled fetch targets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,10 +146,17 @@ CDP_API_KEY_SECRET=
 # MPP (Machine Payment Protocol)
 MPP_SECRET_KEY=              # HMAC secret for MPP challenge verification
 
-# SSRF egress guard (safeFetch + assertUrlIsPublic). Fail-closed by default:
-# outbound requests to private/loopback/link-local/metadata addresses are
-# blocked unless you explicitly opt out below.
-# SAFE_FETCH_ENFORCE=false   # opt into SSRF shadow mode for local dev against localhost / a local chain RPC (default is enforce)
+# SSRF egress guard. Fail-closed by default: outbound requests to
+# private/loopback/link-local/metadata addresses are blocked unless you
+# explicitly opt out below.
+#
+# The opt-out ONLY relaxes safeFetch's own check (e.g. so local dev can reach
+# localhost or a local chain RPC through safeFetch). It does NOT relax the
+# always-on assertUrlIsPublic guard on the user-URL sinks (webhook,
+# http-request, blockscout) -- those reject internal targets regardless of this
+# flag, by design, since the URL is attacker-controlled. Reaching localhost
+# through those sinks is intentionally not supported even in shadow mode.
+# SAFE_FETCH_ENFORCE=false   # opt into safeFetch shadow mode for local dev (default is enforce)
 
 # MailerLite (signup subscriber sync)
 MAILERLITE_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -146,6 +146,11 @@ CDP_API_KEY_SECRET=
 # MPP (Machine Payment Protocol)
 MPP_SECRET_KEY=              # HMAC secret for MPP challenge verification
 
+# SSRF egress guard (safeFetch + assertUrlIsPublic). Fail-closed by default:
+# outbound requests to private/loopback/link-local/metadata addresses are
+# blocked unless you explicitly opt out below.
+# SAFE_FETCH_ENFORCE=false   # opt into SSRF shadow mode for local dev against localhost / a local chain RPC (default is enforce)
+
 # MailerLite (signup subscriber sync)
 MAILERLITE_API_KEY=
 

--- a/lib/safe-fetch.ts
+++ b/lib/safe-fetch.ts
@@ -277,7 +277,12 @@ export function isBlockedHost(
 }
 
 export function isShadowMode(): boolean {
-  return process.env.SAFE_FETCH_ENFORCE !== "true";
+  // Fail-closed by default: enforce SSRF blocking unless an environment
+  // explicitly opts into shadow mode with SAFE_FETCH_ENFORCE="false". Any
+  // other value (including unset) enforces, so an environment that forgets
+  // to set the flag still rejects private/loopback/metadata targets instead
+  // of shipping an unauthenticated SSRF primitive.
+  return process.env.SAFE_FETCH_ENFORCE === "false";
 }
 
 type BlockContext = {
@@ -461,8 +466,9 @@ export type SafeFetchOptions = RequestInit & {
  * call; DNS-resolved IPs are validated via a custom undici Agent lookup on
  * every redirect hop.
  *
- * Shadow mode is the default: blocks are logged and counted but the request
- * proceeds. Set `SAFE_FETCH_ENFORCE=true` to enforce.
+ * Enforce mode is the default (fail-closed): blocked requests throw
+ * `SsrfBlockedError`. Set `SAFE_FETCH_ENFORCE="false"` to opt into shadow
+ * mode, where blocks are logged and counted but the request still proceeds.
  */
 export async function safeFetch(
   input: RequestInfo | URL,

--- a/lib/workflow/nodes/http-request/perform.ts
+++ b/lib/workflow/nodes/http-request/perform.ts
@@ -12,6 +12,7 @@
  */
 import "server-only";
 
+import { ErrorCategory, logUserError } from "@/lib/logging";
 import {
   assertUrlIsPublic,
   SsrfBlockedError,
@@ -211,6 +212,12 @@ export async function httpRequest(
     // fires for both the always-on assertUrlIsPublic pre-check and a safeFetch
     // block in enforce mode.
     if (error instanceof SsrfBlockedError) {
+      logUserError(
+        ErrorCategory.VALIDATION,
+        "[HTTP Request] Blocked SSRF target",
+        error.message,
+        { node_type: "http-request" }
+      );
       return {
         success: false,
         error: `HTTP request failed: URL is not allowed: ${error.message}`,

--- a/lib/workflow/nodes/http-request/perform.ts
+++ b/lib/workflow/nodes/http-request/perform.ts
@@ -223,6 +223,16 @@ export async function httpRequest(
         error: `HTTP request failed: URL is not allowed: ${error.message}`,
       };
     }
+    // A malformed endpoint makes assertUrlIsPublic's URL parse throw a
+    // TypeError. That is a configuration error, not a transient source miss,
+    // so hard-fail it regardless of failOnError rather than soft-failing into
+    // a null-data success an aggregator workflow would silently swallow.
+    if (error instanceof TypeError) {
+      return {
+        success: false,
+        error: `HTTP request failed: ${getErrorMessage(error)}`,
+      };
+    }
     // A timeout abort surfaces here too -- AbortSignal.timeout() rejects the
     // fetch, which getErrorMessage renders as a timeout error.
     const message = `HTTP request failed: ${getErrorMessage(error)}`;

--- a/lib/workflow/nodes/http-request/perform.ts
+++ b/lib/workflow/nodes/http-request/perform.ts
@@ -12,7 +12,11 @@
  */
 import "server-only";
 
-import { safeFetch } from "@/lib/safe-fetch";
+import {
+  assertUrlIsPublic,
+  SsrfBlockedError,
+  safeFetch,
+} from "@/lib/safe-fetch";
 import { getErrorMessage } from "@/lib/utils";
 import { extractTemplateTokens } from "@/lib/utils/template";
 import type { StepInput } from "@/lib/workflow/executor/step-handler";
@@ -170,6 +174,15 @@ export async function httpRequest(
   const httpMethod = resolveHttpMethod(input.httpMethod);
 
   try {
+    // SSRF guard: reject private/loopback/link-local/metadata destinations
+    // before any outbound request. `assertUrlIsPublic` is always-on -- it
+    // ignores `SAFE_FETCH_ENFORCE`/shadow mode -- so a user-supplied endpoint
+    // pointing at an internal address (e.g.
+    // http://169.254.169.254/latest/meta-data/) is blocked here even in
+    // environments where `safeFetch` itself would only log-and-continue.
+    // Mirrors plugins/webhook/steps/send-webhook.ts.
+    await assertUrlIsPublic(endpoint);
+
     const response = await safeFetch(endpoint, {
       method: httpMethod,
       headers: parseHeaders(input.httpHeaders),
@@ -192,6 +205,17 @@ export async function httpRequest(
     const data = await parseResponse(response);
     return { success: true, data, status: response.status };
   } catch (error) {
+    // An SSRF block is a security/config error, not a transient source miss:
+    // hard-fail it regardless of failOnError so an aggregator workflow never
+    // silently swallows a request aimed at an internal/metadata address. This
+    // fires for both the always-on assertUrlIsPublic pre-check and a safeFetch
+    // block in enforce mode.
+    if (error instanceof SsrfBlockedError) {
+      return {
+        success: false,
+        error: `HTTP request failed: URL is not allowed: ${error.message}`,
+      };
+    }
     // A timeout abort surfaces here too -- AbortSignal.timeout() rejects the
     // fetch, which getErrorMessage renders as a timeout error.
     const message = `HTTP request failed: ${getErrorMessage(error)}`;

--- a/plugins/blockscout/steps/blockscout-core.ts
+++ b/plugins/blockscout/steps/blockscout-core.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import {
   assertUrlIsPublic,
@@ -115,6 +116,12 @@ export async function blockscoutGet<T>(
     return { success: true, data };
   } catch (error) {
     if (error instanceof SsrfBlockedError) {
+      logUserError(
+        ErrorCategory.VALIDATION,
+        "[Blockscout] Blocked SSRF target",
+        error.message,
+        { plugin_name: "blockscout" }
+      );
       return {
         success: false,
         error: `Blockscout instance URL is not allowed: ${error.message}`,

--- a/plugins/blockscout/steps/blockscout-core.ts
+++ b/plugins/blockscout/steps/blockscout-core.ts
@@ -1,7 +1,11 @@
 import "server-only";
 
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
-import { safeFetch } from "@/lib/safe-fetch";
+import {
+  assertUrlIsPublic,
+  safeFetch,
+  SsrfBlockedError,
+} from "@/lib/safe-fetch";
 import { getErrorMessage } from "@/lib/utils";
 import type { BlockscoutCredentials } from "../credentials";
 import { BLOCKSCOUT_INSTANCES } from "../chains";
@@ -86,6 +90,14 @@ export async function blockscoutGet<T>(
   }
 
   try {
+    // SSRF guard: the instance URL is user-configurable (BLOCKSCOUT_API_URL on
+    // the connection), so validate it before any outbound request.
+    // `assertUrlIsPublic` is always-on -- it ignores `SAFE_FETCH_ENFORCE`/
+    // shadow mode -- so an instance URL pointing at an internal address is
+    // blocked here even where `safeFetch` would only log-and-continue.
+    // Mirrors plugins/webhook/steps/send-webhook.ts.
+    await assertUrlIsPublic(url.toString());
+
     const response = await safeFetch(url.toString(), {
       plugin: "blockscout",
       method: "GET",
@@ -102,6 +114,12 @@ export async function blockscoutGet<T>(
     const data = (await response.json()) as T;
     return { success: true, data };
   } catch (error) {
+    if (error instanceof SsrfBlockedError) {
+      return {
+        success: false,
+        error: `Blockscout instance URL is not allowed: ${error.message}`,
+      };
+    }
     return {
       success: false,
       error: `Failed to reach Blockscout: ${getErrorMessage(error)}`,

--- a/plugins/webhook/steps/send-webhook.ts
+++ b/plugins/webhook/steps/send-webhook.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
-import { safeFetch } from "@/lib/safe-fetch";
+import { assertUrlIsPublic, safeFetch, SsrfBlockedError } from "@/lib/safe-fetch";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 
@@ -117,6 +117,48 @@ async function stepHandler(
 
   // Parse payload
   const payload = parseJsonSafely(input.webhookPayload);
+
+  // SSRF guard: reject private/loopback/link-local/metadata destinations
+  // before any outbound request. `assertUrlIsPublic` is always-on -- it
+  // ignores `SAFE_FETCH_ENFORCE`/shadow mode -- so an attacker-supplied
+  // webhookUrl pointing at an internal address (e.g.
+  // http://169.254.169.254/latest/meta-data/) is blocked here even in
+  // environments where `safeFetch` itself would only log-and-continue.
+  try {
+    await assertUrlIsPublic(url);
+  } catch (error) {
+    if (error instanceof SsrfBlockedError) {
+      logUserError(
+        ErrorCategory.VALIDATION,
+        "[Webhook] Blocked SSRF target",
+        error.message,
+        {
+          plugin_name: "webhook",
+          action_name: "send-webhook",
+        }
+      );
+      return {
+        success: false,
+        error: `Webhook URL is not allowed: ${error.message}`,
+      };
+    }
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[Webhook] Could not validate webhook URL",
+      error,
+      {
+        plugin_name: "webhook",
+        action_name: "send-webhook",
+      }
+    );
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Webhook URL is invalid or could not be resolved",
+    };
+  }
 
   try {
     console.log("[Webhook] Sending request to webhook");

--- a/tests/unit/blockscout-ssrf.test.ts
+++ b/tests/unit/blockscout-ssrf.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/workflow/executor/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
+  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
+}));
+
+const mockFetchCredentials = vi.fn();
+vi.mock("@/lib/credential-fetcher", () => ({
+  fetchCredentials: (...args: unknown[]) => mockFetchCredentials(...args),
+}));
+
+// safe-fetch pulls in @sentry/nextjs and the metrics collector at module
+// load. Stub both so the real SSRF guard (assertUrlIsPublic / isBlockedIp)
+// runs without dragging in heavyweight deps.
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+vi.mock("@/lib/metrics", () => ({
+  getMetricsCollector: () => ({
+    incrementCounter: vi.fn(),
+    recordLatency: vi.fn(),
+    recordError: vi.fn(),
+    setGauge: vi.fn(),
+  }),
+}));
+
+// Keep the real assertUrlIsPublic + SsrfBlockedError (the load-bearing SSRF
+// pre-check) and stub only the network call. The internal-IP cases below
+// throw inside assertUrlIsPublic before safeFetch is ever reached.
+const { safeFetch } = vi.hoisted(() => ({ safeFetch: vi.fn() }));
+vi.mock("@/lib/safe-fetch", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/safe-fetch")>();
+  return { ...actual, safeFetch };
+});
+
+import { getAddressInfoStep } from "@/plugins/blockscout/steps/get-address-info";
+
+describe("blockscout SSRF guard", () => {
+  beforeEach(() => {
+    mockFetchCredentials.mockReset();
+    safeFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The instance URL is user-controlled via the connection's
+  // BLOCKSCOUT_API_URL, so an attacker-configured internal host must be
+  // rejected before any outbound request.
+  const blockedInstances = [
+    "http://169.254.169.254",
+    "http://127.0.0.1",
+    "http://[::1]",
+    "http://10.0.0.5",
+    "http://192.168.1.1",
+  ];
+
+  for (const instanceUrl of blockedInstances) {
+    it(`rejects internal instance URL ${instanceUrl} without calling safeFetch`, async () => {
+      mockFetchCredentials.mockResolvedValue({
+        BLOCKSCOUT_API_URL: instanceUrl,
+      });
+
+      const result = await getAddressInfoStep({
+        address: "0xabc",
+        integrationId: "int-1",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("not allowed");
+      }
+      // The SSRF pre-check fires before any outbound request.
+      expect(safeFetch).not.toHaveBeenCalled();
+    });
+  }
+
+  it("rejects a non-http(s) instance scheme before fetching", async () => {
+    mockFetchCredentials.mockResolvedValue({
+      BLOCKSCOUT_API_URL: "file:///etc/passwd",
+    });
+
+    const result = await getAddressInfoStep({
+      address: "0xabc",
+      integrationId: "int-1",
+    });
+
+    expect(result.success).toBe(false);
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
+  it("allows a public instance URL and routes it through safeFetch", async () => {
+    // 93.184.216.34 (example.com) is a public address; the IP-literal path in
+    // assertUrlIsPublic resolves synchronously without DNS, so this stays
+    // deterministic and offline.
+    mockFetchCredentials.mockResolvedValue({
+      BLOCKSCOUT_API_URL: "http://93.184.216.34",
+    });
+    safeFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: () => Promise.resolve({ hash: "0xabc" }),
+    });
+
+    const result = await getAddressInfoStep({
+      address: "0xabc",
+      integrationId: "int-1",
+    });
+
+    expect(safeFetch).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+  });
+});

--- a/tests/unit/blockscout-steps.test.ts
+++ b/tests/unit/blockscout-steps.test.ts
@@ -18,7 +18,15 @@ vi.mock("@/lib/credential-fetcher", () => ({
 // Blockscout egress routes through safeFetch (the SSRF guard), not the raw
 // fetch global. Mock it so these tests assert on the URL passed to safeFetch.
 const { safeFetch } = vi.hoisted(() => ({ safeFetch: vi.fn() }));
-vi.mock("@/lib/safe-fetch", () => ({ safeFetch }));
+// blockscout-core runs an always-on assertUrlIsPublic SSRF pre-check before
+// safeFetch; stub it to resolve so these tests exercise the fetch path against
+// the (public) hosted instances. SsrfBlockedError must be a real class so the
+// `instanceof` branch in blockscout-core's catch is callable.
+vi.mock("@/lib/safe-fetch", () => ({
+  safeFetch,
+  assertUrlIsPublic: vi.fn(() => Promise.resolve()),
+  SsrfBlockedError: class SsrfBlockedError extends Error {},
+}));
 
 import { getAddressBalanceStep } from "@/plugins/blockscout/steps/get-address-balance";
 import { getAddressCountersStep } from "@/plugins/blockscout/steps/get-address-counters";
@@ -26,7 +34,10 @@ import { getAddressInfoStep } from "@/plugins/blockscout/steps/get-address-info"
 import { getTokenInfoStep } from "@/plugins/blockscout/steps/get-token-info";
 import { getTransactionStep } from "@/plugins/blockscout/steps/get-transaction";
 
-function mockFetchOnce(body: unknown, init?: { ok?: boolean; status?: number }) {
+function mockFetchOnce(
+  body: unknown,
+  init?: { ok?: boolean; status?: number }
+) {
   const ok = init?.ok ?? true;
   const status = init?.status ?? 200;
   safeFetch.mockReset();
@@ -69,7 +80,9 @@ describe("blockscout get-address-balance", () => {
       isContract: false,
       ensName: "vitalik.eth",
     });
-    expect(lastFetchUrl()).toContain("https://eth.blockscout.com/api/v2/addresses/0xabc");
+    expect(lastFetchUrl()).toContain(
+      "https://eth.blockscout.com/api/v2/addresses/0xabc"
+    );
   });
 
   it("uses the configured instance URL and appends the API key", async () => {
@@ -323,7 +336,9 @@ describe("blockscout chain selection", () => {
 
     await getAddressInfoStep({ address: "0xabc", network: "8453" });
 
-    expect(lastFetchUrl()).toContain("https://base.blockscout.com/api/v2/addresses/0xabc");
+    expect(lastFetchUrl()).toContain(
+      "https://base.blockscout.com/api/v2/addresses/0xabc"
+    );
   });
 
   it("maps Optimism to its canonical instance", async () => {
@@ -331,7 +346,9 @@ describe("blockscout chain selection", () => {
 
     await getAddressCountersStep({ address: "0xabc", network: "10" });
 
-    expect(lastFetchUrl()).toContain("https://explorer.optimism.io/api/v2/addresses/0xabc/counters");
+    expect(lastFetchUrl()).toContain(
+      "https://explorer.optimism.io/api/v2/addresses/0xabc/counters"
+    );
   });
 
   it("defaults to Ethereum mainnet when no chain is selected", async () => {
@@ -345,7 +362,10 @@ describe("blockscout chain selection", () => {
   it("errors for a chain with no hosted instance and no connection", async () => {
     global.fetch = vi.fn() as unknown as typeof fetch;
 
-    const result = await getAddressInfoStep({ address: "0xabc", network: "999999" });
+    const result = await getAddressInfoStep({
+      address: "0xabc",
+      network: "999999",
+    });
 
     expect(result.success).toBe(false);
     expect(global.fetch).not.toHaveBeenCalled();
@@ -366,6 +386,8 @@ describe("blockscout chain selection", () => {
       integrationId: "int-1",
     });
 
-    expect(lastFetchUrl()).toContain("https://custom.blockscout.example/api/v2/addresses/0xabc");
+    expect(lastFetchUrl()).toContain(
+      "https://custom.blockscout.example/api/v2/addresses/0xabc"
+    );
   });
 });

--- a/tests/unit/http-request-ssrf.test.ts
+++ b/tests/unit/http-request-ssrf.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// safe-fetch pulls in @sentry/nextjs and the metrics collector at module
+// load. Stub both so the real SSRF guard (assertUrlIsPublic / isBlockedIp)
+// runs without dragging in heavyweight deps.
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+vi.mock("@/lib/metrics", () => ({
+  getMetricsCollector: () => ({
+    incrementCounter: vi.fn(),
+    recordLatency: vi.fn(),
+    recordError: vi.fn(),
+    setGauge: vi.fn(),
+  }),
+}));
+
+// Keep the real assertUrlIsPublic + SsrfBlockedError (the load-bearing SSRF
+// pre-check) and stub only the network call. The internal-IP cases below
+// throw inside assertUrlIsPublic before safeFetch is ever reached.
+const { safeFetch } = vi.hoisted(() => ({ safeFetch: vi.fn() }));
+vi.mock("@/lib/safe-fetch", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/safe-fetch")>();
+  return { ...actual, safeFetch };
+});
+
+import { httpRequest } from "@/lib/workflow/nodes/http-request/perform";
+
+describe("httpRequest SSRF guard", () => {
+  beforeEach(() => {
+    safeFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const blockedEndpoints = [
+    "http://169.254.169.254/latest/meta-data/",
+    "http://127.0.0.1/internal",
+    "http://[::1]/internal",
+    "http://10.0.0.5/admin",
+    "http://192.168.1.1/",
+  ];
+
+  for (const endpoint of blockedEndpoints) {
+    it(`rejects internal/metadata target ${endpoint} without calling safeFetch`, async () => {
+      const result = await httpRequest({ endpoint });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("URL is not allowed");
+      }
+      // The SSRF pre-check fires before any outbound request.
+      expect(safeFetch).not.toHaveBeenCalled();
+    });
+  }
+
+  it("rejects a non-http(s) scheme before fetching", async () => {
+    const result = await httpRequest({ endpoint: "file:///etc/passwd" });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("URL is not allowed");
+    }
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
+  it("hard-fails an internal target even when failOnError is false", async () => {
+    // SSRF blocks must never be soft-failed into a `{ success: true }` miss --
+    // an aggregator workflow should not silently swallow a request aimed at an
+    // internal/metadata address.
+    const result = await httpRequest({
+      endpoint: "http://169.254.169.254/latest/meta-data/",
+      failOnError: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
+  it("allows a public IP-literal target and routes it through safeFetch", async () => {
+    // 93.184.216.34 (example.com) is a public address; the IP-literal path in
+    // assertUrlIsPublic resolves synchronously without DNS, so this stays
+    // deterministic and offline.
+    safeFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => "application/json" },
+      json: () => Promise.resolve({ received: true }),
+    });
+
+    const result = await httpRequest({
+      endpoint: "http://93.184.216.34/data",
+      httpMethod: "GET",
+    });
+
+    expect(safeFetch).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.status).toBe(200);
+      expect(result.data).toEqual({ received: true });
+    }
+  });
+});

--- a/tests/unit/http-request-ssrf.test.ts
+++ b/tests/unit/http-request-ssrf.test.ts
@@ -79,6 +79,18 @@ describe("httpRequest SSRF guard", () => {
     expect(safeFetch).not.toHaveBeenCalled();
   });
 
+  it("hard-fails a malformed URL even when failOnError is false", async () => {
+    // A malformed endpoint is a config error, not a transient miss: it must
+    // not soft-fail into a `{ success: true }` result an aggregator swallows.
+    const result = await httpRequest({
+      endpoint: "http://",
+      failOnError: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
   it("allows a public IP-literal target and routes it through safeFetch", async () => {
     // 93.184.216.34 (example.com) is a public address; the IP-literal path in
     // assertUrlIsPublic resolves synchronously without DNS, so this stays

--- a/tests/unit/http-request-timeout-soft-fail.test.ts
+++ b/tests/unit/http-request-timeout-soft-fail.test.ts
@@ -8,8 +8,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
+// assertUrlIsPublic is the always-on SSRF pre-check perform.ts runs before
+// safeFetch; stub it to resolve so these timeout/soft-fail cases exercise the
+// fetch path. SsrfBlockedError must be a real class so the `instanceof` branch
+// in perform.ts's catch is callable.
 vi.mock("@/lib/safe-fetch", () => ({
   safeFetch: vi.fn(),
+  assertUrlIsPublic: vi.fn(() => Promise.resolve()),
+  SsrfBlockedError: class SsrfBlockedError extends Error {},
 }));
 
 import { safeFetch } from "@/lib/safe-fetch";

--- a/tests/unit/safe-fetch.test.ts
+++ b/tests/unit/safe-fetch.test.ts
@@ -44,6 +44,7 @@ import {
   assertUrlIsPublic,
   isBlockedHost,
   isBlockedIp,
+  isShadowMode,
   SsrfBlockedError,
   type SsrfBlockReason,
   safeFetch,
@@ -255,6 +256,42 @@ describe("isBlockedHost", () => {
   });
 });
 
+describe("isShadowMode", () => {
+  const originalEnforce = process.env.SAFE_FETCH_ENFORCE;
+
+  afterEach(() => {
+    if (originalEnforce === undefined) {
+      // biome-ignore lint/performance/noDelete: restore unset state
+      delete process.env.SAFE_FETCH_ENFORCE;
+    } else {
+      process.env.SAFE_FETCH_ENFORCE = originalEnforce;
+    }
+  });
+
+  it("is fail-closed (enforces) when SAFE_FETCH_ENFORCE is unset", () => {
+    // biome-ignore lint/performance/noDelete: simulate an env that forgot the flag
+    delete process.env.SAFE_FETCH_ENFORCE;
+    expect(isShadowMode()).toBe(false);
+  });
+
+  it("enforces when SAFE_FETCH_ENFORCE='true'", () => {
+    process.env.SAFE_FETCH_ENFORCE = "true";
+    expect(isShadowMode()).toBe(false);
+  });
+
+  it("enforces for any non-'false' value (e.g. '1', 'shadow')", () => {
+    process.env.SAFE_FETCH_ENFORCE = "1";
+    expect(isShadowMode()).toBe(false);
+    process.env.SAFE_FETCH_ENFORCE = "shadow";
+    expect(isShadowMode()).toBe(false);
+  });
+
+  it("only enters shadow mode on the explicit opt-in SAFE_FETCH_ENFORCE='false'", () => {
+    process.env.SAFE_FETCH_ENFORCE = "false";
+    expect(isShadowMode()).toBe(true);
+  });
+});
+
 describe("safeFetch (enforce mode)", () => {
   const originalEnforce = process.env.SAFE_FETCH_ENFORCE;
 
@@ -375,8 +412,11 @@ describe("safeFetch (shadow mode)", () => {
   const originalEnforce = process.env.SAFE_FETCH_ENFORCE;
 
   beforeEach(() => {
-    // biome-ignore lint/performance/noDelete: default shadow requires unset
-    delete process.env.SAFE_FETCH_ENFORCE;
+    // Shadow mode is now opt-in: it requires an explicit
+    // SAFE_FETCH_ENFORCE="false". Leaving the var unset would enforce
+    // (fail-closed) and throw SsrfBlockedError, which these tests do not
+    // expect.
+    process.env.SAFE_FETCH_ENFORCE = "false";
     incrementCounter.mockClear();
     captureException.mockClear();
   });

--- a/tests/unit/send-webhook-ssrf.test.ts
+++ b/tests/unit/send-webhook-ssrf.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/workflow/executor/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
+  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: {
+    VALIDATION: "validation",
+    CONFIGURATION: "configuration",
+    EXTERNAL_SERVICE: "external_service",
+  },
+  logUserError: vi.fn(),
+}));
+
+// safe-fetch pulls in @sentry/nextjs and the metrics collector at module
+// load. Stub both so the real SSRF guard (assertUrlIsPublic / isBlockedIp)
+// runs without dragging in heavyweight deps.
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+vi.mock("@/lib/metrics", () => ({
+  getMetricsCollector: () => ({
+    incrementCounter: vi.fn(),
+    recordLatency: vi.fn(),
+    recordError: vi.fn(),
+    setGauge: vi.fn(),
+  }),
+}));
+
+// Keep the real assertUrlIsPublic + SsrfBlockedError (the load-bearing SSRF
+// pre-check) and stub only the network call. The internal-IP cases below
+// throw inside assertUrlIsPublic before safeFetch is ever reached.
+const { safeFetch } = vi.hoisted(() => ({ safeFetch: vi.fn() }));
+vi.mock("@/lib/safe-fetch", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/safe-fetch")>();
+  return { ...actual, safeFetch };
+});
+
+import { sendWebhookStep } from "@/plugins/webhook/steps/send-webhook";
+
+const baseInput = {
+  webhookMethod: "POST",
+  webhookHeaders: undefined,
+  webhookPayload: JSON.stringify({ hello: "world" }),
+};
+
+describe("sendWebhookStep SSRF guard", () => {
+  beforeEach(() => {
+    safeFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const blockedUrls = [
+    "http://169.254.169.254/latest/meta-data/",
+    "http://127.0.0.1/internal",
+    "http://[::1]/internal",
+    "http://10.0.0.5/admin",
+    "http://192.168.1.1/",
+  ];
+
+  for (const webhookUrl of blockedUrls) {
+    it(`rejects internal/metadata target ${webhookUrl} without calling safeFetch`, async () => {
+      const result = await sendWebhookStep({ ...baseInput, webhookUrl });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("not allowed");
+      }
+      // The SSRF pre-check fires before any outbound request.
+      expect(safeFetch).not.toHaveBeenCalled();
+    });
+  }
+
+  it("rejects a non-http(s) scheme before fetching", async () => {
+    const result = await sendWebhookStep({
+      ...baseInput,
+      webhookUrl: "file:///etc/passwd",
+    });
+
+    expect(result.success).toBe(false);
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
+  it("allows a public IP-literal target and routes it through safeFetch", async () => {
+    // 93.184.216.34 (example.com) is a public address; the IP-literal path in
+    // assertUrlIsPublic resolves synchronously without DNS, so this stays
+    // deterministic and offline.
+    safeFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => "application/json" },
+      json: () => Promise.resolve({ received: true }),
+    });
+
+    const result = await sendWebhookStep({
+      ...baseInput,
+      webhookUrl: "http://93.184.216.34/hook",
+    });
+
+    expect(safeFetch).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.statusCode).toBe(200);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
The webhook step, the `http-request` system action and the blockscout step take a fully attacker-controlled URL and relied on `safeFetch`, whose enforcement defaulted to shadow mode (allow + log) unless `SAFE_FETCH_ENFORCE=true`. Any environment that omits that env var shipped an unauthenticated SSRF primitive (e.g. `http://169.254.169.254/...` cloud-metadata read).

## Change (whole-class sweep)
- Unconditional `assertUrlIsPublic()` before `safeFetch` on every user-URL sink (webhook, http-request, blockscout). It ignores the enforce flag and always blocks loopback/link-local/metadata/private/reserved hosts + non-http schemes, and hard-fails regardless of `failOnError`.
- Flip the `safeFetch` shadow-mode default to fail-closed (enforce unless `SAFE_FETCH_ENFORCE=false`) so a missing env var fails safe; deployed envs already set it `true`.
- Document the local-dev opt-out in `.env.example`.

## Verification
- Sibling sweep: all other `safeFetch` consumers use fixed vendor hosts or already-guarded URLs; raw-fetch connection-test files are guarded by `assertPluginUrlFieldsArePublic` (KEEP-796).
- New + extended tests assert internal/metadata/loopback/private URLs are rejected before `safeFetch`; full unit suite green. type-check clean.