### PR TITLE
fix(web3): block fund-moving EIP-712 primaryTypes in sign-typed-data step

### DIFF
--- a/lib/metrics/instrumentation/workflow.ts
+++ b/lib/metrics/instrumentation/workflow.ts
@@ -128,6 +128,10 @@ export function recordStepMetrics(options: {
   durationMs: number;
   success: boolean;
   error?: string;
+  // Machine-readable failure code returned by the step (e.g. VALIDATION,
+  // POLICY_BLOCKED, UPSTREAM). Used to distinguish a deliberate guard deny
+  // from a transient failure in step-error metrics.
+  code?: string;
 }): void {
   const metrics = getMetricsCollector();
 
@@ -148,10 +152,16 @@ export function recordStepMetrics(options: {
 
   // Record error if failed
   if (!options.success && options.error) {
+    const errorLabels: Record<string, string> = { ...labels };
+    if (options.code) {
+      // Keep a security/validation deny distinguishable from a transient
+      // upstream failure in WORKFLOW_STEP_ERRORS dashboards and alerts.
+      errorLabels[LabelKeys.ERROR_TYPE] = options.code;
+    }
     metrics.recordError(
       MetricNames.WORKFLOW_STEP_ERRORS,
       { message: options.error },
-      labels
+      errorLabels
     );
   }
 }

--- a/lib/workflow/executor/step-handler.ts
+++ b/lib/workflow/executor/step-handler.ts
@@ -275,7 +275,11 @@ async function withStepLoggingInner<TInput extends StepInput, TOutput>(
       (result as { success: boolean }).success === false;
 
     if (isErrorResult) {
-      const errorResult = result as { success: false; error?: string };
+      const errorResult = result as {
+        success: false;
+        error?: string;
+        code?: string;
+      };
       await logStepComplete(
         logInfo,
         "error",
@@ -292,6 +296,7 @@ async function withStepLoggingInner<TInput extends StepInput, TOutput>(
         durationMs: Date.now() - logInfo.startTime,
         success: false,
         error: errorResult.error,
+        code: errorResult.code,
       });
     } else {
       await logStepComplete(

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -1228,7 +1228,7 @@ const web3Plugin: IntegrationPlugin = {
       slug: "sign-typed-data",
       label: "Sign Typed Data (EIP-712)",
       description:
-        "Produce an EIP-712 signature over a typed-data payload using the org's Turnkey-backed wallet. Suitable for x402 / EIP-3009 transferWithAuthorization, EIP-2612 permits, MPP proofs, and any other off-chain signed intent.",
+        "Produce an EIP-712 signature over a typed-data payload using the org's Turnkey-backed wallet, for off-chain signed intents. Fund-moving authorizations (permits, transfer authorizations, delegations) are refused on this step.",
       category: "Web3",
       requiresCredentials: true,
       stepFunction: "signTypedDataStep",

--- a/plugins/web3/steps/sign-typed-data-core.ts
+++ b/plugins/web3/steps/sign-typed-data-core.ts
@@ -20,6 +20,7 @@ import {
   TurnkeyUpstreamError,
 } from "@/lib/agentic-wallet/sign-typed-data";
 import { toChecksumAddress } from "@/lib/address-utils";
+import { SUPPORTED_CHAIN_IDS } from "@/lib/rpc/types";
 import { getOrganizationWallet } from "@/lib/web3/wallet-helpers";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
 
@@ -28,6 +29,125 @@ import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
 // upstream 502. 32 KiB is comfortably larger than any real EIP-712 payload
 // (the largest production case — Permit2 batched permits — is ~3 KiB).
 const MAX_TYPED_DATA_BYTES = 32 * 1024;
+
+/**
+ * A-06 hardening. This step signs caller/config-supplied EIP-712 typed-data
+ * with the organization's default (creator EOA) Turnkey-backed wallet
+ * unconditionally. A malicious marketplace template can embed a hardcoded
+ * fund-moving authorization (an ERC-2612 / DAI / Permit2 `Permit`, an
+ * EIP-3009 `TransferWithAuthorization`, a governance `DelegateBySig`, etc.)
+ * so that a victim who deploys + runs the template signs an off-chain
+ * approval that drains their tokens. We refuse to sign those primaryTypes
+ * here, at the web3 STEP boundary.
+ *
+ * This guard is deliberately NOT placed in `signTypedDataWithTurnkey`
+ * (lib/agentic-wallet/sign-typed-data.ts). That primitive is shared with the
+ * x402 / MPP / agentic-wallet signers, which legitimately sign arbitrary
+ * buyer-side payloads (including `TransferWithAuthorization`) from a SEPARATE
+ * protected sub-org + entrypoint (lib/agentic-wallet/sign.ts ->
+ * /api/agentic-wallet/sign) and are therefore unaffected by this denylist.
+ *
+ * Matched case-insensitively. The non-`permit` names below are not caught by
+ * the substring backstop, so they must be listed explicitly.
+ */
+const FUND_MOVING_PRIMARY_TYPES: ReadonlySet<string> = new Set(
+  [
+    "Permit",
+    "PermitSingle",
+    "PermitBatch",
+    "PermitTransferFrom",
+    "PermitBatchTransferFrom",
+    "PermitWitnessTransferFrom",
+    "PermitBatchWitnessTransferFrom",
+    "ERC20Permit",
+    "DAIPermit",
+    "TransferWithAuthorization",
+    "ReceiveWithAuthorization",
+    "CancelAuthorization",
+    "DelegateBySig",
+    "Delegation",
+  ].map((name) => name.toLowerCase())
+);
+
+// Backstop: any primaryType whose lowercased form CONTAINS "permit"
+// (e.g. a custom "MyPermitThing") is a fund-moving authorization we refuse
+// to sign even if it is not in the explicit denylist above.
+const PERMIT_SUBSTRING = "permit";
+
+// EIP-712 `domain.chainId`, when present, must name a chain KeeperHub
+// actually supports. An unknown chainId signals a payload aimed at a
+// contract/network we never vetted. Derived from the same canonical
+// `SUPPORTED_CHAIN_IDS` map that `lib/rpc/network-utils` resolves against.
+const SUPPORTED_CHAIN_ID_SET: ReadonlySet<number> = new Set<number>(
+  Object.values(SUPPORTED_CHAIN_IDS)
+);
+
+const HEX_CHAIN_ID_RE = /^0x[0-9a-f]+$/i;
+
+// `domain.chainId` may arrive as a number, a decimal string, a 0x-hex
+// string, or a bigint. Normalize to a positive integer, or null if it is
+// not a parseable positive chain id.
+function normalizeChainId(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isInteger(value) && value > 0 ? value : null;
+  }
+  if (typeof value === "bigint") {
+    return value > BigInt(0) && value <= BigInt(Number.MAX_SAFE_INTEGER)
+      ? Number(value)
+      : null;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    const radix = HEX_CHAIN_ID_RE.test(trimmed) ? 16 : 10;
+    const parsed = Number.parseInt(trimmed, radix);
+    return Number.isNaN(parsed) || parsed <= 0 ? null : parsed;
+  }
+  return null;
+}
+
+type SignTypedDataValidationFailure = {
+  success: false;
+  code: "VALIDATION";
+  error: string;
+};
+
+// A-06 control surface: reject fund-moving primaryTypes and unsupported
+// (present-but-unknown) domain.chainIds. Returns a VALIDATION failure to
+// short-circuit signing, or null when the payload is safe to sign. Absent
+// chainId is allowed: many legitimate EIP-712 domains omit it, so the
+// primaryType denylist remains the primary control.
+function checkSignableTypedData(
+  typedData: EIP712TypedData
+): SignTypedDataValidationFailure | null {
+  const primaryTypeLower = typedData.primaryType.toLowerCase();
+  if (
+    FUND_MOVING_PRIMARY_TYPES.has(primaryTypeLower) ||
+    primaryTypeLower.includes(PERMIT_SUBSTRING)
+  ) {
+    return {
+      success: false,
+      code: "VALIDATION",
+      error: `Refusing to sign fund-moving authorization "${typedData.primaryType}". EIP-712 permit / transfer-authorization / delegation signing is blocked on this step to prevent template-injected token drains.`,
+    };
+  }
+
+  const domainChainId = typedData.domain.chainId;
+  if (domainChainId === undefined || domainChainId === null) {
+    return null;
+  }
+  const normalizedChainId = normalizeChainId(domainChainId);
+  if (
+    normalizedChainId === null ||
+    !SUPPORTED_CHAIN_ID_SET.has(normalizedChainId)
+  ) {
+    return {
+      success: false,
+      code: "VALIDATION",
+      error: `typedData.domain.chainId ${JSON.stringify(domainChainId)} is not a supported chain`,
+    };
+  }
+  return null;
+}
 
 export type SignTypedDataCoreInput = {
   /**
@@ -122,6 +242,14 @@ export async function signTypedDataCore(
       code: "VALIDATION",
       error: `typedData payload exceeds ${MAX_TYPED_DATA_BYTES}-byte limit (got ${serialized.length})`,
     };
+  }
+
+  // A-06: block template-injected Permit/transfer-authorization drains and
+  // unsupported chainIds BEFORE any wallet/org resolution, so a denied
+  // payload never reaches the Turnkey signer. See FUND_MOVING_PRIMARY_TYPES.
+  const signabilityFailure = checkSignableTypedData(typedData);
+  if (signabilityFailure) {
+    return signabilityFailure;
   }
 
   const ctx = await resolveOrganizationContext(

--- a/plugins/web3/steps/sign-typed-data-core.ts
+++ b/plugins/web3/steps/sign-typed-data-core.ts
@@ -148,6 +148,27 @@ type SignTypedDataValidationFailure = {
   error: string;
 };
 
+const MAX_ERROR_FIELD_LEN = 80;
+
+// primaryType / chainId are attacker/template-controlled and get echoed back
+// in VALIDATION errors that flow to execution outputs and logs. Strip control
+// characters (newlines, ANSI escapes) to prevent log injection/spoofing, and
+// cap the length so an oversized value cannot bloat the message. Using String()
+// (not JSON.stringify) also avoids throwing on a bigint chainId.
+function sanitizeForError(value: unknown): string {
+  let cleaned = "";
+  for (const ch of String(value)) {
+    const code = ch.codePointAt(0) ?? 0;
+    // Drop C0 (0x00-0x1F) and C1 (0x7F-0x9F) control chars.
+    if (code >= 0x20 && !(code >= 0x7f && code <= 0x9f)) {
+      cleaned += ch;
+    }
+  }
+  return cleaned.length > MAX_ERROR_FIELD_LEN
+    ? `${cleaned.slice(0, MAX_ERROR_FIELD_LEN)}...`
+    : cleaned;
+}
+
 // A-06 control surface: reject fund-moving primaryTypes and unsupported
 // (present-but-unknown) domain.chainIds. Returns a VALIDATION failure to
 // short-circuit signing, or null when the payload is safe to sign. Absent
@@ -164,7 +185,7 @@ function checkSignableTypedData(
     return {
       success: false,
       code: "VALIDATION",
-      error: `Refusing to sign fund-moving authorization "${typedData.primaryType}". EIP-712 permit / transfer-authorization / delegation signing is blocked on this step to prevent template-injected token drains.`,
+      error: `Refusing to sign fund-moving authorization "${sanitizeForError(typedData.primaryType)}". EIP-712 permit / transfer-authorization / delegation signing is blocked on this step to prevent template-injected token drains.`,
     };
   }
 
@@ -180,7 +201,7 @@ function checkSignableTypedData(
     return {
       success: false,
       code: "VALIDATION",
-      error: `typedData.domain.chainId ${JSON.stringify(domainChainId)} is not a supported chain`,
+      error: `typedData.domain.chainId ${sanitizeForError(domainChainId)} is not a supported chain`,
     };
   }
   return null;

--- a/plugins/web3/steps/sign-typed-data-core.ts
+++ b/plugins/web3/steps/sign-typed-data-core.ts
@@ -94,12 +94,16 @@ const PERMIT_SUBSTRING = "permit";
 // of vetted (chainId, verifyingContract, struct-shape) usages rather than a
 // blocklist of names; see the A-06 follow-up.
 
-// EIP-712 `domain.chainId`, when present, must name a chain KeeperHub
+// EIP-712 `domain.chainId`, when present, must name an EVM chain KeeperHub
 // actually supports. An unknown chainId signals a payload aimed at a
-// contract/network we never vetted. Derived from the same canonical
-// `SUPPORTED_CHAIN_IDS` map that `lib/rpc/network-utils` resolves against.
+// contract/network we never vetted. Derived from the canonical
+// `SUPPORTED_CHAIN_IDS` map, MINUS the Solana entries: `domain.chainId` is
+// an EVM concept, so the Solana pseudo-ids (101/103) would be meaningless
+// here and must not be treated as valid EIP-712 chains.
 const SUPPORTED_CHAIN_ID_SET: ReadonlySet<number> = new Set<number>(
-  Object.values(SUPPORTED_CHAIN_IDS)
+  Object.entries(SUPPORTED_CHAIN_IDS)
+    .filter(([name]) => !name.startsWith("SOLANA"))
+    .map(([, id]) => id)
 );
 
 const HEX_CHAIN_ID_RE = /^0x[0-9a-f]+$/i;

--- a/plugins/web3/steps/sign-typed-data-core.ts
+++ b/plugins/web3/steps/sign-typed-data-core.ts
@@ -66,6 +66,17 @@ const FUND_MOVING_PRIMARY_TYPES: ReadonlySet<string> = new Set(
     "CancelAuthorization",
     "DelegateBySig",
     "Delegation",
+    // Marketplace / intent / account-abstraction authorizations that move
+    // funds via a separate standing approval (or account ownership) rather
+    // than a permit. Each uses a fixed canonical primaryType on-chain, so an
+    // attacker cannot rename it without breaking signature validity - which
+    // is exactly why a name-based denylist is meaningful for these.
+    "SafeTx", // Gnosis Safe execTransaction (arbitrary call from the Safe)
+    "OrderComponents", // Seaport (OpenSea) order
+    "LimitOrder", // 0x v4
+    "RfqOrder", // 0x v4
+    "UserOperation", // ERC-4337 v0.6
+    "PackedUserOperation", // ERC-4337 v0.7
   ].map((name) => name.toLowerCase())
 );
 
@@ -73,6 +84,15 @@ const FUND_MOVING_PRIMARY_TYPES: ReadonlySet<string> = new Set(
 // (e.g. a custom "MyPermitThing") is a fund-moving authorization we refuse
 // to sign even if it is not in the explicit denylist above.
 const PERMIT_SUBSTRING = "permit";
+
+// LIMITATION: this is a denylist, so it is inherently incomplete. It cannot
+// enumerate every fund-moving EIP-712 scheme, and we deliberately do NOT
+// list overly generic names that legitimate custom intents also use - e.g.
+// a bare "Order" (CoW Protocol's GPv2 order primaryType) would block far
+// more legitimate intents than it protects. Such schemes (and any future
+// one) can still be signed here. The durable fix is a default-deny allowlist
+// of vetted (chainId, verifyingContract, struct-shape) usages rather than a
+// blocklist of names; see the A-06 follow-up.
 
 // EIP-712 `domain.chainId`, when present, must name a chain KeeperHub
 // actually supports. An unknown chainId signals a payload aimed at a

--- a/plugins/web3/steps/sign-typed-data-core.ts
+++ b/plugins/web3/steps/sign-typed-data-core.ts
@@ -57,15 +57,10 @@ const MAX_TYPED_DATA_BYTES = 32 * 1024;
  */
 const FUND_MOVING_PRIMARY_TYPES: ReadonlySet<string> = new Set(
   [
-    "Permit",
-    "PermitSingle",
-    "PermitBatch",
-    "PermitTransferFrom",
-    "PermitBatchTransferFrom",
-    "PermitWitnessTransferFrom",
-    "PermitBatchWitnessTransferFrom",
-    "ERC20Permit",
-    "DAIPermit",
+    // Only names that do NOT contain "permit" need to be listed here: every
+    // *permit* variant (ERC-2612 Permit, Permit2 Permit*/Permit*TransferFrom,
+    // ERC20Permit, DAIPermit, ...) is already caught by the PERMIT_SUBSTRING
+    // backstop below, so listing them explicitly would be dead weight.
     "TransferWithAuthorization",
     "ReceiveWithAuthorization",
     "CancelAuthorization",

--- a/plugins/web3/steps/sign-typed-data-core.ts
+++ b/plugins/web3/steps/sign-typed-data-core.ts
@@ -103,13 +103,20 @@ const SUPPORTED_CHAIN_ID_SET: ReadonlySet<number> = new Set<number>(
 );
 
 const HEX_CHAIN_ID_RE = /^0x[0-9a-f]+$/i;
+const DEC_CHAIN_ID_RE = /^[0-9]+$/;
 
 // `domain.chainId` may arrive as a number, a decimal string, a 0x-hex
-// string, or a bigint. Normalize to a positive integer, or null if it is
-// not a parseable positive chain id.
+// string, or a bigint. Normalize to a positive safe integer, or null if it
+// is not one. Parsing is STRICT: the whole string must be a clean hex or
+// decimal integer. We deliberately do not reuse lib/rpc/network-utils
+// getChainIdFromNetwork here - that helper resolves legacy network NAMES and
+// uses a lenient Number.parseInt that would accept "8453garbage" as 8453,
+// validating a value different from the one actually signed.
 function normalizeChainId(value: unknown): number | null {
   if (typeof value === "number") {
-    return Number.isInteger(value) && value > 0 ? value : null;
+    return Number.isInteger(value) && value > 0 && value <= Number.MAX_SAFE_INTEGER
+      ? value
+      : null;
   }
   if (typeof value === "bigint") {
     return value > BigInt(0) && value <= BigInt(Number.MAX_SAFE_INTEGER)
@@ -118,9 +125,15 @@ function normalizeChainId(value: unknown): number | null {
   }
   if (typeof value === "string") {
     const trimmed = value.trim();
-    const radix = HEX_CHAIN_ID_RE.test(trimmed) ? 16 : 10;
-    const parsed = Number.parseInt(trimmed, radix);
-    return Number.isNaN(parsed) || parsed <= 0 ? null : parsed;
+    let parsed: number;
+    if (HEX_CHAIN_ID_RE.test(trimmed)) {
+      parsed = Number.parseInt(trimmed, 16);
+    } else if (DEC_CHAIN_ID_RE.test(trimmed)) {
+      parsed = Number.parseInt(trimmed, 10);
+    } else {
+      return null;
+    }
+    return parsed > 0 && parsed <= Number.MAX_SAFE_INTEGER ? parsed : null;
   }
   return null;
 }

--- a/plugins/web3/steps/sign-typed-data-core.ts
+++ b/plugins/web3/steps/sign-typed-data-core.ts
@@ -4,12 +4,17 @@
  *
  * IMPORTANT: This file must NOT contain "use step" or be a step file.
  *
- * KEEP-473: workflows previously had no way to produce signed EIP-712
- * typed-data destined for HTTP bodies (x402 EIP-3009
- * transferWithAuthorization, MPP, EIP-2612 permits, custom protocol
- * intents). Buyers had to deploy AWS Lambda + KMS to sign outside KH.
- * This primitive routes the request through the org's Turnkey-backed
- * wallet so the signature is produced inside KH's trust boundary.
+ * Workflows use this primitive to produce signed EIP-712 typed-data for
+ * off-chain signed intents (HTTP bodies, contract arguments), routed
+ * through the org's Turnkey-backed wallet so the signature is produced
+ * inside KH's trust boundary.
+ *
+ * NOTE: fund-moving authorizations (EIP-2612 / Permit2 / DAI permits,
+ * EIP-3009 transfer/receive authorizations, governance delegations) are
+ * REFUSED here - see checkSignableTypedData / FUND_MOVING_PRIMARY_TYPES.
+ * Those payloads are signed only via the separate, protected
+ * agentic-wallet entrypoint (lib/agentic-wallet/sign.ts), not from
+ * workflow steps.
  */
 import "server-only";
 

--- a/plugins/web3/steps/sign-typed-data.ts
+++ b/plugins/web3/steps/sign-typed-data.ts
@@ -18,10 +18,11 @@ export type SignTypedDataInput = StepInput & SignTypedDataCoreInput;
 /**
  * Sign Typed Data (EIP-712) Step
  * Produces a 65-byte secp256k1 signature over an EIP-712 typed-data object
- * using the organization's Turnkey-backed wallet. Suitable for x402 /
- * EIP-3009 transferWithAuthorization, MPP proofs, EIP-2612 permits, and
- * arbitrary protocol intents that need an off-chain signature destined for
- * an HTTP body or contract argument.
+ * using the organization's Turnkey-backed wallet, for arbitrary protocol
+ * intents that need an off-chain signature destined for an HTTP body or
+ * contract argument. Fund-moving authorizations (permits, transfer
+ * authorizations, delegations) are refused on this step - see
+ * sign-typed-data-core.
  */
 export async function signTypedDataStep(
   input: SignTypedDataInput

--- a/tests/unit/sign-typed-data.test.ts
+++ b/tests/unit/sign-typed-data.test.ts
@@ -230,4 +230,175 @@ describe("signTypedDataCore (KEEP-473)", () => {
     }
     expect(mockSign).not.toHaveBeenCalled();
   });
+
+  // A-06: a malicious marketplace template can embed a hardcoded
+  // fund-moving EIP-712 authorization; deploy + run would otherwise sign it
+  // with the victim's creator EOA and drain their tokens. The web3 step
+  // must refuse these primaryTypes BEFORE touching the Turnkey signer.
+  it("rejects an EIP-2612 Permit typedData (fund-moving denylist)", async () => {
+    mockGetOrgWallet.mockResolvedValue(WALLET);
+
+    const permit = {
+      ...VALID_TYPED_DATA,
+      primaryType: "Permit",
+      message: {
+        owner: "0x0000000000000000000000000000000000000001",
+        spender: "0x0000000000000000000000000000000000000002",
+        value: "1000000000",
+        nonce: 0,
+        deadline: "9999999999",
+      },
+    };
+
+    const result = await signTypedDataCore({
+      typedData: permit,
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("VALIDATION");
+    }
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it("rejects an EIP-3009 TransferWithAuthorization typedData", async () => {
+    mockGetOrgWallet.mockResolvedValue(WALLET);
+
+    const transferAuth = {
+      ...VALID_TYPED_DATA,
+      primaryType: "TransferWithAuthorization",
+    };
+
+    const result = await signTypedDataCore({
+      typedData: transferAuth,
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("VALIDATION");
+    }
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it("rejects a custom primaryType containing 'permit' via the substring backstop", async () => {
+    mockGetOrgWallet.mockResolvedValue(WALLET);
+
+    const sneaky = { ...VALID_TYPED_DATA, primaryType: "MyPermitThing" };
+
+    const result = await signTypedDataCore({
+      typedData: sneaky,
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("VALIDATION");
+    }
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it("rejects a typedData whose domain.chainId is unsupported", async () => {
+    mockGetOrgWallet.mockResolvedValue(WALLET);
+
+    const unsupportedChain = {
+      ...VALID_TYPED_DATA,
+      domain: { ...VALID_TYPED_DATA.domain, chainId: 999_999 },
+    };
+
+    const result = await signTypedDataCore({
+      typedData: unsupportedChain,
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("VALIDATION");
+    }
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unsupported domain.chainId supplied as a hex string", async () => {
+    mockGetOrgWallet.mockResolvedValue(WALLET);
+
+    const unsupportedHex = {
+      ...VALID_TYPED_DATA,
+      domain: { ...VALID_TYPED_DATA.domain, chainId: "0xf423f" },
+    };
+
+    const result = await signTypedDataCore({
+      typedData: unsupportedHex,
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("VALIDATION");
+    }
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it("signs a benign primaryType (Mail) on a supported chain", async () => {
+    mockGetOrgWallet.mockResolvedValue(WALLET);
+    mockSign.mockResolvedValue(`0x${"ab".repeat(65)}`);
+
+    const mail = {
+      domain: { name: "Ether Mail", version: "1", chainId: 1 },
+      types: {
+        EIP712Domain: [
+          { name: "name", type: "string" },
+          { name: "version", type: "string" },
+          { name: "chainId", type: "uint256" },
+        ],
+        Mail: [{ name: "contents", type: "string" }],
+      },
+      primaryType: "Mail",
+      message: { contents: "hello" },
+    };
+
+    const result = await signTypedDataCore({
+      typedData: mail,
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.signature).toMatch(SIGNATURE_HEX_RE);
+    }
+    expect(mockSign).toHaveBeenCalledWith(
+      WALLET.turnkeySubOrgId,
+      WALLET.walletAddress,
+      mail
+    );
+  });
+
+  it("signs a benign typedData that omits domain.chainId entirely", async () => {
+    mockGetOrgWallet.mockResolvedValue(WALLET);
+    mockSign.mockResolvedValue(`0x${"ab".repeat(65)}`);
+
+    const noChainId = {
+      domain: { name: "Order Book", version: "1" },
+      types: {
+        EIP712Domain: [
+          { name: "name", type: "string" },
+          { name: "version", type: "string" },
+        ],
+        Order: [{ name: "id", type: "uint256" }],
+      },
+      primaryType: "Order",
+      message: { id: 7 },
+    };
+
+    const result = await signTypedDataCore({
+      typedData: noChainId,
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.signature).toMatch(SIGNATURE_HEX_RE);
+    }
+    expect(mockSign).toHaveBeenCalled();
+  });
 });

--- a/tests/unit/sign-typed-data.test.ts
+++ b/tests/unit/sign-typed-data.test.ts
@@ -399,6 +399,109 @@ describe("signTypedDataCore (KEEP-473)", () => {
     if (result.success) {
       expect(result.signature).toMatch(SIGNATURE_HEX_RE);
     }
+    expect(mockSign).toHaveBeenCalledWith(
+      WALLET.turnkeySubOrgId,
+      WALLET.walletAddress,
+      noChainId
+    );
+  });
+
+  it("rejects a Gnosis Safe SafeTx typedData", async () => {
+    mockGetOrgWallet.mockResolvedValue(WALLET);
+
+    const result = await signTypedDataCore({
+      typedData: { ...VALID_TYPED_DATA, primaryType: "SafeTx" },
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("VALIDATION");
+    }
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it("rejects a Seaport OrderComponents typedData", async () => {
+    mockGetOrgWallet.mockResolvedValue(WALLET);
+
+    const result = await signTypedDataCore({
+      typedData: { ...VALID_TYPED_DATA, primaryType: "OrderComponents" },
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("VALIDATION");
+    }
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it("rejects a denylisted primaryType supplied as a JSON string", async () => {
+    mockGetOrgWallet.mockResolvedValue(WALLET);
+
+    const result = await signTypedDataCore({
+      typedData: JSON.stringify({ ...VALID_TYPED_DATA, primaryType: "Permit" }),
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("VALIDATION");
+    }
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it("rejects a junk string chainId that parseInt would leniently truncate", async () => {
+    mockGetOrgWallet.mockResolvedValue(WALLET);
+
+    const result = await signTypedDataCore({
+      typedData: {
+        ...VALID_TYPED_DATA,
+        domain: { ...VALID_TYPED_DATA.domain, chainId: "8453garbage" },
+      },
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("VALIDATION");
+    }
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it("signs when a supported chainId is given as a decimal string", async () => {
+    mockGetOrgWallet.mockResolvedValue(WALLET);
+    mockSign.mockResolvedValue(`0x${"ab".repeat(65)}`);
+
+    const result = await signTypedDataCore({
+      typedData: {
+        ...VALID_TYPED_DATA,
+        domain: { ...VALID_TYPED_DATA.domain, chainId: "8453" },
+      },
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.signature).toMatch(SIGNATURE_HEX_RE);
+    }
     expect(mockSign).toHaveBeenCalled();
+  });
+
+  it("strips control characters from the rejection error message", async () => {
+    mockGetOrgWallet.mockResolvedValue(WALLET);
+
+    const result = await signTypedDataCore({
+      typedData: { ...VALID_TYPED_DATA, primaryType: "Permit\nINJECTED LOG" },
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("VALIDATION");
+      expect(result.error).not.toContain("\n");
+      expect(result.error).toContain("PermitINJECTED LOG");
+    }
+    expect(mockSign).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
The web3 `sign-typed-data` step signs a caller/config-supplied EIP-712 payload with the org's **creator EOA** (the default funded wallet) unconditionally — no domain/primaryType allowlist, and creator Turnkey sub-orgs carry no policy. A marketplace template can embed a hardcoded `Permit`; the deploy path copies the node config verbatim into the victim's org, the executor passes it straight to Turnkey, and the victim's wallet signs it — a supply-chain token-drain via a signed off-chain authorization. (Triaged as a real, default-path risk.)

## Change
- Reject fund-moving `primaryType`s (`Permit`, `PermitSingle/Batch`, `PermitTransferFrom` family, `ERC20Permit`, `DAIPermit`, `TransferWithAuthorization`, `ReceiveWithAuthorization`, `CancelAuthorization`, `DelegateBySig`, `Delegation`, and any type whose name contains `permit`) before any wallet/signer resolution.
- Reject a present-but-unsupported `domain.chainId`.
- Gate lives in the web3 step only; the x402/MPP and agentic signers use a separate, policy-gated sub-org + entrypoint and are unaffected.

## Verification
- No shipped workflow/template routes a Permit through this step today.
- 16 tests pass (Permit / TransferWithAuthorization / substring backstop / bad chainId rejected; benign types still sign). type-check clean.

## Follow-up (not in this PR)
The step's marketing copy still advertises permit support and should be reworded; Turnkey baseline DENY policies on creator sub-orgs (the hard-limit backstop) are a separate hardening epic.