### PR TITLE
fix(sandbox): decode the sandbox HTTP boundary with safe JSON, not v8

### DIFF
--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -168,6 +168,32 @@ function reviveSandboxNumber(token: string): number {
   }
 }
 
+/**
+ * Allowlisted view constructors the decoder will instantiate from a "bytes"
+ * tag. The sandbox payload is UNTRUSTED, so the decoder never resolves an
+ * arbitrary global by name: a forged `k` such as "fetch" would otherwise let a
+ * compromised child select any global constructor (`new fetch(ab)` returns a
+ * promise that rejects unhandled and can crash the process via the server's
+ * unhandledRejection handler). Anything off this list falls back to raw bytes.
+ */
+const SANDBOX_VIEW_CTORS: Record<
+  string,
+  new (buffer: ArrayBuffer) => ArrayBufferView
+> = {
+  Int8Array,
+  Uint8Array,
+  Uint8ClampedArray,
+  Int16Array,
+  Uint16Array,
+  Int32Array,
+  Uint32Array,
+  Float32Array,
+  Float64Array,
+  BigInt64Array,
+  BigUint64Array,
+  DataView,
+};
+
 function reviveSandboxBytes(kind: string, base64: string): unknown {
   const buf = Buffer.from(base64, "base64");
   // Copy into a standalone ArrayBuffer so the result does not alias Node's
@@ -176,15 +202,20 @@ function reviveSandboxBytes(kind: string, base64: string): unknown {
   if (kind === "ArrayBuffer") {
     return ab;
   }
-  if (kind === "DataView") {
-    return new DataView(ab);
+  const Ctor: (new (buffer: ArrayBuffer) => ArrayBufferView) | undefined =
+    SANDBOX_VIEW_CTORS[kind];
+  if (Ctor) {
+    try {
+      return new Ctor(ab);
+    } catch {
+      // A known kind whose byte length is not a multiple of its element size
+      // (a forged/malformed frame would make `new Uint32Array(ab)` throw):
+      // hand back raw bytes rather than throwing on the untrusted boundary.
+      return new Uint8Array(ab);
+    }
   }
-  const Ctor = (globalThis as Record<string, unknown>)[kind];
-  if (typeof Ctor === "function") {
-    return new (Ctor as new (b: ArrayBuffer) => unknown)(ab);
-  }
-  // Unknown view kind from a malformed/compromised child: hand back raw bytes
-  // rather than throwing.
+  // Unknown/forged view kind: never resolve an arbitrary global by name; hand
+  // back raw bytes rather than instantiating it.
   return new Uint8Array(ab);
 }
 

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -76,6 +76,15 @@ const SANDBOX_RESULT_HEADER_BYTES = 4;
  */
 export const SANDBOX_RESULT_MAX_BYTES = 96 * 1024 * 1024;
 
+/**
+ * Identifier for the HTTP wire format between the main app and the standalone
+ * sandbox service (JSON request + tagged-JSON response). The client sends it as
+ * the `X-Sandbox-Wire` request header and the server echoes it on the response;
+ * each side rejects a mismatch so a deploy-time version skew fails fast with a
+ * clear error instead of a confusing parse failure. Bump when the wire changes.
+ */
+export const SANDBOX_WIRE_VERSION = "json-v1";
+
 export type SandboxResultReader = {
   /** Feed a chunk from the parent's fd-3 stream. Chunks after the first
    * complete frame are ignored (first-frame-wins). */

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -259,6 +259,153 @@ export function decodeSandboxResult(text: string): unknown {
   return decodeSandboxNode(JSON.parse(text));
 }
 
+function encodeSandboxNumber(value: number): unknown {
+  if (Number.isFinite(value) && !Object.is(value, -0)) {
+    return value;
+  }
+  let token = "-0";
+  if (Number.isNaN(value)) {
+    token = "NaN";
+  } else if (value === Number.POSITIVE_INFINITY) {
+    token = "Inf";
+  } else if (value === Number.NEGATIVE_INFINITY) {
+    token = "-Inf";
+  }
+  return { [SANDBOX_RESULT_TAG]: "num", v: token };
+}
+
+function encodeSandboxMap(
+  value: Map<unknown, unknown>,
+  seen: Set<unknown>
+): unknown {
+  const entries: [unknown, unknown][] = [];
+  for (const [k, v] of value) {
+    entries.push([encodeSandboxNode(k, seen), encodeSandboxNode(v, seen)]);
+  }
+  return { [SANDBOX_RESULT_TAG]: "map", v: entries };
+}
+
+function encodeSandboxSet(value: Set<unknown>, seen: Set<unknown>): unknown {
+  const items: unknown[] = [];
+  for (const item of value) {
+    items.push(encodeSandboxNode(item, seen));
+  }
+  return { [SANDBOX_RESULT_TAG]: "set", v: items };
+}
+
+function encodeSandboxView(value: ArrayBufferView): unknown {
+  // Mirror the inline encodeResult's falsy check: a missing or empty
+  // constructor name falls back to Uint8Array.
+  const ctorName = value.constructor?.name;
+  const kind =
+    ctorName === undefined || ctorName === "" ? "Uint8Array" : ctorName;
+  return {
+    [SANDBOX_RESULT_TAG]: "bytes",
+    k: kind,
+    v: Buffer.from(value.buffer, value.byteOffset, value.byteLength).toString(
+      "base64"
+    ),
+  };
+}
+
+function encodeSandboxPlainObject(
+  value: Record<string, unknown>,
+  seen: Set<unknown>
+): unknown {
+  const out: Record<string, unknown> = {};
+  let hasTagKey = false;
+  for (const key of Object.keys(value)) {
+    if (key === SANDBOX_RESULT_TAG) {
+      hasTagKey = true;
+    }
+    out[key] = encodeSandboxNode(value[key], seen);
+  }
+  // Escape a plain object that literally carries a "$" key so the parent does
+  // not mistake it for a type tag.
+  return hasTagKey ? { [SANDBOX_RESULT_TAG]: "obj", v: out } : out;
+}
+
+function encodeSandboxComposite(value: object, seen: Set<unknown>): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => encodeSandboxNode(item, seen));
+  }
+  if (value instanceof Date) {
+    return { [SANDBOX_RESULT_TAG]: "date", v: value.getTime() };
+  }
+  if (value instanceof RegExp) {
+    return {
+      [SANDBOX_RESULT_TAG]: "regexp",
+      src: value.source,
+      flags: value.flags,
+    };
+  }
+  if (value instanceof Map) {
+    return encodeSandboxMap(value, seen);
+  }
+  if (value instanceof Set) {
+    return encodeSandboxSet(value, seen);
+  }
+  if (value instanceof ArrayBuffer) {
+    return {
+      [SANDBOX_RESULT_TAG]: "bytes",
+      k: "ArrayBuffer",
+      v: Buffer.from(value).toString("base64"),
+    };
+  }
+  if (ArrayBuffer.isView(value)) {
+    return encodeSandboxView(value);
+  }
+  return encodeSandboxPlainObject(value as Record<string, unknown>, seen);
+}
+
+function encodeSandboxNode(value: unknown, seen: Set<unknown>): unknown {
+  if (value === null) {
+    return null;
+  }
+  if (value === undefined) {
+    return { [SANDBOX_RESULT_TAG]: "undef" };
+  }
+  if (typeof value === "boolean" || typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return encodeSandboxNumber(value);
+  }
+  if (typeof value === "bigint") {
+    return { [SANDBOX_RESULT_TAG]: "bigint", v: value.toString() };
+  }
+  if (typeof value === "function" || typeof value === "symbol") {
+    // Bare reason; the caller (writeRunResult / writeResult) adds the
+    // "Result is not serializable: " prefix so the message is not doubled.
+    throw new Error(typeof value);
+  }
+  if (seen.has(value)) {
+    throw new Error("circular reference");
+  }
+  seen.add(value);
+  try {
+    return encodeSandboxComposite(value, seen);
+  } finally {
+    seen.delete(value);
+  }
+}
+
+/**
+ * Encode an arbitrary value as the tagged-JSON wire form `decodeSandboxResult`
+ * reads back; the exact inverse of `decodeSandboxNode`. Used by the standalone
+ * sandbox server to put a result on the HTTP response (the in-pod grandchild
+ * uses the inline `encodeResult` instead, since it cannot import this module).
+ *
+ * keep in lockstep with decodeSandboxNode and the inline encodeResult in
+ * SANDBOX_CHILD_SOURCE: the three share one tag scheme ("$"-keyed envelopes for
+ * undefined, non-finite/-0 numbers, bigint, Date, RegExp, Map, Set, byte views,
+ * and "$"-collision escaping). Throws on a value with no safe representation
+ * (function, symbol, or a circular reference), mirroring the inline encodeResult.
+ */
+export function encodeSandboxResult(value: unknown): string {
+  return JSON.stringify(encodeSandboxNode(value, new Set<unknown>()));
+}
+
 /**
  * JavaScript source string for the sandbox grandchild. Passed verbatim to
  * `node -e`, so it must be standalone (no imports, no TypeScript syntax).

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -362,15 +362,21 @@ function encodeSandboxPlainObject(
     if (key === SANDBOX_RESULT_TAG) {
       hasTagKey = true;
     }
-    // defineProperty so an own "__proto__" key lands as a data property; a
-    // plain `out[key] =` invokes the prototype setter and silently drops it,
-    // which decodeSandboxObject (which preserves it) would not round-trip.
-    Object.defineProperty(out, key, {
-      value: encodeSandboxNode(value[key], seen),
-      enumerable: true,
-      writable: true,
-      configurable: true,
-    });
+    const encoded = encodeSandboxNode(value[key], seen);
+    if (key === "__proto__") {
+      // Only "__proto__" needs defineProperty: a plain `out[key] =` invokes the
+      // prototype setter and silently drops it (decodeSandboxObject preserves it
+      // as a data property, so dropping would break the round-trip). Every other
+      // key uses cheap assignment.
+      Object.defineProperty(out, key, {
+        value: encoded,
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
+    } else {
+      out[key] = encoded;
+    }
   }
   // Escape a plain object that literally carries a "$" key so the parent does
   // not mistake it for a type tag.
@@ -1055,15 +1061,19 @@ function encodeResult(value, seen) {
       if (key === "$") {
         hasTagKey = true;
       }
-      // defineProperty so an own "__proto__" key lands as a data property
-      // instead of invoking the prototype setter (which drops it); mirrors
-      // decodeSandboxObject so the round-trip is faithful.
-      Object.defineProperty(out, key, {
-        value: encodeResult(value[key], seen),
-        enumerable: true,
-        writable: true,
-        configurable: true,
-      });
+      const encoded = encodeResult(value[key], seen);
+      if (key === "__proto__") {
+        // Only "__proto__" needs defineProperty (a plain assignment invokes the
+        // prototype setter and drops it); every other key uses cheap assignment.
+        Object.defineProperty(out, key, {
+          value: encoded,
+          enumerable: true,
+          writable: true,
+          configurable: true,
+        });
+      } else {
+        out[key] = encoded;
+      }
     }
     // Escape a user object that literally carries a "$" key so the parent does
     // not mistake it for a type tag.

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -79,7 +79,7 @@ export const SANDBOX_RESULT_MAX_BYTES = 96 * 1024 * 1024;
 /**
  * Identifier for the HTTP wire format between the main app and the standalone
  * sandbox service (JSON request + tagged-JSON response). The client sends it as
- * the `X-Sandbox-Wire` request header and the server echoes it on the response;
+ * the `X-KH-Sandbox-Wire` request header and the server echoes it on the response;
  * each side rejects a mismatch so a deploy-time version skew fails fast with a
  * clear error instead of a confusing parse failure. Bump when the wire changes.
  */

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -257,7 +257,11 @@ function decodeSandboxNode(node: unknown): unknown {
     case "num":
       return reviveSandboxNumber(obj.v as string);
     case "date":
-      return new Date(obj.v as number);
+      // A non-number v means an Invalid Date: every encoder emits
+      // value.getTime(), and JSON.stringify(NaN) === null, so an Invalid Date
+      // arrives as null. Revive it as Invalid Date rather than coercing null
+      // (new Date(null)) to the Unix epoch.
+      return new Date(typeof obj.v === "number" ? obj.v : Number.NaN);
     case "regexp":
       return new RegExp(obj.src as string, obj.flags as string);
     case "map":
@@ -349,7 +353,15 @@ function encodeSandboxPlainObject(
     if (key === SANDBOX_RESULT_TAG) {
       hasTagKey = true;
     }
-    out[key] = encodeSandboxNode(value[key], seen);
+    // defineProperty so an own "__proto__" key lands as a data property; a
+    // plain `out[key] =` invokes the prototype setter and silently drops it,
+    // which decodeSandboxObject (which preserves it) would not round-trip.
+    Object.defineProperty(out, key, {
+      value: encodeSandboxNode(value[key], seen),
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
   }
   // Escape a plain object that literally carries a "$" key so the parent does
   // not mistake it for a type tag.
@@ -358,7 +370,14 @@ function encodeSandboxPlainObject(
 
 function encodeSandboxComposite(value: object, seen: Set<unknown>): unknown {
   if (Array.isArray(value)) {
-    return value.map((item) => encodeSandboxNode(item, seen));
+    // for...of yields `undefined` for holes (Array.prototype.map SKIPS them and
+    // JSON would render them as null), matching the inline encoder so a sparse
+    // array round-trips identically through both codecs.
+    const arr: unknown[] = [];
+    for (const item of value) {
+      arr.push(encodeSandboxNode(item, seen));
+    }
+    return arr;
   }
   if (value instanceof Date) {
     return { [SANDBOX_RESULT_TAG]: "date", v: value.getTime() };
@@ -1027,7 +1046,15 @@ function encodeResult(value, seen) {
       if (key === "$") {
         hasTagKey = true;
       }
-      out[key] = encodeResult(value[key], seen);
+      // defineProperty so an own "__proto__" key lands as a data property
+      // instead of invoking the prototype setter (which drops it); mirrors
+      // decodeSandboxObject so the round-trip is faithful.
+      Object.defineProperty(out, key, {
+        value: encodeResult(value[key], seen),
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
     }
     // Escape a user object that literally carries a "$" key so the parent does
     // not mistake it for a type tag.

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -228,17 +228,27 @@ function reviveSandboxBytes(kind: string, base64: string): unknown {
   return new Uint8Array(ab);
 }
 
+// Bound the decoder's recursion on UNTRUSTED input. Legitimate results nest
+// shallowly; a forged frame with thousands of nested tags would otherwise
+// recurse until a RangeError - now thrown in the main-app client, since the
+// server relays the frame unrevived (it does not decode it). Throwing a clear,
+// bounded error here keeps the failure well below the JS stack limit.
+const SANDBOX_MAX_DEPTH = 256;
+
 /**
  * Rebuild a plain object key-by-key, defining each property so a "__proto__"
  * key lands as an own data property instead of invoking the prototype setter
  * (the prototype-pollution guard that makes deserializing untrusted input
  * safe).
  */
-function decodeSandboxObject(obj: Record<string, unknown>): Record<string, unknown> {
+function decodeSandboxObject(
+  obj: Record<string, unknown>,
+  depth: number
+): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const key of Object.keys(obj)) {
     Object.defineProperty(result, key, {
-      value: decodeSandboxNode(obj[key]),
+      value: decodeSandboxNode(obj[key], depth),
       enumerable: true,
       writable: true,
       configurable: true,
@@ -247,16 +257,20 @@ function decodeSandboxObject(obj: Record<string, unknown>): Record<string, unkno
   return result;
 }
 
-function decodeSandboxNode(node: unknown): unknown {
+function decodeSandboxNode(node: unknown, depth = 0): unknown {
+  if (depth > SANDBOX_MAX_DEPTH) {
+    throw new Error("sandbox result nesting too deep");
+  }
+  const next = depth + 1;
   if (Array.isArray(node)) {
-    return node.map(decodeSandboxNode);
+    return node.map((item) => decodeSandboxNode(item, next));
   }
   if (node === null || typeof node !== "object") {
     return node;
   }
   const obj = node as Record<string, unknown>;
   if (!Object.hasOwn(obj, SANDBOX_RESULT_TAG)) {
-    return decodeSandboxObject(obj);
+    return decodeSandboxObject(obj, next);
   }
   switch (obj[SANDBOX_RESULT_TAG]) {
     case "undef":
@@ -276,20 +290,22 @@ function decodeSandboxNode(node: unknown): unknown {
     case "map":
       return new Map(
         (obj.v as [unknown, unknown][]).map((e) => [
-          decodeSandboxNode(e[0]),
-          decodeSandboxNode(e[1]),
+          decodeSandboxNode(e[0], next),
+          decodeSandboxNode(e[1], next),
         ])
       );
     case "set":
-      return new Set((obj.v as unknown[]).map(decodeSandboxNode));
+      return new Set(
+        (obj.v as unknown[]).map((item) => decodeSandboxNode(item, next))
+      );
     case "bytes":
       return reviveSandboxBytes(obj.k as string, obj.v as string);
     case "obj":
       // Escaped plain object: its keys are literal data, never tags.
-      return decodeSandboxObject(obj.v as Record<string, unknown>);
+      return decodeSandboxObject(obj.v as Record<string, unknown>, next);
     default:
       // Unknown tag from a malformed/compromised child: treat as plain data.
-      return decodeSandboxObject(obj);
+      return decodeSandboxObject(obj, next);
   }
 }
 

--- a/lib/sandbox/client.ts
+++ b/lib/sandbox/client.ts
@@ -10,15 +10,28 @@ import {
 const SANDBOX_URL = process.env.SANDBOX_URL;
 const RESULT_SENTINEL = "\u0001RESULT\u0002";
 
+// Parse an integer env override, falling back to `fallback` when unset or
+// invalid (non-numeric, NaN, or below `min`). Mirrors the server's
+// getMaxBodyBytes guard so a stray negative value cannot silently become a
+// negative byte cap (rejecting every response) or skip the retry loop.
+function parseIntEnv(
+  raw: string | undefined,
+  fallback: number,
+  min: number
+): number {
+  if (raw === undefined) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= min ? parsed : fallback;
+}
+
 // HTTP budget on top of the user-code timeout. Sandbox server's in-child
 // wall-clock kill adds 1000 ms; we give 2000 ms more for network RTT,
 // TCP teardown, and kubeproxy conntrack flush. If the socket yields no
 // response within (timeoutMs + HTTP_SLACK_MS), we destroy it so the
 // caller sees a timeout instead of hanging on a dead peer.
-const HTTP_SLACK_MS = Number.parseInt(
-  process.env.SANDBOX_HTTP_SLACK_MS ?? "3000",
-  10
-);
+const HTTP_SLACK_MS = parseIntEnv(process.env.SANDBOX_HTTP_SLACK_MS, 3000, 0);
 
 const sandboxAgent = new Agent({
   keepAlive: true,
@@ -30,10 +43,7 @@ const sandboxAgent = new Agent({
 // short backoff lets the in-flight runs on the pod drain instead of surfacing
 // a hard error to the caller. Bounded so sustained saturation still fails
 // fast rather than amplifying load on an already-full sandbox.
-const MAX_CAPACITY_RETRIES = Number.parseInt(
-  process.env.SANDBOX_MAX_RETRIES ?? "3",
-  10
-);
+const MAX_CAPACITY_RETRIES = parseIntEnv(process.env.SANDBOX_MAX_RETRIES, 3, 0);
 
 // Base backoff for the first retry. We deliberately compute the wait from a
 // fixed schedule rather than the response's Retry-After: deriving a timer
@@ -55,9 +65,11 @@ const HTTP_TOO_MANY_REQUESTS = 429;
 // sandbox. Mirrors the local fd-3 frame cap so a compromised sandbox cannot pin
 // main-app memory by streaming an unbounded body within the time budget.
 // Env-overridable; falls back to the frame cap on a missing/invalid value.
-const MAX_RESPONSE_BYTES =
-  Number.parseInt(process.env.SANDBOX_MAX_RESPONSE_BYTES ?? "", 10) ||
-  SANDBOX_RESULT_MAX_BYTES;
+const MAX_RESPONSE_BYTES = parseIntEnv(
+  process.env.SANDBOX_MAX_RESPONSE_BYTES,
+  SANDBOX_RESULT_MAX_BYTES,
+  1
+);
 
 /**
  * Carries the HTTP status off a non-200 sandbox response so runRemote can

--- a/lib/sandbox/client.ts
+++ b/lib/sandbox/client.ts
@@ -4,6 +4,7 @@ import { Agent, request as httpRequest } from "node:http";
 import {
   decodeSandboxResult,
   SANDBOX_RESULT_MAX_BYTES,
+  SANDBOX_WIRE_VERSION,
 } from "@/lib/sandbox/child-source";
 
 const SANDBOX_URL = process.env.SANDBOX_URL;
@@ -190,6 +191,7 @@ function postOnce(
         headers: {
           "Content-Type": "application/json",
           "Content-Length": body.length.toString(),
+          "X-Sandbox-Wire": SANDBOX_WIRE_VERSION,
         },
       },
       (res) => {
@@ -218,6 +220,18 @@ function postOnce(
                 new SandboxHttpError(
                   res.statusCode ?? 0,
                   `sandbox returned ${res.statusCode ?? "no status"}: ${buf.toString("utf8").slice(0, 200)}`
+                )
+              );
+              return;
+            }
+            // Fail fast on a wire-version skew (e.g. this newer client talking
+            // to an older sandbox that does not speak tagged-JSON) with a clear
+            // message rather than a downstream JSON parse error.
+            const wire = res.headers["x-sandbox-wire"];
+            if (wire !== SANDBOX_WIRE_VERSION) {
+              reject(
+                new Error(
+                  `sandbox wire version mismatch: expected ${SANDBOX_WIRE_VERSION}, got ${typeof wire === "string" ? wire : "none"}`
                 )
               );
               return;

--- a/lib/sandbox/client.ts
+++ b/lib/sandbox/client.ts
@@ -118,7 +118,9 @@ export type RunCodeResult =
 const VM_LINE_REGEX = /user-code\.js:(\d+)/;
 
 function extractLineNumber(stack: string | undefined): number | undefined {
-  if (!stack) {
+  // Defensive: the decoded outcome crosses an untrusted boundary, so `stack`
+  // may not actually be a string at runtime; `.match` on a non-string throws.
+  if (typeof stack !== "string") {
     return undefined;
   }
   const match = stack.match(VM_LINE_REGEX);
@@ -233,18 +235,43 @@ function postOnce(
  * Shape guard for the decoded response. The sandbox is untrusted, so the
  * tagged-JSON payload is validated to be a ChildOutcome envelope before use.
  */
+function isLogEntry(value: unknown): value is LogEntry {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const e = value as { level?: unknown; args?: unknown };
+  return typeof e.level === "string" && Array.isArray(e.args);
+}
+
 function isChildOutcome(value: unknown): value is ChildOutcome {
   if (typeof value !== "object" || value === null) {
     return false;
   }
-  const v = value as { ok?: unknown; logs?: unknown; errorMessage?: unknown };
+  const v = value as {
+    ok?: unknown;
+    logs?: unknown;
+    errorMessage?: unknown;
+    errorStack?: unknown;
+  };
   if (typeof v.ok !== "boolean" || !Array.isArray(v.logs)) {
     return false;
   }
-  // ok:false must carry a string errorMessage; ok:true's `result` is unknown
-  // by design. Reject anything else so a forged or buggy sandbox response
-  // cannot surface as an undefined error/log on this untrusted boundary.
-  return v.ok === true || typeof v.errorMessage === "string";
+  // Every log entry must be well-shaped so a forged logs array cannot surface a
+  // null/garbage entry to downstream consumers on this untrusted boundary.
+  if (!v.logs.every(isLogEntry)) {
+    return false;
+  }
+  if (v.ok === true) {
+    // ok:true's `result` is unknown by design.
+    return true;
+  }
+  // ok:false must carry a string errorMessage and, if present, a string
+  // errorStack: toRunCodeResult passes errorStack to extractLineNumber, which
+  // calls `.match` on it, so a non-string would throw and mask the real error.
+  return (
+    typeof v.errorMessage === "string" &&
+    (v.errorStack === undefined || typeof v.errorStack === "string")
+  );
 }
 
 function parseResponse(buf: Buffer): ChildOutcome {

--- a/lib/sandbox/client.ts
+++ b/lib/sandbox/client.ts
@@ -1,10 +1,7 @@
 import "server-only";
 
 import { Agent, request as httpRequest } from "node:http";
-import {
-  deserialize as v8Deserialize,
-  serialize as v8Serialize,
-} from "node:v8";
+import { decodeSandboxResult } from "@/lib/sandbox/child-source";
 
 const SANDBOX_URL = process.env.SANDBOX_URL;
 const RESULT_SENTINEL = "\u0001RESULT\u0002";
@@ -178,7 +175,7 @@ function postOnce(
         path: url.pathname,
         method: "POST",
         headers: {
-          "Content-Type": "application/octet-stream",
+          "Content-Type": "application/json",
           "Content-Length": body.length.toString(),
         },
       },
@@ -232,6 +229,24 @@ function postOnce(
   });
 }
 
+/**
+ * Shape guard for the decoded response. The sandbox is untrusted, so the
+ * tagged-JSON payload is validated to be a ChildOutcome envelope before use.
+ */
+function isChildOutcome(value: unknown): value is ChildOutcome {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as { ok?: unknown; logs?: unknown; errorMessage?: unknown };
+  if (typeof v.ok !== "boolean" || !Array.isArray(v.logs)) {
+    return false;
+  }
+  // ok:false must carry a string errorMessage; ok:true's `result` is unknown
+  // by design. Reject anything else so a forged or buggy sandbox response
+  // cannot surface as an undefined error/log on this untrusted boundary.
+  return v.ok === true || typeof v.errorMessage === "string";
+}
+
 function parseResponse(buf: Buffer): ChildOutcome {
   const text = buf.toString("utf8");
   const idx = text.lastIndexOf(RESULT_SENTINEL);
@@ -239,8 +254,13 @@ function parseResponse(buf: Buffer): ChildOutcome {
     throw new Error("sandbox response missing sentinel");
   }
   const payload = text.slice(idx + RESULT_SENTINEL.length).trim();
-  const decoded = Buffer.from(payload, "base64");
-  return v8Deserialize(decoded) as ChildOutcome;
+  // Safe by construction: JSON.parse + tag rebuild (prototype-pollution-safe),
+  // never v8.deserialize on sandbox-produced bytes (F-010).
+  const decoded = decodeSandboxResult(payload);
+  if (!isChildOutcome(decoded)) {
+    throw new Error("sandbox response: malformed result");
+  }
+  return decoded;
 }
 
 function toRunCodeResult(outcome: ChildOutcome): RunCodeResult {
@@ -267,10 +287,8 @@ export async function runRemote(input: {
   try {
     const timeoutSeconds = Math.ceil(input.timeoutMs / 1000);
     const body = Buffer.from(
-      v8Serialize({ code: input.code, timeout: timeoutSeconds }).toString(
-        "base64"
-      ),
-      "ascii"
+      JSON.stringify({ code: input.code, timeout: timeoutSeconds }),
+      "utf8"
     );
 
     let lastError: unknown;

--- a/lib/sandbox/client.ts
+++ b/lib/sandbox/client.ts
@@ -1,7 +1,10 @@
 import "server-only";
 
 import { Agent, request as httpRequest } from "node:http";
-import { decodeSandboxResult } from "@/lib/sandbox/child-source";
+import {
+  decodeSandboxResult,
+  SANDBOX_RESULT_MAX_BYTES,
+} from "@/lib/sandbox/child-source";
 
 const SANDBOX_URL = process.env.SANDBOX_URL;
 const RESULT_SENTINEL = "\u0001RESULT\u0002";
@@ -46,6 +49,14 @@ const MAX_BACKOFF_MS = 5000;
 const RETRY_JITTER_MS = 250;
 
 const HTTP_TOO_MANY_REQUESTS = 429;
+
+// Hard ceiling on the response body the client will buffer from the (untrusted)
+// sandbox. Mirrors the local fd-3 frame cap so a compromised sandbox cannot pin
+// main-app memory by streaming an unbounded body within the time budget.
+// Env-overridable; falls back to the frame cap on a missing/invalid value.
+const MAX_RESPONSE_BYTES =
+  Number.parseInt(process.env.SANDBOX_MAX_RESPONSE_BYTES ?? "", 10) ||
+  SANDBOX_RESULT_MAX_BYTES;
 
 /**
  * Carries the HTTP status off a non-200 sandbox response so runRemote can
@@ -183,7 +194,22 @@ function postOnce(
       },
       (res) => {
         const chunks: Buffer[] = [];
-        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        let received = 0;
+        res.on("data", (chunk: Buffer) => {
+          received += chunk.length;
+          if (received > MAX_RESPONSE_BYTES) {
+            settle(() => {
+              req.destroy();
+              reject(
+                new Error(
+                  `sandbox response exceeds maximum size (${MAX_RESPONSE_BYTES} bytes)`
+                )
+              );
+            });
+            return;
+          }
+          chunks.push(chunk);
+        });
         res.on("end", () => {
           settle(() => {
             const buf = Buffer.concat(chunks);

--- a/lib/sandbox/client.ts
+++ b/lib/sandbox/client.ts
@@ -203,7 +203,7 @@ function postOnce(
         headers: {
           "Content-Type": "application/json",
           "Content-Length": body.length.toString(),
-          "X-Sandbox-Wire": SANDBOX_WIRE_VERSION,
+          "X-KH-Sandbox-Wire": SANDBOX_WIRE_VERSION,
         },
       },
       (res) => {
@@ -239,7 +239,7 @@ function postOnce(
             // Fail fast on a wire-version skew (e.g. this newer client talking
             // to an older sandbox that does not speak tagged-JSON) with a clear
             // message rather than a downstream JSON parse error.
-            const wire = res.headers["x-sandbox-wire"];
+            const wire = res.headers["x-kh-sandbox-wire"];
             if (wire !== SANDBOX_WIRE_VERSION) {
               reject(
                 new Error(

--- a/plugins/code/steps/run-code.ts
+++ b/plugins/code/steps/run-code.ts
@@ -95,7 +95,9 @@ function stripStringsAndComments(code: string): string {
 }
 
 function extractLineNumber(stack: string | undefined): number | undefined {
-  if (!stack) {
+  // Defensive: the decoded outcome crosses an untrusted boundary, so `stack`
+  // may not actually be a string at runtime; `.match` on a non-string throws.
+  if (typeof stack !== "string") {
     return undefined;
   }
   const match = stack.match(VM_LINE_REGEX);
@@ -135,11 +137,40 @@ type ChildOutcome =
       logs: LogEntry[];
     };
 
+function isLogEntry(value: unknown): value is LogEntry {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const e = value as { level?: unknown; args?: unknown };
+  return typeof e.level === "string" && Array.isArray(e.args);
+}
+
+// The decoded frame crosses an untrusted boundary (a vm-escaped child can forge
+// it), so validate the whole envelope, not just `ok` -- mirroring the main-app
+// client guard so a forged frame fails closed instead of surfacing undefined
+// error/log fields downstream.
 function isChildOutcome(value: unknown): value is ChildOutcome {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as {
+    ok?: unknown;
+    logs?: unknown;
+    errorMessage?: unknown;
+    errorStack?: unknown;
+  };
+  if (typeof v.ok !== "boolean" || !Array.isArray(v.logs)) {
+    return false;
+  }
+  if (!v.logs.every(isLogEntry)) {
+    return false;
+  }
+  if (v.ok === true) {
+    return true;
+  }
   return (
-    typeof value === "object" &&
-    value !== null &&
-    typeof (value as { ok?: unknown }).ok === "boolean"
+    typeof v.errorMessage === "string" &&
+    (v.errorStack === undefined || typeof v.errorStack === "string")
   );
 }
 

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -1,11 +1,17 @@
 # @keeperhub/sandbox
 
-Standalone HTTP service that evaluates user JavaScript for the KeeperHub Code workflow node. Reuses the original `node:vm` + `child_process` + `\x01RESULT\x02` sentinel wire format verbatim.
+Standalone HTTP service that evaluates user JavaScript for the KeeperHub Code workflow node. Uses `node:vm` + `child_process` with a `\x01RESULT\x02` sentinel framing the response.
 
 ## Endpoints
 
 - `GET /healthz` -> `200 ok`
-- `POST /run` -> body: base64(v8.serialize({ code, timeout })); response: `\x01RESULT\x02` + base64(v8.serialize(ChildOutcome)) + `\n`
+- `POST /run`
+  - Request body: JSON `{ code, timeout }` (`Content-Type: application/json`).
+  - Response: `\x01RESULT\x02` + tagged-JSON(ChildOutcome) + `\n` (`Content-Type: application/json`). The tagged-JSON codec (`encodeSandboxResult` / `decodeSandboxResult` in `lib/sandbox/child-source.ts`) preserves BigInt, Map, Set, Date, RegExp, typed arrays, and `undefined`. Neither direction uses `v8.serialize`/`v8.deserialize`: the response is decoded with a safe `JSON.parse` + prototype-pollution-safe rebuild, so untrusted child bytes can never reach a deserialization gadget.
+
+## Wire protocol is a hard cutover (deploy ordering)
+
+The JSON request + tagged-JSON response above replaced a `base64(v8.serialize(...))` wire in both directions, with **no dual-accept shim**. The sandbox service and the main app deploy as separate artifacts, so a version mismatch in either direction during a wire change makes `POST /run` return `400` and remote Code-node runs fail for that window (clean failure, no crash or corruption). When changing the wire format: deploy the sandbox service first, then the app, as close together as possible. The app's `SANDBOX_BACKEND=local` is an escape hatch that bypasses this HTTP boundary during a cutover.
 
 ## Env
 

--- a/sandbox/src/index.test.ts
+++ b/sandbox/src/index.test.ts
@@ -39,7 +39,7 @@ async function request(
             ? {
                 "Content-Type": "application/json",
                 "Content-Length": Buffer.byteLength(body),
-                "X-Sandbox-Wire": SANDBOX_WIRE_VERSION,
+                "X-KH-Sandbox-Wire": SANDBOX_WIRE_VERSION,
               }
             : {}),
       },
@@ -132,7 +132,7 @@ describe("sandbox HTTP server", () => {
 
   it("POST /run with empty body returns 400", async () => {
     const res = await request(port, "POST", "/run", undefined, {
-      "X-Sandbox-Wire": SANDBOX_WIRE_VERSION,
+      "X-KH-Sandbox-Wire": SANDBOX_WIRE_VERSION,
     });
     expect(res.status).toBe(400);
   });
@@ -235,7 +235,7 @@ describe("sandbox HTTP server", () => {
           headers: {
             "Content-Type": "application/json",
             "Content-Length": Buffer.byteLength(hangingCode),
-            "X-Sandbox-Wire": SANDBOX_WIRE_VERSION,
+            "X-KH-Sandbox-Wire": SANDBOX_WIRE_VERSION,
           },
         },
         () => {

--- a/sandbox/src/index.test.ts
+++ b/sandbox/src/index.test.ts
@@ -5,17 +5,14 @@ import {
   type ServerResponse,
 } from "node:http";
 import { type AddressInfo, createServer as createNetServer } from "node:net";
-import {
-  deserialize as v8Deserialize,
-  serialize as v8Serialize,
-} from "node:v8";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { decodeSandboxResult } from "../../lib/sandbox/child-source.js";
 import { handleRequest } from "./index.js";
 
 const RESULT_SENTINEL = "\u0001RESULT\u0002";
 
 function makeRunBody(payload: unknown): string {
-  return v8Serialize(payload).toString("base64");
+  return JSON.stringify(payload);
 }
 
 async function request(
@@ -34,7 +31,7 @@ async function request(
         path,
         headers: body
           ? {
-              "Content-Type": "application/octet-stream",
+              "Content-Type": "application/json",
               "Content-Length": Buffer.byteLength(body),
             }
           : {},
@@ -59,13 +56,16 @@ async function request(
 }
 
 function parseRunResponse(body: Buffer): unknown {
-  const text = body.toString("binary");
+  const text = body.toString("utf8");
   const idx = text.lastIndexOf(RESULT_SENTINEL);
   if (idx < 0) {
     throw new Error(`no sentinel in response: ${text.slice(0, 80)}`);
   }
-  const base64 = text.slice(idx + RESULT_SENTINEL.length).replace(/\n$/, "");
-  return v8Deserialize(Buffer.from(base64.trim(), "base64"));
+  const payload = text
+    .slice(idx + RESULT_SENTINEL.length)
+    .replace(/\n$/, "")
+    .trim();
+  return decodeSandboxResult(payload);
 }
 
 describe("sandbox HTTP server", () => {
@@ -109,11 +109,11 @@ describe("sandbox HTTP server", () => {
     expect(res.status).toBe(404);
   });
 
-  it("POST /run with valid v8+base64 body returns 200 with sentinel-prefixed ChildOutcome", async () => {
+  it("POST /run with valid JSON body returns 200 with sentinel-prefixed ChildOutcome", async () => {
     const body = makeRunBody({ code: "return 1 + 1;", timeout: 5 });
     const res = await request(port, "POST", "/run", body);
     expect(res.status).toBe(200);
-    const text = res.body.toString("binary");
+    const text = res.body.toString("utf8");
     expect(text.includes(RESULT_SENTINEL)).toBe(true);
     const outcome = parseRunResponse(res.body) as {
       ok: boolean;
@@ -128,14 +128,38 @@ describe("sandbox HTTP server", () => {
     expect(res.status).toBe(400);
   });
 
-  it("POST /run with non-base64 body returns 400", async () => {
+  it("POST /run with non-JSON garbage body returns 400 malformed body", async () => {
     const res = await request(
       port,
       "POST",
       "/run",
-      "this is not v8 base64 !!!"
+      "this is not json at all !!!"
     );
     expect(res.status).toBe(400);
+    expect(res.body.toString()).toBe("malformed body");
+  });
+
+  it("POST /run with valid JSON but no code field returns 400 malformed body", async () => {
+    const res = await request(port, "POST", "/run", JSON.stringify({ timeout: 5 }));
+    expect(res.status).toBe(400);
+    expect(res.body.toString()).toBe("malformed body");
+  });
+
+  it("POST /run round-trips a result containing BigInt and Map through encodeSandboxResult", async () => {
+    const body = makeRunBody({
+      code: "return { b: BigInt('1000000000000000000'), m: new Map([['a', 1]]) };",
+      timeout: 5,
+    });
+    const res = await request(port, "POST", "/run", body);
+    expect(res.status).toBe(200);
+    const outcome = parseRunResponse(res.body) as {
+      ok: boolean;
+      result?: { b: bigint; m: Map<string, number> };
+    };
+    expect(outcome.ok).toBe(true);
+    expect(outcome.result?.b).toBe(BigInt("1000000000000000000"));
+    expect(outcome.result?.m).toBeInstanceOf(Map);
+    expect(outcome.result?.m.get("a")).toBe(1);
   });
 
   it("POST /run where user code throws returns 200 with ok:false ChildOutcome", async () => {

--- a/sandbox/src/index.test.ts
+++ b/sandbox/src/index.test.ts
@@ -6,7 +6,10 @@ import {
 } from "node:http";
 import { type AddressInfo, createServer as createNetServer } from "node:net";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { decodeSandboxResult } from "../../lib/sandbox/child-source.js";
+import {
+  decodeSandboxResult,
+  SANDBOX_WIRE_VERSION,
+} from "../../lib/sandbox/child-source.js";
 import { handleRequest } from "./index.js";
 
 const RESULT_SENTINEL = "\u0001RESULT\u0002";
@@ -19,7 +22,8 @@ async function request(
   port: number,
   method: string,
   path: string,
-  body?: string
+  body?: string,
+  headers?: Record<string, string | number>
 ): Promise<{ status: number; body: Buffer }> {
   const { request: httpRequest } = await import("node:http");
   return await new Promise((resolve, reject) => {
@@ -29,12 +33,15 @@ async function request(
         port,
         method,
         path,
-        headers: body
-          ? {
-              "Content-Type": "application/json",
-              "Content-Length": Buffer.byteLength(body),
-            }
-          : {},
+        headers:
+          headers ??
+          (body
+            ? {
+                "Content-Type": "application/json",
+                "Content-Length": Buffer.byteLength(body),
+                "X-Sandbox-Wire": SANDBOX_WIRE_VERSION,
+              }
+            : {}),
       },
       (res) => {
         const chunks: Buffer[] = [];
@@ -124,8 +131,20 @@ describe("sandbox HTTP server", () => {
   });
 
   it("POST /run with empty body returns 400", async () => {
-    const res = await request(port, "POST", "/run");
+    const res = await request(port, "POST", "/run", undefined, {
+      "X-Sandbox-Wire": SANDBOX_WIRE_VERSION,
+    });
     expect(res.status).toBe(400);
+  });
+
+  it("POST /run without the wire-version header returns 415", async () => {
+    const body = makeRunBody({ code: "return 1;", timeout: 5 });
+    const res = await request(port, "POST", "/run", body, {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(body),
+    });
+    expect(res.status).toBe(415);
+    expect(res.body.toString()).toContain("unsupported sandbox wire version");
   });
 
   it("POST /run with non-JSON garbage body returns 400 malformed body", async () => {
@@ -214,8 +233,9 @@ describe("sandbox HTTP server", () => {
           method: "POST",
           path: "/run",
           headers: {
-            "Content-Type": "application/octet-stream",
+            "Content-Type": "application/json",
             "Content-Length": Buffer.byteLength(hangingCode),
+            "X-Sandbox-Wire": SANDBOX_WIRE_VERSION,
           },
         },
         () => {

--- a/sandbox/src/index.ts
+++ b/sandbox/src/index.ts
@@ -3,10 +3,7 @@ import {
   type IncomingMessage,
   type ServerResponse,
 } from "node:http";
-import {
-  deserialize as v8Deserialize,
-  serialize as v8Serialize,
-} from "node:v8";
+import { encodeSandboxResult } from "../../lib/sandbox/child-source.js";
 import { runCode } from "./run-code.js";
 
 /**
@@ -17,8 +14,9 @@ import { runCode } from "./run-code.js";
 const RESULT_SENTINEL = "\u0001RESULT\u0002";
 
 /** Default maximum request body size (256 KiB). Envelope is small because
- * the body carries only user-written JS plus a v8-serialized envelope; any
- * reasonable Code node fits in a small fraction of this. Env-overridable. */
+ * the body carries only user-written JS plus a small JSON envelope
+ * ({ code, timeout }); any reasonable Code node fits in a small fraction of
+ * this. Env-overridable. */
 const DEFAULT_MAX_BODY_BYTES = 256 * 1024;
 
 /** Default maximum concurrent /run calls per Pod. With 500m CPU + ~80 ms
@@ -96,19 +94,14 @@ async function readBody(
 }
 
 function writeRunResult(res: ServerResponse, outcome: unknown): void {
-  const payload = v8Serialize(outcome).toString("base64");
-  res.writeHead(200, { "Content-Type": "application/octet-stream" });
+  const payload = encodeSandboxResult(outcome);
+  res.writeHead(200, { "Content-Type": "application/json" });
   res.end(`${RESULT_SENTINEL}${payload}\n`);
 }
 
 function decodeRunRequest(raw: Buffer): RunRequest | null {
   try {
-    const bodyBase64 = raw.toString("ascii").trim();
-    const decoded = Buffer.from(bodyBase64, "base64");
-    if (decoded.length === 0) {
-      return null;
-    }
-    const deserialized = v8Deserialize(decoded);
+    const deserialized: unknown = JSON.parse(raw.toString("utf8"));
     if (
       typeof deserialized !== "object" ||
       deserialized === null ||

--- a/sandbox/src/index.ts
+++ b/sandbox/src/index.ts
@@ -3,7 +3,10 @@ import {
   type IncomingMessage,
   type ServerResponse,
 } from "node:http";
-import { encodeSandboxResult } from "../../lib/sandbox/child-source.js";
+import {
+  encodeSandboxResult,
+  SANDBOX_WIRE_VERSION,
+} from "../../lib/sandbox/child-source.js";
 import { runCode, type SandboxRunResult } from "./run-code.js";
 
 /**
@@ -102,7 +105,10 @@ function writeRunResult(res: ServerResponse, result: SandboxRunResult): void {
   const payload = result.relay
     ? result.frame.toString("utf8")
     : encodeSandboxResult(result.outcome);
-  res.writeHead(200, { "Content-Type": "application/json" });
+  res.writeHead(200, {
+    "Content-Type": "application/json",
+    "X-Sandbox-Wire": SANDBOX_WIRE_VERSION,
+  });
   res.end(`${RESULT_SENTINEL}${payload}\n`);
 }
 
@@ -127,6 +133,17 @@ async function handlePostRun(
   req: IncomingMessage,
   res: ServerResponse
 ): Promise<void> {
+  // Reject a wire-version skew up front with a clear 415 (e.g. an older app
+  // that still speaks base64(v8)) instead of a confusing "malformed body".
+  const wire = req.headers["x-sandbox-wire"];
+  if (wire !== SANDBOX_WIRE_VERSION) {
+    res.writeHead(415);
+    res.end(
+      `unsupported sandbox wire version: ${typeof wire === "string" ? wire : "none"}; expected ${SANDBOX_WIRE_VERSION}`
+    );
+    return;
+  }
+
   // Concurrency gate BEFORE anything else so we shed load without paying
   // the cost of reading the body or spawning a child. 429 + Retry-After
   // tells the main-app client to back off; the kept-alive HTTP.Agent there

--- a/sandbox/src/index.ts
+++ b/sandbox/src/index.ts
@@ -4,7 +4,7 @@ import {
   type ServerResponse,
 } from "node:http";
 import { encodeSandboxResult } from "../../lib/sandbox/child-source.js";
-import { runCode } from "./run-code.js";
+import { runCode, type SandboxRunResult } from "./run-code.js";
 
 /**
  * Sentinel bytes byte-identical to the child_process runner. Main-app
@@ -93,8 +93,12 @@ async function readBody(
   return Buffer.concat(chunks);
 }
 
-function writeRunResult(res: ServerResponse, outcome: unknown): void {
-  const payload = encodeSandboxResult(outcome);
+function writeRunResult(res: ServerResponse, result: SandboxRunResult): void {
+  // A relayed frame is the child's tagged-JSON forwarded verbatim; only a
+  // synthetic error outcome needs encoding here.
+  const payload = result.relay
+    ? result.frame.toString("utf8")
+    : encodeSandboxResult(result.outcome);
   res.writeHead(200, { "Content-Type": "application/json" });
   res.end(`${RESULT_SENTINEL}${payload}\n`);
 }
@@ -173,7 +177,7 @@ async function handlePostRun(
         ? request.timeout
         : DEFAULT_TIMEOUT_SECONDS;
     const timeoutMs = Math.max(1, Math.min(120, timeoutSeconds)) * 1000;
-    const outcome = await runCode({
+    const result = await runCode({
       code: request.code,
       timeoutMs,
       signal: abortController.signal,
@@ -183,7 +187,7 @@ async function handlePostRun(
     if (res.writableEnded || res.destroyed) {
       return;
     }
-    writeRunResult(res, outcome);
+    writeRunResult(res, result);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (message === "body too large") {

--- a/sandbox/src/index.ts
+++ b/sandbox/src/index.ts
@@ -107,7 +107,7 @@ function writeRunResult(res: ServerResponse, result: SandboxRunResult): void {
     : encodeSandboxResult(result.outcome);
   res.writeHead(200, {
     "Content-Type": "application/json",
-    "X-Sandbox-Wire": SANDBOX_WIRE_VERSION,
+    "X-KH-Sandbox-Wire": SANDBOX_WIRE_VERSION,
   });
   res.end(`${RESULT_SENTINEL}${payload}\n`);
 }
@@ -135,7 +135,7 @@ async function handlePostRun(
 ): Promise<void> {
   // Reject a wire-version skew up front with a clear 415 (e.g. an older app
   // that still speaks base64(v8)) instead of a confusing "malformed body".
-  const wire = req.headers["x-sandbox-wire"];
+  const wire = req.headers["x-kh-sandbox-wire"];
   if (wire !== SANDBOX_WIRE_VERSION) {
     res.writeHead(415);
     res.end(

--- a/sandbox/src/index.ts
+++ b/sandbox/src/index.ts
@@ -13,11 +13,14 @@ import { runCode, type SandboxRunResult } from "./run-code.js";
  */
 const RESULT_SENTINEL = "\u0001RESULT\u0002";
 
-/** Default maximum request body size (256 KiB). Envelope is small because
- * the body carries only user-written JS plus a small JSON envelope
- * ({ code, timeout }); any reasonable Code node fits in a small fraction of
- * this. Env-overridable. */
-const DEFAULT_MAX_BODY_BYTES = 256 * 1024;
+/** Default maximum request body size (512 KiB). The body is JSON
+ * `{ code, timeout }`, and JSON.stringify can inflate escape-heavy user code
+ * up to ~2x (every quote/backslash/control char escapes) -- versus the old
+ * base64(v8) wire's flat ~1.33x. The cap is raised so a large escape-heavy
+ * Code node that fit the old wire is not rejected with a 413. It is a DoS
+ * backstop, not a product limit; readBody enforces it before any spawn.
+ * Env-overridable. */
+const DEFAULT_MAX_BODY_BYTES = 512 * 1024;
 
 /** Default maximum concurrent /run calls per Pod. With 500m CPU + ~80 ms
  * cold-spawn + V8 compile of CHILD_SOURCE, the Pod saturates around 8

--- a/sandbox/src/run-code.test.ts
+++ b/sandbox/src/run-code.test.ts
@@ -1,7 +1,33 @@
 import { serialize } from "node:v8";
 import { describe, expect, it } from "vitest";
-import { SANDBOX_RESULT_FD } from "../../lib/sandbox/child-source.js";
-import { isChildOutcome, runCode } from "./run-code.js";
+import {
+  decodeSandboxResult,
+  SANDBOX_RESULT_FD,
+} from "../../lib/sandbox/child-source.js";
+import {
+  type ChildOutcome,
+  isRelayableEnvelope,
+  runCode as runCodeRaw,
+  type SandboxRunResult,
+} from "./run-code.js";
+
+// runCode now returns a relayable tagged-JSON frame or a synthetic error
+// outcome. The tests assert on the native ChildOutcome, so decode a relayed
+// frame exactly as the main-app client does. This wrapper shadows `runCode` so
+// the existing call sites need no change.
+function toOutcome(result: SandboxRunResult): ChildOutcome {
+  return result.relay
+    ? (decodeSandboxResult(result.frame.toString("utf8")) as ChildOutcome)
+    : result.outcome;
+}
+
+async function runCode(input: {
+  code: string;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}): Promise<ChildOutcome> {
+  return toOutcome(await runCodeRaw(input));
+}
 
 // A forged result frame an escaped child could write to fd 3: a 4-byte
 // big-endian length prefix followed by a v8-serialized success outcome with an
@@ -268,49 +294,50 @@ describe("runCode — sandbox child_process runner", () => {
   });
 });
 
-// The frame the server decodes is produced by the (untrusted) grandchild; a
-// vm-escaped child can forge it. The guard must validate the full envelope so a
-// malformed frame fails closed rather than surfacing undefined fields.
-describe("isChildOutcome guard rejects forged envelopes", () => {
-  it("accepts a valid ok:true outcome", () => {
-    expect(isChildOutcome({ ok: true, result: 1, logs: [] })).toBe(true);
+// The frame the server relays is produced by the (untrusted) grandchild; a
+// vm-escaped child can forge it. The shallow relay guard confirms a plausible
+// envelope on the UN-REVIVED frame; the main-app client strictly validates the
+// revived form (e.g. errorStack type), so the relay guard does not inspect it.
+describe("isRelayableEnvelope shallow guard", () => {
+  it("accepts a valid ok:true envelope", () => {
+    expect(isRelayableEnvelope({ ok: true, result: 1, logs: [] })).toBe(true);
   });
 
-  it("accepts a valid ok:false outcome with and without errorStack", () => {
-    expect(isChildOutcome({ ok: false, errorMessage: "x", logs: [] })).toBe(
+  it("accepts a valid ok:false envelope, ignoring a tagged errorStack", () => {
+    expect(isRelayableEnvelope({ ok: false, errorMessage: "x", logs: [] })).toBe(
       true
     );
+    // On the un-revived frame errorStack:undefined arrives as { $: "undef" };
+    // the relay guard must accept it (the client validates the revived form).
     expect(
-      isChildOutcome({
+      isRelayableEnvelope({
         ok: false,
         errorMessage: "x",
-        errorStack: "at user-code.js:3",
+        errorStack: { $: "undef" },
         logs: [{ level: "error", args: ["y"] }],
       })
     ).toBe(true);
   });
 
   it("rejects ok:false without a string errorMessage", () => {
-    expect(isChildOutcome({ ok: false, logs: [] })).toBe(false);
-  });
-
-  it("rejects a non-string errorStack", () => {
-    expect(
-      isChildOutcome({ ok: false, errorMessage: "x", errorStack: 1, logs: [] })
-    ).toBe(false);
+    expect(isRelayableEnvelope({ ok: false, logs: [] })).toBe(false);
   });
 
   it("rejects a malformed log entry", () => {
-    expect(isChildOutcome({ ok: true, result: 1, logs: [null] })).toBe(false);
+    expect(isRelayableEnvelope({ ok: true, result: 1, logs: [null] })).toBe(
+      false
+    );
   });
 
   it("rejects missing or non-array logs", () => {
-    expect(isChildOutcome({ ok: true, result: 1 })).toBe(false);
-    expect(isChildOutcome({ ok: true, result: 1, logs: "nope" })).toBe(false);
+    expect(isRelayableEnvelope({ ok: true, result: 1 })).toBe(false);
+    expect(isRelayableEnvelope({ ok: true, result: 1, logs: "nope" })).toBe(
+      false
+    );
   });
 
   it("rejects a non-object value", () => {
-    expect(isChildOutcome(null)).toBe(false);
-    expect(isChildOutcome("ok")).toBe(false);
+    expect(isRelayableEnvelope(null)).toBe(false);
+    expect(isRelayableEnvelope("ok")).toBe(false);
   });
 });

--- a/sandbox/src/run-code.test.ts
+++ b/sandbox/src/run-code.test.ts
@@ -1,7 +1,7 @@
 import { serialize } from "node:v8";
 import { describe, expect, it } from "vitest";
 import { SANDBOX_RESULT_FD } from "../../lib/sandbox/child-source.js";
-import { runCode } from "./run-code.js";
+import { isChildOutcome, runCode } from "./run-code.js";
 
 // A forged result frame an escaped child could write to fd 3: a 4-byte
 // big-endian length prefix followed by a v8-serialized success outcome with an
@@ -265,5 +265,52 @@ describe("runCode — sandbox child_process runner", () => {
     if (outcome.ok) {
       expect(outcome.result).toBe("REAL");
     }
+  });
+});
+
+// The frame the server decodes is produced by the (untrusted) grandchild; a
+// vm-escaped child can forge it. The guard must validate the full envelope so a
+// malformed frame fails closed rather than surfacing undefined fields.
+describe("isChildOutcome guard rejects forged envelopes", () => {
+  it("accepts a valid ok:true outcome", () => {
+    expect(isChildOutcome({ ok: true, result: 1, logs: [] })).toBe(true);
+  });
+
+  it("accepts a valid ok:false outcome with and without errorStack", () => {
+    expect(isChildOutcome({ ok: false, errorMessage: "x", logs: [] })).toBe(
+      true
+    );
+    expect(
+      isChildOutcome({
+        ok: false,
+        errorMessage: "x",
+        errorStack: "at user-code.js:3",
+        logs: [{ level: "error", args: ["y"] }],
+      })
+    ).toBe(true);
+  });
+
+  it("rejects ok:false without a string errorMessage", () => {
+    expect(isChildOutcome({ ok: false, logs: [] })).toBe(false);
+  });
+
+  it("rejects a non-string errorStack", () => {
+    expect(
+      isChildOutcome({ ok: false, errorMessage: "x", errorStack: 1, logs: [] })
+    ).toBe(false);
+  });
+
+  it("rejects a malformed log entry", () => {
+    expect(isChildOutcome({ ok: true, result: 1, logs: [null] })).toBe(false);
+  });
+
+  it("rejects missing or non-array logs", () => {
+    expect(isChildOutcome({ ok: true, result: 1 })).toBe(false);
+    expect(isChildOutcome({ ok: true, result: 1, logs: "nope" })).toBe(false);
+  });
+
+  it("rejects a non-object value", () => {
+    expect(isChildOutcome(null)).toBe(false);
+    expect(isChildOutcome("ok")).toBe(false);
   });
 });

--- a/sandbox/src/run-code.ts
+++ b/sandbox/src/run-code.ts
@@ -79,15 +79,19 @@ export function isRelayableEnvelope(value: unknown): boolean {
   return v.ok === true || typeof v.errorMessage === "string";
 }
 
+/** The ok:false arm of ChildOutcome; every synthetic (non-relay) result is an
+ * error, so it always carries errorMessage. */
+type ChildErrorOutcome = Extract<ChildOutcome, { ok: false }>;
+
 /**
  * A run result the server writes to the HTTP response. A valid child frame is
  * RELAYED verbatim -- it is already the tagged-JSON the main-app client reads,
  * so the server does not revive tagged values nor re-encode them. Synthetic
- * errors (timeout, abort, malformed/no frame) carry a ChildOutcome to encode.
+ * errors (timeout, abort, malformed/no frame) carry an error outcome to encode.
  */
 export type SandboxRunResult =
   | { relay: true; frame: Buffer }
-  | { relay: false; outcome: ChildOutcome };
+  | { relay: false; outcome: ChildErrorOutcome };
 
 function syntheticError(errorMessage: string): SandboxRunResult {
   return { relay: false, outcome: { ok: false, errorMessage, logs: [] } };

--- a/sandbox/src/run-code.ts
+++ b/sandbox/src/run-code.ts
@@ -49,11 +49,42 @@ function buildChildEnv(): NodeJS.ProcessEnv {
   return out as NodeJS.ProcessEnv;
 }
 
-function isChildOutcome(value: unknown): value is ChildOutcome {
+function isLogEntry(value: unknown): value is LogEntry {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const e = value as { level?: unknown; args?: unknown };
+  return typeof e.level === "string" && Array.isArray(e.args);
+}
+
+/**
+ * Exported for unit testing. The decoded frame crosses an untrusted boundary (a
+ * vm-escaped child can forge it), so validate the whole envelope, not just `ok`
+ * -- mirroring the main-app client guard so both sides fail malformed outcomes
+ * closed instead of surfacing undefined error/log fields downstream.
+ */
+export function isChildOutcome(value: unknown): value is ChildOutcome {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as {
+    ok?: unknown;
+    logs?: unknown;
+    errorMessage?: unknown;
+    errorStack?: unknown;
+  };
+  if (typeof v.ok !== "boolean" || !Array.isArray(v.logs)) {
+    return false;
+  }
+  if (!v.logs.every(isLogEntry)) {
+    return false;
+  }
+  if (v.ok === true) {
+    return true;
+  }
   return (
-    typeof value === "object" &&
-    value !== null &&
-    typeof (value as { ok?: unknown }).ok === "boolean"
+    typeof v.errorMessage === "string" &&
+    (v.errorStack === undefined || typeof v.errorStack === "string")
   );
 }
 

--- a/sandbox/src/run-code.ts
+++ b/sandbox/src/run-code.ts
@@ -2,7 +2,6 @@ import { spawn } from "node:child_process";
 import {
   SANDBOX_CHILD_SOURCE as CHILD_SOURCE,
   createSandboxResultReader,
-  decodeSandboxResult,
   SANDBOX_RESULT_FD,
   type SandboxResultReader,
 } from "../../lib/sandbox/child-source.js";
@@ -49,7 +48,7 @@ function buildChildEnv(): NodeJS.ProcessEnv {
   return out as NodeJS.ProcessEnv;
 }
 
-function isLogEntry(value: unknown): value is LogEntry {
+function isLogEntry(value: unknown): boolean {
   if (typeof value !== "object" || value === null) {
     return false;
   }
@@ -58,68 +57,68 @@ function isLogEntry(value: unknown): value is LogEntry {
 }
 
 /**
- * Exported for unit testing. The decoded frame crosses an untrusted boundary (a
- * vm-escaped child can forge it), so validate the whole envelope, not just `ok`
- * -- mirroring the main-app client guard so both sides fail malformed outcomes
- * closed instead of surfacing undefined error/log fields downstream.
+ * Exported for unit testing. A SHALLOW envelope check on the UN-REVIVED frame:
+ * the server only relays the frame to the main-app client, which revives it and
+ * strictly validates (e.g. errorStack type). The child is untrusted (a vm
+ * escape can forge a frame), so we confirm a plausible ChildOutcome envelope --
+ * the `ok` discriminant, well-shaped logs, and a string errorMessage on
+ * ok:false -- without inspecting tagged values like a `{ "$": "undef" }`
+ * errorStack, which only resolves after the client revives the frame.
  */
-export function isChildOutcome(value: unknown): value is ChildOutcome {
+export function isRelayableEnvelope(value: unknown): boolean {
   if (typeof value !== "object" || value === null) {
     return false;
   }
-  const v = value as {
-    ok?: unknown;
-    logs?: unknown;
-    errorMessage?: unknown;
-    errorStack?: unknown;
-  };
+  const v = value as { ok?: unknown; logs?: unknown; errorMessage?: unknown };
   if (typeof v.ok !== "boolean" || !Array.isArray(v.logs)) {
     return false;
   }
   if (!v.logs.every(isLogEntry)) {
     return false;
   }
-  if (v.ok === true) {
-    return true;
-  }
-  return (
-    typeof v.errorMessage === "string" &&
-    (v.errorStack === undefined || typeof v.errorStack === "string")
-  );
+  return v.ok === true || typeof v.errorMessage === "string";
 }
 
-function outcomeFromReader(reader: SandboxResultReader): ChildOutcome {
+/**
+ * A run result the server writes to the HTTP response. A valid child frame is
+ * RELAYED verbatim -- it is already the tagged-JSON the main-app client reads,
+ * so the server does not revive tagged values nor re-encode them. Synthetic
+ * errors (timeout, abort, malformed/no frame) carry a ChildOutcome to encode.
+ */
+export type SandboxRunResult =
+  | { relay: true; frame: Buffer }
+  | { relay: false; outcome: ChildOutcome };
+
+function syntheticError(errorMessage: string): SandboxRunResult {
+  return { relay: false, outcome: { ok: false, errorMessage, logs: [] } };
+}
+
+function resultFromReader(reader: SandboxResultReader): SandboxRunResult {
   if (reader.error) {
-    return { ok: false, errorMessage: reader.error, logs: [] };
+    return syntheticError(reader.error);
   }
   if (!reader.frame) {
-    return { ok: false, errorMessage: "Sandbox produced no result", logs: [] };
+    return syntheticError("Sandbox produced no result");
   }
+  // Validate the envelope WITHOUT reviving tagged values: the server only
+  // relays the frame to the main-app client, which revives it and strictly
+  // validates. A shallow JSON.parse + envelope check is enough here; the frame
+  // is then forwarded verbatim, avoiding a decode + re-encode (and the
+  // BigInt/Map/Buffer allocations + double base64) per request.
   try {
-    // Safe by construction: JSON.parse + tag rebuild, never v8.deserialize on
-    // child-produced bytes (F-010). Validate the envelope shape since the
-    // child is untrusted.
-    const decoded = decodeSandboxResult(reader.frame.toString("utf8"));
-    if (!isChildOutcome(decoded)) {
-      return {
-        ok: false,
-        errorMessage: "Sandbox produced malformed result",
-        logs: [],
-      };
+    const parsed: unknown = JSON.parse(reader.frame.toString("utf8"));
+    if (!isRelayableEnvelope(parsed)) {
+      return syntheticError("Sandbox produced malformed result");
     }
-    return decoded;
-  } catch (_err) {
-    return {
-      ok: false,
-      errorMessage: "Sandbox produced malformed result",
-      logs: [],
-    };
+    return { relay: true, frame: reader.frame };
+  } catch {
+    return syntheticError("Sandbox produced malformed result");
   }
 }
 
 /**
  * Spawn a child Node process with a scrubbed env, run the user code inside
- * it, and return the child's outcome. Kills the child on timeout or when
+ * it, and return the child's result. Kills the child on timeout or when
  * the caller's AbortSignal fires.
  */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: single cohesive spawner with timeout + stream aggregation + graceful teardown + signal wiring
@@ -127,10 +126,10 @@ async function runInChild(
   code: string,
   timeoutMs: number,
   signal?: AbortSignal
-): Promise<ChildOutcome> {
-  return await new Promise<ChildOutcome>((resolve) => {
+): Promise<SandboxRunResult> {
+  return await new Promise<SandboxRunResult>((resolve) => {
     if (signal?.aborted) {
-      resolve({ ok: false, errorMessage: "ABORTED", logs: [] });
+      resolve(syntheticError("ABORTED"));
       return;
     }
 
@@ -146,11 +145,11 @@ async function runInChild(
     let settled = false;
 
     const onAbort = (): void => {
-      finish({ ok: false, errorMessage: "ABORTED", logs: [] });
+      finish(syntheticError("ABORTED"));
     };
     signal?.addEventListener("abort", onAbort, { once: true });
 
-    function finish(outcome: ChildOutcome): void {
+    function finish(result: SandboxRunResult): void {
       if (settled) {
         return;
       }
@@ -164,11 +163,11 @@ async function runInChild(
           // ignore; child may already have exited
         }
       }
-      resolve(outcome);
+      resolve(result);
     }
 
     const killTimer = setTimeout(() => {
-      finish({ ok: false, errorMessage: "WALL_CLOCK_TIMEOUT", logs: [] });
+      finish(syntheticError("WALL_CLOCK_TIMEOUT"));
     }, timeoutMs + 1000);
 
     // Drain stdout so a sandbox escape that writes there cannot fill the pipe
@@ -187,37 +186,45 @@ async function runInChild(
         if (resultReader.done) {
           // First complete frame wins; resolve now and reap the child even if
           // escaped code kept the event loop alive past the result.
-          finish(outcomeFromReader(resultReader));
+          finish(resultFromReader(resultReader));
         }
       });
       resultStream.on("error", () => {
-        // Pipe teardown races process exit; the close handler maps the outcome.
+        // Pipe teardown races process exit; the close handler maps the result.
       });
     }
 
     child.on("error", (err: Error) => {
       finish({
-        ok: false,
-        errorMessage: err.message || String(err),
-        errorStack: err.stack,
-        logs: [],
+        relay: false,
+        outcome: {
+          ok: false,
+          errorMessage: err.message || String(err),
+          errorStack: err.stack,
+          logs: [],
+        },
       });
     });
 
     child.on("close", (exitCode: number | null) => {
-      const parsed = outcomeFromReader(resultReader);
-      if (parsed.ok || exitCode === 0) {
-        finish(parsed);
+      const result = resultFromReader(resultReader);
+      // A valid frame is relayed as-is; so is anything on a clean exit. Only a
+      // synthetic "no result" on a non-zero exit gets the stderr/exit hint.
+      if (result.relay || exitCode === 0) {
+        finish(result);
         return;
       }
-      // Non-zero exit with no result frame; surface stderr as a hint.
+      const noResult =
+        result.outcome.errorMessage === "Sandbox produced no result";
       finish({
-        ok: false,
-        errorMessage:
-          parsed.errorMessage === "Sandbox produced no result"
+        relay: false,
+        outcome: {
+          ok: false,
+          errorMessage: noResult
             ? `Sandbox process exited with code ${String(exitCode)}${stderr ? `: ${stderr.trim().slice(0, 500)}` : ""}`
-            : parsed.errorMessage,
-        logs: [],
+            : result.outcome.errorMessage,
+          logs: [],
+        },
       });
     });
 
@@ -225,24 +232,25 @@ async function runInChild(
       child.stdin.write(JSON.stringify({ code, timeoutMs }));
       child.stdin.end();
     } catch (err) {
-      finish({
-        ok: false,
-        errorMessage: `Failed to send code to sandbox: ${err instanceof Error ? err.message : String(err)}`,
-        logs: [],
-      });
+      finish(
+        syntheticError(
+          `Failed to send code to sandbox: ${err instanceof Error ? err.message : String(err)}`
+        )
+      );
     }
   });
 }
 
 /**
  * Public API: run `code` in a fresh scrubbed child process with a wall-clock
- * timeout of `timeoutMs` milliseconds. Resolves with a ChildOutcome describing
- * either the user result (v8-deserialized) or a structured error.
+ * timeout of `timeoutMs` milliseconds. Resolves with a SandboxRunResult: either
+ * a relayable tagged-JSON frame (the user result, forwarded verbatim) or a
+ * synthetic ChildOutcome describing a structured error.
  */
 export async function runCode(input: {
   code: string;
   timeoutMs: number;
   signal?: AbortSignal;
-}): Promise<ChildOutcome> {
+}): Promise<SandboxRunResult> {
   return runInChild(input.code, input.timeoutMs, input.signal);
 }

--- a/tests/unit/sandbox-child-source.test.ts
+++ b/tests/unit/sandbox-child-source.test.ts
@@ -963,3 +963,20 @@ describe("encodeSandboxResult parity with the inline grandchild encoder", () => 
     expect(moduleEncoded).toEqual(inlineEncoded);
   });
 });
+
+// A forged frame can nest tags far deeper than any legitimate result; the
+// decoder must fail with a bounded error rather than recursing into a
+// RangeError (now in the main-app client, since the server relays unrevived).
+describe("decodeSandboxResult bounds recursion depth", () => {
+  it("throws a clear error on a too-deeply-nested frame", () => {
+    const depth = 1000; // > SANDBOX_MAX_DEPTH (256), well within JSON.parse
+    const json = "[".repeat(depth) + "]".repeat(depth);
+    expect(() => decodeSandboxResult(json)).toThrow(/too deep/);
+  });
+
+  it("still decodes a comfortably-nested frame", () => {
+    const depth = 50;
+    const json = "[".repeat(depth) + "]".repeat(depth);
+    expect(() => decodeSandboxResult(json)).not.toThrow();
+  });
+});

--- a/tests/unit/sandbox-child-source.test.ts
+++ b/tests/unit/sandbox-child-source.test.ts
@@ -903,3 +903,63 @@ describe("encodeSandboxResult fidelity round-trips", () => {
     expect(r[3]).toBe(4);
   });
 });
+
+// Drift guard for finding F-010's two hand-maintained encoders: the module
+// encodeSandboxResult and the inline encodeResult template share one wire
+// format but are separate code. Spawn the real grandchild over a rich corpus,
+// then assert the module encoder reproduces the inline encoder's output exactly
+// (compared after one decode, so we never reconstruct the corpus by hand).
+describe("encodeSandboxResult parity with the inline grandchild encoder", () => {
+  function rawFrame(userCode: string, timeoutMs = 3000): Promise<Buffer> {
+    return new Promise<Buffer>((resolve, reject) => {
+      const child = spawn(process.execPath, ["-e", SANDBOX_CHILD_SOURCE], {
+        stdio: ["pipe", "pipe", "pipe", "pipe"],
+      });
+      const reader = createSandboxResultReader();
+      const killTimer = setTimeout(() => {
+        child.kill("SIGKILL");
+        reject(new Error("harness timeout"));
+      }, timeoutMs + 3000);
+      child.stdout.resume();
+      child.stderr.resume();
+      const stream = child.stdio[SANDBOX_RESULT_FD];
+      if (stream && "on" in stream) {
+        stream.on("data", (chunk: Buffer) => {
+          reader.push(chunk);
+          if (reader.done && reader.frame) {
+            clearTimeout(killTimer);
+            child.kill("SIGKILL");
+            resolve(reader.frame);
+          }
+        });
+      }
+      child.on("error", (err: Error) => {
+        clearTimeout(killTimer);
+        reject(err);
+      });
+      child.stdin.write(JSON.stringify({ code: userCode, timeoutMs }));
+      child.stdin.end();
+    });
+  }
+
+  it("agrees with the inline encoder over a rich corpus", async () => {
+    const code = [
+      "const sparse = [1]; sparse[3] = 4;",
+      'const proto = JSON.parse(\'{"a":1,"__proto__":{"p":1}}\');',
+      "return {",
+      "  negZero: -0, nan: NaN, inf: Infinity, ninf: -Infinity,",
+      "  big: 10n, date: new Date(1700000000000), invalidDate: new Date('x'),",
+      "  re: /ab+c/gi, map: new Map([['a', 1], ['b', 2]]),",
+      "  set: new Set([1, 2, 3]), bytes: new Uint8Array([1, 2, 255]),",
+      "  nested: { a: [1, { b: 2n }] },",
+      "  dollar: { '$': 'bigint', v: '5' }, sparse, proto,",
+      "  undef: undefined, nul: null, str: 'x', bool: true,",
+      "};",
+    ].join("\n");
+    const text = (await rawFrame(code)).toString("utf8");
+    const inlineEncoded = (JSON.parse(text) as { result: unknown }).result;
+    const native = (decodeSandboxResult(text) as { result: unknown }).result;
+    const moduleEncoded = JSON.parse(encodeSandboxResult(native));
+    expect(moduleEncoded).toEqual(inlineEncoded);
+  });
+});

--- a/tests/unit/sandbox-child-source.test.ts
+++ b/tests/unit/sandbox-child-source.test.ts
@@ -864,3 +864,42 @@ describe("decodeSandboxResult bytes tag is safe on a forged kind", () => {
     expect([...(r as Uint16Array)]).toEqual([1, 2]);
   });
 });
+
+// Fidelity fixes: the encoder must be a faithful inverse of the decoder for an
+// Invalid Date, an own "__proto__" key, and sparse-array holes.
+describe("encodeSandboxResult fidelity round-trips", () => {
+  function roundTrip(value: unknown): unknown {
+    return decodeSandboxResult(encodeSandboxResult(value));
+  }
+
+  it("round-trips an Invalid Date as an Invalid Date (not the epoch)", () => {
+    const r = roundTrip(new Date("not-a-date")) as Date;
+    expect(r).toBeInstanceOf(Date);
+    expect(Number.isNaN(r.getTime())).toBe(true);
+  });
+
+  it("decodes a date frame whose v is null as an Invalid Date", () => {
+    const r = decodeSandboxResult('{"$":"date","v":null}') as Date;
+    expect(r).toBeInstanceOf(Date);
+    expect(Number.isNaN(r.getTime())).toBe(true);
+  });
+
+  it("preserves an own __proto__ data key without polluting Object.prototype", () => {
+    const input = JSON.parse('{"a":1,"__proto__":{"polluted":true}}');
+    const r = roundTrip(input) as Record<string, unknown>;
+    expect(Object.hasOwn(r, "__proto__")).toBe(true);
+    expect((r as { a: number }).a).toBe(1);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("round-trips a sparse array with holes as undefined (not null)", () => {
+    const sparse = [1];
+    sparse[3] = 4; // holes at indices 1, 2
+    const r = roundTrip(sparse) as unknown[];
+    expect(r.length).toBe(4);
+    expect(r[0]).toBe(1);
+    expect(r[1]).toBeUndefined();
+    expect(r[2]).toBeUndefined();
+    expect(r[3]).toBe(4);
+  });
+});

--- a/tests/unit/sandbox-child-source.test.ts
+++ b/tests/unit/sandbox-child-source.test.ts
@@ -818,3 +818,49 @@ describe("encodeSandboxResult <-> decodeSandboxResult round-trip", () => {
     expect(() => encodeSandboxResult(() => 1)).toThrow();
   });
 });
+
+// The "bytes" tag carries an attacker-controllable `k` (constructor kind) on an
+// UNTRUSTED boundary. The decoder must only ever instantiate real view
+// constructors from a fixed allowlist, never resolve an arbitrary global by
+// name, and must never throw on a malformed frame.
+describe("decodeSandboxResult bytes tag is safe on a forged kind", () => {
+  const b64 = (bytes: number[]): string =>
+    Buffer.from(bytes).toString("base64");
+
+  it("returns inert Uint8Array bytes for a non-view global kind (e.g. fetch)", () => {
+    const r = decodeSandboxResult(
+      `{"$":"bytes","k":"fetch","v":"${b64([1, 2, 3])}"}`
+    );
+    expect(r).toBeInstanceOf(Uint8Array);
+    expect([...(r as Uint8Array)]).toEqual([1, 2, 3]);
+    expect(typeof r).not.toBe("function");
+  });
+
+  it("returns inert Uint8Array bytes for the Function constructor kind", () => {
+    const r = decodeSandboxResult(
+      `{"$":"bytes","k":"Function","v":"${b64([65])}"}`
+    );
+    expect(r).toBeInstanceOf(Uint8Array);
+    expect(typeof r).not.toBe("function");
+  });
+
+  it("does not throw and falls back to raw bytes for a size-mismatched known kind", () => {
+    // 5 bytes is not a multiple of Uint32Array's 4-byte element size.
+    let decoded: unknown;
+    expect(() => {
+      decoded = decodeSandboxResult(
+        `{"$":"bytes","k":"Uint32Array","v":"${b64([1, 2, 3, 4, 5])}"}`
+      );
+    }).not.toThrow();
+    expect(decoded).toBeInstanceOf(Uint8Array);
+    expect([...(decoded as Uint8Array)]).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("still reconstructs an allowlisted view kind with a valid byte length", () => {
+    const r = decodeSandboxResult(
+      `{"$":"bytes","k":"Uint16Array","v":"${b64([1, 0, 2, 0])}"}`
+    );
+    expect(r).toBeInstanceOf(Uint16Array);
+    expect([...(r as Uint16Array)]).toEqual([1, 2]);
+  });
+});

--- a/tests/unit/sandbox-child-source.test.ts
+++ b/tests/unit/sandbox-child-source.test.ts
@@ -10,6 +10,7 @@ vi.mock("server-only", () => ({}));
 import {
   createSandboxResultReader,
   decodeSandboxResult,
+  encodeSandboxResult,
   SANDBOX_CHILD_SOURCE,
   SANDBOX_RESULT_FD,
   SANDBOX_RESULT_MAX_BYTES,
@@ -743,5 +744,77 @@ describe("decodeSandboxResult is safe on untrusted input", () => {
 
   it("throws on malformed JSON (callers map this to an error outcome)", () => {
     expect(() => decodeSandboxResult("not json")).toThrow();
+  });
+});
+
+// encodeSandboxResult is the module-scope inverse of decodeSandboxResult used
+// by the standalone sandbox server to put a result on the HTTP response. It
+// must be a faithful inverse for every type the tag codec supports.
+describe("encodeSandboxResult <-> decodeSandboxResult round-trip", () => {
+  function roundTrip(value: unknown): unknown {
+    return decodeSandboxResult(encodeSandboxResult(value));
+  }
+
+  it("round-trips undefined", () => {
+    expect(roundTrip(undefined)).toBeUndefined();
+  });
+
+  it("round-trips BigInt", () => {
+    expect(roundTrip(BigInt("1000000000000000000"))).toBe(
+      BigInt("1000000000000000000")
+    );
+  });
+
+  it("round-trips Date", () => {
+    const r = roundTrip(new Date(1_700_000_000_000)) as Date;
+    expect(r).toBeInstanceOf(Date);
+    expect(r.getTime()).toBe(1_700_000_000_000);
+  });
+
+  it("round-trips RegExp", () => {
+    const r = roundTrip(/ab+c/gi) as RegExp;
+    expect(r).toBeInstanceOf(RegExp);
+    expect(r.source).toBe("ab+c");
+    expect(r.flags).toBe("gi");
+  });
+
+  it("round-trips Map", () => {
+    const r = roundTrip(
+      new Map<string, number>([
+        ["a", 1],
+        ["b", 2],
+      ])
+    ) as Map<string, number>;
+    expect(r).toBeInstanceOf(Map);
+    expect(r.get("a")).toBe(1);
+    expect(r.get("b")).toBe(2);
+  });
+
+  it("round-trips Set", () => {
+    const r = roundTrip(new Set([1, 2, 3])) as Set<number>;
+    expect(r).toBeInstanceOf(Set);
+    expect([...r]).toEqual([1, 2, 3]);
+  });
+
+  it("round-trips a typed array", () => {
+    const r = roundTrip(new Uint8Array([1, 2, 255])) as Uint8Array;
+    expect(r).toBeInstanceOf(Uint8Array);
+    expect([...r]).toEqual([1, 2, 255]);
+  });
+
+  it("round-trips nested objects and arrays", () => {
+    const value = { a: [1, { b: BigInt(2) }], c: { d: new Set([9]) } };
+    const r = roundTrip(value) as typeof value;
+    expect(r.a[0]).toBe(1);
+    expect((r.a[1] as { b: bigint }).b).toBe(BigInt(2));
+    expect([...(r.c.d as Set<number>)]).toEqual([9]);
+  });
+
+  it('round-trips an object literally containing a "$" key', () => {
+    expect(roundTrip({ $: "bigint", v: "5" })).toEqual({ $: "bigint", v: "5" });
+  });
+
+  it("throws on a function (not serializable)", () => {
+    expect(() => encodeSandboxResult(() => 1)).toThrow();
   });
 });

--- a/tests/unit/sandbox-client.test.ts
+++ b/tests/unit/sandbox-client.test.ts
@@ -570,3 +570,25 @@ describe("lib/sandbox-client runRemote wire-version skew", () => {
     }
   });
 });
+
+describe("lib/sandbox-client runRemote env override guards", () => {
+  it("ignores a negative SANDBOX_MAX_RESPONSE_BYTES instead of rejecting every response", async () => {
+    currentResponder = (): { status: number; body: string } => ({
+      status: 200,
+      body: sentinelBody({ ok: true, result: 7, logs: [] }),
+    });
+    vi.resetModules();
+    process.env.SANDBOX_URL = `http://127.0.0.1:${port}`;
+    process.env.SANDBOX_MAX_RESPONSE_BYTES = "-1";
+    try {
+      const { runRemote } = await import("@/lib/sandbox/client");
+      const outcome = await runRemote({ code: "x", timeoutMs: 1000 });
+      expect(outcome.success).toBe(true);
+      if (outcome.success) {
+        expect(outcome.result).toBe(7);
+      }
+    } finally {
+      delete process.env.SANDBOX_MAX_RESPONSE_BYTES;
+    }
+  });
+});

--- a/tests/unit/sandbox-client.test.ts
+++ b/tests/unit/sandbox-client.test.ts
@@ -51,7 +51,7 @@ beforeAll(async () => {
       const result = currentResponder({ body: parsed });
       res.writeHead(result.status, {
         "Content-Type": "application/octet-stream",
-        "X-Sandbox-Wire": SANDBOX_WIRE_VERSION,
+        "X-KH-Sandbox-Wire": SANDBOX_WIRE_VERSION,
         ...result.headers,
       });
       res.end(result.body);
@@ -549,7 +549,7 @@ describe("lib/sandbox-client runRemote response size cap", () => {
 });
 
 describe("lib/sandbox-client runRemote wire-version skew", () => {
-  it("rejects a 200 response whose X-Sandbox-Wire header does not match", async () => {
+  it("rejects a 200 response whose X-KH-Sandbox-Wire header does not match", async () => {
     currentResponder = (): {
       status: number;
       body: string;
@@ -558,7 +558,7 @@ describe("lib/sandbox-client runRemote wire-version skew", () => {
       status: 200,
       body: sentinelBody({ ok: true, result: 1, logs: [] }),
       // Simulate an older sandbox advertising a different wire version.
-      headers: { "X-Sandbox-Wire": "json-v0" },
+      headers: { "X-KH-Sandbox-Wire": "json-v0" },
     });
     vi.resetModules();
     process.env.SANDBOX_URL = `http://127.0.0.1:${port}`;

--- a/tests/unit/sandbox-client.test.ts
+++ b/tests/unit/sandbox-client.test.ts
@@ -520,3 +520,26 @@ describe("lib/sandbox-client runRemote untrusted-shape hardening", () => {
     }
   });
 });
+
+describe("lib/sandbox-client runRemote response size cap", () => {
+  it("rejects a response body that exceeds SANDBOX_MAX_RESPONSE_BYTES", async () => {
+    const oversized = `${RESULT_SENTINEL}${"x".repeat(200_000)}\n`;
+    currentResponder = (): { status: number; body: string } => ({
+      status: 200,
+      body: oversized,
+    });
+    vi.resetModules();
+    process.env.SANDBOX_URL = `http://127.0.0.1:${port}`;
+    process.env.SANDBOX_MAX_RESPONSE_BYTES = "1024";
+    try {
+      const { runRemote } = await import("@/lib/sandbox/client");
+      const outcome = await runRemote({ code: "x", timeoutMs: 1000 });
+      expect(outcome.success).toBe(false);
+      if (!outcome.success) {
+        expect(outcome.error).toContain("exceeds maximum size");
+      }
+    } finally {
+      delete process.env.SANDBOX_MAX_RESPONSE_BYTES;
+    }
+  });
+});

--- a/tests/unit/sandbox-client.test.ts
+++ b/tests/unit/sandbox-client.test.ts
@@ -5,11 +5,8 @@ import {
   type ServerResponse,
 } from "node:http";
 import type { AddressInfo } from "node:net";
-import {
-  deserialize as v8Deserialize,
-  serialize as v8Serialize,
-} from "node:v8";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { encodeSandboxResult } from "@/lib/sandbox/child-source";
 
 vi.mock("server-only", () => ({}));
 
@@ -35,9 +32,7 @@ async function readReqBody(req: IncomingMessage): Promise<Buffer> {
 }
 
 function decodeRunPayload(raw: Buffer): unknown {
-  const base64 = raw.toString("ascii").trim();
-  const decoded = Buffer.from(base64, "base64");
-  return v8Deserialize(decoded);
+  return JSON.parse(raw.toString("utf8"));
 }
 
 beforeAll(async () => {
@@ -83,8 +78,7 @@ afterAll(async () => {
 });
 
 function sentinelBody(outcome: unknown): string {
-  const payload = v8Serialize(outcome).toString("base64");
-  return `${RESULT_SENTINEL}${payload}\n`;
+  return `${RESULT_SENTINEL}${encodeSandboxResult(outcome)}\n`;
 }
 
 describe("lib/sandbox-client runRemote", () => {
@@ -178,12 +172,12 @@ describe("lib/sandbox-client runRemote", () => {
   });
 
   it("uses lastIndexOf to tolerate forged sentinels earlier in output", async () => {
-    const fakePayload = Buffer.from([0xff, 0xff, 0xff]).toString("base64");
-    const realPayload = v8Serialize({
+    const fakePayload = "garbage-not-json-payload";
+    const realPayload = encodeSandboxResult({
       ok: true,
       result: "real",
       logs: [],
-    }).toString("base64");
+    });
     currentResponder = (): { status: number; body: string } => ({
       status: 200,
       body: `noise${RESULT_SENTINEL}${fakePayload}\n${RESULT_SENTINEL}${realPayload}\n`,
@@ -198,7 +192,7 @@ describe("lib/sandbox-client runRemote", () => {
     }
   });
 
-  it("sends timeout in SECONDS in the v8 payload", async () => {
+  it("sends timeout in SECONDS in the JSON payload", async () => {
     let capturedPayload: unknown = null;
     currentResponder = ({ body }): { status: number; body: string } => {
       capturedPayload = body;
@@ -326,6 +320,61 @@ describe("lib/sandbox-client runRemote", () => {
     process.env.SANDBOX_URL = `http://127.0.0.1:${port}`;
     const { runRemote } = await import("@/lib/sandbox/client");
     const outcome = await runRemote({ code: "return 1;", timeoutMs: 1000 });
+    expect(outcome.success).toBe(false);
+    if (!outcome.success) {
+      expect(outcome.error).toContain("sandbox client error");
+    }
+  });
+
+  it("rebuilds a __proto__ key as an own property without polluting Object.prototype", async () => {
+    const before = ({} as Record<string, unknown>).polluted;
+    // A hostile sandbox sends a tagged-JSON result carrying a __proto__ key.
+    // decodeSandboxResult rebuilds it as an own data property (JSON.parse +
+    // Object.defineProperty), never invoking the prototype setter.
+    currentResponder = (): { status: number; body: string } => ({
+      status: 200,
+      body: `${RESULT_SENTINEL}{"ok":true,"result":{"__proto__":{"polluted":true}},"logs":[]}\n`,
+    });
+    vi.resetModules();
+    process.env.SANDBOX_URL = `http://127.0.0.1:${port}`;
+    const { runRemote } = await import("@/lib/sandbox/client");
+    const outcome = await runRemote({ code: "x", timeoutMs: 1000 });
+    expect(({} as Record<string, unknown>).polluted).toBe(before);
+    expect(outcome.success).toBe(true);
+    if (outcome.success) {
+      const result = outcome.result as Record<string, unknown>;
+      expect(Object.hasOwn(result, "__proto__")).toBe(true);
+      expect(({} as Record<string, unknown>).polluted).toBe(before);
+    }
+  });
+
+  it("returns a clean error (never v8) when the payload after the sentinel is not JSON", async () => {
+    currentResponder = (): { status: number; body: string } => ({
+      status: 200,
+      body: `${RESULT_SENTINEL}this is not json at all\n`,
+    });
+    vi.resetModules();
+    process.env.SANDBOX_URL = `http://127.0.0.1:${port}`;
+    const { runRemote } = await import("@/lib/sandbox/client");
+    const outcome = await runRemote({ code: "x", timeoutMs: 1000 });
+    expect(outcome.success).toBe(false);
+    if (!outcome.success) {
+      expect(outcome.error).toContain("sandbox client error");
+    }
+  });
+
+  it("rejects a well-typed-discriminant but malformed outcome (ok:false, no errorMessage)", async () => {
+    // Valid tagged-JSON and a valid `ok` discriminant, but the variant fields
+    // are missing -- the tightened ChildOutcome guard must reject it rather
+    // than surface an undefined error/log downstream.
+    currentResponder = (): { status: number; body: string } => ({
+      status: 200,
+      body: `${RESULT_SENTINEL}{"ok":false,"logs":[]}\n`,
+    });
+    vi.resetModules();
+    process.env.SANDBOX_URL = `http://127.0.0.1:${port}`;
+    const { runRemote } = await import("@/lib/sandbox/client");
+    const outcome = await runRemote({ code: "x", timeoutMs: 1000 });
     expect(outcome.success).toBe(false);
     if (!outcome.success) {
       expect(outcome.error).toContain("sandbox client error");

--- a/tests/unit/sandbox-client.test.ts
+++ b/tests/unit/sandbox-client.test.ts
@@ -6,7 +6,10 @@ import {
 } from "node:http";
 import type { AddressInfo } from "node:net";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { encodeSandboxResult } from "@/lib/sandbox/child-source";
+import {
+  encodeSandboxResult,
+  SANDBOX_WIRE_VERSION,
+} from "@/lib/sandbox/child-source";
 
 vi.mock("server-only", () => ({}));
 
@@ -48,6 +51,7 @@ beforeAll(async () => {
       const result = currentResponder({ body: parsed });
       res.writeHead(result.status, {
         "Content-Type": "application/octet-stream",
+        "X-Sandbox-Wire": SANDBOX_WIRE_VERSION,
         ...result.headers,
       });
       res.end(result.body);
@@ -540,6 +544,29 @@ describe("lib/sandbox-client runRemote response size cap", () => {
       }
     } finally {
       delete process.env.SANDBOX_MAX_RESPONSE_BYTES;
+    }
+  });
+});
+
+describe("lib/sandbox-client runRemote wire-version skew", () => {
+  it("rejects a 200 response whose X-Sandbox-Wire header does not match", async () => {
+    currentResponder = (): {
+      status: number;
+      body: string;
+      headers: Record<string, string>;
+    } => ({
+      status: 200,
+      body: sentinelBody({ ok: true, result: 1, logs: [] }),
+      // Simulate an older sandbox advertising a different wire version.
+      headers: { "X-Sandbox-Wire": "json-v0" },
+    });
+    vi.resetModules();
+    process.env.SANDBOX_URL = `http://127.0.0.1:${port}`;
+    const { runRemote } = await import("@/lib/sandbox/client");
+    const outcome = await runRemote({ code: "x", timeoutMs: 1000 });
+    expect(outcome.success).toBe(false);
+    if (!outcome.success) {
+      expect(outcome.error).toContain("wire version mismatch");
     }
   });
 });

--- a/tests/unit/sandbox-client.test.ts
+++ b/tests/unit/sandbox-client.test.ts
@@ -463,3 +463,60 @@ describe("lib/sandbox-client runRemote", () => {
     }
   });
 });
+
+describe("lib/sandbox-client runRemote untrusted-shape hardening", () => {
+  it("rejects a forged non-string errorStack cleanly instead of throwing in extractLineNumber", async () => {
+    currentResponder = (): { status: number; body: string } => ({
+      status: 200,
+      body: sentinelBody({
+        ok: false,
+        errorMessage: "boom",
+        errorStack: 123,
+        logs: [],
+      }),
+    });
+    vi.resetModules();
+    process.env.SANDBOX_URL = `http://127.0.0.1:${port}`;
+    const { runRemote } = await import("@/lib/sandbox/client");
+    const outcome = await runRemote({ code: "x", timeoutMs: 1000 });
+    expect(outcome.success).toBe(false);
+    if (!outcome.success) {
+      expect(outcome.error).toContain("sandbox client error");
+      // Must NOT be the "stack.match is not a function" TypeError.
+      expect(outcome.error).not.toContain("match");
+    }
+  });
+
+  it("rejects a forged logs array containing a non-entry", async () => {
+    currentResponder = (): { status: number; body: string } => ({
+      status: 200,
+      body: sentinelBody({ ok: true, result: 1, logs: [null] }),
+    });
+    vi.resetModules();
+    process.env.SANDBOX_URL = `http://127.0.0.1:${port}`;
+    const { runRemote } = await import("@/lib/sandbox/client");
+    const outcome = await runRemote({ code: "x", timeoutMs: 1000 });
+    expect(outcome.success).toBe(false);
+  });
+
+  it("still surfaces a valid ok:false outcome and extracts the line number", async () => {
+    currentResponder = (): { status: number; body: string } => ({
+      status: 200,
+      body: sentinelBody({
+        ok: false,
+        errorMessage: "kaboom",
+        errorStack: "Error: kaboom\n    at user-code.js:6:7",
+        logs: [],
+      }),
+    });
+    vi.resetModules();
+    process.env.SANDBOX_URL = `http://127.0.0.1:${port}`;
+    const { runRemote } = await import("@/lib/sandbox/client");
+    const outcome = await runRemote({ code: "x", timeoutMs: 1000 });
+    expect(outcome.success).toBe(false);
+    if (!outcome.success) {
+      expect(outcome.error).toBe("kaboom");
+      expect(outcome.line).toBe(5);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`v8.deserialize` ran on untrusted bytes at the two cross-process HTTP hops of the sandbox boundary:
- **Response sink (F-010):** the main-app client `v8.deserialize`d the sandbox server's HTTP response (`lib/sandbox/client.ts`).
- **Request sink (F-029):** the sandbox server `v8.deserialize`d the inbound `/run` body before any structural check (`sandbox/src/index.ts`).

`v8.deserialize` is an unsafe sink on attacker-influenced bytes (host-object gadgets, prototype-pollution wire formats). These were the last `v8` sites after the in-pod child→parent paths were already moved to an fd-3 tagged-JSON frame.

## Change (matched cutover, both ends)

- **Request** (client → server): `JSON.stringify({ code, timeout })`, `Content-Type: application/json`; server `JSON.parse`s and keeps the existing `object` / `"code"`-present validation. Empty/non-JSON body still → `400`.
- **Response** (server → client): server encodes the (already fd-3-laundered) outcome with a new exported `encodeSandboxResult` — the structured-clone-preserving tagged-JSON encoder, the exact inverse of the existing `decodeSandboxResult`, prototype-pollution-safe (`__proto__` keys rebuilt as own data properties). Client decodes with `decodeSandboxResult` + a `ChildOutcome` shape guard.
- **No `node:v8`** remains in either boundary file.

## Deploy ordering (please read)

This is a **hard cutover** — there is no v8/JSON dual-accept. The sandbox service and the main app deploy from **separate pipelines**, so **deploy the sandbox service first**, then the app, to minimise the brief window during rollout where a new client could meet an old (v8-only) server (Code-node executions would fail in that window). Setting the app's `SANDBOX_BACKEND=local` is an available escape hatch during the cutover.

## Verification

- `@keeperhub/sandbox` suite: 32 pass (incl. non-JSON / no-`code` body → `400`, BigInt/Map round-trip through `encodeSandboxResult`).
- Client + codec suites: 84 pass (incl. a malicious `__proto__`-tagged response rebuilt as an own property with **no `Object.prototype` pollution**, non-JSON-after-sentinel → clean error, and encode↔decode round-trips for `undefined`/BigInt/Date/RegExp/Map/Set/typed-array/nested/`"$"`-key).
- Root **and** `@keeperhub/sandbox` type-checks clean. `grep` confirms no `node:v8` in `client.ts`/`index.ts`.
