### PR TITLE
fix: only show run-level error banner for stepless failures

### DIFF
--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -1193,6 +1193,13 @@ export function WorkflowRuns({
           );
         });
         const runErrorMessage = getCustomerRunErrorMessage(execution);
+        // When a step already failed, its own error is shown on that step, so
+        // the run-level banner would just duplicate it. Only surface the
+        // run-level error when no step carries it (phantom / infra failures).
+        const hasFailedStep = executionLogs.some(
+          (log) => log.status === "error"
+        );
+        const showRunError = Boolean(runErrorMessage) && !hasFailedStep;
 
         return (
           <div
@@ -1272,16 +1279,18 @@ export function WorkflowRuns({
 
             {isExpanded && (
               <div className="border-t bg-muted/20">
-                {runErrorMessage && (
+                {showRunError && (
                   <div className="p-4 pb-0">
-                    <Alert>
+                    <Alert className="border-destructive bg-destructive text-white">
                       <TriangleAlert />
-                      <AlertDescription>{runErrorMessage}</AlertDescription>
+                      <AlertDescription className="text-white">
+                        {runErrorMessage}
+                      </AlertDescription>
                     </Alert>
                   </div>
                 )}
                 {executionLogs.length === 0 ? (
-                  runErrorMessage ? null : (
+                  showRunError ? null : (
                     <div className="py-8 text-center text-muted-foreground text-xs">
                       No steps recorded
                     </div>


### PR DESCRIPTION
## Summary

The run-logs panel gained a run-level error banner that renders a
customer-facing message for failed runs. It fires for every failed run,
including ones whose failure is already shown on a failed step - so a
workflow/step error appears twice, and a user-config error that the
classifier defaults to "system" surfaces a misleading `Internal error
(C-NNNN)` banner sitting directly above the step that already shows the
real, actionable message.

This restricts the banner to failures that have no step to attach to.

## Changes

- Suppress the run-level banner whenever any step in the run has `error`
  status - the failing step's own Error section already shows the message.
- The banner now renders only for stepless failures (phantom executions,
  "no steps recorded", infrastructure failures that killed the run around
  the steps), which is what it was intended for.
- Restyle the banner to the destructive red variant with white text.

## Test plan

- [x] Failed condition/step run: banner is gone, step still shows the error.
- [x] User-config failure (e.g. invalid webhook URL): no `Internal error`
      banner; the step shows the real message.
- [x] Stepless failure (phantom / no steps recorded): banner still shows,
      now red with white text.

## Notes

Classifier mislabeling (user-config errors defaulting to `system`) and the
divergence between the run-level and step-level error dashboards are tracked
separately; this PR is the UI half only.
