### PR TITLE
test: make gas credit caps test hermetic to env overrides

### DIFF
--- a/tests/unit/gas-credits.test.ts
+++ b/tests/unit/gas-credits.test.ts
@@ -105,8 +105,14 @@ beforeEach(() => {
   mockOnConflictDoUpdate.mockResolvedValue(undefined);
   mockSelectLimit.mockResolvedValue([]);
   mockReadContract.mockReset();
+  // Clear ALL per-plan gas-credit env overrides (not just free/pro) so caps
+  // fall through to the mocked plan defaults. A developer .env that sets
+  // GAS_CREDITS_BUSINESS_CENTS / GAS_CREDITS_ENTERPRISE_CENTS otherwise leaks
+  // real values into getGasCreditCaps and breaks the assertions below.
   process.env.GAS_CREDITS_FREE_CENTS = undefined;
   process.env.GAS_CREDITS_PRO_CENTS = undefined;
+  process.env.GAS_CREDITS_BUSINESS_CENTS = undefined;
+  process.env.GAS_CREDITS_ENTERPRISE_CENTS = undefined;
 });
 
 describe("getGasCreditCapCents", () => {


### PR DESCRIPTION
## Problem

`tests/unit/gas-credits.test.ts > getGasCreditCaps > returns a cap for every plan` fails locally for anyone whose `.env` sets the per-plan gas-credit cap env vars:

```
expected { free: 500, pro: 500, business: 500, enterprise: 500 }
received { free: 500, pro: 500, business: 2500, enterprise: 10000 }
```

## Root cause

`getGasCreditCapCents` honors `GAS_CREDITS_<PLAN>_CENTS` env vars *before* the (mocked) plan default. The suite's `beforeEach` only neutralized the FREE and PRO overrides. `tests/setup.ts` loads `.env` via `dotenv/config`, so a developer `.env` that sets `GAS_CREDITS_BUSINESS_CENTS` / `GAS_CREDITS_ENTERPRISE_CENTS` leaks real cap values into `getGasCreditCaps`, while FREE/PRO correctly fall through to the mocked default. The test passes on CI (where those vars are unset) but fails on any machine that defines them - a non-hermetic test, not a code regression.

## Fix

Clear all four `GAS_CREDITS_*_CENTS` overrides in `beforeEach` so the caps deterministically fall through to the mocked plan defaults, regardless of ambient `.env`.

## Verification

`pnpm exec vitest run tests/unit/gas-credits.test.ts` -> 21/21 pass with the cap env vars present in `.env` (previously 1 failed).