### PR TITLE
fix(sandbox): validate the URL the sandboxed fetch actually dials

### DIFF
--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -877,10 +877,14 @@ function buildResponseHeaders(rawHeaders) {
 // genuine WHATWG Response so user code keeps the full fetch contract (.ok /
 // .status / .headers / .json() / .text() / .body). Redirects are NOT
 // auto-followed here; the caller's loop re-validates and follows each hop.
-async function pinnedFetch(resource, init, pinnedAddresses) {
-  // Normalise method/headers/body via the WHATWG Request so multipart,
-  // urlencoded, content-type and content-length handling match global fetch.
-  const request = new Request(resource, init);
+async function pinnedFetch(request, pinnedAddresses, signal) {
+  // request is the WHATWG Request the caller already built and validated.
+  // pinnedFetch reads the dial URL from THIS object and never re-derives it from
+  // a raw resource: a crafted resource whose toString() / .url disagree could
+  // otherwise make the dialed URL diverge from the validated one and slip past
+  // the SSRF guard (F-024 follow-up). The caller normalised method/headers/body
+  // on this Request too, so multipart, urlencoded, content-type and
+  // content-length handling still match global fetch.
   const parsed = new URL(request.url);
   const isHttps = parsed.protocol === "https:";
   const transport = isHttps ? https : http;
@@ -899,7 +903,25 @@ async function pinnedFetch(resource, init, pinnedAddresses) {
   }
 
   const hostname = stripIpv6Brackets(parsed.hostname);
-  const callerSignal = init && init.signal ? init.signal : undefined;
+  // Load-bearing backstop for the IP-literal dial path. net.connect dials an IP
+  // literal directly and NEVER invokes pinnedLookup below, so for a literal the
+  // only thing between user code and the socket is that this exact literal was in
+  // the validated, pinned set. Assert it. For DNS names pinnedLookup returns only
+  // pre-validated addresses, so the dial is already constrained to them. This
+  // makes "the address dialed is the address validated" a hard invariant even if
+  // a future change reintroduces a URL derivation that diverges from the guard
+  // (the F-024 class).
+  if (isIP(hostname) !== 0) {
+    const isValidatedLiteral = pinnedAddresses.some(function matchPinned(addr) {
+      return stripIpv6Brackets(addr.address) === hostname;
+    });
+    if (!isValidatedLiteral) {
+      throw new Error(
+        "sandbox fetch: SSRF blocked (unvalidated dial target " + hostname + ")"
+      );
+    }
+  }
+  const callerSignal = signal;
 
   return await new Promise(function dial(resolve, reject) {
     const options = {
@@ -1038,27 +1060,31 @@ function run(input) {
     error: capture("error"),
   };
 
-  function extractUrl(resource) {
-    if (typeof resource === "string") {
-      return resource;
-    }
-    if (resource && typeof resource.url === "string") {
-      return resource.url;
-    }
-    try {
-      return String(resource);
-    } catch (_) {
-      return "";
-    }
-  }
-
   async function sandboxedFetch(resource, init) {
-    const url = extractUrl(resource);
+    // Build the WHATWG Request EXACTLY ONCE. Both the SSRF validation below and
+    // the actual dial (pinnedFetch) read the URL from this single object, so the
+    // address validated is provably the address dialed. The earlier code
+    // validated extractUrl(resource) (=resource.url) while pinnedFetch dialed
+    // new Request(resource).url (=String(resource)); a crafted resource
+    // ({ url: <allowed>, toString: () => <IMDS> }) made those diverge, and when
+    // the dialed value was an IP literal it skipped the pinned lookup entirely
+    // and reached the blocked target (F-024 follow-up). Building once also means
+    // a hostile toString / Symbol.toPrimitive is invoked a single time, so it
+    // cannot hand one value to the guard and another to the socket.
+    let request;
+    try {
+      request = new Request(resource, init);
+    } catch (err) {
+      throw new TypeError(
+        "sandbox fetch: invalid request: " +
+          (err && err.message ? err.message : String(err))
+      );
+    }
     let parsed;
     try {
-      parsed = new URL(url);
+      parsed = new URL(request.url);
     } catch (_e) {
-      throw new TypeError("sandbox fetch: invalid URL: " + url);
+      throw new TypeError("sandbox fetch: invalid URL: " + request.url);
     }
     if (!ALLOWED_SCHEMES.has(parsed.protocol)) {
       throw new Error("sandbox fetch: scheme not allowed: " + parsed.protocol);
@@ -1106,7 +1132,10 @@ function run(input) {
       redirect: "manual",
     });
 
-    let currentResource = resource;
+    // currentRequest is the single, already-built Request dialed this hop.
+    // currentInit only carries the method/body/headers used to build the NEXT
+    // hop's request; the abort signal is passed to pinnedFetch directly.
+    let currentRequest = request;
     let currentBase = parsed;
     let currentInit = baseInit;
     let currentAddresses = resolved.addresses;
@@ -1118,9 +1147,9 @@ function run(input) {
         // not auto-follow redirects, so this loop re-resolves + re-validates
         // each hop below and pins the next hop's addresses before dialing it.
         const response = await pinnedFetch(
-          currentResource,
-          currentInit,
-          currentAddresses
+          currentRequest,
+          currentAddresses,
+          controller.signal
         );
         const location = REDIRECT_STATUSES.has(response.status)
           ? response.headers.get("location")
@@ -1165,7 +1194,10 @@ function run(input) {
         await cancelResponseBody(response);
 
         currentInit = applyRedirectMethod(currentInit, response.status);
-        currentResource = nextUrl.href;
+        // Build the next hop's request from the server-provided, re-validated
+        // URL string (never a raw object), so its dial URL cannot diverge from
+        // what nextResolved just validated.
+        currentRequest = new Request(nextUrl.href, currentInit);
         currentBase = nextUrl;
         currentAddresses = nextResolved.addresses;
       }

--- a/tests/unit/sandbox-child-source.test.ts
+++ b/tests/unit/sandbox-child-source.test.ts
@@ -334,6 +334,11 @@ describe("sandbox grandchild redirect following", () => {
         status: 302,
         location: "http://169.254.169.254/latest/meta-data/",
       },
+      "/r/imds-hex": { status: 302, location: "http://0xa9fea9fe/" },
+      "/r/imds-mapped": {
+        status: 302,
+        location: "http://[::ffff:169.254.169.254]/",
+      },
       "/r/cluster": {
         status: 302,
         location: "http://probe.svc.cluster.local/",
@@ -393,6 +398,22 @@ describe("sandbox grandchild redirect following", () => {
       expect(outcome.errorMessage).toContain("169.254.169.254");
     }
   });
+
+  it.each([
+    ["/r/imds-hex", "hex-literal IMDS (0xa9fea9fe)"],
+    ["/r/imds-mapped", "IPv4-mapped IPv6 IMDS"],
+  ])(
+    "blocks a redirect into a non-canonical IMDS literal via %s (%s)",
+    async (path) => {
+      const outcome = await runSandboxed(
+        getCode(`${base}${path}`),
+        3000,
+        REDIRECT_TEST_SOURCE
+      );
+      expectBlocked(outcome);
+    },
+    10_000
+  );
 
   it("blocks a redirect into a cluster hostname", async () => {
     const outcome = await runSandboxed(
@@ -584,6 +605,126 @@ describe("sandbox grandchild pins the resolved address at dial time (F-024)", ()
       expect(outcome.errorMessage).toContain("169.254.169.254");
     }
   }, 10_000);
+}, 30_000);
+
+// F-024 follow-up: the SSRF guard must validate the SAME canonical URL the dial
+// connects to. The first F-024 fix validated extractUrl(resource) (which read
+// resource.url) while pinnedFetch dialed new Request(resource).url (which
+// coerces the resource via toString / Symbol.toPrimitive). A crafted resource
+// whose .url and toString disagree slipped an allowed host past the guard while
+// dialing a blocked IP literal -- and an IP literal skips the pinned lookup
+// entirely (net.connect dials it directly), so the validated address set was
+// never consulted and the app-layer guard was fully bypassed. The fix builds the
+// WHATWG Request once and validates + dials that single object, and pinnedFetch
+// additionally refuses to dial an IP literal that is not in the validated set.
+describe("sandbox grandchild validates the dialed URL, not a divergent resource view (F-024 follow-up)", () => {
+  let server: Server;
+  let base: string;
+
+  beforeAll(async () => {
+    server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, path: url.pathname }));
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  it("blocks a resource whose toString() returns an IP literal its .url hides (the confirmed bypass)", async () => {
+    // resource.url is a public literal (passed the old guard); toString() is the
+    // value new Request() actually dials -- IMDS link-local. The guard must see
+    // the dialed value and block it. Uses the real source: 1.1.1.1 is a literal
+    // (no DNS) and the IMDS literal is rejected before any socket is opened.
+    const code = `return await fetch({ url: "http://1.1.1.1/", toString() { return "http://169.254.169.254/latest/meta-data/iam/security-credentials/"; } });`;
+    const outcome = await runSandboxed(code);
+    expectBlocked(outcome);
+    if (!outcome.ok) {
+      // The error names the dialed IMDS literal, not the decoy resource.url.
+      expect(outcome.errorMessage).toContain("169.254.169.254");
+      expect(outcome.errorMessage).not.toContain("1.1.1.1");
+    }
+  }, 10_000);
+
+  it("blocks the same divergence expressed via Symbol.toPrimitive", async () => {
+    const code = `return await fetch({ url: "http://1.1.1.1/", [Symbol.toPrimitive]() { return "http://169.254.169.254/"; } });`;
+    const outcome = await runSandboxed(code);
+    expectBlocked(outcome);
+    if (!outcome.ok) {
+      expect(outcome.errorMessage).toContain("169.254.169.254");
+    }
+  }, 10_000);
+
+  // Non-canonical IPv4/IPv6 literal forms must also be blocked. WHATWG URL
+  // normalisation collapses them to canonical IPs inside the single request.url
+  // that is both validated and dialed, so isBlockedIp catches them - but only if
+  // validation and dial read the SAME normalised string, which is exactly the
+  // invariant this fix establishes. (The pre-existing tests only cover canonical
+  // dotted literals.)
+  it.each([
+    ['await fetch("http://0177.0.0.1/")', "octal IPv4 -> 127.0.0.1"],
+    ['await fetch("http://2130706433/")', "decimal IPv4 -> 127.0.0.1"],
+    ['await fetch("http://0xa9fea9fe/")', "hex IPv4 -> 169.254.169.254 (IMDS)"],
+    ['await fetch("http://127.1/")', "short IPv4 -> 127.0.0.1"],
+    [
+      'await fetch("http://[::ffff:169.254.169.254]/")',
+      "IPv4-mapped IPv6 -> IMDS",
+    ],
+  ])("blocks non-canonical literal %s (%s)", async (snippet) => {
+    const outcome = await runSandboxed(`return ${snippet};`);
+    expectBlocked(outcome);
+  }, 10_000);
+
+  it("still allows an object resource whose coerced URL is an allowed host (no over-block)", async () => {
+    // Negative control: object resources remain usable for legitimate targets.
+    const code = `const r = await fetch({ toString() { return ${JSON.stringify(`${base}/ok`)}; } }); return { status: r.status, body: await r.json() };`;
+    const outcome = await runSandboxed(code, 3000, REDIRECT_TEST_SOURCE);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      const r = outcome.result as { status: number; body: { path: string } };
+      expect(r.status).toBe(200);
+      expect(r.body.path).toBe("/ok");
+    }
+  }, 10_000);
+
+  it("coerces the resource exactly once, so a mutating toString() cannot validate one URL and dial another", async () => {
+    // If the resource were coerced twice (once to validate, once to dial) this
+    // toString would pass the guard on call #1 (allowed host) and dial IMDS on
+    // call #2. Building the Request once invokes it a single time: the dial uses
+    // the validated value and n stays 1.
+    const code = `let n = 0; const r = await fetch({ toString() { n++; return n === 1 ? ${JSON.stringify(`${base}/ok`)} : "http://169.254.169.254/"; } }); return { status: r.status, n, body: await r.json() };`;
+    const outcome = await runSandboxed(code, 3000, REDIRECT_TEST_SOURCE);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      const r = outcome.result as {
+        status: number;
+        n: number;
+        body: { path: string };
+      };
+      expect(r.status).toBe(200);
+      expect(r.n).toBe(1);
+      expect(r.body.path).toBe("/ok");
+    }
+  }, 10_000);
+
+  it("refuses to dial an IP literal absent from the validated pinned set (defense-in-depth backstop)", () => {
+    // The literal-dial backstop in pinnedFetch is load-bearing: net.connect
+    // dials an IP literal directly, skipping the pinned lookup, so the literal
+    // must be re-checked against the validated set before connecting.
+    expect(SANDBOX_CHILD_SOURCE).toContain("unvalidated dial target");
+  });
+
+  it("no longer derives the validated URL from a divergent resource.url helper", () => {
+    expect(SANDBOX_CHILD_SOURCE).not.toContain("function extractUrl");
+  });
 }, 30_000);
 
 // Behavioural coverage that the node:http/https pin path is a faithful drop-in


### PR DESCRIPTION
## Problem

The sandbox Code node's wrapped `fetch` validated the SSRF guard against `extractUrl(resource)` (which read `resource.url`) while `pinnedFetch` independently re-derived the dial target via `new Request(resource).url` (which coerces the resource via `toString` / `Symbol.toPrimitive`). For an object resource these two URLs could diverge, and when the dialed value was an IP literal, `node:http`'s `net.connect` dials it directly and **skips the custom pinned lookup**, so the validated address set was never consulted.

User code in a Code node could therefore pass the guard with an allowed host and still dial a blocked target:

```js
fetch({ url: "http://allowed/", toString() { return "http://169.254.169.254/latest/meta-data/iam/security-credentials/"; } })
```

reaching IMDS / ECS (`169.254.170.2`) / K8s ClusterIPs / loopback. External IMDS is backstopped by the sandbox NetworkPolicy, but cluster-internal targets are not, and the app-layer guard added in the previous change was fully bypassed.

Root cause confirmed at the mechanism level: `new Request({ url: public, toString: () => literal }).url` equals the literal (diverges from `.url`), and `node:http` with an IP-literal hostname plus a custom `lookup` never calls the lookup (dials directly).

## Fix

- **Build the WHATWG `Request` exactly once** in `sandboxedFetch` and validate + dial that single object (removes the divergent `extractUrl` helper). A hostile `toString` / `Symbol.toPrimitive` is now invoked a single time, so it cannot hand one value to the guard and another to the socket.
- **`pinnedFetch` reads url/method/headers/body from the passed-in `Request`** (no second construction) and, before dialing, asserts that any IP-literal dial host is in the validated pinned set. This is a load-bearing backstop for the `net.connect` lookup-skip path that holds even if a future change reintroduces a divergent URL derivation.
- **Redirect hops** build the next request from the re-validated `Location` href, so no hop's dial URL can diverge from what was just validated.

Touches `lib/sandbox/child-source.ts` only (inside the `SANDBOX_CHILD_SOURCE` template).

## Tests

Adds regression coverage for the whole validate-vs-dial class:
- the exact bypass (object resource whose `.url` is allowed but `toString` returns an IP literal) and the `Symbol.toPrimitive` variant -> blocked, error names the dialed IP not the decoy `.url`
- a single-coercion lock (resource coerced exactly once)
- non-canonical IPv4/IPv6 literal forms (octal / decimal / hex / short / IPv4-mapped) -> blocked, both directly and via a redirect `Location`
- negative controls: legitimate object-resource fetches still work

`tests/unit/sandbox-child-source.test.ts`: 101 passed. `pnpm type-check`, `pnpm --filter @keeperhub/sandbox typecheck`, and the `@keeperhub/sandbox` suite all pass.