### PR TITLE
feat(notifications): digest email manage link and clearer org

### DIFF
--- a/app/api/internal/execution-digest/route.ts
+++ b/app/api/internal/execution-digest/route.ts
@@ -113,6 +113,7 @@ async function processOrg(
       await sendWorkflowExecutionDigestEmail({
         to,
         orgName: row.orgName,
+        organizationId: row.organizationId,
         cadence,
         since,
         until,

--- a/app/workflows/page.tsx
+++ b/app/workflows/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { api } from "@/lib/api-client";
+
+// Index route for `/workflows` (no workflow selected). Without this the bare
+// path 404s in the canvas. Redirects to the most recently created workflow so
+// the canvas always has content; falls back to an empty state when the org has
+// none. A digest-email deep link (`?digestSettings=`) opens a modal over this
+// page, so we skip the redirect in that case to avoid navigating out from under
+// it.
+export default function WorkflowsIndexPage(): React.ReactElement | null {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const hasDeepLink = searchParams.get("digestSettings") !== null;
+  const resolvedRef = useRef(false);
+  const [empty, setEmpty] = useState(false);
+
+  useEffect(() => {
+    if (hasDeepLink || resolvedRef.current) {
+      return;
+    }
+    resolvedRef.current = true;
+
+    const resolve = async (): Promise<void> => {
+      try {
+        const list = await api.workflow.getAll();
+        const mostRecent = [...list].sort(
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        )[0];
+        if (mostRecent) {
+          router.replace(`/workflows/${mostRecent.id}`);
+        } else {
+          setEmpty(true);
+        }
+      } catch {
+        setEmpty(true);
+      }
+    };
+
+    void resolve();
+  }, [hasDeepLink, router]);
+
+  if (!empty) {
+    return null;
+  }
+
+  return (
+    <div className="flex h-dvh w-full flex-col items-center justify-center gap-3 text-center">
+      <h1 className="font-semibold text-xl">No workflows yet</h1>
+      <p className="text-muted-foreground text-sm">
+        Create your first workflow to get started.
+      </p>
+      <Button onClick={() => router.push("/")}>New workflow</Button>
+    </div>
+  );
+}

--- a/components/organization/execution-digest-section.tsx
+++ b/components/organization/execution-digest-section.tsx
@@ -13,7 +13,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { useFeature } from "@/hooks/use-features";
 import { isBillingEnabled } from "@/lib/billing/feature-flag";
 import {
   DIGEST_REQUIRES_CADENCE_ERROR,
@@ -61,11 +60,11 @@ export function ExecutionDigestSection({
   canManageBilling,
 }: ExecutionDigestSectionProps): React.ReactElement {
   const router = useRouter();
-  const { enabled: featureEnabled, loading: featureLoading } = useFeature(
-    "notifications.execution-digest"
-  );
 
   const [loading, setLoading] = useState(true);
+  // Entitlement is per-org (the API checks this org's plan), not the active
+  // org's, so a digest-email deep link to another org gates correctly.
+  const [eligible, setEligible] = useState(false);
   const [saving, setSaving] = useState(false);
   const [enabled, setEnabled] = useState(false);
   const [cadences, setCadences] = useState<Set<Cadence>>(new Set(["weekly"]));
@@ -85,6 +84,7 @@ export function ExecutionDigestSection({
         setCadences(new Set(data.cadences));
         setSubscribers(new Set(data.subscriberUserIds));
         setMembers(data.members);
+        setEligible(data.eligible);
       })
       .finally(() => {
         if (active) {
@@ -163,7 +163,7 @@ export function ExecutionDigestSection({
     </h4>
   );
 
-  if (!(featureLoading || featureEnabled)) {
+  if (!(loading || eligible)) {
     return (
       <div className="space-y-3">
         {heading}

--- a/components/organization/manage-orgs-modal.tsx
+++ b/components/organization/manage-orgs-modal.tsx
@@ -14,7 +14,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ExecutionDigestSection } from "@/components/organization/execution-digest-section";
@@ -487,6 +487,10 @@ type ManageOrgsModalProps = {
   defaultShowCreateForm?: boolean;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  // When set, this instance consumes the `?digestSettings=<orgId>` deep link
+  // from digest emails: it opens the modal on the Notifications tab for that
+  // org. Enable on exactly one always-mounted instance to avoid double-opens.
+  consumeDeepLink?: boolean;
 };
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Complex modal with multiple states - refactoring would split related logic
@@ -495,12 +499,14 @@ export function ManageOrgsModal({
   defaultShowCreateForm = false,
   open: externalOpen,
   onOpenChange: externalOnOpenChange,
+  consumeDeepLink = false,
 }: ManageOrgsModalProps = {}) {
   const [internalOpen, setInternalOpen] = useState(false);
 
   // Use external state if provided, otherwise use internal state
   const open = externalOpen === undefined ? internalOpen : externalOpen;
   const setOpen = externalOnOpenChange || setInternalOpen;
+  const [activeTab, setActiveTab] = useState("organizations");
   const [showCreateForm, setShowCreateForm] = useState(defaultShowCreateForm);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showLeaveDialog, setShowLeaveDialog] = useState(false);
@@ -534,7 +540,56 @@ export function ManageOrgsModal({
     role: activeOrgRole,
   } = useActiveMember();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { data: session } = authClient.useSession();
+
+  // Arrive from a digest email's "manage emails" link
+  // (`?digestSettings=<orgId>`): switch to that org so the whole context (org
+  // dropdown, role, plan) matches, then open the modal on the Notifications tab
+  // once the switch settles so it's correct on first paint. Runs once; the param
+  // is stripped via history so it can't re-trigger.
+  const deepLinkConsumedRef = useRef(false);
+  useEffect(() => {
+    if (!consumeDeepLink) {
+      return;
+    }
+    const deepLinkOrgId = searchParams.get("digestSettings");
+    if (!deepLinkOrgId) {
+      deepLinkConsumedRef.current = false;
+      return;
+    }
+    if (deepLinkConsumedRef.current) {
+      return;
+    }
+    deepLinkConsumedRef.current = true;
+    const url = new URL(window.location.href);
+    url.searchParams.delete("digestSettings");
+    window.history.replaceState(null, "", url.toString());
+    setActiveTab("notifications");
+    if (organization?.id === deepLinkOrgId) {
+      setOpen(true);
+      return;
+    }
+    switchOrganization(deepLinkOrgId).finally(() => setOpen(true));
+  }, [
+    consumeDeepLink,
+    searchParams,
+    organization?.id,
+    switchOrganization,
+    setOpen,
+  ]);
+
+  // Reset to the default tab when the modal closes so reopening it manually
+  // doesn't land on the deep-linked Notifications tab.
+  const handleDialogOpenChange = useCallback(
+    (next: boolean): void => {
+      setOpen(next);
+      if (!next) {
+        setActiveTab("organizations");
+      }
+    },
+    [setOpen]
+  );
 
   // Get the managed organization object (for detail view)
   const managedOrg = managedOrgId
@@ -1237,7 +1292,7 @@ export function ManageOrgsModal({
 
   return (
     <>
-      <Dialog onOpenChange={setOpen} open={open}>
+      <Dialog onOpenChange={handleDialogOpenChange} open={open}>
         {/* Only show trigger when not controlled externally */}
         {externalOpen === undefined && (
           <DialogTrigger asChild>
@@ -1260,7 +1315,11 @@ export function ManageOrgsModal({
             </DialogDescription>
           </DialogHeader>
 
-          <Tabs className="w-full" defaultValue="organizations">
+          <Tabs
+            className="w-full"
+            onValueChange={setActiveTab}
+            value={activeTab}
+          >
             <TabsList className="grid w-full grid-cols-3">
               <TabsTrigger value="organizations">Organizations</TabsTrigger>
               <TabsTrigger value="invitations">
@@ -1632,10 +1691,19 @@ export function ManageOrgsModal({
 
             <TabsContent className="space-y-4" value="notifications">
               {organization && (isActiveOrgOwner || isActiveOrgAdmin) ? (
-                <ExecutionDigestSection
-                  canManageBilling={isActiveOrgOwner}
-                  organizationId={organization.id}
-                />
+                <>
+                  <p className="text-muted-foreground text-sm">
+                    Settings for{" "}
+                    <span className="font-medium text-foreground">
+                      {organization.name}
+                    </span>
+                  </p>
+                  <ExecutionDigestSection
+                    canManageBilling={isActiveOrgOwner}
+                    key={organization.id}
+                    organizationId={organization.id}
+                  />
+                </>
               ) : (
                 <div className="py-8 text-center text-muted-foreground">
                   Only organization owners and admins can manage notifications.

--- a/components/workflows/user-menu.tsx
+++ b/components/workflows/user-menu.tsx
@@ -229,7 +229,11 @@ const AuthenticatedUserMenu = (): React.ReactElement => {
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-      <ManageOrgsModal onOpenChange={setOrgModalOpen} open={orgModalOpen} />
+      <ManageOrgsModal
+        consumeDeepLink
+        onOpenChange={setOrgModalOpen}
+        open={orgModalOpen}
+      />
     </>
   );
 };

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -792,7 +792,7 @@ ${failingText}
 View runs: ${appUrl}/analytics
 
 You're receiving this digest for ${orgName} because you're an owner or admin of that organization.
-Manage or turn off these emails: ${manageUrl}
+Manage notifications: ${manageUrl}
 
 ---
 KeeperHub - Blockchain Workflow Automation
@@ -883,7 +883,7 @@ ${socialText}
     </div>
     <h2 style="color: #1a1a2e; margin-top: 0;">${escapeHtml(orgName)} workflow digest</h2>
     <p style="color:#666; margin-bottom:10px;">${summaryLabel}</p>
-    <p style="color:#444; font-size:13px; margin:0 0 4px; line-height:1.8;">${formatUtcStamp(since)}<br><span style="color:#aaa;">to</span><br>${formatUtcStamp(until)}</p>
+    <p style="color:#444; font-size:13px; margin:0 0 4px;">${formatUtcStamp(since)} <span style="color:#aaa;">to</span> ${formatUtcStamp(until)}</p>
     <table role="presentation" width="100%" style="border-collapse:collapse; table-layout:fixed; margin:24px 0;">
       <tr>${statCard(stats.total, "Total runs")}${statCard(stats.distinctWorkflows, "Workflows run")}</tr>
     </table>
@@ -908,7 +908,7 @@ ${socialText}
         `<td style="padding:0 8px;"><a href="${s.url}" target="_blank" rel="noopener"><img src="cid:${s.icon}" alt="${s.name}" width="20" height="20" style="display:block;" /></a></td>`
     ).join("")}</tr></table>
     <p style="margin: 0 0 6px;">You're receiving this digest for <strong>${escapeHtml(orgName)}</strong> because you're an owner or admin of that organization.</p>
-    <p style="margin: 0 0 12px;"><a href="${manageUrl}" style="color:#666; text-decoration:underline;">Manage or turn off these emails</a></p>
+    <p style="margin: 0 0 12px;"><a href="${manageUrl}" style="color:#666; text-decoration:underline;">Manage notifications</a></p>
     <p style="margin: 0;">KeeperHub - Blockchain Workflow Automation</p>
   </div>
 </body>

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -588,6 +588,7 @@ KeeperHub - Blockchain Workflow Automation
 type ExecutionDigestEmailData = {
   to: string;
   orgName: string;
+  organizationId: string;
   cadence: "daily" | "weekly" | "monthly";
   // Window the digest summarizes, [since, until).
   since: Date;
@@ -709,6 +710,7 @@ export async function sendWorkflowExecutionDigestEmail(
   const {
     to,
     orgName,
+    organizationId,
     cadence,
     since,
     until,
@@ -734,6 +736,12 @@ export async function sendWorkflowExecutionDigestEmail(
 
   const workflowUrl = (id: string): string =>
     `${appUrl}/workflows/${encodeURIComponent(id)}`;
+
+  // Deep-links into the org's Notifications settings so a recipient can adjust
+  // or turn off this digest. Carries the org id so the app opens the right org.
+  const manageUrl = `${appUrl}/workflows?digestSettings=${encodeURIComponent(
+    organizationId
+  )}`;
 
   const failingText = topFailing.length
     ? topFailing
@@ -764,7 +772,8 @@ export async function sendWorkflowExecutionDigestEmail(
   );
 
   const text = `
-${orgName} - ${summaryLabel}
+Organization: ${orgName}
+${summaryLabel}
 ${periodRange}
 
 Total runs: ${stats.total}
@@ -781,6 +790,9 @@ Top failing workflows:
 ${failingText}
 
 View runs: ${appUrl}/analytics
+
+You're receiving this digest for ${orgName} because you're an owner or admin of that organization.
+Manage or turn off these emails: ${manageUrl}
 
 ---
 KeeperHub - Blockchain Workflow Automation
@@ -865,6 +877,10 @@ ${socialText}
     <img src="${logoUrl}" alt="KeeperHub" style="max-width: 200px; height: auto;" />
   </div>
   <div style="background: #ffffff; padding: 30px; border: 1px solid #e5e5e5; border-top: none; border-radius: 0 0 12px 12px; text-align: center;">
+    <div style="margin:0 0 14px;">
+      <div style="color:#999; font-size:11px; font-weight:600; letter-spacing:0.6px; text-transform:uppercase; margin-bottom:6px;">Organization</div>
+      <span style="display:inline-block; background:#f5f5f5; border:1px solid #e5e5e5; border-radius:999px; padding:6px 14px; color:#1a1a2e; font-weight:600; font-size:14px;">${escapeHtml(orgName)}</span>
+    </div>
     <h2 style="color: #1a1a2e; margin-top: 0;">${escapeHtml(orgName)} workflow digest</h2>
     <p style="color:#666; margin-bottom:10px;">${summaryLabel}</p>
     <p style="color:#444; font-size:13px; margin:0 0 4px; line-height:1.8;">${formatUtcStamp(since)}<br><span style="color:#aaa;">to</span><br>${formatUtcStamp(until)}</p>
@@ -891,6 +907,8 @@ ${socialText}
       (s) =>
         `<td style="padding:0 8px;"><a href="${s.url}" target="_blank" rel="noopener"><img src="cid:${s.icon}" alt="${s.name}" width="20" height="20" style="display:block;" /></a></td>`
     ).join("")}</tr></table>
+    <p style="margin: 0 0 6px;">You're receiving this digest for <strong>${escapeHtml(orgName)}</strong> because you're an owner or admin of that organization.</p>
+    <p style="margin: 0 0 12px;"><a href="${manageUrl}" style="color:#666; text-decoration:underline;">Manage or turn off these emails</a></p>
     <p style="margin: 0;">KeeperHub - Blockchain Workflow Automation</p>
   </div>
 </body>

--- a/tests/unit/execution-digest-email.test.ts
+++ b/tests/unit/execution-digest-email.test.ts
@@ -127,7 +127,7 @@ describe("sendWorkflowExecutionDigestEmail", () => {
     expect(content).toContain(
       "https://app.keeperhub.com/workflows?digestSettings=org-123"
     );
-    expect(content).toContain("Manage or turn off these emails");
+    expect(content).toContain("Manage notifications");
     expect(content).toContain(
       "because you're an owner or admin of that organization"
     );

--- a/tests/unit/execution-digest-email.test.ts
+++ b/tests/unit/execution-digest-email.test.ts
@@ -14,6 +14,7 @@ function baseData() {
   return {
     to: "owner@example.com",
     orgName: "Acme",
+    organizationId: "org-123",
     cadence: "daily" as const,
     since: new Date("2026-06-08T14:00:00.000Z"),
     until: new Date("2026-06-09T14:00:00.000Z"),
@@ -111,6 +112,25 @@ describe("sendWorkflowExecutionDigestEmail", () => {
     expect(content).toContain("https://discord.gg/keeperhub");
     expect(content).toContain("https://x.com/KeeperHubApp");
     expect(content).not.toContain("mailto:");
+  });
+
+  it("names the organization clearly in the body", async () => {
+    await sendWorkflowExecutionDigestEmail(baseData());
+    const content = sentContent();
+    expect(content).toContain("Organization: Acme");
+    expect(content).toContain("Acme workflow digest");
+  });
+
+  it("includes a manage/unsubscribe link deep-linking to the org's settings", async () => {
+    await sendWorkflowExecutionDigestEmail(baseData());
+    const content = sentContent();
+    expect(content).toContain(
+      "https://app.keeperhub.com/workflows?digestSettings=org-123"
+    );
+    expect(content).toContain("Manage or turn off these emails");
+    expect(content).toContain(
+      "because you're an owner or admin of that organization"
+    );
   });
 
   it("attaches the social icons inline (cid) so they render without hosting", async () => {


### PR DESCRIPTION
## Summary

The execution digest email did not clearly say which organization it covered and gave recipients no way to manage or turn it off. This adds clear org identification and a manage/unsubscribe link, plus the in-app handling behind that link.

## Changes

- **Email** (`lib/email.ts`, internal digest cron): an org name pill in the header, an `Organization:` line in the text body, and a footer "manage or turn off these emails" link that deep-links to the org's notification settings via `?digestSettings=<orgId>`. The cron passes the org id through.
- **Deep link** (`manage-orgs-modal.tsx`, `user-menu.tsx`): opens the Manage Organizations modal on the Notifications tab and switches the active org once, so the org dropdown, role, and plan all reflect the linked org. The modal tabs are now controlled.
- **Per-org eligibility** (`execution-digest-section.tsx`): the digest section gates on the API's per-org `eligible` flag instead of the active-org feature snapshot, so a link to another org shows the correct paid/free state.
- **`/workflows` index** (`app/workflows/page.tsx`): new index route so the bare path no longer 404s. It redirects to the most recent workflow, shows an empty state when there are none, and stays put when a digest deep link is present.

## Testing

- `pnpm type-check` clean.
- Unit: `execution-digest`, `execution-digest-email`, `features-registry` (35 passing); added email assertions for the org reinforcement and the manage link.
- Manually verified the deep link end to end against a paid org on local: org dropdown switches, canvas resolves (no 404), modal opens on Notifications with the real controls.