### PR TITLE
fix(workflow): prune stale config when switching node action type

### DIFF
--- a/components/workflow/node-config-panel.tsx
+++ b/components/workflow/node-config-panel.tsx
@@ -60,7 +60,8 @@ import {
   updateNodeDataAtom,
   workflowNotFoundAtom,
 } from "@/lib/workflow/store";
-import { findActionById, flattenConfigFields } from "@/plugins/registry";
+import { buildConfigForActionTypeChange } from "@/lib/workflow/editor/action-type-transition";
+import { findActionById } from "@/plugins/registry";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { ActionConfig } from "./config/action-config";
 import { ActionGrid } from "./config/action-grid";
@@ -562,30 +563,13 @@ export const PanelInner = () => {
   ): void => {
     if (selectedNode) {
       const baseConfig = pendingConfigRef.current ?? selectedNode.data.config;
-      let newConfig = { ...baseConfig, [key]: value };
+      let newConfig: Record<string, unknown> = { ...baseConfig, [key]: value };
 
-      // When action type changes, clear the integrationId since it may not be valid for the new action
-      if (key === "actionType" && baseConfig?.integrationId) {
-        newConfig = { ...newConfig, integrationId: undefined };
-      }
-
-      // When action type is selected, persist defaultValues from configFields
-      // into config so that showWhen conditions and validation work immediately.
-      // For _protocolMeta: always overwrite with the new action's value since
-      // stale metadata causes the wrong contract function to be called at runtime.
       if (key === "actionType" && typeof value === "string") {
-        const selectedAction = findActionById(value);
-        if (selectedAction?.configFields) {
-          for (const field of flattenConfigFields(selectedAction.configFields)) {
-            if (field.defaultValue === undefined) {
-              continue;
-            }
-            const forceUpdate = field.key === "_protocolMeta";
-            if (forceUpdate || !(field.key in newConfig)) {
-              newConfig = { ...newConfig, [field.key]: field.defaultValue };
-            }
-          }
-        }
+        // Prune leftovers from the previous action type and seed the new
+        // action's defaults so showWhen conditions and validation evaluate
+        // immediately. See buildConfigForActionTypeChange for details.
+        newConfig = buildConfigForActionTypeChange(value, newConfig);
       }
 
       pendingConfigRef.current = newConfig;

--- a/lib/workflow/editor/action-type-transition.ts
+++ b/lib/workflow/editor/action-type-transition.ts
@@ -1,0 +1,47 @@
+/**
+ * Builds the next config when an action node's `actionType` changes.
+ *
+ * Switching action types leaves config keys from the previous action behind.
+ * Those leftovers fail the save-time validator (UNKNOWN_FIELD) or surface as
+ * spurious missing/invalid errors. This prunes the config down to the keys the
+ * newly selected action accepts, drops `integrationId` (re-selected per action),
+ * then seeds defaults for the new action's fields so showWhen conditions and
+ * validation evaluate immediately. `_protocolMeta` is always refreshed since
+ * stale metadata would call the wrong contract function at runtime.
+ */
+import { isKnownConfigKeyForAction } from "@/lib/workflow/validation/action-config";
+import { findActionById, flattenConfigFields } from "@/plugins/registry";
+
+const PROTOCOL_META_KEY = "_protocolMeta";
+
+export function buildConfigForActionTypeChange(
+  actionType: string,
+  config: Record<string, unknown>
+): Record<string, unknown> {
+  const pruned: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(config)) {
+    if (key === "integrationId") {
+      continue;
+    }
+    if (isKnownConfigKeyForAction(actionType, key)) {
+      pruned[key] = value;
+    }
+  }
+
+  const action = findActionById(actionType);
+  if (!action?.configFields) {
+    return pruned;
+  }
+
+  for (const field of flattenConfigFields(action.configFields)) {
+    if (field.defaultValue === undefined) {
+      continue;
+    }
+    const forceUpdate = field.key === PROTOCOL_META_KEY;
+    if (forceUpdate || !(field.key in pruned)) {
+      pruned[field.key] = field.defaultValue;
+    }
+  }
+
+  return pruned;
+}

--- a/lib/workflow/validation/action-config.ts
+++ b/lib/workflow/validation/action-config.ts
@@ -159,6 +159,34 @@ function isLegacyIgnoredField(actionType: string, key: string): boolean {
   return LEGACY_IGNORED_FIELDS[actionType]?.has(key) ?? false;
 }
 
+// Whether a config key is accepted for the given action. Mirrors the
+// UNKNOWN_FIELD check in validateWorkflowActionConfigs so the editor can prune
+// cross-action leftovers before save with the same allowlist the server uses.
+// Unknown action types return true; that case is reported separately.
+export function isKnownConfigKeyForAction(
+  actionType: string,
+  key: string
+): boolean {
+  if (RESERVED_CONFIG_KEYS.has(key)) {
+    return true;
+  }
+  const action = findActionById(actionType);
+  if (!action) {
+    return true;
+  }
+  const fieldKeys = new Set(
+    flattenConfigFields(action.configFields).map((field) => field.key)
+  );
+  if (fieldKeys.has(key)) {
+    return true;
+  }
+  const aliasMap = getLegacyAliasMap(actionType);
+  if (aliasMap[key] && fieldKeys.has(aliasMap[key])) {
+    return true;
+  }
+  return isLegacyIgnoredField(actionType, key);
+}
+
 function validateStringLike(value: unknown): boolean {
   return typeof value === "string" || typeof value === "number";
 }

--- a/tests/unit/workflow-action-config-validation.test.ts
+++ b/tests/unit/workflow-action-config-validation.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   formatActionConfigValidationResponse,
+  isKnownConfigKeyForAction,
   validateWorkflowActionConfigs,
 } from "@/lib/workflow/validation/action-config";
 
@@ -1018,6 +1019,46 @@ describe("validateWorkflowActionConfigs", () => {
         ])
       );
     });
+  });
+});
+
+describe("isKnownConfigKeyForAction", () => {
+  it("rejects web3 leftover fields after a switch to discord/send-message", () => {
+    for (const key of ["abi", "network", "abiFunction", "contractAddress"]) {
+      expect(isKnownConfigKeyForAction("discord/send-message", key)).toBe(
+        false
+      );
+    }
+  });
+
+  it("keeps fields the target action declares", () => {
+    expect(
+      isKnownConfigKeyForAction("discord/send-message", "discordMessage")
+    ).toBe(true);
+  });
+
+  it("keeps reserved structural keys for any action", () => {
+    for (const key of ["actionType", "integrationId"]) {
+      expect(isKnownConfigKeyForAction("discord/send-message", key)).toBe(true);
+    }
+  });
+
+  it("keeps legacy aliases that map to a declared field", () => {
+    expect(
+      isKnownConfigKeyForAction("web3/read-contract", "functionName")
+    ).toBe(true);
+  });
+
+  it("keeps legacy ignored fields for the target action", () => {
+    expect(
+      isKnownConfigKeyForAction("web3/query-transactions", "inputMode")
+    ).toBe(true);
+  });
+
+  it("does not prune when the action type is unknown", () => {
+    expect(isKnownConfigKeyForAction("not-a-real/action", "anything")).toBe(
+      true
+    );
   });
 });
 

--- a/tests/unit/workflow-action-type-transition.test.ts
+++ b/tests/unit/workflow-action-type-transition.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import { buildConfigForActionTypeChange } from "@/lib/workflow/editor/action-type-transition";
+import { validateWorkflowActionConfigs } from "@/lib/workflow/validation/action-config";
+import { findActionById, flattenConfigFields } from "@/plugins/registry";
+
+const READ_CONTRACT_ABI = JSON.stringify([
+  {
+    type: "function",
+    name: "reader",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "uint256" }],
+  },
+]);
+
+function defaultsForAction(actionType: string): Record<string, unknown> {
+  const action = findActionById(actionType);
+  const defaults: Record<string, unknown> = {};
+  if (!action?.configFields) {
+    return defaults;
+  }
+  for (const field of flattenConfigFields(action.configFields)) {
+    if (field.defaultValue !== undefined) {
+      defaults[field.key] = field.defaultValue;
+    }
+  }
+  return defaults;
+}
+
+describe("buildConfigForActionTypeChange", () => {
+  it("drops leftover fields from the previous action type", () => {
+    const previous = {
+      actionType: "discord/send-message",
+      network: "1",
+      contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+      abi: READ_CONTRACT_ABI,
+      abiFunction: "reader",
+    };
+
+    const next = buildConfigForActionTypeChange(
+      "discord/send-message",
+      previous
+    );
+
+    expect(next.network).toBeUndefined();
+    expect(next.contractAddress).toBeUndefined();
+    expect(next.abi).toBeUndefined();
+    expect(next.abiFunction).toBeUndefined();
+    expect(next.actionType).toBe("discord/send-message");
+  });
+
+  it("preserves fields the target action shares with the previous one", () => {
+    const previous = {
+      actionType: "web3/write-contract",
+      network: "8453",
+      contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+      abi: READ_CONTRACT_ABI,
+      abiFunction: "reader",
+    };
+
+    const next = buildConfigForActionTypeChange(
+      "web3/write-contract",
+      previous
+    );
+
+    expect(next.network).toBe("8453");
+    expect(next.contractAddress).toBe(
+      "0x6B175474E89094C44Da98b954EedeAC495271d0F"
+    );
+    expect(next.abi).toBe(READ_CONTRACT_ABI);
+    expect(next.abiFunction).toBe("reader");
+  });
+
+  it("always drops integrationId since it is re-selected per action", () => {
+    const next = buildConfigForActionTypeChange("web3/write-contract", {
+      actionType: "web3/write-contract",
+      integrationId: "abc-123",
+      network: "1",
+    });
+
+    expect(next.integrationId).toBeUndefined();
+    expect(next.network).toBe("1");
+  });
+
+  it("seeds the target action's field defaults when missing", () => {
+    const defaults = defaultsForAction("aave-v3/supply");
+    // Guards against the action losing its defaults and the test going vacuous.
+    expect(Object.keys(defaults)).toContain("referralCode");
+
+    const next = buildConfigForActionTypeChange("aave-v3/supply", {
+      actionType: "aave-v3/supply",
+    });
+
+    for (const [key, value] of Object.entries(defaults)) {
+      expect(next[key]).toEqual(value);
+    }
+  });
+
+  it("does not overwrite an existing value with the field default", () => {
+    // blockscout/get-address-balance defaults network to "1"; a user choice
+    // of a different network must survive the transition.
+    const next = buildConfigForActionTypeChange(
+      "blockscout/get-address-balance",
+      {
+        actionType: "blockscout/get-address-balance",
+        network: "8453",
+      }
+    );
+
+    expect(next.network).toBe("8453");
+  });
+
+  it("force-refreshes _protocolMeta to the target action on protocol switch", () => {
+    const borrowMeta = defaultsForAction("aave-v3/borrow")._protocolMeta;
+    const withdrawMeta = defaultsForAction("aave-v3/withdraw")._protocolMeta;
+    expect(borrowMeta).toBeDefined();
+    expect(withdrawMeta).toBeDefined();
+    expect(borrowMeta).not.toEqual(withdrawMeta);
+
+    // Node currently holds borrow's metadata; switching to withdraw must
+    // overwrite it so the runtime calls the right contract function.
+    const next = buildConfigForActionTypeChange("aave-v3/withdraw", {
+      actionType: "aave-v3/withdraw",
+      _protocolMeta: borrowMeta,
+    });
+
+    expect(next._protocolMeta).toEqual(withdrawMeta);
+  });
+
+  it("leaves config untouched (minus integrationId) for unknown action types", () => {
+    const next = buildConfigForActionTypeChange("not-a-real/action", {
+      actionType: "not-a-real/action",
+      integrationId: "keep-out",
+      someLeftover: "kept",
+    });
+
+    expect(next.someLeftover).toBe("kept");
+    expect(next.integrationId).toBeUndefined();
+  });
+
+  it("produces a config that passes validation with no UNKNOWN_FIELD errors", () => {
+    // Switching from a fully-configured read-contract to write-contract: the
+    // shared address/abi survive, the leftover-free result must not raise
+    // UNKNOWN_FIELD or INVALID_FIELD_TYPE for keys carried over from before.
+    const config = buildConfigForActionTypeChange("web3/write-contract", {
+      actionType: "web3/write-contract",
+      network: "1",
+      contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+      abi: READ_CONTRACT_ABI,
+      abiFunction: "reader",
+      // a stale key from a non-web3 action that must be pruned
+      discordMessage: "leftover",
+    });
+
+    const result = validateWorkflowActionConfigs([
+      { type: "action", data: { type: "action", config } },
+    ]);
+
+    const carryoverIssues = result.issues.filter(
+      (issue) =>
+        issue.code === "UNKNOWN_FIELD" || issue.code === "INVALID_FIELD_TYPE"
+    );
+    expect(carryoverIssues).toEqual([]);
+    expect(config.discordMessage).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Switching a workflow node from one action type to another (e.g. a web3 contract action to discord/send-message) left the previous action's config fields behind. On save, the validator rejected them as UNKNOWN_FIELD, producing a 422 INVALID_ACTION_CONFIG with fields like abi, network, abiFunction, and contractAddress flagged against the new action.

## Changes

- Add isKnownConfigKeyForAction to the action-config validator, exposing the same allowlist the save-time UNKNOWN_FIELD check uses (reserved keys, declared fields, legacy aliases, legacy-ignored fields) as a reusable predicate.
- Add buildConfigForActionTypeChange: on an actionType change it prunes the config to keys the new action accepts, drops integrationId (re-selected per action), and seeds the new action's field defaults. _protocolMeta is always refreshed.
- Wire the editor's handleUpdateConfig through the helper.
- Unit tests for the predicate and the transition builder.