### PR TITLE
fix(security): validate sensitive route inputs with Zod schemas

### DIFF
--- a/app/api/execute/_lib/schemas.ts
+++ b/app/api/execute/_lib/schemas.ts
@@ -1,0 +1,233 @@
+import { z } from "zod";
+import { isValidOperator, VALID_OPERATORS } from "./condition";
+import type { ExecuteErrorResponse } from "./types";
+
+/**
+ * Zod schemas backing the /api/execute/* input validators (KEEP-828).
+ *
+ * The execute routes have a stable error contract (`{ error, field, details }`
+ * with field-specific categories) that callers and tests depend on. Rather
+ * than surface Zod's default issue shape, each schema carries the exact
+ * ExecuteErrorResponse on the custom issue's `params`; `firstSchemaError`
+ * reads it back so the public contract is byte-for-byte preserved while the
+ * validation itself now runs through Zod's safeParse at the boundary.
+ */
+
+const HEX_ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+const MAX_PRIORITY_FEE_GWEI = 10_000;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+function isNonNullObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+// KEEP-490: chainId is canonical; network is a deprecated alias. Either counts
+// as present when it carries a numeric chainId or a non-empty string.
+function hasChainInput(record: Record<string, unknown>): boolean {
+  if (typeof record.chainId === "number") {
+    return true;
+  }
+  return isNonEmptyString(record.chainId) || isNonEmptyString(record.network);
+}
+
+function requiredFieldError(field: string): ExecuteErrorResponse {
+  return {
+    error: "Missing required field",
+    field,
+    details: `${field} is required and must be a non-empty string`,
+  };
+}
+
+const chainFieldError: ExecuteErrorResponse = {
+  error: "Missing required field",
+  field: "chainId",
+  details:
+    "chainId is required (network is accepted as a deprecated alias). Pass a numeric chain ID or a known chain name.",
+};
+
+function addError(ctx: z.RefinementCtx, error: ExecuteErrorResponse): void {
+  ctx.addIssue({ code: "custom", message: error.error, params: error });
+}
+
+/** Read the ExecuteErrorResponse carried on the first issue's params. */
+export function firstSchemaError(error: z.ZodError): ExecuteErrorResponse {
+  const issue = error.issues[0] as
+    | { params?: ExecuteErrorResponse }
+    | undefined;
+  return issue?.params ?? { error: "Invalid request body" };
+}
+
+// Every schema operates on an already-confirmed object (callers guard the
+// non-object case to keep the "Request body is required" message), so a loose
+// record is the right base.
+const objectBase = z.record(z.string(), z.unknown());
+
+export const transferInputSchema = objectBase.superRefine((record, ctx) => {
+  if (!hasChainInput(record)) {
+    addError(ctx, chainFieldError);
+    return;
+  }
+  if (!isNonEmptyString(record.recipientAddress)) {
+    addError(ctx, requiredFieldError("recipientAddress"));
+    return;
+  }
+  if (!isNonEmptyString(record.amount)) {
+    addError(ctx, requiredFieldError("amount"));
+  }
+});
+
+export const tokenFieldsSchema = objectBase.superRefine((record, ctx) => {
+  if (
+    "tokenAddress" in record &&
+    (typeof record.tokenAddress !== "string" ||
+      !HEX_ADDRESS_REGEX.test(record.tokenAddress))
+  ) {
+    addError(ctx, {
+      error: "Invalid field type",
+      field: "tokenAddress",
+      details: "tokenAddress must be a valid hex address (0x + 40 hex chars)",
+    });
+    return;
+  }
+
+  if ("tokenConfig" in record) {
+    const isValidString =
+      typeof record.tokenConfig === "string" &&
+      record.tokenConfig.trim() !== "";
+    const isValidObject = isNonNullObject(record.tokenConfig);
+    if (!(isValidString || isValidObject)) {
+      addError(ctx, {
+        error: "Invalid field type",
+        field: "tokenConfig",
+        details: "tokenConfig must be a string or a plain object",
+      });
+    }
+  }
+});
+
+function priorityFeeError(value: unknown): ExecuteErrorResponse | null {
+  if (value === undefined) {
+    return null;
+  }
+  if (typeof value !== "string" || value.trim() === "") {
+    return {
+      error: "Invalid field type",
+      field: "priorityFeeGwei",
+      details: "priorityFeeGwei must be a non-empty decimal string in gwei",
+    };
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return {
+      error: "Invalid field value",
+      field: "priorityFeeGwei",
+      details: "priorityFeeGwei must be a finite positive decimal in gwei",
+    };
+  }
+  if (parsed > MAX_PRIORITY_FEE_GWEI) {
+    return {
+      error: "Invalid field value",
+      field: "priorityFeeGwei",
+      details: `priorityFeeGwei must not exceed ${MAX_PRIORITY_FEE_GWEI} gwei`,
+    };
+  }
+  return null;
+}
+
+export const contractCallInputSchema = objectBase.superRefine((record, ctx) => {
+  if (!isNonEmptyString(record.contractAddress)) {
+    addError(ctx, requiredFieldError("contractAddress"));
+    return;
+  }
+  if (!hasChainInput(record)) {
+    addError(ctx, chainFieldError);
+    return;
+  }
+  if (!isNonEmptyString(record.functionName)) {
+    addError(ctx, requiredFieldError("functionName"));
+    return;
+  }
+  if ("functionArgs" in record && typeof record.functionArgs !== "string") {
+    addError(ctx, {
+      error: "Invalid field type",
+      field: "functionArgs",
+      details: "functionArgs must be a JSON string when provided",
+    });
+    return;
+  }
+  const feeError = priorityFeeError(record.priorityFeeGwei);
+  if (feeError) {
+    addError(ctx, feeError);
+  }
+});
+
+function conditionError(condition: unknown): ExecuteErrorResponse | null {
+  if (!isNonNullObject(condition)) {
+    return {
+      error: "Missing required field",
+      field: "condition",
+      details: "condition must be an object with operator and value",
+    };
+  }
+  if (!isValidOperator(condition.operator)) {
+    return {
+      error: "Invalid condition operator",
+      field: "condition.operator",
+      details: `Valid operators: ${VALID_OPERATORS.join(", ")}`,
+    };
+  }
+  if (!isNonEmptyString(condition.value)) {
+    return {
+      error: "Missing required field",
+      field: "condition.value",
+      details: "condition.value is required and must be a non-empty string",
+    };
+  }
+  return null;
+}
+
+function actionError(action: unknown): ExecuteErrorResponse | null {
+  if (!isNonNullObject(action)) {
+    return {
+      error: "Missing required field",
+      field: "action",
+      details: "action must be an object with contractAddress and functionName",
+    };
+  }
+  if (!isNonEmptyString(action.contractAddress)) {
+    return requiredFieldError("action.contractAddress");
+  }
+  if (!isNonEmptyString(action.functionName)) {
+    return requiredFieldError("action.functionName");
+  }
+  return null;
+}
+
+export const checkAndExecuteInputSchema = objectBase.superRefine(
+  (record, ctx) => {
+    if (!isNonEmptyString(record.contractAddress)) {
+      addError(ctx, requiredFieldError("contractAddress"));
+      return;
+    }
+    if (!hasChainInput(record)) {
+      addError(ctx, chainFieldError);
+      return;
+    }
+    if (!isNonEmptyString(record.functionName)) {
+      addError(ctx, requiredFieldError("functionName"));
+      return;
+    }
+    const condError = conditionError(record.condition);
+    if (condError) {
+      addError(ctx, condError);
+      return;
+    }
+    const actError = actionError(record.action);
+    if (actError) {
+      addError(ctx, actError);
+    }
+  }
+);

--- a/app/api/execute/_lib/validate.ts
+++ b/app/api/execute/_lib/validate.ts
@@ -1,294 +1,45 @@
-import { isValidOperator, VALID_OPERATORS } from "./condition";
+import type { z } from "zod";
+import {
+  checkAndExecuteInputSchema,
+  contractCallInputSchema,
+  firstSchemaError,
+  tokenFieldsSchema,
+  transferInputSchema,
+} from "./schemas";
 import type { ExecuteErrorResponse } from "./types";
-
-const HEX_ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
 
 export type ValidationResult =
   | { valid: true }
   | { valid: false; error: ExecuteErrorResponse };
 
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim() !== "";
-}
-
-function requiredFieldError(field: string): ValidationResult {
-  return {
-    valid: false,
-    error: {
-      error: "Missing required field",
-      field,
-      details: `${field} is required and must be a non-empty string`,
-    },
-  };
-}
-
-// KEEP-490: accept `chainId` as the canonical input field, with `network` as a
-// deprecated alias. Either is treated as present so long as one carries a
-// non-empty string. Numeric chainIds may be sent as numbers; we coerce here.
-function hasChainInput(record: Record<string, unknown>): boolean {
-  if (typeof record.chainId === "number") {
-    return true;
+// Run a body through a Zod schema, mapping a failure back to the route's
+// stable { error, field, details } contract (KEEP-828). The non-object case is
+// reported as "Request body is required" to match the pre-Zod behavior.
+function runSchema(body: unknown, schema: z.ZodType): ValidationResult {
+  if (!body || typeof body !== "object") {
+    return { valid: false, error: { error: "Request body is required" } };
   }
-  return (
-    isNonEmptyString(record.chainId) || isNonEmptyString(record.network)
-  );
-}
-
-function chainFieldError(): ValidationResult {
-  return {
-    valid: false,
-    error: {
-      error: "Missing required field",
-      field: "chainId",
-      details:
-        "chainId is required (network is accepted as a deprecated alias). Pass a numeric chain ID or a known chain name.",
-    },
-  };
+  const result = schema.safeParse(body);
+  if (result.success) {
+    return { valid: true };
+  }
+  return { valid: false, error: firstSchemaError(result.error) };
 }
 
 export function validateTransferInput(body: unknown): ValidationResult {
-  if (!body || typeof body !== "object") {
-    return {
-      valid: false,
-      error: { error: "Request body is required" },
-    };
-  }
-
-  const record = body as Record<string, unknown>;
-
-  if (!hasChainInput(record)) {
-    return chainFieldError();
-  }
-
-  if (!isNonEmptyString(record.recipientAddress)) {
-    return requiredFieldError("recipientAddress");
-  }
-
-  if (!isNonEmptyString(record.amount)) {
-    return requiredFieldError("amount");
-  }
-
-  return { valid: true };
+  return runSchema(body, transferInputSchema);
 }
 
 export function validateContractCallInput(body: unknown): ValidationResult {
-  if (!body || typeof body !== "object") {
-    return {
-      valid: false,
-      error: { error: "Request body is required" },
-    };
-  }
-
-  const record = body as Record<string, unknown>;
-
-  if (!isNonEmptyString(record.contractAddress)) {
-    return requiredFieldError("contractAddress");
-  }
-
-  if (!hasChainInput(record)) {
-    return chainFieldError();
-  }
-
-  if (!isNonEmptyString(record.functionName)) {
-    return requiredFieldError("functionName");
-  }
-
-  if ("functionArgs" in record && typeof record.functionArgs !== "string") {
-    return {
-      valid: false,
-      error: {
-        error: "Invalid field type",
-        field: "functionArgs",
-        details: "functionArgs must be a JSON string when provided",
-      },
-    };
-  }
-
-  const priorityFeeError = validatePriorityFeeGwei(record.priorityFeeGwei);
-  if (priorityFeeError) {
-    return priorityFeeError;
-  }
-
-  return { valid: true };
-}
-
-// Sanity ceiling on caller-supplied priority fees. The override is intended to
-// bypass the chain-specific clamp, not to remove all bounds: 10_000 gwei is
-// ~100x typical worst-case mainnet conditions, so anything above this is
-// almost certainly a fat-finger ("100000" instead of "100"). Reject loudly.
-const MAX_PRIORITY_FEE_GWEI = 10_000;
-
-function validatePriorityFeeGwei(value: unknown): ValidationResult | null {
-  if (value === undefined) {
-    return null;
-  }
-  if (typeof value !== "string" || value.trim() === "") {
-    return {
-      valid: false,
-      error: {
-        error: "Invalid field type",
-        field: "priorityFeeGwei",
-        details: "priorityFeeGwei must be a non-empty decimal string in gwei",
-      },
-    };
-  }
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    return {
-      valid: false,
-      error: {
-        error: "Invalid field value",
-        field: "priorityFeeGwei",
-        details: "priorityFeeGwei must be a finite positive decimal in gwei",
-      },
-    };
-  }
-  if (parsed > MAX_PRIORITY_FEE_GWEI) {
-    return {
-      valid: false,
-      error: {
-        error: "Invalid field value",
-        field: "priorityFeeGwei",
-        details: `priorityFeeGwei must not exceed ${MAX_PRIORITY_FEE_GWEI} gwei`,
-      },
-    };
-  }
-  return null;
-}
-
-function isNonNullObject(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function validateConditionField(condition: unknown): ValidationResult | null {
-  if (!isNonNullObject(condition)) {
-    return {
-      valid: false,
-      error: {
-        error: "Missing required field",
-        field: "condition",
-        details: "condition must be an object with operator and value",
-      },
-    };
-  }
-
-  if (!isValidOperator(condition.operator)) {
-    return {
-      valid: false,
-      error: {
-        error: "Invalid condition operator",
-        field: "condition.operator",
-        details: `Valid operators: ${VALID_OPERATORS.join(", ")}`,
-      },
-    };
-  }
-
-  if (!isNonEmptyString(condition.value)) {
-    return {
-      valid: false,
-      error: {
-        error: "Missing required field",
-        field: "condition.value",
-        details: "condition.value is required and must be a non-empty string",
-      },
-    };
-  }
-
-  return null;
-}
-
-function validateActionField(action: unknown): ValidationResult | null {
-  if (!isNonNullObject(action)) {
-    return {
-      valid: false,
-      error: {
-        error: "Missing required field",
-        field: "action",
-        details:
-          "action must be an object with contractAddress and functionName",
-      },
-    };
-  }
-
-  if (!isNonEmptyString(action.contractAddress)) {
-    return requiredFieldError("action.contractAddress");
-  }
-
-  if (!isNonEmptyString(action.functionName)) {
-    return requiredFieldError("action.functionName");
-  }
-
-  return null;
+  return runSchema(body, contractCallInputSchema);
 }
 
 export function validateTokenFields(
   body: Record<string, unknown>
 ): ValidationResult {
-  if (
-    "tokenAddress" in body &&
-    (typeof body.tokenAddress !== "string" ||
-      !HEX_ADDRESS_REGEX.test(body.tokenAddress))
-  ) {
-    return {
-      valid: false,
-      error: {
-        error: "Invalid field type",
-        field: "tokenAddress",
-        details: "tokenAddress must be a valid hex address (0x + 40 hex chars)",
-      },
-    };
-  }
-
-  if ("tokenConfig" in body) {
-    const isValidString =
-      typeof body.tokenConfig === "string" && body.tokenConfig.trim() !== "";
-    const isValidObject = isNonNullObject(body.tokenConfig);
-    if (!(isValidString || isValidObject)) {
-      return {
-        valid: false,
-        error: {
-          error: "Invalid field type",
-          field: "tokenConfig",
-          details: "tokenConfig must be a string or a plain object",
-        },
-      };
-    }
-  }
-
-  return { valid: true };
+  return runSchema(body, tokenFieldsSchema);
 }
 
 export function validateCheckAndExecuteInput(body: unknown): ValidationResult {
-  if (!body || typeof body !== "object") {
-    return {
-      valid: false,
-      error: { error: "Request body is required" },
-    };
-  }
-
-  const record = body as Record<string, unknown>;
-
-  if (!isNonEmptyString(record.contractAddress)) {
-    return requiredFieldError("contractAddress");
-  }
-
-  if (!hasChainInput(record)) {
-    return chainFieldError();
-  }
-
-  if (!isNonEmptyString(record.functionName)) {
-    return requiredFieldError("functionName");
-  }
-
-  const conditionError = validateConditionField(record.condition);
-  if (conditionError) {
-    return conditionError;
-  }
-
-  const actionError = validateActionField(record.action);
-  if (actionError) {
-    return actionError;
-  }
-
-  return { valid: true };
+  return runSchema(body, checkAndExecuteInputSchema);
 }

--- a/app/api/oauth/register/route.ts
+++ b/app/api/oauth/register/route.ts
@@ -5,6 +5,8 @@ import { type OAuthClient, storeOAuthClient } from "@/lib/mcp/oauth-store";
 import { checkIpRateLimit, getClientIp } from "@/lib/mcp/rate-limit";
 import { isAllowedRedirectUri } from "@/lib/mcp/redirect-uri";
 import { applyRateLimitHeaders } from "@/lib/rate-limit-headers";
+import { oauthRegisterSchema } from "@/lib/schemas/oauth";
+import { validateData } from "@/lib/validate-request";
 
 export const dynamic = "force-dynamic";
 
@@ -18,14 +20,6 @@ function deriveBaseUrl(request: Request): string {
   const url = new URL(request.url);
   return `${url.protocol}//${url.host}`;
 }
-
-type RegistrationRequestBody = {
-  client_name?: unknown;
-  redirect_uris?: unknown;
-  scope?: unknown;
-  grant_types?: unknown;
-  token_endpoint_auth_method?: unknown;
-};
 
 type TokenEndpointAuthMethod =
   | "client_secret_basic"
@@ -72,14 +66,19 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
-  let body: RegistrationRequestBody;
+  let rawBody: unknown;
   try {
-    body = (await request.json()) as RegistrationRequestBody;
+    rawBody = await request.json();
   } catch {
     return Response.json(
       { error: "Invalid JSON body" },
       { status: HttpStatus.BAD_REQUEST }
     );
+  }
+
+  const parsed = validateData(rawBody, oauthRegisterSchema);
+  if (!parsed.success) {
+    return parsed.response;
   }
 
   const {
@@ -88,25 +87,8 @@ export async function POST(request: Request): Promise<Response> {
     scope,
     grant_types,
     token_endpoint_auth_method,
-  } = body;
+  } = parsed.data;
   const authMethod = resolveAuthMethod(token_endpoint_auth_method);
-
-  if (typeof client_name !== "string" || client_name.trim().length === 0) {
-    return Response.json(
-      { error: "client_name is required and must be a string" },
-      { status: HttpStatus.BAD_REQUEST }
-    );
-  }
-
-  if (!isStringArray(redirect_uris) || redirect_uris.length === 0) {
-    return Response.json(
-      {
-        error:
-          "redirect_uris is required and must be a non-empty array of strings",
-      },
-      { status: HttpStatus.BAD_REQUEST }
-    );
-  }
 
   for (const uri of redirect_uris) {
     if (!isAllowedRedirectUri(uri)) {

--- a/app/api/oauth/token/route.ts
+++ b/app/api/oauth/token/route.ts
@@ -14,6 +14,11 @@ import {
 } from "@/lib/mcp/oauth-store";
 import { checkIpRateLimit, getClientIp } from "@/lib/mcp/rate-limit";
 import { applyRateLimitHeaders } from "@/lib/rate-limit-headers";
+import {
+  oauthAuthorizationCodeSchema,
+  oauthRefreshTokenSchema,
+} from "@/lib/schemas/oauth";
+import { validateData } from "@/lib/validate-request";
 import { isUserMemberOfOrganization } from "@/lib/workflow/access";
 
 export const dynamic = "force-dynamic";
@@ -100,17 +105,19 @@ async function handleAuthorizationCode(
   request: Request,
   params: URLSearchParams
 ): Promise<Response> {
-  const code = params.get("code");
-  const clientId = params.get("client_id");
-  const redirectUri = params.get("redirect_uri");
-  const codeVerifier = params.get("code_verifier");
-
-  if (!(code && clientId && redirectUri && codeVerifier)) {
-    return jsonError(
-      "Missing required parameters: code, client_id, redirect_uri, code_verifier",
-      HttpStatus.BAD_REQUEST
-    );
+  const parsed = validateData(
+    Object.fromEntries(params),
+    oauthAuthorizationCodeSchema
+  );
+  if (!parsed.success) {
+    return parsed.response;
   }
+  const {
+    code,
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    code_verifier: codeVerifier,
+  } = parsed.data;
 
   const client = await getOAuthClient(clientId);
   if (!client) {
@@ -188,15 +195,14 @@ async function handleRefreshToken(
   request: Request,
   params: URLSearchParams
 ): Promise<Response> {
-  const refreshTokenValue = params.get("refresh_token");
-  const clientId = params.get("client_id");
-
-  if (!(refreshTokenValue && clientId)) {
-    return jsonError(
-      "Missing required parameters: refresh_token, client_id",
-      HttpStatus.BAD_REQUEST
-    );
+  const parsed = validateData(
+    Object.fromEntries(params),
+    oauthRefreshTokenSchema
+  );
+  if (!parsed.success) {
+    return parsed.response;
   }
+  const { refresh_token: refreshTokenValue, client_id: clientId } = parsed.data;
 
   const client = await getOAuthClient(clientId);
   if (!client) {

--- a/app/api/user/wallet/export-key/verify/route.ts
+++ b/app/api/user/wallet/export-key/verify/route.ts
@@ -9,7 +9,9 @@ import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { requireDualFactor } from "@/lib/mfa/dual-factor";
 import { getActiveOrgId } from "@/lib/middleware/org-context";
 import { requireOwnerWithMfa } from "@/lib/middleware/owner-mfa-guard";
+import { exportKeyVerifySchema } from "@/lib/schemas/wallet";
 import { exportTurnkeyPrivateKey } from "@/lib/turnkey/turnkey-client";
+import { validateBody } from "@/lib/validate-request";
 import { checkVerifyRateLimit } from "../_lib/rate-limit";
 
 /**
@@ -80,7 +82,11 @@ export async function POST(request: Request): Promise<NextResponse> {
       );
     }
 
-    const body: { code?: string; emailOtp?: string } = await request.json();
+    const bodyValidation = await validateBody(request, exportKeyVerifySchema);
+    if (!bodyValidation.success) {
+      return bodyValidation.response;
+    }
+    const body = bodyValidation.data;
     const dual = await requireDualFactor({
       userId: session.user.id,
       email: session.user.email,

--- a/app/api/user/wallet/withdraw/route.ts
+++ b/app/api/user/wallet/withdraw/route.ts
@@ -16,6 +16,8 @@ import {
   executeContractCallAsSafe,
   executeNativeTransferAsSafe,
 } from "@/lib/safe/execute-as-safe";
+import { withdrawSchema } from "@/lib/schemas/wallet";
+import { validateBody } from "@/lib/validate-request";
 import { getGasStrategy } from "@/lib/web3/gas-strategy";
 import { getNonceManager } from "@/lib/web3/nonce-manager";
 import {
@@ -165,19 +167,15 @@ async function validateUserAndOrganization(
 
 export async function POST(request: Request) {
   try {
-    // Parse body up-front so the validator can pull the TOTP code out
-    // for the fresh-challenge step. Everything else still gets
-    // re-destructured below for the action itself.
-    const body = (await request.json()) as {
-      chainId?: number | string;
-      tokenAddress?: string;
-      amount?: string;
-      recipient?: string;
-      fromMax?: boolean;
-      safeId?: string;
-      code?: string;
-      emailOtp?: string;
-    };
+    // Validate the untrusted payload at the boundary (KEEP-828) before any
+    // fund-moving logic. The schema enforces a valid recipient address,
+    // numeric chainId, the fromMax/amount/tokenAddress invariants, and
+    // rejects unknown fields.
+    const bodyValidation = await validateBody(request, withdrawSchema);
+    if (!bodyValidation.success) {
+      return bodyValidation.response;
+    }
+    const body = bodyValidation.data;
 
     // 1. Validate user and permissions (includes dual-factor challenge).
     const validation = await validateUserAndOrganization(
@@ -201,42 +199,12 @@ export async function POST(request: Request) {
     const { organizationId, user } = validation;
 
     const { chainId: rawChainId, tokenAddress, amount, fromMax, safeId } = body;
-    const recipient = body.recipient;
+    const recipientAddr: string = body.recipient;
 
-    if (!(rawChainId && recipient)) {
-      return NextResponse.json(
-        { error: "Missing required fields: chainId, recipient" },
-        { status: 400 }
-      );
-    }
-    // After the guard above, recipient is non-null for the rest of the
-    // handler. TypeScript can't narrow through destructuring, so re-bind
-    // to a const with the narrowed type.
-    const recipientAddr: string = recipient;
-
-    // fromMax is only valid for native transfers: for ERC20, token gas is
-    // paid in the native asset, so sending the full token balance has no
-    // reservation conflict and the client already sets amount = balance.
-    if (fromMax && tokenAddress) {
-      return NextResponse.json(
-        { error: "fromMax is only valid for native transfers" },
-        { status: 400 }
-      );
-    }
-
-    if (!(fromMax || amount)) {
-      return NextResponse.json(
-        { error: "Missing required field: amount" },
-        { status: 400 }
-      );
-    }
-
+    // chainId is schema-validated to be a positive-integer number or string.
     const chainId = Number.parseInt(String(rawChainId), 10);
-    if (Number.isNaN(chainId)) {
-      return NextResponse.json({ error: "Invalid chainId" }, { status: 400 });
-    }
 
-    // Validate recipient address
+    // EIP-55 checksum validation beyond the schema's hex-shape regex.
     if (!ethers.isAddress(recipientAddr)) {
       return NextResponse.json(
         { error: "Invalid recipient address" },
@@ -244,17 +212,10 @@ export async function POST(request: Request) {
       );
     }
 
-    // Validate amount (skipped when fromMax: server computes the value).
-    // The guard above ensures amount is set when fromMax is false; bind to
-    // a non-optional alias so downstream `parseEther`/`parseUnits` calls
-    // type-check without per-site assertions.
+    // amount is schema-guaranteed present and positive unless fromMax is set,
+    // in which case the server computes the drain value. Bind to a
+    // non-optional alias for downstream parseEther/parseUnits calls.
     const amountStr: string = amount ?? "";
-    if (!fromMax) {
-      const parsedAmount = Number.parseFloat(amountStr);
-      if (Number.isNaN(parsedAmount) || parsedAmount <= 0) {
-        return NextResponse.json({ error: "Invalid amount" }, { status: 400 });
-      }
-    }
 
     // 3. Get chain info from database
     const chainResult = await db
@@ -559,7 +520,7 @@ export async function POST(request: Request) {
       chainId,
       tokenAddress: tokenAddress || null,
       amount,
-      recipient,
+      recipient: recipientAddr,
     });
   } catch (error) {
     logSystemError(ErrorCategory.EXTERNAL_SERVICE, "[Withdraw] Failed", error, {

--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -34,6 +34,8 @@ import {
   workflows,
 } from "@/lib/db/schema";
 import { getOrgPlanLabel, getOrgSlug } from "@/lib/db/org-helpers";
+import { webhookPayloadSchema } from "@/lib/schemas/webhook";
+import { validateData } from "@/lib/validate-request";
 import { withBackstopCapture } from "@/lib/security/backstop-capture";
 import { buildAttribution } from "@/lib/security/request-attribution";
 import {
@@ -350,8 +352,30 @@ export async function POST(
       );
     }
 
-    // Parse request body
-    const body = await request.json().catch(() => ({}));
+    // Parse + validate the webhook payload (KEEP-828). Contents are freeform
+    // (forwarded to the workflow as trigger input), but the envelope must be a
+    // JSON object so template references resolve. An empty body is allowed and
+    // triggers the workflow with no input.
+    let body: Record<string, unknown> = {};
+    const rawBody = await request.text();
+    if (rawBody.trim() !== "") {
+      let parsedPayload: unknown;
+      try {
+        parsedPayload = JSON.parse(rawBody);
+      } catch {
+        return failResponse(workflowId, timer, 400, "Invalid JSON body");
+      }
+      const payloadValidation = validateData(parsedPayload, webhookPayloadSchema);
+      if (!payloadValidation.success) {
+        return failResponse(
+          workflowId,
+          timer,
+          400,
+          "Webhook payload must be a JSON object"
+        );
+      }
+      body = payloadValidation.data;
+    }
 
     // Idempotency: a retry carrying the same key + body replays the original
     // executionId instead of triggering the workflow again. Scoped per workflow.

--- a/lib/schemas/oauth.ts
+++ b/lib/schemas/oauth.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+
+/**
+ * Dynamic Client Registration body (RFC 7591) for POST /api/oauth/register.
+ *
+ * Validates only the fields this server consumes. Unknown fields are stripped
+ * rather than rejected: standard DCR clients send many optional metadata
+ * fields (client_uri, logo_uri, contacts, jwks, software_id, ...) and a strict
+ * schema would reject otherwise-valid registrations. Semantic checks that the
+ * schema cannot express (redirect_uri allowlist, scope normalization, grant
+ * filtering) stay in the route.
+ */
+export const oauthRegisterSchema = z.object({
+  client_name: z.string().trim().min(1, "client_name is required"),
+  redirect_uris: z
+    .array(z.string(), {
+      error: "redirect_uris must be a non-empty array of strings",
+    })
+    .min(1, "redirect_uris must contain at least one URI"),
+  scope: z.string().optional(),
+  grant_types: z.array(z.string()).optional(),
+  token_endpoint_auth_method: z.string().optional(),
+});
+
+export type OAuthRegisterInput = z.infer<typeof oauthRegisterSchema>;
+
+/**
+ * Token-endpoint params for the authorization_code grant. The handler reads
+ * client_secret separately from the original request (body or Basic header),
+ * so unknown params are safely stripped here.
+ */
+export const oauthAuthorizationCodeSchema = z.object({
+  code: z.string().min(1),
+  client_id: z.string().min(1),
+  redirect_uri: z.string().min(1),
+  code_verifier: z.string().min(1),
+});
+
+export type OAuthAuthorizationCodeInput = z.infer<
+  typeof oauthAuthorizationCodeSchema
+>;
+
+/** Token-endpoint params for the refresh_token grant. */
+export const oauthRefreshTokenSchema = z.object({
+  refresh_token: z.string().min(1),
+  client_id: z.string().min(1),
+});
+
+export type OAuthRefreshTokenInput = z.infer<typeof oauthRefreshTokenSchema>;

--- a/lib/schemas/wallet.ts
+++ b/lib/schemas/wallet.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+
+/** EVM address: 0x followed by exactly 40 hex characters. */
+export const EVM_ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+
+const evmAddress = z
+  .string()
+  .regex(EVM_ADDRESS_REGEX, "Must be a valid EVM address");
+
+// chainId may arrive as a number or a numeric string (the modal sends a
+// number; some callers send a string). Either must denote a positive integer.
+const chainId = z.union([
+  z.number().int().positive(),
+  z.string().regex(/^\d+$/, "chainId must be a positive integer"),
+]);
+
+/**
+ * Body schema for POST /api/user/wallet/withdraw. `.strict()` rejects unknown
+ * fields so a malformed or mass-assignment payload never reaches the
+ * fund-moving path. The cross-field rules mirror the route's invariants:
+ * fromMax is native-only, and an explicit amount is required unless fromMax
+ * lets the server compute the drain value.
+ */
+export const withdrawSchema = z
+  .object({
+    chainId,
+    recipient: evmAddress,
+    tokenAddress: evmAddress.optional(),
+    amount: z.string().optional(),
+    fromMax: z.boolean().optional(),
+    safeId: z.string().min(1).optional(),
+    code: z.string().optional(),
+    emailOtp: z.string().optional(),
+  })
+  .strict()
+  .superRefine((data, ctx) => {
+    if (data.fromMax && data.tokenAddress) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["fromMax"],
+        message: "fromMax is only valid for native transfers",
+      });
+    }
+
+    if (data.fromMax) {
+      return;
+    }
+
+    if (data.amount === undefined || data.amount.trim() === "") {
+      ctx.addIssue({
+        code: "custom",
+        path: ["amount"],
+        message: "amount is required unless fromMax is set",
+      });
+      return;
+    }
+
+    const parsed = Number.parseFloat(data.amount);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["amount"],
+        message: "amount must be a positive number",
+      });
+    }
+  });
+
+export type WithdrawInput = z.infer<typeof withdrawSchema>;
+
+/**
+ * Body schema for POST /api/user/wallet/export-key/verify. Both factors are
+ * optional: the first call (empty body) mints and emails the OTP; the second
+ * call submits the TOTP code plus the emailed OTP.
+ */
+export const exportKeyVerifySchema = z
+  .object({
+    code: z.string().optional(),
+    emailOtp: z.string().optional(),
+  })
+  .strict();
+
+export type ExportKeyVerifyInput = z.infer<typeof exportKeyVerifySchema>;

--- a/lib/schemas/webhook.ts
+++ b/lib/schemas/webhook.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+/**
+ * Webhook trigger payload for POST /api/workflows/[workflowId]/webhook.
+ *
+ * The contents are intentionally freeform: the payload is forwarded verbatim
+ * to the workflow as its trigger input, so callers send whatever their
+ * integration produces. The only structural requirement is a JSON object
+ * envelope (not an array or primitive) so the workflow's template references
+ * resolve against named fields. An empty request body is allowed and triggers
+ * the workflow with no input.
+ */
+export const webhookPayloadSchema = z.record(z.string(), z.unknown());
+
+export type WebhookPayload = z.infer<typeof webhookPayloadSchema>;

--- a/lib/validate-request.ts
+++ b/lib/validate-request.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+/**
+ * Shared request-body validation for sensitive API routes (KEEP-828).
+ *
+ * Validates untrusted input against a Zod schema at the boundary, before any
+ * business logic runs. On failure it returns a ready-to-send 400 response with
+ * a flattened list of field errors; on success it returns the parsed, typed
+ * data. Routes destructure the result and early-return the response.
+ */
+
+export type ValidationOutcome<T> =
+  | { success: true; data: T }
+  | { success: false; response: NextResponse };
+
+function validationErrorResponse(error: z.ZodError): NextResponse {
+  return NextResponse.json(
+    { error: "Validation failed", details: z.flattenError(error) },
+    { status: 400 }
+  );
+}
+
+/**
+ * Validate an already-parsed value (e.g. a body read earlier in the handler,
+ * or params assembled from a URL-encoded form) against a schema.
+ */
+export function validateData<T extends z.ZodType>(
+  data: unknown,
+  schema: T
+): ValidationOutcome<z.infer<T>> {
+  const result = schema.safeParse(data);
+  if (!result.success) {
+    return { success: false, response: validationErrorResponse(result.error) };
+  }
+  return { success: true, data: result.data };
+}
+
+/**
+ * Read and validate a JSON request body against a schema. Returns a 400 for
+ * malformed JSON before validation runs.
+ */
+export async function validateBody<T extends z.ZodType>(
+  request: Request,
+  schema: T
+): Promise<ValidationOutcome<z.infer<T>>> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return {
+      success: false,
+      response: NextResponse.json(
+        { error: "Invalid JSON body" },
+        { status: 400 }
+      ),
+    };
+  }
+  return validateData(body, schema);
+}

--- a/tests/unit/oauth-register-validation.test.ts
+++ b/tests/unit/oauth-register-validation.test.ts
@@ -1,0 +1,70 @@
+/**
+ * KEEP-828: the registration route rejects malformed metadata with a 400 from
+ * the shared validator before storing a client, and still accepts a valid DCR
+ * body carrying extra RFC 7591 fields.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { mockStoreOAuthClient } = vi.hoisted(() => ({
+  mockStoreOAuthClient: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/mcp/oauth-store", () => ({
+  storeOAuthClient: mockStoreOAuthClient,
+}));
+
+vi.mock("@/lib/mcp/rate-limit", () => ({
+  checkIpRateLimit: () => ({ allowed: true, retryAfter: 0 }),
+  getClientIp: () => "127.0.0.1",
+}));
+
+import { POST } from "@/app/api/oauth/register/route";
+
+function buildRequest(body: unknown): Request {
+  return new Request("http://localhost/api/oauth/register", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  mockStoreOAuthClient.mockClear();
+});
+
+describe("POST /api/oauth/register -- input validation (KEEP-828)", () => {
+  it("returns 400 and stores nothing when client_name is missing", async () => {
+    const response = await POST(
+      buildRequest({ redirect_uris: ["https://example.com/cb"] })
+    );
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("Validation failed");
+    expect(mockStoreOAuthClient).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when redirect_uris is empty", async () => {
+    const response = await POST(
+      buildRequest({ client_name: "App", redirect_uris: [] })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockStoreOAuthClient).not.toHaveBeenCalled();
+  });
+
+  it("accepts a valid registration carrying extra RFC 7591 metadata", async () => {
+    const response = await POST(
+      buildRequest({
+        client_name: "App",
+        redirect_uris: ["https://example.com/cb"],
+        logo_uri: "https://example.com/logo.png",
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockStoreOAuthClient).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/oauth-register-validation.test.ts
+++ b/tests/unit/oauth-register-validation.test.ts
@@ -34,7 +34,7 @@ beforeEach(() => {
   mockStoreOAuthClient.mockClear();
 });
 
-describe("POST /api/oauth/register -- input validation (KEEP-828)", () => {
+describe("POST /api/oauth/register input validation (KEEP-828)", () => {
   it("returns 400 and stores nothing when client_name is missing", async () => {
     const response = await POST(
       buildRequest({ redirect_uris: ["https://example.com/cb"] })

--- a/tests/unit/oauth-schemas.test.ts
+++ b/tests/unit/oauth-schemas.test.ts
@@ -1,0 +1,79 @@
+/**
+ * KEEP-828: OAuth route input schemas. Registration must stay lenient for
+ * RFC 7591 metadata (strip, not strict) while still requiring client_name and
+ * a non-empty redirect_uris; the token-grant schemas require their per-grant
+ * params.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  oauthAuthorizationCodeSchema,
+  oauthRefreshTokenSchema,
+  oauthRegisterSchema,
+} from "@/lib/schemas/oauth";
+
+describe("oauthRegisterSchema", () => {
+  it("accepts a minimal DCR registration", () => {
+    expect(
+      oauthRegisterSchema.safeParse({
+        client_name: "App",
+        redirect_uris: ["https://example.com/cb"],
+      }).success
+    ).toBe(true);
+  });
+
+  it("keeps unknown RFC 7591 metadata fields (strip, not strict)", () => {
+    expect(
+      oauthRegisterSchema.safeParse({
+        client_name: "App",
+        redirect_uris: ["https://example.com/cb"],
+        logo_uri: "https://example.com/logo.png",
+        contacts: ["dev@example.com"],
+      }).success
+    ).toBe(true);
+  });
+
+  it("rejects an empty client_name", () => {
+    expect(
+      oauthRegisterSchema.safeParse({
+        client_name: "   ",
+        redirect_uris: ["https://example.com/cb"],
+      }).success
+    ).toBe(false);
+  });
+
+  it("rejects an empty redirect_uris array", () => {
+    expect(
+      oauthRegisterSchema.safeParse({ client_name: "App", redirect_uris: [] })
+        .success
+    ).toBe(false);
+  });
+});
+
+describe("oauth token-grant param schemas", () => {
+  it("authorization_code requires the full PKCE param set", () => {
+    expect(
+      oauthAuthorizationCodeSchema.safeParse({
+        code: "c",
+        client_id: "i",
+        redirect_uri: "https://example.com/cb",
+        code_verifier: "v",
+      }).success
+    ).toBe(true);
+    expect(
+      oauthAuthorizationCodeSchema.safeParse({ code: "c", client_id: "i" })
+        .success
+    ).toBe(false);
+  });
+
+  it("refresh_token requires refresh_token and client_id", () => {
+    expect(
+      oauthRefreshTokenSchema.safeParse({
+        refresh_token: "t",
+        client_id: "i",
+      }).success
+    ).toBe(true);
+    expect(oauthRefreshTokenSchema.safeParse({ client_id: "i" }).success).toBe(
+      false
+    );
+  });
+});

--- a/tests/unit/validate-request.test.ts
+++ b/tests/unit/validate-request.test.ts
@@ -1,0 +1,65 @@
+/**
+ * KEEP-828: shared request-body validation helper. A valid body passes through
+ * typed; a malformed body returns a ready-to-send 400.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { validateBody, validateData } from "@/lib/validate-request";
+
+const schema = z.object({ name: z.string().min(1) }).strict();
+
+function jsonRequest(body: string): Request {
+  return new Request("http://localhost/x", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+  });
+}
+
+describe("validateData", () => {
+  it("returns typed data on success", () => {
+    const result = validateData({ name: "ok" }, schema);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe("ok");
+    }
+  });
+
+  it("returns a 400 with flattened details on failure", async () => {
+    const result = validateData({ name: "" }, schema);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.response.status).toBe(400);
+      const body = (await result.response.json()) as {
+        error: string;
+        details: unknown;
+      };
+      expect(body.error).toBe("Validation failed");
+      expect(body.details).toBeDefined();
+    }
+  });
+
+  it("rejects unknown fields under strict", () => {
+    expect(validateData({ name: "x", extra: 1 }, schema).success).toBe(false);
+  });
+});
+
+describe("validateBody", () => {
+  it("parses and validates a JSON body", async () => {
+    const result = await validateBody(
+      jsonRequest(JSON.stringify({ name: "a" })),
+      schema
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    const result = await validateBody(jsonRequest("{not json"), schema);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.response.status).toBe(400);
+      const body = (await result.response.json()) as { error: string };
+      expect(body.error).toBe("Invalid JSON body");
+    }
+  });
+});

--- a/tests/unit/wallet-schemas.test.ts
+++ b/tests/unit/wallet-schemas.test.ts
@@ -1,6 +1,6 @@
 /**
  * KEEP-828: wallet route input schemas. The withdraw schema is the tightest
- * gate in the app -- it guards a fund-moving endpoint -- so it must reject bad
+ * gate in the app (it guards a fund-moving endpoint), so it must reject bad
  * addresses, non-positive amounts, the fromMax/token conflict, and unknown
  * fields.
  */

--- a/tests/unit/wallet-schemas.test.ts
+++ b/tests/unit/wallet-schemas.test.ts
@@ -1,0 +1,119 @@
+/**
+ * KEEP-828: wallet route input schemas. The withdraw schema is the tightest
+ * gate in the app -- it guards a fund-moving endpoint -- so it must reject bad
+ * addresses, non-positive amounts, the fromMax/token conflict, and unknown
+ * fields.
+ */
+import { describe, expect, it } from "vitest";
+import { exportKeyVerifySchema, withdrawSchema } from "@/lib/schemas/wallet";
+
+const VALID_ADDRESS = `0x${"a".repeat(40)}`;
+
+describe("withdrawSchema", () => {
+  it("accepts a valid native withdraw", () => {
+    expect(
+      withdrawSchema.safeParse({
+        chainId: 1,
+        recipient: VALID_ADDRESS,
+        amount: "1.5",
+      }).success
+    ).toBe(true);
+  });
+
+  it("accepts fromMax native withdraw without an amount", () => {
+    expect(
+      withdrawSchema.safeParse({
+        chainId: 1,
+        recipient: VALID_ADDRESS,
+        fromMax: true,
+      }).success
+    ).toBe(true);
+  });
+
+  it("accepts a numeric-string chainId", () => {
+    expect(
+      withdrawSchema.safeParse({
+        chainId: "8453",
+        recipient: VALID_ADDRESS,
+        amount: "1",
+      }).success
+    ).toBe(true);
+  });
+
+  it("rejects an invalid recipient address", () => {
+    expect(
+      withdrawSchema.safeParse({
+        chainId: 1,
+        recipient: "not-an-address",
+        amount: "1",
+      }).success
+    ).toBe(false);
+  });
+
+  it("rejects a missing amount when fromMax is not set", () => {
+    expect(
+      withdrawSchema.safeParse({ chainId: 1, recipient: VALID_ADDRESS }).success
+    ).toBe(false);
+  });
+
+  it("rejects a non-positive amount", () => {
+    expect(
+      withdrawSchema.safeParse({
+        chainId: 1,
+        recipient: VALID_ADDRESS,
+        amount: "0",
+      }).success
+    ).toBe(false);
+  });
+
+  it("rejects fromMax combined with a tokenAddress (native only)", () => {
+    expect(
+      withdrawSchema.safeParse({
+        chainId: 1,
+        recipient: VALID_ADDRESS,
+        fromMax: true,
+        tokenAddress: VALID_ADDRESS,
+      }).success
+    ).toBe(false);
+  });
+
+  it("rejects a non-numeric chainId", () => {
+    expect(
+      withdrawSchema.safeParse({
+        chainId: "abc",
+        recipient: VALID_ADDRESS,
+        amount: "1",
+      }).success
+    ).toBe(false);
+  });
+
+  it("rejects unknown fields (strict)", () => {
+    expect(
+      withdrawSchema.safeParse({
+        chainId: 1,
+        recipient: VALID_ADDRESS,
+        amount: "1",
+        evil: true,
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe("exportKeyVerifySchema", () => {
+  it("accepts an empty body (the OTP-mint first call)", () => {
+    expect(exportKeyVerifySchema.safeParse({}).success).toBe(true);
+  });
+
+  it("accepts code plus emailOtp", () => {
+    expect(
+      exportKeyVerifySchema.safeParse({ code: "123456", emailOtp: "999999" })
+        .success
+    ).toBe(true);
+  });
+
+  it("rejects unknown fields (strict)", () => {
+    expect(
+      exportKeyVerifySchema.safeParse({ code: "123456", extra: 1 }).success
+    ).toBe(false);
+  });
+});

--- a/tests/unit/webhook-schema.test.ts
+++ b/tests/unit/webhook-schema.test.ts
@@ -1,7 +1,7 @@
 /**
  * KEEP-828: webhook payload envelope. Contents stay freeform (forwarded to the
  * workflow as trigger input), but the payload must be a JSON object so template
- * references resolve -- arrays and primitives are rejected.
+ * references resolve. Arrays and primitives are rejected.
  */
 import { describe, expect, it } from "vitest";
 import { webhookPayloadSchema } from "@/lib/schemas/webhook";

--- a/tests/unit/webhook-schema.test.ts
+++ b/tests/unit/webhook-schema.test.ts
@@ -1,0 +1,32 @@
+/**
+ * KEEP-828: webhook payload envelope. Contents stay freeform (forwarded to the
+ * workflow as trigger input), but the payload must be a JSON object so template
+ * references resolve -- arrays and primitives are rejected.
+ */
+import { describe, expect, it } from "vitest";
+import { webhookPayloadSchema } from "@/lib/schemas/webhook";
+
+describe("webhookPayloadSchema", () => {
+  it("accepts an object payload with arbitrary fields", () => {
+    expect(
+      webhookPayloadSchema.safeParse({ foo: "bar", count: 1, nested: {} })
+        .success
+    ).toBe(true);
+  });
+
+  it("accepts an empty object", () => {
+    expect(webhookPayloadSchema.safeParse({}).success).toBe(true);
+  });
+
+  it("rejects an array payload", () => {
+    expect(webhookPayloadSchema.safeParse([1, 2, 3]).success).toBe(false);
+  });
+
+  it("rejects a primitive payload", () => {
+    expect(webhookPayloadSchema.safeParse("nope").success).toBe(false);
+  });
+
+  it("rejects null", () => {
+    expect(webhookPayloadSchema.safeParse(null).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Add boundary input validation to the sensitive API routes that previously trusted request bodies. Untrusted input is now validated against a Zod schema before any business logic runs.

## Infrastructure

- `lib/validate-request.ts`: shared `validateBody` / `validateData` helpers returning a `400 { error: "Validation failed", details }` on failure and typed data on success.
- `lib/schemas/`: single source of truth for route schemas (`wallet.ts`, `oauth.ts`, `webhook.ts`).

## Routes wired

- `wallet/withdraw` and `wallet/export-key/verify`: strict schemas (reject unknown fields) covering EVM address shape, numeric `chainId`, and the `fromMax`/`amount`/`tokenAddress` invariants on the fund-moving path. The `ethers.isAddress` EIP-55 checksum check is retained.
- `oauth/register`: lenient schema (RFC 7591 client metadata is stripped, not rejected) requiring `client_name` and a non-empty `redirect_uris`; the redirect-uri allowlist check is unchanged.
- `oauth/token`: per-grant param schemas for `authorization_code` and `refresh_token`.
- `workflows/[workflowId]/webhook`: the payload must be a JSON object envelope; an empty body is allowed and contents stay freeform since they are forwarded to the workflow as input.
- `execute/*` (transfer, contract-call, check-and-execute, token fields): `_lib/validate.ts` now runs through Zod schemas (`app/api/execute/_lib/schemas.ts`) while preserving the exact `{ error, field, details }` contract that callers and existing tests depend on.

## Tests

- New unit tests for the helper and each schema, plus a route-level `400` test for `oauth/register`.
- Existing `execute/*` and `oauth` contract tests remain green (174 passing in the touched suites).

## Notes

- `execute/swap` is a 501 stub (no body), `execute/[...slug]` validates protocol args against the registry, and `[executionId]/status` is a GET, so they are out of scope here.