### PR TITLE
fix: disambiguate Sepolia chain label fallback

### DIFF
--- a/lib/chain-utils.ts
+++ b/lib/chain-utils.ts
@@ -4,7 +4,7 @@ const CHAIN_NAMES: Record<string, string> = {
   "100": "Gnosis",
   "8453": "Base",
   "42161": "Arbitrum",
-  "11155111": "Sepolia",
+  "11155111": "Ethereum Sepolia",
   "84532": "Base Sepolia",
   "42431": "Tempo Testnet",
   "4217": "Tempo",


### PR DESCRIPTION
## Summary

The version-history diff (and other fallbacks) rendered Ethereum Sepolia as
just "Sepolia", which is ambiguous alongside Base Sepolia, Arbitrum Sepolia,
and Optimism Sepolia.

Chain labels resolve as `chains.get(id)?.name ?? getChainName(id)`. The DB
chains table already names it "Ethereum Sepolia", but the hardcoded fallback
map in `lib/chain-utils.ts` mapped `11155111` to "Sepolia" and that fallback
is what rendered.

## Change

Relabel `11155111` to "Ethereum Sepolia" in the fallback map so it matches the
canonical chains-table name and reads unambiguously everywhere the fallback is
used. One-line change; other testnet entries (Base Sepolia, etc.) were already
explicit.