### PR TITLE
ci: free runner disk space before image builds

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -112,6 +112,18 @@ jobs:
           echo "::error::Cannot skip build: one or more images for ${{ steps.vars.outputs.sha_short }} do not exist in ECR. Remove [skip build] from the commit message or push a build first."
           exit 1
 
+      - name: Free runner disk space
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: false
+
       - name: Set up Docker Buildx
         if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/deploy-executor.yaml
+++ b/.github/workflows/deploy-executor.yaml
@@ -70,6 +70,18 @@ jobs:
             echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Free runner disk space
+        if: steps.skip.outputs.skip_build != 'true'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: false
+
       - name: Set up Docker Buildx
         if: steps.skip.outputs.skip_build != 'true'
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
## Problem

Image builds fail intermittently with `ResourceExhausted: ... no space left on device` while BuildKit unpacks `node_modules`. The `ubuntu-latest` runner only has ~14GB free, and our image is large enough to bump that ceiling.

## Fix

Add a `Free runner disk space` step before the Buildx setup in both build jobs that run a bake on `ubuntu-latest`:

- `build-images.yml` (app / migrator / workflow-runner)
- `deploy-executor.yaml` (executor)

It removes preinstalled Android / .NET / Haskell toolchains and large apt packages (~20GB+ reclaimed). `tool-cache: false` keeps the hosted tool cache so CodeQL is untouched. Each step reuses its job's existing skip conditions, so reruns that skip the build also skip the cleanup.