### PR TITLE
fix(metrics): source per-workflow error metric from DB

### DIFF
--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -119,6 +119,28 @@ const workflowExecutionsTotal = getOrCreateGauge(
   ["status", "org_slug", "error_type"]
 );
 
+// TECH-48: per-workflow error counts for managed orgs, DB-sourced so the
+// series is authoritative regardless of which finalization path wrote the
+// error row. Replaces the per-pod `keeperhub_workflow_execution_errors_by_workflow_total`
+// counter, which was only incremented on the kickoff/reaper/MCP paths and so
+// returned no data in prod for normal workflow failures (the managed-client
+// alert numerator + workflow_id dedup key read from this).
+//
+// Gauge, not counter: it carries the all-time cumulative error count per
+// (workflow_id, org_slug, error_type), so the alert recovers a window delta as
+// value(now) - value(now offset W) — the same dedup pattern the alert already
+// uses on workflowExecutionsTotal. No `_total` suffix: that suffix on a
+// poll-driven gauge is exactly the trap KEEP-545 documents below.
+//
+// Cardinality is bounded by scoping to managed orgs in the DB query: only the
+// handful of managed workflows that have ever errored emit a series.
+const workflowErrorsByWorkflow = getOrCreateGauge(
+  dbRegistry,
+  "keeperhub_workflow_errors_by_workflow",
+  "All-time workflow execution errors by workflow_id for managed orgs, by org_slug and error_type",
+  ["workflow_id", "org_slug", "error_type"]
+);
+
 // KEEP-545: the previous DB-sourced gauge `keeperhub_workflow_execution_errors_total`
 // has been removed. It was named with the `_total` counter suffix but was
 // actually a poll-driven gauge that overwrote itself on every scrape with the
@@ -1371,6 +1393,7 @@ async function refreshDbMetricsNow(): Promise<void> {
     // Dynamic import to avoid circular dependencies
     const {
       getWorkflowStatsFromDb,
+      getWorkflowErrorsByWorkflowFromDb,
       getStepStatsFromDb,
       getDailyActiveUsersFromDb,
       getUserStatsFromDb,
@@ -1386,6 +1409,7 @@ async function refreshDbMetricsNow(): Promise<void> {
     } = await import("../db-metrics");
     const [
       workflowStats,
+      errorsByWorkflow,
       stepStats,
       dailyActiveUsers,
       userStats,
@@ -1400,6 +1424,7 @@ async function refreshDbMetricsNow(): Promise<void> {
       billingStats,
     ] = await Promise.all([
       getWorkflowStatsFromDb(),
+      getWorkflowErrorsByWorkflowFromDb(),
       getStepStatsFromDb(),
       getDailyActiveUsersFromDb(),
       getUserStatsFromDb(),
@@ -1432,6 +1457,21 @@ async function refreshDbMetricsNow(): Promise<void> {
     // KEEP-545: the per-org error gauge that used to live here was removed.
     // See `keeperhub_workflow_execution_errors_created_total` (per-pod
     // counter incremented at finalization time) for the replacement.
+
+    // TECH-48: per-workflow error counts for managed orgs. Reset before
+    // populating so a workflow that no longer has errors in a bucket clears
+    // out instead of pinning a stale value.
+    workflowErrorsByWorkflow.reset();
+    for (const row of errorsByWorkflow) {
+      workflowErrorsByWorkflow.set(
+        {
+          workflow_id: row.workflowId,
+          org_slug: row.orgSlug,
+          error_type: row.errorType,
+        },
+        row.count
+      );
+    }
 
     // Update workflow duration histogram buckets
     for (let i = 0; i < WORKFLOW_DURATION_BUCKETS.length; i++) {

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -9,7 +9,7 @@
 
 import "server-only";
 
-import { and, count, countDistinct, eq, gte, sql } from "drizzle-orm";
+import { and, count, countDistinct, eq, gte, inArray, sql } from "drizzle-orm";
 import {
   PLANS,
   type PlanName,
@@ -47,6 +47,14 @@ import type { BillingStatus } from "./types";
 // rows. Also re-exported for the runtime finalization counter so personal
 // workflows still produce a series rather than silently dropping increments.
 export const ANONYMOUS_ORG_SLUG = "_anonymous";
+
+// Org slugs for the managed clients (Sky, Ajna) whose per-workflow error series
+// power the managed-client user-error alerts. The per-workflow gauge is scoped
+// to these slugs so `workflow_id` never becomes an unbounded label across the
+// whole user base — only managed workflows that have errored emit a series.
+// Mirrors `local.managed_org_slugs_regex` in the infra Grafana alert config;
+// adding a managed org requires updating both lists.
+export const MANAGED_ORG_SLUGS = ["techops-services", "ajna"] as const;
 
 // Histogram bucket boundaries in milliseconds (must match prometheus.ts)
 const WORKFLOW_DURATION_BUCKETS = [
@@ -225,6 +233,66 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
       durationSum: 0,
       durationCount: 0,
     };
+  }
+}
+
+// One cumulative all-time error count per (workflow_id, org_slug, error_type)
+// for managed orgs. Mirrors the gauge semantics of
+// executionsByStatusAndOrgSlug: a point-in-time snapshot the alert reads as
+// `value(now) - value(now offset W)` to recover the delta over a window.
+export type WorkflowErrorsByWorkflow = Array<{
+  workflowId: string;
+  orgSlug: string;
+  errorType: string;
+  count: number;
+}>;
+
+/**
+ * Per-workflow error counts for managed orgs, sourced from the DB so the
+ * series is authoritative regardless of which finalization path wrote the
+ * `status='error'` row. Replaces the per-pod counter that only fired on the
+ * rarely-hit kickoff/reaper/MCP paths and so returned no data in prod.
+ *
+ * Scoped to MANAGED_ORG_SLUGS to bound `workflow_id` cardinality. errorType is
+ * the `workflow_executions.error_type` column, projected to "unknown" for
+ * rows that predate classification so every series carries a populated label.
+ */
+export async function getWorkflowErrorsByWorkflowFromDb(): Promise<WorkflowErrorsByWorkflow> {
+  try {
+    const rows = await db
+      .select({
+        workflowId: workflowExecutions.workflowId,
+        orgSlug: organization.slug,
+        errorType: sql<string>`COALESCE(${workflowExecutions.errorType}, 'unknown')`,
+        count: count(),
+      })
+      .from(workflowExecutions)
+      .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
+      .innerJoin(organization, eq(workflows.organizationId, organization.id))
+      .where(
+        and(
+          eq(workflowExecutions.status, "error"),
+          inArray(organization.slug, [...MANAGED_ORG_SLUGS])
+        )
+      )
+      .groupBy(
+        workflowExecutions.workflowId,
+        organization.slug,
+        workflowExecutions.errorType
+      );
+
+    return rows.map((row) => ({
+      workflowId: row.workflowId,
+      orgSlug: row.orgSlug,
+      errorType: row.errorType,
+      count: Number(row.count) || 0,
+    }));
+  } catch (error) {
+    console.error(
+      "[Metrics] Failed to query per-workflow errors from DB:",
+      error
+    );
+    return [];
   }
 }
 

--- a/tests/unit/db-metrics-cache.test.ts
+++ b/tests/unit/db-metrics-cache.test.ts
@@ -26,6 +26,7 @@ const DEFAULT_DB_RETURNS: Record<string, unknown> = {
     durationSum: 0,
     durationCount: 0,
   },
+  getWorkflowErrorsByWorkflowFromDb: [],
   getStepStatsFromDb: {
     countsByType: {},
     durationBuckets: [0, 0, 0, 0, 0, 0, 0, 0],
@@ -108,6 +109,7 @@ vi.mock("@/lib/metrics/rpc-health-probe", () => ({
 import {
   __resetDbMetricsCacheForTest,
   getApiProcessMetrics,
+  getDbMetrics,
   updateDbMetrics,
 } from "@/lib/metrics/collectors/prometheus";
 
@@ -137,6 +139,10 @@ const CACHE_LOOKUP_HIT_RE =
   /keeperhub_db_metrics_cache_lookups_total\{result="hit"\}\s+\d+/;
 const REFRESH_SUCCESS_RE =
   /keeperhub_db_metrics_refresh_total\{outcome="success"\}\s+\d+/;
+const ERRORS_BY_WORKFLOW_SKY_RE =
+  /keeperhub_workflow_errors_by_workflow\{[^}]*workflow_id="wf_sky_1"[^}]*org_slug="techops-services"[^}]*error_type="user"[^}]*\}\s+7/;
+const ERRORS_BY_WORKFLOW_AJNA_RE =
+  /keeperhub_workflow_errors_by_workflow\{[^}]*workflow_id="wf_ajna_1"[^}]*org_slug="ajna"[^}]*error_type="system"[^}]*\}\s+2/;
 
 describe("updateDbMetrics TTL cache", () => {
   const originalTtl = process.env.DB_METRICS_CACHE_TTL_MS;
@@ -156,6 +162,7 @@ describe("updateDbMetrics TTL cache", () => {
 
   afterEach(() => {
     if (originalTtl === undefined) {
+      // biome-ignore lint/performance/noDelete: must truly unset the env var to restore the unset state; assigning "" or undefined changes cache-TTL semantics
       delete process.env.DB_METRICS_CACHE_TTL_MS;
     } else {
       process.env.DB_METRICS_CACHE_TTL_MS = originalTtl;
@@ -349,5 +356,67 @@ describe("updateDbMetrics TTL cache", () => {
     expect(dbMocks.getWorkflowStatsFromDb).toHaveBeenCalledTimes(2);
 
     errSpy.mockRestore();
+  });
+});
+
+// TECH-48: the per-workflow error gauge must be DB-sourced and populated on
+// the metrics scrape (the regression that left the prod metric empty was that
+// nothing wired the per-workflow series into the scrape path at all).
+describe("keeperhub_workflow_errors_by_workflow gauge", () => {
+  const originalTtl = process.env.DB_METRICS_CACHE_TTL_MS;
+
+  beforeEach(() => {
+    __resetDbMetricsCacheForTest();
+    for (const fn of Object.values(dbMocks)) {
+      fn.mockReset();
+    }
+    rebindDefaultDbMockImplementations();
+    // No caching so each updateDbMetrics() re-reads the (overridden) mocks.
+    process.env.DB_METRICS_CACHE_TTL_MS = "0";
+  });
+
+  afterEach(() => {
+    if (originalTtl === undefined) {
+      // biome-ignore lint/performance/noDelete: must truly unset the env var to restore the unset state; assigning "" or undefined changes cache-TTL semantics
+      delete process.env.DB_METRICS_CACHE_TTL_MS;
+    } else {
+      process.env.DB_METRICS_CACHE_TTL_MS = originalTtl;
+    }
+  });
+
+  it("emits one series per (workflow_id, org_slug, error_type) from the DB query", async () => {
+    dbMocks.getWorkflowErrorsByWorkflowFromDb.mockResolvedValue([
+      {
+        workflowId: "wf_sky_1",
+        orgSlug: "techops-services",
+        errorType: "user",
+        count: 7,
+      },
+      {
+        workflowId: "wf_ajna_1",
+        orgSlug: "ajna",
+        errorType: "system",
+        count: 2,
+      },
+    ]);
+
+    await updateDbMetrics();
+    const out = await getDbMetrics();
+
+    expect(out).toMatch(ERRORS_BY_WORKFLOW_SKY_RE);
+    expect(out).toMatch(ERRORS_BY_WORKFLOW_AJNA_RE);
+  });
+
+  it("clears stale series when a workflow stops appearing in the query", async () => {
+    dbMocks.getWorkflowErrorsByWorkflowFromDb.mockResolvedValueOnce([
+      { workflowId: "wf_gone", orgSlug: "ajna", errorType: "user", count: 3 },
+    ]);
+    await updateDbMetrics();
+    expect(await getDbMetrics()).toContain('workflow_id="wf_gone"');
+
+    // Next scrape no longer returns that workflow; reset() must drop the series.
+    dbMocks.getWorkflowErrorsByWorkflowFromDb.mockResolvedValue([]);
+    await updateDbMetrics();
+    expect(await getDbMetrics()).not.toContain('workflow_id="wf_gone"');
   });
 });


### PR DESCRIPTION
## Problem

`keeperhub_workflow_execution_errors_by_workflow_total` returns no data in prod, so the Sky/Ajna managed-client user-error alerts that read it as their numerator sit at OK even during real error bursts (observed: Ajna error spike did not page).

Root cause: it is a per-pod counter incremented only inside `recordExecutionErrorFinalized` (kickoff-catch / reaper / MCP paths). The main finalization path `logWorkflowCompleteDb`, where ~all normal runs terminate, never calls it. Per-pod counters emitted from the short-lived workflow runner are also dropped before Prometheus scrapes them — confirmed in prod, where the org-level `..._created_total` counter is empty for the same reason.

## Fix

Replace the broken counter with `keeperhub_workflow_errors_by_workflow`, a DB-sourced gauge computed on each `/api/metrics/db` scrape from `workflow_executions` (status='error'), grouped by workflow_id / org_slug / error_type and scoped to managed orgs to bound `workflow_id` cardinality. Being DB-sourced, it counts every finalized error row regardless of which code path wrote it — the same pattern the (working) `keeperhub_workflow_executions_total` gauge already uses.

The old counter is left in place for now; a follow-up removes it once the companion alert change (in techops_infrastructure) is switched to the new gauge.

## Validation

- Confirmed against prod via gcx: the new query reads the same rows as `keeperhub_workflow_executions_total{status="error"}`, which has fresh data for both managed orgs (ajna ~5953 user / 642 system; techops-services ~1421 user / 2527 system / 264 unknown). Both per-pod counters return No data in prod.
- New unit tests cover gauge population and stale-series clearing.
- This PR env (deploy-pr-metrics) is used to confirm the gauge is exposed at `/api/metrics/db` and populates end-to-end against a real Postgres.

## Labels

- `deploy-pr-environment` — build the preview env.
- `deploy-pr-metrics` — deploy the metrics-collector satellite so the DB-metrics path (and the new gauge) is exercised in the PR env.