### PR TITLE
fix(security): fail closed in verify-ip when client IP is unresolved

### DIFF
--- a/app/api/user/verify-ip/_lib/ip-match.ts
+++ b/app/api/user/verify-ip/_lib/ip-match.ts
@@ -1,0 +1,26 @@
+import { normalizeIpForTrust } from "@/lib/security/ip-normalize";
+
+/**
+ * Decide whether the current request's network matches the one pinned in the
+ * `pending_ip_verify` cookie at strict-signin time.
+ *
+ * The session-minting path MUST fail closed when the client IP cannot be
+ * resolved. In production a null IP means the request reached the origin
+ * without a `CF-Connecting-IP` header (direct-origin access / Cloudflare
+ * bypass); letting it through would skip the entire IP binding this endpoint
+ * exists to enforce, which is exactly the F-016 / KEEP-741 fail-open. Outside
+ * production `resolveClientIpFromHeaders` has no CF header to read, so a null
+ * IP there is the local-dev case and still passes.
+ *
+ * When an IP is present, both sides are normalized to the /24-or-/64 network so
+ * a user whose egress IP rotates within their subnet mid-flow isn't bounced.
+ */
+export function isVerifyIpMatch(
+  currentRawIp: string | null,
+  cookieIp: string
+): boolean {
+  if (currentRawIp === null) {
+    return process.env.NODE_ENV !== "production";
+  }
+  return normalizeIpForTrust(currentRawIp) === normalizeIpForTrust(cookieIp);
+}

--- a/app/api/user/verify-ip/route.ts
+++ b/app/api/user/verify-ip/route.ts
@@ -27,7 +27,6 @@ import {
 } from "@/lib/pending-ip-cookie";
 import { sanitizeNextPath } from "@/lib/sanitize-next-path";
 import { resolveSigninDevice } from "@/lib/security/device-trust";
-import { normalizeIpForTrust } from "@/lib/security/ip-normalize";
 import {
   buildRiskFlagsJsonForIp,
   cacheTrustedCountry,
@@ -36,6 +35,7 @@ import {
 } from "@/lib/security/login-risk";
 import { verifyUserTotp } from "@/lib/security/totp-verify";
 import { generateId } from "@/lib/utils/id";
+import { isVerifyIpMatch } from "./_lib/ip-match";
 
 /**
  * Completes the deferred dual-factor sign-in for a request that
@@ -228,10 +228,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   // /24-or-/64 network so a user whose egress IP rotates within their
   // subnet mid-flow isn't bounced.
   const currentRawIp = resolveClientIpFromHeaders(request.headers);
-  const ipMatch =
-    !currentRawIp ||
-    normalizeIpForTrust(currentRawIp) ===
-      normalizeIpForTrust(decoded.payload.ip);
+  const ipMatch = isVerifyIpMatch(currentRawIp, decoded.payload.ip);
   logIpVerify("verify-ip:final_check", {
     userId: decoded.payload.userId,
     cookieIp: decoded.payload.ip,

--- a/tests/unit/verify-ip-match.test.ts
+++ b/tests/unit/verify-ip-match.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { isVerifyIpMatch } from "@/app/api/user/verify-ip/_lib/ip-match";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("isVerifyIpMatch (F-016 / KEEP-741 fail-closed)", () => {
+  it("matches when the current IP is in the same /24 network as the cookie IP", () => {
+    expect(isVerifyIpMatch("203.0.113.7", "203.0.113.250")).toBe(true);
+  });
+
+  it("rejects when the current IP is a different network", () => {
+    expect(isVerifyIpMatch("198.51.100.7", "203.0.113.7")).toBe(false);
+  });
+
+  it("FAILS CLOSED in production when the client IP cannot be resolved", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    // Pre-fix this returned true (the !currentRawIp short-circuit), letting a
+    // request that bypassed Cloudflare skip the IP binding entirely.
+    expect(isVerifyIpMatch(null, "203.0.113.7")).toBe(false);
+  });
+
+  it("still passes outside production when the IP is unresolved (local dev)", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    expect(isVerifyIpMatch(null, "203.0.113.7")).toBe(true);
+  });
+});


### PR DESCRIPTION
The session-minting path in /api/user/verify-ip compared the request IP to the one pinned in the pending_ip_verify cookie with a `!currentRawIp` short-circuit, so a null IP made the match pass. In production a null IP means the request reached the origin without CF-Connecting-IP (direct-origin / Cloudflare bypass), letting an attacker holding the cookie plus valid factors finish the session mint on a foreign network.

Extract the decision into `isVerifyIpMatch` and fail closed in production when the IP cannot be resolved; local dev (no CF header) still passes. Unit tested.