### PR TITLE
fix(security): rate-limit finish-credential-signup password oracle

### DIFF
--- a/app/api/auth/_lib/credential-attempt-rate-limit.ts
+++ b/app/api/auth/_lib/credential-attempt-rate-limit.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared in-memory rate limiter for the unauthenticated credential-password
+ * endpoints (F-013 / KEEP-738). Both POST /api/auth/finish-credential-signup
+ * and POST /api/auth/strict-signin/start verify a credential password for any
+ * caller and return a distinguishable 401 vs 200, so without throttling each is
+ * an unauthenticated password oracle (strict-signin/start is the broader one:
+ * a correct password signs a non-TOTP user straight in). Neither sits under
+ * the Better Auth `/api/auth/[...all]` catch-all, so Better Auth's rateLimit
+ * does not cover them.
+ *
+ * Buckets are SHARED across both endpoints, keyed by normalized email and by
+ * client IP, so an attacker cannot get a fresh allowance by hopping between the
+ * two routes for the same target.
+ *
+ * Two independent limiters, both consulted on every attempt:
+ *   - per-email: 5 attempts per 15 minutes per normalized email
+ *   - per-IP:    20 attempts per 15 minutes per client IP
+ *
+ * Mirrors app/api/user/forgot-password/_lib/rate-limit.ts: process-local Map
+ * storage, lazy reset on read, no background timer. If the app grows multiple
+ * replicas, swap in a Redis-backed counter keyed the same way; the public API
+ * stays the same.
+ */
+
+const WINDOW_MS = 15 * 60 * 1000;
+const EMAIL_MAX = 5;
+const IP_MAX = 20;
+
+type Bucket = {
+  count: number;
+  resetAt: number;
+};
+
+const emailBuckets = new Map<string, Bucket>();
+const ipBuckets = new Map<string, Bucket>();
+
+export type RateLimitResult =
+  | { allowed: true }
+  | { allowed: false; retryAfterSeconds: number; scope: "email" | "ip" };
+
+function check(
+  store: Map<string, Bucket>,
+  key: string,
+  max: number,
+  now: number
+): { ok: boolean; retryAfter: number } {
+  const existing = store.get(key);
+  if (!existing || existing.resetAt <= now) {
+    store.set(key, { count: 1, resetAt: now + WINDOW_MS });
+    return { ok: true, retryAfter: 0 };
+  }
+  if (existing.count >= max) {
+    return {
+      ok: false,
+      retryAfter: Math.ceil((existing.resetAt - now) / 1000),
+    };
+  }
+  existing.count += 1;
+  return { ok: true, retryAfter: 0 };
+}
+
+export function checkCredentialAttemptRateLimit(
+  email: string,
+  ip: string
+): RateLimitResult {
+  const now = Date.now();
+  const emailResult = check(emailBuckets, email, EMAIL_MAX, now);
+  if (!emailResult.ok) {
+    return {
+      allowed: false,
+      retryAfterSeconds: emailResult.retryAfter,
+      scope: "email",
+    };
+  }
+  const ipResult = check(ipBuckets, ip, IP_MAX, now);
+  if (!ipResult.ok) {
+    return {
+      allowed: false,
+      retryAfterSeconds: ipResult.retryAfter,
+      scope: "ip",
+    };
+  }
+  return { allowed: true };
+}
+
+/** Test-only hook to reset all counters between unit tests. */
+export function __resetCredentialAttemptRateLimit(): void {
+  emailBuckets.clear();
+  ipBuckets.clear();
+}

--- a/app/api/auth/finish-credential-signup/route.ts
+++ b/app/api/auth/finish-credential-signup/route.ts
@@ -8,6 +8,8 @@ import {
   buildPendingSignupSetCookie,
   encodePendingSignupCookie,
 } from "@/lib/pending-signup-cookie";
+import { resolveClientIpFromHeaders } from "@/lib/security/login-risk";
+import { checkCredentialAttemptRateLimit } from "../_lib/credential-attempt-rate-limit";
 
 /**
  * Bridges credential signup (signUp.email + emailOtp.verifyEmail) to
@@ -70,6 +72,28 @@ export async function POST(request: Request): Promise<NextResponse> {
         code: "missing_credentials",
       },
       { status: 400 }
+    );
+  }
+
+  // F-013 / KEEP-738: this route re-verifies the credential password and
+  // returns a distinguishable 401 vs 200, so it is a password oracle unless
+  // throttled. Limit per-email (brute-forcing one account) and per-IP (email
+  // enumeration spray) before any password comparison. Buckets are shared with
+  // strict-signin/start (the sibling oracle) so hopping between the two routes
+  // does not grant a fresh allowance for the same target.
+  const clientIp = resolveClientIpFromHeaders(request.headers) ?? "unknown";
+  const rateLimit = checkCredentialAttemptRateLimit(email, clientIp);
+  if (!rateLimit.allowed) {
+    return NextResponse.json(
+      {
+        error: "Too many attempts. Wait and try again.",
+        code: "rate_limited",
+        retryAfter: rateLimit.retryAfterSeconds,
+      },
+      {
+        status: 429,
+        headers: { "Retry-After": String(rateLimit.retryAfterSeconds) },
+      }
     );
   }
 

--- a/app/api/auth/strict-signin/start/route.ts
+++ b/app/api/auth/strict-signin/start/route.ts
@@ -6,6 +6,8 @@ import { db } from "@/lib/db";
 import { accounts, users } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { verifyPassword } from "@/lib/password";
+import { resolveClientIpFromHeaders } from "@/lib/security/login-risk";
+import { checkCredentialAttemptRateLimit } from "../../_lib/credential-attempt-rate-limit";
 
 /**
  * First step of the strict atomic dual-factor sign-in.
@@ -58,6 +60,28 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 
+  // F-013 / KEEP-738: this route verifies the credential password and returns a
+  // distinguishable 401 vs 200 (and signs non-TOTP users straight in on a
+  // correct password), so it is an unauthenticated password oracle unless
+  // throttled. Limit per-email + per-IP before any password comparison; buckets
+  // are shared with finish-credential-signup so an attacker cannot get a fresh
+  // allowance by hopping between the two routes for the same target.
+  const clientIp = resolveClientIpFromHeaders(request.headers) ?? "unknown";
+  const rateLimit = checkCredentialAttemptRateLimit(email, clientIp);
+  if (!rateLimit.allowed) {
+    return NextResponse.json(
+      {
+        error: "Too many attempts. Wait and try again.",
+        code: "rate_limited",
+        retryAfter: rateLimit.retryAfterSeconds,
+      },
+      {
+        status: 429,
+        headers: { "Retry-After": String(rateLimit.retryAfterSeconds) },
+      }
+    );
+  }
+
   const [user] = await db
     .select({
       id: users.id,
@@ -99,7 +123,10 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   if (user.deactivatedAt) {
     return NextResponse.json(
-      { error: "Your account has been deactivated.", code: "account_deactivated" },
+      {
+        error: "Your account has been deactivated.",
+        code: "account_deactivated",
+      },
       { status: 403 }
     );
   }

--- a/tests/unit/credential-attempt-rate-limit.test.ts
+++ b/tests/unit/credential-attempt-rate-limit.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  __resetCredentialAttemptRateLimit,
+  checkCredentialAttemptRateLimit,
+} from "@/app/api/auth/_lib/credential-attempt-rate-limit";
+
+beforeEach(() => {
+  __resetCredentialAttemptRateLimit();
+});
+
+describe("checkCredentialAttemptRateLimit (F-013 / KEEP-738)", () => {
+  it("allows the first 5 attempts per email then blocks (password-oracle guard)", () => {
+    const email = "victim@example.com";
+    for (let i = 0; i < 5; i++) {
+      expect(
+        checkCredentialAttemptRateLimit(email, `10.0.0.${i}`).allowed
+      ).toBe(true);
+    }
+    const blocked = checkCredentialAttemptRateLimit(email, "10.0.0.99");
+    expect(blocked.allowed).toBe(false);
+    if (!blocked.allowed) {
+      expect(blocked.scope).toBe("email");
+      expect(blocked.retryAfterSeconds).toBeGreaterThan(0);
+    }
+  });
+
+  it("blocks per-IP after 20 attempts across different emails (enumeration spray)", () => {
+    const ip = "203.0.113.5";
+    for (let i = 0; i < 20; i++) {
+      expect(
+        checkCredentialAttemptRateLimit(`user${i}@example.com`, ip).allowed
+      ).toBe(true);
+    }
+    const blocked = checkCredentialAttemptRateLimit("user99@example.com", ip);
+    expect(blocked.allowed).toBe(false);
+    if (!blocked.allowed) {
+      expect(blocked.scope).toBe("ip");
+    }
+  });
+
+  it("shares the per-email bucket across both oracle endpoints (no fresh allowance by hopping routes)", () => {
+    const email = "target@example.com";
+    // Simulate 5 attempts against finish-credential-signup (different IPs to
+    // isolate the per-email bucket), then a 6th from strict-signin/start: the
+    // shared email bucket must already be exhausted.
+    for (let i = 0; i < 5; i++) {
+      expect(
+        checkCredentialAttemptRateLimit(email, `198.51.100.${i}`).allowed
+      ).toBe(true);
+    }
+    const blocked = checkCredentialAttemptRateLimit(email, "198.51.100.200");
+    expect(blocked.allowed).toBe(false);
+    if (!blocked.allowed) {
+      expect(blocked.scope).toBe("email");
+    }
+  });
+
+  it("keys email and IP buckets independently", () => {
+    expect(
+      checkCredentialAttemptRateLimit("a@example.com", "1.1.1.1").allowed
+    ).toBe(true);
+    expect(
+      checkCredentialAttemptRateLimit("b@example.com", "2.2.2.2").allowed
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Both POST /api/auth/finish-credential-signup and POST /api/auth/strict-signin/start verify a credential password for any caller and return a distinguishable 401 vs 200 (strict-signin/start signs non-TOTP users straight in on a correct password). Neither sits under the Better Auth catch-all, so neither inherited rate limiting — leaving two unauthenticated password oracles.

Adds a shared in-memory limiter (per-email 5/15m + per-IP 20/15m, mirroring the forgot-password limiter) consulted before any password comparison on BOTH routes. Buckets are shared so an attacker cannot get a fresh allowance by hopping between the two endpoints for the same target.

An adversarial pre-merge review flagged that an earlier version only covered finish-credential-signup, leaving strict-signin/start (the broader oracle) unguarded; this version closes both. Unit tested (per-email, per-IP, shared-bucket, independent keying).