### PR TITLE
fix(security): gate protocol write actions through execution guards

### DIFF
--- a/app/api/execute/[...slug]/route.ts
+++ b/app/api/execute/[...slug]/route.ts
@@ -4,6 +4,7 @@ import "@/protocols";
 
 import { NextResponse } from "next/server";
 import { resolveAbi } from "@/lib/abi/cache";
+import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import {
   beginIdempotentFromRequest,
@@ -28,7 +29,16 @@ import {
   writeContractCore,
 } from "@/plugins/web3/steps/write-contract-core";
 import { validateApiKey } from "../_lib/auth";
+import {
+  completeExecution,
+  failExecution,
+  markRunning,
+  redactInput,
+  withRejectedSignerOverride,
+} from "../_lib/execution-service";
 import { checkRateLimit } from "../_lib/rate-limit";
+import { checkAndReserveExecution } from "../_lib/spending-cap";
+import { requireWallet } from "../_lib/wallet-check";
 
 function buildFunctionArgs(
   input: Record<string, unknown>,
@@ -60,7 +70,8 @@ function buildFunctionArgs(
 async function executeProtocolAction(
   actionType: string,
   body: Record<string, unknown>,
-  organizationId: string
+  organizationId: string,
+  apiKeyId: string
 ): Promise<NextResponse> {
   const meta = resolveProtocolMeta({ _actionType: actionType });
   if (!meta) {
@@ -177,6 +188,37 @@ async function executeProtocolAction(
     return NextResponse.json(result);
   }
 
+  // KEEP-793 / A-07: protocol write actions sign and broadcast a real tx from
+  // the org wallet, so they must clear the same gates as every other direct
+  // write path (transfer, contract-call, check-and-execute): plan execution
+  // limit, wallet presence, daily spend cap, and a recorded directExecutions
+  // audit row. Reads above stay ungated.
+  const executionGuard = await enforceExecutionLimit(organizationId);
+  if (executionGuard.blocked) {
+    return executionGuard.response;
+  }
+
+  const walletError = await requireWallet(organizationId);
+  if (walletError) {
+    return walletError;
+  }
+
+  const reserve = await checkAndReserveExecution({
+    organizationId,
+    apiKeyId,
+    type: "protocol-action",
+    network,
+    input: redactInput(withRejectedSignerOverride(body, body)),
+  });
+  if (!reserve.allowed) {
+    return NextResponse.json(
+      { success: false, error: reserve.reason },
+      { status: HttpStatus.FORBIDDEN }
+    );
+  }
+  const { executionId } = reserve;
+  await markRunning(executionId);
+
   const ethValue = body.ethValue ? String(body.ethValue) : undefined;
   const coreInput: WriteContractCoreInput = {
     contractAddress,
@@ -188,6 +230,19 @@ async function executeProtocolAction(
     _context: { organizationId },
   };
   const result = await writeContractCore(coreInput);
+
+  if (result.success) {
+    await completeExecution(executionId, {
+      transactionHash: result.transactionHash,
+      transactionLink: result.transactionLink,
+      gasUsedWei: result.gasUsed,
+      gasPriceWei: result.effectiveGasPrice,
+      output: result as unknown as Record<string, unknown>,
+    });
+  } else {
+    await failExecution(executionId, result.error);
+  }
+
   return NextResponse.json(result);
 }
 
@@ -291,7 +346,12 @@ export async function POST(
     const meta = resolveProtocolMeta({ _actionType: actionType });
     if (meta) {
       const response = await withIdempotencyHeartbeat(idem, () =>
-        executeProtocolAction(actionType, body, apiKeyCtx.organizationId)
+        executeProtocolAction(
+          actionType,
+          body,
+          apiKeyCtx.organizationId,
+          apiKeyCtx.apiKeyId
+        )
       );
       return applyRateLimitHeaders(
         await recordIdempotentResponse(

--- a/app/api/execute/[...slug]/route.ts
+++ b/app/api/execute/[...slug]/route.ts
@@ -8,7 +8,7 @@ import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { enterApiExecuteErrorContext } from "@/lib/db/org-helpers";
 import {
   beginIdempotentFromRequest,
-  type IdempotencyDisposition,
+  type IdempotencyOutcome,
   idempotencyEarlyResponse,
   recordIdempotentResponse,
   withIdempotencyHeartbeat,
@@ -71,35 +71,45 @@ async function executeProtocolAction(
   actionType: string,
   body: Record<string, unknown>,
   organizationId: string,
-  apiKeyId: string
+  apiKeyId: string,
+  idem: IdempotencyOutcome | null
 ): Promise<NextResponse> {
   const meta = resolveProtocolMeta({ _actionType: actionType });
   if (!meta) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: `Could not resolve protocol metadata for: ${actionType}`,
-      },
-      { status: HttpStatus.BAD_REQUEST }
+    return recordIdempotentResponse(
+      idem,
+      NextResponse.json(
+        {
+          success: false,
+          error: `Could not resolve protocol metadata for: ${actionType}`,
+        },
+        { status: HttpStatus.BAD_REQUEST }
+      )
     );
   }
 
   const protocol = getProtocol(meta.protocolSlug);
   if (!protocol) {
-    return NextResponse.json(
-      { success: false, error: `Unknown protocol: ${meta.protocolSlug}` },
-      { status: HttpStatus.BAD_REQUEST }
+    return recordIdempotentResponse(
+      idem,
+      NextResponse.json(
+        { success: false, error: `Unknown protocol: ${meta.protocolSlug}` },
+        { status: HttpStatus.BAD_REQUEST }
+      )
     );
   }
 
   const contract = protocol.contracts[meta.contractKey];
   if (!contract) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: `Unknown contract key "${meta.contractKey}" in protocol "${meta.protocolSlug}"`,
-      },
-      { status: HttpStatus.BAD_REQUEST }
+    return recordIdempotentResponse(
+      idem,
+      NextResponse.json(
+        {
+          success: false,
+          error: `Unknown contract key "${meta.contractKey}" in protocol "${meta.protocolSlug}"`,
+        },
+        { status: HttpStatus.BAD_REQUEST }
+      )
     );
   }
 
@@ -110,13 +120,16 @@ async function executeProtocolAction(
   // numeric chainId, so normalize here once.
   const rawNetwork = String(body.chainId ?? body.network ?? "");
   if (!rawNetwork) {
-    return NextResponse.json(
-      {
-        success: false,
-        error:
-          "Missing required field: chainId (or network, which is a deprecated alias)",
-      },
-      { status: HttpStatus.BAD_REQUEST }
+    return recordIdempotentResponse(
+      idem,
+      NextResponse.json(
+        {
+          success: false,
+          error:
+            "Missing required field: chainId (or network, which is a deprecated alias)",
+        },
+        { status: HttpStatus.BAD_REQUEST }
+      )
     );
   }
 
@@ -124,12 +137,15 @@ async function executeProtocolAction(
   try {
     resolvedChainId = getChainIdFromNetwork(rawNetwork);
   } catch (err: unknown) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: err instanceof Error ? err.message : String(err),
-      },
-      { status: HttpStatus.BAD_REQUEST }
+    return recordIdempotentResponse(
+      idem,
+      NextResponse.json(
+        {
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+        },
+        { status: HttpStatus.BAD_REQUEST }
+      )
     );
   }
   const network = String(resolvedChainId);
@@ -139,14 +155,17 @@ async function executeProtocolAction(
     : contract.addresses[network];
 
   if (!contractAddress) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: contract.userSpecifiedAddress
-          ? `Missing contract address for "${meta.contractKey}"`
-          : `Protocol "${meta.protocolSlug}" contract "${meta.contractKey}" is not deployed on chain ${network} (input: "${rawNetwork}")`,
-      },
-      { status: HttpStatus.BAD_REQUEST }
+    return recordIdempotentResponse(
+      idem,
+      NextResponse.json(
+        {
+          success: false,
+          error: contract.userSpecifiedAddress
+            ? `Missing contract address for "${meta.contractKey}"`
+            : `Protocol "${meta.protocolSlug}" contract "${meta.contractKey}" is not deployed on chain ${network} (input: "${rawNetwork}")`,
+        },
+        { status: HttpStatus.BAD_REQUEST }
+      )
     );
   }
 
@@ -159,12 +178,15 @@ async function executeProtocolAction(
     });
     resolvedAbi = abiResult.abi;
   } catch (err: unknown) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: `Failed to resolve ABI: ${err instanceof Error ? err.message : String(err)}`,
-      },
-      { status: HttpStatus.BAD_REQUEST }
+    return recordIdempotentResponse(
+      idem,
+      NextResponse.json(
+        {
+          success: false,
+          error: `Failed to resolve ABI: ${err instanceof Error ? err.message : String(err)}`,
+        },
+        { status: HttpStatus.BAD_REQUEST }
+      )
     );
   }
 
@@ -185,22 +207,24 @@ async function executeProtocolAction(
       _context: { organizationId },
     };
     const result = await readContractCore(coreInput);
-    return NextResponse.json(result);
+    return recordIdempotentResponse(idem, NextResponse.json(result));
   }
 
   // KEEP-793 / A-07: protocol write actions sign and broadcast a real tx from
   // the org wallet, so they must clear the same gates as every other direct
   // write path (transfer, contract-call, check-and-execute): plan execution
   // limit, wallet presence, daily spend cap, and a recorded directExecutions
-  // audit row. Reads above stay ungated.
+  // audit row. Reads above stay ungated. Each gate fails before any broadcast,
+  // so it releases the idempotency lock for a clean retry instead of finalizing
+  // the error against the key.
   const executionGuard = await enforceExecutionLimit(organizationId);
   if (executionGuard.blocked) {
-    return executionGuard.response;
+    return recordIdempotentResponse(idem, executionGuard.response, "release");
   }
 
   const walletError = await requireWallet(organizationId);
   if (walletError) {
-    return walletError;
+    return recordIdempotentResponse(idem, walletError, "release");
   }
 
   const reserve = await checkAndReserveExecution({
@@ -211,9 +235,13 @@ async function executeProtocolAction(
     input: redactInput(withRejectedSignerOverride(body, body)),
   });
   if (!reserve.allowed) {
-    return NextResponse.json(
-      { success: false, error: reserve.reason },
-      { status: HttpStatus.FORBIDDEN }
+    return recordIdempotentResponse(
+      idem,
+      NextResponse.json(
+        { success: false, error: reserve.reason },
+        { status: HttpStatus.FORBIDDEN }
+      ),
+      "release"
     );
   }
   const { executionId } = reserve;
@@ -229,7 +257,9 @@ async function executeProtocolAction(
     ethValue,
     _context: { organizationId },
   };
-  const result = await writeContractCore(coreInput);
+  const result = await withIdempotencyHeartbeat(idem, () =>
+    writeContractCore(coreInput)
+  );
 
   if (result.success) {
     await completeExecution(executionId, {
@@ -243,27 +273,13 @@ async function executeProtocolAction(
     await failExecution(executionId, result.error);
   }
 
-  return NextResponse.json(result);
-}
-
-// Disposition for a protocol-action response. Reads and successful writes are a
-// replayable success. A write returning success:false (revert) reached the
-// broadcast path, so it is finalized as failed (never released) to keep a retry
-// from re-broadcasting.
-function protocolActionDisposition(
-  response: NextResponse
-): Promise<IdempotencyDisposition> {
-  return response
-    .clone()
-    .json()
-    .then((b: unknown): IdempotencyDisposition => {
-      const record = (b ?? {}) as Record<string, unknown>;
-      return record.success === false ? "failed" : "success";
-    })
-    .catch(
-      (): IdempotencyDisposition =>
-        response.status >= 200 && response.status < 300 ? "success" : "failed"
-    );
+  // The tx reached the broadcast path, so finalize as success or failed and
+  // never release: a retry on the same key must not re-broadcast.
+  return recordIdempotentResponse(
+    idem,
+    NextResponse.json(result),
+    result.success ? "success" : "failed"
+  );
 }
 
 export async function POST(
@@ -345,22 +361,14 @@ export async function POST(
     // Try protocol action first (covers all protocol read/write tools)
     const meta = resolveProtocolMeta({ _actionType: actionType });
     if (meta) {
-      const response = await withIdempotencyHeartbeat(idem, () =>
-        executeProtocolAction(
-          actionType,
-          body,
-          apiKeyCtx.organizationId,
-          apiKeyCtx.apiKeyId
-        )
+      const response = await executeProtocolAction(
+        actionType,
+        body,
+        apiKeyCtx.organizationId,
+        apiKeyCtx.apiKeyId,
+        idem
       );
-      return applyRateLimitHeaders(
-        await recordIdempotentResponse(
-          idem,
-          response,
-          await protocolActionDisposition(response)
-        ),
-        rateLimit
-      );
+      return applyRateLimitHeaders(response, rateLimit);
     }
 
     // Non-protocol actions are not yet supported via direct execution. This

--- a/tests/unit/execute-protocol-execution-guards.test.ts
+++ b/tests/unit/execute-protocol-execution-guards.test.ts
@@ -1,0 +1,175 @@
+import { NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/protocols", () => ({}));
+
+vi.mock("../../app/api/execute/_lib/auth", () => ({
+  validateApiKey: vi
+    .fn()
+    .mockResolvedValue({ organizationId: "org_1", apiKeyId: "key_1" }),
+}));
+
+vi.mock("../../app/api/execute/_lib/rate-limit", () => ({
+  checkRateLimit: vi.fn().mockReturnValue({ allowed: true }),
+}));
+
+vi.mock("@/lib/db/org-helpers", () => ({
+  enterApiExecuteErrorContext: vi.fn(),
+}));
+
+vi.mock("@/lib/abi/cache", () => ({
+  resolveAbi: vi.fn().mockResolvedValue({ abi: "[]", source: "definition" }),
+}));
+
+vi.mock("@/plugins/protocol/steps/resolve-protocol-meta", () => ({
+  resolveProtocolMeta: vi.fn().mockReturnValue({
+    protocolSlug: "test-protocol",
+    contractKey: "router",
+    functionName: "swap",
+    actionType: "write",
+  }),
+}));
+
+vi.mock("@/lib/protocol-registry", () => ({
+  getProtocol: vi.fn().mockReturnValue({
+    contracts: { router: { addresses: { "8453": "0xBaseRouter" } } },
+    actions: [],
+  }),
+}));
+
+const writeContractCoreMock = vi.fn();
+vi.mock("@/plugins/web3/steps/write-contract-core", () => ({
+  writeContractCore: (input: unknown) => writeContractCoreMock(input),
+}));
+
+vi.mock("@/plugins/web3/steps/read-contract-core", () => ({
+  readContractCore: vi.fn(),
+}));
+
+vi.mock("@/lib/step-registry", () => ({
+  PLUGIN_STEP_IMPORTERS: { "test-protocol/swap": () => Promise.resolve({}) },
+}));
+
+// The guards under test (A-07 / KEEP-793).
+const enforceExecutionLimitMock = vi.fn();
+vi.mock("@/lib/billing/execution-guard", () => ({
+  enforceExecutionLimit: (orgId: string) => enforceExecutionLimitMock(orgId),
+}));
+
+const requireWalletMock = vi.fn();
+vi.mock("../../app/api/execute/_lib/wallet-check", () => ({
+  requireWallet: (orgId: string) => requireWalletMock(orgId),
+}));
+
+const checkAndReserveExecutionMock = vi.fn();
+vi.mock("../../app/api/execute/_lib/spending-cap", () => ({
+  checkAndReserveExecution: (params: unknown) =>
+    checkAndReserveExecutionMock(params),
+}));
+
+const markRunningMock = vi.fn();
+const completeExecutionMock = vi.fn();
+const failExecutionMock = vi.fn();
+vi.mock("../../app/api/execute/_lib/execution-service", () => ({
+  markRunning: (id: string) => markRunningMock(id),
+  completeExecution: (id: string, r: unknown) => completeExecutionMock(id, r),
+  failExecution: (id: string, e: string) => failExecutionMock(id, e),
+  redactInput: (x: unknown) => x,
+  withRejectedSignerOverride: (a: unknown) => a,
+}));
+
+async function postSwap(): Promise<Response> {
+  const { POST } = await import("@/app/api/execute/[...slug]/route");
+  const req = new Request("http://test/api/execute/test-protocol/swap", {
+    method: "POST",
+    body: JSON.stringify({ chainId: 8453 }),
+    headers: { "content-type": "application/json", authorization: "Bearer x" },
+  });
+  return POST(req, {
+    params: Promise.resolve({ slug: ["test-protocol", "swap"] }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  enforceExecutionLimitMock.mockResolvedValue({ blocked: false });
+  requireWalletMock.mockResolvedValue(null);
+  checkAndReserveExecutionMock.mockResolvedValue({
+    allowed: true,
+    executionId: "exec_1",
+  });
+  writeContractCoreMock.mockResolvedValue({
+    success: true,
+    transactionHash: "0xtx",
+    transactionLink: "https://scan/0xtx",
+    gasUsed: "21000",
+    effectiveGasPrice: "1000000000",
+  });
+});
+
+describe("A-07 / KEEP-793: protocol write actions are gated and recorded", () => {
+  it("enforces the plan limit, wallet, spend cap, and records the execution", async () => {
+    const response = await postSwap();
+
+    expect(response.status).toBe(200);
+    expect(enforceExecutionLimitMock).toHaveBeenCalledWith("org_1");
+    expect(requireWalletMock).toHaveBeenCalledWith("org_1");
+    expect(checkAndReserveExecutionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: "org_1",
+        apiKeyId: "key_1",
+        type: "protocol-action",
+        network: "8453",
+      })
+    );
+    expect(markRunningMock).toHaveBeenCalledWith("exec_1");
+    expect(completeExecutionMock).toHaveBeenCalledWith(
+      "exec_1",
+      expect.objectContaining({ transactionHash: "0xtx" })
+    );
+    expect(writeContractCoreMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 403 and never broadcasts when the daily spend cap is exceeded", async () => {
+    checkAndReserveExecutionMock.mockResolvedValue({
+      allowed: false,
+      reason: "Daily spending cap exceeded",
+    });
+
+    const response = await postSwap();
+
+    expect(response.status).toBe(403);
+    expect(writeContractCoreMock).not.toHaveBeenCalled();
+    expect(markRunningMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the wallet error and never reserves or broadcasts when no wallet", async () => {
+    requireWalletMock.mockResolvedValue(
+      NextResponse.json(
+        { error: "No wallet", code: "WALLET_NOT_CONFIGURED" },
+        { status: 422 }
+      )
+    );
+
+    const response = await postSwap();
+
+    expect(response.status).toBe(422);
+    expect(checkAndReserveExecutionMock).not.toHaveBeenCalled();
+    expect(writeContractCoreMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the plan-limit block and never broadcasts when over the plan limit", async () => {
+    enforceExecutionLimitMock.mockResolvedValue({
+      blocked: true,
+      response: NextResponse.json({ error: "limit" }, { status: 402 }),
+    });
+
+    const response = await postSwap();
+
+    expect(response.status).toBe(402);
+    expect(requireWalletMock).not.toHaveBeenCalled();
+    expect(checkAndReserveExecutionMock).not.toHaveBeenCalled();
+    expect(writeContractCoreMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/execute-protocol-idempotency-disposition.test.ts
+++ b/tests/unit/execute-protocol-idempotency-disposition.test.ts
@@ -1,0 +1,182 @@
+import { NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/protocols", () => ({}));
+
+vi.mock("../../app/api/execute/_lib/auth", () => ({
+  validateApiKey: vi
+    .fn()
+    .mockResolvedValue({ organizationId: "org_1", apiKeyId: "key_1" }),
+}));
+
+vi.mock("../../app/api/execute/_lib/rate-limit", () => ({
+  checkRateLimit: vi.fn().mockReturnValue({ allowed: true }),
+}));
+
+vi.mock("@/lib/db/org-helpers", () => ({
+  enterApiExecuteErrorContext: vi.fn(),
+}));
+
+vi.mock("@/lib/abi/cache", () => ({
+  resolveAbi: vi.fn().mockResolvedValue({ abi: "[]", source: "definition" }),
+}));
+
+vi.mock("@/plugins/protocol/steps/resolve-protocol-meta", () => ({
+  resolveProtocolMeta: vi.fn().mockReturnValue({
+    protocolSlug: "test-protocol",
+    contractKey: "router",
+    functionName: "swap",
+    actionType: "write",
+  }),
+}));
+
+vi.mock("@/lib/protocol-registry", () => ({
+  getProtocol: vi.fn().mockReturnValue({
+    contracts: { router: { addresses: { "8453": "0xBaseRouter" } } },
+    actions: [],
+  }),
+}));
+
+const writeContractCoreMock = vi.fn();
+vi.mock("@/plugins/web3/steps/write-contract-core", () => ({
+  writeContractCore: (input: unknown) => writeContractCoreMock(input),
+}));
+
+vi.mock("@/plugins/web3/steps/read-contract-core", () => ({
+  readContractCore: vi.fn(),
+}));
+
+vi.mock("@/lib/step-registry", () => ({
+  PLUGIN_STEP_IMPORTERS: { "test-protocol/swap": () => Promise.resolve({}) },
+}));
+
+const enforceExecutionLimitMock = vi.fn();
+vi.mock("@/lib/billing/execution-guard", () => ({
+  enforceExecutionLimit: (orgId: string) => enforceExecutionLimitMock(orgId),
+}));
+
+const requireWalletMock = vi.fn();
+vi.mock("../../app/api/execute/_lib/wallet-check", () => ({
+  requireWallet: (orgId: string) => requireWalletMock(orgId),
+}));
+
+const checkAndReserveExecutionMock = vi.fn();
+vi.mock("../../app/api/execute/_lib/spending-cap", () => ({
+  checkAndReserveExecution: (params: unknown) =>
+    checkAndReserveExecutionMock(params),
+}));
+
+vi.mock("../../app/api/execute/_lib/execution-service", () => ({
+  markRunning: vi.fn(),
+  completeExecution: vi.fn(),
+  failExecution: vi.fn(),
+  redactInput: (x: unknown) => x,
+  withRejectedSignerOverride: (a: unknown) => a,
+}));
+
+// Capture the disposition each response is recorded with. A non-null outcome
+// stands in for a request that carried an Idempotency-Key.
+const recordIdempotentResponseMock = vi.fn(
+  (_outcome: unknown, response: Response, _disposition?: string) =>
+    Promise.resolve(response)
+);
+vi.mock("@/lib/idempotency", () => ({
+  beginIdempotentFromRequest: vi.fn().mockResolvedValue({ kind: "proceed" }),
+  idempotencyEarlyResponse: vi.fn().mockReturnValue(null),
+  recordIdempotentResponse: (
+    outcome: unknown,
+    response: Response,
+    disposition?: string
+  ) => recordIdempotentResponseMock(outcome, response, disposition),
+  withIdempotencyHeartbeat: (_outcome: unknown, fn: () => unknown) => fn(),
+}));
+
+async function postSwap(): Promise<Response> {
+  const { POST } = await import("@/app/api/execute/[...slug]/route");
+  const req = new Request("http://test/api/execute/test-protocol/swap", {
+    method: "POST",
+    body: JSON.stringify({ chainId: 8453 }),
+    headers: {
+      "content-type": "application/json",
+      authorization: "Bearer x",
+      "idempotency-key": "idem_1",
+    },
+  });
+  return POST(req, {
+    params: Promise.resolve({ slug: ["test-protocol", "swap"] }),
+  });
+}
+
+function lastDisposition(): string | undefined {
+  const calls = recordIdempotentResponseMock.mock.calls;
+  return calls.at(-1)?.[2] as string | undefined;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  enforceExecutionLimitMock.mockResolvedValue({ blocked: false });
+  requireWalletMock.mockResolvedValue(null);
+  checkAndReserveExecutionMock.mockResolvedValue({
+    allowed: true,
+    executionId: "exec_1",
+  });
+  writeContractCoreMock.mockResolvedValue({
+    success: true,
+    transactionHash: "0xtx",
+    transactionLink: "https://scan/0xtx",
+    gasUsed: "21000",
+    effectiveGasPrice: "1000000000",
+  });
+});
+
+describe("execute protocol idempotency disposition", () => {
+  it("releases the lock when the plan limit blocks (pre-broadcast)", async () => {
+    enforceExecutionLimitMock.mockResolvedValue({
+      blocked: true,
+      response: NextResponse.json({ error: "limit" }, { status: 402 }),
+    });
+
+    await postSwap();
+
+    expect(lastDisposition()).toBe("release");
+  });
+
+  it("releases the lock when no wallet is configured (pre-broadcast)", async () => {
+    requireWalletMock.mockResolvedValue(
+      NextResponse.json({ error: "No wallet" }, { status: 422 })
+    );
+
+    await postSwap();
+
+    expect(lastDisposition()).toBe("release");
+  });
+
+  it("releases the lock when the spend cap is exceeded (pre-broadcast)", async () => {
+    checkAndReserveExecutionMock.mockResolvedValue({
+      allowed: false,
+      reason: "Daily spending cap exceeded",
+    });
+
+    await postSwap();
+
+    expect(lastDisposition()).toBe("release");
+  });
+
+  it("finalizes as success when the write broadcasts and succeeds", async () => {
+    await postSwap();
+
+    expect(lastDisposition()).toBe("success");
+  });
+
+  it("finalizes as failed when the write reverts after broadcast", async () => {
+    writeContractCoreMock.mockResolvedValue({
+      success: false,
+      error: "reverted",
+    });
+
+    await postSwap();
+
+    expect(lastDisposition()).toBe("failed");
+  });
+});

--- a/tests/unit/execute-protocol-route-chain-resolution.test.ts
+++ b/tests/unit/execute-protocol-route-chain-resolution.test.ts
@@ -62,6 +62,28 @@ vi.mock("@/lib/step-registry", () => ({
   PLUGIN_STEP_IMPORTERS: { "test-protocol/swap": () => Promise.resolve({}) },
 }));
 
+// KEEP-793 write-path guards: happy defaults so chain-resolution still reaches
+// writeContractCore. Behavior of these guards is covered in
+// execute-protocol-execution-guards.test.ts.
+vi.mock("@/lib/billing/execution-guard", () => ({
+  enforceExecutionLimit: vi.fn().mockResolvedValue({ blocked: false }),
+}));
+vi.mock("../../app/api/execute/_lib/wallet-check", () => ({
+  requireWallet: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("../../app/api/execute/_lib/spending-cap", () => ({
+  checkAndReserveExecution: vi
+    .fn()
+    .mockResolvedValue({ allowed: true, executionId: "exec_1" }),
+}));
+vi.mock("../../app/api/execute/_lib/execution-service", () => ({
+  markRunning: vi.fn().mockResolvedValue(undefined),
+  completeExecution: vi.fn().mockResolvedValue(undefined),
+  failExecution: vi.fn().mockResolvedValue(undefined),
+  redactInput: (x: unknown) => x,
+  withRejectedSignerOverride: (a: unknown) => a,
+}));
+
 async function postWithBody(body: Record<string, unknown>): Promise<Response> {
   const { POST } = await import("@/app/api/execute/[...slug]/route");
   const req = new Request("http://test/api/execute/test-protocol/swap", {
@@ -73,6 +95,8 @@ async function postWithBody(body: Record<string, unknown>): Promise<Response> {
     params: Promise.resolve({ slug: ["test-protocol", "swap"] }),
   });
 }
+
+const CHAIN_ID_ERROR_RE = /chainId/;
 
 describe("KEEP-490: /api/execute/[...slug] resolves chain names and chainId aliases", () => {
   it("resolves network='sepolia' to chainId 11155111 for contract address lookup", async () => {
@@ -106,7 +130,7 @@ describe("KEEP-490: /api/execute/[...slug] resolves chain names and chainId alia
     const body = (await response.json()) as { error: string };
 
     expect(response.status).toBe(400);
-    expect(body.error).toMatch(/chainId/);
+    expect(body.error).toMatch(CHAIN_ID_ERROR_RE);
   });
 
   it("returns 400 for an unknown chain name", async () => {


### PR DESCRIPTION
The catch-all /api/execute/[...slug] route (backing the agent-callable execute_protocol_action tool) sent protocol write actions straight to writeContractCore, which signs and broadcasts a real transaction from the org wallet. Unlike every other direct write path it never enforced the plan execution limit, checked for a wallet, reserved against the daily spend cap, or created an execution audit row.

Wrap the write branch with enforceExecutionLimit + requireWallet + checkAndReserveExecution and record the execution, mirroring contract-call. Reads stay ungated. Unit tested.