### PR TITLE
fix(security): validate Tempo MPP inner charge amount and recipient

### DIFF
--- a/app/api/agentic-wallet/sign/route.ts
+++ b/app/api/agentic-wallet/sign/route.ts
@@ -72,6 +72,52 @@ const MAX_VALIDITY_SECONDS = 10 * 60;
 // Small slack on validAfter to tolerate clock skew between agent and server.
 const VALID_AFTER_FUTURE_SLACK_SECONDS = 60;
 
+type TempoChargePeek =
+  | { kind: "charge"; amountMicro: string; recipient: string }
+  | { kind: "proof" }
+  | { kind: "invalid" };
+
+/**
+ * Deserialize a Tempo MPP `serialized` challenge to recover the inner,
+ * server-signed transfer amount + recipient. For the charge intent these are
+ * the fund-moving values (`signMppTransaction` signs `request.amount` to
+ * `request.recipient`); the outer caller-supplied `paymentChallenge.amount` /
+ * `payTo` are 0/empty on Tempo and must NOT be trusted. Proof-intent
+ * challenges move no funds. Malformed input is reported as invalid so the
+ * caller gets a 400 rather than silently skipping the amount checks.
+ */
+function peekTempoCharge(serialized: string): TempoChargePeek {
+  try {
+    const input = serialized.startsWith("Payment ")
+      ? serialized
+      : `Payment ${serialized}`;
+    const parsed = Challenge.deserialize(input);
+    if (parsed.intent !== "charge") {
+      return { kind: "proof" };
+    }
+    const request = parsed.request as unknown as {
+      recipient?: unknown;
+      amount?: unknown;
+    };
+    const amount = request?.amount;
+    if (
+      typeof request?.recipient !== "string" ||
+      (typeof amount !== "string" &&
+        typeof amount !== "number" &&
+        typeof amount !== "bigint")
+    ) {
+      return { kind: "invalid" };
+    }
+    return {
+      kind: "charge",
+      amountMicro: String(amount),
+      recipient: request.recipient,
+    };
+  } catch {
+    return { kind: "invalid" };
+  }
+}
+
 function isNonNegativeSafeInt(value: unknown): value is number {
   return (
     typeof value === "number" &&
@@ -249,6 +295,84 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
+  // KEEP-736 / KEEP-737 (F-011 / F-012): on Tempo the fund-moving amount and
+  // recipient live INSIDE the server-signed `serialized` MPP challenge, not in
+  // the outer caller-supplied fields (which are 0/empty). verifyWorkflowBinding
+  // can only equality-check the outer fields, so it skips amount/payTo on
+  // Tempo. Deserialize the challenge up front and cross-check the inner amount
+  // + recipient against the binding here -- the same equality the base/x402
+  // path enforces -- so a stolen HMAC can't pair a cheap cover-workflow slug
+  // with an expensive charge issued for a different workflow. The verified
+  // inner amount then drives the risk classifier (a $50 charge must reach the
+  // ask tier, not auto, even though the outer amount is 0).
+  let effectiveAmountMicro = amountMicro;
+  // For the ask tier, the approval binding + the row stored for /approve must
+  // carry the real recipient/amount. On Tempo those live in `serialized`, so
+  // enrich the challenge with the verified inner values; deriveApprovalBinding
+  // (and the /approve re-derivation) read them from here, while `serialized`
+  // is preserved for the eventual signing.
+  let approvalChallenge: Record<string, unknown> = challenge;
+  if (chain === "tempo") {
+    const serialized =
+      typeof challenge.serialized === "string" ? challenge.serialized : "";
+    if (!serialized) {
+      return Response.json(
+        {
+          error: "paymentChallenge.serialized is required for tempo",
+          code: "MPP_CHALLENGE_MISSING",
+        },
+        { status: 400 }
+      );
+    }
+    const peeked = peekTempoCharge(serialized);
+    if (peeked.kind === "invalid") {
+      return Response.json(
+        {
+          error: "paymentChallenge.serialized is not a valid MPP challenge",
+          code: "MPP_CHALLENGE_INVALID",
+        },
+        { status: 400 }
+      );
+    }
+    if (peeked.kind === "charge") {
+      if (
+        peeked.recipient.toLowerCase() !== binding.expectedPayTo.toLowerCase()
+      ) {
+        return Response.json(
+          {
+            error: "payTo does not match workflow creator wallet",
+            code: "PAYTO_MISMATCH",
+          },
+          { status: 403 }
+        );
+      }
+      let innerMicro: bigint;
+      try {
+        innerMicro = BigInt(peeked.amountMicro);
+      } catch {
+        return Response.json(
+          { error: "amount is not a valid integer", code: "AMOUNT_MISMATCH" },
+          { status: 403 }
+        );
+      }
+      if (innerMicro !== BigInt(binding.expectedAmountMicro)) {
+        return Response.json(
+          {
+            error: "amount does not match workflow priceUsdcPerCall",
+            code: "AMOUNT_MISMATCH",
+          },
+          { status: 403 }
+        );
+      }
+      effectiveAmountMicro = peeked.amountMicro;
+      approvalChallenge = {
+        ...challenge,
+        recipient: peeked.recipient,
+        amount: peeked.amountMicro,
+      };
+    }
+  }
+
   // Wallet address resolution from DB -- NEVER trust any caller-supplied
   // wallet value (T-33-sign-spoofwallet).
   const rows = await db
@@ -270,7 +394,7 @@ export async function POST(request: Request): Promise<Response> {
   const risk = classifyRisk({
     chain,
     challenge: {
-      amount: amountMicro,
+      amount: effectiveAmountMicro,
       payTo: callerPayTo,
       selector:
         typeof challenge.selector === "string" ? challenge.selector : undefined,
@@ -292,7 +416,7 @@ export async function POST(request: Request): Promise<Response> {
     // helper so /sign's ask-tier and /approval-request agree on recipient /
     // amount / chain / contract exactly. Tempo callers that supply
     // `recipient` instead of `payTo` bind consistently here and on /approve.
-    const binding = deriveApprovalBinding(chain, challenge);
+    const binding = deriveApprovalBinding(chain, approvalChallenge);
     if (!binding) {
       return Response.json(
         {
@@ -307,7 +431,7 @@ export async function POST(request: Request): Promise<Response> {
       const ar = await createApprovalRequest({
         subOrgId: auth.subOrgId,
         riskLevel: "ask",
-        operationPayload: { chain, paymentChallenge: challenge },
+        operationPayload: { chain, paymentChallenge: approvalChallenge },
         binding,
       });
       return Response.json(

--- a/tests/integration/agentic-wallet-sign-route.test.ts
+++ b/tests/integration/agentic-wallet-sign-route.test.ts
@@ -28,6 +28,16 @@ import { privateKeyToAccount } from "viem/accounts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { extractPayerAddress } from "@/lib/payments/x402/payment-gate";
 
+// The sign route's real signing deps (lib/agentic-wallet/sign ->
+// lib/turnkey/agentic-wallet) pull in `server-only`, which throws when
+// imported outside an RSC graph. Stub it so the route module loads under the
+// node test environment (matches the unit-test convention).
+vi.mock("server-only", () => ({}));
+
+// 65-byte secp256k1 signature as 0x + 130 hex chars. Hoisted per
+// lint/performance/useTopLevelRegex.
+const SIGNATURE_HEX_RE = /^0x[0-9a-fA-F]{130}$/;
+
 // A realistic mppx-issued Tempo challenge the route can deserialize. Zero
 // amount intentionally routes to proof-mode (signMppProof) so the existing
 // assertions can continue reading EIP-712 typed-data JSON from Turnkey's
@@ -326,7 +336,7 @@ describe("POST /api/agentic-wallet/sign -- EIP-3009 ecrecover round-trip", () =>
     );
     expect(res.status).toBe(200);
     const json = (await res.json()) as { signature: string };
-    expect(json.signature).toMatch(/^0x[0-9a-fA-F]{130}$/);
+    expect(json.signature).toMatch(SIGNATURE_HEX_RE);
 
     // Assertion A: direct ecrecover via viem
     const recovered = await recoverTypedDataAddress({
@@ -921,6 +931,142 @@ describe("POST /api/agentic-wallet/sign -- MPP chainId enum (Phase 37 fix #3)", 
       domain: { chainId: number };
     };
     expect(typedData.domain.chainId).toBe(4217);
+  });
+});
+
+describe("POST /api/agentic-wallet/sign -- Tempo MPP inner-amount validation (KEEP-736 / KEEP-737)", () => {
+  const CREATOR_PAYTO = "0x1111111111111111111111111111111111111111";
+  const ATTACKER_PAYTO = "0x2222222222222222222222222222222222222222";
+
+  // Build a real charge-intent Tempo MPP challenge whose inner request carries
+  // the fund-moving amount + recipient (what signMppTransaction would sign).
+  function buildTempoCharge(amount: string, recipient: string): string {
+    const full = Challenge.serialize(
+      Challenge.from({
+        secretKey: "mpp-route-test-secret",
+        realm: "test.keeperhub.local",
+        method: "tempo",
+        intent: "charge",
+        request: {
+          amount,
+          currency: "0x20c000000000000000000000b9537d11c60e8b50",
+          recipient,
+          methodDetails: { chainId: 4217 },
+        },
+      })
+    );
+    return full.startsWith("Payment ") ? full.slice("Payment ".length) : full;
+  }
+
+  function postTempo(serialized: string): Promise<Response> {
+    const body = JSON.stringify({
+      chain: "tempo",
+      workflowSlug: "test-slug",
+      paymentChallenge: { chainId: 4217, serialized },
+    });
+    const path = "/api/agentic-wallet/sign";
+    return POST(
+      new Request(`http://localhost:3000${path}`, {
+        method: "POST",
+        headers: buildHmacHeaders("subOrg_test", "POST", path, body),
+        body,
+      })
+    );
+  }
+
+  it("blocks the cover-workflow bypass: cheap slug + expensive inner charge (403 AMOUNT_MISMATCH)", async () => {
+    // Binding resolves the cheap cover workflow's price ($0.05); the serialized
+    // challenge encodes a $100 transfer to the same creator.
+    mockVerifyWorkflowBinding.mockResolvedValue({
+      ok: true,
+      expectedPayTo: CREATOR_PAYTO,
+      expectedAmountMicro: "50000",
+      workflowId: "wf_cheap",
+    });
+    const res = await postTempo(buildTempoCharge("100000000", CREATOR_PAYTO));
+
+    expect(res.status).toBe(403);
+    const json = (await res.json()) as { code: string };
+    expect(json.code).toBe("AMOUNT_MISMATCH");
+    // Gate fires before reserve + signer: no cap burn, no broadcast.
+    expect(mockReserveSpend).not.toHaveBeenCalled();
+    expect(mockSignRawPayload).not.toHaveBeenCalled();
+  });
+
+  it("blocks an inner charge that pays a different recipient (403 PAYTO_MISMATCH)", async () => {
+    mockVerifyWorkflowBinding.mockResolvedValue({
+      ok: true,
+      expectedPayTo: CREATOR_PAYTO,
+      expectedAmountMicro: "50000",
+      workflowId: "wf_cheap",
+    });
+    const res = await postTempo(buildTempoCharge("50000", ATTACKER_PAYTO));
+
+    expect(res.status).toBe(403);
+    const json = (await res.json()) as { code: string };
+    expect(json.code).toBe("PAYTO_MISMATCH");
+    expect(mockReserveSpend).not.toHaveBeenCalled();
+    expect(mockSignRawPayload).not.toHaveBeenCalled();
+  });
+
+  it("feeds the inner charge amount to the risk classifier so a $60 charge reaches the ask tier (F-012)", async () => {
+    mockVerifyWorkflowBinding.mockResolvedValue({
+      ok: true,
+      expectedPayTo: CREATOR_PAYTO,
+      expectedAmountMicro: "60000000",
+      workflowId: "wf_pricey",
+    });
+    mockClassifyRisk.mockReturnValue("ask");
+    mockCreateApprovalRequest.mockResolvedValue({ id: "ar_tempo" });
+
+    const res = await postTempo(buildTempoCharge("60000000", CREATOR_PAYTO));
+
+    expect(res.status).toBe(202);
+    // The classifier must see the inner amount, NOT the outer 0.
+    expect(mockClassifyRisk).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chain: "tempo",
+        challenge: expect.objectContaining({ amount: "60000000" }),
+      })
+    );
+    // The ask-tier binding is derived from the inner recipient + amount.
+    expect(mockCreateApprovalRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        binding: expect.objectContaining({
+          recipient: CREATOR_PAYTO,
+          amountMicro: "60000000",
+          chain: "tempo",
+        }),
+      })
+    );
+  });
+
+  it("reaches the signer when the inner charge matches the binding and is under threshold", async () => {
+    mockVerifyWorkflowBinding.mockResolvedValue({
+      ok: true,
+      expectedPayTo: CREATOR_PAYTO,
+      expectedAmountMicro: "50000",
+      workflowId: "wf_cheap",
+    });
+    mockClassifyRisk.mockReturnValue("auto");
+    mockSignRawPayload.mockResolvedValue({
+      activity: {
+        status: "ACTIVITY_STATUS_COMPLETED",
+        result: {
+          signRawPayloadResult: {
+            r: "ab".repeat(32),
+            s: "cd".repeat(32),
+            v: "00",
+          },
+        },
+      },
+    });
+
+    await postTempo(buildTempoCharge("50000", CREATOR_PAYTO));
+
+    // All gates passed: spend reserved and the signer was reached.
+    expect(mockReserveSpend).toHaveBeenCalledOnce();
+    expect(mockSignRawPayload).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
On the Tempo (MPP) charge path the fund-moving amount and recipient live inside the server-signed serialized challenge, while the outer caller-supplied fields are 0/empty. The binding check only equality-checked the outer fields, so a compromised HMAC could pair a cheap cover-workflow slug with an expensive challenge for a different workflow (under-reserving the daily cap) and keep the outer amount at 0 so the risk classifier never escalated a large charge to human approval.

Deserialize the challenge up front, cross-check the inner amount + recipient against the workflow binding, and feed the verified inner amount to the risk classifier. The ask-tier approval payload is enriched with the inner values so the approve re-derivation stays consistent. Proof-intent challenges unchanged. Tested.