### PR TITLE
fix(security): attribute overage records to the invoice that owns their item

### DIFF
--- a/lib/billing/handle-billing-event.ts
+++ b/lib/billing/handle-billing-event.ts
@@ -86,7 +86,7 @@ export async function handleBillingEvent(
       break;
     }
     case "invoice.paid": {
-      await handleInvoicePaid(data);
+      await handleInvoicePaid(data, provider);
       break;
     }
     case "invoice.payment_failed": {
@@ -492,11 +492,23 @@ async function handleSubscriptionDeleted(
 
 async function markOverageRecordsPaid(
   organizationId: string,
-  invoiceId: string
+  invoiceId: string,
+  provider: BillingProvider
 ): Promise<void> {
-  await db
-    .update(overageBillingRecords)
-    .set({ providerInvoiceId: invoiceId })
+  // F-023 / KEEP-748: attribute an overage record to this invoice ONLY when the
+  // record's own invoice item actually belongs to it. The previous behavior
+  // stamped EVERY billed, unattributed record for the org with whatever invoice
+  // happened to be paid -- so an unrelated standalone/manual invoice could
+  // claim all pending overage, and the subsequent scanAndCreateDebt early-return
+  // (providerInvoiceId set + paid) silently waived it. Resolve each record's
+  // invoice via the same getInvoiceForItem path scanAndCreateDebt uses and only
+  // stamp the records whose item resolves to this exact invoice.
+  const rows = await db
+    .select({
+      id: overageBillingRecords.id,
+      providerInvoiceItemId: overageBillingRecords.providerInvoiceItemId,
+    })
+    .from(overageBillingRecords)
     .where(
       and(
         eq(overageBillingRecords.organizationId, organizationId),
@@ -504,10 +516,38 @@ async function markOverageRecordsPaid(
         isNull(overageBillingRecords.providerInvoiceId)
       )
     );
+
+  for (const row of rows) {
+    if (!row.providerInvoiceItemId) {
+      // No item link -> cannot prove this record belongs to the invoice; leave
+      // it unattributed so scanAndCreateDebt re-resolves it later.
+      continue;
+    }
+    let invoiceInfo: Awaited<ReturnType<BillingProvider["getInvoiceForItem"]>>;
+    try {
+      invoiceInfo = await provider.getInvoiceForItem(row.providerInvoiceItemId);
+    } catch (error) {
+      console.error(
+        LOG_PREFIX,
+        "markOverageRecordsPaid: getInvoiceForItem failed",
+        row.id,
+        error
+      );
+      continue;
+    }
+    if (invoiceInfo?.invoiceId !== invoiceId) {
+      continue;
+    }
+    await db
+      .update(overageBillingRecords)
+      .set({ providerInvoiceId: invoiceId })
+      .where(eq(overageBillingRecords.id, row.id));
+  }
 }
 
 async function handleInvoicePaid(
-  data: BillingWebhookEvent["data"]
+  data: BillingWebhookEvent["data"],
+  provider: BillingProvider
 ): Promise<void> {
   const { providerSubscriptionId, invoiceId, providerCustomerId } = data;
 
@@ -537,7 +577,7 @@ async function handleInvoicePaid(
       );
 
     if (sub && invoiceId) {
-      await markOverageRecordsPaid(sub.organizationId, invoiceId);
+      await markOverageRecordsPaid(sub.organizationId, invoiceId, provider);
     }
 
     getMetricsCollector().incrementCounter(MetricNames.BILLING_INVOICE_PAID, {
@@ -570,7 +610,7 @@ async function handleInvoicePaid(
         );
 
       if (invoiceId) {
-        await markOverageRecordsPaid(sub.organizationId, invoiceId);
+        await markOverageRecordsPaid(sub.organizationId, invoiceId, provider);
       }
 
       getMetricsCollector().incrementCounter(MetricNames.BILLING_INVOICE_PAID, {

--- a/tests/unit/billing-handle-event.test.ts
+++ b/tests/unit/billing-handle-event.test.ts
@@ -40,22 +40,32 @@ vi.mocked(db.insert).mockReturnValue({
   values: mockInsertValues,
 } as unknown as ReturnType<typeof db.insert>);
 
-vi.mocked(db.select).mockReturnValue({
-  from: vi.fn().mockReturnValue({
-    where: vi.fn().mockReturnValue({
-      limit: vi.fn().mockResolvedValue([]),
-    }),
-  }),
-} as unknown as ReturnType<typeof db.select>);
-
-function mockSelectReturning(rows: Record<string, unknown>[]): void {
+// db.select serves two query shapes in this module: subscription lookups
+// (.where().limit(1)) and markOverageRecordsPaid (.where() awaited directly).
+// The where() return value is therefore a Promise (resolving to overage rows)
+// that ALSO carries a .limit() resolving to the subscription rows, so both
+// shapes get the right data from one mock.
+function setBillingSelect(
+  limitRows: Record<string, unknown>[],
+  whereRows: Record<string, unknown>[] = []
+): void {
+  const whereResult = Object.assign(Promise.resolve(whereRows), {
+    limit: vi.fn().mockResolvedValue(limitRows),
+  });
   vi.mocked(db.select).mockReturnValue({
     from: vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue({
-        limit: vi.fn().mockResolvedValue(rows),
-      }),
+      where: vi.fn().mockReturnValue(whereResult),
     }),
   } as unknown as ReturnType<typeof db.select>);
+}
+
+setBillingSelect([]);
+
+function mockSelectReturning(
+  rows: Record<string, unknown>[],
+  overageRows: Record<string, unknown>[] = []
+): void {
+  setBillingSelect(rows, overageRows);
 }
 
 function createMockProvider(
@@ -599,6 +609,66 @@ describe("handleBillingEvent", () => {
       await handleBillingEvent(event, provider);
 
       expect(mockClearDebtForInvoice).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("invoice.paid -- overage attribution (F-023 / KEEP-748)", () => {
+    function stampCount(invoiceId: string): number {
+      return mockSet.mock.calls.filter(
+        ([arg]) =>
+          (arg as Record<string, unknown>)?.providerInvoiceId === invoiceId
+      ).length;
+    }
+
+    it("attributes ONLY records whose item belongs to the paid invoice", async () => {
+      mockSelectReturning(
+        [{ organizationId: "org_1", providerSubscriptionId: "sub_1" }],
+        [
+          { id: "ov_match", providerInvoiceItemId: "item_match" },
+          { id: "ov_other", providerInvoiceItemId: "item_other" },
+        ]
+      );
+
+      const provider = createMockProvider({
+        getInvoiceForItem: vi.fn((itemId: string) =>
+          Promise.resolve(
+            itemId === "item_match"
+              ? { invoiceId: "inv_paid", status: "paid", paid: true }
+              : { invoiceId: "inv_unrelated", status: "open", paid: false }
+          )
+        ),
+      });
+      const event = makeEvent("invoice.paid", {
+        providerSubscriptionId: "sub_1",
+        invoiceId: "inv_paid",
+      });
+
+      await handleBillingEvent(event, provider);
+
+      expect(provider.getInvoiceForItem).toHaveBeenCalledWith("item_match");
+      expect(provider.getInvoiceForItem).toHaveBeenCalledWith("item_other");
+      // Only the matching record is stamped with the paid invoice; the record
+      // whose item lives on a different invoice is left untouched (the F-023
+      // laundering the old broad UPDATE allowed).
+      expect(stampCount("inv_paid")).toBe(1);
+    });
+
+    it("never attributes a record that has no invoice-item link", async () => {
+      mockSelectReturning(
+        [{ organizationId: "org_1", providerSubscriptionId: "sub_1" }],
+        [{ id: "ov_noitem", providerInvoiceItemId: null }]
+      );
+
+      const provider = createMockProvider();
+      const event = makeEvent("invoice.paid", {
+        providerSubscriptionId: "sub_1",
+        invoiceId: "inv_paid",
+      });
+
+      await handleBillingEvent(event, provider);
+
+      expect(provider.getInvoiceForItem).not.toHaveBeenCalled();
+      expect(stampCount("inv_paid")).toBe(0);
     });
   });
 


### PR DESCRIPTION
markOverageRecordsPaid stamped every billed, unattributed overage record for an org whenever any invoice was paid, so an unrelated standalone or manual invoice could claim all pending overage and the follow-up debt scan then silently waived it.

Resolve each candidate record's invoice via the same getInvoiceForItem path the debt scan uses and stamp only records whose item belongs to this exact invoice; records with no item link are left for the scan to re-resolve. The billing provider is threaded through from the event handler. Unit tested.