### PR TITLE
fix(security): show and bind the consent org on the OAuth authorize page

### DIFF
--- a/app/oauth/authorize/_lib/consent-binding.ts
+++ b/app/oauth/authorize/_lib/consent-binding.ts
@@ -1,0 +1,20 @@
+/**
+ * F-022 / KEEP-747: the OAuth consent page renders and shows the user a
+ * specific organization, and the approve form carries that org id back as a
+ * hidden field. The access code is scoped to the org resolved from the
+ * cookie-derived active session at submit time -- which can differ from the one
+ * the user saw if they switched their active org in another tab between viewing
+ * the page and clicking Approve. There is no UI signal for the org, so such a
+ * switch would silently mint a token for an unintended org.
+ *
+ * Returns true when the org resolved at submit time no longer matches the org
+ * the user consented to; the caller must refuse the authorization rather than
+ * scope the token to a different org. A missing bound id (e.g. an older form)
+ * is treated as no mismatch so the guard never breaks a legitimate flow.
+ */
+export function isConsentOrgMismatch(
+  consentedOrgId: string | null | undefined,
+  currentOrgId: string
+): boolean {
+  return Boolean(consentedOrgId) && consentedOrgId !== currentOrgId;
+}

--- a/app/oauth/authorize/page.tsx
+++ b/app/oauth/authorize/page.tsx
@@ -1,10 +1,10 @@
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
 import {
   isAnonymousUserShape,
   logAnonymousExecutionBlock,
 } from "@/lib/auth-anonymous-guard";
-import { auth } from "@/lib/auth";
 import { parseScopes } from "@/lib/mcp/oauth-scopes";
 import {
   AUTH_CODE_TTL_MS,
@@ -13,6 +13,7 @@ import {
 } from "@/lib/mcp/oauth-store";
 import { isAllowedRedirectUri } from "@/lib/mcp/redirect-uri";
 import { getOrgContext } from "@/lib/middleware/org-context";
+import { isConsentOrgMismatch } from "./_lib/consent-binding";
 
 type AuthorizeSearchParams = {
   client_id?: string;
@@ -74,6 +75,16 @@ async function handleApprove(formData: FormData): Promise<void> {
 
   const orgContext = await getOrgContext();
   const organizationId = orgContext.organization?.id ?? session.user.id;
+
+  // F-022 / KEEP-747: the consent page rendered (and showed the user) a
+  // specific org and bound its id into the form. If the active org changed
+  // between viewing the page and approving (e.g. switched in another tab), the
+  // org resolved here no longer matches what the user consented to -- refuse
+  // rather than silently scope the token to a different org.
+  const consentedOrgId = formData.get("organization_id") as string | null;
+  if (isConsentOrgMismatch(consentedOrgId, organizationId)) {
+    errorRedirect(redirectUri, "access_denied", state ?? undefined);
+  }
 
   const code = crypto.randomUUID().replace(/-/g, "");
   await storeAuthCode({
@@ -240,6 +251,14 @@ export default async function AuthorizePage({
     );
   }
 
+  // F-022 / KEEP-747: resolve the org the token will be scoped to and show it,
+  // then bind its id into the approve form so the user explicitly consents to
+  // this specific org and handleApprove can reject a mid-flow org switch.
+  const consentOrgContext = await getOrgContext();
+  const consentOrgId = consentOrgContext.organization?.id ?? session.user.id;
+  const consentOrgName =
+    consentOrgContext.organization?.name ?? "your personal account";
+
   const resolvedScope = scope ?? "mcp:read mcp:write";
   const scopeList = parseScopes(resolvedScope);
 
@@ -300,6 +319,13 @@ export default async function AuthorizePage({
           </div>
 
           <p className="mt-5 text-sm text-muted-foreground">
+            Authorizing access to{" "}
+            <span className="font-medium text-foreground">
+              {consentOrgName}
+            </span>
+          </p>
+
+          <p className="mt-1 text-sm text-muted-foreground">
             Signed in as{" "}
             <span className="font-medium text-foreground">
               {session.user.email}
@@ -324,6 +350,7 @@ export default async function AuthorizePage({
           <form action={handleApprove}>
             <input name="client_id" type="hidden" value={clientId} />
             <input name="redirect_uri" type="hidden" value={redirectUri} />
+            <input name="organization_id" type="hidden" value={consentOrgId} />
             <input name="scope" type="hidden" value={resolvedScope} />
             {state && <input name="state" type="hidden" value={state} />}
             <input name="code_challenge" type="hidden" value={codeChallenge} />

--- a/tests/unit/oauth-authorize-consent-binding.test.ts
+++ b/tests/unit/oauth-authorize-consent-binding.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { isConsentOrgMismatch } from "@/app/oauth/authorize/_lib/consent-binding";
+
+describe("isConsentOrgMismatch (F-022 / KEEP-747)", () => {
+  it("is false when the consented org matches the org resolved at submit time", () => {
+    expect(isConsentOrgMismatch("org_acme", "org_acme")).toBe(false);
+  });
+
+  it("is true when the active org changed between render and approve", () => {
+    // User saw + consented to org_acme but switched to org_personal in another
+    // tab before clicking Approve.
+    expect(isConsentOrgMismatch("org_acme", "org_personal")).toBe(true);
+  });
+
+  it("is false when no org was bound (backward-compatible older form)", () => {
+    expect(isConsentOrgMismatch(null, "org_acme")).toBe(false);
+    expect(isConsentOrgMismatch(undefined, "org_acme")).toBe(false);
+    expect(isConsentOrgMismatch("", "org_acme")).toBe(false);
+  });
+});


### PR DESCRIPTION
The authorize page resolved the token's org from the cookie-active session at click time and never showed which org the token would scope to. A multi-org user who switched their active org in another tab between viewing the page and approving would silently mint a token for an unintended org.

Render the resolved org on the consent screen, bind its id into the approve form, and reject when the org resolved at submit time no longer matches the consented one. A missing bound id stays backward compatible. Unit tested.