### PR TITLE
fix(executor): stamp workflow version hash on every execution trigger

### DIFF
--- a/app/api/internal/executions/route.ts
+++ b/app/api/internal/executions/route.ts
@@ -12,6 +12,7 @@ import {
   buildAttribution,
   type TriggerSource,
 } from "@/lib/security/request-attribution";
+import { hashWorkflowDefinition } from "@/lib/workflow/content-hash";
 
 const VALID_TRIGGER_SOURCES: readonly TriggerSource[] = [
   "manual",
@@ -72,6 +73,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       organizationId: true,
       deletedAt: true,
       nodes: true,
+      edges: true,
       userId: true,
     },
   });
@@ -123,6 +125,13 @@ export async function POST(request: Request): Promise<NextResponse> {
           billable: !isPhantom,
           input: input || {},
           ...attribution,
+          // Tie the run to the workflow version that fired it. For phantoms the
+          // executor restamps this with the definition it actually loads at run
+          // time; this value links the row even if that restamp never lands.
+          executedWorkflowHash: hashWorkflowDefinition(
+            workflow.nodes,
+            workflow.edges
+          ),
         })
         .returning({ id: workflowExecutions.id })
   );

--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -42,6 +42,7 @@ import {
 import { applyRateLimitHeaders } from "@/lib/rate-limit-headers";
 import { withBackstopCapture } from "@/lib/security/backstop-capture";
 import { buildAttribution } from "@/lib/security/request-attribution";
+import { hashWorkflowDefinition } from "@/lib/workflow/content-hash";
 import { workflowReachableConditions } from "@/lib/workflow/executable";
 import { buildExecutorInput } from "@/lib/workflow/executor/build-executor-input";
 import { executeWorkflow } from "@/lib/workflow/executor/executor.workflow";
@@ -162,6 +163,12 @@ async function prepareExecution(
           status: "running",
           input: body,
           ...attribution,
+          // Tie the run to the definition that executed, so it resolves to a
+          // workflow_history version by content hash like every other trigger.
+          executedWorkflowHash: hashWorkflowDefinition(
+            workflow.nodes,
+            workflow.edges
+          ),
         })
         .returning()
   );

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -43,6 +43,7 @@ import { withBackstopCapture } from "../lib/security/backstop-capture";
 import { buildAttribution } from "../lib/security/request-attribution";
 import { generateId } from "../lib/utils/id";
 import { checkConcurrencyLimit } from "../lib/workflow/concurrency";
+import { hashWorkflowDefinition } from "../lib/workflow/content-hash";
 import { getWorkflowExecutability } from "../lib/workflow/executable";
 import type { WorkflowNode } from "../lib/workflow/store";
 import { type ApiExecuteTriggerType, executeViaApi } from "./api-execute";
@@ -394,13 +395,22 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
   // there is no phantom to upgrade -- a legacy message with no id, or a phantom
   // that is missing (best-effort create failed) or already advanced (a
   // duplicate SQS delivery won the upgrade) -- so a run is never dropped.
+  //
+  // Hash of the definition the executor actually loaded, so schedule / block /
+  // event runs link to their workflow_history version like manual / webhook do.
+  const executedWorkflowHash = hashWorkflowDefinition(
+    workflow.nodes,
+    workflow.edges
+  );
+
   let executionId = generateId();
   let upgraded = false;
   if (message.executionId) {
     upgraded = await upgradePhantomToPending(
       db,
       message.executionId,
-      serializedInput
+      serializedInput,
+      executedWorkflowHash
     );
     if (upgraded) {
       executionId = message.executionId;
@@ -424,6 +434,7 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
         status: "pending",
         input: serializedInput,
         ...attribution,
+        executedWorkflowHash,
       })
     );
   }

--- a/keeperhub-executor/lib/db-helpers.ts
+++ b/keeperhub-executor/lib/db-helpers.ts
@@ -72,14 +72,16 @@ export async function updateExecutionStatus(
 export async function upgradePhantomToPending(
   db: PostgresJsDatabase<DbSchema>,
   executionId: string,
-  input: Record<string, unknown>
+  input: Record<string, unknown>,
+  executedWorkflowHash: string
 ): Promise<boolean> {
   const result = await db
     .update(workflowExecutions)
     // KEEP-693: the phantom was created billable=false (it had not run yet);
     // upgrading to pending means it is now a real execution, so it becomes
-    // billable like any owner-initiated run.
-    .set({ status: "pending", input, billable: true })
+    // billable like any owner-initiated run. Stamp the hash of the definition
+    // the executor just loaded so the run links to its workflow_history version.
+    .set({ status: "pending", input, billable: true, executedWorkflowHash })
     .where(
       and(
         eq(workflowExecutions.id, executionId),

--- a/tests/e2e/vitest/phantom-upgrade.test.ts
+++ b/tests/e2e/vitest/phantom-upgrade.test.ts
@@ -34,6 +34,10 @@ const DATABASE_URL = process.env.DATABASE_URL ?? "";
 
 const PREFIX = "test_keep693_phantom_";
 
+// Content hash the executor stamps when it claims the phantom; the test passes
+// a fixed value since it drives the helper directly without loading a workflow.
+const HASH = "test_executed_workflow_hash";
+
 type ExecutionStatus =
   | "pending"
   | "running"
@@ -125,21 +129,30 @@ describe.skipIf(SKIP)("upgradePhantomToPending", () => {
     const id = `${PREFIX}claim`;
     await seedExecution(id, "phantom");
 
-    const upgraded = await upgradePhantomToPending(execDb, id, {
-      triggered: 1,
-    });
+    const upgraded = await upgradePhantomToPending(
+      execDb,
+      id,
+      { triggered: 1 },
+      HASH
+    );
 
     expect(upgraded).toBe(true);
     const row = await readExecution(id);
     expect(row.status).toBe("pending");
     expect(row.input).toEqual({ triggered: 1 });
+    expect(row.executedWorkflowHash).toBe(HASH);
   });
 
   it("is a no-op (returns false) when the row is not phantom", async () => {
     const id = `${PREFIX}running`;
     await seedExecution(id, "running", { original: true });
 
-    const upgraded = await upgradePhantomToPending(execDb, id, { stamped: 2 });
+    const upgraded = await upgradePhantomToPending(
+      execDb,
+      id,
+      { stamped: 2 },
+      HASH
+    );
 
     expect(upgraded).toBe(false);
     const row = await readExecution(id);
@@ -152,7 +165,8 @@ describe.skipIf(SKIP)("upgradePhantomToPending", () => {
     const upgraded = await upgradePhantomToPending(
       execDb,
       `${PREFIX}missing`,
-      {}
+      {},
+      HASH
     );
     expect(upgraded).toBe(false);
   });
@@ -161,8 +175,8 @@ describe.skipIf(SKIP)("upgradePhantomToPending", () => {
     const id = `${PREFIX}dup`;
     await seedExecution(id, "phantom");
 
-    const first = await upgradePhantomToPending(execDb, id, { n: 1 });
-    const second = await upgradePhantomToPending(execDb, id, { n: 2 });
+    const first = await upgradePhantomToPending(execDb, id, { n: 1 }, HASH);
+    const second = await upgradePhantomToPending(execDb, id, { n: 2 }, HASH);
 
     expect(first).toBe(true);
     expect(second).toBe(false);
@@ -182,7 +196,7 @@ describe.skipIf(SKIP)("upgradePhantomToPending", () => {
       billable: false,
     });
 
-    const upgraded = await upgradePhantomToPending(execDb, id, {});
+    const upgraded = await upgradePhantomToPending(execDb, id, {}, HASH);
 
     expect(upgraded).toBe(true);
     const row = await readExecution(id);


### PR DESCRIPTION
Executions store executedWorkflowHash (a content hash of nodes + edges) so a run resolves to its workflow_history version by an indexed equality join. Only the manual and webhook trigger paths stamped it. MCP calls and every executor-driven trigger (scheduled, block, event) did not, so those runs were not linked to any version, and the finalize path never backfills the column.

## What changed

Stamp the hash at every point an execution row is created, always from the definition that actually runs:

- **MCP call route** (`app/api/mcp/workflows/[slug]/call/route.ts`): the workflow is already loaded with nodes + edges; stamp on insert.
- **Internal executions route** (`app/api/internal/executions/route.ts`): load `edges` alongside `nodes` and stamp on the phantom/direct-run insert. This links scheduled/block/event runs at creation time even if the executor restamp never lands.
- **Executor** (`keeperhub-executor/index.ts`, `lib/db-helpers.ts`): hash the definition the executor loads to run, and apply it on both the phantom-upgrade UPDATE and the no-phantom fallback insert. This is the run-time authority: if the workflow was edited between phantom creation and execution, the row reflects the version that actually ran.

The hash uses the shared `hashWorkflowDefinition`, so all paths agree on the same value (cosmetic state like node position is excluded, matching the history version logic).

## Notes

- The executor changes ship with the standalone `keeperhub-executor` service; the route-level stamps cover scheduled/block/event runs regardless of when that service redeploys.
- Existing executions created before this change keep a null hash. A backfill (resolve `executedWorkflowHash` from the current definition, or leave null for runs whose definition has since changed) can be a follow-up if we want historical linkage.