### PR TITLE
fix(api): let org members read a workflow's version history

### DIFF
--- a/app/api/workflows/[workflowId]/history/route.ts
+++ b/app/api/workflows/[workflowId]/history/route.ts
@@ -5,15 +5,15 @@ import { users, workflowHistory, workflows } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { buildPage, parsePageRequest } from "@/lib/pagination";
-import { isOrgAdmin } from "@/lib/security/org-role";
 import { getWorkflowAccess } from "@/lib/workflow/access";
 
 /**
- * Version timeline for a workflow. Admin/owner only (history is an audit
- * trail), scoped to the workflow's org. Returns the lightweight per-version
- * metadata + diff (`change`) for the timeline; the heavy snapshot is fetched
- * on demand via GET /api/workflows/[id]?version=N. `changedBy` is enriched
- * with the actor's name/email so the UI can show "who".
+ * Version timeline for a workflow. Any current member of the workflow's org can
+ * read it -- it's the edit history of a workflow they already have full access
+ * to, not the org-wide security audit (that stays admin/owner only). Returns the
+ * lightweight per-version metadata + diff (`change`) for the timeline; the heavy
+ * snapshot is fetched on demand via GET /api/workflows/[id]?version=N.
+ * `changedBy` is enriched with the actor's name/email so the UI can show "who".
  */
 export async function GET(
   request: Request,
@@ -45,10 +45,7 @@ export async function GET(
       organizationId,
       authMethod: authContext.authMethod,
     });
-    if (
-      !(access.hasFullAccess && userId && workflow.organizationId) ||
-      !(await isOrgAdmin(userId, workflow.organizationId))
-    ) {
+    if (!(access.hasFullAccess && userId && workflow.organizationId)) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -25,7 +25,6 @@ import {
 } from "@/lib/schedule-service";
 import { sanitizeDescription } from "@/lib/sanitize-description";
 import { buildAuditMetadata, recordAuditEvent } from "@/lib/security/audit-log";
-import { isOrgAdmin } from "@/lib/security/org-role";
 import { getWorkflowAccess } from "@/lib/workflow/access";
 import { hashWorkflowDefinition } from "@/lib/workflow/content-hash";
 import { recordWorkflowSnapshot } from "@/lib/workflow/history";
@@ -137,19 +136,17 @@ export async function GET(
 
     const hasFullAccess = access.hasFullAccess;
 
-    // ?version=N returns a historical snapshot instead of the live row.
-    // History is an audit trail, so it is gated to org admins/owners with
-    // full workflow access, scoped to the workflow's org.
+    // ?version=N returns a historical snapshot instead of the live row. It is
+    // the edit history of a workflow the caller already has full access to, so
+    // any current org member can read it (same gate as the /history timeline);
+    // the org-wide security audit stays admin/owner only elsewhere.
     const versionParam = new URL(request.url).searchParams.get("version");
     if (versionParam !== null) {
       const versionNumber = Number.parseInt(versionParam, 10);
       if (Number.isNaN(versionNumber)) {
         return NextResponse.json({ error: "Invalid version" }, { status: 400 });
       }
-      if (
-        !(hasFullAccess && userId && workflow.organizationId) ||
-        !(await isOrgAdmin(userId, workflow.organizationId))
-      ) {
+      if (!(hasFullAccess && userId && workflow.organizationId)) {
         return NextResponse.json({ error: "Forbidden" }, { status: 403 });
       }
       const [historyRow] = await db


### PR DESCRIPTION
A regular org member got a 403 on the workflow History tab (right sidebar) for a workflow they already have full access to. The version timeline (`GET /api/workflows/[id]/history`) and the historical-snapshot fetch (`GET /api/workflows/[id]?version=N`) were both gated on `isOrgAdmin`.

Workflow version history is the edit history of that specific workflow, not the org-wide security audit. Any current member of the workflow's org should be able to read it, the same way they can already open and edit the workflow. The org-wide activity/audit feed stays admin/owner only.

## What changed

Both routes drop the `isOrgAdmin` requirement and keep the existing org-membership gate (`hasFullAccess`, i.e. a current member acting in the workflow's org):

- `app/api/workflows/[workflowId]/history/route.ts` -- the version timeline list.
- `app/api/workflows/[workflowId]/route.ts` -- the `?version=N` snapshot fetch, so members can open a version, not just list them.

Public/unlisted/private visibility and soft-delete handling are unchanged; non-members still cannot read private workflows.