### PR TITLE
feat(activity): move org activity to a dedicated page with search

### DIFF
--- a/app/activity/layout.tsx
+++ b/app/activity/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Activity | KeeperHub",
+  description: "Recent security-sensitive actions across your organization",
+};
+
+export default function ActivityLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  return <>{children}</>;
+}

--- a/app/activity/page.tsx
+++ b/app/activity/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ActivityPage } from "@/components/activity/activity-page";
+
+export default function ActivityRoute(): React.ReactElement {
+  return <ActivityPage />;
+}

--- a/app/api/security/audit/route.ts
+++ b/app/api/security/audit/route.ts
@@ -1,4 +1,15 @@
-import { and, count, desc, eq, gte, inArray, lte, or } from "drizzle-orm";
+import {
+  and,
+  count,
+  desc,
+  eq,
+  gte,
+  ilike,
+  inArray,
+  lte,
+  or,
+  sql,
+} from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
@@ -16,6 +27,13 @@ import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
 import { buildPage, parsePageRequest } from "@/lib/pagination";
 import { redactAuditDiff } from "@/lib/security/audit-redaction";
+
+// Max characters honored from the free-text search; longer input is truncated
+// so a pathological query can't blow up the LIKE scan.
+const MAX_SEARCH_LENGTH = 200;
+// LIKE wildcards + the escape char, neutralized so the user's text is matched
+// literally rather than acting as a pattern.
+const LIKE_SPECIAL = /[\\%_]/g;
 
 /**
  * Read the org's security audit trail. Sensitive forensic data, so it is
@@ -148,6 +166,69 @@ export async function GET(request: Request) {
     if (toDate && !Number.isNaN(toDate.getTime())) {
       conditions.push(lte(securityAuditLog.createdAt, toDate));
     }
+
+    // Free-text search across the human-meaningful fields: the denormalized
+    // actor label, the action, the resource id, the actor's current name/email,
+    // matching workflow names, and the request IP. Every comparison is a
+    // parameterized ILIKE (Drizzle binds the value, so no SQL injection) with
+    // the user's wildcards escaped so the text matches literally. The IP lives
+    // in the metadata JSONB and is matched through Postgres' `->>` accessor, so
+    // the filter runs in the database rather than by scanning rows in JS.
+    const q = (url.searchParams.get("q") ?? "")
+      .trim()
+      .slice(0, MAX_SEARCH_LENGTH);
+    if (q) {
+      const pattern = `%${q.replace(LIKE_SPECIAL, (c) => `\\${c}`)}%`;
+      const [matchedActors, matchedWorkflows] = await Promise.all([
+        db
+          .select({ id: users.id })
+          .from(users)
+          .innerJoin(
+            member,
+            and(
+              eq(member.userId, users.id),
+              eq(member.organizationId, organizationId)
+            )
+          )
+          .where(or(ilike(users.name, pattern), ilike(users.email, pattern))),
+        db
+          .select({ id: workflows.id })
+          .from(workflows)
+          .where(
+            and(
+              eq(workflows.organizationId, organizationId),
+              ilike(workflows.name, pattern)
+            )
+          ),
+      ]);
+      const searchConditions = [
+        ilike(securityAuditLog.actorLabel, pattern),
+        ilike(securityAuditLog.action, pattern),
+        ilike(securityAuditLog.resourceId, pattern),
+        sql`(${securityAuditLog.metadata} ->> 'ip') ILIKE ${pattern}`,
+      ];
+      if (matchedActors.length > 0) {
+        searchConditions.push(
+          inArray(
+            securityAuditLog.actorUserId,
+            matchedActors.map((a) => a.id)
+          )
+        );
+      }
+      if (matchedWorkflows.length > 0) {
+        searchConditions.push(
+          inArray(
+            securityAuditLog.resourceId,
+            matchedWorkflows.map((w) => w.id)
+          )
+        );
+      }
+      const searchClause = or(...searchConditions);
+      if (searchClause) {
+        conditions.push(searchClause);
+      }
+    }
+
     const where = and(...conditions);
 
     const [{ total }] = await db

--- a/app/api/security/audit/route.ts
+++ b/app/api/security/audit/route.ts
@@ -169,17 +169,26 @@ export async function GET(request: Request) {
 
     // Free-text search across the human-meaningful fields: the denormalized
     // actor label, the action, the resource id, the actor's current name/email,
-    // matching workflow names, and the request IP. Every comparison is a
-    // parameterized ILIKE (Drizzle binds the value, so no SQL injection) with
-    // the user's wildcards escaped so the text matches literally. The IP lives
-    // in the metadata JSONB and is matched through Postgres' `->>` accessor, so
-    // the filter runs in the database rather than by scanning rows in JS.
+    // matching resource NAMES (workflows, integrations by name or type, org and
+    // personal API keys), and the request IP. Resource rows carry only ids, so
+    // names are resolved to id sets first and matched back via resourceId. Every
+    // comparison is a parameterized ILIKE (Drizzle binds the value, so no SQL
+    // injection) with the user's wildcards escaped so the text matches
+    // literally. The IP lives in the metadata JSONB and is matched through
+    // Postgres' `->>` accessor, so the filter runs in the database rather than
+    // by scanning rows in JS.
     const q = (url.searchParams.get("q") ?? "")
       .trim()
       .slice(0, MAX_SEARCH_LENGTH);
     if (q) {
       const pattern = `%${q.replace(LIKE_SPECIAL, (c) => `\\${c}`)}%`;
-      const [matchedActors, matchedWorkflows] = await Promise.all([
+      const [
+        matchedActors,
+        matchedWorkflows,
+        matchedIntegrations,
+        matchedOrgKeys,
+        matchedPersonalKeys,
+      ] = await Promise.all([
         db
           .select({ id: users.id })
           .from(users)
@@ -200,7 +209,42 @@ export async function GET(request: Request) {
               ilike(workflows.name, pattern)
             )
           ),
+        // Integrations match on the display name OR the provider type, so
+        // "discord" finds Discord connections even when left unnamed.
+        db
+          .select({ id: integrations.id })
+          .from(integrations)
+          .where(
+            and(
+              eq(integrations.organizationId, organizationId),
+              or(
+                ilike(integrations.name, pattern),
+                ilike(integrations.type, pattern)
+              )
+            )
+          ),
+        db
+          .select({ id: organizationApiKeys.id })
+          .from(organizationApiKeys)
+          .where(
+            and(
+              eq(organizationApiKeys.organizationId, organizationId),
+              ilike(organizationApiKeys.name, pattern)
+            )
+          ),
+        // Personal/webhook keys are user-scoped; the org-scoped audit query
+        // already bounds which of these ids can surface, so no org filter here.
+        db
+          .select({ id: apiKeys.id })
+          .from(apiKeys)
+          .where(ilike(apiKeys.name, pattern)),
       ]);
+      const resourceIdMatches = [
+        ...matchedWorkflows.map((w) => w.id),
+        ...matchedIntegrations.map((i) => i.id),
+        ...matchedOrgKeys.map((k) => k.id),
+        ...matchedPersonalKeys.map((k) => k.id),
+      ];
       const searchConditions = [
         ilike(securityAuditLog.actorLabel, pattern),
         ilike(securityAuditLog.action, pattern),
@@ -215,12 +259,9 @@ export async function GET(request: Request) {
           )
         );
       }
-      if (matchedWorkflows.length > 0) {
+      if (resourceIdMatches.length > 0) {
         searchConditions.push(
-          inArray(
-            securityAuditLog.resourceId,
-            matchedWorkflows.map((w) => w.id)
-          )
+          inArray(securityAuditLog.resourceId, resourceIdMatches)
         );
       }
       const searchClause = or(...searchConditions);

--- a/components/activity/activity-feed.tsx
+++ b/components/activity/activity-feed.tsx
@@ -536,9 +536,22 @@ export function ActivityFeed({
     } else {
       next.delete("size");
     }
+    if (search) {
+      next.set("q", search);
+    } else {
+      next.delete("q");
+    }
     const qs = next.toString();
     router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
-  }, [syncPageToUrl, page, limit, urlPageSizeDefault, pathname, router]);
+  }, [
+    syncPageToUrl,
+    page,
+    limit,
+    search,
+    urlPageSizeDefault,
+    pathname,
+    router,
+  ]);
 
   // Capture the settled content height so the skeleton can hold it on the next
   // load. Without this the embedded feed (no fixed box) collapses to the

--- a/components/activity/activity-feed.tsx
+++ b/components/activity/activity-feed.tsx
@@ -255,7 +255,13 @@ function ActivityRow({
         </span>
         <span className="flex shrink-0 items-center gap-1 whitespace-nowrap text-muted-foreground">
           {capitalize(phrase)}
-          {canOpen && <ChevronRight className="size-3.5" />}
+          {/* Always reserve the chevron slot so non-openable rows keep their
+              label aligned with openable ones. */}
+          {canOpen ? (
+            <ChevronRight className="size-3.5" />
+          ) : (
+            <span aria-hidden="true" className="size-3.5" />
+          )}
         </span>
       </div>
       {resourceName && (

--- a/components/activity/activity-feed.tsx
+++ b/components/activity/activity-feed.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChevronRight, Minus, Pencil, Plus } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ApiKeysOverlay } from "@/components/overlays/api-keys-overlay";
 import { IntegrationsOverlay } from "@/components/overlays/integrations-overlay";
@@ -267,7 +267,7 @@ function ActivityRow({
   );
 
   return (
-    <li className="flex items-start gap-3 py-2.5">
+    <li className="flex items-start gap-3 py-3">
       <ActorAvatarBadge
         actor={actor}
         badgeClassName={KIND_COLOR[kind]}
@@ -343,7 +343,7 @@ const SKELETON_KEYS = ["a", "b", "c", "d", "e", "f"] as const;
 
 function SkeletonRow(): React.ReactElement {
   return (
-    <li className="flex items-start gap-3 py-2.5">
+    <li className="flex items-start gap-3 py-3">
       <Skeleton className="size-7 shrink-0 rounded-full" />
       <div className="flex-1 space-y-2 py-0.5">
         <Skeleton className="h-3.5 w-2/5" />
@@ -358,6 +358,8 @@ export function ActivityFeed({
   params,
   fallback,
   embedded = false,
+  fillHeight = false,
+  syncPageToUrl = false,
 }: {
   params?: FeedParams;
   fallback?: SecurityAuditEvent[];
@@ -367,6 +369,18 @@ export function ActivityFeed({
    * and avoid a nested second scrollbar; the parent owns scrolling.
    */
   embedded?: boolean;
+  /**
+   * Full-page mode: the feed grows to fill its flex parent and the pager is
+   * pinned to the bottom of that space (the list scrolls between header and
+   * pager). The parent must be a flex column with a bounded height.
+   */
+  fillHeight?: boolean;
+  /**
+   * Reflect the current page in the URL (`?page=N`) and seed the initial page
+   * from it, so the feed is deep-linkable and survives refresh/back. Only makes
+   * sense for a route-backed feed, not an overlay.
+   */
+  syncPageToUrl?: boolean;
 }): React.ReactElement {
   const resourceType = params?.resourceType;
   const resourceTypes = params?.resourceTypes;
@@ -386,6 +400,11 @@ export function ActivityFeed({
   // (deep-linked to the exact version when known); integrations and API keys
   // open their management modal on top of the feed.
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const initialPage = syncPageToUrl
+    ? Math.max(1, Number.parseInt(searchParams.get("page") ?? "", 10) || 1)
+    : 1;
   const { closeAll, push } = useOverlay();
   const openResource = useCallback(
     (event: SecurityAuditEvent) => {
@@ -422,6 +441,7 @@ export function ActivityFeed({
   const {
     items: events,
     meta,
+    page,
     setPage,
     loading,
     error,
@@ -457,8 +477,28 @@ export function ActivityFeed({
       from,
       to,
       limit,
-    })
+    }),
+    { initialPage }
   );
+
+  // Reflect the active page in the URL when asked (route-backed feed only), and
+  // drop the param on page 1 / filter resets so the URL stays clean. Reading
+  // searchParams here only to preserve sibling params; it is intentionally not
+  // a dep -- our own replace would otherwise loop.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see note above
+  useEffect(() => {
+    if (!syncPageToUrl) {
+      return;
+    }
+    const next = new URLSearchParams(searchParams.toString());
+    if (page > 1) {
+      next.set("page", String(page));
+    } else {
+      next.delete("page");
+    }
+    const qs = next.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  }, [syncPageToUrl, page, pathname, router]);
 
   // Capture the settled content height so the skeleton can hold it on the next
   // load. Without this the embedded feed (no fixed box) collapses to the
@@ -467,30 +507,44 @@ export function ActivityFeed({
   const listRef = useRef<HTMLDivElement>(null);
   const [reservedHeight, setReservedHeight] = useState<number>();
   useEffect(() => {
-    if (embedded && !loading && listRef.current) {
+    if (embedded && !fillHeight && !loading && listRef.current) {
       setReservedHeight(listRef.current.offsetHeight);
     }
-  }, [embedded, loading]);
+  }, [embedded, fillHeight, loading]);
 
-  // Fixed-height scroll region (when a page size is set) so the modal never
-  // resizes: the skeleton, every page, and the empty/error states all occupy
-  // the same box, and content taller than the box scrolls inside it instead of
-  // growing the modal. The Pager lives outside this box so it stays put.
-  const scrollClass = embedded
-    ? ""
-    : `thin-scrollbar overflow-y-auto ${limit ? "h-[32rem]" : ""}`;
+  // Three layout modes:
+  // - fillHeight (full page): the list grows to fill the flex parent and scrolls
+  //   internally, so the Pager stays pinned at the bottom of the viewport.
+  // - embedded (already-scrolling overlay): no box, the parent owns scrolling.
+  // - default (per-resource overlay): a fixed-height box so the modal never
+  //   resizes; content taller than the box scrolls inside it.
+  let scrollClass: string;
+  if (fillHeight) {
+    scrollClass = "thin-scrollbar min-h-0 flex-1 overflow-y-auto";
+  } else if (embedded) {
+    scrollClass = "";
+  } else {
+    scrollClass = `thin-scrollbar overflow-y-auto ${limit ? "h-[32rem]" : ""}`;
+  }
+
+  // In fillHeight mode the feed is a flex column so the list (flex-1) pushes the
+  // Pager to the bottom; other modes keep the natural block flow.
+  const rootClass = fillHeight ? "flex min-h-0 flex-1 flex-col" : undefined;
+  const pagerClass = fillHeight ? "border-border/60 border-t pt-3" : "pt-2";
 
   // Skeletons show on every load in both modes. In the fixed box the swap is
   // absorbed; when embedded, the skeleton holds the last content height
   // (reservedHeight) so the modal doesn't jump.
   if (loading) {
     return (
-      <div>
+      <div className={rootClass}>
         <div
           className={scrollClass}
-          style={embedded ? { minHeight: reservedHeight } : undefined}
+          style={
+            embedded && !fillHeight ? { minHeight: reservedHeight } : undefined
+          }
         >
-          <ul className="divide-y divide-border/60">
+          <ul>
             {SKELETON_KEYS.slice(
               0,
               Math.min(limit ?? 3, SKELETON_KEYS.length)
@@ -500,7 +554,7 @@ export function ActivityFeed({
           </ul>
         </div>
         {meta && (
-          <div className="pt-2">
+          <div className={pagerClass}>
             <Pager meta={meta} onPage={setPage} unit="events" />
           </div>
         )}
@@ -533,14 +587,14 @@ export function ActivityFeed({
   const groups = groupByDate(merged, (e) => e.createdAt);
 
   return (
-    <div>
-      <div className={`${scrollClass} space-y-4`} ref={listRef}>
+    <div className={rootClass}>
+      <div className={scrollClass} ref={listRef}>
         {groups.map((group) => (
           <div key={group.label}>
-            <p className="sticky top-0 z-10 bg-background py-1 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+            <p className="sticky top-0 z-10 mb-2 border-border/60 border-b bg-background pt-6 pb-2 font-medium text-muted-foreground text-xs uppercase tracking-wide first:pt-0">
               {group.label}
             </p>
-            <ul className="divide-y divide-border/60">
+            <ul>
               {group.items.map((event) => (
                 <ActivityRow
                   event={event}
@@ -555,7 +609,7 @@ export function ActivityFeed({
         ))}
       </div>
       {meta && (
-        <div className="pt-2">
+        <div className={pagerClass}>
           <Pager meta={meta} onPage={setPage} unit="events" />
         </div>
       )}

--- a/components/activity/activity-feed.tsx
+++ b/components/activity/activity-feed.tsx
@@ -360,6 +360,7 @@ export function ActivityFeed({
   embedded = false,
   fillHeight = false,
   syncPageToUrl = false,
+  urlPageSizeDefault,
 }: {
   params?: FeedParams;
   fallback?: SecurityAuditEvent[];
@@ -376,11 +377,18 @@ export function ActivityFeed({
    */
   fillHeight?: boolean;
   /**
-   * Reflect the current page in the URL (`?page=N`) and seed the initial page
-   * from it, so the feed is deep-linkable and survives refresh/back. Only makes
-   * sense for a route-backed feed, not an overlay.
+   * Reflect the current page and page size in the URL (`?page=N&size=M`) and
+   * seed them from it, so the feed is deep-linkable and survives refresh/back.
+   * Page size is seeded by the caller (via params.limit); this only writes it
+   * back. Only makes sense for a route-backed feed, not an overlay.
    */
   syncPageToUrl?: boolean;
+  /**
+   * The page size considered "default" when syncing to the URL: at this size
+   * the `size` param is omitted to keep the URL clean. Defaults to the limit
+   * being absent (always write when a limit is set).
+   */
+  urlPageSizeDefault?: number;
 }): React.ReactElement {
   const resourceType = params?.resourceType;
   const resourceTypes = params?.resourceTypes;
@@ -481,10 +489,12 @@ export function ActivityFeed({
     { initialPage }
   );
 
-  // Reflect the active page in the URL when asked (route-backed feed only), and
-  // drop the param on page 1 / filter resets so the URL stays clean. Reading
-  // searchParams here only to preserve sibling params; it is intentionally not
-  // a dep -- our own replace would otherwise loop.
+  // Reflect the active page + size in the URL when asked (route-backed feed
+  // only), dropping each param at its default (page 1 / default size) so the
+  // URL stays clean. This is the single writer for both params, so size and
+  // page changes never race each other. Reading searchParams here only to
+  // preserve sibling params; it is intentionally not a dep -- our own replace
+  // would otherwise loop.
   // biome-ignore lint/correctness/useExhaustiveDependencies: see note above
   useEffect(() => {
     if (!syncPageToUrl) {
@@ -496,9 +506,14 @@ export function ActivityFeed({
     } else {
       next.delete("page");
     }
+    if (limit && limit !== urlPageSizeDefault) {
+      next.set("size", String(limit));
+    } else {
+      next.delete("size");
+    }
     const qs = next.toString();
     router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
-  }, [syncPageToUrl, page, pathname, router]);
+  }, [syncPageToUrl, page, limit, urlPageSizeDefault, pathname, router]);
 
   // Capture the settled content height so the skeleton can hold it on the next
   // load. Without this the embedded feed (no fixed box) collapses to the

--- a/components/activity/activity-feed.tsx
+++ b/components/activity/activity-feed.tsx
@@ -453,6 +453,7 @@ export function ActivityFeed({
     setPage,
     loading,
     error,
+    reload,
   } = usePaginatedResource<SecurityAuditEvent>(
     (page) =>
       api.security.getAudit({
@@ -471,6 +472,9 @@ export function ActivityFeed({
         page,
         limit,
       }),
+    // `limit` (page size) is intentionally NOT part of the reset key: changing
+    // the page size keeps the current page (it just refetches via the effect
+    // below). Only the actual filters reset the feed back to page 1.
     JSON.stringify({
       resourceType,
       resourceTypes,
@@ -484,10 +488,21 @@ export function ActivityFeed({
       actorUserIds,
       from,
       to,
-      limit,
     }),
     { initialPage }
   );
+
+  // Page size lives outside the reset key, so refetch the current page when it
+  // changes (skip the first render -- the initial fetch already covers it).
+  const didMountLimitRef = useRef(false);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: limit is the change trigger, not read in the body
+  useEffect(() => {
+    if (didMountLimitRef.current) {
+      reload();
+    } else {
+      didMountLimitRef.current = true;
+    }
+  }, [limit, reload]);
 
   // Reflect the active page + size in the URL when asked (route-backed feed
   // only), dropping each param at its default (page 1 / default size) so the

--- a/components/activity/activity-feed.tsx
+++ b/components/activity/activity-feed.tsx
@@ -33,6 +33,7 @@ type FeedParams = {
   actorUserIds?: string[];
   from?: string;
   to?: string;
+  search?: string;
   limit?: number;
 };
 
@@ -408,6 +409,7 @@ export function ActivityFeed({
   const actorUserIds = params?.actorUserIds;
   const from = params?.from;
   const to = params?.to;
+  const search = params?.search;
   const limit = params?.limit;
 
   // Open the event's resource: workflows leave for their editor's History tab
@@ -475,6 +477,7 @@ export function ActivityFeed({
         actorUserIds,
         from,
         to,
+        search,
         page,
         limit,
       }),
@@ -494,6 +497,7 @@ export function ActivityFeed({
       actorUserIds,
       from,
       to,
+      search,
     }),
     { initialPage }
   );

--- a/components/activity/activity-page.tsx
+++ b/components/activity/activity-page.tsx
@@ -44,7 +44,9 @@ export function ActivityPage(): ReactNode {
   )
     ? sizeParam
     : DEFAULT_AUDIT_PAGE_SIZE;
-  const activity = useAuditActivity({ initialPageSize });
+  // Seed the search box from ?q so a shared/refreshed search is honored.
+  const initialSearch = (searchParams.get("q") ?? "").slice(0, 200);
+  const activity = useAuditActivity({ initialPageSize, initialSearch });
 
   // Admin/owner only. Once auth + membership resolve, bounce anyone else home;
   // the server already 403s the data, this just keeps them off the page.

--- a/components/activity/activity-page.tsx
+++ b/components/activity/activity-page.tsx
@@ -97,9 +97,9 @@ export function ActivityPage(): ReactNode {
   }
 
   return (
-    <div className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar">
-      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
-        <div className="flex flex-col gap-6 p-6 pt-[calc(5rem+var(--app-banner-height,0px))]">
+    <div className="pointer-events-auto fixed inset-0 flex flex-col overflow-hidden bg-sidebar">
+      <div className="flex min-h-0 flex-1 flex-col transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+        <div className="flex min-h-0 flex-1 flex-col gap-6 p-6 pt-[calc(5rem+var(--app-banner-height,0px))]">
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div className="space-y-1">
               <h1 className="font-semibold text-2xl tracking-tight">
@@ -133,7 +133,7 @@ export function ActivityPage(): ReactNode {
               onValueChange={(v) => activity.setPageSize(Number(v))}
               value={String(activity.pageSize)}
             >
-              <SelectTrigger className="h-8 w-[110px] text-xs">
+              <SelectTrigger className="h-8 w-28 text-xs">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -146,7 +146,7 @@ export function ActivityPage(): ReactNode {
             </Select>
           </div>
 
-          <ActivityFeed embedded params={activity.feedParams} />
+          <ActivityFeed fillHeight params={activity.feedParams} syncPageToUrl />
         </div>
       </div>
     </div>

--- a/components/activity/activity-page.tsx
+++ b/components/activity/activity-page.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { Activity, Download, LogIn } from "lucide-react";
-import Link from "next/link";
-import { useSearchParams } from "next/navigation";
-import type { ReactNode } from "react";
+import { Download, Search } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { type ReactNode, useEffect } from "react";
 import { ActivityFeed } from "@/components/activity/activity-feed";
 import { AuditFilterBar } from "@/components/activity/audit-filter-bar";
 import { ExportAuditOverlay } from "@/components/overlays/export-audit-overlay";
 import { useOverlay } from "@/components/overlays/overlay-provider";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -24,51 +24,17 @@ import {
 } from "@/lib/hooks/use-audit-activity";
 import { useActiveMember } from "@/lib/hooks/use-organization";
 
-function Gate({
-  icon,
-  title,
-  description,
-  showCta,
-}: {
-  icon: ReactNode;
-  title: string;
-  description: string;
-  showCta: boolean;
-}): ReactNode {
-  return (
-    <div className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar">
-      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
-        <div className="flex min-h-[80vh] flex-col items-center justify-center gap-6 p-6 text-center">
-          <div className="flex size-20 items-center justify-center rounded-2xl bg-muted">
-            {icon}
-          </div>
-          <div className="space-y-2">
-            <h2 className="font-semibold text-xl tracking-tight">{title}</h2>
-            <p className="max-w-sm text-muted-foreground text-sm">
-              {description}
-            </p>
-          </div>
-          {showCta && (
-            <Button asChild>
-              <Link href="/">Get Started</Link>
-            </Button>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
 /**
  * Full-page organization activity feed. Mirrors the body of ActivityOverlay but
  * in page chrome, reachable at /activity from the left nav. Admin/owner only --
- * the read endpoint is gated the same way server-side; non-admins who land here
- * by URL get a gate rather than a stream of 403s.
+ * the read endpoint is gated the same way server-side, and anyone without that
+ * role who lands here by URL is bounced home rather than shown an empty page.
  */
 export function ActivityPage(): ReactNode {
   const { data: session, isPending } = useSession();
   const { isAdmin, isOwner, isLoading } = useActiveMember();
   const { push } = useOverlay();
+  const router = useRouter();
   const searchParams = useSearchParams();
   // Seed page size from the URL so a shared/refreshed ?size=N is honored; an
   // out-of-range value falls back to the default.
@@ -80,31 +46,19 @@ export function ActivityPage(): ReactNode {
     : DEFAULT_AUDIT_PAGE_SIZE;
   const activity = useAuditActivity({ initialPageSize });
 
-  if (isPending || isLoading) {
+  // Admin/owner only. Once auth + membership resolve, bounce anyone else home;
+  // the server already 403s the data, this just keeps them off the page.
+  const resolved = !(isPending || isLoading);
+  const allowed =
+    Boolean(session?.user) && !session?.user?.isAnonymous && isAdmin;
+  useEffect(() => {
+    if (resolved && !allowed) {
+      router.replace("/");
+    }
+  }, [resolved, allowed, router]);
+
+  if (!(resolved && allowed)) {
     return null;
-  }
-
-  const isAnonymous = !session?.user || session.user.isAnonymous;
-  if (isAnonymous) {
-    return (
-      <Gate
-        description="Sign in to your account to view your organization's activity."
-        icon={<LogIn className="size-10 text-muted-foreground" />}
-        showCta={false}
-        title="Sign in to view activity"
-      />
-    );
-  }
-
-  if (!isAdmin) {
-    return (
-      <Gate
-        description="Only organization admins and owners can view activity."
-        icon={<Activity className="size-10 text-muted-foreground" />}
-        showCta={false}
-        title="Admins only"
-      />
-    );
   }
 
   return (
@@ -139,7 +93,18 @@ export function ActivityPage(): ReactNode {
           </div>
 
           <div className="flex flex-wrap items-center justify-between gap-2">
-            <AuditFilterBar activity={activity} />
+            <div className="flex flex-1 flex-wrap items-center gap-2">
+              <div className="relative w-full max-w-xs">
+                <Search className="-translate-y-1/2 absolute top-1/2 left-2.5 size-4 text-muted-foreground" />
+                <Input
+                  className="h-8 pl-8 text-sm"
+                  onChange={(e) => activity.setSearchText(e.target.value)}
+                  placeholder="Search name, email, workflow, IP..."
+                  value={activity.searchText}
+                />
+              </div>
+              <AuditFilterBar activity={activity} />
+            </div>
             <Select
               onValueChange={(v) => activity.setPageSize(Number(v))}
               value={String(activity.pageSize)}

--- a/components/activity/activity-page.tsx
+++ b/components/activity/activity-page.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { Activity, Download, LogIn } from "lucide-react";
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { ActivityFeed } from "@/components/activity/activity-feed";
+import { AuditFilterBar } from "@/components/activity/audit-filter-bar";
+import { ExportAuditOverlay } from "@/components/overlays/export-audit-overlay";
+import { useOverlay } from "@/components/overlays/overlay-provider";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useSession } from "@/lib/auth-client";
+import {
+  PAGE_SIZE_OPTIONS,
+  useAuditActivity,
+} from "@/lib/hooks/use-audit-activity";
+import { useActiveMember } from "@/lib/hooks/use-organization";
+
+function Gate({
+  icon,
+  title,
+  description,
+  showCta,
+}: {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  showCta: boolean;
+}): ReactNode {
+  return (
+    <div className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar">
+      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+        <div className="flex min-h-[80vh] flex-col items-center justify-center gap-6 p-6 text-center">
+          <div className="flex size-20 items-center justify-center rounded-2xl bg-muted">
+            {icon}
+          </div>
+          <div className="space-y-2">
+            <h2 className="font-semibold text-xl tracking-tight">{title}</h2>
+            <p className="max-w-sm text-muted-foreground text-sm">
+              {description}
+            </p>
+          </div>
+          {showCta && (
+            <Button asChild>
+              <Link href="/">Get Started</Link>
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Full-page organization activity feed. Mirrors the body of ActivityOverlay but
+ * in page chrome, reachable at /activity from the left nav. Admin/owner only --
+ * the read endpoint is gated the same way server-side; non-admins who land here
+ * by URL get a gate rather than a stream of 403s.
+ */
+export function ActivityPage(): ReactNode {
+  const { data: session, isPending } = useSession();
+  const { isAdmin, isOwner, isLoading } = useActiveMember();
+  const { push } = useOverlay();
+  const activity = useAuditActivity();
+
+  if (isPending || isLoading) {
+    return null;
+  }
+
+  const isAnonymous = !session?.user || session.user.isAnonymous;
+  if (isAnonymous) {
+    return (
+      <Gate
+        description="Sign in to your account to view your organization's activity."
+        icon={<LogIn className="size-10 text-muted-foreground" />}
+        showCta={false}
+        title="Sign in to view activity"
+      />
+    );
+  }
+
+  if (!isAdmin) {
+    return (
+      <Gate
+        description="Only organization admins and owners can view activity."
+        icon={<Activity className="size-10 text-muted-foreground" />}
+        showCta={false}
+        title="Admins only"
+      />
+    );
+  }
+
+  return (
+    <div className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar">
+      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+        <div className="flex flex-col gap-6 p-6 pt-[calc(5rem+var(--app-banner-height,0px))]">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="space-y-1">
+              <h1 className="font-semibold text-2xl tracking-tight">
+                Organization activity
+              </h1>
+              <p className="text-muted-foreground text-sm">
+                Recent security-sensitive actions across your organization.
+              </p>
+            </div>
+            <Button
+              disabled={!isOwner}
+              onClick={() =>
+                push(ExportAuditOverlay, {
+                  resourceTypes: activity.types,
+                })
+              }
+              size="sm"
+              title={
+                isOwner ? undefined : "Only organization owners can export"
+              }
+              variant="outline"
+            >
+              <Download className="mr-2 size-4" />
+              Export CSV
+            </Button>
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <AuditFilterBar activity={activity} />
+            <Select
+              onValueChange={(v) => activity.setPageSize(Number(v))}
+              value={String(activity.pageSize)}
+            >
+              <SelectTrigger className="h-8 w-[110px] text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PAGE_SIZE_OPTIONS.map((size) => (
+                  <SelectItem key={size} value={String(size)}>
+                    {size} / page
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <ActivityFeed embedded params={activity.feedParams} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/activity/activity-page.tsx
+++ b/components/activity/activity-page.tsx
@@ -2,6 +2,7 @@
 
 import { Activity, Download, LogIn } from "lucide-react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import type { ReactNode } from "react";
 import { ActivityFeed } from "@/components/activity/activity-feed";
 import { AuditFilterBar } from "@/components/activity/audit-filter-bar";
@@ -17,6 +18,7 @@ import {
 } from "@/components/ui/select";
 import { useSession } from "@/lib/auth-client";
 import {
+  DEFAULT_AUDIT_PAGE_SIZE,
   PAGE_SIZE_OPTIONS,
   useAuditActivity,
 } from "@/lib/hooks/use-audit-activity";
@@ -67,7 +69,16 @@ export function ActivityPage(): ReactNode {
   const { data: session, isPending } = useSession();
   const { isAdmin, isOwner, isLoading } = useActiveMember();
   const { push } = useOverlay();
-  const activity = useAuditActivity();
+  const searchParams = useSearchParams();
+  // Seed page size from the URL so a shared/refreshed ?size=N is honored; an
+  // out-of-range value falls back to the default.
+  const sizeParam = Number.parseInt(searchParams.get("size") ?? "", 10);
+  const initialPageSize = (PAGE_SIZE_OPTIONS as readonly number[]).includes(
+    sizeParam
+  )
+    ? sizeParam
+    : DEFAULT_AUDIT_PAGE_SIZE;
+  const activity = useAuditActivity({ initialPageSize });
 
   if (isPending || isLoading) {
     return null;
@@ -146,7 +157,12 @@ export function ActivityPage(): ReactNode {
             </Select>
           </div>
 
-          <ActivityFeed fillHeight params={activity.feedParams} syncPageToUrl />
+          <ActivityFeed
+            fillHeight
+            params={activity.feedParams}
+            syncPageToUrl
+            urlPageSizeDefault={DEFAULT_AUDIT_PAGE_SIZE}
+          />
         </div>
       </div>
     </div>

--- a/components/navigation-sidebar.tsx
+++ b/components/navigation-sidebar.tsx
@@ -21,7 +21,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useAuthPrompt } from "@/components/auth/provider";
 import { DiscordIcon } from "@/components/icons/discord-icon";
-import { ActivityOverlay } from "@/components/overlays/activity-overlay";
 import { AddressBookOverlay } from "@/components/overlays/address-book-overlay";
 import { FeedbackOverlay } from "@/components/overlays/feedback-overlay";
 import { useOverlay } from "@/components/overlays/overlay-provider";
@@ -579,7 +578,7 @@ const NAV_ITEMS: NavItemDef[] = [
     id: "activity",
     icon: Activity,
     label: "Activity",
-    href: null,
+    href: "/activity",
     requireAuth: true,
     adminOnly: true,
   },
@@ -867,11 +866,6 @@ export function NavigationSidebar(): React.ReactNode {
     if (item.id === "address-book") {
       navState.closeAll();
       openOverlay(AddressBookOverlay);
-      return;
-    }
-    if (item.id === "activity") {
-      navState.closeAll();
-      openOverlay(ActivityOverlay);
       return;
     }
     navState.closeAll();

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -971,6 +971,7 @@ export const securityApi = {
     actorUserIds?: string[];
     from?: string;
     to?: string;
+    search?: string;
     page?: number;
     limit?: number;
   }) => {
@@ -1010,6 +1011,9 @@ export const securityApi = {
     }
     if (params?.to) {
       qs.set("to", params.to);
+    }
+    if (params?.search) {
+      qs.set("q", params.search);
     }
     if (params?.page !== undefined) {
       qs.set("page", String(params.page));

--- a/lib/hooks/use-audit-activity.ts
+++ b/lib/hooks/use-audit-activity.ts
@@ -83,14 +83,18 @@ function toggle(list: string[], value: string): string[] {
  * once), and which dimensions are currently shown as chips. Exposes a derived
  * `feedParams` ready to spread into <ActivityFeed>.
  */
-export function useAuditActivity() {
+export const DEFAULT_AUDIT_PAGE_SIZE = 5;
+
+export function useAuditActivity(options?: { initialPageSize?: number }) {
   const [people, setPeople] = useState<string[]>([]);
   const [types, setTypes] = useState<string[]>([]);
   const [projects, setProjects] = useState<string[]>([]);
   const [workflows, setWorkflows] = useState<string[]>([]);
   const [tags, setTags] = useState<string[]>([]);
   const [datePreset, setDatePreset] = useState<string>(ALL);
-  const [pageSize, setPageSize] = useState<number>(5);
+  const [pageSize, setPageSize] = useState<number>(
+    options?.initialPageSize ?? DEFAULT_AUDIT_PAGE_SIZE
+  );
 
   // Option lists for the specific-resource dimensions.
   const [projectOptions, setProjectOptions] = useState<ResourceOption[]>([]);

--- a/lib/hooks/use-audit-activity.ts
+++ b/lib/hooks/use-audit-activity.ts
@@ -76,6 +76,12 @@ function toggle(list: string[], value: string): string[] {
     : [...list, value];
 }
 
+export const DEFAULT_AUDIT_PAGE_SIZE = 5;
+
+// Wait this long after the last keystroke before searching, so typing doesn't
+// fire a request per character.
+const SEARCH_DEBOUNCE_MS = 500;
+
 /**
  * State + data for the audit activity filter builder. Owns the selected values
  * per dimension (person/activity/project/workflow/tag/date), the page size,
@@ -83,8 +89,6 @@ function toggle(list: string[], value: string): string[] {
  * once), and which dimensions are currently shown as chips. Exposes a derived
  * `feedParams` ready to spread into <ActivityFeed>.
  */
-export const DEFAULT_AUDIT_PAGE_SIZE = 5;
-
 export function useAuditActivity(options?: { initialPageSize?: number }) {
   const [people, setPeople] = useState<string[]>([]);
   const [types, setTypes] = useState<string[]>([]);
@@ -95,6 +99,19 @@ export function useAuditActivity(options?: { initialPageSize?: number }) {
   const [pageSize, setPageSize] = useState<number>(
     options?.initialPageSize ?? DEFAULT_AUDIT_PAGE_SIZE
   );
+
+  // Free-text search. `searchText` is the raw input (kept responsive); `search`
+  // is the debounced value that actually drives the query, so typing doesn't
+  // fire a request per keystroke.
+  const [searchText, setSearchText] = useState("");
+  const [search, setSearch] = useState("");
+  useEffect(() => {
+    const id = setTimeout(
+      () => setSearch(searchText.trim()),
+      SEARCH_DEBOUNCE_MS
+    );
+    return () => clearTimeout(id);
+  }, [searchText]);
 
   // Option lists for the specific-resource dimensions.
   const [projectOptions, setProjectOptions] = useState<ResourceOption[]>([]);
@@ -196,8 +213,9 @@ export function useAuditActivity(options?: { initialPageSize?: number }) {
       tagIds: tags.length > 0 ? tags : undefined,
       workflowIds: workflows.length > 0 ? workflows : undefined,
       from,
+      search: search || undefined,
     };
-  }, [pageSize, types, people, projects, workflows, tags, datePreset]);
+  }, [pageSize, types, people, projects, workflows, tags, datePreset, search]);
 
   return {
     // selections
@@ -215,6 +233,8 @@ export function useAuditActivity(options?: { initialPageSize?: number }) {
     setDatePreset,
     pageSize,
     setPageSize,
+    searchText,
+    setSearchText,
     // options
     members,
     projectOptions,

--- a/lib/hooks/use-audit-activity.ts
+++ b/lib/hooks/use-audit-activity.ts
@@ -89,7 +89,10 @@ const SEARCH_DEBOUNCE_MS = 500;
  * once), and which dimensions are currently shown as chips. Exposes a derived
  * `feedParams` ready to spread into <ActivityFeed>.
  */
-export function useAuditActivity(options?: { initialPageSize?: number }) {
+export function useAuditActivity(options?: {
+  initialPageSize?: number;
+  initialSearch?: string;
+}) {
   const [people, setPeople] = useState<string[]>([]);
   const [types, setTypes] = useState<string[]>([]);
   const [projects, setProjects] = useState<string[]>([]);
@@ -103,8 +106,8 @@ export function useAuditActivity(options?: { initialPageSize?: number }) {
   // Free-text search. `searchText` is the raw input (kept responsive); `search`
   // is the debounced value that actually drives the query, so typing doesn't
   // fire a request per keystroke.
-  const [searchText, setSearchText] = useState("");
-  const [search, setSearch] = useState("");
+  const [searchText, setSearchText] = useState(options?.initialSearch ?? "");
+  const [search, setSearch] = useState(options?.initialSearch ?? "");
   useEffect(() => {
     const id = setTimeout(
       () => setSearch(searchText.trim()),

--- a/lib/hooks/use-paginated-resource.ts
+++ b/lib/hooks/use-paginated-resource.ts
@@ -46,17 +46,15 @@ export function usePaginatedResource<T>(
   const fetchRef = useRef(fetchPage);
   fetchRef.current = fetchPage;
 
-  // A new query identity always starts from the first page. Skip the very first
-  // run so an initialPage (e.g. seeded from the URL) survives mount; only an
-  // actual resetKey change after mount snaps back to page 1.
-  const didResetOnceRef = useRef(false);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: resetKey is the change trigger, not read in the body
+  // A new query identity snaps back to page 1, but only on an ACTUAL change of
+  // resetKey -- not on mount, and not on StrictMode's double-invoked effect --
+  // so an initialPage (e.g. seeded from the URL) survives the first render.
+  const prevResetKeyRef = useRef(resetKey);
   useEffect(() => {
-    if (!didResetOnceRef.current) {
-      didResetOnceRef.current = true;
-      return;
+    if (prevResetKeyRef.current !== resetKey) {
+      prevResetKeyRef.current = resetKey;
+      setPage(1);
     }
-    setPage(1);
   }, [resetKey]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: resetKey/reloadTick are refetch triggers; fetchPage is read via ref

--- a/lib/hooks/use-paginated-resource.ts
+++ b/lib/hooks/use-paginated-resource.ts
@@ -28,11 +28,15 @@ type UsePaginatedResourceResult<T> = {
 export function usePaginatedResource<T>(
   fetchPage: (page: number) => Promise<Page<T>>,
   resetKey: string,
-  options?: { enabled?: boolean; refetchIntervalMs?: number }
+  options?: {
+    enabled?: boolean;
+    refetchIntervalMs?: number;
+    initialPage?: number;
+  }
 ): UsePaginatedResourceResult<T> {
   const enabled = options?.enabled ?? true;
   const refetchIntervalMs = options?.refetchIntervalMs;
-  const [page, setPage] = useState(1);
+  const [page, setPage] = useState(options?.initialPage ?? 1);
   const [items, setItems] = useState<T[]>([]);
   const [meta, setMeta] = useState<PageMeta | null>(null);
   const [loading, setLoading] = useState(enabled);
@@ -42,9 +46,16 @@ export function usePaginatedResource<T>(
   const fetchRef = useRef(fetchPage);
   fetchRef.current = fetchPage;
 
-  // A new query identity always starts from the first page.
+  // A new query identity always starts from the first page. Skip the very first
+  // run so an initialPage (e.g. seeded from the URL) survives mount; only an
+  // actual resetKey change after mount snaps back to page 1.
+  const didResetOnceRef = useRef(false);
   // biome-ignore lint/correctness/useExhaustiveDependencies: resetKey is the change trigger, not read in the body
   useEffect(() => {
+    if (!didResetOnceRef.current) {
+      didResetOnceRef.current = true;
+      return;
+    }
     setPage(1);
   }, [resetKey]);
 

--- a/lib/hooks/use-paginated-resource.ts
+++ b/lib/hooks/use-paginated-resource.ts
@@ -71,6 +71,13 @@ export function usePaginatedResource<T>(
         if (active) {
           setItems(res.items);
           setMeta(res.meta);
+          // The endpoint clamps an out-of-range page (e.g. the page size grew
+          // so the current page no longer exists, or rows were deleted) to the
+          // last page. Adopt that page so we refetch its real items instead of
+          // sitting on an empty page; an in-range page is returned unchanged.
+          if (res.meta.page !== page) {
+            setPage(res.meta.page);
+          }
         }
       })
       .catch(() => {


### PR DESCRIPTION
Turns the org Activity feed from a modal into a real page at /activity, and adds the things a full page makes possible: search, deep-linkable state, and proper access protection.

## Navigation
- The left-nav Activity item now routes to /activity instead of opening an overlay. The overlay component is left in place; only the nav wiring changed.

## Page
- New /activity route rendering the same audit feed (filter builder, page-size, export) in page chrome.
- Full-height layout so the pager is pinned to the bottom of the page rather than floating after a short list.
- Date groups are section separators (underlined headers); rows no longer carry inconsistent per-row divider lines.
- Action labels line up whether or not a row is openable (the chevron slot is reserved).

## URL state (deep-linkable)
- page, size, and the search term sync to the URL (?page, ?size, ?q) and seed from it on load, so refresh/back/share restore the view.
- size is validated against the allowed options (off-list values fall back to the default and self-clean from the URL); junk page values snap to 1; an in-range-but-too-high page snaps to the last page.
- Changing page size keeps the current page (unless that page no longer exists, in which case it snaps to the last page).

## Search
- A debounced (500ms) free-text search over the actor label, action, resource id, the actors current name/email, matching workflow names, and the request IP.
- Server-side it is a parameterized ILIKE with the users LIKE wildcards escaped and the input length-capped, so there is no injection or pattern-abuse surface; the IP is matched through the metadata JSONB ->> accessor so the filter runs in Postgres rather than scanning rows in JS.

## Access
- Workflow version history (the right-sidebar timeline) and the ?version=N snapshot are readable by any org member, not just admins -- it is the edit history of a workflow they already have full access to.
- The /activity page redirects anyone who is not an org admin/owner to home once auth and membership resolve; the audit endpoint remains admin/owner gated server-side.

## Shared helpers
- usePaginatedResource gains an initialPage option, only resets to page 1 on an actual query change (not on mount / StrictMode re-invoke), and adopts a server-clamped page so an out-of-range request lands on the last page.
- useAuditActivity owns the debounced search and seeds page size / search from the caller.