### PR TITLE
feat(runs): show the workflow version each run executed, linkable to History

### DIFF
--- a/app/api/workflows/[workflowId]/executions/route.ts
+++ b/app/api/workflows/[workflowId]/executions/route.ts
@@ -1,11 +1,11 @@
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { requireScope } from "@/lib/middleware/require-scope";
 import { db } from "@/lib/db";
-import { workflowExecutions, workflows } from "@/lib/db/schema";
+import { workflowExecutions, workflowHistory, workflows } from "@/lib/db/schema";
 import { getWorkflowAccess } from "@/lib/workflow/access";
 
 function parseIntOrNull(value: string | null): number | null {
@@ -65,6 +65,51 @@ export async function GET(
       limit: 50,
     });
 
+    // Resolve the workflow version each run executed: the run carries the
+    // content hash of the definition it ran (executed_workflow_hash), which
+    // joins to workflow_history.content_hash. Looked up in one batched query.
+    const ranHashes = [
+      ...new Set(
+        executions.map((e) => e.executedWorkflowHash).filter(Boolean)
+      ),
+    ] as string[];
+    const historyRows =
+      ranHashes.length > 0
+        ? await db
+            .select({
+              version: workflowHistory.version,
+              contentHash: workflowHistory.contentHash,
+              createdAt: workflowHistory.createdAt,
+            })
+            .from(workflowHistory)
+            .where(
+              and(
+                eq(workflowHistory.workflowId, workflowId),
+                inArray(workflowHistory.contentHash, ranHashes)
+              )
+            )
+        : [];
+    // A content hash usually maps to exactly one version; a revert can make two
+    // versions share it. In that case pick the version that was in effect when
+    // the run started (the highest version created at or before startedAt).
+    const resolveVersion = (
+      hash: string | null,
+      startedAt: Date | null
+    ): number | null => {
+      if (!hash) {
+        return null;
+      }
+      const candidates = historyRows.filter((h) => h.contentHash === hash);
+      if (candidates.length <= 1) {
+        return candidates[0]?.version ?? null;
+      }
+      const at = startedAt ?? new Date(0);
+      const eligible = candidates.filter((c) => c.createdAt <= at);
+      const pool = eligible.length > 0 ? eligible : candidates;
+      return pool.reduce((best, c) => (c.version > best.version ? c : best))
+        .version;
+    };
+
     // KEEP-481: `total_steps` and `completed_steps` are stored as TEXT and
     // Drizzle returns them as strings, which leaks into the response as
     // string-or-null and breaks type-checked SDK clients (Pydantic, Zod, Go).
@@ -75,6 +120,10 @@ export async function GET(
       ...execution,
       totalSteps: parseIntOrNull(execution.totalSteps),
       completedSteps: parseIntOrNull(execution.completedSteps),
+      ranVersion: resolveVersion(
+        execution.executedWorkflowHash,
+        execution.startedAt
+      ),
     }));
 
     return NextResponse.json(serialized);

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import {
   Ban,
   Check,
@@ -9,12 +9,14 @@ import {
   Clock,
   Copy,
   ExternalLink,
+  GitBranch,
   Loader2,
   Play,
   TriangleAlert,
   X,
 } from "lucide-react";
 import Image from "next/image";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import type { JSX } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toChecksumAddress } from "@/lib/address-utils";
@@ -36,6 +38,7 @@ import { getRelativeTime } from "@/lib/utils/time";
 import {
   currentWorkflowIdAtom,
   executionLogsAtom,
+  propertiesPanelActiveTabAtom,
   runsRefreshTriggerAtom,
   selectedExecutionIdAtom,
 } from "@/lib/workflow/store";
@@ -78,6 +81,9 @@ type WorkflowExecution = {
   lastSuccessfulNodeId: string | null;
   lastSuccessfulNodeName: string | null;
   executionTrace: string[] | null;
+  // The workflow_history version this run executed (resolved server-side from
+  // the run's content hash); null when no matching version exists.
+  ranVersion: number | null;
 };
 
 type WorkflowRunsProps = {
@@ -864,6 +870,23 @@ export function WorkflowRuns({
   );
   const [, setExecutionLogs] = useAtom(executionLogsAtom);
   const runsRefreshTrigger = useAtomValue(runsRefreshTriggerAtom);
+  const setActiveTab = useSetAtom(propertiesPanelActiveTabAtom);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // Open the History tab on the version a run executed, highlighting it there
+  // (the History tab reads ?version=N and rings/expands/scrolls to it).
+  const openRanVersion = useCallback(
+    (version: number) => {
+      const params = new URLSearchParams(searchParams?.toString() ?? "");
+      params.set("tab", "history");
+      params.set("version", String(version));
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+      setActiveTab("history");
+    },
+    [router, pathname, searchParams, setActiveTab]
+  );
   const [executions, setExecutions] = useState<WorkflowExecution[]>([]);
   const [logs, setLogs] = useState<Record<string, ExecutionLog[]>>({});
   const [expandedRuns, setExpandedRuns] = useState<Set<string>>(new Set());
@@ -1263,6 +1286,19 @@ export function WorkflowRuns({
                   )}
                 </div>
               </button>
+
+              {execution.ranVersion !== null && (
+                <button
+                  className="flex shrink-0 items-center gap-1 rounded-full border border-border px-2 py-0.5 font-medium text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground"
+                  onClick={() =>
+                    openRanVersion(execution.ranVersion as number)
+                  }
+                  title={`Ran version ${execution.ranVersion} — open in History`}
+                  type="button"
+                >
+                  <GitBranch className="size-3" />v{execution.ranVersion}
+                </button>
+              )}
 
               <button
                 className="flex shrink-0 items-center justify-center rounded p-1 transition-colors hover:bg-muted"

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -718,6 +718,9 @@ export const workflowApi = {
         lastSuccessfulNodeId: string | null;
         lastSuccessfulNodeName: string | null;
         executionTrace: string[] | null;
+        // The workflow_history version this run executed, resolved from the
+        // run's content hash. Null when no matching version exists yet.
+        ranVersion: number | null;
       }>
     >(`/api/workflows/${id}/executions`),
 


### PR DESCRIPTION
Each run stores the content hash of the definition it executed (executed_workflow_hash), which joins to workflow_history.content_hash. That linkage was written but never surfaced, so there was no way to tell which version a run actually used. This shows it on the Runs tab and links it to the version history.

## What changed

- **Executions endpoint** (app/api/workflows/[workflowId]/executions/route.ts): each run now returns `ranVersion`, resolved from its content hash to the workflow_history version in one batched query. It is timestamp-aware: when a revert makes two versions share a content hash, it picks the version in effect when the run started (highest version created at or before startedAt).
- **API client type**: getExecutions now includes `ranVersion: number | null`.
- **Runs tab** (components/workflow/workflow-runs.tsx): a clickable "v{n}" chip on each run header. Clicking it switches the panel to the History tab and sets `?version=N`; the History tab already rings, auto-expands, and scrolls to that version, so the highlight works however the version is opened. Runs with no resolved version render no chip.

## Notes

- Read-only feature: no schema or write-path changes. The hash is already stamped at execution time.
- Runs created before the hash was stamped (or whose definition has since changed with no matching history row) simply show no chip.