### PR TITLE
fix(metrics): window per-workflow error gauge to last 1h

### DIFF
--- a/drizzle/0115_tech_48_error_completed_at_index.sql
+++ b/drizzle/0115_tech_48_error_completed_at_index.sql
@@ -1,0 +1,20 @@
+-- @requires-db-prep
+-- TECH-48: supporting index for the per-workflow managed-client error gauge.
+--
+-- getWorkflowErrorsByWorkflowFromDb runs on every /api/metrics/db scrape and
+-- filters `status = 'error' AND completed_at >= now() - interval '1 hour'`.
+-- With no index on completed_at, Postgres found error rows via the status
+-- index (which matches EVERY error execution across all orgs) and only then
+-- filtered by time + joined to the managed orgs -- a heavy scan that tripped
+-- the 8s metrics statement_timeout (Postgres 57014). The catch returned [],
+-- so keeperhub_workflow_errors_by_workflow flapped (series vanished on most
+-- scrapes). A partial index on completed_at (status = 'error') turns the
+-- rolling-1h lookup into an index range scan that finishes in milliseconds.
+--
+-- DB-PREP: on prod/staging an operator applies this CONCURRENTLY out-of-band
+-- (`CREATE INDEX CONCURRENTLY IF NOT EXISTS ...`) before merge, so the plain
+-- statement below is a no-op there (IF NOT EXISTS). On dev / PR-env DBs the
+-- table is small, so the plain in-migration build is fine.
+CREATE INDEX IF NOT EXISTS "idx_workflow_executions_error_completed_at"
+  ON "workflow_executions" ("completed_at")
+  WHERE status = 'error';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -806,6 +806,13 @@
       "when": 1781641237005,
       "tag": "0114_unlist_slugless_listed_workflows",
       "breakpoints": true
+    },
+    {
+      "idx": 115,
+      "version": "7",
+      "when": 1781641237006,
+      "tag": "0115_tech_48_error_completed_at_index",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/metrics/METRICS_REFERENCE.md
+++ b/lib/metrics/METRICS_REFERENCE.md
@@ -84,6 +84,7 @@ Error metrics tracking failures and exceptions.
 | Metric Name | Description | Labels | Target | Source |
 |-------------|-------------|--------|--------|--------|
 | `workflow.execution.errors` | Failed workflow executions | - | < 5% | DB |
+| `workflow.errors.by_workflow` | Errored executions in the **last hour** (rolling 1h window), managed orgs only. Powers the Sky/Ajna managed-client error alerts; the alert reads it directly (no offset). Not cumulative. | `workflow_id`, `org_slug`, `error_type` | - | DB |
 | `workflow.step.errors` | Failed step executions | `step_type` | < 10% | DB |
 | `plugin.action.errors` | Failed plugin actions | `plugin_name`, `action_name`, `error_type` | < 20% | API |
 | `api.errors.total` | API errors (webhook failures) | `endpoint`, `status_code`, `error_type` | count | API |

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -119,25 +119,28 @@ const workflowExecutionsTotal = getOrCreateGauge(
   ["status", "org_slug", "error_type"]
 );
 
-// TECH-48: per-workflow error counts for managed orgs, DB-sourced so the
-// series is authoritative regardless of which finalization path wrote the
-// error row. Replaces the per-pod `keeperhub_workflow_execution_errors_by_workflow_total`
-// counter, which was only incremented on the kickoff/reaper/MCP paths and so
-// returned no data in prod for normal workflow failures (the managed-client
-// alert numerator + workflow_id dedup key read from this).
+// TECH-48: per-workflow error counts for managed orgs over a ROLLING 1-HOUR
+// window, DB-sourced so the series is authoritative regardless of which
+// finalization path wrote the error row. Replaces the per-pod
+// `keeperhub_workflow_execution_errors_by_workflow_total` counter, which was
+// only incremented on the kickoff/reaper/MCP paths and so returned no data in
+// prod for normal workflow failures.
 //
-// Gauge, not counter: it carries the all-time cumulative error count per
-// (workflow_id, org_slug, error_type), so the alert recovers a window delta as
-// value(now) - value(now offset W) — the same dedup pattern the alert already
-// uses on workflowExecutionsTotal. No `_total` suffix: that suffix on a
-// poll-driven gauge is exactly the trap KEEP-545 documents below.
+// Value = executions that errored in the last hour, per workflow (see
+// getWorkflowErrorsByWorkflowFromDb). The managed-client alert reads this gauge
+// DIRECTLY as its numerator — no offset/delta. The earlier all-time-cumulative
+// variant forced the alert into `value(now) - value(offset 1h)`, which (a) was
+// fragile when the gauge gapped and (b) made the query scan every error row
+// ever and trip the 8s metrics statement_timeout, so the gauge flapped. The
+// 1h window keeps the query an index range scan that never times out.
 //
-// Cardinality is bounded by scoping to managed orgs in the DB query: only the
-// handful of managed workflows that have ever errored emit a series.
+// No `_total` suffix: that suffix on a poll-driven gauge is the trap KEEP-545
+// documents below. Cardinality is bounded by scoping to managed orgs and the
+// 1h window: only managed workflows that errored in the last hour emit a series.
 const workflowErrorsByWorkflow = getOrCreateGauge(
   dbRegistry,
   "keeperhub_workflow_errors_by_workflow",
-  "All-time workflow execution errors by workflow_id for managed orgs, by org_slug and error_type",
+  "Workflow executions that errored in the last hour, by workflow_id for managed orgs, by org_slug and error_type",
   ["workflow_id", "org_slug", "error_type"]
 );
 

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -263,7 +263,7 @@ export type WorkflowErrorsByWorkflow = Array<{
  * the 8s metrics `statement_timeout` (Postgres 57014), the catch returned [],
  * and the gauge flapped (the series vanished on most scrapes). Bounding to the
  * last hour keeps the row set tiny so the query is an index range scan on
- * idx_workflow_executions_status_completed_at and finishes in milliseconds.
+ * idx_workflow_executions_error_completed_at and finishes in milliseconds.
  *
  * Scoped to MANAGED_ORG_SLUGS to bound `workflow_id` cardinality. errorType is
  * the `workflow_executions.error_type` column, projected to "unknown" for

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -248,10 +248,22 @@ export type WorkflowErrorsByWorkflow = Array<{
 }>;
 
 /**
- * Per-workflow error counts for managed orgs, sourced from the DB so the
- * series is authoritative regardless of which finalization path wrote the
- * `status='error'` row. Replaces the per-pod counter that only fired on the
- * rarely-hit kickoff/reaper/MCP paths and so returned no data in prod.
+ * Per-workflow error counts for managed orgs over a ROLLING 1-HOUR window,
+ * sourced from the DB so the series is authoritative regardless of which
+ * finalization path wrote the `status='error'` row.
+ *
+ * Value semantics: count of executions that errored in the last hour
+ * (`completed_at >= now() - 1h`), per workflow. NOT an all-time cumulative
+ * count. This matches the managed-client alert's "rolling 60-minute window"
+ * definition, so the alert reads this gauge directly (no offset/delta math).
+ *
+ * Why windowed: the previous all-time variant filtered only on
+ * `status='error'`, which matches every error execution across all orgs and
+ * joins them before narrowing to managed orgs — at prod scale that blew past
+ * the 8s metrics `statement_timeout` (Postgres 57014), the catch returned [],
+ * and the gauge flapped (the series vanished on most scrapes). Bounding to the
+ * last hour keeps the row set tiny so the query is an index range scan on
+ * idx_workflow_executions_status_completed_at and finishes in milliseconds.
  *
  * Scoped to MANAGED_ORG_SLUGS to bound `workflow_id` cardinality. errorType is
  * the `workflow_executions.error_type` column, projected to "unknown" for
@@ -272,6 +284,7 @@ export async function getWorkflowErrorsByWorkflowFromDb(): Promise<WorkflowError
       .where(
         and(
           eq(workflowExecutions.status, "error"),
+          sql`${workflowExecutions.completedAt} >= now() - interval '1 hour'`,
           inArray(organization.slug, [...MANAGED_ORG_SLUGS])
         )
       )


### PR DESCRIPTION
## Problem

`keeperhub_workflow_errors_by_workflow` flaps in prod (present ~9% of scrapes), which starved the managed-client alert of data and — combined with the alert's `offset 1h` + `or *0` guard — produced a **false-positive page storm** (the guard read the full all-time cumulative count as a 1h delta).

Confirmed root cause via prod Loki logs: the query times out.
```
[Metrics] Failed to query per-workflow errors from DB: DrizzleQueryError ...
  where status = $1 and organization.slug in ($2,$3) group by workflow_id, slug, error_type
code: '57014', cause: PostgresError: canceling statement due to statement timeout
```
The all-time query filtered only on `status='error'` (matches every error row across all orgs), joined, then narrowed to managed orgs — tripping the 8s metrics `statement_timeout`.

## Fix

Make the gauge a **rolling-1h count** instead of all-time cumulative — same metric name + `workflow_id` label, only the value semantics change:
- Query adds `completed_at >= now() - interval '1 hour'`.
- New partial index `idx_workflow_executions_error_completed_at (completed_at) WHERE status='error'` makes it an index range scan (ms, never near the 8s timeout).
- Matches the alert's documented "rolling 60-minute window", so the companion infra change (techops-services/infrastructure#272) drops the `offset`/`or *0`/`clamp_min` and reads the gauge directly.

## Migration

`0115_tech_48_error_completed_at_index` is **`@requires-db-prep`**: needs the `db-prepped-staging` label (operator applies `CREATE INDEX CONCURRENTLY IF NOT EXISTS` out-of-band; the in-file `CREATE INDEX IF NOT EXISTS` is then a no-op on prod, a fast build on dev/PR).

## Validation

- Unit: gauge-wiring test green; lint + type-check clean.
- PR env (deploy-pr-metrics): will confirm the gauge registers and a seeded managed-org error in the last hour appears.
- Post-prod: confirm the gauge is continuously present (no flapping) and no more 57014 logs, then unsilence the alert.

## Sequencing

Merge after `db-prepped-staging`; deploy to prod; verify gauge is continuous; then merge the infra alert simplification #272; then remove the Grafana silence.