### PR TITLE
feat(metrics): TECH-6544 add keeperhub_system_errors_by_category DB gauge

### DIFF
--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -144,6 +144,22 @@ const workflowErrorsByWorkflow = getOrCreateGauge(
   ["workflow_id", "org_slug", "error_type"]
 );
 
+// TECH-6544: errored executions in the last hour for managed orgs, grouped by
+// (org_slug, error_category, error_type). Sibling of workflowErrorsByWorkflow,
+// but keyed on error_category instead of workflow_id so the infra P3 alert
+// dedups system errors by *cause* — one series per failure mode — rather than
+// fanning a single root cause out into one series per affected workflow. Same
+// 1h-window, DB-sourced, managed-org-scoped design (see
+// getSystemErrorsByCategoryFromDb); cardinality stays bounded because there is
+// no workflow_id label. Value = executions that errored in the last hour per
+// (org_slug, error_category, error_type); the alert reads it directly.
+const systemErrorsByCategory = getOrCreateGauge(
+  dbRegistry,
+  "keeperhub_system_errors_by_category",
+  "Workflow executions that errored in the last hour for managed orgs, by org_slug, error_category and error_type",
+  ["org_slug", "error_category", "error_type"]
+);
+
 // KEEP-545: the previous DB-sourced gauge `keeperhub_workflow_execution_errors_total`
 // has been removed. It was named with the `_total` counter suffix but was
 // actually a poll-driven gauge that overwrote itself on every scrape with the
@@ -1397,6 +1413,7 @@ async function refreshDbMetricsNow(): Promise<void> {
     const {
       getWorkflowStatsFromDb,
       getWorkflowErrorsByWorkflowFromDb,
+      getSystemErrorsByCategoryFromDb,
       getStepStatsFromDb,
       getDailyActiveUsersFromDb,
       getUserStatsFromDb,
@@ -1413,6 +1430,7 @@ async function refreshDbMetricsNow(): Promise<void> {
     const [
       workflowStats,
       errorsByWorkflow,
+      systemErrorsByCategoryRows,
       stepStats,
       dailyActiveUsers,
       userStats,
@@ -1428,6 +1446,7 @@ async function refreshDbMetricsNow(): Promise<void> {
     ] = await Promise.all([
       getWorkflowStatsFromDb(),
       getWorkflowErrorsByWorkflowFromDb(),
+      getSystemErrorsByCategoryFromDb(),
       getStepStatsFromDb(),
       getDailyActiveUsersFromDb(),
       getUserStatsFromDb(),
@@ -1470,6 +1489,21 @@ async function refreshDbMetricsNow(): Promise<void> {
         {
           workflow_id: row.workflowId,
           org_slug: row.orgSlug,
+          error_type: row.errorType,
+        },
+        row.count
+      );
+    }
+
+    // TECH-6544: errored executions per (org_slug, error_category, error_type)
+    // for managed orgs. Reset before populating so a category that no longer
+    // has errors in the window clears out instead of pinning a stale value.
+    systemErrorsByCategory.reset();
+    for (const row of systemErrorsByCategoryRows) {
+      systemErrorsByCategory.set(
+        {
+          org_slug: row.orgSlug,
+          error_category: row.errorCategory,
           error_type: row.errorType,
         },
         row.count

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -144,20 +144,20 @@ const workflowErrorsByWorkflow = getOrCreateGauge(
   ["workflow_id", "org_slug", "error_type"]
 );
 
-// TECH-6544: errored executions in the last hour for managed orgs, grouped by
-// (org_slug, error_category, error_type). Sibling of workflowErrorsByWorkflow,
-// but keyed on error_category instead of workflow_id so the infra P3 alert
+// TECH-6544: errored executions in the last hour, PLATFORM-WIDE, grouped by
+// (error_category, error_type). Keyed on error_category so the infra P3 alert
 // dedups system errors by *cause* — one series per failure mode — rather than
-// fanning a single root cause out into one series per affected workflow. Same
-// 1h-window, DB-sourced, managed-org-scoped design (see
-// getSystemErrorsByCategoryFromDb); cardinality stays bounded because there is
-// no workflow_id label. Value = executions that errored in the last hour per
-// (org_slug, error_category, error_type); the alert reads it directly.
+// fanning a single root cause out into one series per affected workflow/org.
+// System faults are org-agnostic, so there is intentionally no org_slug label;
+// dropping it (and workflow_id) pins cardinality to ~categories * ~types
+// regardless of customer count. 1h-window, DB-sourced (see
+// getSystemErrorsByCategoryFromDb). Value = executions that errored in the last
+// hour per (error_category, error_type); the alert reads it directly.
 const systemErrorsByCategory = getOrCreateGauge(
   dbRegistry,
   "keeperhub_system_errors_by_category",
-  "Workflow executions that errored in the last hour for managed orgs, by org_slug, error_category and error_type",
-  ["org_slug", "error_category", "error_type"]
+  "Workflow executions that errored in the last hour, platform-wide, by error_category and error_type (system errors are org-agnostic; no org_slug label to keep cardinality fixed)",
+  ["error_category", "error_type"]
 );
 
 // KEEP-545: the previous DB-sourced gauge `keeperhub_workflow_execution_errors_total`
@@ -1495,14 +1495,13 @@ async function refreshDbMetricsNow(): Promise<void> {
       );
     }
 
-    // TECH-6544: errored executions per (org_slug, error_category, error_type)
-    // for managed orgs. Reset before populating so a category that no longer
-    // has errors in the window clears out instead of pinning a stale value.
+    // TECH-6544: errored executions per (error_category, error_type),
+    // platform-wide. Reset before populating so a category that no longer has
+    // errors in the window clears out instead of pinning a stale value.
     systemErrorsByCategory.reset();
     for (const row of systemErrorsByCategoryRows) {
       systemErrorsByCategory.set(
         {
-          org_slug: row.orgSlug,
           error_category: row.errorCategory,
           error_type: row.errorType,
         },

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -309,76 +309,70 @@ export async function getWorkflowErrorsByWorkflowFromDb(): Promise<WorkflowError
   }
 }
 
-// TECH-6544: per-(org, error_category, error_type) error counts for managed
-// orgs over a ROLLING 1-HOUR window. Mirrors WorkflowErrorsByWorkflow but
-// dedups system errors by *cause* (error_category) instead of by which
-// workflow tripped, so the infra P3 alert fires once per category spike rather
-// than once per affected workflow.
+// TECH-6544: per-(error_category, error_type) error counts over a ROLLING
+// 1-HOUR window, PLATFORM-WIDE (all orgs). System errors are platform faults
+// (DB, RPC, infra, workflow engine), not a managed-client concern, so this
+// dedups by *cause* (error_category) across every org rather than by which
+// workflow or org tripped. The infra P3 alert reads it filtered to
+// error_type="system" and fires once per category spike. Dropping org_slug
+// keeps cardinality FIXED (~categories * ~types) regardless of customer count.
 export type SystemErrorsByCategory = Array<{
-  orgSlug: string;
   errorCategory: string;
   errorType: string;
   count: number;
 }>;
 
 /**
- * Per-(org, error_category, error_type) error counts for managed orgs over a
- * ROLLING 1-HOUR window, sourced from the DB so the series is authoritative
- * regardless of which finalization path wrote the `status='error'` row.
+ * Per-(error_category, error_type) error counts over a ROLLING 1-HOUR window,
+ * platform-wide, sourced from the DB so the series is authoritative regardless
+ * of which finalization path wrote the `status='error'` row.
  *
  * Value semantics: count of executions that errored in the last hour
- * (`completed_at >= now() - 1h`), per (org_slug, error_category, error_type).
- * NOT an all-time cumulative count. This matches the infra P3 alert's "rolling
+ * (`completed_at >= now() - 1h`), per (error_category, error_type). NOT an
+ * all-time cumulative count. This matches the infra P3 alert's "rolling
  * 60-minute window" definition, so the alert reads this gauge directly (no
  * offset/delta math).
  *
- * Why dedup by category: the per-workflow gauge (getWorkflowErrorsByWorkflowFromDb)
- * fans a single underlying cause — e.g. an RPC outage — out into one alerting
- * series per affected workflow, paging repeatedly for the same root cause. This
- * gauge collapses those into one series per (error_category, error_type), so the
- * P3 alert dedups by cause/category and pages once per distinct failure mode.
+ * Why dedup by category (not org or workflow): a system fault — e.g. an RPC
+ * outage — surfaces across many workflows and orgs at once. Grouping by cause
+ * collapses all of them into one series per (error_category, error_type), so
+ * the P3 alert pages once per distinct failure mode, not once per affected
+ * workflow/org. org_slug is intentionally NOT a label: a platform fault is
+ * org-agnostic, and omitting it pins cardinality so it can't grow with the
+ * customer base. Per-org context, if ever needed, lives on other org-labelled
+ * metrics / dashboards.
  *
  * Why windowed: filtering only on `status='error'` matches every error
- * execution across all orgs and joins them before narrowing to managed orgs —
- * at prod scale that blew past the 8s metrics `statement_timeout` (Postgres
- * 57014), the catch returned [], and the gauge flapped. Bounding to the last
- * hour keeps the row set tiny so the query is an index range scan on
- * idx_workflow_executions_error_completed_at and finishes in milliseconds.
+ * execution ever, which at prod scale blew past the 8s metrics
+ * `statement_timeout` (Postgres 57014), the catch returned [], and the gauge
+ * flapped. Bounding to the last hour keeps the row set tiny so the query is an
+ * index range scan on idx_workflow_executions_error_completed_at and finishes
+ * in milliseconds. No joins are needed — error_category/error_type live on
+ * workflow_executions directly (migration 0073).
  *
- * Scoped to MANAGED_ORG_SLUGS to keep cardinality bounded. errorCategory and
- * errorType are read from the `workflow_executions.error_category` /
- * `error_type` columns, projected to "unknown" for rows that predate
- * classification so every series carries populated labels. Cardinality is
- * bounded at roughly (~2 managed orgs) * (~8 categories seen in the window) *
- * (2 error types) — small and stable.
+ * errorCategory and errorType are read from the `workflow_executions`
+ * error_category / error_type columns, projected to "unknown" for rows that
+ * predate classification so every series carries populated labels. Cardinality
+ * is bounded at roughly (~11 categories) * (~3 error types) — small and stable.
  */
 export async function getSystemErrorsByCategoryFromDb(): Promise<SystemErrorsByCategory> {
   try {
     const rows = await db
       .select({
-        orgSlug: organization.slug,
         errorCategory: sql<string>`COALESCE(${workflowExecutions.errorCategory}, 'unknown')`,
         errorType: sql<string>`COALESCE(${workflowExecutions.errorType}, 'unknown')`,
         count: count(),
       })
       .from(workflowExecutions)
-      .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
-      .innerJoin(organization, eq(workflows.organizationId, organization.id))
       .where(
         and(
           eq(workflowExecutions.status, "error"),
-          sql`${workflowExecutions.completedAt} >= now() - interval '1 hour'`,
-          inArray(organization.slug, [...MANAGED_ORG_SLUGS])
+          sql`${workflowExecutions.completedAt} >= now() - interval '1 hour'`
         )
       )
-      .groupBy(
-        organization.slug,
-        workflowExecutions.errorCategory,
-        workflowExecutions.errorType
-      );
+      .groupBy(workflowExecutions.errorCategory, workflowExecutions.errorType);
 
     return rows.map((row) => ({
-      orgSlug: row.orgSlug,
       errorCategory: row.errorCategory,
       errorType: row.errorType,
       count: Number(row.count) || 0,

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -309,6 +309,89 @@ export async function getWorkflowErrorsByWorkflowFromDb(): Promise<WorkflowError
   }
 }
 
+// TECH-6544: per-(org, error_category, error_type) error counts for managed
+// orgs over a ROLLING 1-HOUR window. Mirrors WorkflowErrorsByWorkflow but
+// dedups system errors by *cause* (error_category) instead of by which
+// workflow tripped, so the infra P3 alert fires once per category spike rather
+// than once per affected workflow.
+export type SystemErrorsByCategory = Array<{
+  orgSlug: string;
+  errorCategory: string;
+  errorType: string;
+  count: number;
+}>;
+
+/**
+ * Per-(org, error_category, error_type) error counts for managed orgs over a
+ * ROLLING 1-HOUR window, sourced from the DB so the series is authoritative
+ * regardless of which finalization path wrote the `status='error'` row.
+ *
+ * Value semantics: count of executions that errored in the last hour
+ * (`completed_at >= now() - 1h`), per (org_slug, error_category, error_type).
+ * NOT an all-time cumulative count. This matches the infra P3 alert's "rolling
+ * 60-minute window" definition, so the alert reads this gauge directly (no
+ * offset/delta math).
+ *
+ * Why dedup by category: the per-workflow gauge (getWorkflowErrorsByWorkflowFromDb)
+ * fans a single underlying cause — e.g. an RPC outage — out into one alerting
+ * series per affected workflow, paging repeatedly for the same root cause. This
+ * gauge collapses those into one series per (error_category, error_type), so the
+ * P3 alert dedups by cause/category and pages once per distinct failure mode.
+ *
+ * Why windowed: filtering only on `status='error'` matches every error
+ * execution across all orgs and joins them before narrowing to managed orgs —
+ * at prod scale that blew past the 8s metrics `statement_timeout` (Postgres
+ * 57014), the catch returned [], and the gauge flapped. Bounding to the last
+ * hour keeps the row set tiny so the query is an index range scan on
+ * idx_workflow_executions_error_completed_at and finishes in milliseconds.
+ *
+ * Scoped to MANAGED_ORG_SLUGS to keep cardinality bounded. errorCategory and
+ * errorType are read from the `workflow_executions.error_category` /
+ * `error_type` columns, projected to "unknown" for rows that predate
+ * classification so every series carries populated labels. Cardinality is
+ * bounded at roughly (~2 managed orgs) * (~8 categories seen in the window) *
+ * (2 error types) — small and stable.
+ */
+export async function getSystemErrorsByCategoryFromDb(): Promise<SystemErrorsByCategory> {
+  try {
+    const rows = await db
+      .select({
+        orgSlug: organization.slug,
+        errorCategory: sql<string>`COALESCE(${workflowExecutions.errorCategory}, 'unknown')`,
+        errorType: sql<string>`COALESCE(${workflowExecutions.errorType}, 'unknown')`,
+        count: count(),
+      })
+      .from(workflowExecutions)
+      .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
+      .innerJoin(organization, eq(workflows.organizationId, organization.id))
+      .where(
+        and(
+          eq(workflowExecutions.status, "error"),
+          sql`${workflowExecutions.completedAt} >= now() - interval '1 hour'`,
+          inArray(organization.slug, [...MANAGED_ORG_SLUGS])
+        )
+      )
+      .groupBy(
+        organization.slug,
+        workflowExecutions.errorCategory,
+        workflowExecutions.errorType
+      );
+
+    return rows.map((row) => ({
+      orgSlug: row.orgSlug,
+      errorCategory: row.errorCategory,
+      errorType: row.errorType,
+      count: Number(row.count) || 0,
+    }));
+  } catch (error) {
+    console.error(
+      "[Metrics] Failed to query system errors by category from DB:",
+      error
+    );
+    return [];
+  }
+}
+
 export type StepStats = {
   // Counts by step type and status
   countsByType: Record<string, { success: number; error: number }>;

--- a/tests/unit/db-metrics-cache.test.ts
+++ b/tests/unit/db-metrics-cache.test.ts
@@ -27,6 +27,7 @@ const DEFAULT_DB_RETURNS: Record<string, unknown> = {
     durationCount: 0,
   },
   getWorkflowErrorsByWorkflowFromDb: [],
+  getSystemErrorsByCategoryFromDb: [],
   getStepStatsFromDb: {
     countsByType: {},
     durationBuckets: [0, 0, 0, 0, 0, 0, 0, 0],
@@ -143,6 +144,10 @@ const ERRORS_BY_WORKFLOW_SKY_RE =
   /keeperhub_workflow_errors_by_workflow\{[^}]*workflow_id="wf_sky_1"[^}]*org_slug="techops-services"[^}]*error_type="user"[^}]*\}\s+7/;
 const ERRORS_BY_WORKFLOW_AJNA_RE =
   /keeperhub_workflow_errors_by_workflow\{[^}]*workflow_id="wf_ajna_1"[^}]*org_slug="ajna"[^}]*error_type="system"[^}]*\}\s+2/;
+const ERRORS_BY_CATEGORY_SKY_RE =
+  /keeperhub_system_errors_by_category\{[^}]*org_slug="techops-services"[^}]*error_category="network_rpc"[^}]*error_type="system"[^}]*\}\s+5/;
+const ERRORS_BY_CATEGORY_AJNA_RE =
+  /keeperhub_system_errors_by_category\{[^}]*org_slug="ajna"[^}]*error_category="unknown"[^}]*error_type="user"[^}]*\}\s+3/;
 
 describe("updateDbMetrics TTL cache", () => {
   const originalTtl = process.env.DB_METRICS_CACHE_TTL_MS;
@@ -418,5 +423,73 @@ describe("keeperhub_workflow_errors_by_workflow gauge", () => {
     dbMocks.getWorkflowErrorsByWorkflowFromDb.mockResolvedValue([]);
     await updateDbMetrics();
     expect(await getDbMetrics()).not.toContain('workflow_id="wf_gone"');
+  });
+});
+
+// TECH-6544: the system-errors-by-category gauge dedups errors by cause for the
+// infra P3 alert. Like the per-workflow gauge it must be DB-sourced and
+// populated on the metrics scrape, grouped by (org_slug, error_category,
+// error_type) with no workflow_id label.
+describe("keeperhub_system_errors_by_category gauge", () => {
+  const originalTtl = process.env.DB_METRICS_CACHE_TTL_MS;
+
+  beforeEach(() => {
+    __resetDbMetricsCacheForTest();
+    for (const fn of Object.values(dbMocks)) {
+      fn.mockReset();
+    }
+    rebindDefaultDbMockImplementations();
+    // No caching so each updateDbMetrics() re-reads the (overridden) mocks.
+    process.env.DB_METRICS_CACHE_TTL_MS = "0";
+  });
+
+  afterEach(() => {
+    if (originalTtl === undefined) {
+      // biome-ignore lint/performance/noDelete: must truly unset the env var to restore the unset state; assigning "" or undefined changes cache-TTL semantics
+      delete process.env.DB_METRICS_CACHE_TTL_MS;
+    } else {
+      process.env.DB_METRICS_CACHE_TTL_MS = originalTtl;
+    }
+  });
+
+  it("emits one series per (org_slug, error_category, error_type) from the DB query", async () => {
+    dbMocks.getSystemErrorsByCategoryFromDb.mockResolvedValue([
+      {
+        orgSlug: "techops-services",
+        errorCategory: "network_rpc",
+        errorType: "system",
+        count: 5,
+      },
+      {
+        orgSlug: "ajna",
+        errorCategory: "unknown",
+        errorType: "user",
+        count: 3,
+      },
+    ]);
+
+    await updateDbMetrics();
+    const out = await getDbMetrics();
+
+    expect(out).toMatch(ERRORS_BY_CATEGORY_SKY_RE);
+    expect(out).toMatch(ERRORS_BY_CATEGORY_AJNA_RE);
+  });
+
+  it("clears stale series when a category stops appearing in the query", async () => {
+    dbMocks.getSystemErrorsByCategoryFromDb.mockResolvedValueOnce([
+      {
+        orgSlug: "ajna",
+        errorCategory: "billing",
+        errorType: "user",
+        count: 4,
+      },
+    ]);
+    await updateDbMetrics();
+    expect(await getDbMetrics()).toContain('error_category="billing"');
+
+    // Next scrape no longer returns that category; reset() must drop the series.
+    dbMocks.getSystemErrorsByCategoryFromDb.mockResolvedValue([]);
+    await updateDbMetrics();
+    expect(await getDbMetrics()).not.toContain('error_category="billing"');
   });
 });

--- a/tests/unit/db-metrics-cache.test.ts
+++ b/tests/unit/db-metrics-cache.test.ts
@@ -144,10 +144,10 @@ const ERRORS_BY_WORKFLOW_SKY_RE =
   /keeperhub_workflow_errors_by_workflow\{[^}]*workflow_id="wf_sky_1"[^}]*org_slug="techops-services"[^}]*error_type="user"[^}]*\}\s+7/;
 const ERRORS_BY_WORKFLOW_AJNA_RE =
   /keeperhub_workflow_errors_by_workflow\{[^}]*workflow_id="wf_ajna_1"[^}]*org_slug="ajna"[^}]*error_type="system"[^}]*\}\s+2/;
-const ERRORS_BY_CATEGORY_SKY_RE =
-  /keeperhub_system_errors_by_category\{[^}]*org_slug="techops-services"[^}]*error_category="network_rpc"[^}]*error_type="system"[^}]*\}\s+5/;
-const ERRORS_BY_CATEGORY_AJNA_RE =
-  /keeperhub_system_errors_by_category\{[^}]*org_slug="ajna"[^}]*error_category="unknown"[^}]*error_type="user"[^}]*\}\s+3/;
+const ERRORS_BY_CATEGORY_SYSTEM_RE =
+  /keeperhub_system_errors_by_category\{[^}]*error_category="network_rpc"[^}]*error_type="system"[^}]*\}\s+5/;
+const ERRORS_BY_CATEGORY_UNKNOWN_RE =
+  /keeperhub_system_errors_by_category\{[^}]*error_category="unknown"[^}]*error_type="user"[^}]*\}\s+3/;
 
 describe("updateDbMetrics TTL cache", () => {
   const originalTtl = process.env.DB_METRICS_CACHE_TTL_MS;
@@ -427,9 +427,9 @@ describe("keeperhub_workflow_errors_by_workflow gauge", () => {
 });
 
 // TECH-6544: the system-errors-by-category gauge dedups errors by cause for the
-// infra P3 alert. Like the per-workflow gauge it must be DB-sourced and
-// populated on the metrics scrape, grouped by (org_slug, error_category,
-// error_type) with no workflow_id label.
+// infra P3 alert. It must be DB-sourced and populated on the metrics scrape,
+// grouped by (error_category, error_type) only — platform-wide, with no
+// org_slug or workflow_id label.
 describe("keeperhub_system_errors_by_category gauge", () => {
   const originalTtl = process.env.DB_METRICS_CACHE_TTL_MS;
 
@@ -452,16 +452,14 @@ describe("keeperhub_system_errors_by_category gauge", () => {
     }
   });
 
-  it("emits one series per (org_slug, error_category, error_type) from the DB query", async () => {
+  it("emits one series per (error_category, error_type) from the DB query", async () => {
     dbMocks.getSystemErrorsByCategoryFromDb.mockResolvedValue([
       {
-        orgSlug: "techops-services",
         errorCategory: "network_rpc",
         errorType: "system",
         count: 5,
       },
       {
-        orgSlug: "ajna",
         errorCategory: "unknown",
         errorType: "user",
         count: 3,
@@ -471,14 +469,13 @@ describe("keeperhub_system_errors_by_category gauge", () => {
     await updateDbMetrics();
     const out = await getDbMetrics();
 
-    expect(out).toMatch(ERRORS_BY_CATEGORY_SKY_RE);
-    expect(out).toMatch(ERRORS_BY_CATEGORY_AJNA_RE);
+    expect(out).toMatch(ERRORS_BY_CATEGORY_SYSTEM_RE);
+    expect(out).toMatch(ERRORS_BY_CATEGORY_UNKNOWN_RE);
   });
 
   it("clears stale series when a category stops appearing in the query", async () => {
     dbMocks.getSystemErrorsByCategoryFromDb.mockResolvedValueOnce([
       {
-        orgSlug: "ajna",
         errorCategory: "billing",
         errorType: "user",
         count: 4,


### PR DESCRIPTION
## What

Adds a DB-sourced Prometheus gauge **`keeperhub_system_errors_by_category`** — a rolling 1-hour count of errored workflow executions grouped by `(error_category, error_type)`, **platform-wide** (org-agnostic; no `org_slug` label).

Backs the infra **P3 system-error alert** ([TECH-6544](https://techopsservices.atlassian.net/browse/TECH-6544); infra PR techops-services/infrastructure#268), which dedups system errors **per cause** (`error_category`) rather than per workflow.

## Why

- **Per-cause dedup** (dumitru's rule 1: *"if there is a system problem with read contract node that is ongoing, only one P3 alert to be triggered"*): one ongoing cause should be a single incident even when it breaks many workflows. The per-workflow gauge `keeperhub_workflow_errors_by_workflow` fans one root cause into one series per affected workflow (~52 in prod) → would page per workflow. Grouping by `error_category` collapses a cause into one series.
- **No new classification needed** (nickk's question on the ticket): `workflow_executions` already stores `error_type` + `error_category` (migration 0073). This just surfaces `error_category` on a windowed gauge.
- **Platform-wide / no `org_slug`:** system errors (`database`, `auth`, `infrastructure`, `workflow_engine`) are platform faults, not customer-specific — matching the existing platform-wide system-error alert. Dropping `org_slug` keeps cardinality fixed (categories × types) instead of multiplying by org count.

## Why a new metric (not the existing one with this label)

The only existing metric carrying `error_category` — `keeperhub_workflow_execution_errors_created_total` — is a per-pod counter emitted from workflow-runner pods that exit before Prometheus scrapes them, so it returns **no data in prod**. Verified side-by-side over the same hour in prod:

| metric (has `error_category`) | value, last 1h |
|---|---|
| **new** `keeperhub_system_errors_by_category` (DB query) | **397** (`billing`/`user`) |
| `keeperhub_workflow_execution_errors_created_total` | **No data** |
| cross-check: `workflow_executions_total` user-error 1h delta | **397** (exact match) |

Same label — but the old metric reports 0 while 397 real errors occur. Reusing it would mean alerting on a permanently-zero series.

## How

Mirrors the `getWorkflowErrorsByWorkflowFromDb` / windowed-gauge pattern:

- `lib/metrics/db-metrics.ts` — `getSystemErrorsByCategoryFromDb()` + `SystemErrorsByCategory` type. `status='error' AND completed_at >= now() - interval '1 hour'`, `GROUP BY error_category, error_type` (no join — both columns live on `workflow_executions`), both columns `COALESCE`'d to `'unknown'`, try/catch-returns-`[]`.
- `lib/metrics/collectors/prometheus.ts` — `systemErrorsByCategory` gauge (labels `error_category`, `error_type`), wired into `refreshDbMetricsNow` (import, `Promise.all`, `.reset()` + `set()`).
- `tests/unit/db-metrics-cache.test.ts` — series emission + stale-series clearing.

Cardinality stays bounded and **fixed**: ~11 `ErrorCategory` enum values × ~3 `error_type` ≈ 33 series.

## Validation

**PR env (`pr-1583`, deploy-pr-environment + deploy-pr-metrics):** gauge registers, scrape clean (no `57014` / query-failure logs), and a live error workflow produced `keeperhub_system_errors_by_category{error_category="configuration",error_type="user"} 1`.

**Prod DB (the proof the PR env can't give):**
- Index dependency present: `idx_workflow_executions_error_completed_at` — partial `(completed_at) WHERE status='error'` (from #1580 / `0115`).
- Query returns valid, enum-bounded data (`billing/user → 397` in the last hour), confirmed exactly against the working `workflow_executions_total` cross-check.
- `EXPLAIN (ANALYZE, BUFFERS)`: **Index Scan on `idx_workflow_executions_error_completed_at`, 0.464 ms** — ~17,000× under the 8s metrics `statement_timeout`; ~2,500× faster than the old all-history shape (1,198 ms, scanning ~142k rows, and growing). Constant-time as the table grows — it only touches the last hour's error rows.

## Checks

- `pnpm type-check` (tsc --noEmit): clean
- `pnpm exec ultracite check` on changed files: 0 errors
- `pnpm exec vitest run tests/unit/db-metrics-cache.test.ts`: 12 passed (incl. 2 new)

(One unrelated pre-existing failure in `agentic-wallet-rate-limit.test.ts` — a clock-dependent assertion that fails identically on the clean base branch, not introduced here.)

## Deploy note

Depends on `idx_workflow_executions_error_completed_at` (#1580 — already merged and live in prod, so satisfied). The infra alert (infra#268) is dormant (no-data → OK) until this gauge reaches prod. Safe to merge independently.
