### PR TITLE
feat(activity): refresh on org switch and add member/guest views

### DIFF
--- a/components/activity/activity-feed.tsx
+++ b/components/activity/activity-feed.tsx
@@ -1,23 +1,17 @@
 "use client";
 
-import { ChevronRight, Minus, Pencil, Plus } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ApiKeysOverlay } from "@/components/overlays/api-keys-overlay";
 import { IntegrationsOverlay } from "@/components/overlays/integrations-overlay";
 import { useOverlay } from "@/components/overlays/overlay-provider";
-import { relativeTime } from "@/components/settings/session-format";
 import { Skeleton } from "@/components/ui/skeleton";
 import { groupByDate } from "@/lib/activity/time-groups";
 import { api, type SecurityAuditEvent } from "@/lib/api-client";
+import { authClient } from "@/lib/auth-client";
 import { usePaginatedResource } from "@/lib/hooks/use-paginated-resource";
 import type { PageMeta } from "@/lib/pagination";
-import {
-  type AuditActionKind,
-  describeAuditAction,
-} from "@/lib/security/audit-actions";
-import { SENSITIVE_FIELD } from "@/lib/security/audit-redaction";
-import { ActorAvatarBadge, actorLabel } from "./actor-avatar";
+import { ActivityRow } from "./activity-row";
 import { Pager } from "./pager";
 
 type FeedParams = {
@@ -36,279 +30,6 @@ type FeedParams = {
   search?: string;
   limit?: number;
 };
-
-const KIND_ICON: Record<AuditActionKind, typeof Plus> = {
-  add: Plus,
-  remove: Minus,
-  change: Pencil,
-};
-
-const KIND_COLOR: Record<AuditActionKind, string> = {
-  add: "text-keeperhub-green",
-  remove: "text-destructive",
-  change: "text-amber-400",
-};
-
-function metadataLine(event: SecurityAuditEvent): string | null {
-  const meta = event.metadata as Record<string, unknown> | null;
-  if (!meta) {
-    return null;
-  }
-  const parts: string[] = [];
-  if (typeof meta.ip === "string") {
-    parts.push(meta.ip);
-  }
-  if (typeof meta.country === "string") {
-    parts.push(meta.country);
-  }
-  return parts.length > 0 ? parts.join(" · ") : null;
-}
-
-function capitalize(text: string): string {
-  return text.charAt(0).toUpperCase() + text.slice(1);
-}
-
-function roleLabel(role?: string | null): string | null {
-  return role ? capitalize(role) : null;
-}
-
-type DiffEntry = { label: string; from: string | null; to: string | null };
-
-// Opaque machine values that read as noise in a human feed (e.g. a definition
-// content hash). The change is still recorded; we just don't print the value.
-const HIDDEN_FIELDS = new Set(["contentHash"]);
-
-function humanizeField(path: Array<string | number>): string {
-  const key = String(path.at(-1) ?? "");
-  const spaced = key
-    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
-    .replace(/[_.]+/g, " ")
-    .trim();
-  return spaced ? spaced.charAt(0).toUpperCase() + spaced.slice(1) : "Value";
-}
-
-function formatValue(value: unknown, sensitive: boolean): string | null {
-  if (value === null || value === undefined || value === "") {
-    return null;
-  }
-  if (sensitive) {
-    return "•••";
-  }
-  if (typeof value === "boolean") {
-    return value ? "Yes" : "No";
-  }
-  if (typeof value === "number") {
-    return String(value);
-  }
-  if (typeof value === "string") {
-    return value;
-  }
-  return "[changed]";
-}
-
-// Turn the stored deep-diff array into readable "Field: old -> new" rows.
-function diffEntries(diff: unknown): DiffEntry[] {
-  if (!Array.isArray(diff)) {
-    return [];
-  }
-  const entries: DiffEntry[] = [];
-  for (const change of diff) {
-    if (!change || typeof change !== "object") {
-      continue;
-    }
-    const c = change as {
-      kind?: string;
-      path?: Array<string | number>;
-      lhs?: unknown;
-      rhs?: unknown;
-    };
-    const path = c.path ?? [];
-    // Root-level changes (no field path) are whole-object create/delete diffs;
-    // the action phrase ("created a project") already says it, so skip them
-    // rather than printing "Value: [changed]".
-    if (path.length === 0) {
-      continue;
-    }
-    const fieldKey = String(path.at(-1) ?? "");
-    if (HIDDEN_FIELDS.has(fieldKey)) {
-      continue;
-    }
-    const sensitive = SENSITIVE_FIELD.test(fieldKey);
-    const label = humanizeField(path);
-    if (c.kind === "E") {
-      entries.push({
-        label,
-        from: formatValue(c.lhs, sensitive),
-        to: formatValue(c.rhs, sensitive),
-      });
-    } else if (c.kind === "N") {
-      entries.push({ label, from: null, to: formatValue(c.rhs, sensitive) });
-    } else if (c.kind === "D") {
-      entries.push({ label, from: formatValue(c.lhs, sensitive), to: null });
-    }
-  }
-  return entries.filter((e) => e.from !== null || e.to !== null).slice(0, 6);
-}
-
-const HEX_COLOR = /^#[0-9a-f]{3,8}$/i;
-
-function ValuePiece({ value }: { value: string }): React.ReactElement {
-  if (HEX_COLOR.test(value)) {
-    return (
-      <span
-        className="inline-block size-3 rounded-full border border-border align-middle"
-        style={{ backgroundColor: value }}
-        title={value}
-      />
-    );
-  }
-  return <>{value}</>;
-}
-
-function DiffLines({ diff }: { diff: unknown }): React.ReactElement | null {
-  const entries = diffEntries(diff);
-  if (entries.length === 0) {
-    return null;
-  }
-  return (
-    <ul className="mt-1 space-y-0.5">
-      {entries.map((entry) => (
-        <li
-          className="text-muted-foreground text-xs"
-          key={`${entry.label}:${entry.from ?? ""}:${entry.to ?? ""}`}
-        >
-          <span className="font-medium text-foreground/70">{entry.label}:</span>{" "}
-          {entry.from !== null && (
-            <span className="opacity-60">
-              <ValuePiece value={entry.from} />
-            </span>
-          )}
-          {entry.from !== null && entry.to !== null && " → "}
-          {entry.to !== null && (
-            <span>
-              <ValuePiece value={entry.to} />
-            </span>
-          )}
-        </li>
-      ))}
-    </ul>
-  );
-}
-
-// The workflow definition (nodes/edges/config) is audited as a content hash;
-// when it appears in the diff the build itself changed, even if no scalar field
-// did. We don't print the hash (it's a HIDDEN_FIELD), so surface a plain note
-// instead so the row says what kind of update happened.
-function definitionChanged(diff: unknown): boolean {
-  if (!Array.isArray(diff)) {
-    return false;
-  }
-  return diff.some((c) => {
-    const path = (c as { path?: Array<string | number> })?.path ?? [];
-    return String(path.at(-1) ?? "") === "contentHash";
-  });
-}
-
-// Resource types a feed row can open: workflows go to their editor's version
-// History; integrations and API keys open their management modal. Types with no
-// such destination (wallet signings, projects, tags) stay non-clickable.
-const OPENABLE_TYPES = new Set([
-  "workflow",
-  "integration",
-  "api_key",
-  "org_api_key",
-]);
-
-function isOpenableEvent(event: SecurityAuditEvent): boolean {
-  return (
-    Boolean(event.resourceId) &&
-    event.resourceType !== null &&
-    OPENABLE_TYPES.has(event.resourceType)
-  );
-}
-
-function ActivityRow({
-  event,
-  onOpen,
-}: {
-  event: SecurityAuditEvent;
-  onOpen?: (event: SecurityAuditEvent) => void;
-}): React.ReactElement {
-  const { phrase, kind } = describeAuditAction(event.action);
-  const Icon = KIND_ICON[kind];
-  const meta = metadataLine(event);
-  const actor = event.actor;
-  const role = roleLabel(actor?.role);
-  // Show the email on its own line only when we also have a name -- otherwise
-  // actorLabel already falls back to the email.
-  const email = actor?.name ? actor.email : null;
-  const resourceName = event.resourceName;
-  const canOpen = Boolean(onOpen) && isOpenableEvent(event);
-
-  const header = (
-    <>
-      <div className="flex items-baseline justify-between gap-2 text-sm leading-snug">
-        <span className="min-w-0 truncate">
-          <span className="font-medium">{actorLabel(actor)}</span>
-          {role && (
-            <span className="ml-1 text-muted-foreground text-xs">· {role}</span>
-          )}
-        </span>
-        <span className="flex shrink-0 items-center gap-1 whitespace-nowrap text-muted-foreground">
-          {capitalize(phrase)}
-          {/* Always reserve the chevron slot so non-openable rows keep their
-              label aligned with openable ones. */}
-          {canOpen ? (
-            <ChevronRight className="size-3.5" />
-          ) : (
-            <span aria-hidden="true" className="size-3.5" />
-          )}
-        </span>
-      </div>
-      {resourceName && (
-        <div className="mt-0.5 truncate font-medium text-foreground/90 text-sm">
-          {resourceName}
-        </div>
-      )}
-    </>
-  );
-
-  return (
-    <li className="flex items-start gap-3 py-3">
-      <ActorAvatarBadge
-        actor={actor}
-        badgeClassName={KIND_COLOR[kind]}
-        icon={Icon}
-      />
-      <div className="min-w-0 flex-1">
-        {canOpen ? (
-          <button
-            className="-mx-1 block w-full rounded px-1 text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            onClick={() => onOpen?.(event)}
-            type="button"
-          >
-            {header}
-          </button>
-        ) : (
-          header
-        )}
-        <DiffLines diff={event.diff} />
-        {definitionChanged(event.diff) && (
-          <p className="mt-1 text-muted-foreground text-xs">
-            Definition updated
-          </p>
-        )}
-        {email && (
-          <p className="truncate text-muted-foreground text-xs">{email}</p>
-        )}
-        <p className="text-muted-foreground text-xs">
-          {relativeTime(event.createdAt)}
-          {meta ? ` · ${meta}` : ""}
-        </p>
-      </div>
-    </li>
-  );
-}
 
 // Synthesized baseline entries stand in for a resource's creation when no
 // audit event was ever recorded (it pre-dates auditing). A creation is the
@@ -418,6 +139,12 @@ export function ActivityFeed({
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  // Scope the feed to the active org: switching orgs must reset to page 1 and
+  // refetch. router.refresh() (fired by the org switcher) re-renders server
+  // components but keeps this client state, so without the org in the reset key
+  // the feed would keep showing the previous org's events.
+  const { data: activeOrg } = authClient.useActiveOrganization();
+  const activeOrgId = activeOrg?.id ?? null;
   const initialPage = syncPageToUrl
     ? Math.max(1, Number.parseInt(searchParams.get("page") ?? "", 10) || 1)
     : 1;
@@ -483,8 +210,10 @@ export function ActivityFeed({
       }),
     // `limit` (page size) is intentionally NOT part of the reset key: changing
     // the page size keeps the current page (it just refetches via the effect
-    // below). Only the actual filters reset the feed back to page 1.
+    // below). Only the actual filters -- and the active org -- reset the feed
+    // back to page 1.
     JSON.stringify({
+      orgId: activeOrgId,
       resourceType,
       resourceTypes,
       resourceId,

--- a/components/activity/activity-member-preview.tsx
+++ b/components/activity/activity-member-preview.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { Info } from "lucide-react";
+import { type ReactNode, useMemo } from "react";
+import { groupByDate } from "@/lib/activity/time-groups";
+import type { SecurityAuditEvent } from "@/lib/api-client";
+import { ActivityRow } from "./activity-row";
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+// Synthetic sample rows shown to members, who can't read the real audit log
+// (the endpoint 403s them). Names/emails are fictional and IPs are from the
+// 203.0.113.0/24 documentation range, so nothing real ever reaches a member's
+// browser.
+function buildSampleEvents(now: number): SecurityAuditEvent[] {
+  return [
+    {
+      id: "sample-1",
+      action: "workflow.updated",
+      resourceType: "workflow",
+      resourceId: null,
+      resourceName: "Treasury rebalance",
+      version: 8,
+      createdAt: new Date(now - 2 * HOUR_MS).toISOString(),
+      diff: [{ kind: "E", path: ["schedule"], lhs: "Daily", rhs: "Hourly" }],
+      metadata: { ip: "203.0.113.10", country: "US" },
+      actor: {
+        id: "sample-a",
+        name: "Jordan Lee",
+        email: "jordan@example.com",
+        role: "admin",
+      },
+    },
+    {
+      id: "sample-2",
+      action: "integration.created",
+      resourceType: "integration",
+      resourceId: null,
+      resourceName: "Discord",
+      version: null,
+      createdAt: new Date(now - 6 * HOUR_MS).toISOString(),
+      diff: null,
+      metadata: { ip: "203.0.113.24", country: "DE" },
+      actor: {
+        id: "sample-b",
+        name: "Sam Rivera",
+        email: "sam@example.com",
+        role: "owner",
+      },
+    },
+    {
+      id: "sample-3",
+      action: "member.invited",
+      resourceType: "member",
+      resourceId: null,
+      resourceName: null,
+      version: null,
+      createdAt: new Date(now - DAY_MS - 3 * HOUR_MS).toISOString(),
+      diff: null,
+      metadata: { ip: "203.0.113.51", country: "GB" },
+      actor: {
+        id: "sample-c",
+        name: "Avery Stone",
+        email: "avery@example.com",
+        role: "owner",
+      },
+    },
+    {
+      id: "sample-4",
+      action: "api_key.revoked",
+      resourceType: "api_key",
+      resourceId: null,
+      resourceName: "CI deploy key",
+      version: null,
+      createdAt: new Date(now - 2 * DAY_MS).toISOString(),
+      diff: null,
+      metadata: { ip: "203.0.113.77", country: "US" },
+      actor: {
+        id: "sample-d",
+        name: "Jordan Lee",
+        email: "jordan@example.com",
+        role: "admin",
+      },
+    },
+  ];
+}
+
+/**
+ * Members can see that an activity log exists, but not its contents. This shows
+ * a labelled sample of the page with a banner pointing to the role that unlocks
+ * the real data. It never calls the audit endpoint -- the rows are mock data.
+ */
+export function ActivityMemberPreview(): ReactNode {
+  const groups = useMemo(() => {
+    const events = buildSampleEvents(Date.now());
+    return groupByDate(events, (e) => e.createdAt);
+  }, []);
+
+  return (
+    <div className="pointer-events-auto fixed inset-0 flex flex-col overflow-hidden bg-sidebar">
+      <div className="flex min-h-0 flex-1 flex-col transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+        <div className="flex min-h-0 flex-1 flex-col gap-6 p-6 pt-[calc(5rem+var(--app-banner-height,0px))]">
+          <div className="space-y-1">
+            <h1 className="font-semibold text-2xl tracking-tight">
+              Organization activity
+            </h1>
+            <p className="text-muted-foreground text-sm">
+              Recent security-sensitive actions across your organization.
+            </p>
+          </div>
+
+          <div className="flex items-start gap-3 rounded-lg border border-border bg-muted/40 p-4">
+            <Info className="mt-0.5 size-5 shrink-0 text-muted-foreground" />
+            <div className="space-y-0.5">
+              <p className="font-medium text-sm">Sample activity</p>
+              <p className="text-muted-foreground text-sm">
+                This is example data. The full organization activity log is
+                visible to Owners and Admins.
+              </p>
+            </div>
+          </div>
+
+          <div className="thin-scrollbar min-h-0 flex-1 overflow-y-auto">
+            {groups.map((group) => (
+              <div key={group.label}>
+                <p className="sticky top-0 z-10 mb-2 border-border/60 border-b bg-background pt-6 pb-2 font-medium text-muted-foreground text-xs uppercase tracking-wide first:pt-0">
+                  {group.label}
+                </p>
+                <ul>
+                  {group.items.map((event) => (
+                    <ActivityRow event={event} key={event.id} />
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/activity/activity-page.tsx
+++ b/components/activity/activity-page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { Download, Search } from "lucide-react";
-import { useRouter, useSearchParams } from "next/navigation";
-import { type ReactNode, useEffect } from "react";
+import { Download, LogIn, Search } from "lucide-react";
+import { useSearchParams } from "next/navigation";
+import type { ReactNode } from "react";
 import { ActivityFeed } from "@/components/activity/activity-feed";
+import { ActivityMemberPreview } from "@/components/activity/activity-member-preview";
 import { AuditFilterBar } from "@/components/activity/audit-filter-bar";
+import { useAuthPrompt } from "@/components/auth/provider";
 import { ExportAuditOverlay } from "@/components/overlays/export-audit-overlay";
 import { useOverlay } from "@/components/overlays/overlay-provider";
 import { Button } from "@/components/ui/button";
@@ -25,16 +27,52 @@ import {
 import { useActiveMember } from "@/lib/hooks/use-organization";
 
 /**
- * Full-page organization activity feed. Mirrors the body of ActivityOverlay but
- * in page chrome, reachable at /activity from the left nav. Admin/owner only --
- * the read endpoint is gated the same way server-side, and anyone without that
- * role who lands here by URL is bounced home rather than shown an empty page.
+ * In-page sign-in panel for the Activity route. Signed-out users reach the page
+ * (the nav item is visible to everyone) and get a sign-in prompt here rather
+ * than being bounced home.
  */
-export function ActivityPage(): ReactNode {
-  const { data: session, isPending } = useSession();
-  const { isAdmin, isOwner, isLoading } = useActiveMember();
+function ActivityGuestGate(): ReactNode {
+  const { openAuthPrompt } = useAuthPrompt();
+  return (
+    <div className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar">
+      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+        <div className="flex min-h-[80vh] flex-col items-center justify-center gap-6 p-6 text-center">
+          <div className="flex size-20 items-center justify-center rounded-2xl bg-muted">
+            <LogIn className="size-10 text-muted-foreground" />
+          </div>
+          <div className="space-y-2">
+            <h2 className="font-semibold text-xl tracking-tight">
+              Sign in to view activity
+            </h2>
+            <p className="max-w-sm text-muted-foreground text-sm">
+              Sign in to see security-sensitive actions across your
+              organization.
+            </p>
+          </div>
+          <Button
+            onClick={() =>
+              openAuthPrompt({
+                action: "nav:activity",
+                redirectTo: "/activity",
+              })
+            }
+          >
+            Sign in
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Full activity feed for owners and admins -- the real, server-backed view.
+ * Isolated in its own component so the audit data hook only runs for the roles
+ * allowed to read it.
+ */
+function ActivityAdminView(): ReactNode {
+  const { isOwner } = useActiveMember();
   const { push } = useOverlay();
-  const router = useRouter();
   const searchParams = useSearchParams();
   // Seed page size from the URL so a shared/refreshed ?size=N is honored; an
   // out-of-range value falls back to the default.
@@ -47,21 +85,6 @@ export function ActivityPage(): ReactNode {
   // Seed the search box from ?q so a shared/refreshed search is honored.
   const initialSearch = (searchParams.get("q") ?? "").slice(0, 200);
   const activity = useAuditActivity({ initialPageSize, initialSearch });
-
-  // Admin/owner only. Once auth + membership resolve, bounce anyone else home;
-  // the server already 403s the data, this just keeps them off the page.
-  const resolved = !(isPending || isLoading);
-  const allowed =
-    Boolean(session?.user) && !session?.user?.isAnonymous && isAdmin;
-  useEffect(() => {
-    if (resolved && !allowed) {
-      router.replace("/");
-    }
-  }, [resolved, allowed, router]);
-
-  if (!(resolved && allowed)) {
-    return null;
-  }
 
   return (
     <div className="pointer-events-auto fixed inset-0 flex flex-col overflow-hidden bg-sidebar">
@@ -134,4 +157,38 @@ export function ActivityPage(): ReactNode {
       </div>
     </div>
   );
+}
+
+/**
+ * Full-page organization activity feed, reachable at /activity from the left
+ * nav (visible to everyone). What's shown depends on the viewer's role in the
+ * active org: owners/admins get the real feed, members get a labelled sample,
+ * and signed-out users get an in-page sign-in prompt. The read endpoint is
+ * gated the same way server-side, so the member/guest views never hold real
+ * audit data. Re-evaluates on org switch via useActiveMember.
+ */
+export function ActivityPage(): ReactNode {
+  const { data: session, isPending } = useSession();
+  const { isAdmin, isLoading } = useActiveMember();
+
+  if (isPending) {
+    return null;
+  }
+
+  const signedIn = Boolean(session?.user) && !session?.user?.isAnonymous;
+  if (!signedIn) {
+    return <ActivityGuestGate />;
+  }
+
+  // Wait for the active-org membership to resolve before choosing member vs
+  // admin, so a switch doesn't flash the wrong view.
+  if (isLoading) {
+    return null;
+  }
+
+  if (!isAdmin) {
+    return <ActivityMemberPreview />;
+  }
+
+  return <ActivityAdminView />;
 }

--- a/components/activity/activity-row.tsx
+++ b/components/activity/activity-row.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { ChevronRight, Minus, Pencil, Plus } from "lucide-react";
+import { relativeTime } from "@/components/settings/session-format";
+import type { SecurityAuditEvent } from "@/lib/api-client";
+import {
+  type AuditActionKind,
+  describeAuditAction,
+} from "@/lib/security/audit-actions";
+import { SENSITIVE_FIELD } from "@/lib/security/audit-redaction";
+import { ActorAvatarBadge, actorLabel } from "./actor-avatar";
+
+const KIND_ICON: Record<AuditActionKind, typeof Plus> = {
+  add: Plus,
+  remove: Minus,
+  change: Pencil,
+};
+
+const KIND_COLOR: Record<AuditActionKind, string> = {
+  add: "text-keeperhub-green",
+  remove: "text-destructive",
+  change: "text-amber-400",
+};
+
+function metadataLine(event: SecurityAuditEvent): string | null {
+  const meta = event.metadata as Record<string, unknown> | null;
+  if (!meta) {
+    return null;
+  }
+  const parts: string[] = [];
+  if (typeof meta.ip === "string") {
+    parts.push(meta.ip);
+  }
+  if (typeof meta.country === "string") {
+    parts.push(meta.country);
+  }
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+
+function capitalize(text: string): string {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+function roleLabel(role?: string | null): string | null {
+  return role ? capitalize(role) : null;
+}
+
+type DiffEntry = { label: string; from: string | null; to: string | null };
+
+// Opaque machine values that read as noise in a human feed (e.g. a definition
+// content hash). The change is still recorded; we just don't print the value.
+const HIDDEN_FIELDS = new Set(["contentHash"]);
+
+function humanizeField(path: Array<string | number>): string {
+  const key = String(path.at(-1) ?? "");
+  const spaced = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_.]+/g, " ")
+    .trim();
+  return spaced ? spaced.charAt(0).toUpperCase() + spaced.slice(1) : "Value";
+}
+
+function formatValue(value: unknown, sensitive: boolean): string | null {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+  if (sensitive) {
+    return "•••";
+  }
+  if (typeof value === "boolean") {
+    return value ? "Yes" : "No";
+  }
+  if (typeof value === "number") {
+    return String(value);
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  return "[changed]";
+}
+
+// Turn the stored deep-diff array into readable "Field: old -> new" rows.
+function diffEntries(diff: unknown): DiffEntry[] {
+  if (!Array.isArray(diff)) {
+    return [];
+  }
+  const entries: DiffEntry[] = [];
+  for (const change of diff) {
+    if (!change || typeof change !== "object") {
+      continue;
+    }
+    const c = change as {
+      kind?: string;
+      path?: Array<string | number>;
+      lhs?: unknown;
+      rhs?: unknown;
+    };
+    const path = c.path ?? [];
+    // Root-level changes (no field path) are whole-object create/delete diffs;
+    // the action phrase ("created a project") already says it, so skip them
+    // rather than printing "Value: [changed]".
+    if (path.length === 0) {
+      continue;
+    }
+    const fieldKey = String(path.at(-1) ?? "");
+    if (HIDDEN_FIELDS.has(fieldKey)) {
+      continue;
+    }
+    const sensitive = SENSITIVE_FIELD.test(fieldKey);
+    const label = humanizeField(path);
+    if (c.kind === "E") {
+      entries.push({
+        label,
+        from: formatValue(c.lhs, sensitive),
+        to: formatValue(c.rhs, sensitive),
+      });
+    } else if (c.kind === "N") {
+      entries.push({ label, from: null, to: formatValue(c.rhs, sensitive) });
+    } else if (c.kind === "D") {
+      entries.push({ label, from: formatValue(c.lhs, sensitive), to: null });
+    }
+  }
+  return entries.filter((e) => e.from !== null || e.to !== null).slice(0, 6);
+}
+
+const HEX_COLOR = /^#[0-9a-f]{3,8}$/i;
+
+function ValuePiece({ value }: { value: string }): React.ReactElement {
+  if (HEX_COLOR.test(value)) {
+    return (
+      <span
+        className="inline-block size-3 rounded-full border border-border align-middle"
+        style={{ backgroundColor: value }}
+        title={value}
+      />
+    );
+  }
+  return <>{value}</>;
+}
+
+function DiffLines({ diff }: { diff: unknown }): React.ReactElement | null {
+  const entries = diffEntries(diff);
+  if (entries.length === 0) {
+    return null;
+  }
+  return (
+    <ul className="mt-1 space-y-0.5">
+      {entries.map((entry) => (
+        <li
+          className="text-muted-foreground text-xs"
+          key={`${entry.label}:${entry.from ?? ""}:${entry.to ?? ""}`}
+        >
+          <span className="font-medium text-foreground/70">{entry.label}:</span>{" "}
+          {entry.from !== null && (
+            <span className="opacity-60">
+              <ValuePiece value={entry.from} />
+            </span>
+          )}
+          {entry.from !== null && entry.to !== null && " → "}
+          {entry.to !== null && (
+            <span>
+              <ValuePiece value={entry.to} />
+            </span>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// The workflow definition (nodes/edges/config) is audited as a content hash;
+// when it appears in the diff the build itself changed, even if no scalar field
+// did. We don't print the hash (it's a HIDDEN_FIELD), so surface a plain note
+// instead so the row says what kind of update happened.
+function definitionChanged(diff: unknown): boolean {
+  if (!Array.isArray(diff)) {
+    return false;
+  }
+  return diff.some((c) => {
+    const path = (c as { path?: Array<string | number> })?.path ?? [];
+    return String(path.at(-1) ?? "") === "contentHash";
+  });
+}
+
+// Resource types a feed row can open: workflows go to their editor's version
+// History; integrations and API keys open their management modal. Types with no
+// such destination (wallet signings, projects, tags) stay non-clickable.
+const OPENABLE_TYPES = new Set([
+  "workflow",
+  "integration",
+  "api_key",
+  "org_api_key",
+]);
+
+export function isOpenableEvent(event: SecurityAuditEvent): boolean {
+  return (
+    Boolean(event.resourceId) &&
+    event.resourceType !== null &&
+    OPENABLE_TYPES.has(event.resourceType)
+  );
+}
+
+export function ActivityRow({
+  event,
+  onOpen,
+}: {
+  event: SecurityAuditEvent;
+  onOpen?: (event: SecurityAuditEvent) => void;
+}): React.ReactElement {
+  const { phrase, kind } = describeAuditAction(event.action);
+  const Icon = KIND_ICON[kind];
+  const meta = metadataLine(event);
+  const actor = event.actor;
+  const role = roleLabel(actor?.role);
+  // Show the email on its own line only when we also have a name -- otherwise
+  // actorLabel already falls back to the email.
+  const email = actor?.name ? actor.email : null;
+  const resourceName = event.resourceName;
+  const canOpen = Boolean(onOpen) && isOpenableEvent(event);
+
+  const header = (
+    <>
+      <div className="flex items-baseline justify-between gap-2 text-sm leading-snug">
+        <span className="min-w-0 truncate">
+          <span className="font-medium">{actorLabel(actor)}</span>
+          {role && (
+            <span className="ml-1 text-muted-foreground text-xs">· {role}</span>
+          )}
+        </span>
+        <span className="flex shrink-0 items-center gap-1 whitespace-nowrap text-muted-foreground">
+          {capitalize(phrase)}
+          {/* Always reserve the chevron slot so non-openable rows keep their
+              label aligned with openable ones. */}
+          {canOpen ? (
+            <ChevronRight className="size-3.5" />
+          ) : (
+            <span aria-hidden="true" className="size-3.5" />
+          )}
+        </span>
+      </div>
+      {resourceName && (
+        <div className="mt-0.5 truncate font-medium text-foreground/90 text-sm">
+          {resourceName}
+        </div>
+      )}
+    </>
+  );
+
+  return (
+    <li className="flex items-start gap-3 py-3">
+      <ActorAvatarBadge
+        actor={actor}
+        badgeClassName={KIND_COLOR[kind]}
+        icon={Icon}
+      />
+      <div className="min-w-0 flex-1">
+        {canOpen ? (
+          <button
+            className="-mx-1 block w-full rounded px-1 text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={() => onOpen?.(event)}
+            type="button"
+          >
+            {header}
+          </button>
+        ) : (
+          header
+        )}
+        <DiffLines diff={event.diff} />
+        {definitionChanged(event.diff) && (
+          <p className="mt-1 text-muted-foreground text-xs">
+            Definition updated
+          </p>
+        )}
+        {email && (
+          <p className="truncate text-muted-foreground text-xs">{email}</p>
+        )}
+        <p className="text-muted-foreground text-xs">
+          {relativeTime(event.createdAt)}
+          {meta ? ` · ${meta}` : ""}
+        </p>
+      </div>
+    </li>
+  );
+}

--- a/components/navigation-sidebar.tsx
+++ b/components/navigation-sidebar.tsx
@@ -575,12 +575,14 @@ const NAV_ITEMS: NavItemDef[] = [
     requireAuth: true,
   },
   {
+    // Visible to everyone and routable while signed-out: the page itself shows
+    // an in-page sign-in for guests, a labelled sample for members, and the
+    // real feed for owners/admins. So this is neither requireAuth nor adminOnly.
     id: "activity",
     icon: Activity,
     label: "Activity",
     href: "/activity",
-    requireAuth: true,
-    adminOnly: true,
+    requireAuth: false,
   },
 ];
 

--- a/lib/hooks/use-audit-activity.ts
+++ b/lib/hooks/use-audit-activity.ts
@@ -121,7 +121,12 @@ export function useAuditActivity(options?: {
   const [tagOptions, setTagOptions] = useState<ResourceOption[]>([]);
   const [workflowOptions, setWorkflowOptions] = useState<ResourceOption[]>([]);
 
-  // Projects and tags are stable pickers, loaded once.
+  const { data: activeOrg } = authClient.useActiveOrganization();
+  const activeOrgId = activeOrg?.id ?? null;
+
+  // Projects and tags pickers, reloaded when the active org changes so a switch
+  // doesn't leave the previous org's options in the filter bar.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: activeOrgId is the refetch trigger on org switch; the endpoints scope by the active org server-side, so it is not read in the body
   useEffect(() => {
     let cancelled = false;
     const load = async () => {
@@ -143,10 +148,11 @@ export function useAuditActivity(options?: {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [activeOrgId]);
 
   // Workflow picker cascades to the selected project(s)/tag(s); the scoping is
   // applied server-side by /api/workflows, never by filtering a full list here.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: activeOrgId is the refetch trigger on org switch; the endpoint scopes by the active org server-side, so it is not read in the body
   useEffect(() => {
     let cancelled = false;
     const load = async () => {
@@ -181,9 +187,8 @@ export function useAuditActivity(options?: {
     return () => {
       cancelled = true;
     };
-  }, [projects, tags]);
+  }, [projects, tags, activeOrgId]);
 
-  const { data: activeOrg } = authClient.useActiveOrganization();
   const members: AuditActivityMember[] = useMemo(() => {
     const list = (activeOrg?.members ?? []) as Array<{
       userId: string;


### PR DESCRIPTION
## Summary

Fixes stale data on the Organization activity page when switching orgs, and opens the page to all roles with appropriate content instead of redirecting non-admins home.

## Changes

- **Org-scope the feed.** The active org id is now part of the feed reset key and the project/tag/workflow option-list loaders, so a switch resets to page 1 and refetches. Previously `router.refresh()` kept client state, so the feed showed the previous org's events while the Export CSV button re-enabled for the new org.
- **Role-based content** replaces the admin-only redirect:
  - Owners/Admins: the real, server-backed feed (unchanged).
  - Members: a labelled sample of the page with a banner pointing to the role that unlocks the real data. Mock data only; never calls the audit endpoint.
  - Signed-out users: an in-page sign-in prompt.
- **Nav item** is visible to everyone and routable while signed-out.
- Extracted the shared activity row into its own module so the real feed and the member sample render identically.

## Security

The audit read endpoint keeps its server-side owner/admin gate. The member and guest views never request or hold real audit data.

## Verification

- Org switch owner to owner: data refreshes, no stale Export.
- Org switch owner to member: sample view + banner, no redirect, no audit request.
- Signed-out: in-page sign-in.
- type-check and lint clean on the changed files.