### PR TITLE
fix(activity): prevent duplicate-name rows from co-highlighting in activity filter

### DIFF
--- a/components/activity/audit-filter-bar.tsx
+++ b/components/activity/audit-filter-bar.tsx
@@ -234,7 +234,7 @@ function ValueList({
                     onBack();
                   }
                 }}
-                value={opt.search}
+                value={`${opt.search} ${opt.value}`}
               >
                 {opt.node ?? <span>{opt.label}</span>}
                 {checked && <Check className="ml-auto size-4 shrink-0" />}


### PR DESCRIPTION
## Problem

In the Activity filter's workflow picker, two distinct workflows that share a display name (e.g. multiple "Untitled 100") highlight together on hover, and selecting one appears to select both.

## Root cause

The picker uses `cmdk`, which tracks the active/highlighted row by its `value` string. Each `CommandItem` set `value` to the option's search text (the workflow name), so same-named rows collapsed to a single cmdk value and lit up together. The underlying selection state was already correct (it keys off the workflow id), and the workflow list is deduped by id, so the duplicate rows are genuinely separate workflows, only the highlight was wrong.

## Fix

Append the unique resource id to each item's cmdk `value` so every row is distinct. Search by name still works because cmdk substring-matches and the name remains in the value string. The change lives in the shared value-list renderer, so it also hardens the person, project, and tag pickers against the same collision.