### PR TITLE
feat: auto-provision non-custodial wallet at signup with sponsored-run badge

### DIFF
--- a/app/api/user/wallet/provision/route.ts
+++ b/app/api/user/wallet/provision/route.ts
@@ -1,0 +1,58 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { apiError } from "@/lib/api-error";
+import { requireOrganization } from "@/lib/middleware/require-org";
+import { createProvisionWalletStreamStart } from "@/lib/turnkey/provision-wallet-stream";
+
+// Reject anonymous / unverified placeholder emails - those orgs never get a
+// non-custodial wallet (mirrors the guard in POST /api/user/wallet).
+function isProvisionableEmail(email: string | undefined): email is string {
+  if (!email) {
+    return false;
+  }
+  if (email.startsWith("temp-")) {
+    return false;
+  }
+  return !(email.includes("@http://") || email.includes("@https://"));
+}
+
+export const GET = requireOrganization(
+  async (req: NextRequest, context): Promise<Response> => {
+    try {
+      const organizationId = context.organization?.id;
+      if (!organizationId) {
+        return NextResponse.json(
+          { error: "No active organization" },
+          { status: 400 }
+        );
+      }
+
+      const user = context.user;
+      if (!(user && isProvisionableEmail(user.email))) {
+        return NextResponse.json(
+          { error: "A verified email is required to provision a wallet" },
+          { status: 400 }
+        );
+      }
+
+      const start = createProvisionWalletStreamStart({
+        signal: req.signal,
+        input: { userId: user.id, organizationId, email: user.email },
+      });
+
+      const stream = new ReadableStream<Uint8Array>({ start });
+
+      return await Promise.resolve(
+        new Response(stream, {
+          headers: {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            Connection: "keep-alive",
+          },
+        })
+      );
+    } catch (error: unknown) {
+      return apiError(error, "Failed to start wallet provisioning stream");
+    }
+  }
+);

--- a/app/api/user/wallet/route.ts
+++ b/app/api/user/wallet/route.ts
@@ -1,15 +1,9 @@
 import { and, eq } from "drizzle-orm";
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
-import { recordWalletInAddressBook } from "@/lib/address-book/record-wallet";
-import { normalizeAddressForStorage } from "@/lib/address-utils";
 import { apiError } from "@/lib/api-error";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-import {
-  buildWalletIntegrationPayload,
-  createIntegration,
-} from "@/lib/db/integrations";
 import { integrations, organizationWallets } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import {
@@ -19,7 +13,7 @@ import {
 } from "@/lib/middleware/auth-helpers";
 import { getActiveOrgId } from "@/lib/middleware/org-context";
 import { buildAuditMetadata, recordAuditEvent } from "@/lib/security/audit-log";
-import { createTurnkeyWallet } from "@/lib/turnkey/turnkey-client";
+import { provisionOrganizationWallet } from "@/lib/turnkey/provision-org-wallet";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -160,55 +154,6 @@ function getErrorResponse(error: unknown): NextResponse {
   return NextResponse.json({ error: errorMessage }, { status: statusCode });
 }
 
-async function storeTurnkeyWalletAndIntegration(options: {
-  userId: string;
-  organizationId: string;
-  email: string;
-  walletAddress: string;
-  turnkeySubOrgId: string;
-  turnkeyWalletId: string;
-  turnkeyPrivateKeyId: string;
-}): Promise<{ walletAddress: string; walletId: string }> {
-  const {
-    userId,
-    organizationId,
-    email,
-    walletAddress,
-    turnkeySubOrgId,
-    turnkeyWalletId,
-    turnkeyPrivateKeyId,
-  } = options;
-
-  const normalizedWalletAddress = normalizeAddressForStorage(walletAddress);
-
-  await db.insert(organizationWallets).values({
-    userId,
-    organizationId,
-    email,
-    walletAddress: normalizedWalletAddress,
-    turnkeySubOrgId,
-    turnkeyWalletId,
-    turnkeyPrivateKeyId,
-  });
-
-  await createIntegration(
-    buildWalletIntegrationPayload(
-      userId,
-      organizationId,
-      normalizedWalletAddress
-    )
-  );
-
-  await recordWalletInAddressBook({
-    organizationId,
-    address: normalizedWalletAddress,
-    label: "Org Wallet",
-    createdBy: userId,
-  });
-
-  return { walletAddress: normalizedWalletAddress, walletId: turnkeyWalletId };
-}
-
 export async function GET(request: Request): Promise<NextResponse> {
   let authContext: DualAuthContext | null = null;
   try {
@@ -310,34 +255,35 @@ export async function POST(request: Request) {
       );
     }
 
-    const orgName = `org-${organizationId.slice(0, 8)}`;
-    const turnkeyResult = await createTurnkeyWallet(walletEmail, orgName);
+    const result = await provisionOrganizationWallet({
+      userId: user.id,
+      organizationId,
+      email: walletEmail,
+    });
 
-    const { walletAddress: storedAddress, walletId } =
-      await storeTurnkeyWalletAndIntegration({
-        userId: user.id,
-        organizationId,
-        email: walletEmail,
-        walletAddress: turnkeyResult.walletAddress,
-        turnkeySubOrgId: turnkeyResult.subOrgId,
-        turnkeyWalletId: turnkeyResult.walletId,
-        turnkeyPrivateKeyId: turnkeyResult.privateKeyId,
-      });
+    // checkExistingWallet passed, so a non-created result means a concurrent
+    // request created the wallet first.
+    if (!result.created) {
+      return NextResponse.json(
+        { error: "A wallet already exists for this organization" },
+        { status: 409 }
+      );
+    }
 
     await recordAuditEvent({
       actor: { userId: user.id, organizationId, authMethod: "session" },
       action: "org_wallet.created",
       resourceType: "org_wallet",
-      resourceId: turnkeyResult.subOrgId,
-      after: { walletAddress: storedAddress },
+      resourceId: result.subOrgId ?? organizationId,
+      after: { walletAddress: result.walletAddress },
       metadata: buildAuditMetadata(request),
     });
 
     return NextResponse.json({
       success: true,
       wallet: {
-        address: storedAddress,
-        walletId,
+        address: result.walletAddress,
+        walletId: result.walletId,
         email: walletEmail,
         organizationId,
       },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,7 @@ import { MobileWarningDialog } from "@/components/mobile-warning-dialog";
 import { OverlayProvider } from "@/components/overlays/overlay-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
+import { WalletProvisioningTrigger } from "@/components/wallet/wallet-provisioning-trigger";
 import { mono, sans } from "@/lib/fonts";
 import { cn } from "@/lib/utils";
 
@@ -123,6 +124,7 @@ const RootLayout = async ({ children }: RootLayoutProps) => {
             <AuthProvider>
               <FeatureSessionInvalidator />
               <PendingTemplateRunner />
+              <WalletProvisioningTrigger />
               <OverlayProvider>
                 <AppBanner />
                 <LayoutContent>{children}</LayoutContent>

--- a/components/wallet/wallet-provisioning-trigger.tsx
+++ b/components/wallet/wallet-provisioning-trigger.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useWalletProvisioning } from "@/lib/wallet/use-wallet-provisioning";
+
+/**
+ * Invisible global trigger mounted once in the root layout so signup-time
+ * wallet provisioning runs no matter where the user lands after email or social
+ * signup (the wallet toolbar only exists on workflow pages).
+ */
+export function WalletProvisioningTrigger(): null {
+  useWalletProvisioning();
+  return null;
+}

--- a/components/workflow/wallet-toolbar-button.tsx
+++ b/components/workflow/wallet-toolbar-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Copy, Plus, Wallet } from "lucide-react";
+import { Copy, Loader2, Plus, Wallet } from "lucide-react";
 import { toast } from "sonner";
 import { useOverlay } from "@/components/overlays/overlay-provider";
 import { WalletOverlay } from "@/components/overlays/wallet-overlay";
@@ -14,6 +14,7 @@ import { toChecksumAddress, truncateAddress } from "@/lib/address-utils";
 import { useSession } from "@/lib/auth-client";
 import { isAnonymousUser } from "@/lib/is-anonymous";
 import { useWalletInfo } from "@/lib/wallet/use-wallet-info";
+import { useWalletProvisioning } from "@/lib/wallet/use-wallet-provisioning";
 
 /**
  * Compact toolbar affordance for the organization wallet.
@@ -50,12 +51,27 @@ export function WalletToolbarButton(): React.ReactElement | null {
 function AuthenticatedWalletToolbarButton(): React.ReactElement | null {
   const { open: openOverlay } = useOverlay();
   const { hasWallet, walletAddress, isLoading } = useWalletInfo();
+  const { isProvisioning } = useWalletProvisioning();
 
   if (isLoading && !walletAddress) {
     return null;
   }
 
   if (!hasWallet || !walletAddress) {
+    // Signup-time provisioning in flight: show a silent setup indicator
+    // instead of the manual "Create wallet" affordance.
+    if (isProvisioning) {
+      return (
+        <div
+          className="flex h-9 items-center gap-2 rounded-md border bg-secondary px-3 text-secondary-foreground text-sm"
+          data-testid="wallet-toolbar-provisioning"
+        >
+          <Loader2 className="size-4 animate-spin" />
+          <span className="hidden sm:inline">Setting up wallet</span>
+        </div>
+      );
+    }
+
     return (
       <Button
         className="h-9"

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -123,6 +123,17 @@ function isBase64ImageOutput(output: unknown): output is { base64: string } {
   );
 }
 
+// A sponsored on-chain step carries `sponsored: true` in its output (set by the
+// web3 step cores when Turnkey's gas station covered the gas).
+function isSponsoredOutput(output: unknown): boolean {
+  return (
+    typeof output === "object" &&
+    output !== null &&
+    "sponsored" in output &&
+    (output as { sponsored?: unknown }).sponsored === true
+  );
+}
+
 // Helper to convert execution logs to a map by nodeId for the global atom.
 // For nodes that appear multiple times (e.g., For Each body nodes),
 // this intentionally keeps only the last entry -- used by template
@@ -810,6 +821,11 @@ function ExecutionLogEntry({
                 <span className="truncate font-medium text-sm transition-colors group-hover:text-foreground">
                   {log.nodeName || log.nodeType}
                 </span>
+                {isSponsoredOutput(log.output) && (
+                  <span className="shrink-0 rounded-full border border-primary/20 bg-primary/10 px-2 py-0.5 font-medium text-primary text-xs">
+                    Gas sponsored
+                  </span>
+                )}
               </div>
             </div>
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -31,8 +31,6 @@ import {
 } from "@/lib/security/login-risk";
 import { reportSessionBackstop } from "@/lib/security/session-backstop";
 import { TRUSTED_ORIGINS } from "@/lib/trusted-origins";
-import { provisionOrganizationWallet } from "@/lib/turnkey/provision-org-wallet";
-import { organizationHasWallet } from "@/lib/web3/wallet-helpers";
 import { wrapWithSessionTokenHash } from "./auth-session-token-hash";
 import { db } from "./db";
 import {
@@ -556,6 +554,11 @@ async function backstopProvisionWallet(
   organizationId: string
 ): Promise<void> {
   try {
+    // Lazy-loaded: these wallet modules pull in `server-only` (and Turnkey /
+    // ethers). Importing them statically would drag all of that into every
+    // consumer of lib/auth.ts at module-eval - including auth plugin
+    // registration - so keep them out of the static graph and load on demand.
+    const { organizationHasWallet } = await import("@/lib/web3/wallet-helpers");
     if (await organizationHasWallet(organizationId)) {
       return;
     }
@@ -571,6 +574,9 @@ async function backstopProvisionWallet(
       return;
     }
 
+    const { provisionOrganizationWallet } = await import(
+      "@/lib/turnkey/provision-org-wallet"
+    );
     await provisionOrganizationWallet({ userId, organizationId, email });
   } catch (error) {
     logSystemError(

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -626,7 +626,6 @@ export const auth = betterAuth({
           const baseName = user.name || user.email?.split("@")[0] || "User";
           const slug = `${baseName.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-${nanoid(6)}`;
 
-          let provisionedOrgId: string | undefined;
           try {
             const orgId = randomUUID();
             const memberId = randomUUID();
@@ -650,8 +649,6 @@ export const auth = betterAuth({
               role: "owner",
               createdAt: new Date(),
             });
-
-            provisionedOrgId = org.id;
           } catch (error) {
             logSystemError(
               ErrorCategory.AUTH,
@@ -672,28 +669,11 @@ export const auth = betterAuth({
             return;
           }
 
-          // Auto-provision the org's non-custodial wallet in the background.
-          // Fire-and-forget: the Turnkey call can take ~1-2s and must never
-          // delay or fail signup. provisionOrganizationWallet is idempotent, and
-          // session.create.after re-attempts if this misses (failed call or a
-          // pod killed mid-flight).
-          if (provisionedOrgId && user.email) {
-            const orgIdForWallet = provisionedOrgId;
-            const emailForWallet = user.email;
-            // Intentionally not awaited - see comment above.
-            provisionOrganizationWallet({
-              userId: user.id,
-              organizationId: orgIdForWallet,
-              email: emailForWallet,
-            }).catch((error) => {
-              logSystemError(
-                ErrorCategory.EXTERNAL_SERVICE,
-                "[Auth] Background wallet provisioning failed at signup",
-                error,
-                { userId: user.id, organizationId: orgIdForWallet }
-              );
-            });
-          }
+          // The org's non-custodial wallet is provisioned client-side after
+          // signup via the streamed GET /api/user/wallet/provision endpoint,
+          // which awaits the Turnkey call and reports readiness to the UI.
+          // session.create.after backstops any signup that never opens that
+          // stream (API-only signup, or a tab closed mid-flight).
 
           // Notify external services for OAuth signups (already verified at creation).
           // `databaseHooks.user.create.after` only fires on actual user-row

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -31,6 +31,8 @@ import {
 } from "@/lib/security/login-risk";
 import { reportSessionBackstop } from "@/lib/security/session-backstop";
 import { TRUSTED_ORIGINS } from "@/lib/trusted-origins";
+import { provisionOrganizationWallet } from "@/lib/turnkey/provision-org-wallet";
+import { organizationHasWallet } from "@/lib/web3/wallet-helpers";
 import { wrapWithSessionTokenHash } from "./auth-session-token-hash";
 import { db } from "./db";
 import {
@@ -542,6 +544,44 @@ async function notifyDiscordSignup(user: {
     });
 }
 
+/**
+ * Backstop for the signup-time fire-and-forget wallet provisioning. Runs on
+ * login (session.create.after): if the org still has no active wallet - because
+ * the signup attempt failed or the pod was killed mid-flight - it re-attempts
+ * provisioning in the background. Idempotent and non-fatal: skips anonymous
+ * accounts and never throws into the auth flow.
+ */
+async function backstopProvisionWallet(
+  userId: string,
+  organizationId: string
+): Promise<void> {
+  try {
+    if (await organizationHasWallet(organizationId)) {
+      return;
+    }
+
+    const [userRow] = await db
+      .select({ email: users.email, name: users.name })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1);
+
+    const email = userRow?.email;
+    if (!email || userRow?.name === "Anonymous" || email.startsWith("temp-")) {
+      return;
+    }
+
+    await provisionOrganizationWallet({ userId, organizationId, email });
+  } catch (error) {
+    logSystemError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      "[Auth] Backstop wallet provisioning failed on session create",
+      error,
+      { userId, organizationId }
+    );
+  }
+}
+
 export const auth = betterAuth({
   baseURL: getBaseURL(),
   database: wrapWithSessionTokenHash(
@@ -586,6 +626,7 @@ export const auth = betterAuth({
           const baseName = user.name || user.email?.split("@")[0] || "User";
           const slug = `${baseName.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-${nanoid(6)}`;
 
+          let provisionedOrgId: string | undefined;
           try {
             const orgId = randomUUID();
             const memberId = randomUUID();
@@ -609,6 +650,8 @@ export const auth = betterAuth({
               role: "owner",
               createdAt: new Date(),
             });
+
+            provisionedOrgId = org.id;
           } catch (error) {
             logSystemError(
               ErrorCategory.AUTH,
@@ -627,6 +670,29 @@ export const auth = betterAuth({
           // email (name "Anonymous" / temp- prefixed address).
           if (isAnonymous) {
             return;
+          }
+
+          // Auto-provision the org's non-custodial wallet in the background.
+          // Fire-and-forget: the Turnkey call can take ~1-2s and must never
+          // delay or fail signup. provisionOrganizationWallet is idempotent, and
+          // session.create.after re-attempts if this misses (failed call or a
+          // pod killed mid-flight).
+          if (provisionedOrgId && user.email) {
+            const orgIdForWallet = provisionedOrgId;
+            const emailForWallet = user.email;
+            // Intentionally not awaited - see comment above.
+            provisionOrganizationWallet({
+              userId: user.id,
+              organizationId: orgIdForWallet,
+              email: emailForWallet,
+            }).catch((error) => {
+              logSystemError(
+                ErrorCategory.EXTERNAL_SERVICE,
+                "[Auth] Background wallet provisioning failed at signup",
+                error,
+                { userId: user.id, organizationId: orgIdForWallet }
+              );
+            });
           }
 
           // Notify external services for OAuth signups (already verified at creation).
@@ -818,6 +884,15 @@ export const auth = betterAuth({
               userAgent: sessionRow.userAgent ?? null,
             },
           });
+
+          // Backstop the signup-time wallet provisioning (fire-and-forget):
+          // re-provision if the org somehow has no wallet yet. Intentionally
+          // not awaited; backstopProvisionWallet handles its own errors.
+          if (orgId) {
+            backstopProvisionWallet(session.userId, orgId).catch(
+              () => undefined
+            );
+          }
         },
       },
     },

--- a/lib/turnkey/provision-org-wallet.ts
+++ b/lib/turnkey/provision-org-wallet.ts
@@ -1,0 +1,149 @@
+import "server-only";
+import { and, eq } from "drizzle-orm";
+import { recordWalletInAddressBook } from "@/lib/address-book/record-wallet";
+import { normalizeAddressForStorage } from "@/lib/address-utils";
+import { db } from "@/lib/db";
+import {
+  buildWalletIntegrationPayload,
+  createIntegration,
+} from "@/lib/db/integrations";
+import { type OrganizationWallet, organizationWallets } from "@/lib/db/schema";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { createTurnkeyWallet } from "@/lib/turnkey/turnkey-client";
+
+export type ProvisionWalletInput = {
+  userId: string;
+  organizationId: string;
+  email: string;
+};
+
+export type ProvisionWalletResult = {
+  // true when this call created the wallet; false when an active wallet
+  // already existed (idempotent no-op, including the lost side of a race).
+  created: boolean;
+  walletAddress: string;
+  walletId: string | null;
+  subOrgId: string | null;
+};
+
+function isUniqueViolation(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const cause = error.cause;
+  return (
+    typeof cause === "object" &&
+    cause !== null &&
+    "code" in cause &&
+    (cause as { code?: unknown }).code === "23505"
+  );
+}
+
+async function getActiveWallet(
+  organizationId: string
+): Promise<OrganizationWallet | null> {
+  const rows = await db
+    .select()
+    .from(organizationWallets)
+    .where(
+      and(
+        eq(organizationWallets.organizationId, organizationId),
+        eq(organizationWallets.isActive, true)
+      )
+    )
+    .limit(1);
+
+  return rows[0] ?? null;
+}
+
+function toResult(
+  wallet: OrganizationWallet,
+  created: boolean
+): ProvisionWalletResult {
+  return {
+    created,
+    walletAddress: wallet.walletAddress,
+    walletId: wallet.turnkeyWalletId,
+    subOrgId: wallet.turnkeySubOrgId,
+  };
+}
+
+/**
+ * Idempotently provision an organization's non-custodial Turnkey wallet.
+ *
+ * Returns the existing wallet untouched if one is already active for the org
+ * (so it is safe to call from multiple places - the signup hook, the session
+ * backstop, and the manual POST /api/user/wallet route). A concurrent caller
+ * that loses the partial-unique-index race (organization_wallets_org_active_unique)
+ * is also treated as a no-op rather than an error.
+ *
+ * Note: the Turnkey sub-org creation is not transactional with the DB insert,
+ * so the race loser can leave an orphaned (unused) Turnkey sub-org. This
+ * matches the pre-existing behaviour of the wallet route and is accepted.
+ */
+export async function provisionOrganizationWallet(
+  input: ProvisionWalletInput
+): Promise<ProvisionWalletResult> {
+  const { userId, organizationId, email } = input;
+
+  const existing = await getActiveWallet(organizationId);
+  if (existing) {
+    return toResult(existing, false);
+  }
+
+  const orgName = `org-${organizationId.slice(0, 8)}`;
+  const turnkeyResult = await createTurnkeyWallet(email, orgName);
+  const normalizedWalletAddress = normalizeAddressForStorage(
+    turnkeyResult.walletAddress
+  );
+
+  try {
+    await db.insert(organizationWallets).values({
+      userId,
+      organizationId,
+      email,
+      walletAddress: normalizedWalletAddress,
+      turnkeySubOrgId: turnkeyResult.subOrgId,
+      turnkeyWalletId: turnkeyResult.walletId,
+      turnkeyPrivateKeyId: turnkeyResult.privateKeyId,
+    });
+  } catch (error) {
+    // A concurrent caller won the race and inserted first. The Turnkey
+    // sub-org we just created is orphaned; return the wallet that won.
+    if (isUniqueViolation(error)) {
+      logSystemError(
+        ErrorCategory.EXTERNAL_SERVICE,
+        "[Wallet] Provisioning race: another caller created the wallet first; orphaned Turnkey sub-org",
+        error,
+        { organizationId, orphanedSubOrgId: turnkeyResult.subOrgId }
+      );
+      const winner = await getActiveWallet(organizationId);
+      if (winner) {
+        return toResult(winner, false);
+      }
+    }
+    throw error;
+  }
+
+  await createIntegration(
+    buildWalletIntegrationPayload(
+      userId,
+      organizationId,
+      normalizedWalletAddress
+    )
+  );
+
+  await recordWalletInAddressBook({
+    organizationId,
+    address: normalizedWalletAddress,
+    label: "Org Wallet",
+    createdBy: userId,
+  });
+
+  return {
+    created: true,
+    walletAddress: normalizedWalletAddress,
+    walletId: turnkeyResult.walletId,
+    subOrgId: turnkeyResult.subOrgId,
+  };
+}

--- a/lib/turnkey/provision-wallet-stream.ts
+++ b/lib/turnkey/provision-wallet-stream.ts
@@ -1,0 +1,104 @@
+import "server-only";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
+import {
+  type ProvisionWalletInput,
+  provisionOrganizationWallet,
+} from "@/lib/turnkey/provision-org-wallet";
+
+/**
+ * Events emitted over the wallet-provisioning SSE stream. The client opens the
+ * stream right after signup; the connection stays open for the duration of the
+ * upstream Turnkey call (the actual latency we are hiding), then reports the
+ * result.
+ */
+export type ProvisionStreamEvent =
+  | { type: "provisioning" }
+  | { type: "ready"; walletAddress: string; created: boolean }
+  | { type: "error"; message: string };
+
+export type ProvisionWalletStreamOpts = {
+  signal: AbortSignal;
+  input: ProvisionWalletInput;
+  // Injectable for tests; defaults to the real provisioning service.
+  provision?: (input: ProvisionWalletInput) => Promise<{
+    walletAddress: string;
+    created: boolean;
+  }>;
+};
+
+function formatSSE(event: ProvisionStreamEvent): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
+
+/**
+ * Build the `start` callback for a one-shot wallet-provisioning ReadableStream.
+ *
+ * Emits `provisioning` immediately, awaits the Turnkey-backed
+ * provisionOrganizationWallet (idempotent), then emits `ready` with the address
+ * or `error` on failure, and closes. If the client aborts mid-flight the
+ * provisioning promise is intentionally left running so the wallet still gets
+ * created - we simply stop reporting. session.create.after backstops the rest.
+ */
+export function createProvisionWalletStreamStart(
+  opts: ProvisionWalletStreamOpts
+): (controller: ReadableStreamDefaultController<Uint8Array>) => void {
+  const { signal, input, provision = provisionOrganizationWallet } = opts;
+
+  return (controller): void => {
+    const encoder = new TextEncoder();
+    let closed = false;
+
+    const onAbort = (): void => {
+      safeClose();
+    };
+
+    function safeClose(): void {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      signal.removeEventListener("abort", onAbort);
+      try {
+        controller.close();
+      } catch {
+        // controller may already be closed by the platform
+      }
+    }
+
+    const emit = (event: ProvisionStreamEvent): void => {
+      if (closed) {
+        return;
+      }
+      try {
+        controller.enqueue(encoder.encode(formatSSE(event)));
+      } catch {
+        safeClose();
+      }
+    };
+
+    signal.addEventListener("abort", onAbort, { once: true });
+
+    emit({ type: "provisioning" });
+
+    provision(input)
+      .then((result) => {
+        emit({
+          type: "ready",
+          walletAddress: result.walletAddress,
+          created: result.created,
+        });
+      })
+      .catch((error: unknown) => {
+        logSystemError(
+          ErrorCategory.EXTERNAL_SERVICE,
+          "[Wallet] Stream provisioning failed at signup",
+          error,
+          { userId: input.userId, organizationId: input.organizationId }
+        );
+        emit({ type: "error", message: "Wallet provisioning failed" });
+      })
+      .finally(() => {
+        safeClose();
+      });
+  };
+}

--- a/lib/wallet/use-wallet-provisioning.ts
+++ b/lib/wallet/use-wallet-provisioning.ts
@@ -1,0 +1,122 @@
+"use client";
+
+import { atom, useAtomValue, useSetAtom } from "jotai";
+import { useEffect } from "react";
+import { authClient, useSession } from "@/lib/auth-client";
+import {
+  useInvalidateWalletInfo,
+  useWalletInfo,
+} from "@/lib/wallet/use-wallet-info";
+
+type ProvisionEvent =
+  | { type: "provisioning" }
+  | { type: "ready"; walletAddress: string; created: boolean }
+  | { type: "error"; message: string };
+
+/**
+ * Orgs whose provisioning stream has already been opened this page-session.
+ * Module-level so the multiple mounted consumers (the global trigger plus the
+ * workflow toolbar) never open the stream twice for the same org.
+ */
+const attemptedOrgIds = new Set<string>();
+
+/** Shared so the toolbar badge reflects provisioning regardless of which mounted hook opened the stream. */
+const provisioningAtom = atom(false);
+
+function parseEvent(frame: string): ProvisionEvent | null {
+  const dataLine = frame.split("\n").find((line) => line.startsWith("data:"));
+  if (!dataLine) {
+    return null;
+  }
+  try {
+    return JSON.parse(dataLine.slice(5).trim()) as ProvisionEvent;
+  } catch {
+    return null;
+  }
+}
+
+async function runProvisionStream(onReady: () => void): Promise<void> {
+  const response = await fetch("/api/user/wallet/provision");
+  if (!(response.ok && response.body)) {
+    return;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let done = false;
+
+  while (!done) {
+    const chunk = await reader.read();
+    done = chunk.done;
+    buffer += decoder.decode(chunk.value ?? new Uint8Array(), {
+      stream: !done,
+    });
+
+    let separator = buffer.indexOf("\n\n");
+    while (separator !== -1) {
+      const event = parseEvent(buffer.slice(0, separator));
+      buffer = buffer.slice(separator + 2);
+      if (event?.type === "ready") {
+        onReady();
+      }
+      separator = buffer.indexOf("\n\n");
+    }
+  }
+}
+
+/**
+ * Drives signup-time wallet provisioning from the client: when a verified user
+ * has an active org but no wallet yet, opens the streamed provisioning endpoint
+ * once, awaits the Turnkey call, and refreshes wallet info when it is ready.
+ * Self-gating and idempotent - safe to mount in global chrome. On failure it
+ * stays silent; the next-login backstop (session.create.after) is the fallback.
+ */
+export function useWalletProvisioning(): { isProvisioning: boolean } {
+  const { data: session } = useSession();
+  const { data: activeOrg } = authClient.useActiveOrganization();
+  const { hasWallet, isLoading } = useWalletInfo();
+  const invalidate = useInvalidateWalletInfo();
+  const isProvisioning = useAtomValue(provisioningAtom);
+  const setProvisioning = useSetAtom(provisioningAtom);
+
+  const email = session?.user?.email;
+  const isAuthed =
+    !!session?.user?.id &&
+    !!email &&
+    !email.startsWith("temp-") &&
+    session?.user?.emailVerified === true;
+  const activeOrgId = activeOrg?.id ?? null;
+
+  useEffect(() => {
+    if (!(isAuthed && activeOrgId)) {
+      return;
+    }
+    // Wait for the wallet-status fetch to resolve before deciding.
+    if (isLoading || hasWallet) {
+      return;
+    }
+    if (attemptedOrgIds.has(activeOrgId)) {
+      return;
+    }
+
+    attemptedOrgIds.add(activeOrgId);
+    setProvisioning(true);
+    runProvisionStream(invalidate)
+      .catch(() => {
+        // Network/stream failure: fall back silently to the login backstop.
+      })
+      .finally(() => {
+        setProvisioning(false);
+      });
+  }, [
+    isAuthed,
+    activeOrgId,
+    isLoading,
+    hasWallet,
+    invalidate,
+    setProvisioning,
+  ]);
+
+  return { isProvisioning };
+}

--- a/lib/wallet/use-wallet-provisioning.ts
+++ b/lib/wallet/use-wallet-provisioning.ts
@@ -66,6 +66,29 @@ async function runProvisionStream(onReady: () => void): Promise<void> {
 }
 
 /**
+ * Pure gate for whether to open the provisioning stream: a verified, org-scoped
+ * user whose org has no wallet yet and that we have not already attempted this
+ * page-session. Extracted so it can be unit-tested without rendering the hook.
+ */
+function shouldOpenProvisionStream(params: {
+  isAuthed: boolean;
+  activeOrgId: string | null;
+  isLoading: boolean;
+  hasWallet: boolean;
+  attempted: boolean;
+}): boolean {
+  const { isAuthed, activeOrgId, isLoading, hasWallet, attempted } = params;
+  if (!(isAuthed && activeOrgId)) {
+    return false;
+  }
+  // Wait for the wallet-status fetch to resolve before deciding.
+  if (isLoading || hasWallet) {
+    return false;
+  }
+  return !attempted;
+}
+
+/**
  * Drives signup-time wallet provisioning from the client: when a verified user
  * has an active org but no wallet yet, opens the streamed provisioning endpoint
  * once, awaits the Turnkey call, and refreshes wallet info when it is ready.
@@ -89,14 +112,17 @@ export function useWalletProvisioning(): { isProvisioning: boolean } {
   const activeOrgId = activeOrg?.id ?? null;
 
   useEffect(() => {
-    if (!(isAuthed && activeOrgId)) {
+    if (!activeOrgId) {
       return;
     }
-    // Wait for the wallet-status fetch to resolve before deciding.
-    if (isLoading || hasWallet) {
-      return;
-    }
-    if (attemptedOrgIds.has(activeOrgId)) {
+    const open = shouldOpenProvisionStream({
+      isAuthed,
+      activeOrgId,
+      isLoading,
+      hasWallet,
+      attempted: attemptedOrgIds.has(activeOrgId),
+    });
+    if (!open) {
       return;
     }
 
@@ -120,3 +146,9 @@ export function useWalletProvisioning(): { isProvisioning: boolean } {
 
   return { isProvisioning };
 }
+
+export {
+  parseEvent as __parseEventForTesting,
+  runProvisionStream as __runProvisionStreamForTesting,
+  shouldOpenProvisionStream as __shouldOpenProvisionStreamForTesting,
+};

--- a/tests/e2e/playwright/organization-wallet.test.ts
+++ b/tests/e2e/playwright/organization-wallet.test.ts
@@ -5,8 +5,6 @@ import { signUpAndVerify as signUpAndVerifyBase } from "./utils/auth";
 // Regex patterns (moved to top level for performance)
 const SLUG_PATTERN = /test-org-/;
 const CREATED_PATTERN = /created/i;
-const WALLET_CREATED_PATTERN = /wallet created/i;
-const ADDRESS_PATTERN = /0x.*\.\.\./;
 const COPIED_PATTERN = /copied/i;
 
 // Sign up a fresh user and wait for org switcher (used by wallet tests that need a new org)
@@ -71,22 +69,14 @@ async function openWalletOverlay(page: Page): Promise<void> {
   });
 }
 
-// Create a wallet via the overlay form and wait for the success toast
-async function createWalletViaOverlay(page: Page): Promise<void> {
-  await page.locator('button:has-text("Create Organization Wallet")').click();
-
-  const createBtn = page.locator(
-    'button[data-slot="button"]:has-text("Create Wallet")'
-  );
-  await expect(createBtn).toBeEnabled({ timeout: 5000 });
-  await createBtn.click();
-
-  // Wait for success toast (Para API can be slow in beta environments)
+// Wait for the wallet that is auto-provisioned at signup to resolve. The
+// toolbar address only appears once provisioning (a real Turnkey call) has
+// completed, so this is the signal that the org has its wallet.
+async function waitForAutoProvisionedWallet(page: Page): Promise<void> {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
   await expect(
-    page
-      .locator("[data-sonner-toast]")
-      .filter({ hasText: WALLET_CREATED_PATTERN })
-  ).toBeVisible({ timeout: 30_000 });
+    page.locator('[data-testid="wallet-toolbar-address"]')
+  ).toBeVisible({ timeout: 45_000 });
 }
 
 // Run tests serially to avoid session state conflicts
@@ -210,133 +200,26 @@ test.describe("Organization Management", () => {
   });
 });
 
-test.describe("Para Wallet Management", () => {
-  // biome-ignore lint/suspicious/noSkippedTests: Para beta API unreliable in CI
-  test.skip(!!process.env.CI, "Para beta API unreliable in CI");
+// The org wallet is now auto-provisioned at signup (Turnkey), so these specs
+// assert the overlay UI against that auto-created wallet. The manual
+// create-from-empty form is intentionally not covered here: provisioning runs
+// on every wallet-less org, so the empty-state entry point is no longer
+// reachable (deleting the wallet just re-triggers provisioning). The
+// auto-provision path itself is covered in wallet-autoprovision.test.ts.
+test.describe("Organization Wallet (auto-provisioned)", () => {
+  test.skip(!!process.env.CI, "Turnkey API unreliable in CI");
 
   test.beforeEach(async ({ context }) => {
     await context.clearCookies();
   });
 
-  test.describe("Wallet Creation", () => {
-    test("WALLET-CREATE-1: admin can create organization wallet", async ({
-      page,
-    }) => {
-      const { email } = await signUpAndVerify(page);
-
-      // Open wallet overlay
-      await openWalletOverlay(page);
-
-      // Wallet overlay doesn't have role="dialog" - scope to page
-      const overlay = page;
-
-      // Verify no wallet message is shown
-      await expect(overlay.locator("text=No wallet found")).toBeVisible({
-        timeout: 5000,
-      });
-
-      // Click create wallet button
-      await overlay
-        .locator('button:has-text("Create Organization Wallet")')
-        .click();
-
-      // Verify form appears with pre-filled email
-      const emailInput = overlay.locator("#wallet-email");
-      await expect(emailInput).toBeVisible({ timeout: 5000 });
-      await expect(emailInput).toHaveValue(email);
-
-      // Submit the form
-      const createBtn = overlay.locator(
-        'button[data-slot="button"]:has-text("Create Wallet")'
-      );
-      await expect(createBtn).toBeEnabled({ timeout: 5000 });
-      await createBtn.click();
-
-      // Wait for wallet creation to complete (Para API can take ~5s)
-      // Verify wallet details section appears (proves creation succeeded)
-      await expect(overlay.locator("text=Account details")).toBeVisible({
-        timeout: 30_000,
-      });
-    });
-
-    test("WALLET-CREATE-2: wallet shows address after creation", async ({
-      page,
-    }) => {
-      const { email } = await signUpAndVerify(page);
-
-      await openWalletOverlay(page);
-
-      // Create wallet
-      await createWalletViaOverlay(page);
-
-      // Verify wallet address is displayed (format: 0x...xxxx)
-      await expect(page.locator("code")).toContainText(ADDRESS_PATTERN);
-
-      // Verify email is displayed
-      await expect(page.locator(`text=${email}`)).toBeVisible();
-    });
-
-    test("WALLET-CREATE-3: wallet form can be cancelled", async ({ page }) => {
-      await signUpAndVerify(page);
-
-      await openWalletOverlay(page);
-      // Wallet overlay doesn't have role="dialog" - scope to page
-      const overlay = page;
-
-      // Click create wallet button
-      await overlay
-        .locator('button:has-text("Create Organization Wallet")')
-        .click();
-
-      // Verify form appears
-      await expect(overlay.locator("#wallet-email")).toBeVisible({
-        timeout: 5000,
-      });
-
-      // Click cancel
-      await overlay.locator('button:has-text("Cancel")').click();
-
-      // Verify form is hidden and original message is shown
-      await expect(overlay.locator("#wallet-email")).toBeHidden();
-      await expect(overlay.locator("text=No wallet found")).toBeVisible();
-    });
-
-    test("WALLET-CREATE-4: wallet creation requires email", async ({
-      page,
-    }) => {
-      await signUpAndVerify(page);
-
-      await openWalletOverlay(page);
-      // Wallet overlay doesn't have role="dialog" - scope to page
-      const overlay = page;
-
-      // Open create form
-      await overlay
-        .locator('button:has-text("Create Organization Wallet")')
-        .click();
-
-      // Clear the pre-filled email
-      const emailInput = overlay.locator("#wallet-email");
-      await emailInput.clear();
-
-      // Create button should be disabled when email is empty
-      const createButton = overlay.locator(
-        'button[data-slot="button"]:has-text("Create Wallet")'
-      );
-      await expect(createButton).toBeDisabled();
-    });
-  });
-
   test.describe("Wallet Display", () => {
-    test("WALLET-DISPLAY-1: wallet shows balance sections after creation", async ({
+    test("WALLET-DISPLAY-1: wallet shows balance sections", async ({
       page,
     }) => {
       await signUpAndVerify(page);
-
+      await waitForAutoProvisionedWallet(page);
       await openWalletOverlay(page);
-
-      // Create wallet
-      await createWalletViaOverlay(page);
 
       // Verify balance section appears
       await expect(page.locator('h3:has-text("Balances")')).toBeVisible({
@@ -352,11 +235,8 @@ test.describe("Para Wallet Management", () => {
       page,
     }) => {
       await signUpAndVerify(page);
-
+      await waitForAutoProvisionedWallet(page);
       await openWalletOverlay(page);
-
-      // Create wallet first
-      await createWalletViaOverlay(page);
 
       // Wait for balance section
       await expect(page.locator('h3:has-text("Balances")')).toBeVisible({
@@ -380,11 +260,8 @@ test.describe("Para Wallet Management", () => {
 
     test("WALLET-DISPLAY-3: admin can refresh balances", async ({ page }) => {
       await signUpAndVerify(page);
-
+      await waitForAutoProvisionedWallet(page);
       await openWalletOverlay(page);
-
-      // Create wallet
-      await createWalletViaOverlay(page);
 
       // Wait for balance section
       await expect(page.locator('h3:has-text("Balances")')).toBeVisible({
@@ -404,11 +281,8 @@ test.describe("Para Wallet Management", () => {
   test.describe("Wallet Copy Address", () => {
     test("WALLET-COPY-1: user can copy wallet address", async ({ page }) => {
       await signUpAndVerify(page);
-
+      await waitForAutoProvisionedWallet(page);
       await openWalletOverlay(page);
-
-      // Create wallet
-      await createWalletViaOverlay(page);
 
       // Wait for wallet details to load
       await expect(page.locator("text=Account details")).toBeVisible({

--- a/tests/e2e/playwright/wallet-autoprovision.test.ts
+++ b/tests/e2e/playwright/wallet-autoprovision.test.ts
@@ -1,0 +1,75 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "./fixtures";
+import { signUpAndVerify } from "./utils/auth";
+
+const ADDRESS_PATTERN = /0x.*\.\.\./;
+
+// Turnkey is the real external wallet provider and, like the manual-wallet
+// specs, is unreliable in CI - so this auto-provisioning suite runs locally
+// only (needs a dev server with Turnkey creds at http://localhost:3000).
+test.describe.configure({ mode: "serial" });
+
+// Open the organization wallet overlay from the user menu.
+async function openWalletOverlay(page: Page): Promise<void> {
+  const userMenuButton = page
+    .locator('button[aria-haspopup="menu"]')
+    .filter({ has: page.locator("span.relative") })
+    .first();
+  await userMenuButton.click();
+
+  const dropdownMenu = page.locator('[role="menu"]');
+  await expect(dropdownMenu).toBeVisible({ timeout: 5000 });
+  await dropdownMenu.locator('div[role="menuitem"]:has-text("Wallet")').click();
+
+  await expect(page.locator('h2:has-text("Organization Wallet")')).toBeVisible({
+    timeout: 5000,
+  });
+}
+
+test.describe("Wallet auto-provisioning at signup", () => {
+  test.skip(!!process.env.CI, "Turnkey API unreliable in CI");
+
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+  });
+
+  test("AUTOPROV-1: signup provisions a wallet with no manual action", async ({
+    page,
+  }) => {
+    // Completing signup (org auto-created, switcher visible) also confirms the
+    // removed signup-time eager hook did not break the auth flow.
+    await signUpAndVerify(page);
+
+    // The workflow page hosts the wallet toolbar affordance.
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    const address = page.locator('[data-testid="wallet-toolbar-address"]');
+
+    // The toolbar resolves to a real address on its own - no wallet overlay
+    // opened and no "Create wallet" click - proving signup auto-provisioned it.
+    await expect(address).toBeVisible({ timeout: 45_000 });
+    await expect(address).toContainText("0x");
+  });
+
+  test("AUTOPROV-2: auto-provisioned wallet appears in the wallet overlay", async ({
+    page,
+  }) => {
+    const { email } = await signUpAndVerify(page);
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    // Wait for the auto-provisioned wallet to resolve in the toolbar first.
+    await expect(
+      page.locator('[data-testid="wallet-toolbar-address"]')
+    ).toBeVisible({ timeout: 45_000 });
+
+    await openWalletOverlay(page);
+
+    // The overlay reflects the same wallet (address + the signup email it was
+    // derived from), created without the manual overlay form.
+    await expect(page.locator("text=Account details")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.locator("code")).toContainText(ADDRESS_PATTERN);
+    await expect(page.locator(`text=${email}`)).toBeVisible();
+  });
+});

--- a/tests/integration/wallet-provision-route.test.ts
+++ b/tests/integration/wallet-provision-route.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mockGetOrgContext = vi.fn();
+vi.mock("@/lib/middleware/org-context", () => ({
+  getOrgContext: (...args: unknown[]) => mockGetOrgContext(...args),
+  getActiveOrgId: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+const mockProvision = vi.fn();
+vi.mock("@/lib/turnkey/provision-org-wallet", () => ({
+  provisionOrganizationWallet: (...args: unknown[]) => mockProvision(...args),
+}));
+
+const mockLogSystemError = vi.fn();
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { EXTERNAL_SERVICE: "EXTERNAL_SERVICE" },
+  logSystemError: (...args: unknown[]) => mockLogSystemError(...args),
+}));
+
+import { GET } from "@/app/api/user/wallet/provision/route";
+
+const ORG_ID = "org-1";
+const USER_ID = "user-1";
+const EMAIL = "new@example.com";
+
+function request(): Parameters<typeof GET>[0] {
+  return new Request("http://localhost/api/user/wallet/provision", {
+    method: "GET",
+  }) as Parameters<typeof GET>[0];
+}
+
+function authedContext(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    user: { id: USER_ID, email: EMAIL, name: "New User", image: null },
+    organization: { id: ORG_ID, name: "Org", createdAt: new Date() },
+    member: {
+      id: "m-1",
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      role: "owner",
+      createdAt: new Date(),
+    },
+    isAnonymous: false,
+    needsOrganization: false,
+    ...overrides,
+  };
+}
+
+describe("GET /api/user/wallet/provision", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 for an anonymous session", async () => {
+    mockGetOrgContext.mockResolvedValue({
+      user: null,
+      organization: null,
+      member: null,
+      isAnonymous: true,
+      needsOrganization: false,
+    });
+
+    const res = await GET(request());
+
+    expect(res.status).toBe(401);
+    expect(mockProvision).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the user has no organization", async () => {
+    mockGetOrgContext.mockResolvedValue({
+      user: { id: USER_ID, email: EMAIL, name: "x" },
+      organization: null,
+      member: null,
+      isAnonymous: false,
+      needsOrganization: true,
+    });
+
+    const res = await GET(request());
+
+    expect(res.status).toBe(403);
+    expect(mockProvision).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the org context carries no organization id", async () => {
+    mockGetOrgContext.mockResolvedValue(authedContext({ organization: null }));
+
+    const res = await GET(request());
+
+    expect(res.status).toBe(400);
+    expect(mockProvision).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a placeholder / anonymous email", async () => {
+    mockGetOrgContext.mockResolvedValue(
+      authedContext({
+        user: { id: USER_ID, email: "temp-abc@example.com", name: "Anonymous" },
+      })
+    );
+
+    const res = await GET(request());
+
+    expect(res.status).toBe(400);
+    expect(mockProvision).not.toHaveBeenCalled();
+  });
+
+  it("streams provisioning then ready and calls the provisioner with org + email", async () => {
+    mockGetOrgContext.mockResolvedValue(authedContext());
+    mockProvision.mockResolvedValue({
+      created: true,
+      walletAddress: "0xabc",
+      walletId: "w-1",
+      subOrgId: "s-1",
+    });
+
+    const res = await GET(request());
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+
+    const body = await res.text();
+    expect(body).toContain('"type":"provisioning"');
+    expect(body).toContain('"type":"ready"');
+    expect(body).toContain('"walletAddress":"0xabc"');
+
+    expect(mockProvision).toHaveBeenCalledWith({
+      userId: USER_ID,
+      organizationId: ORG_ID,
+      email: EMAIL,
+    });
+  });
+
+  it("streams an error frame and logs when provisioning fails", async () => {
+    mockGetOrgContext.mockResolvedValue(authedContext());
+    mockProvision.mockRejectedValue(new Error("turnkey down"));
+
+    const res = await GET(request());
+
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain('"type":"error"');
+    expect(mockLogSystemError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/provision-org-wallet.test.ts
+++ b/tests/unit/provision-org-wallet.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mockCreateTurnkeyWallet = vi.fn();
+vi.mock("@/lib/turnkey/turnkey-client", () => ({
+  createTurnkeyWallet: (...args: unknown[]) => mockCreateTurnkeyWallet(...args),
+}));
+
+const mockSelectLimit = vi.fn();
+const mockInsertValues = vi.fn();
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: (...args: unknown[]) => mockSelectLimit(...args),
+        })),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: (...args: unknown[]) => mockInsertValues(...args),
+    })),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  organizationWallets: {
+    organizationId: "organization_id",
+    isActive: "is_active",
+  },
+}));
+
+vi.mock("@/lib/address-utils", () => ({
+  normalizeAddressForStorage: (address: string) => address,
+}));
+
+const mockCreateIntegration = vi.fn();
+vi.mock("@/lib/db/integrations", () => ({
+  createIntegration: (...args: unknown[]) => mockCreateIntegration(...args),
+  buildWalletIntegrationPayload: (
+    userId: string,
+    organizationId: string,
+    walletAddress: string
+  ) => ({ userId, organizationId, walletAddress }),
+}));
+
+const mockRecordWalletInAddressBook = vi.fn();
+vi.mock("@/lib/address-book/record-wallet", () => ({
+  recordWalletInAddressBook: (...args: unknown[]) =>
+    mockRecordWalletInAddressBook(...args),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { EXTERNAL_SERVICE: "EXTERNAL_SERVICE" },
+  logSystemError: vi.fn(),
+}));
+
+import { provisionOrganizationWallet } from "@/lib/turnkey/provision-org-wallet";
+
+const INPUT = {
+  userId: "user-1",
+  organizationId: "org-12345678",
+  email: "user@example.com",
+};
+
+const TURNKEY_RESULT = {
+  subOrgId: "tk-sub-org",
+  walletId: "tk-wallet",
+  privateKeyId: "",
+  walletAddress: "0x00000000000000000000000000000000000000aa",
+};
+
+function existingRow(): Record<string, unknown> {
+  return {
+    id: "wallet-existing",
+    walletAddress: "0x00000000000000000000000000000000000000bb",
+    turnkeyWalletId: "tk-wallet-existing",
+    turnkeySubOrgId: "tk-sub-org-existing",
+    isActive: true,
+  };
+}
+
+function uniqueViolation(): Error {
+  const err = new Error("duplicate key value violates unique constraint");
+  (err as Error & { cause: unknown }).cause = { code: "23505" };
+  return err;
+}
+
+describe("provisionOrganizationWallet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelectLimit.mockReset();
+    mockInsertValues.mockReset();
+  });
+
+  it("is a no-op when an active wallet already exists", async () => {
+    mockSelectLimit.mockResolvedValueOnce([existingRow()]);
+
+    const result = await provisionOrganizationWallet(INPUT);
+
+    expect(result.created).toBe(false);
+    expect(result.walletAddress).toBe(existingRow().walletAddress);
+    expect(mockCreateTurnkeyWallet).not.toHaveBeenCalled();
+    expect(mockInsertValues).not.toHaveBeenCalled();
+  });
+
+  it("creates the wallet, integration, and address-book entry on the happy path", async () => {
+    mockSelectLimit.mockResolvedValueOnce([]);
+    mockCreateTurnkeyWallet.mockResolvedValueOnce(TURNKEY_RESULT);
+    mockInsertValues.mockResolvedValueOnce(undefined);
+
+    const result = await provisionOrganizationWallet(INPUT);
+
+    expect(result).toEqual({
+      created: true,
+      walletAddress: TURNKEY_RESULT.walletAddress,
+      walletId: TURNKEY_RESULT.walletId,
+      subOrgId: TURNKEY_RESULT.subOrgId,
+    });
+    expect(mockCreateTurnkeyWallet).toHaveBeenCalledWith(
+      INPUT.email,
+      `org-${INPUT.organizationId.slice(0, 8)}`
+    );
+    expect(mockCreateIntegration).toHaveBeenCalledTimes(1);
+    expect(mockRecordWalletInAddressBook).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a unique-constraint race as already provisioned", async () => {
+    mockSelectLimit
+      .mockResolvedValueOnce([]) // initial check: no wallet
+      .mockResolvedValueOnce([existingRow()]); // re-read after the race
+    mockCreateTurnkeyWallet.mockResolvedValueOnce(TURNKEY_RESULT);
+    mockInsertValues.mockRejectedValueOnce(uniqueViolation());
+
+    const result = await provisionOrganizationWallet(INPUT);
+
+    expect(result.created).toBe(false);
+    expect(result.walletAddress).toBe(existingRow().walletAddress);
+    // We lost the race, so we must not write the integration/address book.
+    expect(mockCreateIntegration).not.toHaveBeenCalled();
+    expect(mockRecordWalletInAddressBook).not.toHaveBeenCalled();
+  });
+
+  it("rethrows a non-unique insert error", async () => {
+    mockSelectLimit.mockResolvedValueOnce([]);
+    mockCreateTurnkeyWallet.mockResolvedValueOnce(TURNKEY_RESULT);
+    mockInsertValues.mockRejectedValueOnce(new Error("connection reset"));
+
+    await expect(provisionOrganizationWallet(INPUT)).rejects.toThrow(
+      "connection reset"
+    );
+  });
+});

--- a/tests/unit/provision-wallet-stream.test.ts
+++ b/tests/unit/provision-wallet-stream.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mockLogSystemError = vi.fn();
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { EXTERNAL_SERVICE: "EXTERNAL_SERVICE" },
+  logSystemError: (...args: unknown[]) => mockLogSystemError(...args),
+}));
+
+// Stub the real provisioning service so importing the module is side-effect
+// free; every test injects its own `provision` via opts.
+vi.mock("@/lib/turnkey/provision-org-wallet", () => ({
+  provisionOrganizationWallet: vi.fn(),
+}));
+
+import {
+  createProvisionWalletStreamStart,
+  type ProvisionStreamEvent,
+} from "@/lib/turnkey/provision-wallet-stream";
+
+const INPUT = {
+  userId: "user-1",
+  organizationId: "org-1",
+  email: "new@example.com",
+};
+
+async function collectEvents(
+  start: (controller: ReadableStreamDefaultController<Uint8Array>) => void
+): Promise<ProvisionStreamEvent[]> {
+  const stream = new ReadableStream<Uint8Array>({ start });
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  const events: ProvisionStreamEvent[] = [];
+  let buffer = "";
+
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) {
+      break;
+    }
+    buffer += decoder.decode(value, { stream: true });
+    let separator = buffer.indexOf("\n\n");
+    while (separator !== -1) {
+      const dataLine = buffer
+        .slice(0, separator)
+        .split("\n")
+        .find((line) => line.startsWith("data:"));
+      buffer = buffer.slice(separator + 2);
+      if (dataLine) {
+        events.push(
+          JSON.parse(dataLine.slice(5).trim()) as ProvisionStreamEvent
+        );
+      }
+      separator = buffer.indexOf("\n\n");
+    }
+  }
+
+  return events;
+}
+
+describe("createProvisionWalletStreamStart", () => {
+  beforeEach(() => {
+    mockLogSystemError.mockClear();
+  });
+
+  it("emits provisioning then ready and closes on success", async () => {
+    const provision = vi
+      .fn()
+      .mockResolvedValue({ walletAddress: "0xabc", created: true });
+
+    const events = await collectEvents(
+      createProvisionWalletStreamStart({
+        signal: new AbortController().signal,
+        input: INPUT,
+        provision,
+      })
+    );
+
+    expect(provision).toHaveBeenCalledWith(INPUT);
+    expect(events).toEqual([
+      { type: "provisioning" },
+      { type: "ready", walletAddress: "0xabc", created: true },
+    ]);
+    expect(mockLogSystemError).not.toHaveBeenCalled();
+  });
+
+  it("emits provisioning then error and logs when provisioning throws", async () => {
+    const provision = vi.fn().mockRejectedValue(new Error("turnkey down"));
+
+    const events = await collectEvents(
+      createProvisionWalletStreamStart({
+        signal: new AbortController().signal,
+        input: INPUT,
+        provision,
+      })
+    );
+
+    expect(events).toEqual([
+      { type: "provisioning" },
+      { type: "error", message: "Wallet provisioning failed" },
+    ]);
+    expect(mockLogSystemError).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps provisioning running after an early client abort", async () => {
+    const controller = new AbortController();
+    let resolveProvision: (value: {
+      walletAddress: string;
+      created: boolean;
+    }) => void = () => undefined;
+    const provision = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveProvision = resolve;
+      })
+    );
+
+    const events = await collectEvents((streamController) => {
+      const start = createProvisionWalletStreamStart({
+        signal: controller.signal,
+        input: INPUT,
+        provision,
+      });
+      start(streamController);
+      // Client disconnects before Turnkey responds.
+      controller.abort();
+      // Upstream call still completes; we just no longer report it.
+      resolveProvision({ walletAddress: "0xabc", created: true });
+    });
+
+    expect(provision).toHaveBeenCalledWith(INPUT);
+    // The stream was closed by the abort; only the initial frame made it out.
+    expect(events).toEqual([{ type: "provisioning" }]);
+  });
+});

--- a/tests/unit/use-wallet-provisioning.test.ts
+++ b/tests/unit/use-wallet-provisioning.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The hook module is "use client" and pulls auth-client + wallet-info at import.
+// We only exercise its pure test-seam exports, so stub those deps to keep the
+// import hermetic in the node test environment.
+vi.mock("@/lib/auth-client", () => ({
+  useSession: vi.fn(),
+  authClient: { useActiveOrganization: vi.fn() },
+}));
+
+vi.mock("@/lib/wallet/use-wallet-info", () => ({
+  useWalletInfo: vi.fn(),
+  useInvalidateWalletInfo: vi.fn(),
+}));
+
+import {
+  __parseEventForTesting as parseEvent,
+  __runProvisionStreamForTesting as runProvisionStream,
+  __shouldOpenProvisionStreamForTesting as shouldOpenProvisionStream,
+} from "@/lib/wallet/use-wallet-provisioning";
+
+const BASE = {
+  isAuthed: true,
+  activeOrgId: "org-1",
+  isLoading: false,
+  hasWallet: false,
+  attempted: false,
+};
+
+function sseFrame(event: unknown): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
+
+function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+describe("shouldOpenProvisionStream", () => {
+  it("opens for a verified, org-scoped, wallet-less first attempt", () => {
+    expect(shouldOpenProvisionStream(BASE)).toBe(true);
+  });
+
+  it("stays closed when unauthenticated, org-less, loading, already provisioned, or already attempted", () => {
+    expect(shouldOpenProvisionStream({ ...BASE, isAuthed: false })).toBe(false);
+    expect(shouldOpenProvisionStream({ ...BASE, activeOrgId: null })).toBe(
+      false
+    );
+    expect(shouldOpenProvisionStream({ ...BASE, isLoading: true })).toBe(false);
+    expect(shouldOpenProvisionStream({ ...BASE, hasWallet: true })).toBe(false);
+    expect(shouldOpenProvisionStream({ ...BASE, attempted: true })).toBe(false);
+  });
+});
+
+describe("parseEvent", () => {
+  it("parses well-formed SSE data frames", () => {
+    expect(parseEvent('data: {"type":"provisioning"}')).toEqual({
+      type: "provisioning",
+    });
+    expect(
+      parseEvent(
+        'data: {"type":"ready","walletAddress":"0xabc","created":true}'
+      )
+    ).toEqual({ type: "ready", walletAddress: "0xabc", created: true });
+  });
+
+  it("returns null for a frame with no data line or malformed JSON", () => {
+    expect(parseEvent(": keep-alive comment")).toBeNull();
+    expect(parseEvent("data: not-json")).toBeNull();
+  });
+});
+
+describe("runProvisionStream", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("invokes onReady once when a ready frame arrives", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        body: streamFromChunks([
+          sseFrame({ type: "provisioning" }),
+          sseFrame({ type: "ready", walletAddress: "0xabc", created: true }),
+        ]),
+      })
+    );
+    const onReady = vi.fn();
+
+    await runProvisionStream(onReady);
+
+    expect(onReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("reassembles a ready frame split across two chunks", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        body: streamFromChunks([
+          'data: {"type":"ready","walletAddress":"0xa',
+          'bc","created":true}\n\n',
+        ]),
+      })
+    );
+    const onReady = vi.fn();
+
+    await runProvisionStream(onReady);
+
+    expect(onReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invoke onReady on an error-only stream", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        body: streamFromChunks([
+          sseFrame({ type: "provisioning" }),
+          sseFrame({ type: "error", message: "Wallet provisioning failed" }),
+        ]),
+      })
+    );
+    const onReady = vi.fn();
+
+    await runProvisionStream(onReady);
+
+    expect(onReady).not.toHaveBeenCalled();
+  });
+
+  it("returns early without onReady when the response is not ok", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, body: null })
+    );
+    const onReady = vi.fn();
+
+    await runProvisionStream(onReady);
+
+    expect(onReady).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Auto-provision an org's non-custodial Turnkey wallet at signup so new users reach a sponsored first run without manually creating a wallet, and surface a "Gas sponsored" badge on sponsored run steps.

Provisioning is driven by a **streamed HTTP endpoint** the browser opens right after signup. The connection is held open for the duration of the upstream Turnkey call (the actual latency), then reports readiness live, so the user never has to create a wallet later or wait on a blank UI.

## How

- **`GET /api/user/wallet/provision` (SSE)** - awaits the idempotent `provisionOrganizationWallet` (the Turnkey call) and emits `provisioning` -> `ready{walletAddress}` / `error`, then closes. A client abort intentionally leaves the provisioning promise running so the wallet still gets created; we just stop reporting.
- **Removed the eager `user.create.after` fire-and-forget call.** Having both the auth hook and the stream call Turnkey would race and orphan a Turnkey sub-org. The `session.create.after` backstop stays as the only fallback - it covers signups that never open the stream (API-only signup, or a tab closed mid-flight) on next login.
- **`useWalletProvisioning` + a global trigger** mounted in the root layout drives the stream once per wallet-less org, so both email and social signups provision regardless of landing page. A "Setting up wallet" badge shows in the workflow toolbar while in flight; on failure it falls back silently to the manual create path / native gas.
- Unit tests for the stream factory (provisioning / ready / error / abort).

## Notes / follow-ups

- The client trigger fires for any verified, wallet-less org (consistent with the existing login backstop, which already re-provisions wallet-less orgs). Consequence: deleting a wallet auto-provisions a new one on next load. Can be narrowed to fresh-signup-only if desired.
- Gas-credit grant on org creation + first-action entitlement (ticket items 2-3) and the E2E signup -> sponsored-run coverage are not in this change.
