### PR TITLE
ci(deploy): enforce IRSA role-arn on keeperhub-stack deploys

### DIFF
--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -120,7 +120,7 @@ jobs:
           timeout: 15m0s
           name: ${{ env.SERVICE_NAME }}
           chart-repository: https://techops-services.github.io/helm-charts
-          version: 0.1.0
+          version: 0.2.0
           atomic: true
 
       - name: Wait for deployment health check
@@ -149,6 +149,18 @@ jobs:
               echo "Deployment did not become ready in time"
               exit 1
             '
+
+      - name: Set up Helm
+        if: steps.skip.outputs.skip_deploy != 'true'
+        uses: azure/setup-helm@v4
+
+      - name: Validate IRSA credentials end-to-end
+        if: steps.skip.outputs.skip_deploy != 'true'
+        run: |
+          helm test "${SERVICE_NAME}" \
+            --namespace "${NAMESPACE}" \
+            --filter "name=${SERVICE_NAME}-common-test-irsa-auth" \
+            --logs
 
   # DISABLED: remote E2E tests temporarily disabled while KEEP-1351 stabilises auth/rate-limit infrastructure
   e2e-playwright-remote:

--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -109,6 +109,9 @@ app:
 
   serviceAccount:
     create: true
+    requireRoleArn: true
+    irsaCheck:
+      enabled: true
     annotations:
       eks.amazonaws.com/role-arn: ${SERVICE_ACCOUNT_ROLE_ARN}
     name: keeperhub-prod

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -109,6 +109,9 @@ app:
 
   serviceAccount:
     create: true
+    requireRoleArn: true
+    irsaCheck:
+      enabled: true
     annotations:
       eks.amazonaws.com/role-arn: ${SERVICE_ACCOUNT_ROLE_ARN}
     name: keeperhub-staging


### PR DESCRIPTION
## Context

Companion to techops-services/helm-charts#70. After the 2026-06-18 prod incident (empty `eks.amazonaws.com/role-arn` annotation left the dispatchers and executor without AWS credentials while `helm upgrade` still reported success), the `common` chart now supports a fail-closed role-arn guard and an IRSA end-to-end helm-test. This wires both into the KeeperHub deploy.

## Changes

- Enable `serviceAccount.requireRoleArn: true` and `serviceAccount.irsaCheck.enabled: true` on the app component (the owner of the shared service account) in staging and prod values.
- Bump the deployed `keeperhub-stack` chart pin 0.1.0 -> 0.2.0.
- Run `helm test` after the upgrade, filtered to the IRSA auth pod, so a credential-less deploy fails the pipeline instead of silently dropping AWS access.

## Verification

Rendered the v0.2.0 chart against these staging deploy values with the CI sed substitutions applied: a valid role-arn renders cleanly (one IRSA test pod); an empty role-arn now aborts the render with `serviceAccount eks.amazonaws.com/role-arn is missing or malformed`, reproducing and blocking the incident condition.

## Ordering (draft until ready)

Held as draft until helm-charts#70 merges and chart-releaser publishes `keeperhub-stack` 0.2.0. Merging before then would 404 the deploy on the 0.2.0 pin.