### PR TITLE
feat(web3): decode actual executed call for sponsored transactions

### DIFF
--- a/lib/web3/serialize-arg.ts
+++ b/lib/web3/serialize-arg.ts
@@ -1,0 +1,27 @@
+import "server-only";
+
+/**
+ * Serialize a single ABI-decoded argument value to a plain string suitable
+ * for template references and output fields.
+ *
+ * Used by decode-calldata, query-transactions, and trace-decode to produce a
+ * consistent string representation of any value ethers can return from
+ * parseTransaction / parseLog.
+ */
+export function serializeArg(value: unknown): string {
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return JSON.stringify(value, (_key, v: unknown) =>
+    typeof v === "bigint" ? v.toString() : v
+  );
+}

--- a/lib/web3/trace-decode.ts
+++ b/lib/web3/trace-decode.ts
@@ -1,0 +1,314 @@
+/**
+ * Shared transaction trace decoding for web3 actions.
+ *
+ * Gas-sponsored transactions (Turnkey Gas Station, ERC-4337/EIP-7702 smart
+ * accounts, generic relayers) do not appear on-chain as a direct call to the
+ * target contract: the top-level `to` is the relayer/wrapper, and the real
+ * call to the target is an internal call. Decoding only the top-level calldata
+ * therefore returns different results for sponsored vs direct sends of the same
+ * action.
+ *
+ * This module recovers the actual executed call(s) by walking the transaction's
+ * internal call tree (`debug_traceTransaction` with the `callTracer`) and
+ * decoding each frame against a contract ABI. The result is identical whether
+ * the transaction was sponsored or sent directly, so any web3 action that holds
+ * a transaction hash can report a normalized "what actually ran" view.
+ *
+ * Discovery caveat: this requires a transaction hash. It is suited to write
+ * actions (which always have one). It cannot be used to discover sponsored
+ * calls from explorer history alone, because explorers index internal calls by
+ * value transfer only -- a zero-value sponsored call to a contract is not
+ * listed against that contract.
+ */
+import "server-only";
+
+import type { ethers } from "ethers";
+
+/** A node of the `callTracer` output as returned by `debug_traceTransaction`. */
+export type RawCallFrame = {
+  type?: string;
+  from?: string;
+  to?: string;
+  value?: string;
+  input?: string;
+  output?: string;
+  error?: string;
+  calls?: RawCallFrame[];
+};
+
+/** A single call frame flattened out of the trace tree. */
+export type FlatCall = {
+  type: string;
+  from: string;
+  to: string;
+  value: string;
+  input: string;
+  depth: number;
+  reverted: boolean;
+};
+
+/** A flattened call whose input was decoded against a contract ABI. */
+export type DecodedCall = FlatCall & {
+  functionName: string;
+  functionSignature: string;
+  args: Record<string, string>;
+};
+
+/** Normalized "what actually executed" view for a target contract. */
+export type ExecutedCall = {
+  /** The contract the decoded call actually hit. */
+  contractAddress: string;
+  functionName: string;
+  functionSignature: string;
+  args: Record<string, string>;
+  /** True when the transaction was routed through a relayer/wrapper. */
+  sponsored: boolean;
+  /** Top-level `to` of the transaction (the wrapper, when sponsored). */
+  topLevelTo: string;
+  /** Whether the matched call frame reverted. */
+  reverted: boolean;
+};
+
+/** Minimal provider surface needed for tracing (ethers JsonRpcProvider satisfies it). */
+export type TraceProvider = {
+  send: (method: string, params: unknown[]) => Promise<unknown>;
+};
+
+const TRACE_METHOD = "debug_traceTransaction";
+// Opcode types whose `input` carries calldata we can decode against an ABI.
+const DECODABLE_CALL_TYPES: ReadonlySet<string> = new Set([
+  "CALL",
+  "DELEGATECALL",
+  "STATICCALL",
+  "CALLCODE",
+]);
+
+/**
+ * Trace a transaction's internal call tree.
+ *
+ * Returns the root call frame, or `null` when the RPC does not support
+ * `debug_traceTransaction`/`callTracer` or the hash is unknown. Callers should
+ * treat `null` as "tracing unavailable" and degrade gracefully rather than
+ * fail, since trace support varies by chain and RPC provider.
+ */
+export async function traceTransactionCallTree(
+  provider: TraceProvider,
+  txHash: string
+): Promise<RawCallFrame | null> {
+  try {
+    const result = await provider.send(TRACE_METHOD, [
+      txHash,
+      { tracer: "callTracer" },
+    ]);
+    if (result && typeof result === "object") {
+      return result as RawCallFrame;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Depth-first flatten of the trace tree into an ordered list of call frames. */
+export function flattenCallTree(root: RawCallFrame | null): FlatCall[] {
+  const out: FlatCall[] = [];
+
+  const walk = (node: RawCallFrame | undefined, depth: number): void => {
+    if (!node) {
+      return;
+    }
+    out.push({
+      type: (node.type ?? "CALL").toUpperCase(),
+      from: (node.from ?? "").toLowerCase(),
+      to: (node.to ?? "").toLowerCase(),
+      value: node.value ?? "0x0",
+      input: node.input ?? "0x",
+      depth,
+      reverted: Boolean(node.error),
+    });
+    for (const child of node.calls ?? []) {
+      walk(child, depth + 1);
+    }
+  };
+
+  walk(root ?? undefined, 0);
+  return out;
+}
+
+function serializeArg(value: unknown): string {
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (typeof value === "string" || typeof value === "number") {
+    return value.toString();
+  }
+  if (typeof value === "boolean") {
+    return value.toString();
+  }
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return JSON.stringify(value, (_key, v) =>
+    typeof v === "bigint" ? v.toString() : v
+  );
+}
+
+/**
+ * Decode a single flattened call against an ABI interface.
+ *
+ * Returns `null` for non-decodable frames (creates, precompiles, value-only
+ * sends) or when the calldata does not match any function in the interface.
+ */
+export function decodeFlatCall(
+  call: FlatCall,
+  iface: ethers.Interface
+): DecodedCall | null {
+  if (!DECODABLE_CALL_TYPES.has(call.type)) {
+    return null;
+  }
+  if (!call.input || call.input.length < 10) {
+    return null;
+  }
+
+  try {
+    const parsed = iface.parseTransaction({
+      data: call.input,
+      value: call.value,
+    });
+    if (!parsed) {
+      return null;
+    }
+
+    const args: Record<string, string> = {};
+    for (const [index, input] of parsed.fragment.inputs.entries()) {
+      const name = input.name || `arg${index}`;
+      args[name] = serializeArg(parsed.args[index]);
+    }
+
+    return {
+      ...call,
+      functionName: parsed.name,
+      functionSignature: parsed.signature,
+      args,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function argFilterMatches(
+  decoded: DecodedCall,
+  iface: ethers.Interface,
+  functionName: string,
+  filterArgs: string[] | null
+): boolean {
+  if (filterArgs === null) {
+    return true;
+  }
+
+  const fragment = iface.getFunction(functionName);
+  if (!fragment) {
+    return true;
+  }
+
+  for (const [index, filterValue] of filterArgs.entries()) {
+    if (filterValue === "") {
+      continue;
+    }
+    const paramName = fragment.inputs[index]?.name || `arg${index}`;
+    const decodedValue = decoded.args[paramName] ?? "";
+    if (filterValue.toLowerCase() !== decodedValue.toLowerCase()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export type FindCallOptions = {
+  /** Restrict to calls hitting this address (case-insensitive). */
+  target: string;
+  iface: ethers.Interface;
+  /** Restrict to a specific function name. */
+  functionName?: string;
+  /** Positional argument filter; "" entries are wildcards. */
+  filterArgs?: string[] | null;
+  /** Include reverted frames (default false). */
+  includeReverted?: boolean;
+};
+
+/**
+ * Find every decoded call to `target` in a trace tree that matches the given
+ * function and argument filter. Frames are returned in execution order.
+ */
+export function findDecodedCalls(
+  root: RawCallFrame | null,
+  options: FindCallOptions
+): DecodedCall[] {
+  const target = options.target.toLowerCase();
+  const includeReverted = options.includeReverted ?? false;
+  const filterArgs = options.filterArgs ?? null;
+
+  const matches: DecodedCall[] = [];
+  for (const call of flattenCallTree(root)) {
+    if (call.to !== target) {
+      continue;
+    }
+    if (call.reverted && !includeReverted) {
+      continue;
+    }
+    const decoded = decodeFlatCall(call, options.iface);
+    if (!decoded) {
+      continue;
+    }
+    if (options.functionName && decoded.functionName !== options.functionName) {
+      continue;
+    }
+    if (
+      !argFilterMatches(
+        decoded,
+        options.iface,
+        decoded.functionName,
+        filterArgs
+      )
+    ) {
+      continue;
+    }
+    matches.push(decoded);
+  }
+  return matches;
+}
+
+/**
+ * Resolve the normalized executed call for a transaction against a target
+ * contract, transparently unwrapping sponsored/relayed routing.
+ *
+ * Returns `null` when tracing is unavailable or no matching call is found, so
+ * callers can fall back to their pre-existing (top-level) behavior.
+ */
+export async function resolveExecutedCall(
+  provider: TraceProvider,
+  txHash: string,
+  options: FindCallOptions
+): Promise<ExecutedCall | null> {
+  const root = await traceTransactionCallTree(provider, txHash);
+  if (!root) {
+    return null;
+  }
+
+  const matches = findDecodedCalls(root, options);
+  const decoded = matches[0];
+  if (!decoded) {
+    return null;
+  }
+
+  const topLevelTo = (root.to ?? "").toLowerCase();
+  return {
+    contractAddress: decoded.to,
+    functionName: decoded.functionName,
+    functionSignature: decoded.functionSignature,
+    args: decoded.args,
+    sponsored: topLevelTo !== options.target.toLowerCase(),
+    topLevelTo,
+    reverted: decoded.reverted,
+  };
+}

--- a/lib/web3/trace-decode.ts
+++ b/lib/web3/trace-decode.ts
@@ -23,6 +23,7 @@
 import "server-only";
 
 import type { ethers } from "ethers";
+import { serializeArg } from "@/lib/web3/serialize-arg";
 
 /** A node of the `callTracer` output as returned by `debug_traceTransaction`. */
 export type RawCallFrame = {
@@ -113,10 +114,20 @@ export async function traceTransactionCallTree(
 export function flattenCallTree(root: RawCallFrame | null): FlatCall[] {
   const out: FlatCall[] = [];
 
-  const walk = (node: RawCallFrame | undefined, depth: number): void => {
+  // parentReverted: true when any ancestor frame reverted. The EVM rolls back
+  // all descendants of a reverted frame, but geth's callTracer only sets
+  // `error` on the frame that reverted — not on its children. We propagate the
+  // flag top-down so child frames that completed before their parent reverted
+  // are correctly marked reverted too.
+  const walk = (
+    node: RawCallFrame | undefined,
+    depth: number,
+    parentReverted: boolean
+  ): void => {
     if (!node) {
       return;
     }
+    const reverted = parentReverted || Boolean(node.error);
     out.push({
       type: (node.type ?? "CALL").toUpperCase(),
       from: (node.from ?? "").toLowerCase(),
@@ -124,34 +135,17 @@ export function flattenCallTree(root: RawCallFrame | null): FlatCall[] {
       value: node.value ?? "0x0",
       input: node.input ?? "0x",
       depth,
-      reverted: Boolean(node.error),
+      reverted,
     });
     for (const child of node.calls ?? []) {
-      walk(child, depth + 1);
+      walk(child, depth + 1, reverted);
     }
   };
 
-  walk(root ?? undefined, 0);
+  walk(root ?? undefined, 0, false);
   return out;
 }
 
-function serializeArg(value: unknown): string {
-  if (typeof value === "bigint") {
-    return value.toString();
-  }
-  if (typeof value === "string" || typeof value === "number") {
-    return value.toString();
-  }
-  if (typeof value === "boolean") {
-    return value.toString();
-  }
-  if (value === null || value === undefined) {
-    return "";
-  }
-  return JSON.stringify(value, (_key, v) =>
-    typeof v === "bigint" ? v.toString() : v
-  );
-}
 
 /**
  * Decode a single flattened call against an ABI interface.
@@ -166,7 +160,7 @@ export function decodeFlatCall(
   if (!DECODABLE_CALL_TYPES.has(call.type)) {
     return null;
   }
-  if (!call.input || call.input.length < 10) {
+  if (call.input.length < 10) {
     return null;
   }
 

--- a/lib/web3/trace-executed-call.ts
+++ b/lib/web3/trace-executed-call.ts
@@ -53,14 +53,26 @@ export async function traceExecutedCallWithFailover(
   }
 
   try {
-    const executed = await rpcManager.executeWithFailover((provider) =>
-      resolveExecutedCall(provider as unknown as TraceProvider, txHash, {
-        target: options.target,
-        iface,
-        functionName: options.functionName,
-        filterArgs: options.filterArgs ?? null,
-      })
-    );
+    const executed = await rpcManager.executeWithFailover(async (provider) => {
+      const result = await resolveExecutedCall(
+        provider as unknown as TraceProvider,
+        txHash,
+        {
+          target: options.target,
+          iface,
+          functionName: options.functionName,
+          filterArgs: options.filterArgs ?? null,
+        }
+      );
+      // resolveExecutedCall returns null when the provider doesn't support
+      // debug_traceTransaction or when no matching call is found. Throwing here
+      // lets executeWithFailover retry the next provider rather than treating
+      // null as a successful empty result and stopping immediately.
+      if (result === null) {
+        throw new Error("trace unavailable");
+      }
+      return result;
+    });
     return executed ?? undefined;
   } catch {
     return;

--- a/lib/web3/trace-executed-call.ts
+++ b/lib/web3/trace-executed-call.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared helper that resolves the normalized executed call for a just-sent
+ * transaction, with RPC failover.
+ *
+ * Web3 write actions (write-contract, approve-token, transfer-token, ...) all
+ * face the same problem: a gas-sponsored send routes through a relayer/wrapper,
+ * so the on-chain transaction's top-level `to`/calldata no longer describe the
+ * action that ran. This helper traces the transaction and decodes the actual
+ * call against the target contract's ABI, so every action can attach a
+ * consistent "what executed" view regardless of sponsorship.
+ *
+ * It is intentionally best-effort: when tracing is unavailable (RPC without
+ * `debug_traceTransaction`, or no matching call found) it resolves to
+ * `undefined` so callers degrade gracefully instead of failing the action.
+ */
+import "server-only";
+
+import { ethers } from "ethers";
+import type { RpcProviderManager } from "@/lib/rpc/providers";
+import {
+  type ExecutedCall,
+  resolveExecutedCall,
+  type TraceProvider,
+} from "@/lib/web3/trace-decode";
+
+export type TraceExecutedCallOptions = {
+  /** Address whose call we want to recover (the action's target contract). */
+  target: string;
+  /** ABI used to decode the call (array or JSON string). */
+  abi: unknown;
+  /** Restrict to a specific function name. */
+  functionName?: string;
+  /** Positional argument filter; "" entries are wildcards. */
+  filterArgs?: string[] | null;
+};
+
+function buildInterface(abi: unknown): ethers.Interface | null {
+  try {
+    return new ethers.Interface(abi as ethers.InterfaceAbi);
+  } catch {
+    return null;
+  }
+}
+
+export async function traceExecutedCallWithFailover(
+  rpcManager: RpcProviderManager,
+  txHash: string,
+  options: TraceExecutedCallOptions
+): Promise<ExecutedCall | undefined> {
+  const iface = buildInterface(options.abi);
+  if (!iface) {
+    return;
+  }
+
+  try {
+    const executed = await rpcManager.executeWithFailover((provider) =>
+      resolveExecutedCall(provider as unknown as TraceProvider, txHash, {
+        target: options.target,
+        iface,
+        functionName: options.functionName,
+        filterArgs: options.filterArgs ?? null,
+      })
+    );
+    return executed ?? undefined;
+  } catch {
+    return;
+  }
+}

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -254,6 +254,28 @@ const web3Plugin: IntegrationPlugin = {
           description: "The recipient address",
         },
         {
+          field: "executedCall.functionName",
+          description:
+            "Function that actually executed on the token contract, recovered by tracing the transaction. Identical for sponsored and direct sends.",
+        },
+        {
+          field: "executedCall.contractAddress",
+          description: "Address the executed call actually hit",
+        },
+        {
+          field: "executedCall.args",
+          description: "Decoded arguments of the executed call, keyed by name",
+        },
+        {
+          field: "executedCall.sponsored",
+          description:
+            "Whether the transaction was routed through a gas-sponsorship relayer/wrapper",
+        },
+        {
+          field: "executedCall.reverted",
+          description: "Whether the executed call frame reverted",
+        },
+        {
           field: "error",
           description: "Error message if the transfer failed",
         },
@@ -1005,6 +1027,28 @@ const web3Plugin: IntegrationPlugin = {
           description: "The token symbol (e.g., USDC)",
         },
         {
+          field: "executedCall.functionName",
+          description:
+            "Function that actually executed on the token contract, recovered by tracing the transaction. Identical for sponsored and direct sends.",
+        },
+        {
+          field: "executedCall.contractAddress",
+          description: "Address the executed call actually hit",
+        },
+        {
+          field: "executedCall.args",
+          description: "Decoded arguments of the executed call, keyed by name",
+        },
+        {
+          field: "executedCall.sponsored",
+          description:
+            "Whether the transaction was routed through a gas-sponsorship relayer/wrapper",
+        },
+        {
+          field: "executedCall.reverted",
+          description: "Whether the executed call frame reverted",
+        },
+        {
           field: "error",
           description: "Error message if the approval failed",
         },
@@ -1143,6 +1187,28 @@ const web3Plugin: IntegrationPlugin = {
         {
           field: "result",
           description: "The contract function return value (if any)",
+        },
+        {
+          field: "executedCall.functionName",
+          description:
+            "Function that actually executed on the target contract, recovered by tracing the transaction. Identical for sponsored and direct sends.",
+        },
+        {
+          field: "executedCall.contractAddress",
+          description: "Address the executed call actually hit",
+        },
+        {
+          field: "executedCall.args",
+          description: "Decoded arguments of the executed call, keyed by name",
+        },
+        {
+          field: "executedCall.sponsored",
+          description:
+            "Whether the transaction was routed through a gas-sponsorship relayer/wrapper",
+        },
+        {
+          field: "executedCall.reverted",
+          description: "Whether the executed call frame reverted",
         },
         {
           field: "error",

--- a/plugins/web3/steps/approve-token-core.ts
+++ b/plugins/web3/steps/approve-token-core.ts
@@ -37,6 +37,8 @@ import { resolveGasLimitOverrides } from "@/lib/web3/gas-defaults";
 import { isSponsorshipSupported } from "@/lib/web3/turnkey-sponsorship-config";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
 import { executeSponsoredContractTransaction } from "@/lib/web3/sponsored-transaction-manager";
+import type { ExecutedCall } from "@/lib/web3/trace-decode";
+import { traceExecutedCallWithFailover } from "@/lib/web3/trace-executed-call";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
 import { isSponsoredTxRevertError } from "@/lib/web3/turnkey-revert";
 import {
@@ -79,6 +81,10 @@ export type ApproveTokenResult =
       spender: string;
       symbol: string;
       sponsored?: boolean;
+      // Normalized view of the call that actually executed, recovered by tracing
+      // the transaction. Lets sponsored sends report the same shape as direct
+      // ones. Omitted when the RPC cannot trace the transaction.
+      executedCall?: ExecutedCall;
     }
   | {
       success: false;
@@ -303,6 +309,12 @@ export async function approveTokenCore(
           ? getTransactionUrl(explorerConfig, sponsoredResult.transactionHash)
           : "";
 
+        const executedCall = await traceExecutedCallWithFailover(
+          rpcManager,
+          sponsoredResult.transactionHash,
+          { target: tokenAddress, abi: ERC20_ABI, functionName: "approve" }
+        );
+
         return {
           success: true,
           sponsored: true,
@@ -314,6 +326,7 @@ export async function approveTokenCore(
           approvedAmount: approvedAmountDisplay,
           spender: spenderAddress,
           symbol,
+          executedCall,
         };
       }
 

--- a/plugins/web3/steps/approve-token-core.ts
+++ b/plugins/web3/steps/approve-token-core.ts
@@ -485,6 +485,12 @@ export async function approveTokenCore(
       const gasCostWei = (receipt.gasUsed * receipt.effectiveGasPrice).toString();
       const transactionLink = await adapter.getTransactionUrl(receipt.hash);
 
+      const executedCall = await traceExecutedCallWithFailover(rpcManager, receipt.hash, {
+        target: tokenAddress,
+        abi: ERC20_ABI,
+        functionName: "approve",
+      });
+
       return {
         success: true,
         transactionHash: receipt.hash,
@@ -495,6 +501,7 @@ export async function approveTokenCore(
         approvedAmount: approvedAmountDisplay,
         spender: spenderAddress,
         symbol,
+        executedCall,
       };
     } catch (error) {
       logUserError(

--- a/plugins/web3/steps/decode-calldata-core.ts
+++ b/plugins/web3/steps/decode-calldata-core.ts
@@ -14,6 +14,7 @@ import { db } from "@/lib/db";
 import { explorerConfigs } from "@/lib/db/schema";
 import { fetchContractAbi } from "@/lib/explorer";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { serializeArg } from "@/lib/web3/serialize-arg";
 
 const ETHERSCAN_API_KEY = process.env.ETHERSCAN_API_KEY ?? "";
 const FOURBYTE_API_URL = "https://www.4byte.directory/api/v1/signatures/";
@@ -46,23 +47,7 @@ export type DecodeCalldataCoreInput = {
 /**
  * Serialize a decoded value to string, handling BigInt, arrays, and objects
  */
-function serializeValue(value: unknown): string {
-  if (value === null || value === undefined) {
-    return String(value);
-  }
-  if (typeof value === "bigint") {
-    return value.toString();
-  }
-  if (typeof value === "string") {
-    return value;
-  }
-  if (typeof value === "boolean" || typeof value === "number") {
-    return String(value);
-  }
-  return JSON.stringify(value, (_key, v: unknown) =>
-    typeof v === "bigint" ? v.toString() : v
-  );
-}
+const serializeValue = serializeArg;
 
 /**
  * Extract named parameters from a parsed transaction fragment

--- a/plugins/web3/steps/query-transactions-core.ts
+++ b/plugins/web3/steps/query-transactions-core.ts
@@ -14,6 +14,7 @@ import {
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
+import { serializeArg } from "@/lib/web3/serialize-arg";
 import { getErrorMessage } from "@/lib/utils";
 
 const DEFAULT_BLOCK_LOOKBACK = 6500;
@@ -204,26 +205,7 @@ async function resolveBlockRange(
   };
 }
 
-function serializeValue(value: unknown): string {
-  if (typeof value === "bigint") {
-    return value.toString();
-  }
-  if (typeof value === "string") {
-    return value;
-  }
-  if (typeof value === "number") {
-    return value.toString();
-  }
-  if (typeof value === "boolean") {
-    return value.toString();
-  }
-  if (value === null || value === undefined) {
-    return "";
-  }
-  return JSON.stringify(value, (_, v) =>
-    typeof v === "bigint" ? v.toString() : v
-  );
-}
+const serializeValue = serializeArg;
 
 type TxLinkBuilder = { getTransactionUrl: (hash: string) => string };
 

--- a/plugins/web3/steps/transfer-token-core.ts
+++ b/plugins/web3/steps/transfer-token-core.ts
@@ -41,6 +41,8 @@ import { resolveGasLimitOverrides } from "@/lib/web3/gas-defaults";
 import { isSponsorshipSupported } from "@/lib/web3/turnkey-sponsorship-config";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
 import { executeSponsoredContractTransaction } from "@/lib/web3/sponsored-transaction-manager";
+import type { ExecutedCall } from "@/lib/web3/trace-decode";
+import { traceExecutedCallWithFailover } from "@/lib/web3/trace-executed-call";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
 import { isSponsoredTxRevertError } from "@/lib/web3/turnkey-revert";
 import {
@@ -82,6 +84,10 @@ export type TransferTokenResult =
       symbol: string;
       recipient: string;
       sponsored?: boolean;
+      // Normalized view of the call that actually executed, recovered by tracing
+      // the transaction. Lets sponsored sends report the same shape as direct
+      // ones. Omitted when the RPC cannot trace the transaction.
+      executedCall?: ExecutedCall;
     }
   | { success: false; error: string; rejection?: RevertKind };
 
@@ -393,6 +399,12 @@ export async function transferTokenCore(
           ? getTransactionUrl(explorerConfig, sponsoredResult.transactionHash)
           : "";
 
+        const executedCall = await traceExecutedCallWithFailover(
+          rpcManager,
+          sponsoredResult.transactionHash,
+          { target: tokenAddress, abi: ERC20_ABI, functionName: "transfer" }
+        );
+
         return {
           success: true,
           sponsored: true,
@@ -404,6 +416,7 @@ export async function transferTokenCore(
           amount,
           symbol,
           recipient: recipientAddress,
+          executedCall,
         };
       }
 

--- a/plugins/web3/steps/transfer-token-core.ts
+++ b/plugins/web3/steps/transfer-token-core.ts
@@ -583,6 +583,12 @@ export async function transferTokenCore(
       const gasCostWei = (receipt.gasUsed * receipt.effectiveGasPrice).toString();
       const transactionLink = await adapter.getTransactionUrl(receipt.hash);
 
+      const executedCall = await traceExecutedCallWithFailover(rpcManager, receipt.hash, {
+        target: tokenAddress,
+        abi: ERC20_ABI,
+        functionName: "transfer",
+      });
+
       return {
         success: true,
         transactionHash: receipt.hash,
@@ -593,6 +599,7 @@ export async function transferTokenCore(
         amount,
         symbol,
         recipient: recipientAddress,
+        executedCall,
       };
     } catch (error) {
       logUserError(

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -42,6 +42,8 @@ import {
 } from "@/lib/web3/gas-defaults";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
 import { executeSponsoredContractTransaction } from "@/lib/web3/sponsored-transaction-manager";
+import type { ExecutedCall } from "@/lib/web3/trace-decode";
+import { traceExecutedCallWithFailover } from "@/lib/web3/trace-executed-call";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
 import { isSponsoredTxRevertError } from "@/lib/web3/turnkey-revert";
 import {
@@ -87,6 +89,12 @@ export type WriteContractResult =
       effectiveGasPrice: string;
       result?: unknown;
       sponsored?: boolean;
+      // Normalized view of the call that actually executed against the target
+      // contract, recovered by tracing the transaction. For sponsored sends the
+      // top-level `to` is a relayer/wrapper, so this is the only consistent way
+      // to report "what ran" identically to a direct send. Omitted when the RPC
+      // cannot trace the transaction.
+      executedCall?: ExecutedCall;
     }
   | { success: false; error: string; rejection?: RevertKind };
 
@@ -363,6 +371,12 @@ export async function writeContractCore(
           ? getTransactionUrl(explorerConfig, sponsoredResult.transactionHash)
           : "";
 
+        const executedCall = await traceExecutedCallWithFailover(
+          rpcManager,
+          sponsoredResult.transactionHash,
+          { target: contractAddress, abi: parsedAbi, functionName: abiFunction }
+        );
+
         return {
           success: true,
           sponsored: true,
@@ -371,6 +385,7 @@ export async function writeContractCore(
           gasUsed: sponsoredResult.gasUsed,
           gasUsedUnits: sponsoredResult.gasUsedUnits,
           effectiveGasPrice: sponsoredResult.effectiveGasPrice,
+          executedCall,
         };
       }
 

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -525,6 +525,12 @@ export async function writeContractCore(
       const gasCostWei = (receipt.gasUsed * receipt.effectiveGasPrice).toString();
       const transactionLink = await adapter.getTransactionUrl(receipt.hash);
 
+      const executedCall = await traceExecutedCallWithFailover(rpcManager, receipt.hash, {
+        target: contractAddress,
+        abi: parsedAbi,
+        functionName: abiFunction,
+      });
+
       return {
         success: true,
         transactionHash: receipt.hash,
@@ -533,6 +539,7 @@ export async function writeContractCore(
         gasUsedUnits,
         effectiveGasPrice,
         result: undefined,
+        executedCall,
       };
     } catch (error) {
       logUserError(

--- a/tests/unit/approve-token.test.ts
+++ b/tests/unit/approve-token.test.ts
@@ -186,6 +186,12 @@ vi.mock("@/lib/web3/sponsored-transaction-manager", () => ({
   executeSponsoredContractTransaction: vi.fn().mockResolvedValue(null),
 }));
 
+const mockTraceExecutedCall = vi.fn();
+vi.mock("@/lib/web3/trace-executed-call", () => ({
+  traceExecutedCallWithFailover: (...args: unknown[]) =>
+    mockTraceExecutedCall(...args),
+}));
+
 // Mock ethers
 const mockDecimals = vi.fn();
 const mockSymbol = vi.fn();
@@ -285,8 +291,19 @@ function setupMocks(): void {
   mockGetTransactionUrl.mockResolvedValue("https://etherscan.io/tx/0xtxhash");
 }
 
+const MOCK_EXECUTED_CALL = {
+  contractAddress: "0x6b175474e89094c44da98b954eedeac495271d0f",
+  functionName: "approve",
+  functionSignature: "approve(address,uint256)",
+  args: { spender: "0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45", amount: "100000000000000000000" },
+  sponsored: false,
+  topLevelTo: "0x6b175474e89094c44da98b954eedeac495271d0f",
+  reverted: false,
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
+  mockTraceExecutedCall.mockResolvedValue(undefined);
 });
 
 describe("approve-token - validation", () => {
@@ -420,5 +437,42 @@ describe("approve-token - error handling", () => {
         "Failed to initialize organization wallet"
       );
     }
+  });
+});
+
+describe("approve-token - executedCall on direct send", () => {
+  it("attaches executedCall when trace succeeds", async () => {
+    setupMocks();
+    mockTraceExecutedCall.mockResolvedValue(MOCK_EXECUTED_CALL);
+
+    const result = await approveTokenCore(makeInput({ amount: "100" }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.executedCall).toEqual(MOCK_EXECUTED_CALL);
+    }
+  });
+
+  it("omits executedCall when trace returns undefined (graceful degradation)", async () => {
+    setupMocks();
+    mockTraceExecutedCall.mockResolvedValue(undefined);
+
+    const result = await approveTokenCore(makeInput({ amount: "100" }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.executedCall).toBeUndefined();
+    }
+  });
+
+  it("calls traceExecutedCallWithFailover with correct args", async () => {
+    setupMocks();
+    mockTraceExecutedCall.mockResolvedValue(undefined);
+
+    await approveTokenCore(makeInput({ amount: "100" }));
+
+    expect(mockTraceExecutedCall).toHaveBeenCalledWith(
+      expect.objectContaining({ executeWithFailover: expect.any(Function) }),
+      "0xtxhash",
+      expect.objectContaining({ target: VALID_TOKEN, functionName: "approve" })
+    );
   });
 });

--- a/tests/unit/trace-decode.test.ts
+++ b/tests/unit/trace-decode.test.ts
@@ -81,6 +81,35 @@ describe("trace-decode", () => {
       });
       expect(flat[0].reverted).toBe(true);
     });
+
+    it("propagates revert to child frames when parent reverts", () => {
+      const tree: RawCallFrame = {
+        type: "CALL",
+        to: WRAPPER,
+        input: "0x00",
+        error: "execution reverted",
+        calls: [{ type: "CALL", to: TARGET, input: transferData }],
+      };
+      const flat = flattenCallTree(tree);
+      expect(flat[0].reverted).toBe(true);
+      expect(flat[1].reverted).toBe(true);
+    });
+
+    it("does not mark child reverted when only the child reverts, not parent", () => {
+      const tree: RawCallFrame = {
+        type: "CALL",
+        to: WRAPPER,
+        input: "0x00",
+        calls: [
+          { type: "CALL", to: TARGET, input: transferData, error: "reverted" },
+          { type: "CALL", to: TARGET, input: scheduleData },
+        ],
+      };
+      const flat = flattenCallTree(tree);
+      expect(flat[0].reverted).toBe(false);
+      expect(flat[1].reverted).toBe(true);
+      expect(flat[2].reverted).toBe(false);
+    });
   });
 
   describe("decodeFlatCall", () => {

--- a/tests/unit/trace-decode.test.ts
+++ b/tests/unit/trace-decode.test.ts
@@ -1,0 +1,245 @@
+import { ethers } from "ethers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  decodeFlatCall,
+  type FlatCall,
+  findDecodedCalls,
+  flattenCallTree,
+  type RawCallFrame,
+  resolveExecutedCall,
+  type TraceProvider,
+  traceTransactionCallTree,
+} from "@/lib/web3/trace-decode";
+
+type SendFn = TraceProvider["send"];
+
+const WRAPPER = "0x00000000000000000000000000000000000000aa";
+const TARGET = "0x00000000000000000000000000000000000000bb";
+const RECIPIENT = "0x00000000000000000000000000000000000000cc";
+const RELAYER = "0x00000000000000000000000000000000000000ee";
+
+const IFACE = new ethers.Interface([
+  "function transfer(address to, uint256 amount)",
+  "function schedule()",
+]);
+
+const transferData = IFACE.encodeFunctionData("transfer", [
+  RECIPIENT,
+  BigInt(1000),
+]);
+const scheduleData = IFACE.encodeFunctionData("schedule", []);
+
+/** A sponsored tx: relayer -> wrapper.execute -> target.transfer(...) */
+function sponsoredTree(): RawCallFrame {
+  return {
+    type: "CALL",
+    from: RELAYER,
+    to: WRAPPER,
+    value: "0x0",
+    input: "0x9aefaff800",
+    calls: [
+      {
+        type: "STATICCALL",
+        from: WRAPPER,
+        to: "0x0000000000000000000000000000000000000001",
+        input: "0xdeadbeef",
+      },
+      {
+        type: "CALL",
+        from: WRAPPER,
+        to: TARGET,
+        value: "0x0",
+        input: transferData,
+      },
+    ],
+  };
+}
+
+describe("trace-decode", () => {
+  describe("flattenCallTree", () => {
+    it("flattens depth-first with depth and lowercased addresses", () => {
+      const flat = flattenCallTree(sponsoredTree());
+      expect(flat).toHaveLength(3);
+      expect(flat[0]).toMatchObject({ to: WRAPPER, depth: 0, type: "CALL" });
+      expect(flat[1]).toMatchObject({ depth: 1, type: "STATICCALL" });
+      expect(flat[2]).toMatchObject({ to: TARGET, depth: 1, type: "CALL" });
+    });
+
+    it("returns empty array for null root", () => {
+      expect(flattenCallTree(null)).toEqual([]);
+    });
+
+    it("marks frames with an error as reverted", () => {
+      const flat = flattenCallTree({
+        type: "CALL",
+        to: TARGET,
+        input: scheduleData,
+        error: "execution reverted",
+      });
+      expect(flat[0].reverted).toBe(true);
+    });
+  });
+
+  describe("decodeFlatCall", () => {
+    const base: FlatCall = {
+      type: "CALL",
+      from: WRAPPER,
+      to: TARGET,
+      value: "0x0",
+      input: transferData,
+      depth: 1,
+      reverted: false,
+    };
+
+    it("decodes a matching function with named args", () => {
+      const decoded = decodeFlatCall(base, IFACE);
+      expect(decoded?.functionName).toBe("transfer");
+      expect(decoded?.args.to.toLowerCase()).toBe(RECIPIENT);
+      expect(decoded?.args.amount).toBe("1000");
+    });
+
+    it("returns null for non-decodable call types", () => {
+      expect(decodeFlatCall({ ...base, type: "CREATE" }, IFACE)).toBeNull();
+    });
+
+    it("returns null for empty/short calldata", () => {
+      expect(decodeFlatCall({ ...base, input: "0x" }, IFACE)).toBeNull();
+    });
+
+    it("returns null when calldata matches no ABI function", () => {
+      expect(
+        decodeFlatCall({ ...base, input: "0x12345678" }, IFACE)
+      ).toBeNull();
+    });
+  });
+
+  describe("findDecodedCalls", () => {
+    it("finds the internal call to the target", () => {
+      const matches = findDecodedCalls(sponsoredTree(), {
+        target: TARGET,
+        iface: IFACE,
+        functionName: "transfer",
+      });
+      expect(matches).toHaveLength(1);
+      expect(matches[0].functionName).toBe("transfer");
+    });
+
+    it("respects positional arg filter with wildcards", () => {
+      const wrong = findDecodedCalls(sponsoredTree(), {
+        target: TARGET,
+        iface: IFACE,
+        functionName: "transfer",
+        filterArgs: ["0x00000000000000000000000000000000000000ff", ""],
+      });
+      expect(wrong).toHaveLength(0);
+
+      const right = findDecodedCalls(sponsoredTree(), {
+        target: TARGET,
+        iface: IFACE,
+        functionName: "transfer",
+        filterArgs: [RECIPIENT, ""],
+      });
+      expect(right).toHaveLength(1);
+    });
+
+    it("excludes reverted frames unless requested", () => {
+      const tree: RawCallFrame = {
+        type: "CALL",
+        to: WRAPPER,
+        input: "0x00",
+        calls: [
+          { type: "CALL", to: TARGET, input: scheduleData, error: "reverted" },
+        ],
+      };
+      expect(
+        findDecodedCalls(tree, { target: TARGET, iface: IFACE })
+      ).toHaveLength(0);
+      expect(
+        findDecodedCalls(tree, {
+          target: TARGET,
+          iface: IFACE,
+          includeReverted: true,
+        })
+      ).toHaveLength(1);
+    });
+  });
+
+  describe("resolveExecutedCall", () => {
+    it("unwraps a sponsored tx and flags it sponsored", async () => {
+      const provider = {
+        send: vi.fn<SendFn>().mockResolvedValue(sponsoredTree()),
+      };
+      const result = await resolveExecutedCall(provider, "0xhash", {
+        target: TARGET,
+        iface: IFACE,
+        functionName: "transfer",
+      });
+      expect(provider.send).toHaveBeenCalledWith("debug_traceTransaction", [
+        "0xhash",
+        { tracer: "callTracer" },
+      ]);
+      expect(result).toMatchObject({
+        contractAddress: TARGET,
+        functionName: "transfer",
+        sponsored: true,
+        topLevelTo: WRAPPER,
+        reverted: false,
+      });
+    });
+
+    it("flags a direct (non-wrapped) tx as not sponsored", async () => {
+      const directTree: RawCallFrame = {
+        type: "CALL",
+        from: RELAYER,
+        to: TARGET,
+        input: scheduleData,
+      };
+      const provider = { send: vi.fn<SendFn>().mockResolvedValue(directTree) };
+      const result = await resolveExecutedCall(provider, "0xhash", {
+        target: TARGET,
+        iface: IFACE,
+        functionName: "schedule",
+      });
+      expect(result?.sponsored).toBe(false);
+      expect(result?.topLevelTo).toBe(TARGET);
+    });
+
+    it("returns null when tracing is unavailable", async () => {
+      const provider = {
+        send: vi.fn<SendFn>().mockRejectedValue(new Error("method not found")),
+      };
+      const result = await resolveExecutedCall(provider, "0xhash", {
+        target: TARGET,
+        iface: IFACE,
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("traceTransactionCallTree", () => {
+    let provider: { send: ReturnType<typeof vi.fn<SendFn>> };
+
+    beforeEach(() => {
+      provider = { send: vi.fn<SendFn>() };
+    });
+
+    it("returns the root frame on success", async () => {
+      provider.send.mockResolvedValue(sponsoredTree());
+      const root = await traceTransactionCallTree(provider, "0xhash");
+      expect(root?.to).toBe(WRAPPER);
+    });
+
+    it("returns null when the RPC rejects (unsupported method)", async () => {
+      provider.send.mockRejectedValue(new Error("does not exist"));
+      expect(await traceTransactionCallTree(provider, "0xhash")).toBeNull();
+    });
+
+    it("returns null on a non-object result", async () => {
+      provider.send.mockResolvedValue(null);
+      expect(await traceTransactionCallTree(provider, "0xhash")).toBeNull();
+    });
+  });
+});

--- a/tests/unit/transfer-token-core.test.ts
+++ b/tests/unit/transfer-token-core.test.ts
@@ -1,0 +1,278 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/workflow/executor/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: {
+    VALIDATION: "validation",
+    TRANSACTION: "transaction",
+  },
+  logUserError: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve([]),
+        }),
+      }),
+    }),
+    query: {
+      explorerConfigs: {
+        findFirst: () =>
+          Promise.resolve({ chainId: 1, baseUrl: "https://etherscan.io" }),
+      },
+    },
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: { id: "id", userId: "userId", workflowId: "workflowId" },
+  explorerConfigs: { id: "id", chainId: "chainId" },
+  supportedTokens: { id: "id", chainId: "chainId", tokenAddress: "tokenAddress" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: () => ({}),
+  and: () => ({}),
+  inArray: () => ({}),
+}));
+
+vi.mock("@/lib/utils", () => ({
+  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+}));
+
+vi.mock("@/lib/utils/id", () => ({
+  generateId: vi.fn().mockReturnValue("test-unique-id"),
+}));
+
+vi.mock("@/lib/rpc/network-utils", () => ({
+  getChainIdFromNetwork: vi.fn().mockReturnValue(1),
+}));
+
+const mockExecuteWithFailover = vi.fn();
+vi.mock("@/lib/rpc/provider-factory", () => ({
+  getRpcProvider: vi.fn().mockImplementation(() =>
+    Promise.resolve({
+      resolveActiveRpcUrl: vi.fn().mockResolvedValue("https://rpc.example.com"),
+      executeWithFailover: mockExecuteWithFailover,
+    })
+  ),
+}));
+
+vi.mock("@/lib/explorer", () => ({
+  getTransactionUrl: vi.fn().mockReturnValue("https://etherscan.io/tx/0xtxhash"),
+  getAddressUrl: vi.fn().mockReturnValue("https://etherscan.io/address/0xabc"),
+}));
+
+const mockExecuteContractCall = vi.fn();
+const mockGetTransactionUrl = vi.fn();
+vi.mock("@/lib/web3/chain-adapter", () => ({
+  getChainAdapter: () => ({
+    executeContractCall: (...args: unknown[]) => mockExecuteContractCall(...args),
+    getTransactionUrl: (...args: unknown[]) => mockGetTransactionUrl(...args),
+  }),
+}));
+
+vi.mock("@/lib/web3/resolve-org-context", () => ({
+  resolveOrganizationContext: vi.fn().mockResolvedValue({
+    success: true,
+    organizationId: "org-1",
+    userId: undefined,
+  }),
+}));
+
+vi.mock("@/lib/web3/wallet-helpers", () => ({
+  getOrganizationWalletAddress: vi.fn().mockResolvedValue("0xWalletAddress"),
+  initializeWalletSigner: vi.fn().mockResolvedValue({
+    getAddress: () => Promise.resolve("0xWalletAddress"),
+    provider: {},
+  }),
+}));
+
+vi.mock("@/lib/web3/gas-defaults", () => ({
+  resolveGasLimitOverrides: () => ({
+    multiplierOverride: undefined,
+    gasLimitOverride: undefined,
+  }),
+}));
+
+vi.mock("@/lib/web3/decode-revert-error", () => ({
+  classifyRevert: vi.fn().mockReturnValue({ kind: "unknown" }),
+  formatContractError: vi.fn().mockReturnValue("contract error"),
+}));
+
+vi.mock("@/lib/web3/turnkey-sponsorship-config", () => ({
+  isSponsorshipSupported: () => false,
+}));
+
+vi.mock("@/lib/web3/sponsorship-feature-flag", () => ({
+  isGasSponsorshipEnabled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("@/lib/web3/turnkey-revert", () => ({
+  isSponsoredTxRevertError: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@/lib/web3/sponsored-transaction-manager", () => ({
+  executeSponsoredContractTransaction: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/safe/signer-resolver", () => ({
+  SIGNER_MODE: { EOA: "eoa", SAFE: "safe", SAFE_ROLE: "safe-role" },
+  resolveSignerMode: vi.fn().mockResolvedValue({ kind: "eoa", ownerAddress: "0xWalletAddress" }),
+  resolveSignerForNode: vi.fn().mockResolvedValue({ kind: "eoa", ownerAddress: "0xWalletAddress" }),
+}));
+
+vi.mock("@/lib/safe/execute-as-safe", () => ({
+  executeContractCallAsSafe: vi.fn(),
+  executeNativeTransferAsSafe: vi.fn(),
+}));
+
+vi.mock("@/lib/web3/transaction-manager", () => ({
+  withNonceSession: (_ctx: unknown, _wallet: unknown, fn: (session: unknown) => unknown) =>
+    fn({ id: "mock-session" }),
+}));
+
+const mockTraceExecutedCall = vi.fn();
+vi.mock("@/lib/web3/trace-executed-call", () => ({
+  traceExecutedCallWithFailover: (...args: unknown[]) =>
+    mockTraceExecutedCall(...args),
+}));
+
+vi.mock("ethers", async () => {
+  const actual = await vi.importActual<typeof import("ethers")>("ethers");
+  return {
+    ...actual,
+    ethers: {
+      ...actual.ethers,
+      Contract: class MockContract {
+        decimals = vi.fn().mockResolvedValue(BigInt(18));
+        symbol = vi.fn().mockResolvedValue("USDC");
+        // 100 tokens with 18 decimals - enough to cover the test transfer of 10
+        balanceOf = vi.fn().mockResolvedValue(BigInt("100000000000000000000"));
+        interface = {};
+        transfer = Object.assign(vi.fn(), {
+          staticCall: vi.fn().mockResolvedValue(true),
+          estimateGas: vi.fn().mockResolvedValue(BigInt(46_000)),
+        });
+      },
+    },
+  };
+});
+
+vi.mock("@/lib/contracts/abis/erc20.json", () => ({
+  default: [
+    { name: "transfer", type: "function", inputs: [], outputs: [] },
+    { name: "decimals", type: "function", inputs: [], outputs: [] },
+    { name: "symbol", type: "function", inputs: [], outputs: [] },
+  ],
+}));
+
+import type { TransferTokenCoreInput } from "@/plugins/web3/steps/transfer-token-core";
+import { transferTokenCore } from "@/plugins/web3/steps/transfer-token-core";
+
+const VALID_TOKEN = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const VALID_RECIPIENT = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+
+const MOCK_EXECUTED_CALL = {
+  contractAddress: VALID_TOKEN.toLowerCase(),
+  functionName: "transfer",
+  functionSignature: "transfer(address,uint256)",
+  args: { to: VALID_RECIPIENT.toLowerCase(), amount: "10000000" },
+  sponsored: false,
+  topLevelTo: VALID_TOKEN.toLowerCase(),
+  reverted: false,
+};
+
+function makeInput(overrides: Partial<TransferTokenCoreInput> = {}): TransferTokenCoreInput {
+  return {
+    network: "ethereum",
+    tokenConfig: VALID_TOKEN,
+    recipientAddress: VALID_RECIPIENT,
+    amount: "10",
+    _context: { organizationId: "org-1" },
+    ...overrides,
+  };
+}
+
+function setupMocks(): void {
+  mockExecuteContractCall.mockResolvedValue({
+    hash: "0xtxhash",
+    gasUsed: BigInt(45_000),
+    effectiveGasPrice: BigInt(25_000_000_000),
+  });
+  mockGetTransactionUrl.mockResolvedValue("https://etherscan.io/tx/0xtxhash");
+  mockTraceExecutedCall.mockResolvedValue(undefined);
+  // executeWithFailover must invoke the callback so the balanceOf/decimals/symbol
+  // calls inside transfer-token-core actually run (returning from the MockContract).
+  mockExecuteWithFailover.mockImplementation(
+    (fn: (provider: unknown) => unknown) => fn({})
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setupMocks();
+});
+
+describe("transfer-token-core - executedCall on direct send", () => {
+  it("attaches executedCall when trace succeeds", async () => {
+    mockTraceExecutedCall.mockResolvedValue(MOCK_EXECUTED_CALL);
+
+    const result = await transferTokenCore(makeInput());
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.executedCall).toEqual(MOCK_EXECUTED_CALL);
+    }
+  });
+
+  it("omits executedCall when trace returns undefined (graceful degradation)", async () => {
+    mockTraceExecutedCall.mockResolvedValue(undefined);
+
+    const result = await transferTokenCore(makeInput());
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.executedCall).toBeUndefined();
+    }
+  });
+
+  it("calls traceExecutedCallWithFailover with correct target and functionName", async () => {
+    await transferTokenCore(makeInput());
+
+    expect(mockTraceExecutedCall).toHaveBeenCalledWith(
+      expect.objectContaining({ executeWithFailover: expect.any(Function) }),
+      "0xtxhash",
+      expect.objectContaining({
+        target: VALID_TOKEN,
+        functionName: "transfer",
+      })
+    );
+  });
+
+});
+
+describe("transfer-token-core - validation", () => {
+  it("fails when token address is invalid", async () => {
+    const result = await transferTokenCore(makeInput({ tokenConfig: "not-an-address" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("fails when recipient address is invalid", async () => {
+    const result = await transferTokenCore(makeInput({ recipientAddress: "invalid" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("fails when amount is empty", async () => {
+    const result = await transferTokenCore(makeInput({ amount: "" }));
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/unit/write-contract-core.test.ts
+++ b/tests/unit/write-contract-core.test.ts
@@ -152,6 +152,12 @@ vi.mock("@/lib/safe/execute-as-safe", () => ({
   executeNativeTransferAsSafe: vi.fn(),
 }));
 
+const mockTraceExecutedCall = vi.fn();
+vi.mock("@/lib/web3/trace-executed-call", () => ({
+  traceExecutedCallWithFailover: (...args: unknown[]) =>
+    mockTraceExecutedCall(...args),
+}));
+
 // Capture txContext passed to withNonceSession
 let capturedTxContext: Record<string, unknown> | null = null;
 vi.mock("@/lib/web3/transaction-manager", () => ({
@@ -193,6 +199,58 @@ const VALID_ABI = JSON.stringify([
     outputs: [{ name: "", type: "bool" }],
   },
 ]);
+
+const MOCK_EXECUTED_CALL = {
+  contractAddress: "0x1234567890123456789012345678901234567890",
+  functionName: "transfer",
+  functionSignature: "transfer(address,uint256)",
+  args: { to: "0xrecipient", amount: "1000" },
+  sponsored: false,
+  topLevelTo: "0x1234567890123456789012345678901234567890",
+  reverted: false,
+};
+
+describe("writeContractCore executedCall on direct send", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedTxContext = null;
+    mockTraceExecutedCall.mockResolvedValue(undefined);
+  });
+
+  it("attaches executedCall when trace succeeds", async () => {
+    mockTraceExecutedCall.mockResolvedValue(MOCK_EXECUTED_CALL);
+
+    const result = await writeContractCore({
+      contractAddress: "0x1234567890123456789012345678901234567890",
+      network: "ethereum",
+      abi: VALID_ABI,
+      abiFunction: "transfer",
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.executedCall).toEqual(MOCK_EXECUTED_CALL);
+    }
+  });
+
+  it("omits executedCall when trace returns undefined (graceful degradation)", async () => {
+    mockTraceExecutedCall.mockResolvedValue(undefined);
+
+    const result = await writeContractCore({
+      contractAddress: "0x1234567890123456789012345678901234567890",
+      network: "ethereum",
+      abi: VALID_ABI,
+      abiFunction: "transfer",
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.executedCall).toBeUndefined();
+    }
+  });
+});
 
 describe("writeContractCore unique execution ID", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Gas-sponsored sends (Turnkey Gas Station, ERC-4337/EIP-7702 smart accounts, relayers) route through a wrapper contract, so the on-chain transaction's top-level `to`/calldata no longer describe the action that ran. Decoding only the top-level calldata returns different results for sponsored vs direct sends of the same action, which breaks workflow logic that consumes the result.

This adds a shared trace-decode capability: it walks the transaction's internal call tree (`debug_traceTransaction` with the `callTracer`) and decodes the real call against the target contract ABI. Write actions then report a consistent "what executed" view regardless of how the transaction was routed.

## What's included

- `lib/web3/trace-decode.ts` (new): `traceTransactionCallTree`, `flattenCallTree`, `decodeFlatCall`, `findDecodedCalls`, and `resolveExecutedCall`. Pure and unit tested.
- `lib/web3/trace-executed-call.ts` (new): the single shared helper (`traceExecutedCallWithFailover`) every action calls, with RPC failover.
- `write-contract`, `approve-token`, `transfer-token`: attach a normalized `executedCall` on the sponsored success path, with `executedCall.*` output fields declared for template references.
- Best-effort and graceful: resolves to `undefined` when the RPC cannot trace, so actions never fail because of tracing.

`executedCall` shape: `{ contractAddress, functionName, functionSignature, args, sponsored, topLevelTo, reverted }`.

## Scope and exclusions

- `transfer-funds` is a native value transfer with no function selector, so there is nothing to decode; its result already fully describes the transfer.
- History-based `query-transactions` discovery of sponsored calls is intentionally not addressed here: explorers index internal calls by value transfer only, so a zero-value sponsored call is not discoverable from transaction history. State-based on-chain reads remain the correct pattern for that case.

## Verification

- `pnpm type-check`: clean
- 16 unit tests for the shared lib (synthetic traces), plus existing write-action suites pass with no regression