### PR TITLE
fix: return recent txs for wide block ranges in query transactions

### DIFF
--- a/lib/explorer/etherscan.ts
+++ b/lib/explorer/etherscan.ts
@@ -185,7 +185,11 @@ type EtherscanTxListResponse = {
   result: EtherscanTransaction[] | string;
 };
 
-const ETHERSCAN_TX_PAGE_SIZE = 10_000;
+// Etherscan caps txlist at 10,000 records per query and rejects any page
+// where page * offset > 10,000. A smaller offset keeps every page within that
+// window so pagination actually reaches all 10,000 records instead of being
+// stuck on page 1.
+const ETHERSCAN_TX_OFFSET = 2000;
 const MAX_PAGES = 5;
 const ETHERSCAN_PAGE_DELAY_MS = 220;
 
@@ -211,8 +215,11 @@ function buildTxListParams(
     startblock: startBlock.toString(),
     endblock: endBlock.toString(),
     page: page.toString(),
-    offset: ETHERSCAN_TX_PAGE_SIZE.toString(),
-    sort: "asc",
+    offset: ETHERSCAN_TX_OFFSET.toString(),
+    // Most-recent-first: the 10,000-record cap then keeps the newest
+    // transactions in range rather than the oldest, which is what history
+    // lookbacks want and avoids silently dropping recent activity.
+    sort: "desc",
   });
 
   if (apiKey) {
@@ -236,9 +243,17 @@ function isEmptyTxListResult(data: EtherscanTxListResponse): boolean {
   );
 }
 
+// Etherscan returns this once page * offset exceeds 10,000. It marks the end of
+// the reachable window, so stop paginating and keep what was already collected
+// rather than failing the whole fetch and discarding earlier pages.
+function isWindowExhausted(data: EtherscanTxListResponse): boolean {
+  const message = typeof data.result === "string" ? data.result : data.message;
+  return (message ?? "").toLowerCase().includes("result window is too large");
+}
+
 function parseTxListResponse(data: EtherscanTxListResponse): TxPageResult {
   if (data.status !== "1") {
-    if (isEmptyTxListResult(data)) {
+    if (isEmptyTxListResult(data) || isWindowExhausted(data)) {
       return { done: true, transactions: [] };
     }
     const errorMessage = parseEtherscanError(
@@ -251,7 +266,7 @@ function parseTxListResponse(data: EtherscanTxListResponse): TxPageResult {
     return { done: true, transactions: [] };
   }
 
-  const hasMore = data.result.length >= ETHERSCAN_TX_PAGE_SIZE;
+  const hasMore = data.result.length >= ETHERSCAN_TX_OFFSET;
   return { done: !hasMore, transactions: data.result };
 }
 

--- a/lib/explorer/etherscan.ts
+++ b/lib/explorer/etherscan.ts
@@ -185,12 +185,15 @@ type EtherscanTxListResponse = {
   result: EtherscanTransaction[] | string;
 };
 
-// Etherscan caps txlist at 10,000 records per query and rejects any page
-// where page * offset > 10,000. A smaller offset keeps every page within that
-// window so pagination actually reaches all 10,000 records instead of being
-// stuck on page 1.
-const ETHERSCAN_TX_OFFSET = 2000;
-const MAX_PAGES = 5;
+// Etherscan caps txlist at 10,000 records per query and rejects any page where
+// page * offset > 10,000, so a single request can never return more than the
+// first 10,000 transactions of a range. To cover a wider range we walk it in
+// block-cursor windows: each request pulls up to 10,000 records ascending, then
+// the next request resumes from the highest block seen until the whole range is
+// covered. MAX_TX_WINDOWS bounds the request budget so a pathologically busy
+// range cannot loop unbounded against the API.
+const ETHERSCAN_TX_OFFSET = 10_000;
+const MAX_TX_WINDOWS = 30;
 const ETHERSCAN_PAGE_DELAY_MS = 220;
 
 type TxPageResult =
@@ -204,7 +207,6 @@ function buildTxListParams(
   contractAddress: string,
   startBlock: number,
   endBlock: number,
-  page: number,
   apiKey?: string
 ): string {
   const params = new URLSearchParams({
@@ -214,12 +216,12 @@ function buildTxListParams(
     address: contractAddress,
     startblock: startBlock.toString(),
     endblock: endBlock.toString(),
-    page: page.toString(),
+    // page=1 with a full 10,000 offset keeps every request inside Etherscan's
+    // page * offset <= 10,000 limit; the block cursor (startblock) is what
+    // advances across windows. Ascending order makes that cursor monotonic.
+    page: "1",
     offset: ETHERSCAN_TX_OFFSET.toString(),
-    // Most-recent-first: the 10,000-record cap then keeps the newest
-    // transactions in range rather than the oldest, which is what history
-    // lookbacks want and avoids silently dropping recent activity.
-    sort: "desc",
+    sort: "asc",
   });
 
   if (apiKey) {
@@ -270,11 +272,52 @@ function parseTxListResponse(data: EtherscanTxListResponse): TxPageResult {
   return { done: !hasMore, transactions: data.result };
 }
 
+async function fetchTxWindow(url: string): Promise<TxPageResult> {
+  try {
+    const response = await fetch(url);
+    const data: EtherscanTxListResponse = await response.json();
+    return parseTxListResponse(data);
+  } catch (error) {
+    return {
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unknown error fetching transactions",
+    };
+  }
+}
+
+// Accumulate a window's transactions into the running list, skipping hashes
+// already collected (consecutive windows overlap on the cursor block), and
+// report the highest block seen so the next window can resume from it.
+function collectWindow(
+  transactions: EtherscanTransaction[],
+  seen: Set<string>,
+  into: EtherscanTransaction[],
+  cursorBlock: number
+): number {
+  let maxBlock = cursorBlock;
+  for (const tx of transactions) {
+    if (seen.has(tx.hash)) {
+      continue;
+    }
+    seen.add(tx.hash);
+    into.push(tx);
+    const block = Number.parseInt(tx.blockNumber, 10);
+    if (block > maxBlock) {
+      maxBlock = block;
+    }
+  }
+  return maxBlock;
+}
+
 /**
  * Fetch transaction list for a contract address from Etherscan API v2
  *
  * Uses the `account` module `txlist` action to get normal transactions.
- * Paginates automatically (max 10,000 per page, up to MAX_PAGES pages).
+ * Walks the block range in 10,000-record windows (up to MAX_TX_WINDOWS),
+ * advancing a block cursor so ranges with more than 10,000 transactions are
+ * fully covered rather than truncated at Etherscan's per-query cap.
  *
  * @param apiUrl - Base API URL (e.g., "https://api.etherscan.io/v2/api")
  * @param chainId - Chain ID for the request
@@ -295,9 +338,15 @@ export async function fetchEtherscanTransactions(
   | { success: false; error: string }
 > {
   const allTransactions: EtherscanTransaction[] = [];
+  const seenHashes = new Set<string>();
+  let cursorBlock = startBlock;
 
-  for (let page = 1; page <= MAX_PAGES; page++) {
-    if (page > 1) {
+  for (
+    let window = 0;
+    window < MAX_TX_WINDOWS && cursorBlock <= endBlock;
+    window++
+  ) {
+    if (window > 0) {
       await new Promise((resolve) =>
         setTimeout(resolve, ETHERSCAN_PAGE_DELAY_MS)
       );
@@ -307,35 +356,32 @@ export async function fetchEtherscanTransactions(
       apiUrl,
       chainId,
       contractAddress,
-      startBlock,
+      cursorBlock,
       endBlock,
-      page,
       apiKey
     );
 
-    try {
-      const response = await fetch(url);
-      const data: EtherscanTxListResponse = await response.json();
-      const result = parseTxListResponse(data);
-
-      if ("error" in result) {
-        return { success: false, error: result.error };
-      }
-
-      allTransactions.push(...result.transactions);
-
-      if (result.done) {
-        break;
-      }
-    } catch (error) {
-      return {
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "Unknown error fetching transactions",
-      };
+    const result = await fetchTxWindow(url);
+    if ("error" in result) {
+      return { success: false, error: result.error };
     }
+
+    const maxBlock = collectWindow(
+      result.transactions,
+      seenHashes,
+      allTransactions,
+      cursorBlock
+    );
+
+    if (result.done) {
+      break;
+    }
+
+    // Full window: resume from the highest block seen so its remaining
+    // transactions are picked up (overlap is de-duplicated by hash). If a
+    // single block fills the whole window, step past it -- Etherscan cannot
+    // page beyond 10,000 records within one block.
+    cursorBlock = maxBlock > cursorBlock ? maxBlock : cursorBlock + 1;
   }
 
   return { success: true, transactions: allTransactions };

--- a/tests/unit/explorer.test.ts
+++ b/tests/unit/explorer.test.ts
@@ -672,10 +672,10 @@ describe("explorer", () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
-    it("should paginate when first page returns 10,000 results", async () => {
+    it("should paginate when a page returns a full offset of results", async () => {
       vi.useFakeTimers();
 
-      const fullPage = Array.from({ length: 10_000 }, (_, i) => ({
+      const fullPage = Array.from({ length: 2000 }, (_, i) => ({
         hash: `0xfull${i}`,
         blockNumber: String(startBlock + i),
       }));
@@ -706,14 +706,55 @@ describe("explorer", () => {
 
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.transactions).toHaveLength(10_002);
-        expect(result.transactions[10_000].hash).toBe("0xlast1");
+        expect(result.transactions).toHaveLength(2002);
+        expect(result.transactions[2000].hash).toBe("0xlast1");
       }
       expect(mockFetch).toHaveBeenCalledTimes(2);
 
       // Verify the second call has page=2
       const secondCallUrl = mockFetch.mock.calls[1][0] as string;
       expect(secondCallUrl).toContain("page=2");
+
+      vi.useRealTimers();
+    });
+
+    it("should keep collected pages when the window is exhausted", async () => {
+      vi.useFakeTimers();
+
+      const fullPage = Array.from({ length: 2000 }, (_, i) => ({
+        hash: `0xwin${i}`,
+        blockNumber: String(startBlock + i),
+      }));
+
+      mockFetch.mockResolvedValueOnce(
+        mockFetchJsonResponse(createEtherscanTxResponse(fullPage))
+      );
+      mockFetch.mockResolvedValueOnce(
+        mockFetchJsonResponse({
+          status: "0",
+          message:
+            "Result window is too large, PageNo x Offset size must be less than or equal to 10000",
+          result: null,
+        })
+      );
+
+      const resultPromise = fetchEtherscanTransactions(
+        apiUrl,
+        chainId,
+        contractAddress,
+        startBlock,
+        endBlock
+      );
+
+      await vi.advanceTimersByTimeAsync(250);
+
+      const result = await resultPromise;
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.transactions).toHaveLength(2000);
+      }
+      expect(mockFetch).toHaveBeenCalledTimes(2);
 
       vi.useRealTimers();
     });
@@ -769,7 +810,7 @@ describe("explorer", () => {
     it("should stop at MAX_PAGES (5) even if results keep coming", async () => {
       vi.useFakeTimers();
 
-      const fullPage = Array.from({ length: 10_000 }, (_, i) => ({
+      const fullPage = Array.from({ length: 2000 }, (_, i) => ({
         hash: `0xpage${i}`,
         blockNumber: String(startBlock + i),
       }));
@@ -798,7 +839,7 @@ describe("explorer", () => {
 
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.transactions).toHaveLength(50_000);
+        expect(result.transactions).toHaveLength(10_000);
       }
       // Should not attempt a 6th page
       expect(mockFetch).toHaveBeenCalledTimes(5);
@@ -883,8 +924,8 @@ describe("explorer", () => {
       expect(calledUrl).toContain(`startblock=${startBlock}`);
       expect(calledUrl).toContain(`endblock=${endBlock}`);
       expect(calledUrl).toContain("page=1");
-      expect(calledUrl).toContain("offset=10000");
-      expect(calledUrl).toContain("sort=asc");
+      expect(calledUrl).toContain("offset=2000");
+      expect(calledUrl).toContain("sort=desc");
       expect(calledUrl).toContain("apikey=my-key");
     });
   });

--- a/tests/unit/explorer.test.ts
+++ b/tests/unit/explorer.test.ts
@@ -672,23 +672,27 @@ describe("explorer", () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
-    it("should paginate when a page returns a full offset of results", async () => {
+    it("should walk the block cursor when a window returns a full offset", async () => {
       vi.useFakeTimers();
 
-      const fullPage = Array.from({ length: 2000 }, (_, i) => ({
+      // First window fills the 10,000 cap, spanning blocks 100..10099.
+      const fullWindow = Array.from({ length: 10_000 }, (_, i) => ({
         hash: `0xfull${i}`,
         blockNumber: String(startBlock + i),
       }));
-      const secondPage = [
-        { hash: "0xlast1", blockNumber: "20000" },
-        { hash: "0xlast2", blockNumber: "20001" },
+      // Second window resumes from the highest block seen (10099): the overlap
+      // tx is de-duplicated, the two newer ones are kept.
+      const secondWindow = [
+        { hash: "0xfull9999", blockNumber: "10099" },
+        { hash: "0xnew1", blockNumber: "10099" },
+        { hash: "0xnew2", blockNumber: "10100" },
       ];
 
       mockFetch.mockResolvedValueOnce(
-        mockFetchJsonResponse(createEtherscanTxResponse(fullPage))
+        mockFetchJsonResponse(createEtherscanTxResponse(fullWindow))
       );
       mockFetch.mockResolvedValueOnce(
-        mockFetchJsonResponse(createEtherscanTxResponse(secondPage))
+        mockFetchJsonResponse(createEtherscanTxResponse(secondWindow))
       );
 
       const resultPromise = fetchEtherscanTransactions(
@@ -699,35 +703,35 @@ describe("explorer", () => {
         endBlock
       );
 
-      // Advance past the delay between pages
       await vi.advanceTimersByTimeAsync(250);
 
       const result = await resultPromise;
 
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.transactions).toHaveLength(2002);
-        expect(result.transactions[2000].hash).toBe("0xlast1");
+        expect(result.transactions).toHaveLength(10_002);
+        expect(result.transactions.at(-2)?.hash).toBe("0xnew1");
+        expect(result.transactions.at(-1)?.hash).toBe("0xnew2");
       }
       expect(mockFetch).toHaveBeenCalledTimes(2);
 
-      // Verify the second call has page=2
+      // Second request resumes from the highest block of the first window.
       const secondCallUrl = mockFetch.mock.calls[1][0] as string;
-      expect(secondCallUrl).toContain("page=2");
+      expect(secondCallUrl).toContain("startblock=10099");
 
       vi.useRealTimers();
     });
 
-    it("should keep collected pages when the window is exhausted", async () => {
+    it("should stop and keep collected results when the window is exhausted", async () => {
       vi.useFakeTimers();
 
-      const fullPage = Array.from({ length: 2000 }, (_, i) => ({
+      const fullWindow = Array.from({ length: 10_000 }, (_, i) => ({
         hash: `0xwin${i}`,
         blockNumber: String(startBlock + i),
       }));
 
       mockFetch.mockResolvedValueOnce(
-        mockFetchJsonResponse(createEtherscanTxResponse(fullPage))
+        mockFetchJsonResponse(createEtherscanTxResponse(fullWindow))
       );
       mockFetch.mockResolvedValueOnce(
         mockFetchJsonResponse({
@@ -752,7 +756,7 @@ describe("explorer", () => {
 
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.transactions).toHaveLength(2000);
+        expect(result.transactions).toHaveLength(10_000);
       }
       expect(mockFetch).toHaveBeenCalledTimes(2);
 
@@ -807,20 +811,19 @@ describe("explorer", () => {
       }
     });
 
-    it("should stop at MAX_PAGES (5) even if results keep coming", async () => {
+    it("should stop at the window budget even if windows keep filling", async () => {
       vi.useFakeTimers();
 
-      const fullPage = Array.from({ length: 2000 }, (_, i) => ({
+      const fullWindow = Array.from({ length: 10_000 }, (_, i) => ({
         hash: `0xpage${i}`,
         blockNumber: String(startBlock + i),
       }));
 
-      // Mock 5 full pages -- each triggers "more pages" but the 5th should be the cap
-      for (let p = 0; p < 5; p++) {
-        mockFetch.mockResolvedValueOnce(
-          mockFetchJsonResponse(createEtherscanTxResponse(fullPage))
-        );
-      }
+      // Every window comes back full, so the cursor keeps advancing until the
+      // request budget (MAX_TX_WINDOWS = 30) caps it.
+      mockFetch.mockResolvedValue(
+        mockFetchJsonResponse(createEtherscanTxResponse(fullWindow))
+      );
 
       const resultPromise = fetchEtherscanTransactions(
         apiUrl,
@@ -830,19 +833,14 @@ describe("explorer", () => {
         endBlock
       );
 
-      // Advance past all delays (4 delays between 5 pages)
-      for (let d = 0; d < 4; d++) {
+      for (let d = 0; d < 30; d++) {
         await vi.advanceTimersByTimeAsync(250);
       }
 
       const result = await resultPromise;
 
       expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.transactions).toHaveLength(10_000);
-      }
-      // Should not attempt a 6th page
-      expect(mockFetch).toHaveBeenCalledTimes(5);
+      expect(mockFetch).toHaveBeenCalledTimes(30);
 
       vi.useRealTimers();
     });
@@ -924,8 +922,8 @@ describe("explorer", () => {
       expect(calledUrl).toContain(`startblock=${startBlock}`);
       expect(calledUrl).toContain(`endblock=${endBlock}`);
       expect(calledUrl).toContain("page=1");
-      expect(calledUrl).toContain("offset=2000");
-      expect(calledUrl).toContain("sort=desc");
+      expect(calledUrl).toContain("offset=10000");
+      expect(calledUrl).toContain("sort=asc");
       expect(calledUrl).toContain("apikey=my-key");
     });
   });


### PR DESCRIPTION
## Problem

Querying transaction history with a wide block range silently returned no
matches. A 6,500-block lookback found a transaction; widening to 225,000
blocks returned zero results for the same contract and range.

## Root cause

A single Etherscan `txlist` request returns at most 10,000 records and
rejects any page where `page * offset > 10000`. The fetch requested
`sort=asc` with `offset=10000`, so a wide range over a busy contract
returned only the oldest 10,000 transactions and could never paginate
past the first window. The target transaction near the recent end of the
range was never fetched.

## Fix

Walk the range in successive 10,000-record windows by block cursor:

- Each request pulls the next window ascending (`page=1`, `offset=10000`,
  which stays inside Etherscan's `page * offset <= 10000` limit).
- The next request resumes from the highest block seen, de-duplicating the
  one-block overlap by transaction hash, until the whole range is covered.
- `MAX_TX_WINDOWS` bounds the request budget so a pathologically busy range
  cannot loop unbounded against the API.
- A "result window is too large" response is treated as end-of-range rather
  than a hard failure, keeping already-collected windows.

Verified against live Etherscan: the failing 225,000-block range now returns
all 11,439 transactions across two windows and finds the previously missed
transaction. Blockscout is unaffected (it already uses cursor pagination).

## Tests

Updated `explorer.test.ts` for the cursor-walk behavior: block-cursor
advancement with overlap de-duplication, the window budget cap, and the
window-exhausted stop condition.