### PR TITLE
fix: highlight Activity nav item on /activity page

### DIFF
--- a/components/navigation-sidebar.tsx
+++ b/components/navigation-sidebar.tsx
@@ -672,6 +672,7 @@ export function NavigationSidebar(): React.ReactNode {
   const isHubPage = pathname === "/hub";
   const isAnalyticsPage = pathname === "/analytics";
   const isEarningsPage = pathname === "/earnings";
+  const isActivityPage = pathname === "/activity";
 
   const expanded = navState.state.sidebar;
   const setExpanded = navState.setSidebar;
@@ -796,6 +797,9 @@ export function NavigationSidebar(): React.ReactNode {
     }
     if (id === "earnings") {
       return isEarningsPage;
+    }
+    if (id === "activity") {
+      return isActivityPage;
     }
     return false;
   }


### PR DESCRIPTION
## Summary

The Activity sidebar menu item was never highlighted when viewing the `/activity` page. While the item defined `href: "/activity"`, the `isActive()` helper in `navigation-sidebar.tsx` had no case for the `"activity"` id, so it always returned `false` for that item.

## Fix

Added `/activity` pathname detection following the existing pattern used for hub, analytics, and earnings:
- `const isActivityPage = pathname === "/activity";`
- A matching branch in `isActive()` returning `isActivityPage` for the `"activity"` id

The Activity item now receives the active `bg-muted` styling when on its page.