### PR TITLE
fix(condition): preserve null vs undefined in resolved condition values

### DIFF
--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -159,6 +159,32 @@ export function recordCatchOutput(
 const ARRAY_ACCESS_PATTERN = /^([^[]+)\[(\d+)\]$/;
 
 /**
+ * Render a resolved condition value for the logged input/output panels while
+ * preserving the null/undefined distinction. `undefined` (e.g. a reference to a
+ * branch node that never executed) is shown as the string "undefined" so it is
+ * not mistaken for `null` -- `null` JSON-serializes fine and is left as-is, but
+ * `undefined` would otherwise be dropped/collapsed and read as `null`, making a
+ * strict `=== null` (isNull) check look like it should have matched. Recurses
+ * through plain objects and arrays. Display-only; never fed back into eval.
+ */
+function formatConditionValueForDisplay(value: unknown): unknown {
+  if (value === undefined) {
+    return "undefined";
+  }
+  if (Array.isArray(value)) {
+    return value.map(formatConditionValueForDisplay);
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value)) {
+      out[key] = formatConditionValueForDisplay(nested);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
  * Spurious-max-retries recovery poll window. When the framework re-fires a
  * step after a lost completion event and throws before the step's success row
  * is committed, the real success lands ~0.3-0.5s later. The catch handler
@@ -383,8 +409,12 @@ export function evaluateConditionExpression(
             nodeMap,
             executionResults
           );
-          // Store the resolved value with a readable key (the display text from the template)
-          resolvedValues[rest] = evalContext[varName];
+          // Store the resolved value with a readable key (the display text
+          // from the template), preserving the null/undefined distinction so a
+          // strict `isNull` (=== null) check is not mistaken for a match.
+          resolvedValues[rest] = formatConditionValueForDisplay(
+            evalContext[varName]
+          );
           return varName;
         }
       );

--- a/tests/unit/condition-executor.test.ts
+++ b/tests/unit/condition-executor.test.ts
@@ -954,6 +954,33 @@ describe("dead-branch grace: references to nodes that never executed", () => {
     expect(result.result).toBe(true);
   });
 
+  it("reports a non-executed reference as 'undefined' in resolvedValues, not null", () => {
+    // The logged values panel must preserve the null/undefined distinction so a
+    // strict isNull (=== null) check is not mistaken for a match: a non-executed
+    // branch node is undefined, not null.
+    const expression =
+      "{{@dead:Query Transaction History.matchCount}} === undefined";
+    const result = evaluateConditionExpression(expression, {}, deadNodeMap, {});
+    expect(result.result).toBe(true);
+    expect(result.resolvedValues["Query Transaction History.matchCount"]).toBe(
+      "undefined"
+    );
+  });
+
+  it("keeps a real null value as null in resolvedValues (not 'undefined')", () => {
+    // A node that executed and produced a genuine null must stay null, so null
+    // and undefined remain distinguishable in the display.
+    const expression = "{{@ran:Check if already scheduled?.matchCount}} === null";
+    const outputs = {
+      ran: { label: "Check if already scheduled?", data: { matchCount: null } },
+    };
+    const result = evaluateConditionExpression(expression, outputs);
+    expect(result.result).toBe(true);
+    expect(
+      result.resolvedValues["Check if already scheduled?.matchCount"]
+    ).toBeNull();
+  });
+
   it("evaluates a convergence condition when one referenced branch ran and the other did not", () => {
     const expression =
       "{{@ran:Check if already scheduled?.matchCount}} == 0 && ({{@dead:Query Transaction History.matchCount}} === null || {{@dead:Query Transaction History.matchCount}} === undefined)";


### PR DESCRIPTION
## Summary

A Condition that references a node on a branch that did not execute binds `undefined` for that reference. The logged run panel collapsed `undefined` to `null`, so a strict `is null` (`=== null`) check looked like it should have matched when it correctly did not. This made conditions appear to evaluate wrongly when they were actually right, and sent debugging in circles (the panel showed `"...matchCount": null` for a value that was really `undefined`).

This renders resolved condition values for display while preserving the distinction:
- `undefined` shows as the string `"undefined"` (e.g. a reference to a branch node that never ran)
- `null` stays `null`
- real values are untouched (recurses through objects and arrays)

The resolved-values map is display/logging only and is never fed back into evaluation, so routing behavior is unchanged.

## Why it matters

`is null` compiles to strict `=== null`, which does not match `undefined`. When the panel shows `null` for an actually-`undefined` value, an author cannot tell why `is null` failed. With the distinction preserved, `undefined` is visible and the correct operator (`does not exist`, i.e. `=== null || === undefined`) is obvious.

## Changes

- `lib/workflow/executor/executor.workflow.ts`: add `formatConditionValueForDisplay` and apply it when building the condition's resolved-values map.
- Tests: a non-executed reference reports `"undefined"`; a genuine `null` stays `null`.

## Notes

A Condition node's output is just `{ condition: <boolean> }`, so there are no resolved null/undefined values on the output side to mislabel. This change targets the input values panel where the issue occurs.

## Verification

- `pnpm type-check`: clean
- `tests/unit/condition-executor.test.ts`: 72 pass (incl. the two new cases); broader condition suites green