### PR TITLE
fix: scope step stats queries to last hour to reduce RDS memory pressure (TECH-53)

### DIFF
--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -441,7 +441,12 @@ export async function getStepStatsFromDb(): Promise<StepStats> {
         count: count(),
       })
       .from(workflowExecutionLogs)
-      .where(sql`${workflowExecutionLogs.status} IN ('success', 'error')`)
+      .where(
+        and(
+          sql`${workflowExecutionLogs.status} IN ('success', 'error')`,
+          gte(workflowExecutionLogs.startedAt, sql`now() - interval '1 hour'`)
+        )
+      )
       .groupBy(workflowExecutionLogs.nodeType, workflowExecutionLogs.status);
 
     const stats: StepStats = {
@@ -480,7 +485,8 @@ export async function getStepStatsFromDb(): Promise<StepStats> {
       .where(
         and(
           sql`${workflowExecutionLogs.status} IN ('success', 'error')`,
-          sql`${workflowExecutionLogs.duration} IS NOT NULL`
+          sql`${workflowExecutionLogs.duration} IS NOT NULL`,
+          gte(workflowExecutionLogs.startedAt, sql`now() - interval '1 hour'`)
         )
       );
 


### PR DESCRIPTION
The `getStepStatsFromDb` queries previously scanned the entire `workflow_execution_logs` table. On large datasets this caused full-table reads that pushed RDS into swap. Both queries (step count by type/status and average duration) now include a `startedAt >= now() - interval '1 hour'` filter, limiting each scan to the last hour of execution logs.