### PR TITLE
fix: gate user-destination egress actions by capability

### DIFF
--- a/components/workflow/config/action-config.tsx
+++ b/components/workflow/config/action-config.tsx
@@ -45,7 +45,7 @@ import { resolveConditionExpression } from "@/lib/workflow/nodes/condition/resol
 import { validateConditionExpressionUI } from "@/lib/workflow/nodes/condition/validator";
 import { useFeatures } from "@/hooks/use-features";
 import type { FeatureDefinition } from "@/lib/features";
-import { getFeatureForActionType } from "@/lib/features";
+import { resolveActionFeature } from "@/lib/features";
 import {
   integrationsAtom,
   integrationsVersionAtom,
@@ -812,7 +812,7 @@ export function ActionConfig({
   );
 
   const isActionLocked = (actionId: string): FeatureDefinition | null => {
-    const feature = getFeatureForActionType(actionId);
+    const feature = resolveActionFeature(actionId);
     if (!feature) {
       return null;
     }

--- a/components/workflow/config/action-grid.tsx
+++ b/components/workflow/config/action-grid.tsx
@@ -33,7 +33,7 @@ import {
 import { useFeatures } from "@/hooks/use-features";
 import { useIsTouch } from "@/hooks/use-touch";
 import type { FeatureDefinition } from "@/lib/features";
-import { getFeatureForActionType } from "@/lib/features";
+import { resolveActionFeature } from "@/lib/features";
 import { cn } from "@/lib/utils";
 import { nodesAtom } from "@/lib/workflow/store";
 import { getAllActions } from "@/plugins/registry";
@@ -242,7 +242,7 @@ export function ActionGrid({
   const getGate = (
     actionId: string
   ): { feature: FeatureDefinition | undefined; enabled: boolean } => {
-    const feature = getFeatureForActionType(actionId);
+    const feature = resolveActionFeature(actionId);
     if (!feature) {
       return { feature: undefined, enabled: true };
     }

--- a/hooks/use-features.ts
+++ b/hooks/use-features.ts
@@ -7,7 +7,7 @@ import type {
   FeatureId,
   FeatureSnapshotForClient,
 } from "@/lib/features";
-import { getFeatureForActionType } from "@/lib/features";
+import { resolveActionFeature } from "@/lib/features";
 
 type SnapshotResponse = FeatureSnapshotForClient & { billingEnabled: boolean };
 
@@ -167,7 +167,7 @@ type UseActionFeatureResult = {
 
 export function useActionFeature(actionType: string): UseActionFeatureResult {
   const { snapshot, loading } = useFeatures();
-  const feature = getFeatureForActionType(actionType);
+  const feature = resolveActionFeature(actionType);
 
   if (!feature) {
     return { feature: undefined, enabled: true, loading };
@@ -202,7 +202,7 @@ export function useGatedWorkflowWarning(
     const gatedNames: string[] = [];
     const seenFeatureIds = new Set<string>();
     for (const actionType of actionTypes) {
-      const feature = getFeatureForActionType(actionType);
+      const feature = resolveActionFeature(actionType);
       if (!feature) {
         continue;
       }

--- a/lib/features/action-egress.ts
+++ b/lib/features/action-egress.ts
@@ -1,0 +1,66 @@
+// Resolves an action's network-egress classification and the plan-gate that
+// follows from it. Unlike ./registry (a pure, explicit lookup table), this
+// module reads the live plugin registry, so it is plugin-aware - import it only
+// where the plugin registry is already loaded (the workflow validator and the
+// workflow-builder UI), not in edge/middleware.
+//
+// Gating rule: an action whose egress is "user-destination" (the user controls
+// the destination host) is gated behind the catch-all "action.external-request"
+// feature, unless an explicit feature already covers it. Everything else keeps
+// its explicit gate (or none).
+
+import type { EgressTier } from "@/plugins/registry";
+import { findActionById, getIntegration } from "@/plugins/registry";
+import { FEATURES, getFeatureForActionType } from "./registry";
+import { getSystemActionEgress } from "./system-action-capabilities";
+import type { FeatureDefinition } from "./types";
+
+// "unknown" means the actionType resolves to neither a system action nor a
+// registered plugin action - i.e. nothing the executor can dispatch.
+export type ResolvedEgress = EgressTier | "unknown";
+
+/**
+ * Classify an action's network egress. Checks the system-action map first, then
+ * resolves the action via the plugin registry (which also follows legacy action
+ * aliases) and reads its per-action `egress` or the plugin-level default.
+ */
+export function getActionEgress(actionType: string): ResolvedEgress {
+  const systemEgress = getSystemActionEgress(actionType);
+  if (systemEgress) {
+    return systemEgress;
+  }
+
+  const action = findActionById(actionType);
+  if (!action) {
+    return "unknown";
+  }
+
+  if (action.egress) {
+    return action.egress;
+  }
+
+  const plugin = getIntegration(action.integration);
+  return plugin?.egress ?? "unknown";
+}
+
+/**
+ * The feature that gates an action, including the egress-derived gate. Returns
+ * an explicit feature when one is mapped; otherwise the catch-all
+ * "action.external-request" feature for user-destination actions; otherwise
+ * undefined (ungated). Drop-in superset of getFeatureForActionType for the
+ * gating-aware call sites (validator + workflow-builder UI).
+ */
+export function resolveActionFeature(
+  actionType: string
+): FeatureDefinition | undefined {
+  const explicit = getFeatureForActionType(actionType);
+  if (explicit) {
+    return explicit;
+  }
+
+  if (getActionEgress(actionType) === "user-destination") {
+    return FEATURES["action.external-request"];
+  }
+
+  return undefined;
+}

--- a/lib/features/index.ts
+++ b/lib/features/index.ts
@@ -1,4 +1,9 @@
 export {
+  getActionEgress,
+  type ResolvedEgress,
+  resolveActionFeature,
+} from "./action-egress";
+export {
   buildFeatureSnapshot,
   type FeatureSnapshotForClient,
   getEnabledFeatureIdsForPlan,

--- a/lib/features/registry.ts
+++ b/lib/features/registry.ts
@@ -45,6 +45,22 @@ export const FEATURES: Record<FeatureId, FeatureDefinition> = {
     requiredPlan: "pro",
     actionTypes: ["webhook/send-webhook"],
   },
+  // Catch-all gate for any action that lets the user choose the destination
+  // host (a custom URL or self-hosted endpoint). It carries no `actionTypes`:
+  // membership is derived at lookup time from the action's `egress`
+  // classification (see resolveActionFeature in ./action-egress), so a new
+  // user-destination action is gated automatically without editing this list.
+  "action.external-request": {
+    id: "action.external-request",
+    name: "Custom destination actions",
+    description:
+      "Actions that send requests to a destination you control, such as a custom or self-hosted URL.",
+    category: "workflow-action",
+    enabled: true,
+    requiredPlan: "pro",
+    upgradeCta:
+      "Upgrade to use actions that call a destination of your choosing.",
+  },
   "notifications.execution-digest": {
     id: "notifications.execution-digest",
     name: "Execution digest",

--- a/lib/features/system-action-capabilities.ts
+++ b/lib/features/system-action-capabilities.ts
@@ -1,0 +1,28 @@
+// Egress classification for built-in / system actions.
+//
+// System actions are not plugins, so they carry no `egress` field. This map is
+// their source of truth and MUST mirror the keys of SYSTEM_ACTIONS in
+// lib/workflow/executor/executor.workflow.ts (the executor's built-in dispatch
+// table). The features egress invariant test asserts the two stay in sync, so a
+// new system action cannot ship without a classification here.
+//
+// Pure data, no imports - safe for client, server, and the validator.
+
+import type { EgressTier } from "@/plugins/registry";
+
+export const SYSTEM_ACTION_EGRESS: Record<string, EgressTier> = {
+  // The user supplies the connection (host) the runner queries.
+  "Database Query": "user-destination",
+  // The user supplies the full request URL.
+  "HTTP Request": "user-destination",
+  // Control-flow actions: no outbound network request.
+  Condition: "none",
+  "For Each": "none",
+  Collect: "none",
+};
+
+export function getSystemActionEgress(
+  actionType: string
+): EgressTier | undefined {
+  return SYSTEM_ACTION_EGRESS[actionType];
+}

--- a/lib/features/system-action-capabilities.ts
+++ b/lib/features/system-action-capabilities.ts
@@ -1,16 +1,22 @@
 // Egress classification for built-in / system actions.
 //
 // System actions are not plugins, so they carry no `egress` field. This map is
-// their source of truth and MUST mirror the keys of SYSTEM_ACTIONS in
-// lib/workflow/executor/executor.workflow.ts (the executor's built-in dispatch
-// table). The features egress invariant test asserts the two stay in sync, so a
-// new system action cannot ship without a classification here.
+// their source of truth. It is typed `Record<SystemActionType, EgressTier>`,
+// and the executor's SYSTEM_ACTIONS dispatch table is `satisfies
+// Record<SystemActionType, StepImporter>` - both keyed off the shared
+// SYSTEM_ACTION_TYPES union - so a new system action is a compile error until it
+// is both dispatched and classified here.
 //
-// Pure data, no imports - safe for client, server, and the validator.
+// Light imports only (a type and a const) - safe for client, server, edge, and
+// the validator; does not pull in the executor.
 
+import {
+  SYSTEM_ACTION_TYPES,
+  type SystemActionType,
+} from "@/lib/workflow/executor/system-action-types";
 import type { EgressTier } from "@/plugins/registry";
 
-export const SYSTEM_ACTION_EGRESS: Record<string, EgressTier> = {
+export const SYSTEM_ACTION_EGRESS: Record<SystemActionType, EgressTier> = {
   // The user supplies the connection (host) the runner queries.
   "Database Query": "user-destination",
   // The user supplies the full request URL.
@@ -21,8 +27,15 @@ export const SYSTEM_ACTION_EGRESS: Record<string, EgressTier> = {
   Collect: "none",
 };
 
+const SYSTEM_ACTION_TYPE_SET: ReadonlySet<string> = new Set(
+  SYSTEM_ACTION_TYPES
+);
+
 export function getSystemActionEgress(
   actionType: string
 ): EgressTier | undefined {
-  return SYSTEM_ACTION_EGRESS[actionType];
+  if (!SYSTEM_ACTION_TYPE_SET.has(actionType)) {
+    return undefined;
+  }
+  return SYSTEM_ACTION_EGRESS[actionType as SystemActionType];
 }

--- a/lib/features/types.ts
+++ b/lib/features/types.ts
@@ -12,6 +12,7 @@ export type FeatureId =
   | "action.http-request"
   | "action.code"
   | "action.webhook"
+  | "action.external-request"
   | "notifications.execution-digest";
 
 // High-level grouping used for UI ("Workflow actions", "API access", etc.)

--- a/lib/features/workflow-validator.ts
+++ b/lib/features/workflow-validator.ts
@@ -3,9 +3,12 @@
 //
 // Gating resolves through resolveActionFeature (not the pure registry lookup)
 // so the egress-derived gate applies: any "user-destination" action is gated
-// even when it has no explicit feature entry. This is the default-deny half of
-// the fix - a new custom-destination action is blocked for free plans the
-// moment it is classified, without being added to a hand-maintained list.
+// even when it has no explicit feature entry - a new custom-destination action
+// is blocked for free plans the moment it is classified, without being added to
+// a hand-maintained list. Unknown/unclassified action types are not blocked
+// here (the executor rejects them at dispatch); the build-time invariant
+// (tests/unit/features-egress-invariant.test.ts) is what guarantees every
+// dispatchable egress action is classified and gated.
 
 import type { PlanName } from "@/lib/billing/plans";
 import { resolveActionFeature } from "./action-egress";

--- a/lib/features/workflow-validator.ts
+++ b/lib/features/workflow-validator.ts
@@ -1,9 +1,15 @@
 // Validates a workflow's nodes against the feature registry given a plan.
 // Used at save time (reject if violations) and at execute time (hard block).
+//
+// Gating resolves through resolveActionFeature (not the pure registry lookup)
+// so the egress-derived gate applies: any "user-destination" action is gated
+// even when it has no explicit feature entry. This is the default-deny half of
+// the fix - a new custom-destination action is blocked for free plans the
+// moment it is classified, without being added to a hand-maintained list.
 
 import type { PlanName } from "@/lib/billing/plans";
+import { resolveActionFeature } from "./action-egress";
 import { isFeatureEnabled } from "./check";
-import { getFeatureForActionType } from "./registry";
 import type {
   FeatureId,
   WorkflowFeatureViolation,
@@ -17,7 +23,7 @@ export function validateWorkflowFeatures(
   const violations = new Map<FeatureId, WorkflowFeatureViolation>();
 
   for (const node of nodes) {
-    const feature = getFeatureForActionType(node.actionType);
+    const feature = resolveActionFeature(node.actionType);
     if (!feature) {
       continue;
     }

--- a/lib/protocol-registry.ts
+++ b/lib/protocol-registry.ts
@@ -483,6 +483,9 @@ export function protocolToPlugin(def: ProtocolDefinition): IntegrationPlugin {
     icon: def.icon
       ? createProtocolIconComponent(def.icon, def.name)
       : ProtocolIcon,
+    // Protocol actions interact with chains via platform-resolved RPC and with
+    // fixed protocol service APIs - never a user-chosen host.
+    egress: "fixed-host",
     requiresCredentials: false,
     singleConnection: true,
     formFields: [],

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -85,11 +85,16 @@ import {
 } from "@/lib/workflow/nodes/condition/validator";
 import { ARRAY_SOURCE_RE } from "@/lib/workflow/nodes/for-each/utils";
 import { triggerStep } from "@/lib/workflow/nodes/trigger/step";
+import type { SystemActionType } from "@/lib/workflow/executor/system-action-types";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 import { LEGACY_ACTION_MAPPINGS } from "@/plugins/legacy-mappings";
 
-// System actions that don't have plugins - maps to module import functions
-const SYSTEM_ACTIONS: Record<string, StepImporter> = {
+// System actions that don't have plugins - maps to module import functions.
+// `satisfies Record<SystemActionType, ...>` makes the dispatch table and the
+// egress classification map (lib/features/system-action-capabilities.ts) a
+// compile-time mirror: a key here that is not in SystemActionType (or vice
+// versa) fails the build, so a new system action cannot ship unclassified.
+const SYSTEM_ACTIONS = {
   "Database Query": {
     // biome-ignore lint/suspicious/noExplicitAny: Dynamic module import
     importer: () =>
@@ -120,7 +125,7 @@ const SYSTEM_ACTIONS: Record<string, StepImporter> = {
       import("@/lib/workflow/nodes/collect/step") as Promise<any>,
     stepFunction: "collectStep",
   },
-};
+} satisfies Record<SystemActionType, StepImporter>;
 
 export {
   computeFinalSuccess,
@@ -551,7 +556,9 @@ async function executeActionStep(input: {
   }
 
   // Check system actions first (Database Query, HTTP Request)
-  const systemAction = SYSTEM_ACTIONS[actionType];
+  const systemAction = (SYSTEM_ACTIONS as Record<string, StepImporter>)[
+    actionType
+  ];
   if (systemAction) {
     const module = await systemAction.importer();
     const stepFunction = module[systemAction.stepFunction];

--- a/lib/workflow/executor/system-action-types.ts
+++ b/lib/workflow/executor/system-action-types.ts
@@ -1,0 +1,17 @@
+// Single source of truth for the built-in (non-plugin) action types the
+// executor dispatches. Both the executor's SYSTEM_ACTIONS dispatch table
+// (lib/workflow/executor/executor.workflow.ts) and the egress classification
+// map (lib/features/system-action-capabilities.ts) are keyed off this union via
+// `satisfies` / `Record<SystemActionType, ...>`, so adding a system action is a
+// compile error until it is BOTH dispatched and classified. No imports - safe to
+// load anywhere (client, server, edge, tests).
+
+export const SYSTEM_ACTION_TYPES = [
+  "Database Query",
+  "HTTP Request",
+  "Condition",
+  "For Each",
+  "Collect",
+] as const;
+
+export type SystemActionType = (typeof SYSTEM_ACTION_TYPES)[number];

--- a/plugins/ai-gateway/index.ts
+++ b/plugins/ai-gateway/index.ts
@@ -4,6 +4,7 @@ import AiGatewayIcon from "./icon";
 
 const aiGatewayPlugin: IntegrationPlugin = {
   type: "ai-gateway",
+  egress: "fixed-host",
   label: "AI Gateway",
   description: "Generate text and images using AI models",
 

--- a/plugins/blockscout/index.ts
+++ b/plugins/blockscout/index.ts
@@ -20,6 +20,7 @@ const NETWORK_FIELD: ActionConfigField = {
 
 const blockscoutPlugin: IntegrationPlugin = {
   type: "blockscout",
+  egress: "user-destination",
   label: "Blockscout",
   description: "Query the Blockscout block explorer REST API",
 

--- a/plugins/clerk/index.ts
+++ b/plugins/clerk/index.ts
@@ -4,6 +4,7 @@ import { ClerkIcon } from "./icon";
 
 const clerkPlugin: IntegrationPlugin = {
   type: "clerk",
+  egress: "fixed-host",
   label: "Clerk",
   description: "User authentication and management",
 

--- a/plugins/code/index.ts
+++ b/plugins/code/index.ts
@@ -4,6 +4,7 @@ import { CodeIcon } from "./icon";
 
 const codePlugin: IntegrationPlugin = {
   type: "code",
+  egress: "none",
   label: "Code",
   description:
     "Execute custom JavaScript code server-side in a sandboxed VM. Code can make outbound HTTP requests via fetch (subject to the configured timeout). Not a security boundary; intended for authenticated team members only.",

--- a/plugins/code/index.ts
+++ b/plugins/code/index.ts
@@ -4,7 +4,10 @@ import { CodeIcon } from "./icon";
 
 const codePlugin: IntegrationPlugin = {
   type: "code",
-  egress: "none",
+  // User code runs `fetch` against any host it chooses - a user-controlled
+  // destination. Already paid-gated via the explicit "action.code" feature;
+  // classified honestly so nothing downstream treats it as non-egressing.
+  egress: "user-destination",
   label: "Code",
   description:
     "Execute custom JavaScript code server-side in a sandboxed VM. Code can make outbound HTTP requests via fetch (subject to the configured timeout). Not a security boundary; intended for authenticated team members only.",

--- a/plugins/discord/index.ts
+++ b/plugins/discord/index.ts
@@ -4,6 +4,7 @@ import { DiscordIcon } from "./icon";
 
 const discordPlugin: IntegrationPlugin = {
   type: "discord",
+  egress: "fixed-host",
   label: "Discord",
   description: "Send messages to Discord channels via webhooks",
 

--- a/plugins/hyperliquid/index.ts
+++ b/plugins/hyperliquid/index.ts
@@ -4,6 +4,7 @@ import { HyperliquidIcon } from "./icon";
 
 const hyperliquidPlugin: IntegrationPlugin = {
   type: "hyperliquid",
+  egress: "fixed-host",
   label: "Hyperliquid",
   description:
     "Read-only wrappers over the Hyperliquid Info REST API for vault operator reporting, validator monitoring, and account state queries.",

--- a/plugins/math/index.ts
+++ b/plugins/math/index.ts
@@ -4,6 +4,7 @@ import { MathIcon } from "./icon";
 
 const mathPlugin: IntegrationPlugin = {
   type: "math",
+  egress: "none",
   label: "Math",
   description:
     "Aggregation and arithmetic operations across array data or multiple upstream node outputs.",

--- a/plugins/registry.ts
+++ b/plugins/registry.ts
@@ -196,6 +196,25 @@ export type OutputDisplayConfig = {
 };
 
 /**
+ * Network egress classification for plan gating and SSRF posture.
+ *
+ *   "user-destination" - user-supplied input (action config or a connection
+ *     `url` formField) can determine the host/origin the runner connects to.
+ *     This is the generic "make an arbitrary request" capability: it is plan
+ *     gated (paid) and its step must route through the SSRF guard.
+ *   "fixed-host" - egresses only to a constant origin (a branded third-party
+ *     API). User input may flow into the path/query/body but never the host.
+ *     Free; still routed through `safeFetch` per the plugin egress CI check.
+ *   "none" - performs no outbound network request.
+ *
+ * Gating keys solely on host control; a fixed-host action that incorporates
+ * user input stays free and relies on `safeFetch` for SSRF safety. A
+ * misclassification therefore fails safe: the worst case is under-gating
+ * (revenue), never an unguarded egress.
+ */
+export type EgressTier = "user-destination" | "fixed-host" | "none";
+
+/**
  * Action Definition
  * Describes a single action provided by a plugin
  */
@@ -203,6 +222,12 @@ export type PluginAction = {
   // Unique slug for this action (e.g., "send-email")
   // Full action ID will be computed as `{integration}/{slug}` (e.g., "resend/send-email")
   slug: string;
+
+  // Per-action override of the plugin-level `egress` classification. Set this
+  // only when an action's network reach differs from its plugin's default
+  // (e.g. a read-only action in an otherwise fixed-host plugin). When omitted,
+  // the action inherits the plugin's `egress`.
+  egress?: EgressTier;
 
   // Human-readable label (e.g., "Send Email")
   label: string;
@@ -259,6 +284,12 @@ export type IntegrationPlugin = {
   type: IntegrationType;
   label: string;
   description: string;
+
+  // Default network egress classification for this plugin's actions. Required
+  // so every plugin (and every future one) must declare whether it lets users
+  // reach a host of their choosing. Drives plan gating: "user-destination"
+  // plugins are paid-gated. Individual actions may override via `egress`.
+  egress: EgressTier;
 
   // Icon component (should be exported from plugins/[name]/icon.tsx)
   icon: React.ComponentType<{ className?: string }>;

--- a/plugins/resend/index.ts
+++ b/plugins/resend/index.ts
@@ -4,6 +4,7 @@ import { ResendIcon } from "./icon";
 
 const resendPlugin: IntegrationPlugin = {
   type: "resend",
+  egress: "fixed-host",
   label: "Resend",
   description: "Send transactional emails",
 

--- a/plugins/sendgrid/index.ts
+++ b/plugins/sendgrid/index.ts
@@ -4,6 +4,7 @@ import { SendGridIcon } from "./icon";
 
 const sendgridPlugin: IntegrationPlugin = {
   type: "sendgrid",
+  egress: "fixed-host",
   label: "Email",
   description: "Send transactional emails",
 

--- a/plugins/slack/index.ts
+++ b/plugins/slack/index.ts
@@ -4,6 +4,7 @@ import { SlackIcon } from "./icon";
 
 const slackPlugin: IntegrationPlugin = {
   type: "slack",
+  egress: "fixed-host",
   label: "Slack",
   description: "Send messages to Slack channels",
 

--- a/plugins/telegram/index.ts
+++ b/plugins/telegram/index.ts
@@ -4,6 +4,7 @@ import { TelegramIcon } from "./icon";
 
 const telegramPlugin: IntegrationPlugin = {
   type: "telegram",
+  egress: "fixed-host",
   label: "Telegram",
   description: "Send messages to Telegram chats via bot API",
 

--- a/plugins/v0/index.ts
+++ b/plugins/v0/index.ts
@@ -4,6 +4,7 @@ import { V0Icon } from "./icon";
 
 const v0Plugin: IntegrationPlugin = {
   type: "v0",
+  egress: "fixed-host",
   label: "v0",
   description: "Generate UI components with AI",
 

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -4,6 +4,7 @@ import { Web3Icon } from "./icon";
 
 const web3Plugin: IntegrationPlugin = {
   type: "web3",
+  egress: "fixed-host",
   label: "Web3",
   description: "Interact with blockchain networks using your KeeperHub wallet",
 

--- a/plugins/webflow/index.ts
+++ b/plugins/webflow/index.ts
@@ -4,6 +4,7 @@ import { WebflowIcon } from "./icon";
 
 const webflowPlugin: IntegrationPlugin = {
   type: "webflow",
+  egress: "fixed-host",
   label: "Webflow",
   description: "Publish and manage Webflow sites",
 

--- a/plugins/webhook/index.ts
+++ b/plugins/webhook/index.ts
@@ -4,6 +4,7 @@ import { WebhookIcon } from "./icon";
 
 const webhookPlugin: IntegrationPlugin = {
   type: "webhook",
+  egress: "user-destination",
   label: "Webhook",
   description: "Send HTTP requests to webhook endpoints",
 

--- a/tests/unit/executor-feature-guard.test.ts
+++ b/tests/unit/executor-feature-guard.test.ts
@@ -26,6 +26,12 @@ const conditionNodeJson = {
   data: { config: { actionType: "Condition" } },
 };
 
+// User-destination plugin action gated solely by its egress classification.
+const blockscoutNodeJson = {
+  id: "node-bs-1",
+  data: { config: { actionType: "blockscout/get-address-balance" } },
+};
+
 const ORIGINAL_BILLING_FLAG = process.env.NEXT_PUBLIC_BILLING_ENABLED;
 
 beforeEach(() => {
@@ -94,6 +100,22 @@ describe("checkWorkflowFeaturesForExecutor", () => {
     expect(result.violations).toHaveLength(1);
     expect(result.violations[0].featureId).toBe("action.database-query");
     expect(result.violations[0].nodeIds).toEqual(["node-db-1"]);
+  });
+
+  it("blocks a user-destination plugin action (blockscout) for a free org at execute time", async () => {
+    const db = makeDb([{ plan: "free" }]);
+
+    const result = await checkWorkflowFeaturesForExecutor(db, "org_1", [
+      blockscoutNodeJson,
+    ]);
+
+    expect(result.allowed).toBe(false);
+    if (result.allowed) {
+      return;
+    }
+    expect(result.reason).toBe("upgrade_required");
+    expect(result.violations[0].featureId).toBe("action.external-request");
+    expect(result.violations[0].nodeIds).toEqual(["node-bs-1"]);
   });
 
   it("default-denies when org context is missing and a node is gated", async () => {

--- a/tests/unit/features-egress-invariant.test.ts
+++ b/tests/unit/features-egress-invariant.test.ts
@@ -15,22 +15,13 @@ import { describe, expect, it } from "vitest";
 
 import {
   getActionEgress,
+  getFeatureForActionType,
   isFeatureEnabled,
   resolveActionFeature,
 } from "@/lib/features";
 import { SYSTEM_ACTION_EGRESS } from "@/lib/features/system-action-capabilities";
+import { SYSTEM_ACTION_TYPES } from "@/lib/workflow/executor/system-action-types";
 import { getAllActions, getAllIntegrations } from "@/plugins/registry";
-
-// Mirrors the keys of SYSTEM_ACTIONS in lib/workflow/executor/executor.workflow.ts.
-// If a built-in action is added there, it must be classified in
-// SYSTEM_ACTION_EGRESS too - this list is the drift guard.
-const EXPECTED_SYSTEM_ACTIONS = [
-  "Collect",
-  "Condition",
-  "Database Query",
-  "For Each",
-  "HTTP Request",
-];
 
 describe("egress classification completeness", () => {
   it("classifies every registered plugin action (no unknowns)", () => {
@@ -41,9 +32,13 @@ describe("egress classification completeness", () => {
     expect(unclassified).toEqual([]);
   });
 
-  it("keeps the system-action capability map in sync with the executor", () => {
+  // The executor's SYSTEM_ACTIONS and SYSTEM_ACTION_EGRESS are both keyed off
+  // SYSTEM_ACTION_TYPES via `satisfies` / `Record<SystemActionType, ...>`, so
+  // this is enforced at compile time too; the assertion documents it and
+  // catches any runtime divergence.
+  it("classifies exactly the executor's system actions", () => {
     expect(Object.keys(SYSTEM_ACTION_EGRESS).sort()).toEqual(
-      EXPECTED_SYSTEM_ACTIONS
+      [...SYSTEM_ACTION_TYPES].sort()
     );
   });
 });
@@ -73,6 +68,24 @@ describe("user-destination actions are plan gated", () => {
       }
       expect(isFeatureEnabled(feature.id, "free")).toBe(false);
     }
+  });
+});
+
+describe("fixed-host and none actions stay free", () => {
+  // The egress fallback must gate ONLY user-destination actions. A fixed-host
+  // or none action with no explicit feature must remain ungated, so branded
+  // integrations (Slack, Discord, web3, etc.) keep working on the free plan.
+  it("does not let the egress fallback gate non-user-destination actions", () => {
+    const wronglyGated = getAllActions()
+      .filter((action) => {
+        const tier = getActionEgress(action.id);
+        return tier === "fixed-host" || tier === "none";
+      })
+      .filter((action) => !getFeatureForActionType(action.id))
+      .filter((action) => resolveActionFeature(action.id) !== undefined)
+      .map((action) => action.id);
+
+    expect(wronglyGated).toEqual([]);
   });
 });
 

--- a/tests/unit/features-egress-invariant.test.ts
+++ b/tests/unit/features-egress-invariant.test.ts
@@ -1,0 +1,102 @@
+// Recurrence backstop for the egress-gating fix.
+//
+// These invariants make "a new network-egress action ships ungated" a build
+// failure rather than a production incident. They enumerate the real dispatch
+// universe (every registered plugin action plus the built-in system actions)
+// and assert that (a) every action is classified, (b) every action the user can
+// point at a destination of their choosing is plan-gated, and (c) any plugin
+// that exposes a user-supplied connection URL is classified accordingly.
+//
+// Requires the plugin registry to be loaded (and `pnpm discover-plugins` to
+// have generated the protocol barrel), so this is intentionally not a pure
+// unit test.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  getActionEgress,
+  isFeatureEnabled,
+  resolveActionFeature,
+} from "@/lib/features";
+import { SYSTEM_ACTION_EGRESS } from "@/lib/features/system-action-capabilities";
+import { getAllActions, getAllIntegrations } from "@/plugins/registry";
+
+// Mirrors the keys of SYSTEM_ACTIONS in lib/workflow/executor/executor.workflow.ts.
+// If a built-in action is added there, it must be classified in
+// SYSTEM_ACTION_EGRESS too - this list is the drift guard.
+const EXPECTED_SYSTEM_ACTIONS = [
+  "Collect",
+  "Condition",
+  "Database Query",
+  "For Each",
+  "HTTP Request",
+];
+
+describe("egress classification completeness", () => {
+  it("classifies every registered plugin action (no unknowns)", () => {
+    const unclassified = getAllActions()
+      .filter((action) => getActionEgress(action.id) === "unknown")
+      .map((action) => action.id);
+
+    expect(unclassified).toEqual([]);
+  });
+
+  it("keeps the system-action capability map in sync with the executor", () => {
+    expect(Object.keys(SYSTEM_ACTION_EGRESS).sort()).toEqual(
+      EXPECTED_SYSTEM_ACTIONS
+    );
+  });
+});
+
+describe("user-destination actions are plan gated", () => {
+  it("gates every user-destination plugin action for the free plan", () => {
+    const ungated = getAllActions()
+      .filter((action) => getActionEgress(action.id) === "user-destination")
+      .filter((action) => {
+        const feature = resolveActionFeature(action.id);
+        return !feature || isFeatureEnabled(feature.id, "free");
+      })
+      .map((action) => action.id);
+
+    expect(ungated).toEqual([]);
+  });
+
+  it("gates every user-destination system action for the free plan", () => {
+    for (const [actionType, tier] of Object.entries(SYSTEM_ACTION_EGRESS)) {
+      if (tier !== "user-destination") {
+        continue;
+      }
+      const feature = resolveActionFeature(actionType);
+      expect(feature).toBeDefined();
+      if (!feature) {
+        continue;
+      }
+      expect(isFeatureEnabled(feature.id, "free")).toBe(false);
+    }
+  });
+});
+
+describe("connection URL surfaces are classified", () => {
+  it("classifies every plugin that exposes a user-supplied connection URL as user-destination", () => {
+    const misclassified = getAllIntegrations()
+      .filter((plugin) =>
+        plugin.formFields.some((field) => field.type === "url")
+      )
+      .filter((plugin) => plugin.egress !== "user-destination")
+      .map((plugin) => plugin.type);
+
+    expect(misclassified).toEqual([]);
+  });
+});
+
+describe("known fixtures", () => {
+  it("classifies blockscout as user-destination and gates it for free", () => {
+    expect(getActionEgress("blockscout/get-address-balance")).toBe(
+      "user-destination"
+    );
+    const feature = resolveActionFeature("blockscout/get-address-balance");
+    expect(feature?.id).toBe("action.external-request");
+    expect(isFeatureEnabled("action.external-request", "free")).toBe(false);
+    expect(isFeatureEnabled("action.external-request", "pro")).toBe(true);
+  });
+});

--- a/tests/unit/features-registry.test.ts
+++ b/tests/unit/features-registry.test.ts
@@ -45,7 +45,7 @@ describe("feature registry", () => {
 
   it("filters by category", () => {
     const workflowActions = getFeaturesByCategory("workflow-action");
-    expect(workflowActions.length).toBe(4);
+    expect(workflowActions.length).toBe(5);
     for (const feature of workflowActions) {
       expect(feature.category).toBe("workflow-action");
     }
@@ -93,6 +93,7 @@ describe("getEnabledFeatureIdsForPlan", () => {
       "action.http-request",
       "action.code",
       "action.webhook",
+      "action.external-request",
       "notifications.execution-digest",
     ];
     for (const plan of ["pro", "business", "enterprise"] as const) {

--- a/tests/unit/features-route-guard.test.ts
+++ b/tests/unit/features-route-guard.test.ts
@@ -24,6 +24,14 @@ const conditionNode = {
   actionType: "Condition",
 };
 
+// A plugin action with no explicit feature entry, gated only by its
+// "user-destination" egress classification (the catch-all external-request
+// gate). Exercises the egress-derived path, not the static actionTypes map.
+const blockscoutNode = {
+  id: "node-bs-1",
+  actionType: "blockscout/get-address-balance",
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -75,6 +83,33 @@ describe("enforceWorkflowFeatures", () => {
     expect(body.violations[0].nodeIds).toEqual(["node-db-1"]);
   });
 
+  it("blocks a user-destination plugin action (blockscout) on the free plan via the egress gate", async () => {
+    vi.mocked(isBillingEnabled).mockReturnValue(true);
+    vi.mocked(getOrgPlan).mockResolvedValue("free");
+
+    const result = await enforceWorkflowFeatures([blockscoutNode], "org_1");
+
+    expect(result.blocked).toBe(true);
+    if (!result.blocked) {
+      return;
+    }
+    expect(result.response.status).toBe(402);
+    const body = await result.response.json();
+    expect(body.code).toBe("upgrade_required");
+    expect(body.violations[0].featureId).toBe("action.external-request");
+    expect(body.violations[0].requiredPlan).toBe("pro");
+    expect(body.violations[0].nodeIds).toEqual(["node-bs-1"]);
+  });
+
+  it("allows the user-destination action on a paid plan", async () => {
+    vi.mocked(isBillingEnabled).mockReturnValue(true);
+    vi.mocked(getOrgPlan).mockResolvedValue("pro");
+
+    const result = await enforceWorkflowFeatures([blockscoutNode], "org_1");
+
+    expect(result.blocked).toBe(false);
+  });
+
   it("default-denies when no org context is provided and a node is gated", async () => {
     vi.mocked(isBillingEnabled).mockReturnValue(true);
 
@@ -97,11 +132,9 @@ describe("enforceWorkflowFeatures", () => {
     vi.mocked(isBillingEnabled).mockReturnValue(true);
     vi.mocked(getOrgPlan).mockResolvedValue("free");
 
-    const result = await enforceWorkflowFeatures(
-      [databaseQueryNode],
-      "org_1",
-      { errorMessage: "Custom upgrade copy for this route" }
-    );
+    const result = await enforceWorkflowFeatures([databaseQueryNode], "org_1", {
+      errorMessage: "Custom upgrade copy for this route",
+    });
 
     expect(result.blocked).toBe(true);
     if (!result.blocked) {


### PR DESCRIPTION
## Problem

Workflow plan gating was a hand-maintained allowlist of four action types, decoupled from the executor's full dispatch universe (system actions + the entire plugin registry + legacy aliases). The validator skipped any unrecognized action type, so any other network-egress action shipped ungated. In practice a free account could run an outbound request via an ungated action whose connection exposes a user-controlled URL (e.g. blockscout's custom-instance URL).

## Approach

Classify network egress at the action source and derive the gate from it.

- New `egress: "user-destination" | "fixed-host" | "none"` is required on `IntegrationPlugin` (optional per-action override), so every current and future plugin must classify itself or the build fails. System/built-in actions are classified in `lib/features/system-action-capabilities.ts`.
- Gating keys only on host control: a `user-destination` action (the user can choose the destination host) is gated behind a new pro-only `action.external-request` feature via `resolveActionFeature`, applied in the workflow validator (save and execute) and the workflow-builder UI. Branded fixed-host integrations stay free.
- SSRF safety is unchanged and already enforced (always-on `assertUrlIsPublic` plus the existing "Forbid raw network egress in plugins" check), so a misclassification fails safe: under-gating at worst, never an unguarded egress.

## Tests

- New `tests/unit/features-egress-invariant.test.ts`: every dispatchable action is classified, every user-destination action is gated for free, the system map mirrors the executor, and any plugin exposing a user-supplied connection URL is classified user-destination. A future ungated egress action becomes a build failure.
- Extended the route-guard and executor-guard tests to cover a user-destination plugin action being blocked at save and execute time.
- Full unit suite green (6469 tests); type-check and lint clean.

## Follow-ups

Tracked as sub-issues: the connection-test (`test.ts`) raw-fetch egress surface (server-side proxy needed), and the blockscout gating granularity decision (gate only the custom-URL path vs all reads).