### PR TITLE
fix: pass Turnstile signup captcha in CI and load tests

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -20,6 +20,7 @@ import { isDisposableEmailDomain } from "@/lib/auth-disposable-emails";
 import { DISPOSABLE_EMAIL_REJECTION_MESSAGE } from "@/lib/auth-disposable-emails-message";
 import { isFreshSignup } from "@/lib/auth-notification-guard";
 import { sendInvitationEmail, sendVerificationOTP } from "@/lib/email";
+import { hasValidLoadTestBypass } from "@/lib/load-test-bypass";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { revokeRefreshTokensForUserOrg } from "@/lib/mcp/oauth-store";
 import { recordAuditEvent } from "@/lib/security/audit-log";
@@ -141,7 +142,10 @@ function getBaseURL() {
 // exercised before prod. Note: with the plugin loaded, the X-Test-API-Key
 // signup bypass no longer applies - that environment's site/secret keys must
 // be ones the widget+server can pass (e.g. Cloudflare's always-pass test
-// keys) for any UI-driven signup E2E to keep working.
+// keys) for any UI-driven signup E2E to keep working. Headless load-test /
+// e2e clients that cannot solve a challenge present the LOAD_TEST_BYPASS_TOKEN
+// instead (see the plugin wrapper below).
+const SIGNUP_CAPTCHA_ENDPOINT = "/sign-up/email";
 const captchaSecretKey = process.env.TURNSTILE_SECRET_KEY;
 const captchaForceEnabled = process.env.TURNSTILE_ENFORCE === "true";
 const captchaSkippedForTests =
@@ -152,12 +156,17 @@ const captchaSkippedForTests =
     process.env.NODE_ENV !== "production");
 
 // Captcha is mandatory in production and in any environment that explicitly
-// opts in via TURNSTILE_ENFORCE. next build evaluates route modules during
-// the "Collecting page data" phase with NODE_ENV=production but no runtime
-// secrets injected, so skip the assertion during that phase to avoid crashing
-// the build. The assertion still fires at server boot (phase-production-server)
-// and under any custom server that doesn't set NEXT_PHASE.
+// opts in via TURNSTILE_ENFORCE. The secret is only required where the plugin
+// is actually loaded, so gate on !captchaSkippedForTests too: a production
+// build run with CI=true / NODE_ENV=test (the ephemeral e2e job boots the
+// prod image with CI=true) skips the plugin entirely, and must not crash at
+// module load demanding a secret it will never use. next build also evaluates
+// route modules during the "Collecting page data" phase with NODE_ENV=production
+// but no runtime secrets injected, so skip the assertion during that phase to
+// avoid crashing the build. The assertion still fires at server boot
+// (phase-production-server) of any environment that actually enforces captcha.
 const captchaRequired =
+  !captchaSkippedForTests &&
   (process.env.NODE_ENV === "production" || captchaForceEnabled) &&
   process.env.NEXT_PHASE !== "phase-production-build";
 if (captchaRequired && !captchaSecretKey) {
@@ -166,15 +175,35 @@ if (captchaRequired && !captchaSecretKey) {
   );
 }
 
+// Wrap the captcha plugin's onRequest so trusted load-test / e2e traffic can
+// skip the Turnstile check on signup. A real challenge cannot be solved
+// headlessly, so k6 / Playwright present the LOAD_TEST_BYPASS_TOKEN (via the
+// x-load-test-mfa-bypass header) - the same token that already clears the MFA
+// gate (proxy.ts). Production never provisions the token, so the bypass is
+// inert there and normal users always hit the real Turnstile verification.
+function buildTurnstilePlugin(secretKey: string): ReturnType<typeof captcha> {
+  const turnstile = captcha({
+    provider: "cloudflare-turnstile",
+    secretKey,
+    endpoints: [SIGNUP_CAPTCHA_ENDPOINT],
+  });
+  return {
+    ...turnstile,
+    onRequest: (request, ctx) => {
+      if (
+        request.url.includes(SIGNUP_CAPTCHA_ENDPOINT) &&
+        hasValidLoadTestBypass(request)
+      ) {
+        return Promise.resolve(undefined);
+      }
+      return turnstile.onRequest(request, ctx);
+    },
+  };
+}
+
 const captchaPlugins =
   !captchaSkippedForTests && captchaSecretKey
-    ? [
-        captcha({
-          provider: "cloudflare-turnstile",
-          secretKey: captchaSecretKey,
-          endpoints: ["/sign-up/email"],
-        }),
-      ]
+    ? [buildTurnstilePlugin(captchaSecretKey)]
     : [];
 
 // Build plugins array conditionally

--- a/lib/load-test-bypass.ts
+++ b/lib/load-test-bypass.ts
@@ -1,0 +1,40 @@
+import { timingSafeEqual } from "node:crypto";
+
+/**
+ * Header carrying the load-test bypass token.
+ *
+ * Introduced for the mandatory-MFA enrollment bypass (proxy.ts); it now also
+ * clears the signup Turnstile challenge (lib/auth.ts) for the same trusted
+ * load-test / e2e traffic. The name is retained because the k6 and Playwright
+ * clients already send this header on every request.
+ */
+export const LOAD_TEST_BYPASS_HEADER = "x-load-test-mfa-bypass";
+
+/**
+ * True iff the request carries a valid load-test bypass token.
+ *
+ * One token clears the anti-abuse gates that a headless client cannot satisfy:
+ * the mandatory-MFA enrollment gate (proxy.ts) and the signup Turnstile
+ * challenge (lib/auth.ts). A real Turnstile challenge cannot be solved by a
+ * headless k6 / API client, so this is the only way automated signup can run
+ * against an enforcing environment such as staging.
+ *
+ * Active only when LOAD_TEST_BYPASS_TOKEN is set, compared in constant time.
+ * Production never provisions the token, so this always returns false there.
+ */
+export function hasValidLoadTestBypass(request: Request): boolean {
+  const token = process.env.LOAD_TEST_BYPASS_TOKEN;
+  if (!token) {
+    return false;
+  }
+  const provided = request.headers.get(LOAD_TEST_BYPASS_HEADER);
+  if (!provided) {
+    return false;
+  }
+  const providedBuf = Buffer.from(provided, "utf8");
+  const expectedBuf = Buffer.from(token, "utf8");
+  if (providedBuf.length !== expectedBuf.length) {
+    return false;
+  }
+  return timingSafeEqual(providedBuf, expectedBuf);
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,7 +1,7 @@
-import { timingSafeEqual } from "node:crypto";
 import { type NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { readDeviceCookie } from "@/lib/device-cookie";
+import { hasValidLoadTestBypass } from "@/lib/load-test-bypass";
 import {
   buildPendingIpSetCookie,
   encodePendingIpCookie,
@@ -169,24 +169,6 @@ const MFA_EXEMPT_PAGE_PREFIXES: readonly string[] = [
   "/sign-up",
 ];
 
-const LOAD_TEST_BYPASS_TOKEN = process.env.LOAD_TEST_BYPASS_TOKEN;
-
-function hasValidLoadTestMfaBypass(request: NextRequest): boolean {
-  if (!LOAD_TEST_BYPASS_TOKEN) {
-    return false;
-  }
-  const provided = request.headers.get("x-load-test-mfa-bypass");
-  if (!provided) {
-    return false;
-  }
-  const providedBuf = Buffer.from(provided, "utf8");
-  const expectedBuf = Buffer.from(LOAD_TEST_BYPASS_TOKEN, "utf8");
-  if (providedBuf.length !== expectedBuf.length) {
-    return false;
-  }
-  return timingSafeEqual(providedBuf, expectedBuf);
-}
-
 function isMfaExemptPath(pathname: string): boolean {
   if (pathname.startsWith("/api/")) {
     for (const prefix of MFA_EXEMPT_API_PREFIXES) {
@@ -243,7 +225,7 @@ async function mfaBlock(request: NextRequest): Promise<MfaResult> {
   if (isMfaExemptPath(pathname)) {
     return { kind: "pass", user: null };
   }
-  if (hasValidLoadTestMfaBypass(request)) {
+  if (hasValidLoadTestBypass(request)) {
     return { kind: "pass", user: null };
   }
   // No session cookie at all → no session → nothing to gate on. Route

--- a/tests/unit/signup-defenses.test.ts
+++ b/tests/unit/signup-defenses.test.ts
@@ -78,6 +78,10 @@ describe("signup defenses: captcha plugin", () => {
 
   it("throws at module load in production when TURNSTILE_SECRET_KEY is missing", async () => {
     vi.stubEnv("NODE_ENV", "production");
+    // Pin CI off: a real prod deploy never sets CI=true, so the plugin is
+    // enforced and the guard must fire. The CI runner sets CI=true ambiently,
+    // which would otherwise skip the guard (see the CI=true case below).
+    vi.stubEnv("CI", "");
     await expect(import("@/lib/auth")).rejects.toThrow(
       MISSING_CAPTCHA_SECRET_ERROR
     );

--- a/tests/unit/signup-defenses.test.ts
+++ b/tests/unit/signup-defenses.test.ts
@@ -26,6 +26,8 @@ function clearTurnstileEnv(): void {
   delete process.env.NEXT_PHASE;
   // biome-ignore lint/performance/noDelete: same
   delete process.env.TURNSTILE_ENFORCE;
+  // biome-ignore lint/performance/noDelete: same
+  delete process.env.LOAD_TEST_BYPASS_TOKEN;
 }
 
 describe("signup defenses: captcha plugin", () => {
@@ -81,6 +83,17 @@ describe("signup defenses: captcha plugin", () => {
     );
   });
 
+  it("does not throw in production when CI=true even without the secret (ephemeral e2e boots the prod image with the plugin skipped)", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CI", "true");
+    const { auth } = await import("@/lib/auth");
+    expect(auth).toBeDefined();
+    const plugin = (auth.options.plugins ?? []).find(
+      (p) => (p as CaptchaPluginShape).id === "captcha"
+    );
+    expect(plugin).toBeUndefined();
+  });
+
   it("does not throw during next build phase even without the secret", async () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("NEXT_PHASE", "phase-production-build");
@@ -127,6 +140,88 @@ describe("signup defenses: captcha plugin", () => {
     await expect(import("@/lib/auth")).rejects.toThrow(
       MISSING_CAPTCHA_SECRET_ERROR
     );
+  });
+});
+
+describe("signup defenses: captcha load-test bypass", () => {
+  const BYPASS_TOKEN = "load-test-captcha-bypass-token-32-bytes!";
+
+  type CaptchaOnRequest = (
+    request: Request,
+    ctx: unknown
+  ) => Promise<{ response?: Response } | undefined>;
+
+  const ctxStub: unknown = {
+    options: {},
+    logger: { error: () => undefined },
+  };
+
+  function signupRequest(headers: Record<string, string>): Request {
+    return new Request("http://localhost:3000/api/auth/sign-up/email", {
+      method: "POST",
+      headers,
+    });
+  }
+
+  async function loadCaptchaOnRequest(): Promise<CaptchaOnRequest | undefined> {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("CI", "");
+    process.env.TURNSTILE_SECRET_KEY = "test-secret";
+    const { auth } = await import("@/lib/auth");
+    const plugin = (auth.options.plugins ?? []).find(
+      (p) => (p as CaptchaPluginShape).id === "captcha"
+    ) as { onRequest?: CaptchaOnRequest } | undefined;
+    return plugin?.onRequest;
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    clearTurnstileEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    clearTurnstileEnv();
+  });
+
+  it("skips Turnstile on signup when a valid LOAD_TEST_BYPASS_TOKEN is presented", async () => {
+    process.env.LOAD_TEST_BYPASS_TOKEN = BYPASS_TOKEN;
+    const onRequest = await loadCaptchaOnRequest();
+    expect(onRequest).toBeDefined();
+    const result = await onRequest?.(
+      signupRequest({ "x-load-test-mfa-bypass": BYPASS_TOKEN }),
+      ctxStub
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("enforces Turnstile on signup without the bypass header", async () => {
+    process.env.LOAD_TEST_BYPASS_TOKEN = BYPASS_TOKEN;
+    const onRequest = await loadCaptchaOnRequest();
+    // No bypass header and no x-captcha-response -> upstream rejects with a
+    // 400 response rather than passing the request through.
+    const result = await onRequest?.(signupRequest({}), ctxStub);
+    expect(result?.response).toBeInstanceOf(Response);
+  });
+
+  it("enforces Turnstile when the bypass token does not match", async () => {
+    process.env.LOAD_TEST_BYPASS_TOKEN = BYPASS_TOKEN;
+    const onRequest = await loadCaptchaOnRequest();
+    const result = await onRequest?.(
+      signupRequest({ "x-load-test-mfa-bypass": "not-the-real-token-value!!" }),
+      ctxStub
+    );
+    expect(result?.response).toBeInstanceOf(Response);
+  });
+
+  it("does not bypass when LOAD_TEST_BYPASS_TOKEN is unset (production posture)", async () => {
+    const onRequest = await loadCaptchaOnRequest();
+    const result = await onRequest?.(
+      signupRequest({ "x-load-test-mfa-bypass": BYPASS_TOKEN }),
+      ctxStub
+    );
+    expect(result?.response).toBeInstanceOf(Response);
   });
 });
 
@@ -207,13 +302,11 @@ describe("signup defenses: /sign-in/anonymous rate limit rule", () => {
   it("returns { window: 3600, max: 5 } for anonymous sign-in attempts", async () => {
     vi.stubEnv("NODE_ENV", "development");
     const { auth } = await import("@/lib/auth");
-    const rule = auth.options.rateLimit?.customRules?.[
-      "/sign-in/anonymous"
-    ] as RateLimitRuleFn | undefined;
+    const rule = auth.options.rateLimit?.customRules?.["/sign-in/anonymous"] as
+      | RateLimitRuleFn
+      | undefined;
     expect(typeof rule).toBe("function");
-    const req = new Request(
-      "http://localhost:3000/api/auth/sign-in/anonymous"
-    );
+    const req = new Request("http://localhost:3000/api/auth/sign-in/anonymous");
     const resolved = await rule?.(req, { window: 60, max: 100 });
     expect(resolved).toEqual({ window: 3600, max: 5 });
   });
@@ -223,9 +316,9 @@ describe("signup defenses: /sign-in/anonymous rate limit rule", () => {
     vi.stubEnv("INCLUDE_TEST_ENDPOINTS", "true");
     process.env.TEST_API_KEY = TEST_API_KEY;
     const { auth } = await import("@/lib/auth");
-    const rule = auth.options.rateLimit?.customRules?.[
-      "/sign-in/anonymous"
-    ] as RateLimitRuleFn | undefined;
+    const rule = auth.options.rateLimit?.customRules?.["/sign-in/anonymous"] as
+      | RateLimitRuleFn
+      | undefined;
     const req = new Request(
       "http://localhost:3000/api/auth/sign-in/anonymous",
       { headers: { "X-Test-API-Key": TEST_API_KEY } }


### PR DESCRIPTION
## Problem

The `e2e-vitest-ephemeral` CI job fails at "Start application" on pushes to `staging`. The job boots the production Docker image (`NODE_ENV=production`, `CI=true`) but passes no `TURNSTILE_SECRET_KEY`, so `lib/auth.ts` throws at module load:

```
Error: TURNSTILE_SECRET_KEY is required in production (or when TURNSTILE_ENFORCE=true) ...
```

Root cause: `captchaSkippedForTests` (true when `CI=true`) already skips *loading* the captcha plugin, but the boot assertion only checked `NODE_ENV==="production" || TURNSTILE_ENFORCE` - so it demanded a secret the plugin would never use, crashing the app before it could serve any request. The bare-metal start path already worked around this with a dummy secret; the Docker path (used on push events) did not.

Separately, headless load tests (k6 against `staging`, which enforces Turnstile with real keys) cannot solve a real Cloudflare challenge, so signup is blocked there.

## Changes

1. `lib/auth.ts` - gate the boot assertion on `!captchaSkippedForTests`. The secret is required only where the plugin is actually loaded. Production posture is unchanged: `CI` is never `true` in a real deploy, and staging/prod/PR-env all still require the secret and still boot-guard.

2. `lib/load-test-bypass.ts` (new) + `lib/auth.ts` - wrap the captcha plugin's `onRequest` so trusted load-test / e2e traffic skips the Turnstile check on `/sign-up/email`. It reuses the existing `LOAD_TEST_BYPASS_TOKEN` (header `x-load-test-mfa-bypass`) that already clears the MFA-enrollment gate and is already sent by the k6 and Playwright clients - so no k6 / Playwright / deploy changes are needed. The token is compared in constant time. Production never provisions the token, so the bypass is inert there.

3. `proxy.ts` - refactored to use the shared `hasValidLoadTestBypass` helper (single source of truth for the token check; previously duplicated inline).

## Why reuse `LOAD_TEST_BYPASS_TOKEN`

It is a dedicated, narrowly-scoped load-test credential (vs the broader `X-Test-API-Key`), its Parameter Store entry is literally named `load-test-captcha-bypass-token`, and it is already plumbed through the workflows and sent on the signup request.

## Safety

- Prod: `LOAD_TEST_BYPASS_TOKEN` is not set and the test/CI skips never apply - real users always hit real Turnstile, and the boot guard still fires if the secret is missing.
- Staging: keeps real Turnstile for normal traffic; only token-bearing load-test traffic bypasses.

## Testing

- Added unit tests in `tests/unit/signup-defenses.test.ts`: production + `CI=true` boots without the secret and skips the plugin; the captcha bypass skips on a valid token and enforces on a missing / wrong / unset token.
- `pnpm type-check` clean on the changed files and `pnpm vitest run tests/unit/signup-defenses.test.ts tests/unit/proxy.test.ts` (70 passed) locally.

Note: the `run-e2e-tests-ephemeral` label exercises the bare-metal e2e path (already booting), so it validates no regressions; the original Docker-path crash is fixed at the source and is validated on merge to `staging`.
