### PR TITLE
ci: forward test-harness env to the e2e Docker app

### DIFF
--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -119,6 +119,8 @@ runs:
         TURNKEY_API_PUBLIC_KEY: ${{ inputs.turnkey_api_public_key }}
         TURNKEY_API_PRIVATE_KEY: ${{ inputs.turnkey_api_private_key }}
         TURNKEY_ORGANIZATION_ID: ${{ inputs.turnkey_organization_id }}
+        ALLOW_TEST_ENDPOINTS: ${{ inputs.allow_test_endpoints }}
+        LOAD_TEST_BYPASS_TOKEN: ${{ inputs.load_test_bypass_token }}
       run: |
         IMAGE="${ECR_REGISTRY}/${ECR_REPO}:app-${IMAGE_TAG}"
         echo "Pulling ${IMAGE}..."
@@ -141,7 +143,11 @@ runs:
         # such values. INTEGRATION_ENCRYPTION_KEY must match the test process's
         # key so getIntegrationById's decryptConfig can read seeded rows.
         # TURNKEY_* are required for the Turnkey-managed org-wallet path the
-        # protocol-coverage suites exercise.
+        # protocol-coverage suites exercise. ALLOW_TEST_ENDPOINTS (runtime
+        # opt-in for testEndpointsEnabled, gating the admin OTP endpoint +
+        # rate-limit bypass) and LOAD_TEST_BYPASS_TOKEN (MFA-enrollment bypass,
+        # verified in proxy.ts) are required for the Playwright auth setup -
+        # the bare-metal path already sets them.
         docker run -d --name keeperhub-app --network host \
           --env-file /tmp/keeperhub-app.env \
           -e "CHAIN_RPC_CONFIG=${CHAIN_RPC_CONFIG}" \
@@ -149,6 +155,8 @@ runs:
           -e "TURNKEY_API_PUBLIC_KEY=${TURNKEY_API_PUBLIC_KEY}" \
           -e "TURNKEY_API_PRIVATE_KEY=${TURNKEY_API_PRIVATE_KEY}" \
           -e "TURNKEY_ORGANIZATION_ID=${TURNKEY_ORGANIZATION_ID}" \
+          -e "ALLOW_TEST_ENDPOINTS=${ALLOW_TEST_ENDPOINTS}" \
+          -e "LOAD_TEST_BYPASS_TOKEN=${LOAD_TEST_BYPASS_TOKEN}" \
           "${IMAGE}"
 
         for i in $(seq 1 30); do


### PR DESCRIPTION
## Problem

On the release CI (push to `staging`), `e2e-tests / e2e-playwright-ephemeral` fails: all 4 `auth.setup.ts` setups fail because the org switcher (`button[role="combobox"]`) never appears - the sign-in dialog never closes, because sign-in cannot complete.

Root cause: the `start-app` **Docker path** (push events) forwards only `TEST_API_KEY` to the container and drops `ALLOW_TEST_ENDPOINTS` and `LOAD_TEST_BYPASS_TOKEN`, even though the Playwright job already passes them as inputs. In the production-mode container that means:

- `ALLOW_TEST_ENDPOINTS` unset -> `testEndpointsEnabled()` is false -> the admin OTP retrieval endpoint and the rate-limit bypass are disabled.
- `LOAD_TEST_BYPASS_TOKEN` unset -> the MFA-enrollment bypass (verified in `proxy.ts`) is disabled.

So the seeded-user sign-in can't get its OTP / clear MFA, the dialog stays open, and all 120 downstream tests are blocked.

This only surfaced now because the recent Turnstile boot fix let the push-path app start, so Playwright ran on the Docker path for the first time.

## Change

Forward `ALLOW_TEST_ENDPOINTS` and `LOAD_TEST_BYPASS_TOKEN` (already-defined `start-app` inputs) into the Docker-path container, matching what the bare-metal path already does. One CI-action file; no app/runtime code touched.

## Evidence

`e2e-playwright-ephemeral` passes on the **bare-metal** path (e.g. PR #1611's label run), which sets both vars. The only difference on the push/Docker path was these two missing vars, so this brings the Docker path to parity.

## Validation note

A PR/label run exercises the bare-metal path (already passing), so it confirms no regression + actionlint. The Docker-path fix itself is exercised on the **push event when this merges to `staging`**.
