### PR TITLE
ci(deploy): add IRSA preflight init-container to keeperhub-stack

### DIFF
--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -87,6 +87,20 @@ app:
   deployment:
     enabled: true
     initContainers:
+      # IRSA hard gate: assume the role and run a read-only AWS probe before the
+      # main container starts, so --atomic rolls the release back if IRSA is broken.
+      # Anchored here and reused by the other components below.
+      - &irsa_preflight
+        name: irsa-preflight
+        image: amazon/aws-cli
+        command:
+          - /bin/sh
+          - -c
+        args:
+          - |
+            set -euo pipefail
+            aws sts get-caller-identity
+            aws sqs get-queue-url --queue-name keeperhub-workflow-queue-prod --region us-east-2
       - name: db-migration
         image: "${ECR_REGISTRY}/keeperhub-prod:migrator-${IMAGE_TAG}"
         command:
@@ -599,6 +613,8 @@ executor:
 
   deployment:
     enabled: true
+    initContainers:
+      - *irsa_preflight
 
   serviceAccount:
     create: false
@@ -799,6 +815,8 @@ schedule:
 
   deployment:
     enabled: true
+    initContainers:
+      - *irsa_preflight
 
   # Use the same service account as main app
   serviceAccount:
@@ -896,6 +914,8 @@ block:
 
   deployment:
     enabled: true
+    initContainers:
+      - *irsa_preflight
 
   # Use the same service account as main app
   serviceAccount:
@@ -1014,6 +1034,8 @@ metricsCollector:
 
   deployment:
     enabled: true
+    initContainers:
+      - *irsa_preflight
 
   serviceAccount:
     create: false

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -87,6 +87,20 @@ app:
   deployment:
     enabled: true
     initContainers:
+      # IRSA hard gate: assume the role and run a read-only AWS probe before the
+      # main container starts, so --atomic rolls the release back if IRSA is broken.
+      # Anchored here and reused by the other components below.
+      - &irsa_preflight
+        name: irsa-preflight
+        image: amazon/aws-cli
+        command:
+          - /bin/sh
+          - -c
+        args:
+          - |
+            set -euo pipefail
+            aws sts get-caller-identity
+            aws sqs get-queue-url --queue-name keeperhub-workflow-queue-staging --region us-east-1
       - name: db-migration
         image: "${ECR_REGISTRY}/keeperhub-staging:migrator-${IMAGE_TAG}"
         command:
@@ -601,6 +615,8 @@ executor:
 
   deployment:
     enabled: true
+    initContainers:
+      - *irsa_preflight
 
   serviceAccount:
     create: false
@@ -801,6 +817,8 @@ schedule:
 
   deployment:
     enabled: true
+    initContainers:
+      - *irsa_preflight
 
   # Use the same service account as main app
   serviceAccount:
@@ -898,6 +916,8 @@ block:
 
   deployment:
     enabled: true
+    initContainers:
+      - *irsa_preflight
 
   # Use the same service account as main app
   serviceAccount:
@@ -1016,6 +1036,8 @@ metricsCollector:
 
   deployment:
     enabled: true
+    initContainers:
+      - *irsa_preflight
 
   serviceAccount:
     create: false


### PR DESCRIPTION
## What

Adds an `irsa-preflight` init container to all five keeperhub-stack components (app, executor, schedule, block, metricsCollector) in staging and prod. It assumes the shared IRSA role and runs a read-only AWS probe before the main container starts:

- `aws sts get-caller-identity` - proves the assume-role works
- `aws sqs get-queue-url --queue-name <queue>` - proves SQS reachability and the role's queue grants

If the probe fails the pod never becomes Ready, so `helm upgrade --atomic --wait` rolls the release back instead of silently dropping AWS access for the dispatchers and executor.

## Why

The existing `irsaCheck` helm-test is a post-deploy sanity check - it runs after the release already succeeded, so a broken IRSA config can still roll out. This adds the missing hard gate at pod startup. The two are complementary; the helm-test is kept.

## Approach

No chart change. The `common` chart already supports `deployment.initContainers`, so the gate is a plain entry in that list - nothing to bump or republish, and it stays flexible per component. The probe is defined once per env file via a YAML anchor (`&irsa_preflight`) and reused across the other components, the same pattern this file already uses for `shared_env`.

Per-env values: staging `us-east-1` / `keeperhub-workflow-queue-staging`, prod `us-east-2` / `keeperhub-workflow-queue-prod`. Queue **name** only, no account-id-bearing URLs. `get-queue-url` is the only truly read-only call within the queue policy (`GetQueueAttributes` is not granted; `ReceiveMessage` would side-effect a message). The preflight carries no resource requests/limits - acceptable for a short-lived gate unless the namespace enforces a LimitRange.

## Verification

Rendered the deployed chart against these exact values (envsubst): all five components get one `irsa-preflight` init container with the right region/queue per env; the app component keeps its `db-migration` init container after the preflight. The live STS/SQS path is validated staging-first on EKS (watch a pod init, then a negative test with a bogus queue name to confirm Init:Error + atomic rollback) before prod.