### PR TITLE
test(e2e): fix consistently-failing ephemeral playwright tests

### DIFF
--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -87,6 +87,14 @@ inputs:
     description: 'ALLOW_TEST_ENDPOINTS - runtime production opt-in required alongside include_test_endpoints for testEndpointsEnabled() to return true under NODE_ENV=production.'
     required: false
     default: ''
+  sandbox_backend:
+    description: 'SANDBOX_BACKEND - set "remote" for jobs that execute workflow step bundles against a live sandbox (start-sandbox). The Docker path forwards it to the container; empty leaves step execution unconfigured. The bare-metal path already hardcodes remote.'
+    required: false
+    default: ''
+  sandbox_url:
+    description: 'SANDBOX_URL - base URL of the code-execution sandbox (e.g. http://localhost:8787) the app dispatches step bundles to (lib/sandbox/client.ts). Forwarded to the container on the Docker path.'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -121,6 +129,8 @@ runs:
         TURNKEY_ORGANIZATION_ID: ${{ inputs.turnkey_organization_id }}
         ALLOW_TEST_ENDPOINTS: ${{ inputs.allow_test_endpoints }}
         LOAD_TEST_BYPASS_TOKEN: ${{ inputs.load_test_bypass_token }}
+        SANDBOX_BACKEND: ${{ inputs.sandbox_backend }}
+        SANDBOX_URL: ${{ inputs.sandbox_url }}
       run: |
         IMAGE="${ECR_REGISTRY}/${ECR_REPO}:app-${IMAGE_TAG}"
         echo "Pulling ${IMAGE}..."
@@ -137,6 +147,18 @@ runs:
           "TEST_API_KEY=${TEST_API_KEY}" \
           "WORKFLOW_TARGET_WORLD=@workflow/world-postgres" \
           > /tmp/keeperhub-app.env
+
+        # Jobs that execute workflow step bundles (e.g. the credential-bundle
+        # suite) start a live sandbox and pass sandbox_backend/sandbox_url so the
+        # app dispatches steps to it. Appended only when set so other jobs leave
+        # step execution unconfigured. URL has no special chars, so the env-file
+        # is safe here.
+        if [ -n "${SANDBOX_BACKEND}" ]; then
+          printf '%s\n' \
+            "SANDBOX_BACKEND=${SANDBOX_BACKEND}" \
+            "SANDBOX_URL=${SANDBOX_URL}" \
+            >> /tmp/keeperhub-app.env
+        fi
 
         # Pass values with potentially special chars (JSON / base64 / =-padding)
         # via -e rather than the env-file, which parses literally and breaks on

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -327,6 +327,13 @@ jobs:
           turnkey_api_private_key: ${{ secrets.TURNKEY_API_PRIVATE_KEY }}
           turnkey_organization_id: ${{ secrets.TURNKEY_ORGANIZATION_ID }}
 
+      # The credential-bundle suite executes real workflow step bundles, which
+      # the app dispatches to a code-execution sandbox. Without it the step
+      # endpoint 500s and the run never reaches a terminal status. Mirror the
+      # vitest job, which already runs a sandbox for its execution suites.
+      - name: Start code-execution sandbox
+        uses: ./.github/actions/start-sandbox
+
       - name: Start application
         uses: ./.github/actions/start-app
         with:
@@ -350,6 +357,11 @@ jobs:
           # suite signs in repeatedly as a few shared users). Scoped to this job.
           include_test_endpoints: "true"
           allow_test_endpoints: "true"
+          # Point the app's step-bundle execution at the sandbox started above.
+          # The Docker path needs these forwarded explicitly; the bare-metal path
+          # already hardcodes the same values.
+          sandbox_backend: remote
+          sandbox_url: http://localhost:8787
 
       - name: Run Playwright tests
         run: pnpm test:e2e

--- a/tests/e2e/playwright/fixtures.ts
+++ b/tests/e2e/playwright/fixtures.ts
@@ -8,6 +8,7 @@ import type {
 } from "@playwright/test";
 import { test as base } from "@playwright/test";
 import { probe } from "./utils/discover";
+import { stubTurnstile } from "./utils/turnstile";
 
 export { expect } from "@playwright/test";
 
@@ -54,9 +55,17 @@ interface NetworkFailure {
  * Import { test, expect } from this file instead of @playwright/test.
  */
 export const test = base.extend<{
+  _turnstileStub: undefined;
   _autoFailureDiagnostics: undefined;
   apiRequest: AuthenticatedApiRequest;
 }>({
+  _turnstileStub: [
+    async ({ page }, use) => {
+      await stubTurnstile(page);
+      await use(undefined);
+    },
+    { auto: true },
+  ],
   apiRequest: async ({ page, baseURL }, use) => {
     const origin = baseURL ?? "http://localhost:3000";
     const withOrigin = (

--- a/tests/e2e/playwright/utils/turnstile.ts
+++ b/tests/e2e/playwright/utils/turnstile.ts
@@ -1,0 +1,71 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Deterministically satisfy the signup Cloudflare Turnstile challenge.
+ *
+ * The signup "Create account" button is disabled until the Turnstile widget
+ * produces a token (components/auth/dialog.tsx: `disabled={loading ||
+ * (!!turnstileSiteKey && !captchaToken)}`). The real widget is loaded from
+ * challenges.cloudflare.com and only resolves interactively, so in the headless
+ * CI runner it never issues a token and every UI-signup test hangs on the
+ * disabled button until the 60s timeout. The server-side captcha gate is already
+ * bypassed in CI (lib/auth.ts under CI=true), so any client token unblocks the
+ * flow; this stub supplies one without the network round-trip.
+ *
+ * Installs a `window.turnstile` shim that immediately invokes the success
+ * callback `@marsidev/react-turnstile` passes to `render()`, and serves an empty
+ * body for the real api.js so the library's load gate resolves without the live
+ * script overwriting the shim (and without firing an onError that would clear
+ * the token). Call before the first navigation that may render the auth dialog.
+ */
+export async function stubTurnstile(page: Page): Promise<void> {
+  await page.route("**/turnstile/v0/api.js**", (route) =>
+    route.fulfill({
+      contentType: "application/javascript",
+      body: "",
+    })
+  );
+
+  await page.addInitScript(() => {
+    const TOKEN = "e2e-turnstile-stub-token";
+    const widgets = new Map<string, { callback?: (token: string) => void }>();
+    let counter = 0;
+
+    const fireSuccess = (id: string): void => {
+      const params = widgets.get(id);
+      if (params?.callback) {
+        Promise.resolve().then(() => params.callback?.(TOKEN));
+      }
+    };
+
+    (window as unknown as { turnstile: unknown }).turnstile = {
+      render(_container: unknown, params: { callback?: (t: string) => void }) {
+        const id = `turnstile-stub-${counter++}`;
+        widgets.set(id, params);
+        fireSuccess(id);
+        return id;
+      },
+      reset(id?: string) {
+        if (id) {
+          fireSuccess(id);
+        }
+      },
+      remove(id?: string) {
+        if (id) {
+          widgets.delete(id);
+        }
+      },
+      execute(id?: string) {
+        if (id) {
+          fireSuccess(id);
+        }
+      },
+      getResponse() {
+        return TOKEN;
+      },
+      isExpired() {
+        return false;
+      },
+    };
+  });
+}


### PR DESCRIPTION
## Summary

The five ephemeral Playwright tests that fail in CI but pass locally are not flaky. The same five fail on every run, with two distinct CI-only root causes.

**Turnstile (auth, invitations).** The signup "Create account" button stays disabled until the Cloudflare Turnstile widget issues a token. The CI image bakes the real site key, so the headless runner has to solve a live challenge that never resolves, and every UI signup test hangs to the 60s timeout. The server side captcha gate is already bypassed under CI, so any client token unblocks the flow. This adds a deterministic `window.turnstile` stub, wired as an auto fixture, that supplies a token without the network round trip.

**Missing sandbox (credential-bundle).** These tests execute real workflow step bundles, which the app dispatches to a code execution sandbox. The vitest job starts one; the playwright job did not, so the step endpoint returns 500 and the run never reaches a terminal status. This starts a sandbox in the playwright job and forwards `SANDBOX_BACKEND` and `SANDBOX_URL` into the app container on the Docker path (the bare metal path already hardcodes them).

## Changes

- `tests/e2e/playwright/utils/turnstile.ts`: Turnstile stub helper
- `tests/e2e/playwright/fixtures.ts`: auto fixture installing the stub before each test
- `.github/workflows/e2e-tests-ephemeral.yml`: start a sandbox in the playwright job and point the app container at it
- `.github/actions/start-app/action.yml`: optional `sandbox_backend` / `sandbox_url` inputs forwarded to the container on the Docker path

## Validation

All five previously failing tests pass locally in pipeline equivalent mode (production runtime with the sandbox running): the auth signup view, INV-SEND-2, and the three credential-bundle cases.