### PR TITLE
feat: copy and compare values in workflow version history

### DIFF
--- a/components/workflow/version-history-content.tsx
+++ b/components/workflow/version-history-content.tsx
@@ -106,6 +106,35 @@ function toneChip(tone: "before" | "after"): string {
     : "bg-keeperhub-green-dark/10 text-keeperhub-green-dark ring-1 ring-keeperhub-green-dark/20";
 }
 
+// A small copy-to-clipboard button that flips to a check for ~1.2s on success.
+// Shared by the address chip and the generic value chip so long, trimmed values
+// can be copied in full.
+function CopyButton({
+  value,
+  label,
+}: {
+  value: string;
+  label: string;
+}): React.ReactElement {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    navigator.clipboard.writeText(value).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    });
+  };
+  return (
+    <button
+      aria-label={label}
+      className="flex h-5 shrink-0 items-center opacity-70 transition-opacity hover:opacity-100"
+      onClick={copy}
+      type="button"
+    >
+      {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+    </button>
+  );
+}
+
 // An EVM address value: checksummed + shortened, with the full address on
 // hover, a copy button, and a network-aware explorer link when known.
 function AddressChip({
@@ -117,13 +146,6 @@ function AddressChip({
   label: string;
   tone: "before" | "after";
 }): React.ReactElement {
-  const [copied, setCopied] = useState(false);
-  const copy = () => {
-    navigator.clipboard.writeText(address.full).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1200);
-    });
-  };
   return (
     <TooltipProvider>
       <Tooltip>
@@ -134,18 +156,7 @@ function AddressChip({
             )}`}
           >
             {label}
-            <button
-              aria-label="Copy address"
-              className="opacity-70 transition-opacity hover:opacity-100"
-              onClick={copy}
-              type="button"
-            >
-              {copied ? (
-                <Check className="size-3" />
-              ) : (
-                <Copy className="size-3" />
-              )}
-            </button>
+            <CopyButton label="Copy address" value={address.full} />
             {address.href && (
               <a
                 aria-label="View on explorer"
@@ -182,13 +193,14 @@ function DiffValue({
   }
   if (resolved.deleted) {
     return (
-      <span className="inline-flex items-center gap-1.5 rounded bg-muted px-1.5 py-0.5 leading-relaxed">
+      <span className="inline-flex items-start gap-1.5 rounded bg-muted px-1.5 py-0.5 leading-relaxed">
         <span className="break-all text-muted-foreground line-through">
           {resolved.label}
         </span>
         <span className="rounded bg-destructive/15 px-1 font-medium text-[10px] text-destructive uppercase">
           deleted
         </span>
+        <CopyButton label="Copy value" value={resolved.label} />
       </span>
     );
   }
@@ -203,11 +215,12 @@ function DiffValue({
   }
   return (
     <span
-      className={`break-all rounded px-1.5 py-0.5 font-medium text-xs leading-relaxed ${toneChip(
+      className={`inline-flex max-w-full items-start gap-1.5 rounded px-1.5 py-0.5 font-medium text-xs leading-relaxed ${toneChip(
         tone
       )}`}
     >
-      {resolved.label}
+      <span className="whitespace-pre-wrap break-all">{resolved.label}</span>
+      <CopyButton label="Copy value" value={resolved.label} />
     </span>
   );
 }
@@ -444,9 +457,22 @@ function ChangeRow({ item }: { item: ChangeItem }): React.ReactElement {
 }
 
 // Narrow a version's diff to a single node: node add/remove/config/rename/
-// enable match by id; connections match the node's current label (they're
-// stored by label, not id). Workflow-level settings are dropped -- they aren't
+// enable match by id. Connections match by endpoint node id when the diff
+// carries it, falling back to the current label for diffs recorded before ids
+// were stored -- matching by label alone drops a node's connection changes once
+// the node has been renamed. Workflow-level settings are dropped -- they aren't
 // node-specific. Used by the per-node History tab.
+function connectionTouchesNode(
+  c: VersionDiff["connectionsAdded"][number],
+  nodeId: string,
+  nodeLabel: string | null
+): boolean {
+  if (c.fromId || c.toId) {
+    return c.fromId === nodeId || c.toId === nodeId;
+  }
+  return nodeLabel ? c.from === nodeLabel || c.to === nodeLabel : false;
+}
+
 function filterDiffToNode(
   diff: VersionDiff,
   nodeId: string,
@@ -458,16 +484,12 @@ function filterDiffToNode(
     nodesAdded: diff.nodesAdded.filter((n) => n.id === nodeId),
     nodesRemoved: diff.nodesRemoved.filter((n) => n.id === nodeId),
     nodesChanged: diff.nodesChanged.filter((n) => n.id === nodeId),
-    connectionsAdded: nodeLabel
-      ? diff.connectionsAdded.filter(
-          (c) => c.from === nodeLabel || c.to === nodeLabel
-        )
-      : [],
-    connectionsRemoved: nodeLabel
-      ? diff.connectionsRemoved.filter(
-          (c) => c.from === nodeLabel || c.to === nodeLabel
-        )
-      : [],
+    connectionsAdded: diff.connectionsAdded.filter((c) =>
+      connectionTouchesNode(c, nodeId, nodeLabel)
+    ),
+    connectionsRemoved: diff.connectionsRemoved.filter((c) =>
+      connectionTouchesNode(c, nodeId, nodeLabel)
+    ),
   };
 }
 
@@ -568,6 +590,13 @@ function VersionRow({
               {relativeTime(version.createdAt)}
             </span>
           </span>
+          {/* The displayed name can be renamed, so show the immutable email too
+              when it isn't already what's shown as the name. */}
+          {version.changedBy?.name && version.changedBy.email && (
+            <span className="block truncate text-muted-foreground/70 text-xs">
+              {version.changedBy.email}
+            </span>
+          )}
         </span>
         <ChevronRight
           className={`mt-1 size-4 shrink-0 text-muted-foreground transition-transform ${

--- a/lib/workflow/version-diff.ts
+++ b/lib/workflow/version-diff.ts
@@ -6,7 +6,13 @@
  * differ".
  */
 
+import { findAbiFunction } from "@/lib/abi/utils";
 import { getActionLabel } from "@/lib/step-registry";
+import {
+  type ConditionGroup,
+  type ConditionRule,
+  isConditionGroup,
+} from "@/lib/workflow/nodes/condition/builder-types";
 
 type AnyRecord = Record<string, unknown>;
 
@@ -34,7 +40,8 @@ export type NodeFieldDelta = {
   before?: string;
   after?: string;
   configKeys?: string[];
-  // Per-field before/after for configuration changes (values truncated).
+  // Per-field before/after for configuration changes (full values, so the
+  // history UI can copy and visually compare them).
   configChanges?: ConfigChange[];
 };
 
@@ -51,7 +58,16 @@ export type NodeFieldChange = {
   deltas: NodeFieldDelta[];
 };
 
-export type ConnectionRef = { from: string; to: string };
+export type ConnectionRef = {
+  from: string;
+  to: string;
+  // Stable node ids for the endpoints, so the per-node history can match a
+  // connection to its node even after the node's label changed (labels are
+  // what the user sees; ids never change). Optional: diffs recorded before
+  // this field shipped carry only labels.
+  fromId?: string;
+  toId?: string;
+};
 
 export type VersionDiff = {
   settings: SettingChange[];
@@ -137,17 +153,124 @@ function byId(nodes: AnyRecord[]): Map<string, AnyRecord> {
   return map;
 }
 
-const MAX_VALUE_LEN = 80;
-
-function shortConfigValue(value: unknown): string {
+// The full value is kept (not truncated) so the history UI can copy and
+// visually compare long values; only node-id noise in template refs is stripped.
+function configValueText(value: unknown): string {
   if (value === undefined || value === null || value === "") {
     return "empty";
   }
   const raw = typeof value === "string" ? value : JSON.stringify(value);
-  const text = cleanTemplateRefs(raw);
-  return text.length > MAX_VALUE_LEN
-    ? `${text.slice(0, MAX_VALUE_LEN - 1)}…`
-    : text;
+  return cleanTemplateRefs(raw);
+}
+
+// A web3 contract call stores its arguments as a positional JSON array, which
+// on its own reads as `["","0333..."]`. Pair each value with its ABI parameter
+// name (resolved from the same node's `abi` + `abiFunction`) so the diff shows
+// what each argument is. Returns null when the value isn't a parseable arg
+// array, so the caller falls back to the raw text.
+function namedContractArgs(
+  config: AnyRecord,
+  argsValue: unknown
+): string | null {
+  let args: unknown;
+  try {
+    args = typeof argsValue === "string" ? JSON.parse(argsValue) : argsValue;
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(args)) {
+    return null;
+  }
+  let inputs: Array<{ name?: string }> = [];
+  const abiRaw = config.abi;
+  const fnKey = config.abiFunction;
+  if (typeof abiRaw === "string" && typeof fnKey === "string") {
+    try {
+      const abi = JSON.parse(abiRaw);
+      if (Array.isArray(abi)) {
+        inputs = findAbiFunction(abi, fnKey)?.inputs ?? [];
+      }
+    } catch {
+      // Unparseable ABI: fall back to positional arg names below.
+    }
+  }
+  // Drop the trailing empty-string padding the UI appends past the real params.
+  const effective =
+    inputs.length > 0 && args.length > inputs.length
+      ? args.slice(0, inputs.length)
+      : args;
+  const named: Record<string, unknown> = {};
+  for (const [i, value] of effective.entries()) {
+    named[inputs[i]?.name?.trim() || `arg${i}`] = value;
+  }
+  // Pretty-print so the history UI shows one named argument per line.
+  return cleanTemplateRefs(JSON.stringify(named, null, 2));
+}
+
+function conditionRuleText(rule: ConditionRule): string {
+  const left = rule.leftOperand?.trim() || '""';
+  const right = rule.rightOperand?.trim();
+  // Unary operators (isEmpty, exists, ...) carry no right operand.
+  return right
+    ? `${left} ${rule.operator} ${right}`
+    : `${left} ${rule.operator}`;
+}
+
+// Append a group's rules as a numbered list with the AND/OR operator placed
+// between consecutive rules, mirroring the visual builder (where the operator
+// sits between the conditions it joins) instead of a single JSON blob.
+function appendConditionGroup(
+  lines: string[],
+  group: ConditionGroup,
+  depth: number
+): void {
+  const pad = "  ".repeat(depth);
+  const logic = group.logic ?? "AND";
+  const rules = Array.isArray(group.rules) ? group.rules : [];
+  for (const [i, item] of rules.entries()) {
+    if (i > 0) {
+      lines.push(`${pad}${logic}`);
+    }
+    if (isConditionGroup(item)) {
+      lines.push(`${pad}${i + 1}. group`);
+      appendConditionGroup(lines, item, depth + 1);
+    } else {
+      lines.push(`${pad}${i + 1}. ${conditionRuleText(item)}`);
+    }
+  }
+}
+
+// A Condition node's `conditionConfig` is the visual builder state; on its own
+// it reads as a dense JSON object. Render it as an ordered rule list so the
+// history diff is legible and the rule order is preserved.
+function namedConditionConfig(value: unknown): string | null {
+  let parsed: unknown;
+  try {
+    parsed = typeof value === "string" ? JSON.parse(value) : value;
+  } catch {
+    return null;
+  }
+  const group = (parsed as { group?: ConditionGroup } | null)?.group;
+  if (!(group && Array.isArray(group.rules))) {
+    return null;
+  }
+  const lines: string[] = [];
+  appendConditionGroup(lines, group, 0);
+  return cleanTemplateRefs(lines.join("\n"));
+}
+
+function configChangeValue(
+  config: AnyRecord,
+  key: string,
+  value: unknown
+): string {
+  if (key === "functionArgs") {
+    return namedContractArgs(config, value) ?? configValueText(value);
+  }
+  if (key === "conditionConfig") {
+    return namedConditionConfig(value) ?? configValueText(value);
+  }
+  return configValueText(value);
 }
 
 function changedConfigDetails(
@@ -160,8 +283,8 @@ function changedConfigDetails(
     if (JSON.stringify(before[key]) !== JSON.stringify(after[key])) {
       changed.push({
         key,
-        before: shortConfigValue(before[key]),
-        after: shortConfigValue(after[key]),
+        before: configChangeValue(before, key, before[key]),
+        after: configChangeValue(after, key, after[key]),
       });
     }
   }
@@ -233,9 +356,14 @@ function connectionRef(
   edge: AnyRecord,
   labels: Map<string, string>
 ): ConnectionRef {
-  const from = labels.get(String(edge.source)) ?? String(edge.source);
-  const to = labels.get(String(edge.target)) ?? String(edge.target);
-  return { from, to };
+  const fromId = String(edge.source);
+  const toId = String(edge.target);
+  return {
+    from: labels.get(fromId) ?? fromId,
+    to: labels.get(toId) ?? toId,
+    fromId,
+    toId,
+  };
 }
 
 function diffSettings(

--- a/tests/unit/version-diff.test.ts
+++ b/tests/unit/version-diff.test.ts
@@ -54,6 +54,114 @@ describe("computeVersionDiff", () => {
     expect(delta.configKeys).toEqual(["amount"]);
   });
 
+  it("names web3 contract arguments by their ABI parameter", () => {
+    const abi = JSON.stringify([
+      {
+        type: "function",
+        name: "addPerson",
+        inputs: [
+          { name: "_name", type: "string" },
+          { name: "_favoriteNumber", type: "uint256" },
+        ],
+        outputs: [],
+      },
+    ]);
+    const cfg = (functionArgs: string) => ({
+      actionType: "web3/write-contract",
+      abi,
+      abiFunction: "addPerson",
+      functionArgs,
+    });
+    const before = {
+      nodes: [node("n1", "Write Contract", cfg(JSON.stringify(["", "7"])))],
+      edges: [],
+    };
+    const after = {
+      nodes: [node("n1", "Write Contract", cfg(JSON.stringify(["joel", "7"])))],
+      edges: [],
+    };
+    const delta = computeVersionDiff(before, after).nodesChanged[0].deltas.find(
+      (d) => d.field === "configuration"
+    );
+    const change = delta?.configChanges?.find((c) => c.key === "functionArgs");
+    expect(change?.before).toBe(
+      '{\n  "_name": "",\n  "_favoriteNumber": "7"\n}'
+    );
+    expect(change?.after).toBe(
+      '{\n  "_name": "joel",\n  "_favoriteNumber": "7"\n}'
+    );
+  });
+
+  it("renders conditionConfig as an ordered rule list", () => {
+    const conditionConfig = {
+      group: {
+        id: "g1",
+        logic: "AND",
+        rules: [
+          {
+            id: "r1",
+            leftOperand: "{{Manual.triggeredAt}}",
+            operator: "==",
+            rightOperand: "{{Write Contract.success}}",
+          },
+          {
+            id: "r2",
+            leftOperand: "{{Write Contract.success}}",
+            operator: "==",
+            rightOperand: "{{System.unixTimestamp}}",
+          },
+        ],
+      },
+    };
+    const cfg = (rightOperand: string) => ({
+      actionType: "Condition",
+      conditionConfig: JSON.stringify({
+        group: {
+          ...conditionConfig.group,
+          rules: [
+            conditionConfig.group.rules[0],
+            { ...conditionConfig.group.rules[1], rightOperand },
+          ],
+        },
+      }),
+    });
+    const before = {
+      nodes: [node("n1", "Condition", cfg(""))],
+      edges: [],
+    };
+    const after = {
+      nodes: [node("n1", "Condition", cfg("{{System.unixTimestamp}}"))],
+      edges: [],
+    };
+    const delta = computeVersionDiff(before, after).nodesChanged[0].deltas.find(
+      (d) => d.field === "configuration"
+    );
+    const change = delta?.configChanges?.find(
+      (c) => c.key === "conditionConfig"
+    );
+    expect(change?.after).toBe(
+      "1. {{Manual.triggeredAt}} == {{Write Contract.success}}\nAND\n2. {{Write Contract.success}} == {{System.unixTimestamp}}"
+    );
+    // Rule order is preserved and the empty right operand renders as a bare op.
+    expect(change?.before).toBe(
+      "1. {{Manual.triggeredAt}} == {{Write Contract.success}}\nAND\n2. {{Write Contract.success}} =="
+    );
+  });
+
+  it("tags connection refs with endpoint node ids", () => {
+    const before = {
+      nodes: [node("n1", "Trigger"), node("n2", "Send")],
+      edges: [],
+    };
+    const after = {
+      nodes: [node("n1", "Trigger"), node("n2", "Send")],
+      edges: [{ id: "e1", source: "n1", target: "n2" }],
+    };
+    expect(computeVersionDiff(before, after).connectionsAdded).toEqual([
+      { from: "Trigger", to: "Send", fromId: "n1", toId: "n2" },
+    ]);
+  });
+
   it("detects added and removed connections with node labels", () => {
     const before = {
       nodes: [node("n1", "Trigger"), node("n2", "Send")],
@@ -64,9 +172,11 @@ describe("computeVersionDiff", () => {
       edges: [{ id: "e1", source: "n1", target: "n2" }],
     };
     const diff = computeVersionDiff(before, after);
-    expect(diff.connectionsAdded).toEqual([{ from: "Trigger", to: "Send" }]);
+    expect(diff.connectionsAdded).toEqual([
+      { from: "Trigger", to: "Send", fromId: "n1", toId: "n2" },
+    ]);
     expect(computeVersionDiff(after, before).connectionsRemoved).toEqual([
-      { from: "Trigger", to: "Send" },
+      { from: "Trigger", to: "Send", fromId: "n1", toId: "n2" },
     ]);
   });
 


### PR DESCRIPTION
## Summary
Comparing workflow versions in the History tab was hard to use: long config values were truncated and could not be copied or compared, contract arguments showed as a bare positional array, condition rules rendered as a dense JSON blob, and a node's connection changes disappeared from its per-node history once the node was renamed.

This change reworks how the version diff is computed and displayed:

- **Full, copyable values.** Config values are stored in full instead of being truncated to 80 characters, and each before/after value chip has a copy button. Long values wrap so they can be read and compared in place.
- **Named contract arguments.** Web3 contract `functionArgs` render as named, pretty-printed JSON, with parameter names resolved from the node's ABI and selected function, instead of a positional array.
- **Readable condition rules.** A Condition node's `conditionConfig` renders as an ordered, numbered rule list with the AND/OR operator placed between the rules it joins, mirroring the visual builder, instead of raw JSON.
- **Per-node connection history survives renames.** Connection diffs now carry the endpoint node ids, and the per-node History view matches connections by id (falling back to label for older diffs), so a node's connect/disconnect events stay visible after it is renamed.
- **Editor email.** Each version row shows the editor's email beneath their name, since display names can change but emails are stable.

The diff is computed and stored when a version is recorded, so the richer formatting applies to versions created from this change onward; existing rows keep their previous form.

## Tests
Unit tests in `tests/unit/version-diff.test.ts` cover the named-argument formatting, the ordered condition rendering, and the connection node-id tagging.
