### PR TITLE
fix(ci): skip prod ECR image in e2e, fall back to bare-metal build

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -26,6 +26,12 @@ jobs:
   # - Push to staging or prod
   # - PRs with run-e2e-tests-ephemeral label
   # - Manual workflow_dispatch
+  #
+  # The e2e job always runs under the staging environment (staging creds, test
+  # endpoints). On a prod push, build-images builds and pushes to the prod ECR
+  # repo with prod creds, and the prod image strips test endpoints -- so the
+  # staging-cred e2e job can neither pull that image nor exercise it. Withhold
+  # the ECR coordinates on prod so e2e falls back to its bare-metal source build.
   e2e-tests:
     needs: [build-images]
     if: ${{ !failure() && !cancelled() }}
@@ -35,10 +41,10 @@ jobs:
       caller_action: ${{ github.event.action }}
       has_e2e_label: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-e2e-tests-ephemeral') || false }}
       label_name: ${{ github.event.label.name || '' }}
-      image_tag: ${{ needs.build-images.outputs.image_tag || '' }}
-      ecr_registry: ${{ needs.build-images.outputs.ecr_registry || '' }}
-      ecr_repo: ${{ needs.build-images.outputs.ecr_repo || '' }}
-      ecr_region: ${{ needs.build-images.outputs.ecr_region || '' }}
+      image_tag: ${{ github.ref_name == 'prod' && '' || (needs.build-images.outputs.image_tag || '') }}
+      ecr_registry: ${{ github.ref_name == 'prod' && '' || (needs.build-images.outputs.ecr_registry || '') }}
+      ecr_repo: ${{ github.ref_name == 'prod' && '' || (needs.build-images.outputs.ecr_repo || '') }}
+      ecr_region: ${{ github.ref_name == 'prod' && '' || (needs.build-images.outputs.ecr_region || '') }}
     secrets: inherit
 
   # Deploy runs after build-images and e2e-tests.


### PR DESCRIPTION
## Problem

On a `prod` push, the prod deploy pipeline fails when the e2e job tries to pull the app image:

```
denied: User: arn:aws:iam::020732533267:user/techops-staging-cicd is not
authorized to perform: ecr:BatchGetImage on resource: .../keeperhub-prod
```

Root cause is a credential and image mismatch in the CI pipeline:

- `build-images` runs under the `prod` environment on prod pushes, builds and pushes the app image to the `keeperhub-prod` ECR repo using prod credentials, and outputs `ecr_repo=keeperhub-prod`.
- `ci-pipeline` forwards those prod ECR coordinates into the e2e job.
- The e2e workflow is hard-pinned to `environment: staging`, so it authenticates as the staging CICD user and tries to pull `keeperhub-prod:app-<sha>`. The staging user has no access to the prod repo, hence the denial.

It is doubly broken: the prod image is built without `INCLUDE_TEST_ENDPOINTS`, so even with pull access the e2e suite could not exercise it.

## Fix

Withhold the ECR coordinates from the e2e job on prod refs. The e2e workflow already builds bare-metal from source whenever `image_tag` is empty, so on prod it now falls back to that path: staging credentials, test endpoints enabled. This keeps e2e as a deploy gate without the credential and test-endpoint mismatch. Staging and PR behavior are unchanged.
