### PR TITLE
fix(ci): reuse prebuilt e2e image only on staging push

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -41,10 +41,14 @@ jobs:
       caller_action: ${{ github.event.action }}
       has_e2e_label: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-e2e-tests-ephemeral') || false }}
       label_name: ${{ github.event.label.name || '' }}
-      image_tag: ${{ github.ref_name == 'prod' && '' || (needs.build-images.outputs.image_tag || '') }}
-      ecr_registry: ${{ github.ref_name == 'prod' && '' || (needs.build-images.outputs.ecr_registry || '') }}
-      ecr_repo: ${{ github.ref_name == 'prod' && '' || (needs.build-images.outputs.ecr_repo || '') }}
-      ecr_region: ${{ github.ref_name == 'prod' && '' || (needs.build-images.outputs.ecr_region || '') }}
+      # Only a staging push reuses the prebuilt ECR image. An empty string is
+      # falsy in Actions expressions, so the value we want to pass through (the
+      # build output) MUST sit on the `&&` side and '' must be the fallthrough;
+      # `cond && '' || build_output` would always yield build_output.
+      image_tag: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.image_tag || '') || '' }}
+      ecr_registry: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.ecr_registry || '') || '' }}
+      ecr_repo: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.ecr_repo || '') || '' }}
+      ecr_region: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.ecr_region || '') || '' }}
     secrets: inherit
 
   # Deploy runs after build-images and e2e-tests.


### PR DESCRIPTION
## Problem

On a `prod` push the deploy pipeline fails at `e2e-tests / e2e-vitest-ephemeral` -> Start application. The e2e job runs under staging credentials but is handed the prod ECR coordinates, so the `docker pull` of the prod app image is denied:

```
denied: User: arn:aws:iam::020732533267:user/techops-staging-cicd is not
authorized to perform: ecr:BatchGetImage on resource: .../keeperhub-prod
```

## Why the previous attempt was a no-op

The earlier guard withheld the coordinates with:

```
image_tag: ${{ github.ref_name == 'prod' && '' || (needs.build-images.outputs.image_tag || '') }}
```

An empty string is falsy in Actions expressions, so on a prod push `true && ''` collapses to `''` and the expression falls through to `|| build_output`. `image_tag` was still the prod build output, the Docker path (`if: inputs.image_tag != ''`) still ran, and the pull still failed.

## Fix

Whitelist `staging` so the truthy build output sits on the `&&` side and `''` is the natural fallthrough:

```
image_tag: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.image_tag || '') || '' }}
```
(same for `ecr_registry` / `ecr_repo` / `ecr_region`)

- staging push -> reuses the prebuilt image (Docker path, unchanged)
- prod push -> empty -> bare-metal source build (no ECR pull)
- PR / dispatch -> empty -> bare-metal (unchanged)

Bare-metal on prod is the correct end state: the prod image is built without `INCLUDE_TEST_ENDPOINTS`, so the e2e suite could not exercise it even with pull access.

## Validation

- YAML parses clean.
- Expression evaluated against Actions truthiness for all three trigger cases (staging push -> Docker, prod push -> bare-metal, PR/dispatch -> bare-metal).
- CI-YAML-only change; the repo CI does not lint workflows, so there is no app pipeline to run locally for this diff.