### PR TITLE
fix(metrics): scope getWorkflowStatsFromDb queries to a 1-hour window (TECH-55)

### DIFF
--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -127,6 +127,9 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
     // Postgres groups NULLs together (NULLs are equal in GROUP BY), and the
     // SELECT-side expressions render those groups as ANONYMOUS_ORG_SLUG /
     // "unknown" / "na" as appropriate.
+    //
+    // Bounded to startedAt >= now() - 1h. startedAt is used instead of
+    // completedAt so in-flight running/pending rows are included.
     const breakdown = await db
       .select({
         status: workflowExecutions.status,
@@ -141,6 +144,9 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
       .from(workflowExecutions)
       .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
       .leftJoin(organization, eq(workflows.organizationId, organization.id))
+      .where(
+        gte(workflowExecutions.startedAt, sql`now() - interval '1 hour'`)
+      )
       .groupBy(
         workflowExecutions.status,
         organization.slug,
@@ -197,7 +203,8 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
       .where(
         and(
           sql`${workflowExecutions.status} IN ('success', 'error')`,
-          sql`${workflowExecutions.duration} IS NOT NULL`
+          sql`${workflowExecutions.duration} IS NOT NULL`,
+          gte(workflowExecutions.startedAt, sql`now() - interval '1 hour'`)
         )
       );
 


### PR DESCRIPTION
Both queries inside `getWorkflowStatsFromDb` in `lib/metrics/db-metrics.ts` were unbounded full-table scans: the breakdown query aggregated all-time execution counts across `workflow_executions` with no WHERE clause, and the duration histogram query scanned the same table filtered only on status and a non-null duration.

In prod, both consistently exceeded the 8-second metrics `statement_timeout`, which generated RDS memory pressure that cascaded into statement cancellations for the workflow runner pods and recorded those as `workflow_engine` system errors (["Incident #32940"](https://docs.google.com/document/d/19u28oZvaCt08RhL-EdsF7TyJN7k6_gvtSbwYeVTq1Kc/edit?tab=t.0#heading=h.5rfsaupzrcdb)). This is the same class of bug fixed for `getStepStatsFromDb` in PR #1607 ([TECH-53](https://linear.app/keeperhubapp/issue/TECH-53/deal-with-increasing-amount-of-swap-usage-alerts)).

The fix adds `startedAt >= now() - interval '1 hour'` to both queries, matching the pattern already used by `getWorkflowErrorsByWorkflowFromDb` and `getSystemErrorsByCategoryFromDb`.

`startedAt` is used rather than `completedAt` on the breakdown query so in-flight `running` and `pending` executions started within the window are still counted.