### PR TITLE
refactor: unify console logging into a single structured contract

### DIFF
--- a/app/api/ai/generate/route.ts
+++ b/app/api/ai/generate/route.ts
@@ -4,7 +4,7 @@ import type { LanguageModelV2 } from "@ai-sdk/provider";
 import { streamText } from "ai";
 import { NextResponse } from "next/server";
 import { HttpStatus } from "@/lib/http-status";
-import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { ErrorCategory, logSystemError, logWarn } from "@/lib/logging";
 import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { createTimer, getMetricsCollector } from "@/lib/metrics";
 import { MetricNames } from "@/lib/metrics/types";
@@ -76,7 +76,9 @@ function tryParseAndEnqueueOperation(
 
     return newCount;
   } catch {
-    console.warn("[API] Skipping invalid JSON line:", trimmed.substring(0, 50));
+    logWarn("[API] Skipping invalid JSON line", {
+      line_preview: trimmed.substring(0, 50),
+    });
     return operationCount;
   }
 }

--- a/app/api/cron/security-behavioral-scan/route.ts
+++ b/app/api/cron/security-behavioral-scan/route.ts
@@ -34,11 +34,11 @@
  * to a single page), not from this endpoint.
  */
 
-import { captureMessage } from "@sentry/nextjs";
 import { and, eq, gt, isNotNull } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { users, workflowExecutions } from "@/lib/db/schema";
 import { authenticateInternalService } from "@/lib/internal-service-auth";
+import { logSecurityEvent } from "@/lib/logging";
 
 export const dynamic = "force-dynamic";
 
@@ -104,9 +104,17 @@ async function scanNewAccountFirstWorkflow(
     // executionId so those duplicates collapse into a single Sentry issue
     // (Loki already dedupes the page); the row's full detail still rides on
     // each event's tags/extra for triage.
-    try {
-      captureMessage("security.behavioral.new_account_first_workflow", {
-        level: "warning",
+    logSecurityEvent(
+      "behavioral.new_account_first_workflow",
+      {
+        userId: row.userId,
+        workflowId: row.workflowId,
+        executionId: row.executionId,
+        triggerSource: row.triggerSource,
+        triggeredByCountry: row.triggeredByCountry,
+        ageSecondsSinceSignup: ageSeconds,
+      },
+      {
         fingerprint: [
           "security.behavioral.new_account_first_workflow",
           row.executionId,
@@ -122,20 +130,7 @@ async function scanNewAccountFirstWorkflow(
           triggeredByCountry: row.triggeredByCountry,
           ageSecondsSinceSignup: ageSeconds,
         },
-      });
-    } catch {
-      // swallow; observability must not interrupt the scan
-    }
-    console.warn(
-      JSON.stringify({
-        event: "security.behavioral.new_account_first_workflow",
-        userId: row.userId,
-        workflowId: row.workflowId,
-        executionId: row.executionId,
-        triggerSource: row.triggerSource,
-        triggeredByCountry: row.triggeredByCountry,
-        ageSecondsSinceSignup: ageSeconds,
-      })
+      }
     );
   }
 
@@ -178,21 +173,15 @@ export async function GET(request: Request): Promise<Response> {
     // observable as its own event rather than a bare job-failure alert, then
     // surface the 500. Mirrors content-scanner's security.content_scanner_error.
     const message = error instanceof Error ? error.message : String(error);
-    try {
-      captureMessage("security.behavioral.scan_error", {
+    const durationMs = Date.now() - startedAt;
+    logSecurityEvent(
+      "behavioral.scan_error",
+      { message, durationMs },
+      {
         level: "error",
         tags: { security: "behavioral.scan_error" },
-        extra: { message, durationMs: Date.now() - startedAt },
-      });
-    } catch {
-      // never let the failure-signal emission mask the original error
-    }
-    console.error(
-      JSON.stringify({
-        event: "security.behavioral.scan_error",
-        message,
-        durationMs: Date.now() - startedAt,
-      })
+        extra: { message, durationMs },
+      }
     );
     return Response.json({ error: "scan_failed" }, { status: 500 });
   }

--- a/app/api/notifications/status/route.ts
+++ b/app/api/notifications/status/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { isBillingEnabled } from "@/lib/billing/feature-flag";
 import { isBillingLimitReached } from "@/lib/billing/limit-status";
+import { ErrorCategory, logSystemWarn } from "@/lib/logging";
 import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
 
 export type NotificationType = "billing_limit_reached";
@@ -41,7 +42,8 @@ export async function GET(
 
     return NextResponse.json({ unreadCount: types.length, types });
   } catch (error) {
-    console.warn(
+    logSystemWarn(
+      ErrorCategory.INFRASTRUCTURE,
       "[notifications-status] degraded; returning empty response",
       error
     );

--- a/app/api/web3/fetch-abi/route.ts
+++ b/app/api/web3/fetch-abi/route.ts
@@ -7,7 +7,7 @@ import { db } from "@/lib/db";
 import { explorerConfigs } from "@/lib/db/schema";
 import { fetchEtherscanSourceCode } from "@/lib/explorer/etherscan";
 import { detectProxyViaRpc } from "@/lib/explorer/proxy-detection";
-import { ErrorCategory, logUserError } from "@/lib/logging";
+import { ErrorCategory, logUserError, logWarn } from "@/lib/logging";
 import { SCOPE_MCP_READ } from "@/lib/mcp/oauth-scopes";
 import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
 import { requireScope } from "@/lib/middleware/require-scope";
@@ -437,9 +437,11 @@ async function fetchOneFacet(
   try {
     facetAbi = await fetchAbiFromAddress(baseUrl, chainId, facetAddress);
   } catch (error) {
-    console.warn(
-      `[Diamond] Failed to fetch ABI for facet ${facetAddress}:`,
-      error instanceof Error ? error.message : "Unknown error"
+    logUserError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      `[Diamond] Failed to fetch ABI for facet ${facetAddress}`,
+      error,
+      { service: "etherscan", component: "diamond-proxy" }
     );
     return { address: facetAddress, name: null, failed: true };
   }
@@ -587,9 +589,11 @@ async function handleDiamondContract(
       );
     }
   } catch (error) {
-    console.warn(
-      "[Diamond] RPC loupe failed, using Etherscan facet list if available:",
-      error instanceof Error ? error.message : "Unknown error"
+    logUserError(
+      ErrorCategory.NETWORK_RPC,
+      "[Diamond] RPC loupe failed, using Etherscan facet list if available",
+      error,
+      { component: "diamond-proxy" }
     );
   }
 
@@ -641,7 +645,9 @@ async function handleDiamondContract(
       `[Diamond] Combined ${facetAbis.length} facet ABIs into one ABI with ${functionCount} total functions`
     );
   } catch (error) {
-    console.warn("[Diamond] Failed to parse combined ABI for stats:", error);
+    logWarn("[Diamond] Failed to parse combined ABI for stats", {
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 
   let diamondDirectAbi: string | undefined;
@@ -879,9 +885,11 @@ async function fetchProxyAbi(
     console.log("[Etherscan] Fetched proxy ABI directly");
     return proxyAbi;
   } catch (error) {
-    console.warn(
-      "[Etherscan] Failed to fetch proxy ABI:",
-      error instanceof Error ? error.message : "Unknown error"
+    logUserError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      "[Etherscan] Failed to fetch proxy ABI",
+      error,
+      { service: "etherscan" }
     );
     return;
   }
@@ -918,7 +926,9 @@ async function handleRegularProxy(
 
   // Validate implementation address
   if (!ethers.isAddress(implementationAddress)) {
-    console.warn("[Etherscan] Invalid implementation address, using proxy ABI");
+    logWarn("[Etherscan] Invalid implementation address, using proxy ABI", {
+      service: "etherscan",
+    });
     const proxyAbi = await fetchAbiFromAddress(
       baseUrl,
       chainId,
@@ -958,9 +968,11 @@ async function handleRegularProxy(
       proxyAbi,
     };
   } catch (error) {
-    console.warn(
-      "[Etherscan] Failed to fetch implementation ABI:",
-      error instanceof Error ? error.message : "Unknown error"
+    logUserError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      "[Etherscan] Failed to fetch implementation ABI",
+      error,
+      { service: "etherscan" }
     );
 
     if (proxyAbi) {
@@ -1013,9 +1025,11 @@ async function tryRpcDetectionOnAbiFailure(
       };
     }
   } catch (rpcError) {
-    console.warn(
-      "[Etherscan] RPC proxy detection also failed:",
-      rpcError instanceof Error ? rpcError.message : "Unknown error"
+    logUserError(
+      ErrorCategory.NETWORK_RPC,
+      "[Etherscan] RPC proxy detection also failed",
+      rpcError,
+      { component: "proxy-detection" }
     );
   }
   throw error;
@@ -1068,9 +1082,11 @@ async function tryRpcDetectionOnProxyPattern(
       };
     }
   } catch (rpcError) {
-    console.warn(
-      "[Etherscan] RPC proxy detection failed:",
-      rpcError instanceof Error ? rpcError.message : "Unknown error"
+    logUserError(
+      ErrorCategory.NETWORK_RPC,
+      "[Etherscan] RPC proxy detection failed",
+      rpcError,
+      { component: "proxy-detection" }
     );
   }
   return null;

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -1,7 +1,7 @@
 import { and, eq, inArray, sql } from "drizzle-orm";
 import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
-import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { ErrorCategory, logSystemError, logSystemWarn } from "@/lib/logging";
 import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { requireScope } from "@/lib/middleware/require-scope";
@@ -335,9 +335,11 @@ async function handlePostUpdateSideEffects(
       body.nodes as Parameters<typeof syncWorkflowSchedule>[1]
     );
     if (!syncResult.synced) {
-      console.warn(
-        `[Workflow] Schedule sync failed for ${workflowId}:`,
-        syncResult.error
+      logSystemWarn(
+        ErrorCategory.WORKFLOW_ENGINE,
+        "[Workflow] Schedule sync failed",
+        syncResult.error,
+        { workflow_id: workflowId }
       );
     }
   }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next";
 import { db } from "@/lib/db";
 import { publicTags } from "@/lib/db/schema";
+import { logWarn } from "@/lib/logging";
 
 const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.keeperhub.com";
 
@@ -34,10 +35,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     if (isConfiguredProdBuild) {
       throw err;
     }
-    console.warn(
-      "[sitemap] tag DB read failed, emitting static-only sitemap:",
-      err
-    );
+    logWarn("[sitemap] tag DB read failed, emitting static-only sitemap", {
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 
   const tagEntries: MetadataRoute.Sitemap = tagRows.map((row) => ({

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -29,6 +29,8 @@
       "!lib/atoms",
       "!keeperhub-events",
       "!keeperhub-scheduler",
+      "!keeperhub-executor",
+      "!keeperhub-metrics-collector",
       "!.history",
       "!tests/k6",
       "!packages/*/dist",
@@ -51,7 +53,17 @@
         // Bitwise operators are legitimate for hashing/masking
         "noBitwiseOperators": "off",
         // New rule from biome bump - pre-existing test.skip() to be addressed separately
-        "noSkippedTests": "off"
+        "noSkippedTests": "off",
+        // KEEP-814: route failures through the structured logger
+        // (logSystemError / logUserError / logSystemWarn) so they reach
+        // Prometheus + Sentry. console.log/info/debug stay allowed (the
+        // lib/logger facade normalizes them to canonical JSON); console.warn /
+        // console.error are disallowed in server code. Client (browser),
+        // tests, and the logging infra itself are exempted in `overrides`.
+        "noConsole": {
+          "level": "error",
+          "options": { "allow": ["log", "info", "debug"] }
+        }
       },
       "nursery": {
         // These are experimental rules that add friction without clear benefit
@@ -62,5 +74,29 @@
         "noSubstr": "off"
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      // noConsole is server-only. These paths legitimately use console:
+      //  - client/browser code (logs go to the browser console + client Sentry;
+      //    the server logger's ALS/Prometheus path does not apply)
+      //  - tests (console spies and scaffolding)
+      //  - the logging infra itself (captures/patches the real console)
+      //  - staging-only admin test routes
+      "includes": [
+        "components/**",
+        "app/page.tsx",
+        "app/accept-invite/**",
+        "app/workflows/**",
+        "lib/hooks/**",
+        "lib/api-client.ts",
+        "tests/**",
+        "**/*.staging.ts",
+        "lib/log/core.ts",
+        "lib/logger.ts",
+        "instrumentation.ts"
+      ],
+      "linter": { "rules": { "suspicious": { "noConsole": "off" } } }
+    }
+  ]
 }

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -13,14 +13,19 @@ import {
 const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN || process.env.SENTRY_DSN;
 const SENTRY_ENVIRONMENT = process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT;
 
+// Env-driven performance-trace sampling; defaults to 0.1 (errors are always
+// captured regardless). Override via NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE
+// (must be NEXT_PUBLIC_ to reach the browser bundle).
+const tracesEnv = process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE;
+const tracesSampleRate =
+  tracesEnv && Number.isFinite(Number(tracesEnv)) ? Number(tracesEnv) : 0.1;
+
 if (SENTRY_DSN) {
   init({
     dsn: SENTRY_DSN,
     ...(SENTRY_ENVIRONMENT && { environment: SENTRY_ENVIRONMENT }),
 
-    // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-    // 1 = 100% of traces are sent
-    tracesSampleRate: 1,
+    tracesSampleRate,
 
     // Enable logs to be sent to Sentry
     enableLogs: true,

--- a/keeperhub-events/event-tracker/lib/utils/logger.ts
+++ b/keeperhub-events/event-tracker/lib/utils/logger.ts
@@ -1,3 +1,24 @@
+/**
+ * Event-tracker structured logger.
+ *
+ * Emits canonical single-line JSON ({ level, ts, msg, ... }) matching the
+ * KeeperHub app's logging contract (lib/log/core.ts) so Grafana Loki can query
+ * across the app and all satellite services uniformly via `| json`. Previously
+ * this emitted multi-line pretty-printed JSON (`log :: <ts> - {...}`), which
+ * broke line-based aggregation. Kept dependency-free: this is a separate
+ * package and cannot import the app's `@/lib/*`.
+ */
+
+type LogLevel = "info" | "warn" | "error";
+
+function safeStringify(data: unknown): string {
+  try {
+    return JSON.stringify(data);
+  } catch {
+    return String(data);
+  }
+}
+
 export class Logger {
   private logger: Console;
 
@@ -5,26 +26,36 @@ export class Logger {
     this.logger = loggerInstance;
   }
 
+  private emit(level: LogLevel, message: unknown): void {
+    const msg = typeof message === "string" ? message : safeStringify(message);
+    const line = JSON.stringify({
+      level,
+      ts: new Date().toISOString(),
+      msg,
+    });
+    if (level === "error") {
+      this.logger.error(line);
+    } else if (level === "warn") {
+      this.logger.warn(line);
+    } else {
+      this.logger.log(line);
+    }
+  }
+
   log(message: unknown): void {
-    this.logger.log(
-      `log :: ${new Date().toISOString()} - ${this.stringify(message)}`,
-    );
+    this.emit("info", message);
   }
 
   error(message: unknown): void {
-    this.logger.error(
-      `error :: ${new Date().toISOString()} - ${this.stringify(message)}`,
-    );
+    this.emit("error", message);
   }
 
   warn(message: unknown): void {
-    this.logger.warn(
-      `warn :: ${new Date().toISOString()} - ${this.stringify(message)}`,
-    );
+    this.emit("warn", message);
   }
 
   stringify(data: unknown): string {
-    return JSON.stringify(data, null, 2);
+    return safeStringify(data);
   }
 
   formatAddress(address: string): string {

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -21,6 +21,9 @@
  *   JOB_ACTIVE_DEADLINE - Max Job execution time in seconds (default: 300)
  */
 
+// Normalize all console.* output in this process to canonical JSON. Must be
+// the first import so the patch installs before any module logs.
+import "./log-facade";
 import { createServer, type IncomingMessage } from "node:http";
 import {
   DeleteMessageCommand,

--- a/keeperhub-executor/log-facade.ts
+++ b/keeperhub-executor/log-facade.ts
@@ -52,7 +52,7 @@ function describe(arg: unknown): string {
 function emit(
   level: LogLevel,
   write: (line: string) => void,
-  args: unknown[]
+  args: unknown[],
 ): void {
   if (LEVELS[level] < threshold()) {
     return;

--- a/keeperhub-executor/log-facade.ts
+++ b/keeperhub-executor/log-facade.ts
@@ -1,0 +1,82 @@
+/**
+ * Vendored console facade for the keeperhub-executor satellite.
+ *
+ * Normalizes all console.* output in this process to canonical single-line
+ * JSON ({ level, ts, msg, err? }) matching the KeeperHub app's logging contract
+ * (lib/log/core.ts), so Grafana Loki `| json` works uniformly across the app
+ * and every satellite service. Import this module FIRST at the service
+ * entrypoint, before any module that logs.
+ *
+ * Self-contained by design: satellites are separate packages and cannot import
+ * the app's `@/lib/*`. Keep in sync with the app's lib/log/core.ts +
+ * lib/logger.ts.
+ */
+
+type LogLevel = "debug" | "info" | "warn" | "error";
+
+const LEVELS: Record<string, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+  silent: 4,
+};
+
+const original = {
+  log: console.log.bind(console),
+  info: console.info.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  debug: console.debug.bind(console),
+};
+
+function threshold(): number {
+  const level = (process.env.LOG_LEVEL || "info").toLowerCase();
+  return level in LEVELS ? LEVELS[level] : LEVELS.info;
+}
+
+function describe(arg: unknown): string {
+  if (typeof arg === "string") {
+    return arg;
+  }
+  if (arg instanceof Error) {
+    return `${arg.name}: ${arg.message}`;
+  }
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
+}
+
+function emit(
+  level: LogLevel,
+  write: (line: string) => void,
+  args: unknown[]
+): void {
+  if (LEVELS[level] < threshold()) {
+    return;
+  }
+  const payload: Record<string, unknown> = {
+    level,
+    ts: new Date().toISOString(),
+    msg: args.map(describe).join(" "),
+  };
+  const error = args.find((a): a is Error => a instanceof Error);
+  if (error) {
+    payload.err = {
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+    };
+  }
+  write(JSON.stringify(payload));
+}
+
+console.debug = (...args: unknown[]) => emit("debug", original.debug, args);
+console.log = (...args: unknown[]) => emit("info", original.log, args);
+console.info = (...args: unknown[]) => emit("info", original.info, args);
+console.warn = (...args: unknown[]) => emit("warn", original.warn, args);
+console.error = (...args: unknown[]) => emit("error", original.error, args);
+
+export {};

--- a/keeperhub-metrics-collector/index.ts
+++ b/keeperhub-metrics-collector/index.ts
@@ -12,6 +12,9 @@
  *   PORT          HTTP port for /metrics and /health (default 9090)
  *   DATABASE_URL  Postgres connection (consumed by lib/db)
  */
+// Normalize all console.* output in this process to canonical JSON. Must be
+// the first import so the patch installs before any module logs.
+import "./log-facade";
 import type { Server } from "node:http";
 import { buildServer } from "./server";
 

--- a/keeperhub-metrics-collector/log-facade.ts
+++ b/keeperhub-metrics-collector/log-facade.ts
@@ -1,0 +1,82 @@
+/**
+ * Vendored console facade for the keeperhub-metrics-collector satellite.
+ *
+ * Normalizes all console.* output in this process to canonical single-line
+ * JSON ({ level, ts, msg, err? }) matching the KeeperHub app's logging contract
+ * (lib/log/core.ts), so Grafana Loki `| json` works uniformly across the app
+ * and every satellite service. Import this module FIRST at the service
+ * entrypoint, before any module that logs.
+ *
+ * Self-contained by design: satellites are separate packages and cannot import
+ * the app's `@/lib/*`. Keep in sync with the app's lib/log/core.ts +
+ * lib/logger.ts.
+ */
+
+type LogLevel = "debug" | "info" | "warn" | "error";
+
+const LEVELS: Record<string, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+  silent: 4,
+};
+
+const original = {
+  log: console.log.bind(console),
+  info: console.info.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  debug: console.debug.bind(console),
+};
+
+function threshold(): number {
+  const level = (process.env.LOG_LEVEL || "info").toLowerCase();
+  return level in LEVELS ? LEVELS[level] : LEVELS.info;
+}
+
+function describe(arg: unknown): string {
+  if (typeof arg === "string") {
+    return arg;
+  }
+  if (arg instanceof Error) {
+    return `${arg.name}: ${arg.message}`;
+  }
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
+}
+
+function emit(
+  level: LogLevel,
+  write: (line: string) => void,
+  args: unknown[]
+): void {
+  if (LEVELS[level] < threshold()) {
+    return;
+  }
+  const payload: Record<string, unknown> = {
+    level,
+    ts: new Date().toISOString(),
+    msg: args.map(describe).join(" "),
+  };
+  const error = args.find((a): a is Error => a instanceof Error);
+  if (error) {
+    payload.err = {
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+    };
+  }
+  write(JSON.stringify(payload));
+}
+
+console.debug = (...args: unknown[]) => emit("debug", original.debug, args);
+console.log = (...args: unknown[]) => emit("info", original.log, args);
+console.info = (...args: unknown[]) => emit("info", original.info, args);
+console.warn = (...args: unknown[]) => emit("warn", original.warn, args);
+console.error = (...args: unknown[]) => emit("error", original.error, args);
+
+export {};

--- a/keeperhub-metrics-collector/log-facade.ts
+++ b/keeperhub-metrics-collector/log-facade.ts
@@ -52,7 +52,7 @@ function describe(arg: unknown): string {
 function emit(
   level: LogLevel,
   write: (line: string) => void,
-  args: unknown[]
+  args: unknown[],
 ): void {
   if (LEVELS[level] < threshold()) {
     return;

--- a/keeperhub-scheduler/block-dispatcher/index.ts
+++ b/keeperhub-scheduler/block-dispatcher/index.ts
@@ -17,6 +17,9 @@
  *   HEALTH_PORT            - Health check server port (default: 3050)
  */
 
+// Normalize all console.* output in this process to canonical JSON. Must be
+// the first import so the patch installs before any module logs.
+import "../log-facade.js";
 import express from "express";
 import {
   KEEPERHUB_URL,

--- a/keeperhub-scheduler/log-facade.ts
+++ b/keeperhub-scheduler/log-facade.ts
@@ -1,0 +1,82 @@
+/**
+ * Vendored console facade for the keeperhub-scheduler satellite.
+ *
+ * Normalizes all console.* output in this process to canonical single-line
+ * JSON ({ level, ts, msg, err? }) matching the KeeperHub app's logging contract
+ * (lib/log/core.ts), so Grafana Loki `| json` works uniformly across the app
+ * and every satellite service. Import this module FIRST at the service
+ * entrypoint, before any module that logs.
+ *
+ * Self-contained by design: satellites are separate packages and cannot import
+ * the app's `@/lib/*`. Keep in sync with the app's lib/log/core.ts +
+ * lib/logger.ts.
+ */
+
+type LogLevel = "debug" | "info" | "warn" | "error";
+
+const LEVELS: Record<string, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+  silent: 4,
+};
+
+const original = {
+  log: console.log.bind(console),
+  info: console.info.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  debug: console.debug.bind(console),
+};
+
+function threshold(): number {
+  const level = (process.env.LOG_LEVEL || "info").toLowerCase();
+  return level in LEVELS ? LEVELS[level] : LEVELS.info;
+}
+
+function describe(arg: unknown): string {
+  if (typeof arg === "string") {
+    return arg;
+  }
+  if (arg instanceof Error) {
+    return `${arg.name}: ${arg.message}`;
+  }
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
+}
+
+function emit(
+  level: LogLevel,
+  write: (line: string) => void,
+  args: unknown[]
+): void {
+  if (LEVELS[level] < threshold()) {
+    return;
+  }
+  const payload: Record<string, unknown> = {
+    level,
+    ts: new Date().toISOString(),
+    msg: args.map(describe).join(" "),
+  };
+  const error = args.find((a): a is Error => a instanceof Error);
+  if (error) {
+    payload.err = {
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+    };
+  }
+  write(JSON.stringify(payload));
+}
+
+console.debug = (...args: unknown[]) => emit("debug", original.debug, args);
+console.log = (...args: unknown[]) => emit("info", original.log, args);
+console.info = (...args: unknown[]) => emit("info", original.info, args);
+console.warn = (...args: unknown[]) => emit("warn", original.warn, args);
+console.error = (...args: unknown[]) => emit("error", original.error, args);
+
+export {};

--- a/keeperhub-scheduler/log-facade.ts
+++ b/keeperhub-scheduler/log-facade.ts
@@ -52,7 +52,7 @@ function describe(arg: unknown): string {
 function emit(
   level: LogLevel,
   write: (line: string) => void,
-  args: unknown[]
+  args: unknown[],
 ): void {
   if (LEVELS[level] < threshold()) {
     return;

--- a/keeperhub-scheduler/schedule-dispatcher/index.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/index.ts
@@ -15,6 +15,9 @@
  *   HEALTH_PORT - Health check server port (default: 3060)
  */
 
+// Normalize all console.* output in this process to canonical JSON. Must be
+// the first import so the patch installs before any module logs.
+import "../log-facade.js";
 import express from "express";
 import { KEEPERHUB_URL, SQS_QUEUE_URL } from "../lib/config.js";
 import { dispatch } from "./dispatch.js";

--- a/lib/api-error.ts
+++ b/lib/api-error.ts
@@ -1,11 +1,14 @@
 import { NextResponse } from "next/server";
+import { ErrorCategory, logSystemError, logWarn } from "@/lib/logging";
 
 /**
  * Standardized API error handler
  *
- * Logs the error with context and returns a consistent JSON response.
- * All errors flow through the logger which adds timestamps and
- * source locations (in staging with LOG_LEVEL=debug).
+ * Emits a canonical structured log line and returns a consistent JSON
+ * response. 5xx are treated as system failures (Prometheus metric + Sentry
+ * error) so they surface on dashboards and alerts; 4xx are logged at warn with
+ * no metric/Sentry so routine client errors do not trip system-error alerts or
+ * page on-call.
  *
  * @param error - The caught error
  * @param context - Description of what operation failed (e.g., "Failed to get workflows")
@@ -18,9 +21,14 @@ export function apiError(
 ): NextResponse {
   const message = error instanceof Error ? error.message : String(error);
   const rootCause = getRootCause(error);
-  const stack = error instanceof Error ? error.stack : undefined;
 
-  console.error(`[API] ${context}:`, message, stack ?? "");
+  if (status >= 500) {
+    logSystemError(ErrorCategory.UNKNOWN, `[API] ${context}`, error, {
+      status_code: String(status),
+    });
+  } else {
+    logWarn(`[API] ${context}: ${message}`, { status_code: String(status) });
+  }
 
   return NextResponse.json(
     {

--- a/lib/api-key-auth.ts
+++ b/lib/api-key-auth.ts
@@ -18,7 +18,6 @@
  */
 
 import { createHash } from "node:crypto";
-import { captureMessage } from "@sentry/nextjs";
 import { and, eq, gt, isNull, or } from "drizzle-orm";
 import {
   isAnonymousUserShape,
@@ -26,6 +25,7 @@ import {
 } from "@/lib/auth-anonymous-guard";
 import { db } from "@/lib/db";
 import { member, organizationApiKeys, users } from "@/lib/db/schema";
+import { ErrorCategory, logSecurityEvent, logSystemError } from "@/lib/logging";
 
 export type ApiKeyAuthResult = {
   authenticated: boolean;
@@ -162,32 +162,23 @@ export async function authenticateApiKey(
     if (apiKey.createdBy && apiKey.creatorDeactivatedAt) {
       // KEEP-612: signal the third deactivated-login surface (session and
       // account are handled in lib/auth.ts). Best-effort, never blocks.
-      try {
-        captureMessage("security.deactivated_login_attempt", {
-          level: "warning",
+      logSecurityEvent(
+        "deactivated_login_attempt",
+        {
+          surface: "api_key",
+          userId: apiKey.createdBy,
+          apiKeyId: apiKey.id,
+          organizationId: apiKey.organizationId,
+        },
+        {
           tags: {
             security: "deactivated_login_attempt",
             surface: "api_key",
           },
           user: { id: apiKey.createdBy },
           extra: { apiKeyId: apiKey.id, organizationId: apiKey.organizationId },
-        });
-      } catch {
-        // swallow; observability must not block auth response
-      }
-      try {
-        console.warn(
-          JSON.stringify({
-            event: "security.deactivated_login_attempt",
-            surface: "api_key",
-            userId: apiKey.createdBy,
-            apiKeyId: apiKey.id,
-            organizationId: apiKey.organizationId,
-          })
-        );
-      } catch {
-        // swallow; logging must not block auth response
-      }
+        }
+      );
       return {
         authenticated: false,
         error: "API key creator account is deactivated",
@@ -210,7 +201,11 @@ export async function authenticateApiKey(
       .where(eq(organizationApiKeys.id, apiKey.id))
       .catch((error) => {
         // Log error but don't fail the request
-        console.error("[API Key Auth] Failed to update lastUsedAt:", error);
+        logSystemError(
+          ErrorCategory.DATABASE,
+          "[API Key Auth] Failed to update lastUsedAt",
+          error
+        );
       });
 
     return {
@@ -220,7 +215,11 @@ export async function authenticateApiKey(
       userId: apiKey.createdBy ?? undefined,
     };
   } catch (error) {
-    console.error("[API Key Auth] Authentication error:", error);
+    logSystemError(
+      ErrorCategory.AUTH,
+      "[API Key Auth] Authentication error",
+      error
+    );
     return {
       authenticated: false,
       error: "Internal authentication error",

--- a/lib/auth-anonymous-guard.ts
+++ b/lib/auth-anonymous-guard.ts
@@ -1,4 +1,4 @@
-import { captureMessage } from "@sentry/nextjs";
+import { logSecurityEvent } from "@/lib/logging";
 
 /**
  * Anonymous-user gate for sensitive account operations.
@@ -41,26 +41,13 @@ export function logAnonymousExecutionBlock(
   userId: string | null | undefined,
   extra?: Record<string, string>
 ): void {
-  try {
-    captureMessage("security.anonymous_execution_blocked", {
-      level: "warning",
+  logSecurityEvent(
+    "anonymous_execution_blocked",
+    { surface, userId: userId ?? null, ...extra },
+    {
       tags: { security: "anonymous_execution_blocked", surface },
       user: userId ? { id: userId } : undefined,
       extra,
-    });
-  } catch {
-    // observability must never affect the auth response
-  }
-  try {
-    console.warn(
-      JSON.stringify({
-        event: "security.anonymous_execution_blocked",
-        surface,
-        userId: userId ?? null,
-        ...extra,
-      })
-    );
-  } catch {
-    // logging must never affect the auth response
-  }
+    }
+  );
 }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { captureMessage } from "@sentry/nextjs";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { APIError } from "better-auth/api";
@@ -20,7 +19,14 @@ import { isDisposableEmailDomain } from "@/lib/auth-disposable-emails";
 import { DISPOSABLE_EMAIL_REJECTION_MESSAGE } from "@/lib/auth-disposable-emails-message";
 import { isFreshSignup } from "@/lib/auth-notification-guard";
 import { sendInvitationEmail, sendVerificationOTP } from "@/lib/email";
-import { ErrorCategory, logSystemError } from "@/lib/logging";
+import {
+  ErrorCategory,
+  logSecurityEvent,
+  logSystemError,
+  logSystemWarn,
+  logUserError,
+  logWarn,
+} from "@/lib/logging";
 import { revokeRefreshTokensForUserOrg } from "@/lib/mcp/oauth-store";
 import { recordAuditEvent } from "@/lib/security/audit-log";
 import {
@@ -223,9 +229,13 @@ const plugins = [
       if (!success) {
         const msg = `[Auth] Failed to send verification email to ${email} — OTP is stored in DB`;
         if (process.env.CI || process.env.NODE_ENV === "test") {
-          console.warn(msg);
+          logWarn(msg);
         } else {
-          console.error(msg);
+          logSystemError(
+            ErrorCategory.EXTERNAL_SERVICE,
+            msg,
+            new Error("verification email send failed")
+          );
         }
       }
     },
@@ -337,7 +347,8 @@ const plugins = [
           inviteLink,
         });
       } catch (error) {
-        console.warn(
+        logSystemWarn(
+          ErrorCategory.EXTERNAL_SERVICE,
           `[Invitation] Email delivery failed for ${data.email}, invitation is still valid`,
           error
         );
@@ -487,13 +498,20 @@ async function subscribeToMailerLite(user: {
   })
     .then((res) => {
       if (!res.ok) {
-        console.error(
-          `[MailerLite] Subscribe failed: ${res.status} ${res.statusText}`
+        logUserError(
+          ErrorCategory.EXTERNAL_SERVICE,
+          "[MailerLite] Subscribe failed",
+          new Error(`${res.status} ${res.statusText}`),
+          { status_code: String(res.status) }
         );
       }
     })
     .catch((err: unknown) => {
-      console.error("[MailerLite] Subscribe request error:", err);
+      logUserError(
+        ErrorCategory.EXTERNAL_SERVICE,
+        "[MailerLite] Subscribe request error",
+        err
+      );
     });
 }
 
@@ -532,13 +550,20 @@ async function notifyDiscordSignup(user: {
   })
     .then((res) => {
       if (!res.ok) {
-        console.error(
-          `[Discord] Webhook failed: ${res.status} ${res.statusText}`
+        logUserError(
+          ErrorCategory.EXTERNAL_SERVICE,
+          "[Discord] Webhook failed",
+          new Error(`${res.status} ${res.statusText}`),
+          { status_code: String(res.status) }
         );
       }
     })
     .catch((err: unknown) => {
-      console.error("[Discord] Webhook request error:", err);
+      logUserError(
+        ErrorCategory.EXTERNAL_SERVICE,
+        "[Discord] Webhook request error",
+        err
+      );
     });
 }
 
@@ -567,7 +592,8 @@ export const auth = betterAuth({
           await Promise.resolve();
           const email = typeof user.email === "string" ? user.email : null;
           if (email && isDisposableEmailDomain(email)) {
-            console.warn(
+            logUserError(
+              ErrorCategory.VALIDATION,
               `[Auth] Rejected signup for disposable email domain: ${email}`
             );
             throw new APIError("BAD_REQUEST", {
@@ -655,10 +681,11 @@ export const auth = betterAuth({
                 headers: new Headers(),
               });
             } catch (error) {
-              console.error(
+              logSystemError(
+                ErrorCategory.AUTH,
                 "[Auth] Failed to dispatch signup verification OTP",
-                { email: user.email, userId: user.id },
-                error
+                error,
+                { email: user.email ?? "", userId: user.id }
               );
             }
           }
@@ -702,27 +729,16 @@ export const auth = betterAuth({
             // Wrapped in try/catch so a Sentry transport throw cannot
             // propagate out of the better-auth hook and surface as a
             // generic login error instead of the deactivated-user deny.
-            try {
-              captureMessage("security.deactivated_login_attempt", {
-                level: "warning",
+            logSecurityEvent(
+              "deactivated_login_attempt",
+              { surface: "session", userId },
+              {
                 tags: {
                   security: "deactivated_login_attempt",
                   surface: "session",
                 },
                 user: { id: userId },
-              });
-            } catch {
-              // swallow; observability must not change auth flow shape
-            }
-            // Structured stdout line so Loki / log-only alert rules pick
-            // up the signal even when SENTRY_DSN is unset (local dev) or
-            // when the Sentry transport drops.
-            console.warn(
-              JSON.stringify({
-                event: "security.deactivated_login_attempt",
-                surface: "session",
-                userId,
-              })
+              }
             );
             return false;
           }
@@ -836,24 +852,16 @@ export const auth = betterAuth({
             // Wrapped in try/catch so a Sentry transport throw cannot
             // propagate out of the OAuth re-link hook -- see session
             // surface above for the same pattern.
-            try {
-              captureMessage("security.deactivated_login_attempt", {
-                level: "warning",
+            logSecurityEvent(
+              "deactivated_login_attempt",
+              { surface: "account", userId },
+              {
                 tags: {
                   security: "deactivated_login_attempt",
                   surface: "account",
                 },
                 user: { id: userId },
-              });
-            } catch {
-              // swallow; observability must not change auth flow shape
-            }
-            console.warn(
-              JSON.stringify({
-                event: "security.deactivated_login_attempt",
-                surface: "account",
-                userId,
-              })
+              }
             );
             return false;
           }
@@ -862,23 +870,17 @@ export const auth = betterAuth({
     },
   },
   onAPIError: {
-    onError: (error, ctx) => {
+    onError: (error, _ctx) => {
       // KEEP-612: emit the sessions-backstop detection signal if this error
       // is the migration-0090 KH001 reject (a deactivated-user session insert
       // that bypassed the session.create.before gate). reportSessionBackstop
       // walks the wrapped-error cause chain + message fallback and is
       // unit-tested independently of the Better Auth config.
       reportSessionBackstop(error);
-      console.error("[Better Auth API Error]", {
-        error:
-          error instanceof Error
-            ? {
-                message: error.message,
-                stack: error.stack,
-                name: error.name,
-              }
-            : error,
-        context: ctx,
+      const errName = error instanceof Error ? error.name : "unknown";
+      const errMessage = error instanceof Error ? error.message : String(error);
+      logWarn(`[Better Auth API Error] ${errName}: ${errMessage}`, {
+        error_name: errName,
       });
     },
   },

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -766,7 +766,9 @@ export const auth = betterAuth({
                 ErrorCategory.AUTH,
                 "[Auth] Failed to dispatch signup verification OTP",
                 error,
-                { email: user.email ?? "", userId: user.id }
+                // No email label - PII. userId is enough to investigate; the
+                // email is derivable from it if needed.
+                { userId: user.id }
               );
             }
           }

--- a/lib/billing/execution-debt.ts
+++ b/lib/billing/execution-debt.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { and, eq, isNull, lt, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { executionDebt, overageBillingRecords } from "@/lib/db/schema";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
 import type { BillingProvider } from "./provider";
 import { getBillingProvider } from "./providers";
 
@@ -132,11 +133,11 @@ export async function scanAndCreateDebt(): Promise<DebtScanResult> {
         skipped++;
       }
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error(
-        LOG_PREFIX,
-        `Failed to process overage record ${row.id}:`,
-        message
+      logSystemError(
+        ErrorCategory.BILLING,
+        `${LOG_PREFIX} Failed to process overage record`,
+        error,
+        { overage_record_id: row.id }
       );
       skipped++;
     }

--- a/lib/billing/handle-billing-event.ts
+++ b/lib/billing/handle-billing-event.ts
@@ -4,6 +4,12 @@ import {
   organizationSubscriptions,
   overageBillingRecords,
 } from "@/lib/db/schema";
+import {
+  ErrorCategory,
+  logSystemWarn,
+  logUserError,
+  logWarn,
+} from "@/lib/logging";
 import { getMetricsCollector } from "@/lib/metrics";
 import { MetricNames } from "@/lib/metrics/types";
 import { recordAuditEvent } from "@/lib/security/audit-log";
@@ -113,12 +119,18 @@ async function handleCheckoutCompleted(
   const { organizationId, providerSubscriptionId } = data;
 
   if (!organizationId) {
-    console.error("[Billing Webhook] No organizationId in checkout event");
+    logUserError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      "[Billing Webhook] No organizationId in checkout event"
+    );
     return;
   }
 
   if (!providerSubscriptionId) {
-    console.error("[Billing Webhook] No subscription in checkout event");
+    logUserError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      "[Billing Webhook] No subscription in checkout event"
+    );
     return;
   }
 
@@ -140,7 +152,10 @@ async function handleCheckoutCompleted(
   );
 
   if (!details.priceId) {
-    console.error(LOG_PREFIX, "No price ID found in subscription");
+    logUserError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      `${LOG_PREFIX} No price ID found in subscription`
+    );
     return;
   }
 
@@ -149,10 +164,11 @@ async function handleCheckoutCompleted(
     price: details.priceMetadata,
   });
   if (!resolved) {
-    console.error(
-      LOG_PREFIX,
-      "Unknown priceId, cannot resolve plan:",
-      details.priceId
+    logUserError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      `${LOG_PREFIX} Unknown priceId, cannot resolve plan`,
+      undefined,
+      { price_id: details.priceId }
     );
     return;
   }
@@ -273,10 +289,8 @@ async function handleSubscriptionUpdated(
 
   const current = await findSubscriptionByProviderId(providerSubscriptionId);
   if (!current) {
-    console.warn(
-      LOG_PREFIX,
-      "subscription.updated - no matching row for subId:",
-      providerSubscriptionId
+    logWarn(
+      `${LOG_PREFIX} subscription.updated - no matching row for subId: ${providerSubscriptionId}`
     );
     return;
   }
@@ -302,12 +316,11 @@ async function handleSubscriptionUpdated(
         current.currentPeriodEnd
       );
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.warn(
-        LOG_PREFIX,
-        "Failed to bill overage for org (will be retried by scan):",
-        current.organizationId,
-        message
+      logSystemWarn(
+        ErrorCategory.BILLING,
+        `${LOG_PREFIX} Failed to bill overage for org (will be retried by scan)`,
+        error,
+        { org_id: current.organizationId }
       );
     }
   }
@@ -527,11 +540,11 @@ async function markOverageRecordsPaid(
     try {
       invoiceInfo = await provider.getInvoiceForItem(row.providerInvoiceItemId);
     } catch (error) {
-      console.error(
-        LOG_PREFIX,
-        "markOverageRecordsPaid: getInvoiceForItem failed",
-        row.id,
-        error
+      logUserError(
+        ErrorCategory.EXTERNAL_SERVICE,
+        `${LOG_PREFIX} markOverageRecordsPaid: getInvoiceForItem failed`,
+        error,
+        { overage_record_id: row.id }
       );
       continue;
     }
@@ -626,9 +639,8 @@ async function handleInvoicePaymentFailed(
   const { providerSubscriptionId, invoiceUrl } = data;
 
   if (!providerSubscriptionId) {
-    console.warn(
-      LOG_PREFIX,
-      "invoice.payment_failed - no subscriptionId, skipping"
+    logWarn(
+      `${LOG_PREFIX} invoice.payment_failed - no subscriptionId, skipping`
     );
     return;
   }
@@ -667,7 +679,7 @@ async function handleInvoiceOverdue(
   const { providerSubscriptionId, invoiceUrl } = data;
 
   if (!providerSubscriptionId) {
-    console.warn(LOG_PREFIX, "invoice.overdue - no subscriptionId, skipping");
+    logWarn(`${LOG_PREFIX} invoice.overdue - no subscriptionId, skipping`);
     return;
   }
 
@@ -694,9 +706,8 @@ async function handleInvoicePaymentActionRequired(
   const { providerSubscriptionId, invoiceUrl } = data;
 
   if (!providerSubscriptionId) {
-    console.warn(
-      LOG_PREFIX,
-      "invoice.payment_action_required - no subscriptionId, skipping"
+    logWarn(
+      `${LOG_PREFIX} invoice.payment_action_required - no subscriptionId, skipping`
     );
     return;
   }

--- a/lib/billing/limit-status.ts
+++ b/lib/billing/limit-status.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { and, count, eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
+import { ErrorCategory, logSystemWarn } from "@/lib/logging";
 import { getPlanLimits, parsePlanName, parseTierKey } from "./plans";
 import { getOrgSubscription } from "./plans-server";
 
@@ -72,7 +73,8 @@ export async function isBillingLimitReached(
     const used = await getCurrentMonthUsage(organizationId);
     return used >= limits.maxExecutionsPerMonth;
   } catch (error) {
-    console.warn(
+    logSystemWarn(
+      ErrorCategory.DATABASE,
       "[limit-status] isBillingLimitReached failed; treating as not-reached",
       error
     );

--- a/lib/billing/overage.ts
+++ b/lib/billing/overage.ts
@@ -6,6 +6,7 @@ import {
   organizationSubscriptions,
   overageBillingRecords,
 } from "@/lib/db/schema";
+import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getMetricsCollector } from "@/lib/metrics";
 import { MetricNames } from "@/lib/metrics/types";
 import { getPlanLimits, PLANS, parsePlanName, parseTierKey } from "./plans";
@@ -155,7 +156,11 @@ export async function billOverageForOrg(
     return { billed: true, overageCount, totalChargeCents };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error(LOG_PREFIX, "Failed to create invoice item:", message);
+    logUserError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      `${LOG_PREFIX} Failed to create invoice item`,
+      error
+    );
 
     await db
       .update(overageBillingRecords)

--- a/lib/db/integrations.ts
+++ b/lib/db/integrations.ts
@@ -4,6 +4,7 @@ import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
 import { and, eq, isNull } from "drizzle-orm";
 import { toChecksumAddress } from "@/lib/address-utils";
 import { filterUnauthorizedIntegrationIds } from "@/lib/integrations/authorization";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
 import {
   getOrganizationWallet,
   organizationHasWallet,
@@ -101,7 +102,11 @@ function decryptConfig(encryptedConfig: string): Record<string, unknown> {
     const decrypted = decrypt(encryptedConfig);
     return JSON.parse(decrypted);
   } catch (error) {
-    console.error("Failed to decrypt integration config:", error);
+    logSystemError(
+      ErrorCategory.INFRASTRUCTURE,
+      "[Integrations] Failed to decrypt integration config",
+      error
+    );
     return {};
   }
 }

--- a/lib/earnings/queries.ts
+++ b/lib/earnings/queries.ts
@@ -4,6 +4,7 @@ import { and, count, desc, eq, inArray, isNotNull, sum } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
 import { workflowPayments } from "@/lib/db/schema-payments";
+import { logWarn } from "@/lib/logging";
 import type {
   ChainEarnings,
   EarningsSummary,
@@ -31,7 +32,7 @@ export function parsePlatformFeePercent(envValue: string | undefined): number {
   }
   const parsed = Number.parseInt(envValue, 10);
   if (!Number.isFinite(parsed) || parsed < 0 || parsed > 100) {
-    console.warn(
+    logWarn(
       `[earnings] Invalid PLATFORM_FEE_PERCENT="${envValue}", falling back to ${DEFAULT_PLATFORM_FEE_PERCENT}`
     );
     return DEFAULT_PLATFORM_FEE_PERCENT;

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -5,7 +5,12 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { ErrorCategory, logSystemError, logUserError } from "@/lib/logging";
+import {
+  ErrorCategory,
+  logSystemError,
+  logUserError,
+  logWarn,
+} from "@/lib/logging";
 
 const isTestEnv = !!process.env.CI || process.env.NODE_ENV === "test";
 
@@ -66,9 +71,7 @@ export async function sendEmail(options: SendEmailOptions): Promise<boolean> {
 
   if (!apiKey) {
     if (isTestEnv) {
-      console.warn(
-        "[Email] SENDGRID_API_KEY not configured — skipping email send"
-      );
+      logWarn("[Email] SENDGRID_API_KEY not configured — skipping email send");
     } else {
       logSystemError(
         ErrorCategory.INFRASTRUCTURE,
@@ -266,9 +269,7 @@ KeeperHub - Blockchain Workflow Automation
   if (success) {
     console.log(`[Email] OTP sent to ${email} for ${type}`);
   } else if (isTestEnv) {
-    console.warn(
-      `[Email] Failed to send OTP to ${email} — OTP is stored in DB`
-    );
+    logWarn(`[Email] Failed to send OTP to ${email} — OTP is stored in DB`);
   } else {
     logUserError(
       ErrorCategory.EXTERNAL_SERVICE,
@@ -458,7 +459,7 @@ KeeperHub - Blockchain Workflow Automation
   if (success) {
     console.log(`[Email] Invitation sent to ${inviteeEmail}`);
   } else if (isTestEnv) {
-    console.warn(
+    logWarn(
       `[Email] Failed to send invitation to ${inviteeEmail} — invitation is stored in DB`
     );
   } else {

--- a/lib/explorer/proxy-detection.ts
+++ b/lib/explorer/proxy-detection.ts
@@ -10,6 +10,7 @@
  */
 
 import { ethers } from "ethers";
+import { logWarn } from "@/lib/logging";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
 
 export type ProxyDetectionResult = {
@@ -242,8 +243,9 @@ export async function detectProxyViaRpc(
   try {
     rpcManager = await getRpcProvider({ chainId });
   } catch {
-    console.warn(
-      `[Proxy Detection] No RPC config found for chain ${chainId}, skipping detection`
+    logWarn(
+      `[Proxy Detection] No RPC config found for chain ${chainId}, skipping detection`,
+      { chain_id: String(chainId) }
     );
     return { isProxy: false };
   }

--- a/lib/log/core.test.ts
+++ b/lib/log/core.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { emitLogLine, getLogLevel, rawConsole, shouldLog } from "./core";
+
+// rawConsole is exported `as const` (readonly keys); alias to a mutable record
+// so vi.spyOn type-checks. It is the same underlying object emitLogLine reads.
+const raw = rawConsole as unknown as Record<
+  "debug" | "info" | "warn" | "error",
+  (line: string) => void
+>;
+
+function capture(level: "debug" | "info" | "warn" | "error") {
+  return vi.spyOn(raw, level).mockImplementation(() => {
+    // swallow output during tests
+  });
+}
+
+describe("log core: emitLogLine", () => {
+  const originalLevel = process.env.LOG_LEVEL;
+
+  beforeEach(() => {
+    process.env.LOG_LEVEL = "debug";
+  });
+
+  afterEach(() => {
+    process.env.LOG_LEVEL = originalLevel;
+    vi.restoreAllMocks();
+  });
+
+  it("emits one single-line JSON object with level, ts and payload merged in", () => {
+    const spy = capture("info");
+
+    emitLogLine("info", { msg: "hello", a: 1 });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const line = spy.mock.calls[0][0];
+    // The whole line must be valid JSON (no prefix) so Loki `| json` works.
+    expect(line.startsWith("{")).toBe(true);
+    expect(line).not.toContain("\n");
+    const parsed = JSON.parse(line);
+    expect(parsed).toMatchObject({ level: "info", msg: "hello", a: 1 });
+    expect(typeof parsed.ts).toBe("string");
+    expect(Number.isNaN(Date.parse(parsed.ts))).toBe(false);
+  });
+
+  it("routes each level to the matching console method and stamps level", () => {
+    for (const level of ["debug", "info", "warn", "error"] as const) {
+      const spy = capture(level);
+      emitLogLine(level, { msg: level });
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(spy.mock.calls[0][0]).level).toBe(level);
+    }
+  });
+
+  it("drops lines below the configured LOG_LEVEL", () => {
+    process.env.LOG_LEVEL = "warn";
+    const info = capture("info");
+    const error = capture("error");
+
+    emitLogLine("info", { msg: "dropped" });
+    emitLogLine("error", { msg: "kept" });
+
+    expect(info).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledTimes(1);
+  });
+
+  it("silent disables all output", () => {
+    process.env.LOG_LEVEL = "silent";
+    const error = capture("error");
+
+    emitLogLine("error", { msg: "x" });
+
+    expect(error).not.toHaveBeenCalled();
+  });
+});
+
+describe("log core: level resolution", () => {
+  const originalLevel = process.env.LOG_LEVEL;
+
+  afterEach(() => {
+    process.env.LOG_LEVEL = originalLevel;
+  });
+
+  it("defaults to info when LOG_LEVEL is unset or unknown", () => {
+    process.env.LOG_LEVEL = "bogus";
+    expect(getLogLevel()).toBe("info");
+    expect(shouldLog("info")).toBe(true);
+    expect(shouldLog("debug")).toBe(false);
+    expect(shouldLog("error")).toBe(true);
+  });
+});

--- a/lib/log/core.ts
+++ b/lib/log/core.ts
@@ -1,0 +1,72 @@
+/**
+ * Canonical structured-log writer.
+ *
+ * Single source of truth for the JSON log-line schema. Every authoritative
+ * emitter (the global console facade in `lib/logger.ts`, the structured error
+ * helpers in `lib/logging.ts`, `lib/mcp/logging.ts`) routes through
+ * `emitLogLine` so that ALL stdout is single-line JSON of one shape and
+ * Grafana Loki `| json` works uniformly.
+ *
+ * Canonical schema (keys added here: `level`, `ts`):
+ *   { "level": "info", "ts": "<ISO-8601>", "msg": "...", ...payload }
+ *
+ * Output goes through the ORIGINAL console methods captured at module load,
+ * so lines are never re-wrapped by the `lib/logger.ts` facade (which would
+ * otherwise double-encode JSON inside JSON). Because the facade imports this
+ * module, ES module evaluation guarantees this body runs - capturing the
+ * pristine console - before the facade patches the globals.
+ */
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export const LOG_LEVELS: Record<LogLevel | "silent", number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+  silent: 4,
+};
+
+/**
+ * The original console methods, bound before any patching. Authoritative
+ * emitters that maintain their own JSON schema (e.g. the metrics console
+ * collector) write through these to bypass the facade's normalization.
+ */
+export const rawConsole = {
+  debug: console.debug.bind(console),
+  info: console.info.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+} as const;
+
+export function getLogLevel(): LogLevel | "silent" {
+  const level = (process.env.LOG_LEVEL || "info").toLowerCase();
+  return level in LOG_LEVELS ? (level as LogLevel | "silent") : "info";
+}
+
+export function shouldLog(level: LogLevel): boolean {
+  return LOG_LEVELS[level] >= LOG_LEVELS[getLogLevel()];
+}
+
+export type LogPayload = Record<string, unknown> & { msg: string };
+
+/**
+ * Emit one canonical JSON log line. Prepends `level` and `ts`; respects
+ * `LOG_LEVEL`. No-op when the level is below the configured threshold.
+ *
+ * The writer is selected from `rawConsole` by level name at call time
+ * (error/warn -> stderr, info/debug -> stdout), preserving stream semantics
+ * for any consumer reading the stream rather than the JSON `level` field.
+ */
+export function emitLogLine(level: LogLevel, payload: LogPayload): void {
+  if (!shouldLog(level)) {
+    return;
+  }
+  rawConsole[level](
+    JSON.stringify({
+      level,
+      ts: new Date().toISOString(),
+      ...payload,
+    })
+  );
+}

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,116 +1,132 @@
 /**
- * Console wrapper with LOG_LEVEL support
+ * Global console facade with LOG_LEVEL support.
+ *
+ * Patches console.* so any stray (non-structured) console call is normalized
+ * into the canonical single-line JSON schema (`lib/log/core.ts`) instead of a
+ * freeform prefixed string. Every server stdout line is therefore valid JSON
+ * and Grafana Loki `| json` works uniformly.
+ *
+ * Authoritative structured emitters (`lib/logging.ts`, `lib/mcp/logging.ts`,
+ * the metrics console collector) call into `lib/log/core` directly and are
+ * unaffected by this patch.
+ *
+ * Import this file once at app startup (instrumentation.ts) to patch console
+ * globally. All existing console.log/warn/error calls then emit structured
+ * JSON that respects LOG_LEVEL.
  *
  * LOG_LEVEL can be: "debug" | "info" | "warn" | "error" | "silent"
- *
- * Import this file once at app startup to patch console globally.
- * All existing console.log/warn/error calls will respect LOG_LEVEL.
- *
- * In staging, set LOG_LEVEL=debug to see all logs
- * In production, set LOG_LEVEL=warn or LOG_LEVEL=error
+ *   - staging:    LOG_LEVEL=debug to see all logs (adds a `caller` field)
+ *   - production: LOG_LEVEL=info (default)
  */
 
-type LogLevel = "debug" | "info" | "warn" | "error" | "silent";
-
-const LOG_LEVELS: Record<LogLevel, number> = {
-  debug: 0,
-  info: 1,
-  warn: 2,
-  error: 3,
-  silent: 4,
-};
+import {
+  emitLogLine,
+  getLogLevel,
+  type LogPayload,
+  shouldLog,
+} from "@/lib/log/core";
 
 // Regex patterns for stack trace parsing (top-level for performance)
 const STACK_PATTERN_PARENS = /\((.+):(\d+):\d+\)$/;
 const STACK_PATTERN_AT = /at (.+):(\d+):\d+$/;
 const PATH_STRIP_PATTERN = /^.*\//;
 
-function getLogLevel(): LogLevel {
-  const level = (process.env.LOG_LEVEL || "info").toLowerCase() as LogLevel;
-  return LOG_LEVELS[level] === undefined ? "info" : level;
-}
-
-function shouldLog(level: LogLevel): boolean {
-  const currentLevel = getLogLevel();
-  return LOG_LEVELS[level] >= LOG_LEVELS[currentLevel];
-}
-
 function getCallerLocation(): string {
   const err = new Error("stack");
   const stack = err.stack?.split("\n") || [];
-  // Stack: Error -> getCallerLocation -> formatArgs -> console.X wrapper -> actual caller
-  // We want index 4 (the actual caller)
-  const callerLine = stack[4] || "";
+  // Stack: Error -> getCallerLocation -> console.X wrapper -> actual caller.
+  // We want index 3 (the actual caller).
+  const callerLine = stack[3] || "";
 
-  // Extract file:line from stack trace
-  // Formats: "at functionName (file:line:col)" or "at file:line:col"
   const match =
     callerLine.match(STACK_PATTERN_PARENS) ||
     callerLine.match(STACK_PATTERN_AT);
 
   if (match) {
     const file = match[1].replace(PATH_STRIP_PATTERN, ""); // Get just filename
-    const line = match[2];
-    return `${file}:${line}`;
+    return `${file}:${match[2]}`;
   }
   return "";
 }
 
-function formatArgs(prefix: string, args: unknown[]): unknown[] {
-  const timestamp = new Date().toISOString();
-  // Only include source references when LOG_LEVEL is debug
-  const includeLocation = getLogLevel() === "debug";
-  const location = includeLocation ? getCallerLocation() : "";
-  const locationStr = location ? ` (${location})` : "";
-  return [`[${timestamp}] ${prefix}${locationStr}`, ...args];
+function describeArg(arg: unknown): string {
+  if (typeof arg === "string") {
+    return arg;
+  }
+  if (arg instanceof Error) {
+    return `${arg.name}: ${arg.message}`;
+  }
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
 }
 
-// Store original console methods
-const originalConsole = {
-  log: console.log.bind(console),
-  info: console.info.bind(console),
-  warn: console.warn.bind(console),
-  error: console.error.bind(console),
-  debug: console.debug.bind(console),
-};
+/**
+ * Turn console varargs into a canonical payload. The args are joined into a
+ * human-readable `msg`; the first Error (if any) is attached as a structured
+ * `err` field so stray error logs remain queryable. The source `caller` is
+ * added only at debug level (cost of constructing a stack trace).
+ */
+function buildPayload(args: unknown[]): LogPayload {
+  const payload: LogPayload = { msg: args.map(describeArg).join(" ") };
 
-// Patch console methods
+  const error = args.find((a): a is Error => a instanceof Error);
+  if (error) {
+    payload.err = {
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+    };
+  }
+
+  if (getLogLevel() === "debug") {
+    const caller = getCallerLocation();
+    if (caller) {
+      payload.caller = caller;
+    }
+  }
+
+  return payload;
+}
+
+// Patch console methods. console.log is treated as info level (matching the
+// previous behaviour where it was gated at the info threshold). Level gating
+// is short-circuited here to avoid building payloads for dropped lines.
 console.debug = (...args: unknown[]) => {
   if (shouldLog("debug")) {
-    originalConsole.debug(...formatArgs("[DEBUG]", args));
+    emitLogLine("debug", buildPayload(args));
   }
 };
 
 console.log = (...args: unknown[]) => {
   if (shouldLog("info")) {
-    originalConsole.log(...formatArgs("[LOG]", args));
+    emitLogLine("info", buildPayload(args));
   }
 };
 
 console.info = (...args: unknown[]) => {
   if (shouldLog("info")) {
-    originalConsole.info(...formatArgs("[INFO]", args));
+    emitLogLine("info", buildPayload(args));
   }
 };
 
 console.warn = (...args: unknown[]) => {
   if (shouldLog("warn")) {
-    originalConsole.warn(...formatArgs("[WARN]", args));
+    emitLogLine("warn", buildPayload(args));
   }
 };
 
 console.error = (...args: unknown[]) => {
   if (shouldLog("error")) {
-    originalConsole.error(...formatArgs("[ERROR]", args));
+    emitLogLine("error", buildPayload(args));
   }
 };
 
-// Log that patching occurred (at debug level)
+// Announce the patch (debug level only).
 if (shouldLog("debug")) {
-  originalConsole.debug(
-    `[${new Date().toISOString()}] [DEBUG] Console patched with LOG_LEVEL=${getLogLevel()}`
-  );
+  emitLogLine("debug", {
+    msg: `[Logger] Console patched with LOG_LEVEL=${getLogLevel()}`,
+  });
 }
-
-// Export to make this a module (required for dynamic import)
-export {};

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -21,7 +21,8 @@
  * logSystemError(ErrorCategory.INFRASTRUCTURE, "[Para] API key missing:", error, { component: "para-service" });
  */
 
-import { captureException } from "@sentry/nextjs";
+import { captureException, captureMessage } from "@sentry/nextjs";
+import { emitLogLine, type LogLevel, type LogPayload } from "@/lib/log/core";
 import { getMetricsCollector } from "@/lib/metrics";
 import { LabelKeys, MetricNames } from "@/lib/metrics/types";
 import { getWorkflowErrorContext } from "@/lib/workflow/executor/error-context";
@@ -36,10 +37,30 @@ const HIGH_CARDINALITY_LABELS = new Set<string>([
   "execution_id",
   "org_id",
   "owner_id",
-  // KEEP-344: wallet addresses are unbounded across users. Console and Sentry
-  // still see this label; Prometheus does not.
+  // KEEP-344: wallet addresses are unbounded across users; never sent to
+  // Prometheus. KEEP-814: also scrubbed from Sentry extras (see SENTRY_PII_LABELS).
+  // They remain in the structured console line for incident debugging.
   "wallet_address",
 ]);
+
+/**
+ * Labels scrubbed from Sentry `extra` payloads (PII / sensitive). They are kept
+ * in the structured console line (captured by Loki, access-controlled) but not
+ * shipped to Sentry, which has a broader audience and longer retention.
+ */
+const SENTRY_PII_LABELS = new Set<string>(["wallet_address"]);
+
+function scrubSentryExtra(
+  labels: Record<string, string>
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(labels)) {
+    if (!SENTRY_PII_LABELS.has(k)) {
+      out[k] = v;
+    }
+  }
+  return out;
+}
 
 function mergeLabels(
   labels: Record<string, string> | undefined
@@ -115,8 +136,7 @@ function buildErrPayload(
  * The human-readable `msg` field retains the original message and the
  * `[org:Sky][exec:xyz]` tag so `kubectl logs` greps still work.
  */
-function serializeStructuredLogLine(args: {
-  level: "warn" | "error";
+function buildStructuredPayload(args: {
   message: string;
   tag: string;
   fullLabels: Record<string, string>;
@@ -124,11 +144,10 @@ function serializeStructuredLogLine(args: {
   context: string;
   errorType: "user" | "system" | undefined;
   error: unknown;
-}): string {
+}): LogPayload {
   const errPayload = buildErrPayload(args.error);
 
-  const payload: Record<string, unknown> = {
-    level: args.level,
+  const payload: LogPayload = {
     msg: `${args.message}${args.tag}`,
     error_category: args.category,
     error_context: args.context,
@@ -144,7 +163,7 @@ function serializeStructuredLogLine(args: {
   if (errPayload) {
     payload.err = errPayload;
   }
-  return JSON.stringify(payload);
+  return payload;
 }
 
 /**
@@ -243,9 +262,9 @@ export function logUserError(
   // error_category, execution_id, org_slug as queryable labels via `| json`.
   // User errors are logged at warn level so they don't page on-call.
   const tag = buildLogTag(fullLabels);
-  console.warn(
-    serializeStructuredLogLine({
-      level: "warn",
+  emitLogLine(
+    "warn",
+    buildStructuredPayload({
       message,
       tag,
       fullLabels,
@@ -269,20 +288,11 @@ export function logUserError(
     }
   );
 
-  // Report to Sentry as warning-level (user errors are tracked but don't alert)
-  if (error !== undefined) {
-    const sentryError =
-      error instanceof Error ? error : new Error(String(error));
-    captureException(sentryError, {
-      level: "warning",
-      tags: {
-        error_category: category,
-        error_context: context,
-        error_type: "user",
-      },
-      extra: fullLabels,
-    });
-  }
+  // User errors are tracked via the Prometheus metric above and the structured
+  // console line; they are intentionally NOT sent to Sentry. They are expected
+  // and high-volume (invalid addresses, validation failures, external-API
+  // hiccups) and would drown actionable system errors and burn Sentry quota.
+  // Alert on the user-error metric rates in Grafana instead.
 }
 
 /**
@@ -317,9 +327,9 @@ export function logSystemError(
   // KEEP-545: emit structured JSON so Loki indexes error_type,
   // error_category, execution_id, org_slug as queryable labels via `| json`.
   const tag = buildLogTag(fullLabels);
-  console.error(
-    serializeStructuredLogLine({
-      level: "error",
+  emitLogLine(
+    "error",
+    buildStructuredPayload({
       message,
       tag,
       fullLabels,
@@ -350,7 +360,7 @@ export function logSystemError(
       error_category: category,
       error_context: context,
     },
-    extra: fullLabels,
+    extra: scrubSentryExtra(fullLabels),
   });
 }
 
@@ -396,9 +406,9 @@ export function logSystemWarn(
   // alerts that filter `error_type="system"` therefore won't re-trip on
   // these events. See logSystemWarn jsdoc for full reasoning.
   const tag = buildLogTag(fullLabels);
-  console.warn(
-    serializeStructuredLogLine({
-      level: "warn",
+  emitLogLine(
+    "warn",
+    buildStructuredPayload({
       message,
       tag,
       fullLabels,
@@ -416,7 +426,7 @@ export function logSystemWarn(
       error_category: category,
       error_context: context,
     },
-    extra: fullLabels,
+    extra: scrubSentryExtra(fullLabels),
   });
 }
 
@@ -444,8 +454,7 @@ export function logInternalAuthEvent(fields: {
   reason?: string;
   latencyMs?: number;
 }): void {
-  const payload: Record<string, unknown> = {
-    level: "info",
+  const payload: LogPayload = {
     msg: `[InternalAuth] ${fields.outcome} caller=${fields.caller} scheme=${fields.scheme} route=${fields.route}`,
     event: "internal_service_auth",
     outcome: fields.outcome,
@@ -469,5 +478,105 @@ export function logInternalAuthEvent(fields: {
   // Structured audit-log sink intended to land in Grafana Loki via stdout
   // capture; no Sentry capture by design (accepts would page on every
   // internal request; rejects are better caught by a Grafana threshold).
-  console.log(JSON.stringify(payload));
+  emitLogLine("info", payload);
+}
+
+/**
+ * Structured non-error logging helpers.
+ *
+ * Emit a single canonical JSON line (no Prometheus metric, no Sentry) for
+ * informational, lifecycle, and developer-debug logs. They merge the
+ * async-local workflow context (org/owner/workflow/execution ids) and append
+ * the human-readable `[org:..][exec:..]` tag, so breadcrumbs correlate with
+ * the error lines emitted by logUserError/logSystemError.
+ *
+ * Use logInfo for lifecycle/state-transition notes, logDebug for verbose
+ * troubleshooting traces (gated by LOG_LEVEL=debug), and logWarn for benign
+ * fallbacks that are not operational failures and do not warrant a metric.
+ */
+function logAtLevel(
+  level: LogLevel,
+  message: string,
+  labels?: Record<string, string>
+): void {
+  const fullLabels = mergeLabels(labels);
+  const tag = buildLogTag(fullLabels);
+  const payload: LogPayload = { msg: `${message}${tag}` };
+  for (const [k, v] of Object.entries(fullLabels)) {
+    if (v !== undefined && !(k in payload)) {
+      payload[k] = v;
+    }
+  }
+  emitLogLine(level, payload);
+}
+
+export function logDebug(
+  message: string,
+  labels?: Record<string, string>
+): void {
+  logAtLevel("debug", message, labels);
+}
+
+export function logInfo(
+  message: string,
+  labels?: Record<string, string>
+): void {
+  logAtLevel("info", message, labels);
+}
+
+export function logWarn(
+  message: string,
+  labels?: Record<string, string>
+): void {
+  logAtLevel("warn", message, labels);
+}
+
+/**
+ * Emit a KEEP-612 `security.*` detection signal: a Sentry event (for triage
+ * pivots) plus a canonical structured stdout line (for the Loki line-filter
+ * alerts in keeperhub-security-alerts.tf). Both transports are best-effort and
+ * self-guarded so a transport failure never escapes into the caller - these
+ * fire from auth hooks and the executor hot path, where a throw would change
+ * request/execution semantics.
+ *
+ * `name` is the event suffix without the `security.` prefix (e.g.
+ * "backstop_session_blocked"); the literal `security.<name>` string is what
+ * the Loki alerts match, so it must stay verbatim in the emitted line.
+ *
+ * Sentry capture is skipped entirely when `sentry` is omitted (some signals -
+ * e.g. content_scanner_error - are log-only by design).
+ */
+export function logSecurityEvent(
+  name: string,
+  fields?: Record<string, unknown>,
+  sentry?: {
+    level?: "warning" | "error";
+    tags?: Record<string, string>;
+    user?: { id?: string };
+    extra?: Record<string, unknown>;
+    fingerprint?: string[];
+  }
+): void {
+  const event = `security.${name}`;
+
+  if (sentry) {
+    try {
+      captureMessage(event, {
+        level: sentry.level ?? "warning",
+        ...(sentry.tags ? { tags: sentry.tags } : {}),
+        ...(sentry.user ? { user: sentry.user } : {}),
+        ...(sentry.extra ? { extra: sentry.extra } : {}),
+        ...(sentry.fingerprint ? { fingerprint: sentry.fingerprint } : {}),
+      });
+    } catch {
+      // observability must never escape into the caller
+    }
+  }
+
+  try {
+    const level: LogLevel = sentry?.level === "error" ? "error" : "warn";
+    emitLogLine(level, { msg: `[Security] ${name}`, event, ...fields });
+  } catch {
+    // emission must never escape into the caller
+  }
 }

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -48,7 +48,7 @@ const HIGH_CARDINALITY_LABELS = new Set<string>([
  * in the structured console line (captured by Loki, access-controlled) but not
  * shipped to Sentry, which has a broader audience and longer retention.
  */
-const SENTRY_PII_LABELS = new Set<string>(["wallet_address"]);
+const SENTRY_PII_LABELS = new Set<string>(["wallet_address", "email"]);
 
 function scrubSentryExtra(
   labels: Record<string, string>

--- a/lib/mcp/logging.ts
+++ b/lib/mcp/logging.ts
@@ -1,18 +1,15 @@
 // Structured event logger for MCP operations.
-// Emits structured JSON lines to stdout so they are captured by the host log
-// aggregator (CloudWatch). Do NOT log tokens, API keys, or other secrets.
+// Emits canonical single-line JSON (via lib/log/core) so events are captured
+// by the host log aggregator and queryable in Loki via `| json`. Do NOT log
+// tokens, API keys, or other secrets.
+
+import { emitLogLine } from "@/lib/log/core";
 
 export function logMcpEvent(
   event: string,
   data: Record<string, unknown>
 ): void {
-  const entry = {
-    level: "info",
-    event,
-    ts: new Date().toISOString(),
-    ...data,
-  };
-  console.log(JSON.stringify(entry));
+  emitLogLine("info", { msg: event, event, ...data });
 }
 
 /**

--- a/lib/mcp/oauth-auth.ts
+++ b/lib/mcp/oauth-auth.ts
@@ -1,4 +1,3 @@
-import { captureMessage } from "@sentry/nextjs";
 import { eq } from "drizzle-orm";
 import { jwtVerify, SignJWT } from "jose";
 import {
@@ -7,6 +6,7 @@ import {
 } from "@/lib/auth-anonymous-guard";
 import { db } from "@/lib/db";
 import { users } from "@/lib/db/schema";
+import { logSecurityEvent } from "@/lib/logging";
 import { isUserMemberOfOrganization } from "@/lib/workflow/access";
 
 export type OAuthTokenPayload = {
@@ -190,26 +190,21 @@ export async function authenticateOAuthToken(
     // still-valid MCP OAuth JWT hitting MCP endpoints is exactly the
     // anomaly the detection layer wants surfaced. Best-effort; never
     // blocks the 401.
-    try {
-      captureMessage("security.deactivated_login_attempt", {
-        level: "warning",
+    logSecurityEvent(
+      "deactivated_login_attempt",
+      {
+        surface: "mcp_oauth",
+        userId: payload.sub,
+        organizationId: payload.org,
+      },
+      {
         tags: {
           security: "deactivated_login_attempt",
           surface: "mcp_oauth",
         },
         user: { id: payload.sub },
         extra: { organizationId: payload.org },
-      });
-    } catch {
-      // swallow; observability must not affect the auth response
-    }
-    console.warn(
-      JSON.stringify({
-        event: "security.deactivated_login_attempt",
-        surface: "mcp_oauth",
-        userId: payload.sub,
-        organizationId: payload.org,
-      })
+      }
     );
     return {
       authenticated: false,

--- a/lib/metrics/collectors/console.ts
+++ b/lib/metrics/collectors/console.ts
@@ -5,6 +5,7 @@
  * Use for server-side metric collection.
  */
 
+import { rawConsole } from "@/lib/log/core";
 import type {
   ErrorContext,
   MetricEvent,
@@ -102,9 +103,9 @@ function emitErrorEvent(
   const eventWithError = { ...event, error: errorContext };
 
   if (level === "error") {
-    console.error(JSON.stringify(eventWithError));
+    rawConsole.error(JSON.stringify(eventWithError));
   } else {
-    console.warn(JSON.stringify(eventWithError));
+    rawConsole.warn(JSON.stringify(eventWithError));
   }
 }
 
@@ -133,12 +134,12 @@ export const consoleMetricsCollector: MetricsCollector = {
       value: durationMs,
       labels,
     });
-    console.info(JSON.stringify(event));
+    rawConsole.info(JSON.stringify(event));
   },
 
   incrementCounter(name: string, labels?: MetricLabels, value = 1): void {
     const event = createMetricEvent({ name, type: "counter", value, labels });
-    console.info(JSON.stringify(event));
+    rawConsole.info(JSON.stringify(event));
   },
 
   recordError(
@@ -159,7 +160,7 @@ export const consoleMetricsCollector: MetricsCollector = {
 
   setGauge(name: string, value: number, labels?: MetricLabels): void {
     const event = createMetricEvent({ name, type: "gauge", value, labels });
-    console.info(JSON.stringify(event));
+    rawConsole.info(JSON.stringify(event));
   },
 };
 

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -8,6 +8,7 @@
 import "server-only";
 
 import { Counter, Gauge, Histogram, Registry } from "prom-client";
+import { ErrorCategory, logSystemWarn, logWarn } from "@/lib/logging";
 import type { ErrorContext, MetricLabels, MetricsCollector } from "../types";
 
 // Use global singletons to prevent duplicate registration during hot reload
@@ -1141,7 +1142,7 @@ export const prometheusMetricsCollector: MetricsCollector = {
     if (histogram) {
       histogram.observe(sanitizeLabels(labels), durationMs);
     } else {
-      console.warn(`[Prometheus] Unknown latency metric: ${name}`);
+      logWarn(`[Prometheus] Unknown latency metric: ${name}`);
     }
   },
 
@@ -1154,7 +1155,7 @@ export const prometheusMetricsCollector: MetricsCollector = {
     if (counter) {
       counter.inc(sanitizeLabels(labels), value);
     } else {
-      console.warn(`[Prometheus] Unknown counter metric: ${name}`);
+      logWarn(`[Prometheus] Unknown counter metric: ${name}`);
     }
   },
 
@@ -1184,7 +1185,7 @@ export const prometheusMetricsCollector: MetricsCollector = {
     if (gauge) {
       gauge.set(sanitizeLabels(labels), value);
     } else {
-      console.warn(`[Prometheus] Unknown gauge metric: ${name}`);
+      logWarn(`[Prometheus] Unknown gauge metric: ${name}`);
     }
   },
 };
@@ -1199,7 +1200,7 @@ function recordErrorCounter(
   }
   const counter = errorCounterMap[name];
   if (!counter) {
-    console.warn(`[Prometheus] Unknown error metric: ${name}`);
+    logWarn(`[Prometheus] Unknown error metric: ${name}`);
     return;
   }
   const sanitized = sanitizeLabels(labels);
@@ -1217,7 +1218,11 @@ function recordErrorCounter(
     // Defense-in-depth: if filtering missed something or prom-client rejects
     // the label set for any other reason, never let metrics break the
     // user-facing operation that called us.
-    console.warn(`[Prometheus] Failed to record error counter ${name}:`, err);
+    logSystemWarn(
+      ErrorCategory.INFRASTRUCTURE,
+      `[Prometheus] Failed to record error counter ${name}`,
+      err
+    );
   }
 }
 
@@ -1688,7 +1693,11 @@ async function refreshDbMetricsNow(): Promise<void> {
 
     updateHubVoteMetrics(voteStats);
   } catch (error) {
-    console.error("[Prometheus] Failed to update DB metrics:", error);
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[Prometheus] Failed to update DB metrics",
+      error
+    );
     // Propagate so the TTL cache wrapper evicts the failed entry instead
     // of pinning it; updateDbMetrics() catches before returning to callers,
     // preserving the previous "metrics endpoint never 500s" behavior.

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -39,6 +39,7 @@ import {
   workflowSchedules,
   workflows,
 } from "@/lib/db/schema";
+import { ErrorCategory, logSystemWarn } from "@/lib/logging";
 import type { BillingStatus } from "./types";
 
 // Label value used for workflow executions whose workflow has no organization
@@ -220,7 +221,11 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
 
     return stats;
   } catch (error) {
-    console.error("[Metrics] Failed to query workflow stats from DB:", error);
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[Metrics] Failed to query workflow stats from DB",
+      error
+    );
     // Return zeros on error to avoid breaking metrics endpoint
     return {
       totalSuccess: 0,
@@ -301,8 +306,9 @@ export async function getWorkflowErrorsByWorkflowFromDb(): Promise<WorkflowError
       count: Number(row.count) || 0,
     }));
   } catch (error) {
-    console.error(
-      "[Metrics] Failed to query per-workflow errors from DB:",
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[Metrics] Failed to query per-workflow errors from DB",
       error
     );
     return [];
@@ -378,8 +384,9 @@ export async function getSystemErrorsByCategoryFromDb(): Promise<SystemErrorsByC
       count: Number(row.count) || 0,
     }));
   } catch (error) {
-    console.error(
-      "[Metrics] Failed to query system errors by category from DB:",
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[Metrics] Failed to query system errors by category from DB",
       error
     );
     return [];
@@ -493,7 +500,11 @@ export async function getStepStatsFromDb(): Promise<StepStats> {
 
     return stats;
   } catch (error) {
-    console.error("[Metrics] Failed to query step stats from DB:", error);
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[Metrics] Failed to query step stats from DB",
+      error
+    );
     // Return zeros on error to avoid breaking metrics endpoint
     return {
       countsByType: {},
@@ -527,8 +538,9 @@ export async function getDailyActiveUsersFromDb(): Promise<number> {
 
     return Number(result[0]?.count) || 0;
   } catch (error) {
-    console.error(
-      "[Metrics] Failed to query daily active users from DB:",
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[Metrics] Failed to query daily active users from DB",
       error
     );
     return 0;
@@ -585,7 +597,11 @@ export async function getUserStatsFromDb(): Promise<UserStats> {
       withIntegrations: Number(withIntegrationsResult[0]?.count) || 0,
     };
   } catch (error) {
-    console.error("[Metrics] Failed to query user stats from DB:", error);
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[Metrics] Failed to query user stats from DB",
+      error
+    );
     return {
       total: 0,
       verified: 0,
@@ -655,7 +671,11 @@ export async function getOrgStatsFromDb(): Promise<OrgStats> {
       withWorkflows: Number(withWorkflowsResult[0]?.count) || 0,
     };
   } catch (error) {
-    console.error("[Metrics] Failed to query org stats from DB:", error);
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[Metrics] Failed to query org stats from DB",
+      error
+    );
     return {
       total: 0,
       membersTotal: 0,
@@ -692,7 +712,11 @@ export async function getUserListFromDb(): Promise<UserListEntry[]> {
       createdAt: row.createdAt,
     }));
   } catch (error) {
-    console.error("[Metrics] Failed to query user list from DB:", error);
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[Metrics] Failed to query user list from DB",
+      error
+    );
     return [];
   }
 }
@@ -748,7 +772,11 @@ export async function getOrgListFromDb(): Promise<OrgListEntry[]> {
           : parseBillingStatus(row.billingStatus),
     }));
   } catch (error) {
-    console.error("[Metrics] Failed to query org list from DB:", error);
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[Metrics] Failed to query org list from DB",
+      error
+    );
     return [];
   }
 }
@@ -789,8 +817,9 @@ export async function getWorkflowDefinitionStatsFromDb(): Promise<WorkflowDefini
       anonymous: Number(anonymousResult[0]?.count) || 0,
     };
   } catch (error) {
-    console.error(
-      "[Metrics] Failed to query workflow definition stats from DB:",
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[Metrics] Failed to query workflow definition stats from DB",
       error
     );
     return { total: 0, public: 0, private: 0, anonymous: 0 };
@@ -844,7 +873,11 @@ export async function getScheduleStatsFromDb(): Promise<ScheduleStats> {
       byLastStatus,
     };
   } catch (error) {
-    console.error("[Metrics] Failed to query schedule stats from DB:", error);
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[Metrics] Failed to query schedule stats from DB",
+      error
+    );
     return { total: 0, enabled: 0, disabled: 0, byLastStatus: {} };
   }
 }
@@ -888,8 +921,9 @@ export async function getIntegrationStatsFromDb(): Promise<IntegrationStats> {
       byType,
     };
   } catch (error) {
-    console.error(
-      "[Metrics] Failed to query integration stats from DB:",
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[Metrics] Failed to query integration stats from DB",
       error
     );
     return { total: 0, managed: 0, byType: {} };
@@ -944,7 +978,11 @@ export async function getInfraStatsFromDb(): Promise<InfraStats> {
       sessionsActive: Number(sessionsResult[0]?.count) || 0,
     };
   } catch (error) {
-    console.error("[Metrics] Failed to query infra stats from DB:", error);
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[Metrics] Failed to query infra stats from DB",
+      error
+    );
     return {
       apiKeysTotal: 0,
       chainsTotal: 0,
@@ -1034,7 +1072,11 @@ export async function getVoteStatsFromDb(): Promise<VoteStats> {
       })),
     };
   } catch (error) {
-    console.error("[Metrics] Failed to query vote stats from DB:", error);
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[Metrics] Failed to query vote stats from DB",
+      error
+    );
     return {
       totalVotes: 0,
       totalUpvotes: 0,
@@ -1059,7 +1101,11 @@ export async function getEnabledChainNamesFromDb(): Promise<string[]> {
 
     return results.map((r) => r.name);
   } catch (error) {
-    console.error("[Metrics] Failed to query enabled chain names:", error);
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[Metrics] Failed to query enabled chain names",
+      error
+    );
     return [];
   }
 }
@@ -1253,7 +1299,11 @@ export async function getBillingStatsFromDb(): Promise<BillingStats> {
 
     return stats;
   } catch (error) {
-    console.error("[Metrics] Failed to query billing stats from DB:", error);
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[Metrics] Failed to query billing stats from DB",
+      error
+    );
     return emptyBillingStats();
   }
 }

--- a/lib/metrics/rpc-health-probe.ts
+++ b/lib/metrics/rpc-health-probe.ts
@@ -12,6 +12,7 @@
 import "server-only";
 
 import { Connection } from "@solana/web3.js";
+import { ErrorCategory, logSystemWarn } from "@/lib/logging";
 import { classifyRpcError } from "@/lib/rpc/providers";
 import { rpcProbeMetrics } from "./collectors/prometheus";
 import type { ProbeChainConfig } from "./db-metrics";
@@ -60,7 +61,11 @@ async function runProbeAllChains(): Promise<void> {
     const { getEnabledChainConfigsForProbe } = await import("./db-metrics");
     chainConfigs = await getEnabledChainConfigsForProbe();
   } catch (error: unknown) {
-    console.error("RPC health probe: failed to load chain configs", error);
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[RPC Probe] Failed to load chain configs",
+      error
+    );
     return;
   }
 

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,4 +1,5 @@
 import { Redis } from "ioredis";
+import { logWarn } from "@/lib/logging";
 
 /**
  * Best-effort Redis for the app tier: a cross-replica coordination layer,
@@ -20,7 +21,7 @@ function logRedisError(err: Error): void {
     return;
   }
   lastErrorLoggedAt = now;
-  console.warn("[redis] client error (best-effort, ignoring)", err.message);
+  logWarn(`[redis] client error (best-effort, ignoring): ${err.message}`);
 }
 
 function createClient(): Redis | null {

--- a/lib/refetch-organizations.ts
+++ b/lib/refetch-organizations.ts
@@ -5,6 +5,8 @@
  * without having direct access to the React hooks.
  */
 
+import { ErrorCategory, logSystemError } from "@/lib/logging";
+
 type RefetchCallback = () => void;
 
 const refetchCallbacks: Set<RefetchCallback> = new Set();
@@ -35,7 +37,11 @@ export function refetchOrganizations(): void {
     try {
       callback();
     } catch (error) {
-      console.error("[refetchOrganizations] Error in callback:", error);
+      logSystemError(
+        ErrorCategory.UNKNOWN,
+        "[refetchOrganizations] Error in callback",
+        error
+      );
     }
   }
 }

--- a/lib/rpc/config-service.ts
+++ b/lib/rpc/config-service.ts
@@ -12,6 +12,7 @@ import {
   type UserRpcPreference,
   userRpcPreferences,
 } from "@/lib/db/schema";
+import { logWarn } from "@/lib/logging";
 import type { ResolvedRpcConfig } from "./types";
 
 /**
@@ -135,7 +136,7 @@ function applyPrivateMempoolSwap(
   }
 
   if (!(baseConfig.usePrivateMempoolRpc && baseConfig.privateRpcUrl)) {
-    console.warn(
+    logWarn(
       `[rpc-config] Private mempool requested for chain ${baseConfig.chainId} ` +
         "but chain does not support it; proceeding with public mempool"
     );

--- a/lib/rpc/provider-factory.ts
+++ b/lib/rpc/provider-factory.ts
@@ -5,6 +5,7 @@
  * configuration resolved from user preferences or chain defaults.
  */
 
+import { ErrorCategory, logSystemError } from "@/lib/logging";
 import {
   createRpcProviderManager,
   type FailoverStateChangeCallback,
@@ -149,7 +150,11 @@ export async function getRpcProvider(
       try {
         failoverCallback(chain, isUsingFallback, reason);
       } catch (error) {
-        console.error("Metrics failover callback error:", error);
+        logSystemError(
+          ErrorCategory.INFRASTRUCTURE,
+          "[Metrics] Metrics failover callback error",
+          error
+        );
       }
       onFailoverStateChange?.(chain, isUsingFallback, reason);
     },
@@ -194,7 +199,11 @@ export async function getSolanaProvider(
       try {
         failoverCallback(chain, isUsingFallback, reason);
       } catch (error) {
-        console.error("Metrics failover callback error:", error);
+        logSystemError(
+          ErrorCategory.INFRASTRUCTURE,
+          "[Metrics] Metrics failover callback error",
+          error
+        );
       }
       onFailoverStateChange?.(chain, isUsingFallback, reason);
     },

--- a/lib/rpc/providers/index.ts
+++ b/lib/rpc/providers/index.ts
@@ -1,4 +1,5 @@
 import { ethers, isError } from "ethers";
+import { ErrorCategory, logUserError } from "@/lib/logging";
 import { safeEthersGetUrl } from "../safe-ethers-fetch";
 import { isNonRetryableError } from "./error-classification";
 
@@ -319,14 +320,14 @@ export class RpcProviderManager {
         }
 
         // Fallback failed - try primary in case it recovered
-        console.warn(
-          JSON.stringify({
-            level: "warn",
+        logUserError(
+          ErrorCategory.NETWORK_RPC,
+          `[RPC] Fallback RPC failed for ${this.config.chainName}, attempting primary recovery`,
+          fallbackResult.error,
+          {
             event: "RPC_FALLBACK_FAILED",
-            message: `Fallback RPC failed for ${this.config.chainName}, attempting primary recovery`,
             chain: this.config.chainName,
-            timestamp: new Date().toISOString(),
-          })
+          }
         );
 
         const primaryProvider = this.getPrimaryProvider();
@@ -362,16 +363,14 @@ export class RpcProviderManager {
 
         // Both failed -- throw without redundant retry
         this.metricsCollector.recordBothFailed(this.config.chainName);
-        console.error(
-          JSON.stringify({
-            level: "error",
+        logUserError(
+          ErrorCategory.NETWORK_RPC,
+          `[RPC] Both primary and fallback RPC failed for ${this.config.chainName}`,
+          `Fallback: ${fallbackResult.error}. Primary: ${primaryResult.error}`,
+          {
             event: "RPC_BOTH_ENDPOINTS_FAILED",
-            message: `Both primary and fallback RPC failed for ${this.config.chainName}`,
             chain: this.config.chainName,
-            fallbackError: fallbackResult.error,
-            primaryError: primaryResult.error,
-            timestamp: new Date().toISOString(),
-          })
+          }
         );
         throw new Error(
           `RPC failed on both endpoints. Fallback: ${fallbackResult.error}. Primary: ${primaryResult.error}`
@@ -412,17 +411,16 @@ export class RpcProviderManager {
       );
 
       if (fallbackResult.success) {
-        console.warn(
-          JSON.stringify({
-            level: "warn",
+        logUserError(
+          ErrorCategory.NETWORK_RPC,
+          `[RPC] Primary RPC failed for ${this.config.chainName}, switching to fallback`,
+          primaryResult.error,
+          {
             event: "RPC_FAILOVER_ACTIVATED",
-            message: `Primary RPC failed for ${this.config.chainName}, switching to fallback`,
             chain: this.config.chainName,
-            previousState: "primary",
-            newState: "fallback",
-            primaryError: primaryResult.error,
-            timestamp: new Date().toISOString(),
-          })
+            previous_state: "primary",
+            new_state: "fallback",
+          }
         );
         this.isUsingFallback = true;
         this.onFailoverStateChange?.(this.config.chainName, true, "failover");
@@ -430,16 +428,14 @@ export class RpcProviderManager {
       }
 
       this.metricsCollector.recordBothFailed(this.config.chainName);
-      console.error(
-        JSON.stringify({
-          level: "error",
+      logUserError(
+        ErrorCategory.NETWORK_RPC,
+        `[RPC] Both primary and fallback RPC failed for ${this.config.chainName}`,
+        `Primary: ${primaryResult.error}. Fallback: ${fallbackResult.error}`,
+        {
           event: "RPC_BOTH_ENDPOINTS_FAILED",
-          message: `Both primary and fallback RPC failed for ${this.config.chainName}`,
           chain: this.config.chainName,
-          primaryError: primaryResult.error,
-          fallbackError: fallbackResult.error,
-          timestamp: new Date().toISOString(),
-        })
+        }
       );
       throw new Error(
         `RPC failed on both endpoints. Primary: ${primaryResult.error}. Fallback: ${fallbackResult.error}`

--- a/lib/rpc/providers/solana.ts
+++ b/lib/rpc/providers/solana.ts
@@ -1,4 +1,5 @@
 import { type Commitment, Connection } from "@solana/web3.js";
+import { ErrorCategory, logUserError } from "@/lib/logging";
 import { safeFetch } from "@/lib/safe-fetch";
 import {
   RPC_CONNECTION_ERROR_PATTERNS,
@@ -274,14 +275,14 @@ export class SolanaProviderManager {
           return fallbackResult.result as T;
         }
 
-        console.warn(
-          JSON.stringify({
-            level: "warn",
+        logUserError(
+          ErrorCategory.NETWORK_RPC,
+          `[Solana RPC] Fallback RPC failed for ${this.config.chainName}, attempting primary recovery`,
+          fallbackResult.error,
+          {
             event: "SOLANA_RPC_FALLBACK_FAILED",
-            message: `Fallback RPC failed for ${this.config.chainName}, attempting primary recovery`,
             chain: this.config.chainName,
-            timestamp: new Date().toISOString(),
-          })
+          }
         );
       }
     }
@@ -340,17 +341,16 @@ export class SolanaProviderManager {
           operationType
         );
         if (!this.isUsingFallback) {
-          console.warn(
-            JSON.stringify({
-              level: "warn",
+          logUserError(
+            ErrorCategory.NETWORK_RPC,
+            `[Solana RPC] Primary RPC failed for ${this.config.chainName}, switching to fallback`,
+            primaryResult.error,
+            {
               event: "SOLANA_RPC_FAILOVER_ACTIVATED",
-              message: `Primary RPC failed for ${this.config.chainName}, switching to fallback`,
               chain: this.config.chainName,
-              previousState: "primary",
-              newState: "fallback",
-              primaryError: primaryResult.error,
-              timestamp: new Date().toISOString(),
-            })
+              previous_state: "primary",
+              new_state: "fallback",
+            }
           );
           this.isUsingFallback = true;
           this.onFailoverStateChange?.(this.config.chainName, true, "failover");
@@ -359,16 +359,14 @@ export class SolanaProviderManager {
       }
 
       this.metricsCollector.recordBothFailed(this.config.chainName);
-      console.error(
-        JSON.stringify({
-          level: "error",
+      logUserError(
+        ErrorCategory.NETWORK_RPC,
+        `[Solana RPC] Both primary and fallback RPC failed for ${this.config.chainName}`,
+        `Primary: ${primaryResult.error}. Fallback: ${fallbackResult.error}`,
+        {
           event: "SOLANA_RPC_BOTH_ENDPOINTS_FAILED",
-          message: `Both primary and fallback RPC failed for ${this.config.chainName}`,
           chain: this.config.chainName,
-          primaryError: primaryResult.error,
-          fallbackError: fallbackResult.error,
-          timestamp: new Date().toISOString(),
-        })
+        }
       );
       throw new Error(
         `Solana RPC failed on both endpoints. Primary: ${primaryResult.error}. Fallback: ${fallbackResult.error}`

--- a/lib/rpc/rpc-config.ts
+++ b/lib/rpc/rpc-config.ts
@@ -21,6 +21,8 @@
  *   }
  */
 
+import { logWarn } from "@/lib/logging";
+
 /**
  * Public RPC defaults (no API keys required)
  * These are used as last resort when no config is provided
@@ -265,12 +267,10 @@ function getRpcConfigSingleton(): RpcConfig {
     const result = parseRpcConfigWithDetails(envValue);
 
     if (envValue && Object.keys(result.config).length === 0) {
-      console.warn(
-        "[rpc-config] Failed to parse CHAIN_RPC_CONFIG, using public RPC defaults"
+      logWarn(
+        "[rpc-config] Failed to parse CHAIN_RPC_CONFIG, using public RPC defaults",
+        result.error ? { parse_error: result.error } : undefined
       );
-      if (result.error) {
-        console.warn(`  Parse error: ${result.error}`);
-      }
     }
 
     _rpcConfigSingleton = result.config;

--- a/lib/safe-fetch.ts
+++ b/lib/safe-fetch.ts
@@ -9,6 +9,7 @@ import {
 import { BlockList, isIP } from "node:net";
 import { captureException } from "@sentry/nextjs";
 import { Agent, buildConnector, fetch as undiciFetch } from "undici";
+import { logWarn } from "@/lib/logging";
 import { getMetricsCollector } from "@/lib/metrics";
 import {
   SSRF_BLOCKED_HOST_EXACT,
@@ -343,7 +344,12 @@ function recordBlock(ctx: BlockContext, shadow: boolean): void {
       : "";
   const pluginSuffix =
     ctx.plugin === undefined ? "" : ` [plugin=${ctx.plugin}]`;
-  console.warn(
+  // logWarn (JSON line only, NO metric, NO Sentry): the metric and Sentry
+  // capture are emitted directly above/below. Routing through
+  // logUserError/logSystemError would emit a second error metric whose fixed
+  // initial labelset rejects hostname/resolved_ip and turns shadow mode into
+  // a synchronous throw.
+  logWarn(
     `[safe-fetch] Blocked outbound request${modeSuffix}: ${ctx.hostname}${resolvedSuffix} (reason=${ctx.reason})${pluginSuffix}`
   );
 

--- a/lib/schedule-service.ts
+++ b/lib/schedule-service.ts
@@ -3,7 +3,7 @@ import { eq } from "drizzle-orm";
 import { IntervalTooSmallError, parseIntervalSeconds } from "@/lib/cron-utils";
 import { db } from "@/lib/db";
 import { workflowSchedules } from "@/lib/db/schema";
-import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { ErrorCategory, logSystemError, logUserError } from "@/lib/logging";
 import { generateId } from "@/lib/utils/id";
 import type { WorkflowNode } from "@/lib/workflow/store";
 
@@ -239,8 +239,11 @@ export async function syncWorkflowSchedule(
 
   // Validate timezone (shared by both modes)
   if (!validateTimezone(timezone)) {
-    console.warn(
-      `[Schedule] Invalid timezone for workflow ${workflowId}: ${timezone}`
+    logUserError(
+      ErrorCategory.VALIDATION,
+      `[Schedule] Invalid timezone for workflow ${workflowId}: ${timezone}`,
+      undefined,
+      { workflow_id: workflowId }
     );
     return {
       synced: false,
@@ -256,8 +259,11 @@ export async function syncWorkflowSchedule(
       scheduleConfig.cronExpression
     );
     if (!cronValidation.valid) {
-      console.warn(
-        `[Schedule] Invalid cron for workflow ${workflowId}: ${cronValidation.error}`
+      logUserError(
+        ErrorCategory.VALIDATION,
+        `[Schedule] Invalid cron for workflow ${workflowId}: ${cronValidation.error}`,
+        undefined,
+        { workflow_id: workflowId }
       );
       return {
         synced: false,
@@ -418,7 +424,12 @@ export async function updateScheduleAfterRun(
   });
 
   if (!schedule) {
-    console.error(`[Schedule] Schedule not found: ${scheduleId}`);
+    logSystemError(
+      ErrorCategory.WORKFLOW_ENGINE,
+      "[Schedule] Schedule not found",
+      new Error(`Schedule not found: ${scheduleId}`),
+      { schedule_id: scheduleId }
+    );
     return;
   }
 

--- a/lib/security/backstop-capture.ts
+++ b/lib/security/backstop-capture.ts
@@ -28,7 +28,7 @@
  * rethrow.
  */
 
-import { captureMessage } from "@sentry/nextjs";
+import { logSecurityEvent } from "@/lib/logging";
 import type { TriggerSource } from "./request-attribution";
 
 const PG_RAISE_INSUFFICIENT_PRIVILEGE = "42501";
@@ -76,39 +76,25 @@ export async function withBackstopCapture<T>(
     return await insert();
   } catch (err) {
     if (isBackstopRejection(err)) {
-      // Best-effort: never let a Sentry transport failure shadow the
-      // original backstop exception. Callers downstream depend on the pg
-      // error shape to render correct error responses.
-      try {
-        captureMessage("security.backstop_execution_blocked", {
-          level: "warning",
+      // Best-effort dual emit (Sentry + structured stdout); logSecurityEvent
+      // self-guards both transports so a failure never shadows the original
+      // backstop exception that downstream callers depend on.
+      logSecurityEvent(
+        "backstop_execution_blocked",
+        {
+          workflowId: context.workflowId,
+          userId: context.userId,
+          source: context.source,
+        },
+        {
           tags: {
             security: "backstop_execution_blocked",
             source: context.source,
           },
           user: { id: context.userId },
-          extra: {
-            workflowId: context.workflowId,
-            source: context.source,
-          },
-        });
-      } catch {
-        // swallow; capture is observability, not a contract
-      }
-      // Structured stdout line for Loki / log-only alerting. Independent
-      // of Sentry transport so the signal is durable.
-      try {
-        console.warn(
-          JSON.stringify({
-            event: "security.backstop_execution_blocked",
-            workflowId: context.workflowId,
-            userId: context.userId,
-            source: context.source,
-          })
-        );
-      } catch {
-        // never let log emission shadow the original error
-      }
+          extra: { workflowId: context.workflowId, source: context.source },
+        }
+      );
     }
     throw err;
   }

--- a/lib/security/content-scanner.ts
+++ b/lib/security/content-scanner.ts
@@ -24,7 +24,7 @@
  * neon_auth, refresh_token, client_secret, DATABASE_URL".
  */
 
-import { captureMessage } from "@sentry/nextjs";
+import { logSecurityEvent } from "@/lib/logging";
 
 type Pattern = {
   readonly name: string;
@@ -222,9 +222,19 @@ export function emitScanReport(
     return;
   }
   const unique = dedupeHits(hits);
-  try {
-    captureMessage("security.content_scanner_hit", {
-      level: "warning",
+  // Best-effort dual emit (Sentry + structured stdout); logSecurityEvent
+  // self-guards both so a transport failure can never escape into the
+  // executor or change workflow execution semantics.
+  logSecurityEvent(
+    "content_scanner_hit",
+    {
+      workflowId: context.workflowId,
+      executionId: context.executionId,
+      organizationId: context.organizationId,
+      hitCount: unique.length,
+      hits: unique,
+    },
+    {
       tags: { security: "content_scanner_hit" },
       extra: {
         workflowId: context.workflowId,
@@ -233,27 +243,8 @@ export function emitScanReport(
         hitCount: unique.length,
         hits: unique,
       },
-    });
-  } catch {
-    // Best-effort. Sentry transport failure must never escape into the
-    // executor or change workflow execution semantics.
-  }
-  // Structured stdout line for Loki / log-only alerting. Independent of
-  // Sentry transport so the signal lands even with SENTRY_DSN unset.
-  try {
-    console.warn(
-      JSON.stringify({
-        event: "security.content_scanner_hit",
-        workflowId: context.workflowId,
-        executionId: context.executionId,
-        organizationId: context.organizationId,
-        hitCount: unique.length,
-        hits: unique,
-      })
-    );
-  } catch {
-    // never let log emission escape into the executor
-  }
+    }
+  );
 }
 
 /**
@@ -300,18 +291,13 @@ export function scanAndReport(
     // but nobody is watching" blind spot this layer exists to remove. Emit
     // one structured line (self-guarded so the failure-signal can't escape
     // either) so a probe that quietly stopped working is itself observable.
-    try {
-      console.warn(
-        JSON.stringify({
-          event: "security.content_scanner_error",
-          workflowId: context.workflowId,
-          executionId: context.executionId,
-          organizationId: context.organizationId,
-          message: error instanceof Error ? error.message : String(error),
-        })
-      );
-    } catch {
-      // never let the failure-signal emission escape into the executor
-    }
+    // Log-only self-signal (no Sentry by design); logSecurityEvent self-guards
+    // emission so it can never escape into the executor.
+    logSecurityEvent("content_scanner_error", {
+      workflowId: context.workflowId,
+      executionId: context.executionId,
+      organizationId: context.organizationId,
+      message: error instanceof Error ? error.message : String(error),
+    });
   }
 }

--- a/lib/security/session-backstop.ts
+++ b/lib/security/session-backstop.ts
@@ -18,7 +18,7 @@
  * constructing the Better Auth config.
  */
 
-import { captureMessage } from "@sentry/nextjs";
+import { logSecurityEvent } from "@/lib/logging";
 
 export const KH001_SQLSTATE = "KH001";
 
@@ -64,14 +64,8 @@ export function reportSessionBackstop(error: unknown): boolean {
   if (!isKh001SessionBackstop(error)) {
     return false;
   }
-  try {
-    captureMessage("security.backstop_session_blocked", {
-      level: "warning",
-      tags: { security: "backstop_session_blocked", surface: "session" },
-    });
-  } catch {
-    // swallow; observability must not affect auth error handling
-  }
-  console.warn(JSON.stringify({ event: "security.backstop_session_blocked" }));
+  logSecurityEvent("backstop_session_blocked", undefined, {
+    tags: { security: "backstop_session_blocked", surface: "session" },
+  });
   return true;
 }

--- a/lib/utils/redact.ts
+++ b/lib/utils/redact.ts
@@ -3,6 +3,8 @@
  * before storage or display in observability tools
  */
 
+import { ErrorCategory, logSystemError } from "@/lib/logging";
+
 /**
  * List of sensitive field keys that should be redacted
  */
@@ -170,7 +172,11 @@ export function redactSensitiveData(data: any): any {
   try {
     return redactObject(data);
   } catch (error) {
-    console.error("[Redact] Error redacting data:", error);
+    logSystemError(
+      ErrorCategory.UNKNOWN,
+      "[Redact] Error redacting data",
+      error
+    );
     return "[REDACTION_ERROR]";
   }
 }

--- a/lib/web3/gas-strategy.ts
+++ b/lib/web3/gas-strategy.ts
@@ -19,6 +19,12 @@ import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { db } from "@/lib/db";
 import { chains } from "@/lib/db/schema";
+import {
+  ErrorCategory,
+  logSystemWarn,
+  logUserError,
+  logWarn,
+} from "@/lib/logging";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 
 /**
@@ -181,7 +187,9 @@ async function measureVolatility(
     };
   } catch (error) {
     // If fee history fails (some chains don't support it), return non-volatile
-    console.warn("[GasStrategy] Failed to fetch fee history:", error);
+    logWarn("[GasStrategy] Failed to fetch fee history", {
+      error: error instanceof Error ? error.message : String(error),
+    });
     return {
       baseFees: [],
       mean: BigInt(0),
@@ -239,7 +247,9 @@ async function getPercentileFees(
     return { baseFee, priorityFee };
   } catch (error) {
     // Fallback if fee history fails
-    console.warn("[GasStrategy] Failed to get percentile fees:", error);
+    logWarn("[GasStrategy] Failed to get percentile fees", {
+      error: error instanceof Error ? error.message : String(error),
+    });
     const feeData = await runRpc(rpcManager, provider, (p) => p.getFeeData());
     return {
       baseFee: feeData.maxFeePerGas ?? parseGwei("50"),
@@ -490,9 +500,11 @@ export class AdaptiveGasStrategy {
       }
     } catch (error) {
       // Database unavailable, fall back to hardcoded
-      console.warn(
-        "[GasStrategy] Failed to fetch chain config from DB:",
-        error
+      logSystemWarn(
+        ErrorCategory.DATABASE,
+        "[GasStrategy] Failed to fetch chain config from DB",
+        error,
+        { chain_id: String(chainId) }
       );
     }
 
@@ -715,8 +727,14 @@ export async function executeWithRetry(
     }
 
     // Transaction stuck - will retry with higher gas (replacement)
-    console.warn(
-      `[GasStrategy] Transaction ${tx.hash} stuck after ${config.stuckThresholdMs}ms`
+    logUserError(
+      ErrorCategory.TRANSACTION,
+      `[GasStrategy] Transaction ${tx.hash} stuck after ${config.stuckThresholdMs}ms`,
+      undefined,
+      {
+        tx_hash: tx.hash,
+        stuck_threshold_ms: String(config.stuckThresholdMs),
+      }
     );
   }
 

--- a/lib/web3/nonce-manager.ts
+++ b/lib/web3/nonce-manager.ts
@@ -20,7 +20,12 @@ import { and, eq, isNull, lt, or, sql } from "drizzle-orm";
 import type { ethers } from "ethers";
 import { db } from "@/lib/db";
 import { pendingTransactions, walletLocks } from "@/lib/db/schema-extensions";
-import { ErrorCategory, logSystemError } from "@/lib/logging";
+import {
+  ErrorCategory,
+  logSystemError,
+  logSystemWarn,
+  logWarn,
+} from "@/lib/logging";
 
 export type NonceSession = {
   walletAddress: string;
@@ -134,10 +139,9 @@ export class NonceManager {
       );
 
       if (validation.warnings.length > 0) {
-        console.warn(
-          "[NonceManager] Validation warnings:",
-          validation.warnings
-        );
+        logWarn("[NonceManager] Validation warnings", {
+          warnings: validation.warnings.join("; "),
+        });
       }
 
       return { session, validation };
@@ -449,10 +453,22 @@ export class NonceManager {
           const expiredAgoMs = priorExpires
             ? Date.now() - priorExpires.getTime()
             : null;
-          console.warn(
-            `[NonceManager] Lock takeover for ${walletAddress}:${chainId}, ` +
-              `priorHolder=${priorHolder}, expiredAgoMs=${expiredAgoMs}, ` +
-              `newHolder=${executionId}`
+          logSystemWarn(
+            ErrorCategory.INFRASTRUCTURE,
+            `[NonceManager] Lock takeover for ${walletAddress}:${chainId}`,
+            new Error(
+              `[NonceManager] Lock takeover for ${walletAddress}:${chainId}, ` +
+                `priorHolder=${priorHolder}, expiredAgoMs=${expiredAgoMs}, ` +
+                `newHolder=${executionId}`
+            ),
+            {
+              wallet_address: walletAddress,
+              chain_id: String(chainId),
+              prior_holder: priorHolder,
+              expired_ago_ms:
+                expiredAgoMs === null ? "unknown" : String(expiredAgoMs),
+              execution_id: executionId,
+            }
           );
         }
         console.log(

--- a/lib/web3/transaction-manager.ts
+++ b/lib/web3/transaction-manager.ts
@@ -20,10 +20,10 @@ import type { ethers } from "ethers";
 import { db } from "@/lib/db";
 import { explorerConfigs } from "@/lib/db/schema";
 import { getTransactionUrl } from "@/lib/explorer";
-import { ErrorCategory, logUserError } from "@/lib/logging";
-import { initializeWalletSigner } from "@/lib/web3/wallet-helpers";
+import { ErrorCategory, logUserError, logWarn } from "@/lib/logging";
 import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
+import { initializeWalletSigner } from "@/lib/web3/wallet-helpers";
 import { getGasStrategy } from "./gas-strategy";
 import { getNonceManager, type NonceSession } from "./nonce-manager";
 import {
@@ -383,10 +383,9 @@ export async function withNonceSession<T>(
   );
 
   if (!validation.valid) {
-    console.warn(
-      "[TransactionManager] Starting workflow with warnings:",
-      validation.warnings
-    );
+    logWarn("[TransactionManager] Starting workflow with warnings", {
+      warnings: validation.warnings.join("; "),
+    });
   }
 
   try {

--- a/lib/workflow/nodes/database-query/step.ts
+++ b/lib/workflow/nodes/database-query/step.ts
@@ -16,6 +16,7 @@ import {
   getPostgresConnectionOptions,
   type PostgresSslOption,
 } from "@/lib/db/connection-utils";
+import { ErrorCategory, logUserError } from "@/lib/logging";
 import {
   type StepInput,
   withStepLogging,
@@ -169,7 +170,11 @@ async function databaseQuery(
       count: Array.isArray(result) ? result.length : 0,
     };
   } catch (error) {
-    console.error("[Database Query] Raw connection error:", error);
+    logUserError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      "[Database Query] Raw connection error",
+      error
+    );
     return {
       success: false,
       error: `Database query failed: ${getDatabaseErrorMessage(error)}`,

--- a/lib/workflow/store.ts
+++ b/lib/workflow/store.ts
@@ -3,6 +3,7 @@ import { applyEdgeChanges, applyNodeChanges } from "@xyflow/react";
 import { atom } from "jotai";
 import { toast } from "sonner";
 import { api } from "@/lib/api-client";
+import { ErrorCategory, logSystemError, logUserError } from "@/lib/logging";
 import { computeAutoLayout } from "@/lib/workflow/editor/auto-layout";
 import { buildExecutionLogsMap } from "@/lib/workflow/editor/template-helpers";
 
@@ -219,7 +220,11 @@ export const autosaveAtom = atom(
         // Leave hasUnsavedChangesAtom set (only cleared on success) and tell the
         // user: a rejected save - e.g. the server refusing an out-of-org
         // connection reference - must not fail silently.
-        console.warn("Autosave failed:", error);
+        logUserError(
+          ErrorCategory.VALIDATION,
+          "[Workflow] Autosave failed",
+          error
+        );
         toast.error("Couldn't save workflow changes. Please try again.");
       } finally {
         await new Promise((resolve) => setTimeout(resolve, 800));
@@ -682,7 +687,11 @@ export const loadWorkflowAtom = atom(null, async (get, set) => {
         });
     }
   } catch (error) {
-    console.error("Failed to load workflow:", error);
+    logSystemError(
+      ErrorCategory.UNKNOWN,
+      "[Workflow] Failed to load workflow",
+      error
+    );
   } finally {
     set(isLoadingAtom, false);
   }
@@ -708,7 +717,11 @@ export const saveWorkflowAsAtom = atom(
       });
       return workflow;
     } catch (error) {
-      console.error("Failed to save workflow:", error);
+      logSystemError(
+        ErrorCategory.UNKNOWN,
+        "[Workflow] Failed to save workflow",
+        error
+      );
       throw error;
     }
   }

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -5,14 +5,18 @@ import { init } from "@sentry/nextjs";
 
 const { SENTRY_DSN, SENTRY_ENVIRONMENT } = process.env;
 
+// Env-driven performance-trace sampling; defaults to 0.1 (errors are always
+// captured regardless). Override per environment via SENTRY_TRACES_SAMPLE_RATE.
+const tracesEnv = process.env.SENTRY_TRACES_SAMPLE_RATE;
+const tracesSampleRate =
+  tracesEnv && Number.isFinite(Number(tracesEnv)) ? Number(tracesEnv) : 0.1;
+
 if (SENTRY_DSN) {
   init({
     dsn: SENTRY_DSN,
     environment: SENTRY_ENVIRONMENT,
 
-    // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-    // 1 = 100% of traces are sent
-    tracesSampleRate: 1,
+    tracesSampleRate,
 
     // Enable logs to be sent to Sentry
     enableLogs: true,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -6,14 +6,20 @@ import { init } from "@sentry/nextjs";
 
 const { SENTRY_DSN, SENTRY_ENVIRONMENT } = process.env;
 
+// Performance-trace sampling is env-driven (SENTRY_TRACES_SAMPLE_RATE) and
+// defaults to 0.1 to cap cost/volume in production. This only samples
+// performance traces - error events are always captured. Set the env var per
+// environment (e.g. 1 in staging) to override.
+const tracesEnv = process.env.SENTRY_TRACES_SAMPLE_RATE;
+const tracesSampleRate =
+  tracesEnv && Number.isFinite(Number(tracesEnv)) ? Number(tracesEnv) : 0.1;
+
 if (SENTRY_DSN) {
   init({
     dsn: SENTRY_DSN,
     environment: SENTRY_ENVIRONMENT,
 
-    // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-    // 1 = 100% of traces are sent
-    tracesSampleRate: 1,
+    tracesSampleRate,
 
     // Enable logs to be sent to Sentry
     enableLogs: true,

--- a/specs/logging-and-metrics/logging-metrics-system.md
+++ b/specs/logging-and-metrics/logging-metrics-system.md
@@ -4,6 +4,33 @@
 
 The unified logging system ensures 100% metric coverage for all errors and warnings by providing two core functions that automatically log to console AND emit Prometheus metrics.
 
+## Architecture (KEEP-814 unification)
+
+Every service emits a single canonical log-line shape so Grafana Loki `| json`
+works uniformly across the app and all satellites:
+
+```
+{ "level": "debug|info|warn|error", "ts": "<ISO-8601>", "msg": "...", ...fields }
+```
+
+- **One writer** - `lib/log/core.ts` `emitLogLine(level, payload)` stamps
+  `level`+`ts`, JSON-stringifies a single line, and writes via the original
+  (unpatched) console (`rawConsole`). It respects `LOG_LEVEL`.
+- **Facade** - `lib/logger.ts` patches `console.*` so any stray
+  `console.log/info/debug/warn/error` is normalized into the canonical JSON
+  shape instead of a freeform prefixed string. Loaded once at startup via
+  `instrumentation.ts`. (Previously it prepended `[ts] [LEVEL]` text, which
+  broke `| json`; it now *produces* JSON.)
+- **Helpers** (`lib/logging.ts`):
+  - `logUserError` / `logSystemError` - errors (JSON + Prometheus metric + Sentry where applicable).
+  - `logSystemWarn` - system warning (JSON + Sentry warning, no metric).
+  - `logInfo` / `logWarn` / `logDebug` - structured non-error logs (JSON only, no metric, no Sentry); merge async-local workflow context.
+  - `logSecurityEvent(name, fields?, sentry?)` - KEEP-612 `security.*` detection signals (canonical JSON line + optional Sentry `captureMessage`), self-guarded.
+  - `logInternalAuthEvent`, `lib/mcp/logging.ts` `logMcpEvent` - structured audit/event lines.
+- **Enforcement** - Biome `suspicious/noConsole` with `allow: ["log","info","debug"]` makes raw `console.warn`/`console.error` a lint error in server code, forcing failures through the structured helpers. Client (browser), tests, the logging infra, and the satellite packages are exempted in `biome.jsonc` `overrides`/`files`.
+- **Sentry** - `tracesSampleRate` is env-driven (`SENTRY_TRACES_SAMPLE_RATE` / `NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE`, default `0.1`; errors are always captured). `logUserError` no longer sends to Sentry (expected/high-volume; tracked via metric + log). `wallet_address` is scrubbed from Sentry `extra` (kept only in the console line).
+- **Satellites** - `keeperhub-events` (the `Logger` class), `keeperhub-scheduler`, `keeperhub-executor`, and `keeperhub-metrics-collector` are separate packages that cannot import `@/lib/*`. They emit the same canonical schema via a vendored `log-facade.ts` (console patch, imported first at each entrypoint) or, for event-tracker, the updated `Logger`. Consistency is guaranteed by the shared schema, not shared code.
+
 ## API
 
 ### Core Functions
@@ -27,9 +54,10 @@ Use for errors caused by user actions or external factors (not system failures).
 - `ErrorCategory.TRANSACTION` - Transaction failures, gas estimation errors, nonce issues
 
 **Behavior:**
-- Logs to console using `console.warn` (user errors don't wake up DevOps)
+- Emits a canonical JSON line at `warn` level via `emitLogLine` (user errors don't wake up DevOps)
 - Emits Prometheus metric with `error_type: "user"`
 - Extracts context from message prefix (e.g., `"[Discord]"` becomes `"Discord"`)
+- Does NOT report to Sentry (KEEP-814): user errors are expected and high-volume; alert on the metric rate in Grafana instead
 
 #### logSystemError
 ```typescript
@@ -45,8 +73,9 @@ Use for errors caused by system failures (critical infrastructure issues).
 - `ErrorCategory.WORKFLOW_ENGINE` - Workflow execution failures, step resolution errors
 
 **Behavior:**
-- Logs to console using `console.error` (critical failures)
+- Emits a canonical JSON line at `error` level via `emitLogLine` (critical failures)
 - Emits Prometheus metric with `error_type: "system"`
+- Reports to Sentry (`wallet_address` scrubbed from `extra`)
 - Extracts context from message prefix
 
 ## Usage Examples

--- a/tests/integration/security-behavioral-scan.test.ts
+++ b/tests/integration/security-behavioral-scan.test.ts
@@ -17,8 +17,14 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import type { InternalServiceAuthResult } from "@/lib/internal-service-auth";
+import { rawConsole } from "@/lib/log/core";
+
+// logSecurityEvent writes the structured line via lib/log/core's rawConsole.
+const raw = rawConsole as unknown as Record<
+  "debug" | "info" | "warn" | "error",
+  (line: string) => void
+>;
 
 // authenticateInternalService is async and returns a discriminated union;
 // reassigned per-test to drive the route's handling of each verdict.
@@ -68,10 +74,10 @@ vi.mock("@/lib/db/schema", () => ({
 
 const { GET } = await import("@/app/api/cron/security-behavioral-scan/route");
 
-const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+const warnSpy = vi.spyOn(raw, "warn").mockImplementation(() => {
   // suppress test noise; we assert against the spy below
 });
-const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {
+const errorSpy = vi.spyOn(raw, "error").mockImplementation(() => {
   // suppress test noise; we assert against the spy below
 });
 

--- a/tests/unit/content-scanner.test.ts
+++ b/tests/unit/content-scanner.test.ts
@@ -1,4 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { rawConsole } from "@/lib/log/core";
+
+// logSecurityEvent writes the structured line via lib/log/core's rawConsole.
+const raw = rawConsole as unknown as Record<
+  "debug" | "info" | "warn" | "error",
+  (line: string) => void
+>;
 
 const captureMessageMock = vi.fn();
 vi.mock("@sentry/nextjs", () => ({
@@ -197,7 +204,7 @@ describe("scanAndReport", () => {
   });
 
   it("emits a structured error signal when the scan itself throws", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+    const warnSpy = vi.spyOn(raw, "warn").mockImplementation(() => {
       // swallow the line in test
     });
     // Force a throw inside the scan: reading `.nodes` blows up, simulating a
@@ -209,7 +216,9 @@ describe("scanAndReport", () => {
         throw new Error("scanner exploded");
       },
     } as unknown as { nodes: never };
-    expect(() => scanAndReport(exploding, { workflowId: "wf_err" })).not.toThrow();
+    expect(() =>
+      scanAndReport(exploding, { workflowId: "wf_err" })
+    ).not.toThrow();
     const errorLine = warnSpy.mock.calls
       .map((call) => String(call[0]))
       .find((line) => line.includes("security.content_scanner_error"));

--- a/tests/unit/logging.test.ts
+++ b/tests/unit/logging.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { rawConsole } from "@/lib/log/core";
 import {
   ErrorCategory,
   logSystemError,
@@ -13,23 +14,34 @@ import {
 } from "@/lib/metrics/types";
 import { createMockMetricsCollector } from "../mocks/metrics";
 
+// The structured logger writes via lib/log/core's rawConsole (the original
+// console methods bound at module load), so spies must target rawConsole, not
+// the global console (which the facade would patch in a real runtime).
+const raw = rawConsole as unknown as Record<
+  "debug" | "info" | "warn" | "error",
+  (line: string) => void
+>;
+
 describe("Unified Logging Helpers", () => {
   let mockCollector: MetricsCollector;
   let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  const originalLevel = process.env.LOG_LEVEL;
 
   beforeEach(() => {
     vi.clearAllMocks();
     resetMetricsCollector();
+    // Make console emission deterministic regardless of ambient LOG_LEVEL.
+    process.env.LOG_LEVEL = "debug";
 
     mockCollector = createMockMetricsCollector();
     setMetricsCollector(mockCollector);
 
-    // Spy on console methods
-    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+    // Spy on the canonical sink (rawConsole), not the global console.
+    consoleWarnSpy = vi.spyOn(raw, "warn").mockImplementation(() => {
       // noop - suppress console output
     });
-    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {
+    consoleErrorSpy = vi.spyOn(raw, "error").mockImplementation(() => {
       // noop - suppress console output
     });
   });
@@ -37,6 +49,7 @@ describe("Unified Logging Helpers", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     resetMetricsCollector();
+    process.env.LOG_LEVEL = originalLevel;
   });
 
   // KEEP-545: log helpers now emit a single structured JSON line so Grafana
@@ -44,11 +57,15 @@ describe("Unified Logging Helpers", () => {
   // and `org_slug` via `| json`. This helper parses the JSON arg and returns
   // the payload so per-test assertions can check fields without coupling to
   // the on-the-wire serialization order.
-  function lastJsonLine(spy: ReturnType<typeof vi.spyOn>): Record<string, unknown> {
-    const calls = spy.mock.calls;
-    expect(calls.length).toBeGreaterThan(0);
-    const last = calls[calls.length - 1];
-    expect(last.length).toBe(1);
+  function lastJsonLine(
+    spy: ReturnType<typeof vi.spyOn>
+  ): Record<string, unknown> {
+    const last = spy.mock.calls.at(-1);
+    if (!last || last.length !== 1) {
+      throw new Error(
+        `expected exactly one structured log arg, got ${JSON.stringify(spy.mock.calls)}`
+      );
+    }
     return JSON.parse(last[0] as string) as Record<string, unknown>;
   }
 

--- a/tests/unit/metrics.test.ts
+++ b/tests/unit/metrics.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { rawConsole } from "@/lib/log/core";
 import {
   createTimer,
   getMetricsCollector,
@@ -15,6 +16,13 @@ import { noopMetricsCollector } from "@/lib/metrics/collectors/noop";
 import { LabelKeys, MetricNames } from "@/lib/metrics/types";
 import { createMockMetricsCollector } from "../mocks/metrics";
 
+// The console metrics collector writes via lib/log/core's rawConsole (the
+// original console methods, bypassing the facade), so spies target rawConsole.
+const raw = rawConsole as unknown as Record<
+  "debug" | "info" | "warn" | "error",
+  (line: string) => void
+>;
+
 describe("Metrics Collectors", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -28,7 +36,7 @@ describe("Metrics Collectors", () => {
 
   describe("consoleMetricsCollector", () => {
     it("should output JSON for recordLatency", () => {
-      const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {
+      const consoleSpy = vi.spyOn(raw, "info").mockImplementation(() => {
         // noop - suppress console output
       });
 
@@ -48,7 +56,7 @@ describe("Metrics Collectors", () => {
     });
 
     it("should output JSON for incrementCounter", () => {
-      const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {
+      const consoleSpy = vi.spyOn(raw, "info").mockImplementation(() => {
         // noop - suppress console output
       });
 
@@ -66,7 +74,7 @@ describe("Metrics Collectors", () => {
     });
 
     it("should increment counter with custom value", () => {
-      const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {
+      const consoleSpy = vi.spyOn(raw, "info").mockImplementation(() => {
         // noop - suppress console output
       });
 
@@ -77,7 +85,7 @@ describe("Metrics Collectors", () => {
     });
 
     it("should output JSON for recordError with Error object", () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {
+      const consoleSpy = vi.spyOn(raw, "error").mockImplementation(() => {
         // noop - suppress console output
       });
 
@@ -100,7 +108,7 @@ describe("Metrics Collectors", () => {
     });
 
     it("should output JSON for recordWarning at warn level", () => {
-      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+      const consoleSpy = vi.spyOn(raw, "warn").mockImplementation(() => {
         // noop - suppress console output
       });
 
@@ -122,7 +130,7 @@ describe("Metrics Collectors", () => {
     });
 
     it("should output JSON for recordError with ErrorContext", () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {
+      const consoleSpy = vi.spyOn(raw, "error").mockImplementation(() => {
         // noop - suppress console output
       });
 
@@ -140,7 +148,7 @@ describe("Metrics Collectors", () => {
     });
 
     it("should output JSON for setGauge", () => {
-      const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {
+      const consoleSpy = vi.spyOn(raw, "info").mockImplementation(() => {
         // noop - suppress console output
       });
 
@@ -157,7 +165,7 @@ describe("Metrics Collectors", () => {
     });
 
     it("should handle labels with different value types", () => {
-      const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {
+      const consoleSpy = vi.spyOn(raw, "info").mockImplementation(() => {
         // noop - suppress console output
       });
 
@@ -178,7 +186,7 @@ describe("Metrics Collectors", () => {
     });
 
     it("should handle undefined labels", () => {
-      const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {
+      const consoleSpy = vi.spyOn(raw, "info").mockImplementation(() => {
         // noop - suppress console output
       });
 
@@ -221,10 +229,10 @@ describe("Metrics Collectors", () => {
     });
 
     it("should not output to console", () => {
-      const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {
+      const infoSpy = vi.spyOn(raw, "info").mockImplementation(() => {
         // noop - suppress console output
       });
-      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {
+      const errorSpy = vi.spyOn(raw, "error").mockImplementation(() => {
         // noop - suppress console output
       });
 
@@ -240,7 +248,7 @@ describe("Metrics Collectors", () => {
 
   describe("createPrefixedConsoleCollector", () => {
     it("should prefix all metric names", () => {
-      const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {
+      const consoleSpy = vi.spyOn(raw, "info").mockImplementation(() => {
         // noop - suppress console output
       });
       const prefixed = createPrefixedConsoleCollector("myapp");

--- a/tests/unit/nonce-manager.test.ts
+++ b/tests/unit/nonce-manager.test.ts
@@ -38,13 +38,19 @@ vi.mock("@/lib/db/schema-extensions", () => ({
   },
 }));
 
-const { mockLogSystemError } = vi.hoisted(() => ({
-  mockLogSystemError: vi.fn(),
-}));
+const { mockLogSystemError, mockLogSystemWarn, mockLogWarn } = vi.hoisted(
+  () => ({
+    mockLogSystemError: vi.fn(),
+    mockLogSystemWarn: vi.fn(),
+    mockLogWarn: vi.fn(),
+  })
+);
 
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: { INFRASTRUCTURE: "infrastructure" },
   logSystemError: mockLogSystemError,
+  logSystemWarn: mockLogSystemWarn,
+  logWarn: mockLogWarn,
 }));
 
 import {
@@ -284,10 +290,6 @@ describe("NonceManager", () => {
         }),
       });
 
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
-        // suppress test output
-      });
-
       const manager = new NonceManager();
       const provider = createMockProvider();
 
@@ -298,12 +300,11 @@ describe("NonceManager", () => {
         provider as unknown as import("ethers").Provider
       );
 
-      const takeoverLogged = warnSpy.mock.calls.some((call) =>
-        String(call[0] ?? "").includes("Lock takeover")
+      // Lock takeover is a system-level smoke signal: logSystemWarn(message).
+      const takeoverLogged = mockLogSystemWarn.mock.calls.some((call) =>
+        String(call[1] ?? "").includes("Lock takeover")
       );
       expect(takeoverLogged).toBe(true);
-
-      warnSpy.mockRestore();
     });
   });
 

--- a/tests/unit/oauth-auth-anonymous.test.ts
+++ b/tests/unit/oauth-auth-anonymous.test.ts
@@ -1,4 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { rawConsole } from "@/lib/log/core";
+
+// logSecurityEvent writes the structured line via lib/log/core's rawConsole.
+const raw = rawConsole as unknown as Record<
+  "debug" | "info" | "warn" | "error",
+  (line: string) => void
+>;
 
 vi.mock("server-only", () => ({}));
 
@@ -63,7 +70,9 @@ describe("authenticateOAuthToken -- anonymous principal handling", () => {
 
     expect(result.authenticated).toBe(false);
     expect(result.statusCode).toBe(403);
-    expect(result.error).toBe("Anonymous accounts cannot use API access tokens");
+    expect(result.error).toBe(
+      "Anonymous accounts cannot use API access tokens"
+    );
   });
 
   it("rejects a token whose subject only matches the anonymous name/email shape", async () => {
@@ -88,7 +97,7 @@ describe("authenticateOAuthToken -- anonymous principal handling", () => {
   });
 
   it("emits the anonymous-block detection signal", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+    const warnSpy = vi.spyOn(raw, "warn").mockImplementation(() => {
       // assert against the spy, suppress noise
     });
     const token = await createAccessToken({

--- a/tests/unit/oauth-auth-deactivated.test.ts
+++ b/tests/unit/oauth-auth-deactivated.test.ts
@@ -1,4 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { rawConsole } from "@/lib/log/core";
+
+// logSecurityEvent writes the structured line via lib/log/core's rawConsole.
+const raw = rawConsole as unknown as Record<
+  "debug" | "info" | "warn" | "error",
+  (line: string) => void
+>;
 
 vi.mock("server-only", () => ({}));
 
@@ -94,7 +101,7 @@ describe("authenticateOAuthToken -- deactivated user handling", () => {
   });
 
   it("emits the structured stdout signal alongside Sentry", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+    const warnSpy = vi.spyOn(raw, "warn").mockImplementation(() => {
       // assert against the spy, suppress noise
     });
     const token = await createAccessToken({
@@ -119,7 +126,7 @@ describe("authenticateOAuthToken -- deactivated user handling", () => {
   });
 
   it("still rejects (and logs) when Sentry capture throws", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+    const warnSpy = vi.spyOn(raw, "warn").mockImplementation(() => {
       // suppress noise
     });
     mockCaptureMessage.mockImplementationOnce(() => {

--- a/tests/unit/prometheus-collector.test.ts
+++ b/tests/unit/prometheus-collector.test.ts
@@ -17,6 +17,7 @@
  * the log.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { rawConsole } from "@/lib/log/core";
 
 vi.mock("server-only", () => ({}));
 
@@ -25,11 +26,18 @@ import {
   prometheusMetricsCollector,
 } from "@/lib/metrics/collectors/prometheus";
 
+// The collector's unknown-metric path logs via logWarn -> lib/log/core's
+// rawConsole, so the spy must target rawConsole, not the global console.
+const raw = rawConsole as unknown as Record<
+  "debug" | "info" | "warn" | "error",
+  (line: string) => void
+>;
+
 describe("prometheusMetricsCollector.recordError -- defensive label filtering", () => {
   let warnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+    warnSpy = vi.spyOn(raw, "warn").mockImplementation(() => {
       // suppress
     });
   });

--- a/tests/unit/session-backstop.test.ts
+++ b/tests/unit/session-backstop.test.ts
@@ -1,4 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { rawConsole } from "@/lib/log/core";
+
+// logSecurityEvent writes the structured line via lib/log/core's rawConsole.
+const raw = rawConsole as unknown as Record<
+  "debug" | "info" | "warn" | "error",
+  (line: string) => void
+>;
 
 const { mockCaptureMessage } = vi.hoisted(() => ({
   mockCaptureMessage: vi.fn(),
@@ -75,16 +82,19 @@ describe("isKh001SessionBackstop", () => {
 
 describe("reportSessionBackstop (onAPIError emit wiring)", () => {
   let warnSpy: ReturnType<typeof vi.spyOn>;
+  const originalLevel = process.env.LOG_LEVEL;
 
   beforeEach(() => {
+    process.env.LOG_LEVEL = "debug";
     mockCaptureMessage.mockReset();
-    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+    warnSpy = vi.spyOn(raw, "warn").mockImplementation(() => {
       // assert against the spy, suppress noise
     });
   });
 
   afterEach(() => {
     warnSpy.mockRestore();
+    process.env.LOG_LEVEL = originalLevel;
   });
 
   it("emits Sentry + structured stdout and returns true on a wrapped KH001", () => {
@@ -105,7 +115,8 @@ describe("reportSessionBackstop (onAPIError emit wiring)", () => {
       surface: "session",
     });
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(JSON.parse(warnSpy.mock.calls[0][0] as string)).toEqual({
+    expect(JSON.parse(warnSpy.mock.calls[0][0] as string)).toMatchObject({
+      level: "warn",
       event: "security.backstop_session_blocked",
     });
   });


### PR DESCRIPTION
## Summary

Unifies KeeperHub logging onto a single, structured, enforced contract. Previously there were five parallel logging mechanisms (a structured error+metrics+Sentry helper, a console monkeypatch that prefixed text, two more JSON emitters with different field names, and a multi-line pretty-printer in event-tracker) plus ~1,400 raw `console.*` calls. Errors logged via raw `console.error` reached neither Prometheus nor Sentry, and the console patch's `[ts] [LEVEL]` text prefix defeated Loki `| json`.

Now every service emits one canonical single-line JSON shape, so `{namespace="keeperhub"} | json` works uniformly:

```
{ "level": "info", "ts": "<ISO-8601>", "msg": "...", ...fields }
```

## What changed

- **One writer** (`lib/log/core.ts` `emitLogLine`) stamps `level`+`ts` and writes single-line JSON via the original console. The `lib/logger.ts` facade now produces JSON instead of prefixing text.
- **Helpers** (`lib/logging.ts`): `logUserError` / `logSystemError` / `logSystemWarn` (errors route to metric/Sentry as appropriate), new `logInfo` / `logWarn` / `logDebug` (structured, no metric/Sentry), and `logSecurityEvent` for the `security.*` detection signals (preserving the substring the Loki line-filter alerts match).
- **~100 failure-path `console.error/warn`** across rpc, web3, billing, metrics, db, auth and app routes migrated to the structured helpers, so failures reach Prometheus + Sentry. `lib/metrics/**` uses the metric-free helpers to avoid recursion.
- **Sentry tuning**: `tracesSampleRate` is env-driven (default 0.1; error events are always captured); user errors are no longer sent to Sentry (expected/high-volume, metric-tracked); `wallet_address` is scrubbed from Sentry extras.
- **Enforcement**: Biome `noConsole` (`allow: [log, info, debug]`) makes raw `console.warn/error` a lint error in server code. Client (browser) code, tests, the logging infra itself, and satellite packages are exempted.
- **Satellites**: the event-tracker `Logger` is rewritten from multi-line pretty JSON to single-line; a vendored console facade is added to keeperhub-executor, keeperhub-scheduler and keeperhub-metrics-collector so their output matches the same schema with no call-site churn.

Split into six reviewable commits (contract, security/auth, failure-path, Sentry config, enforcement, satellites + docs).

## Verification

- `pnpm type-check`: 0 errors.
- Full unit suite: 381 files / 6,475 tests pass.
- Biome `noConsole`: 0 violations across the repo.

## Notes / follow-ups

- The satellite packages' own test/build pipelines should run in their CI; their deps are not installed in the dev worktree, so only the vendored facades' standalone type-check was verified here.
- Sentry defaults changed (`tracesSampleRate` 1 to 0.1; user errors off Sentry). Deploy values can override `SENTRY_TRACES_SAMPLE_RATE` per environment; please confirm this matches the intended cost/visibility tradeoff.
- The repo has pre-existing Biome debt unrelated to this change; this PR adds no net-new lint errors but does not clean up the existing baseline.
- The structured-JSON drilldown the logging was designed for now works end to end; Loki dashboards/runbooks (infra repo) that worked around the old text prefix can be simplified.
