### PR TITLE
refactor: remove SAFE_FETCH_ENFORCE toggle, make SSRF enforce-by-default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -156,7 +156,11 @@ MPP_SECRET_KEY=              # HMAC secret for MPP challenge verification
 # http-request, blockscout) -- those reject internal targets regardless of this
 # flag, by design, since the URL is attacker-controlled. Reaching localhost
 # through those sinks is intentionally not supported even in shadow mode.
-# SAFE_FETCH_ENFORCE=false   # opt into safeFetch shadow mode for local dev (default is enforce)
+#
+# Shadow mode is dev/CI-only: real production (NODE_ENV=production, outside CI)
+# always enforces and ignores this flag, so a stray value cannot relax SSRF in
+# prod.
+# SAFE_FETCH_SHADOW=true   # opt into safeFetch shadow mode for local dev (default is enforce)
 
 # MailerLite (signup subscriber sync)
 MAILERLITE_API_KEY=

--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -71,8 +71,8 @@ inputs:
     description: 'AI_MODEL - a claude-* id routes /api/ai/generate to Anthropic'
     required: false
     default: ''
-  safe_fetch_enforce:
-    description: 'SAFE_FETCH_ENFORCE - set "false" for shadow-mode SSRF so the app can reach the localhost anvil fork (safe-roles-orchestrator-fork suite)'
+  safe_fetch_shadow:
+    description: 'SAFE_FETCH_SHADOW - set "true" for shadow-mode SSRF so the app can reach the localhost anvil fork (safe-roles-orchestrator-fork suite). CI runs under NODE_ENV=production but is CI-exempt, so the flag still takes effect.'
     required: false
     default: ''
   load_test_bypass_token:
@@ -239,10 +239,10 @@ runs:
         NEXT_PUBLIC_AI_PROMPT_ENABLED: ${{ inputs.ai_prompt_enabled }}
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
         AI_MODEL: ${{ inputs.ai_model }}
-        # Shadow-mode SSRF (existing per-env opt-out): safeFetch logs but allows,
+        # Shadow-mode SSRF (dev/CI-only opt-in): safeFetch logs but allows,
         # so the app can reach the localhost anvil fork (safe-roles suite).
         # Unset/empty = enforced (default), so other jobs keep full SSRF.
-        SAFE_FETCH_ENFORCE: ${{ inputs.safe_fetch_enforce }}
+        SAFE_FETCH_SHADOW: ${{ inputs.safe_fetch_shadow }}
         # App-side verification of the x-load-test-mfa-bypass header (proxy.ts)
         # so playwright e2e sign-in clears the mandatory-MFA enrollment gate.
         LOAD_TEST_BYPASS_TOKEN: ${{ inputs.load_test_bypass_token }}

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -208,7 +208,7 @@ jobs:
           ai_prompt_enabled: "true"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           ai_model: claude-3-5-haiku-20241022
-          safe_fetch_enforce: "false"
+          safe_fetch_shadow: "true"
 
       - name: Start anvil Sepolia fork for orchestrator integration tests
         run: |
@@ -260,8 +260,8 @@ jobs:
           SANDBOX_URL: http://localhost:8787
           # safe-roles-orchestrator-fork calls reconcileSafeRoleFromChain
           # in-process, so the vitest process (not just the app) needs shadow-mode
-          # SSRF (existing per-env opt-out) to reach the localhost anvil fork.
-          SAFE_FETCH_ENFORCE: "false"
+          # SSRF (dev/CI-only opt-in) to reach the localhost anvil fork.
+          SAFE_FETCH_SHADOW: "true"
 
       - name: Dump app container logs
         if: failure() && inputs.image_tag != ''

--- a/deploy/executor/prod/values.yaml
+++ b/deploy/executor/prod/values.yaml
@@ -161,9 +161,6 @@ env:
   GAS_CREDITS_ENTERPRISE_CENTS:
     type: kv
     value: "10000"
-  SAFE_FETCH_ENFORCE:
-    type: kv
-    value: "true"
   SANDBOX_BACKEND:
     type: kv
     value: "remote"

--- a/deploy/executor/staging/values.yaml
+++ b/deploy/executor/staging/values.yaml
@@ -161,9 +161,6 @@ env:
   GAS_CREDITS_ENTERPRISE_CENTS:
     type: kv
     value: "10000"
-  SAFE_FETCH_ENFORCE:
-    type: kv
-    value: "true"
   SANDBOX_BACKEND:
     type: kv
     value: "remote"

--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -464,9 +464,6 @@ app:
       type: parameterStore
       name: kh-admin-secret
       parameter_name: /eks/techops-prod/keeperhub/kh-admin-secret
-    SAFE_FETCH_ENFORCE:
-      type: kv
-      value: "true"
 
   externalSecrets:
     clusterSecretStoreName: techops-prod
@@ -734,9 +731,6 @@ executor:
     GAS_CREDITS_ENTERPRISE_CENTS:
       type: kv
       value: "10000"
-    SAFE_FETCH_ENFORCE:
-      type: kv
-      value: "true"
     SANDBOX_BACKEND:
       type: kv
       value: "remote"

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -466,9 +466,6 @@ app:
       type: parameterStore
       name: kh-admin-secret
       parameter_name: /eks/techops-staging/keeperhub/kh-admin-secret
-    SAFE_FETCH_ENFORCE:
-      type: kv
-      value: "true"
 
   externalSecrets:
     clusterSecretStoreName: techops-staging
@@ -736,9 +733,6 @@ executor:
     GAS_CREDITS_ENTERPRISE_CENTS:
       type: kv
       value: "10000"
-    SAFE_FETCH_ENFORCE:
-      type: kv
-      value: "true"
     SANDBOX_BACKEND:
       type: kv
       value: "remote"

--- a/deploy/keeperhub/prod/values.yaml
+++ b/deploy/keeperhub/prod/values.yaml
@@ -449,9 +449,6 @@ env:
     type: parameterStore
     name: kh-admin-secret
     parameter_name: /eks/techops-prod/keeperhub/kh-admin-secret
-  SAFE_FETCH_ENFORCE:
-    type: kv
-    value: "true"
 
 externalSecrets:
   clusterSecretStoreName: techops-prod

--- a/deploy/keeperhub/staging/values.yaml
+++ b/deploy/keeperhub/staging/values.yaml
@@ -451,9 +451,6 @@ env:
     type: parameterStore
     name: kh-admin-secret
     parameter_name: /eks/techops-staging/keeperhub/kh-admin-secret
-  SAFE_FETCH_ENFORCE:
-    type: kv
-    value: "true"
 
 externalSecrets:
   clusterSecretStoreName: techops-staging

--- a/keeperhub-executor/k8s-job.test.ts
+++ b/keeperhub-executor/k8s-job.test.ts
@@ -78,6 +78,7 @@ describe("createWorkflowJob", () => {
     delete process.env.METRICS_COLLECTOR;
     delete process.env.EXECUTOR_METRICS_INGEST_URL;
     delete process.env.METRICS_INGEST_TOKEN;
+    delete process.env.SAFE_FETCH_SHADOW;
   });
 
   it("forwards non-secret metrics env vars as literals when set", async () => {
@@ -277,13 +278,14 @@ describe("createWorkflowJob", () => {
     expect(getSecretRef(envVars, "CHAIN_RPC_CONFIG")?.optional).toBe(true);
   });
 
-  it("force-enables SAFE_FETCH_ENFORCE on runner pods even when unset on controller", async () => {
+  it("injects no SSRF shadow opt-in on runner pods, so they enforce by default", async () => {
     // SSRF guard must be on regardless of controller config to prevent
     // workflow runs from reaching internal hosts (cloud IMDS, RFC1918,
-    // in-cluster services). The runner pod is the actual execution path,
-    // not the controller; if the controller's env ever drifts the runner
-    // must still enforce.
-    delete process.env.SAFE_FETCH_ENFORCE;
+    // in-cluster services). The runner pod is the actual execution path.
+    // safeFetch is fail-closed by default, so the executor injects no
+    // shadow opt-in; the absence of SAFE_FETCH_SHADOW means the runner
+    // enforces.
+    delete process.env.SAFE_FETCH_SHADOW;
 
     await createWorkflowJob({
       workflowId: "wf-1",
@@ -293,13 +295,14 @@ describe("createWorkflowJob", () => {
     });
 
     const envVars = getJobEnvVars(getSubmittedJob());
-    expect(getEnvVar(envVars, "SAFE_FETCH_ENFORCE")).toBe("true");
+    expect(getEnvVar(envVars, "SAFE_FETCH_SHADOW")).toBeUndefined();
   });
 
-  it("force-enables SAFE_FETCH_ENFORCE even when controller has it set to shadow", async () => {
-    // Hardcoded `value: "true"` in k8s-job.ts wins over any controller
-    // env. Flipping shadow mode for runner pods requires a code change.
-    process.env.SAFE_FETCH_ENFORCE = "false";
+  it("does not forward the controller's SAFE_FETCH_SHADOW opt-in to runner pods", async () => {
+    // A controller-level shadow opt-in (a dev/CI escape hatch) must never
+    // propagate to the runner, which executes user workflow code. The
+    // executor neither injects nor forwards SAFE_FETCH_SHADOW.
+    process.env.SAFE_FETCH_SHADOW = "true";
 
     await createWorkflowJob({
       workflowId: "wf-1",
@@ -309,9 +312,7 @@ describe("createWorkflowJob", () => {
     });
 
     const envVars = getJobEnvVars(getSubmittedJob());
-    expect(getEnvVar(envVars, "SAFE_FETCH_ENFORCE")).toBe("true");
-    const occurrences = envVars.filter((v) => v.name === "SAFE_FETCH_ENFORCE");
-    expect(occurrences).toHaveLength(1);
+    expect(getEnvVar(envVars, "SAFE_FETCH_SHADOW")).toBeUndefined();
   });
 
   it("runs under the dedicated SA with no mounted token", async () => {

--- a/keeperhub-executor/k8s-job.ts
+++ b/keeperhub-executor/k8s-job.ts
@@ -117,13 +117,10 @@ export async function createWorkflowJob(params: {
     // below. tsx/esbuild and any plugin temp writes resolve through TMPDIR, so
     // point it there to keep the runner working under the hardened context.
     { name: "TMPDIR", value: "/tmp" },
-    // SSRF guard: force-enable on every workflow runner pod regardless
-    // of controller env. Hardcoded (rather than forwarded via
-    // RUNNER_SYSTEM_ENV_VARS) so the runner enforces even if the
-    // controller's Helm values drift or a deploy omits the entry.
-    // Flipping back to shadow mode is a deliberate code change here,
-    // which is the intended posture for SSRF protection.
-    { name: "SAFE_FETCH_ENFORCE", value: "true" },
+    // SSRF guard: runner pods enforce by default. safeFetch's shadow-mode
+    // opt-in (SAFE_FETCH_SHADOW) is neither injected here nor listed in
+    // RUNNER_SYSTEM_ENV_VARS, so a controller's env can never relax the
+    // runner's SSRF enforcement -- the runner is the actual execution path.
     // High-value credentials as Secret references, never literal values.
     ...Object.keys(SECRET_ENV_SLUGS).map(secretEnvRef),
     ...(process.env.METRICS_COLLECTOR

--- a/lib/db/test-connection.ts
+++ b/lib/db/test-connection.ts
@@ -94,7 +94,7 @@ export async function handleDatabaseTest(
  * immediately after, so the rebinding window is negligible.
  *
  * Note: `assertUrlIsPublic` is always-on; it does not honor
- * `SAFE_FETCH_ENFORCE`, matching the database-test and RPC pre-flights. So
+ * `SAFE_FETCH_SHADOW`, matching the database-test and RPC pre-flights. So
  * "Test Connection" blocks a `localhost`/private instance URL even in local
  * dev, where `safeFetch` (used by workflow execution) runs in shadow mode and
  * would allow it. If you need to test against a local explorer in dev, run the

--- a/lib/safe-fetch.ts
+++ b/lib/safe-fetch.ts
@@ -277,12 +277,20 @@ export function isBlockedHost(
 }
 
 export function isShadowMode(): boolean {
-  // Fail-closed by default: enforce SSRF blocking unless an environment
-  // explicitly opts into shadow mode with SAFE_FETCH_ENFORCE="false". Any
-  // other value (including unset) enforces, so an environment that forgets
-  // to set the flag still rejects private/loopback/metadata targets instead
-  // of shipping an unauthenticated SSRF primitive.
-  return process.env.SAFE_FETCH_ENFORCE === "false";
+  // Real production can never enter shadow mode, regardless of any flag. This
+  // closes the foot-gun where a stray env var silently re-enables an
+  // unauthenticated SSRF primitive in prod. CI runs the app under
+  // NODE_ENV="production" too, so it is exempted via CI to keep the
+  // localhost-anvil e2e suites (which opt into shadow) working.
+  if (process.env.NODE_ENV === "production" && process.env.CI !== "true") {
+    return false;
+  }
+  // Fail-closed by default elsewhere: SSRF blocking is enforced unless an
+  // environment explicitly opts into shadow mode with SAFE_FETCH_SHADOW="true"
+  // (any other value, including unset, enforces). Shadow mode is a dev/CI-only
+  // escape hatch for reaching localhost/private targets through safeFetch
+  // (e.g. a local anvil node).
+  return process.env.SAFE_FETCH_SHADOW === "true";
 }
 
 type BlockContext = {
@@ -467,8 +475,9 @@ export type SafeFetchOptions = RequestInit & {
  * every redirect hop.
  *
  * Enforce mode is the default (fail-closed): blocked requests throw
- * `SsrfBlockedError`. Set `SAFE_FETCH_ENFORCE="false"` to opt into shadow
- * mode, where blocks are logged and counted but the request still proceeds.
+ * `SsrfBlockedError`. Set `SAFE_FETCH_SHADOW="true"` to opt into shadow mode
+ * (dev/CI only -- real production always enforces), where blocks are logged
+ * and counted but the request still proceeds.
  */
 export async function safeFetch(
   input: RequestInfo | URL,

--- a/lib/workflow/nodes/http-request/perform.ts
+++ b/lib/workflow/nodes/http-request/perform.ts
@@ -177,7 +177,7 @@ export async function httpRequest(
   try {
     // SSRF guard: reject private/loopback/link-local/metadata destinations
     // before any outbound request. `assertUrlIsPublic` is always-on -- it
-    // ignores `SAFE_FETCH_ENFORCE`/shadow mode -- so a user-supplied endpoint
+    // ignores `SAFE_FETCH_SHADOW`/shadow mode -- so a user-supplied endpoint
     // pointing at an internal address (e.g.
     // http://169.254.169.254/latest/meta-data/) is blocked here even in
     // environments where `safeFetch` itself would only log-and-continue.

--- a/plugins/AGENTS.md
+++ b/plugins/AGENTS.md
@@ -369,7 +369,7 @@ with `type: "url"`, e.g. a custom instance URL) is validated on the server by
 `assertUrlIsPublic` in `handlePluginTest` (`lib/db/test-connection.ts`) before
 the test runs, so a connection test still cannot reach internal hosts.
 
-That server-side guard is always-on (it does not honor `SAFE_FETCH_ENFORCE`),
+That server-side guard is always-on (it does not honor `SAFE_FETCH_SHADOW`),
 so in local dev "Test Connection" will block a `localhost`/private instance URL
 even though workflow execution against it works (`safeFetch` runs in shadow
 mode locally). To exercise a local instance in dev, run the workflow instead of

--- a/plugins/blockscout/steps/blockscout-core.ts
+++ b/plugins/blockscout/steps/blockscout-core.ts
@@ -93,7 +93,7 @@ export async function blockscoutGet<T>(
   try {
     // SSRF guard: the instance URL is user-configurable (BLOCKSCOUT_API_URL on
     // the connection), so validate it before any outbound request.
-    // `assertUrlIsPublic` is always-on -- it ignores `SAFE_FETCH_ENFORCE`/
+    // `assertUrlIsPublic` is always-on -- it ignores `SAFE_FETCH_SHADOW`/
     // shadow mode -- so an instance URL pointing at an internal address is
     // blocked here even where `safeFetch` would only log-and-continue.
     // Mirrors plugins/webhook/steps/send-webhook.ts.

--- a/plugins/webhook/steps/send-webhook.ts
+++ b/plugins/webhook/steps/send-webhook.ts
@@ -120,7 +120,7 @@ async function stepHandler(
 
   // SSRF guard: reject private/loopback/link-local/metadata destinations
   // before any outbound request. `assertUrlIsPublic` is always-on -- it
-  // ignores `SAFE_FETCH_ENFORCE`/shadow mode -- so an attacker-supplied
+  // ignores `SAFE_FETCH_SHADOW`/shadow mode -- so an attacker-supplied
   // webhookUrl pointing at an internal address (e.g.
   // http://169.254.169.254/latest/meta-data/) is blocked here even in
   // environments where `safeFetch` itself would only log-and-continue.

--- a/tests/unit/safe-fetch.test.ts
+++ b/tests/unit/safe-fetch.test.ts
@@ -257,58 +257,55 @@ describe("isBlockedHost", () => {
 });
 
 describe("isShadowMode", () => {
-  const originalEnforce = process.env.SAFE_FETCH_ENFORCE;
-
   afterEach(() => {
-    if (originalEnforce === undefined) {
-      // biome-ignore lint/performance/noDelete: restore unset state
-      delete process.env.SAFE_FETCH_ENFORCE;
-    } else {
-      process.env.SAFE_FETCH_ENFORCE = originalEnforce;
-    }
+    vi.unstubAllEnvs();
   });
 
-  it("is fail-closed (enforces) when SAFE_FETCH_ENFORCE is unset", () => {
-    // biome-ignore lint/performance/noDelete: simulate an env that forgot the flag
-    delete process.env.SAFE_FETCH_ENFORCE;
+  it("is fail-closed (enforces) when SAFE_FETCH_SHADOW is unset", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("SAFE_FETCH_SHADOW", undefined);
     expect(isShadowMode()).toBe(false);
   });
 
-  it("enforces when SAFE_FETCH_ENFORCE='true'", () => {
-    process.env.SAFE_FETCH_ENFORCE = "true";
+  it("enters shadow mode on the explicit opt-in SAFE_FETCH_SHADOW='true' outside prod", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("SAFE_FETCH_SHADOW", "true");
+    expect(isShadowMode()).toBe(true);
+  });
+
+  it("enforces for any non-'true' value (e.g. '1', 'false')", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("SAFE_FETCH_SHADOW", "1");
+    expect(isShadowMode()).toBe(false);
+    vi.stubEnv("SAFE_FETCH_SHADOW", "false");
     expect(isShadowMode()).toBe(false);
   });
 
-  it("enforces for any non-'false' value (e.g. '1', 'shadow')", () => {
-    process.env.SAFE_FETCH_ENFORCE = "1";
-    expect(isShadowMode()).toBe(false);
-    process.env.SAFE_FETCH_ENFORCE = "shadow";
+  it("hard-enforces in real production (NODE_ENV=production, no CI) even with SAFE_FETCH_SHADOW='true'", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CI", undefined);
+    vi.stubEnv("SAFE_FETCH_SHADOW", "true");
     expect(isShadowMode()).toBe(false);
   });
 
-  it("only enters shadow mode on the explicit opt-in SAFE_FETCH_ENFORCE='false'", () => {
-    process.env.SAFE_FETCH_ENFORCE = "false";
+  it("honors the opt-in under CI even when NODE_ENV=production (localhost-anvil e2e suites)", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CI", "true");
+    vi.stubEnv("SAFE_FETCH_SHADOW", "true");
     expect(isShadowMode()).toBe(true);
   });
 });
 
 describe("safeFetch (enforce mode)", () => {
-  const originalEnforce = process.env.SAFE_FETCH_ENFORCE;
-
   beforeEach(() => {
-    process.env.SAFE_FETCH_ENFORCE = "true";
+    // Unset opt-in => default enforce (fail-closed).
+    vi.stubEnv("SAFE_FETCH_SHADOW", undefined);
     incrementCounter.mockClear();
     captureException.mockClear();
   });
 
   afterEach(() => {
-    if (originalEnforce === undefined) {
-      process.env.SAFE_FETCH_ENFORCE = undefined;
-      // biome-ignore lint/performance/noDelete: ensure env var is fully removed
-      delete process.env.SAFE_FETCH_ENFORCE;
-    } else {
-      process.env.SAFE_FETCH_ENFORCE = originalEnforce;
-    }
+    vi.unstubAllEnvs();
   });
 
   const blockedSchemes = [
@@ -409,25 +406,18 @@ describe("safeFetch (enforce mode)", () => {
 });
 
 describe("safeFetch (shadow mode)", () => {
-  const originalEnforce = process.env.SAFE_FETCH_ENFORCE;
-
   beforeEach(() => {
-    // Shadow mode is now opt-in: it requires an explicit
-    // SAFE_FETCH_ENFORCE="false". Leaving the var unset would enforce
-    // (fail-closed) and throw SsrfBlockedError, which these tests do not
-    // expect.
-    process.env.SAFE_FETCH_ENFORCE = "false";
+    // Shadow mode is opt-in via SAFE_FETCH_SHADOW="true" (honored everywhere
+    // except real production; the test runner is not real prod). Leaving it
+    // unset would enforce (fail-closed) and throw SsrfBlockedError, which
+    // these tests do not expect.
+    vi.stubEnv("SAFE_FETCH_SHADOW", "true");
     incrementCounter.mockClear();
     captureException.mockClear();
   });
 
   afterEach(() => {
-    if (originalEnforce === undefined) {
-      // biome-ignore lint/performance/noDelete: restore unset state
-      delete process.env.SAFE_FETCH_ENFORCE;
-    } else {
-      process.env.SAFE_FETCH_ENFORCE = originalEnforce;
-    }
+    vi.unstubAllEnvs();
   });
 
   it("records a block with shadow=true but does not throw SsrfBlockedError on IP literal", async () => {


### PR DESCRIPTION
## Summary

Removes the `SAFE_FETCH_ENFORCE` toggle. After the SSRF egress guard's default flipped to fail-closed, the toggle was redundant config and a foot-gun: a stray `="false"` could silently re-enable shadow mode for `safeFetch` in any environment.

`safeFetch` now enforces by default everywhere, with a renamed positive-sense `SAFE_FETCH_SHADOW="true"` opt-in retained for dev/CI only. Real production (`NODE_ENV=production`, outside CI) is hard-locked to enforce and ignores the flag entirely, so no env var can re-enable an SSRF bypass in prod.

## Why a renamed opt-in rather than full removal

`NODE_ENV` cannot gate shadow mode: staging runs `NODE_ENV=development` (must enforce) while the CI e2e app runs `NODE_ENV=production` yet deliberately opts into shadow to reach the localhost anvil fork. No ambient signal separates those cases, so an explicit per-environment opt-in is unavoidable. The chosen mechanism keeps the dev/CI escape hatch while making real prod un-bypassable.

## Changes

- `lib/safe-fetch.ts`: `isShadowMode()` hard-enforces in real prod (`NODE_ENV==="production" && CI!=="true"`); otherwise honors `SAFE_FETCH_SHADOW==="true"` (default unset = enforce). Doc comments updated.
- `keeperhub-executor/k8s-job.ts`: drop the hardcoded `SAFE_FETCH_ENFORCE:"true"` runner-pod injection. Runners enforce by default; the var is not forwarded via `RUNNER_SYSTEM_ENV_VARS`, so it cannot drift in.
- Helm values (app + executor + stack, prod + staging): remove the now-redundant `SAFE_FETCH_ENFORCE` kv entries (unset = enforce).
- CI: the `start-app` action input and `e2e-tests-ephemeral` flipped to positive `SAFE_FETCH_SHADOW=true` so the localhost-anvil suites (which run under `NODE_ENV=production`, CI-exempt) still reach the fork.
- `.env.example` and comment-only references updated to the new var name.
- Unit tests rewritten to cover enforce-by-default, the prod hard-lock, the CI exemption, and the opt-in.

## Notes

- Behavior change for local dev: reaching localhost via `safeFetch` now needs `SAFE_FETCH_SHADOW=true` in `.env` (was `SAFE_FETCH_ENFORCE=false`). The always-on `assertUrlIsPublic` guard on user-URL sinks (webhook, http-request, blockscout) is unchanged.
- No SSM parameter removal needed: `SAFE_FETCH_ENFORCE` was inline `type: kv`, never `parameterStore`. Verified in infra Terraform (`keeperhub-infrastructure/ssm.tf`) - no such parameter is defined, so there is no orphan to delete.

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm check` (lint) clean
- [x] SSRF unit suites green (`tests/unit/safe-fetch.test.ts`, `keeperhub-executor/k8s-job.test.ts`, `keeperhub-executor/runner-env.test.ts`) - 161 tests pass
- [ ] CI green
- [ ] Deploy to staging and confirm egress still enforced before prod
