### PR TITLE
feat: configurable connection timeout and retries for the Database Query step

### DIFF
--- a/components/workflow/config/action-config.tsx
+++ b/components/workflow/config/action-config.tsx
@@ -121,6 +121,47 @@ function DatabaseQueryFields({
           }
         />
       </div>
+      <div className="space-y-2">
+        <Label htmlFor="connectTimeout">Connection timeout (seconds)</Label>
+        <Input
+          disabled={disabled}
+          id="connectTimeout"
+          max={60}
+          min={1}
+          onChange={(e) => {
+            const raw = e.target.value.replace(/[^0-9]/g, "");
+            onUpdateConfig("connectTimeout", raw);
+          }}
+          placeholder="30"
+          type="number"
+          value={(config?.connectTimeout as string) || ""}
+        />
+        <p className="text-muted-foreground text-xs">
+          How long to wait to connect. Default 30 seconds, max 60. Raise this
+          for serverless databases that scale to zero and need time to wake.
+        </p>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="retries">Connection retries</Label>
+        <Input
+          disabled={disabled}
+          id="retries"
+          max={3}
+          min={0}
+          onChange={(e) => {
+            const raw = e.target.value.replace(/[^0-9]/g, "");
+            onUpdateConfig("retries", raw);
+          }}
+          placeholder="1"
+          type="number"
+          value={(config?.retries as string) || ""}
+        />
+        <p className="text-muted-foreground text-xs">
+          Retries only when the database is unreachable at connect time (safe
+          for cold starts). It never re-runs a query that already started.
+          Default 1, max 3.
+        </p>
+      </div>
     </>
   );
 }

--- a/lib/db/connection-utils.ts
+++ b/lib/db/connection-utils.ts
@@ -94,6 +94,33 @@ function formatPgQueryError(error: PgQueryError): string {
   return message;
 }
 
+/** Max error -> cause levels to inspect (drizzle wraps the driver error). */
+const MAX_ERROR_CAUSE_DEPTH = 5;
+
+/**
+ * Collect the `code` values and concatenated messages across an error's
+ * cause chain. The driver error is often wrapped (drizzle nests it under
+ * `cause`), so the connection code/message can live below the top level.
+ */
+function collectErrorChain(error: Error): { codes: Set<string>; text: string } {
+  const codes = new Set<string>();
+  const messages: string[] = [];
+  let current: unknown = error;
+  for (
+    let depth = 0;
+    depth <= MAX_ERROR_CAUSE_DEPTH && current instanceof Error;
+    depth++
+  ) {
+    messages.push(current.message);
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === "string") {
+      codes.add(code);
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return { codes, text: messages.join(" ") };
+}
+
 /**
  * Returns a safe, user-facing message for database errors.
  * Shows query errors from PostgreSQL directly (they don't contain credentials).
@@ -119,28 +146,36 @@ export function getDatabaseErrorMessage(error: unknown): string {
     return formatPgQueryError(cause);
   }
 
-  // Connection-level errors -- sanitize to avoid leaking credentials
-  const errorMessage = error.message;
+  // Connection-level errors -- sanitize to avoid leaking credentials. Classify
+  // against the code + message of the whole cause chain (drizzle wraps the
+  // driver error), preferring `code` for socket/connect failures so query text
+  // can't trigger a false match. Only canned strings are returned, never raw text.
+  const { codes, text } = collectErrorChain(error);
 
-  if (errorMessage.includes("ECONNREFUSED")) {
+  if (codes.has("ECONNREFUSED") || text.includes("ECONNREFUSED")) {
     return "Connection refused. Please check your database URL and ensure the database is running.";
   }
-  if (errorMessage.includes("ENOTFOUND")) {
+  if (codes.has("ENOTFOUND") || text.includes("ENOTFOUND")) {
     return "Database host not found. Please check your database URL.";
   }
-  if (errorMessage.includes("ENETUNREACH")) {
+  if (codes.has("ENETUNREACH") || text.includes("ENETUNREACH")) {
     return "Network unreachable. The database host may resolve to an IPv6 address; try using an IPv4 address or a hostname that resolves to IPv4.";
   }
-  if (errorMessage.includes("authentication failed")) {
-    return "Authentication failed. Please check your database credentials.";
-  }
-  if (errorMessage.includes("does not exist")) {
-    return "Database or resource not found. Please verify the database name and user permissions.";
-  }
-  if (errorMessage.includes("timeout") || errorMessage.includes("ETIMEDOUT")) {
+  if (
+    codes.has("CONNECT_TIMEOUT") ||
+    codes.has("ETIMEDOUT") ||
+    text.includes("CONNECT_TIMEOUT") ||
+    text.includes("ETIMEDOUT")
+  ) {
     return "Connection timed out. Please check your database host and network settings.";
   }
-  if (errorMessage.includes("SSL") || errorMessage.includes("TLS")) {
+  if (text.includes("authentication failed")) {
+    return "Authentication failed. Please check your database credentials.";
+  }
+  if (text.includes("does not exist")) {
+    return "Database or resource not found. Please verify the database name and user permissions.";
+  }
+  if (text.includes("SSL") || text.includes("TLS")) {
     return "SSL/TLS connection error. Try a different SSL mode (e.g. Require or Disable).";
   }
 

--- a/lib/mcp/workflow-schema-constants.ts
+++ b/lib/mcp/workflow-schema-constants.ts
@@ -73,6 +73,10 @@ export const SYSTEM_ACTIONS = {
     },
     optionalFields: {
       dbSchema: "string - JSON schema for result typing",
+      connectTimeout:
+        "number - Connection timeout in seconds (default 30, min 1, max 60). Raise for serverless databases that scale to zero and need time to wake on a cold start.",
+      retries:
+        "number - Connection retries (default 1, min 0, max 3). Retries only pre-query connection failures (e.g. a cold-start connect timeout); never re-runs a query that already started, so writes are not duplicated.",
     },
     outputFields: {
       rows: "array - Query result rows",

--- a/lib/workflow/nodes/database-query/step.ts
+++ b/lib/workflow/nodes/database-query/step.ts
@@ -42,6 +42,12 @@ export type DatabaseQueryInput = StepInput & {
   dbQuery?: string;
   query?: string;
   _dbParams?: SqlParam[];
+  // Connection timeout in seconds (default 30, clamped 1-60). Raised from the
+  // previous hardcoded 10s to absorb serverless Postgres cold starts.
+  connectTimeout?: number | string;
+  // Number of times to retry the connection (default 1, clamped 0-3). Retries
+  // fire ONLY for pre-query connection failures, so a write is never re-run.
+  retries?: number | string;
 };
 
 function validateInput(input: DatabaseQueryInput): string | null {
@@ -54,13 +60,24 @@ function validateInput(input: DatabaseQueryInput): string | null {
   return null;
 }
 
+const DEFAULT_CONNECT_TIMEOUT_SECONDS = 30;
+const MIN_CONNECT_TIMEOUT_SECONDS = 1;
+const MAX_CONNECT_TIMEOUT_SECONDS = 60;
+const DEFAULT_RETRIES = 1;
+const MIN_RETRIES = 0;
+const MAX_RETRIES = 3;
+// Short linear backoff between connection attempts; the cold start that timed
+// out the first attempt has usually finished warming by the retry.
+const RETRY_BACKOFF_MS = 500;
+
 function createDatabaseClient(
   normalizedUrl: string,
-  ssl: PostgresSslOption
+  ssl: PostgresSslOption,
+  connectTimeoutSeconds: number = DEFAULT_CONNECT_TIMEOUT_SECONDS
 ): postgres.Sql {
   return postgres(normalizedUrl, {
     max: 1,
-    connect_timeout: 10,
+    connect_timeout: connectTimeoutSeconds,
     idle_timeout: 20,
     ssl: ssl as false | "require" | "prefer",
   });
@@ -111,6 +128,87 @@ async function cleanupClient(client: postgres.Sql | null): Promise<void> {
 }
 
 /**
+ * Resolve the connection timeout in seconds. Accepts the raw config value
+ * (numbers from MCP callers, strings from the visual editor), coerces it, and
+ * clamps to [1, 60]. Missing / empty / non-numeric falls back to the 30s
+ * default. Exported for tests.
+ */
+export function resolveConnectTimeoutSeconds(connectTimeout: unknown): number {
+  if (
+    connectTimeout === undefined ||
+    connectTimeout === null ||
+    connectTimeout === ""
+  ) {
+    return DEFAULT_CONNECT_TIMEOUT_SECONDS;
+  }
+  const requested =
+    typeof connectTimeout === "number"
+      ? connectTimeout
+      : Number(connectTimeout);
+  if (!Number.isFinite(requested)) {
+    return DEFAULT_CONNECT_TIMEOUT_SECONDS;
+  }
+  return Math.min(
+    Math.max(MIN_CONNECT_TIMEOUT_SECONDS, requested),
+    MAX_CONNECT_TIMEOUT_SECONDS
+  );
+}
+
+/**
+ * Resolve the retry count. Clamps to [0, 3] and truncates to an integer.
+ * Missing / empty / non-numeric falls back to 1. Exported for tests.
+ */
+export function resolveRetries(retries: unknown): number {
+  if (retries === undefined || retries === null || retries === "") {
+    return DEFAULT_RETRIES;
+  }
+  const requested = typeof retries === "number" ? retries : Number(retries);
+  if (!Number.isFinite(requested)) {
+    return DEFAULT_RETRIES;
+  }
+  return Math.min(Math.max(MIN_RETRIES, Math.trunc(requested)), MAX_RETRIES);
+}
+
+/**
+ * Connection errors safe to retry because the query was never sent: the
+ * TCP/startup handshake never completed, so re-running cannot double-execute a
+ * write. postgres.js raises CONNECT_TIMEOUT when its connect_timeout elapses;
+ * ECONNREFUSED means the server is not yet accepting connections (a cold start
+ * still spinning up). Ambiguous mid-connection codes (ECONNRESET, ETIMEDOUT)
+ * are excluded - they can occur after the query was transmitted.
+ */
+const RETRYABLE_CONNECTION_CODES = new Set(["CONNECT_TIMEOUT", "ECONNREFUSED"]);
+
+function isRetryableConnectionError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  // A Postgres query error carries a `severity` (ERROR/FATAL/...): the query
+  // reached the server and the failure is deterministic. Never retry it.
+  if (
+    "severity" in error &&
+    typeof (error as { severity: unknown }).severity === "string"
+  ) {
+    return false;
+  }
+  const code = (error as { code?: unknown }).code;
+  if (typeof code === "string" && RETRYABLE_CONNECTION_CODES.has(code)) {
+    return true;
+  }
+  // Some driver paths surface the code only in the message.
+  const message = error.message;
+  return (
+    message.includes("CONNECT_TIMEOUT") || message.includes("ECONNREFUSED")
+  );
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
  * Database query logic
  */
 async function databaseQuery(
@@ -158,25 +256,46 @@ async function databaseQuery(
   }
 
   const queryString = (input.dbQuery || input.query) as string;
-  let client: postgres.Sql | null = null;
+  const connectTimeoutSeconds = resolveConnectTimeoutSeconds(
+    input.connectTimeout
+  );
+  const maxAttempts = resolveRetries(input.retries) + 1;
+  let lastError: unknown;
 
-  try {
-    client = createDatabaseClient(normalizedUrl, ssl);
-    const result = await executeQuery(client, queryString, input._dbParams);
-    return {
-      success: true,
-      rows: result,
-      count: Array.isArray(result) ? result.length : 0,
-    };
-  } catch (error) {
-    console.error("[Database Query] Raw connection error:", error);
-    return {
-      success: false,
-      error: `Database query failed: ${getDatabaseErrorMessage(error)}`,
-    };
-  } finally {
-    await cleanupClient(client);
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let client: postgres.Sql | null = null;
+    try {
+      client = createDatabaseClient(normalizedUrl, ssl, connectTimeoutSeconds);
+      const result = await executeQuery(client, queryString, input._dbParams);
+      return {
+        success: true,
+        rows: result,
+        count: Array.isArray(result) ? result.length : 0,
+      };
+    } catch (error) {
+      lastError = error;
+      console.error("[Database Query] Raw connection error:", error);
+      // Retry only pre-query connection failures: a query that already reached
+      // the server (or a deterministic SQL error) must not be re-run.
+      if (attempt < maxAttempts && isRetryableConnectionError(error)) {
+        await delay(RETRY_BACKOFF_MS * attempt);
+        continue;
+      }
+      return {
+        success: false,
+        error: `Database query failed: ${getDatabaseErrorMessage(error)}`,
+      };
+    } finally {
+      await cleanupClient(client);
+    }
   }
+
+  // The loop returns on success or on the final failure; reachable only if
+  // maxAttempts < 1, which resolveRetries prevents.
+  return {
+    success: false,
+    error: `Database query failed: ${getDatabaseErrorMessage(lastError)}`,
+  };
 }
 
 /**

--- a/lib/workflow/nodes/database-query/step.ts
+++ b/lib/workflow/nodes/database-query/step.ts
@@ -178,28 +178,41 @@ export function resolveRetries(retries: unknown): number {
  * are excluded - they can occur after the query was transmitted.
  */
 const RETRYABLE_CONNECTION_CODES = new Set(["CONNECT_TIMEOUT", "ECONNREFUSED"]);
+const MAX_CAUSE_DEPTH = 5;
 
 function isRetryableConnectionError(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-  // A Postgres query error carries a `severity` (ERROR/FATAL/...): the query
-  // reached the server and the failure is deterministic. Never retry it.
-  if (
-    "severity" in error &&
-    typeof (error as { severity: unknown }).severity === "string"
+  // Walk the error -> cause chain. A direct postgres.js call exposes the code
+  // at the top level (`error.code`), but the step's non-parameterized path runs
+  // through drizzle, which wraps the driver error so the real code lands on
+  // `error.cause.code`. Inspect every level so both paths are covered.
+  let current: unknown = error;
+  for (
+    let depth = 0;
+    depth <= MAX_CAUSE_DEPTH && current instanceof Error;
+    depth++
   ) {
-    return false;
+    // A Postgres query error carries a `severity` (ERROR/FATAL/...): the query
+    // reached the server and the failure is deterministic. Never retry it.
+    if (
+      "severity" in current &&
+      typeof (current as { severity: unknown }).severity === "string"
+    ) {
+      return false;
+    }
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === "string" && RETRYABLE_CONNECTION_CODES.has(code)) {
+      return true;
+    }
+    // Some driver paths surface the code only in the message.
+    if (
+      current.message.includes("CONNECT_TIMEOUT") ||
+      current.message.includes("ECONNREFUSED")
+    ) {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
   }
-  const code = (error as { code?: unknown }).code;
-  if (typeof code === "string" && RETRYABLE_CONNECTION_CODES.has(code)) {
-    return true;
-  }
-  // Some driver paths surface the code only in the message.
-  const message = error.message;
-  return (
-    message.includes("CONNECT_TIMEOUT") || message.includes("ECONNREFUSED")
-  );
+  return false;
 }
 
 function delay(ms: number): Promise<void> {

--- a/tests/unit/connection-utils.test.ts
+++ b/tests/unit/connection-utils.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { getDatabaseErrorMessage } from "@/lib/db/connection-utils";
+
+const REFUSED =
+  "Connection refused. Please check your database URL and ensure the database is running.";
+const TIMED_OUT =
+  "Connection timed out. Please check your database host and network settings.";
+const GENERIC =
+  "Database connection failed. Please verify your connection settings.";
+
+/** Mimic drizzle: a "Failed query" wrapper whose `cause` is the driver error. */
+function drizzleWrapped(
+  causeMessage: string,
+  props: Record<string, unknown> = {}
+): Error {
+  const top = new Error("Failed query: SELECT 1") as Error & {
+    cause?: unknown;
+  };
+  top.cause = Object.assign(new Error(causeMessage), props);
+  return top;
+}
+
+describe("getDatabaseErrorMessage", () => {
+  it("maps a top-level ECONNREFUSED (direct postgres.js path)", () => {
+    const error = Object.assign(
+      new Error("connect ECONNREFUSED 1.2.3.4:5432"),
+      {
+        code: "ECONNREFUSED",
+      }
+    );
+    expect(getDatabaseErrorMessage(error)).toBe(REFUSED);
+  });
+
+  it("maps a top-level CONNECT_TIMEOUT (the incident error) to a timeout message", () => {
+    const error = Object.assign(
+      new Error("write CONNECT_TIMEOUT 1.2.3.4:5432"),
+      { code: "CONNECT_TIMEOUT" }
+    );
+    expect(getDatabaseErrorMessage(error)).toBe(TIMED_OUT);
+  });
+
+  it("maps a drizzle-wrapped ECONNREFUSED (code on cause)", () => {
+    const error = drizzleWrapped("connect ECONNREFUSED 1.2.3.4:5432", {
+      code: "ECONNREFUSED",
+    });
+    expect(getDatabaseErrorMessage(error)).toBe(REFUSED);
+  });
+
+  it("maps a drizzle-wrapped CONNECT_TIMEOUT (code on cause)", () => {
+    const error = drizzleWrapped("write CONNECT_TIMEOUT 1.2.3.4:5432", {
+      code: "CONNECT_TIMEOUT",
+    });
+    expect(getDatabaseErrorMessage(error)).toBe(TIMED_OUT);
+  });
+
+  it("returns the formatted Postgres query error (severity) and does not misclassify it", () => {
+    const error = Object.assign(new Error('relation "x" does not exist'), {
+      severity: "ERROR",
+      code: "42P01",
+    });
+    const message = getDatabaseErrorMessage(error);
+    expect(message).toContain("does not exist");
+    expect(message).toContain("42P01");
+  });
+
+  it("falls back to the generic message and does not leak raw text", () => {
+    const error = drizzleWrapped(
+      "opaque failure for postgres://user:secret@host/db"
+    );
+    const message = getDatabaseErrorMessage(error);
+    expect(message).toBe(GENERIC);
+    expect(message).not.toContain("secret");
+  });
+});

--- a/tests/unit/database-query-step.test.ts
+++ b/tests/unit/database-query-step.test.ts
@@ -35,6 +35,8 @@ vi.mock("@/lib/workflow/executor/step-handler", () => ({
 import {
   type DatabaseQueryInput,
   databaseQueryStep,
+  resolveConnectTimeoutSeconds,
+  resolveRetries,
 } from "@/lib/workflow/nodes/database-query/step";
 
 const STEP_INPUT_BASE: DatabaseQueryInput = {
@@ -130,5 +132,172 @@ describe("databaseQueryStep guard wiring", () => {
     expect(error).not.toContain("supersecret");
     expect(error).not.toContain("10.0.0.1");
     expect(error).not.toContain("internal");
+  });
+});
+
+function makeClient(unsafe: (...args: unknown[]) => Promise<unknown>): {
+  unsafe: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
+} {
+  return {
+    unsafe: vi.fn(unsafe),
+    end: vi.fn(() => Promise.resolve()),
+  };
+}
+
+// Uses the _dbParams path so executeQuery routes through client.unsafe (which
+// the postgres mock controls) instead of drizzle, which is not mocked.
+const PUBLIC_DB_INPUT: DatabaseQueryInput = {
+  integrationId: "integration-1",
+  dbQuery: "SELECT $1",
+  _dbParams: ["x"],
+};
+
+function connectTimeoutError(): Error {
+  const error = new Error("write CONNECT_TIMEOUT") as Error & { code?: string };
+  error.code = "CONNECT_TIMEOUT";
+  return error;
+}
+
+describe("resolveConnectTimeoutSeconds", () => {
+  it("defaults to 30 for missing / empty / non-numeric", () => {
+    expect(resolveConnectTimeoutSeconds(undefined)).toBe(30);
+    expect(resolveConnectTimeoutSeconds(null)).toBe(30);
+    expect(resolveConnectTimeoutSeconds("")).toBe(30);
+    expect(resolveConnectTimeoutSeconds("abc")).toBe(30);
+  });
+
+  it("coerces strings and clamps to [1, 60]", () => {
+    expect(resolveConnectTimeoutSeconds("45")).toBe(45);
+    expect(resolveConnectTimeoutSeconds(0)).toBe(1);
+    expect(resolveConnectTimeoutSeconds(999)).toBe(60);
+  });
+});
+
+describe("resolveRetries", () => {
+  it("defaults to 1 for missing / empty / non-numeric", () => {
+    expect(resolveRetries(undefined)).toBe(1);
+    expect(resolveRetries(null)).toBe(1);
+    expect(resolveRetries("")).toBe(1);
+    expect(resolveRetries("abc")).toBe(1);
+  });
+
+  it("coerces, truncates, and clamps to [0, 3]", () => {
+    expect(resolveRetries("2")).toBe(2);
+    expect(resolveRetries(-5)).toBe(0);
+    expect(resolveRetries(99)).toBe(3);
+    expect(resolveRetries(1.9)).toBe(1);
+  });
+});
+
+describe("databaseQueryStep connection timeout + retry", () => {
+  beforeEach(() => {
+    mockFetchCredentials.mockResolvedValue({
+      DATABASE_URL: "postgres://u:p@93.184.216.34:5432/db",
+    });
+  });
+
+  it("passes the default 30s connect_timeout to postgres", async () => {
+    mockPostgres.mockImplementation(() =>
+      makeClient(() => Promise.resolve([{ ok: 1 }]))
+    );
+
+    const result = (await databaseQueryStep(PUBLIC_DB_INPUT)) as {
+      success: boolean;
+    };
+
+    expect(result.success).toBe(true);
+    expect(mockPostgres).toHaveBeenCalledTimes(1);
+    const options = mockPostgres.mock.calls[0][1] as {
+      connect_timeout: number;
+    };
+    expect(options.connect_timeout).toBe(30);
+  });
+
+  it("passes a configured connect_timeout, clamped to 60", async () => {
+    mockPostgres.mockImplementation(() =>
+      makeClient(() => Promise.resolve([{ ok: 1 }]))
+    );
+
+    await databaseQueryStep({ ...PUBLIC_DB_INPUT, connectTimeout: 999 });
+
+    const options = mockPostgres.mock.calls[0][1] as {
+      connect_timeout: number;
+    };
+    expect(options.connect_timeout).toBe(60);
+  });
+
+  it("retries a CONNECT_TIMEOUT and succeeds on the second attempt", async () => {
+    let call = 0;
+    mockPostgres.mockImplementation(() =>
+      makeClient(() => {
+        call++;
+        return call === 1
+          ? Promise.reject(connectTimeoutError())
+          : Promise.resolve([{ ok: 1 }]);
+      })
+    );
+
+    const result = (await databaseQueryStep(PUBLIC_DB_INPUT)) as {
+      success: boolean;
+    };
+
+    expect(result.success).toBe(true);
+    expect(mockPostgres).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a Postgres query error (write safety)", async () => {
+    mockPostgres.mockImplementation(() =>
+      makeClient(() => {
+        const error = new Error("duplicate key value") as Error & {
+          severity?: string;
+        };
+        error.severity = "ERROR";
+        return Promise.reject(error);
+      })
+    );
+
+    const result = (await databaseQueryStep({
+      ...PUBLIC_DB_INPUT,
+      retries: 3,
+    })) as { success: boolean };
+
+    expect(result.success).toBe(false);
+    expect(mockPostgres).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a mid-query ECONNRESET (write safety)", async () => {
+    mockPostgres.mockImplementation(() =>
+      makeClient(() => {
+        const error = new Error("write ECONNRESET") as Error & {
+          code?: string;
+        };
+        error.code = "ECONNRESET";
+        return Promise.reject(error);
+      })
+    );
+
+    const result = (await databaseQueryStep({
+      ...PUBLIC_DB_INPUT,
+      retries: 3,
+    })) as { success: boolean };
+
+    expect(result.success).toBe(false);
+    expect(mockPostgres).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops after exhausting retries and returns a sanitized error", async () => {
+    mockPostgres.mockImplementation(() =>
+      makeClient(() => Promise.reject(connectTimeoutError()))
+    );
+
+    const result = (await databaseQueryStep({
+      ...PUBLIC_DB_INPUT,
+      retries: 2,
+    })) as { success: boolean; error?: string };
+
+    expect(result.success).toBe(false);
+    expect(mockPostgres).toHaveBeenCalledTimes(3);
+    expect(result.error ?? "").not.toContain("93.184.216.34");
   });
 });

--- a/tests/unit/database-query-step.test.ts
+++ b/tests/unit/database-query-step.test.ts
@@ -300,4 +300,56 @@ describe("databaseQueryStep connection timeout + retry", () => {
     expect(mockPostgres).toHaveBeenCalledTimes(3);
     expect(result.error ?? "").not.toContain("93.184.216.34");
   });
+
+  it("retries a drizzle-wrapped connection error (code on error.cause)", async () => {
+    let call = 0;
+    mockPostgres.mockImplementation(() =>
+      makeClient(() => {
+        call++;
+        if (call === 1) {
+          // The non-parameterized path runs through drizzle, which wraps the
+          // driver error so the real code lands on error.cause, not the top.
+          const wrapped = new Error("Failed query: SELECT $1") as Error & {
+            cause?: unknown;
+          };
+          wrapped.cause = Object.assign(
+            new Error("connect ECONNREFUSED 10.1.2.3:5432"),
+            { code: "ECONNREFUSED" }
+          );
+          return Promise.reject(wrapped);
+        }
+        return Promise.resolve([{ ok: 1 }]);
+      })
+    );
+
+    const result = (await databaseQueryStep(PUBLIC_DB_INPUT)) as {
+      success: boolean;
+    };
+
+    expect(result.success).toBe(true);
+    expect(mockPostgres).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a drizzle-wrapped Postgres query error (severity on cause)", async () => {
+    mockPostgres.mockImplementation(() =>
+      makeClient(() => {
+        const wrapped = new Error("Failed query: INSERT ...") as Error & {
+          cause?: unknown;
+        };
+        wrapped.cause = Object.assign(new Error("duplicate key value"), {
+          severity: "ERROR",
+          code: "23505",
+        });
+        return Promise.reject(wrapped);
+      })
+    );
+
+    const result = (await databaseQueryStep({
+      ...PUBLIC_DB_INPUT,
+      retries: 3,
+    })) as { success: boolean };
+
+    expect(result.success).toBe(false);
+    expect(mockPostgres).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary

The Database Query step hardcoded a 10s connection timeout and never retried, so a serverless Postgres cold start that took longer than 10s (e.g. a Neon scale-to-zero endpoint waking up) failed the whole run with no recovery. This raises the default connection timeout, adds a bounded connection retry, and exposes both as configurable fields on the step.

## Behavior

- Connection timeout default raised from 10s to 30s (configurable per node, clamped 1-60s).
- Bounded connection retry (default 1, configurable 0-3) with a short linear backoff.
- Retries fire only for pre-query connection failures (`CONNECT_TIMEOUT`, `ECONNREFUSED`) where the query was never transmitted, so a write is never re-run. Postgres query errors and mid-query failures (`ECONNRESET`, `ETIMEDOUT`) are not retried.
- The step keeps `maxRetries = 0`: it returns failures rather than throwing, and the workflow SDK only re-fires a step on a thrown error, so the retry is implemented inside the step where it can be scoped to safe connection errors.

## Changes

- `lib/workflow/nodes/database-query/step.ts`: parameterized connect timeout, resolvers for the two new fields, a connection-error classifier, and a bounded retry loop.
- `components/workflow/config/action-config.tsx`: two numeric inputs in the Database Query config UI, mirroring the HTTP Request step.
- `lib/mcp/workflow-schema-constants.ts`: document the new optional fields (surfaced to the MCP schemas endpoint).
- `tests/unit/database-query-step.test.ts`: resolver bounds, connect-timeout passthrough, retry-then-succeed, write-safety (no retry on query or mid-query errors), and retry exhaustion.

## Notes

- The executor K8s Job budget (`JOB_ACTIVE_DEADLINE`) is 300s in all environments, so the maximum configurable wait (60s x 4 attempts) fits within a single job with headroom.

## Test plan

- [x] Unit tests pass (`pnpm test tests/unit/database-query-step.test.ts`, 21/21)
- [x] Lint (biome) and type-check clean
- [ ] Verify on staging