### PR TITLE
ci: parallelize e2e jobs and overlap prod e2e with image build

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_BUILD == 'true' && 'arc-keeperhub-build' || 'ubuntu-latest' }}
     environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
     outputs:
       image_tag: ${{ steps.vars.outputs.sha_short }}
@@ -128,7 +128,7 @@ jobs:
           exit 1
 
       - name: Free runner disk space
-        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.USE_SELF_HOSTED_BUILD != 'true'
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
@@ -139,8 +139,15 @@ jobs:
           docker-images: false
           swap-storage: false
 
+      - name: Set up Docker Buildx (remote)
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.USE_SELF_HOSTED_BUILD == 'true'
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver: remote
+          endpoint: ${{ vars.BUILDKITD_ENDPOINT }}
+
       - name: Set up Docker Buildx
-        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.USE_SELF_HOSTED_BUILD != 'true'
         uses: docker/setup-buildx-action@v4
 
       - name: Build and push all images to ECR

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ vars.USE_SELF_HOSTED_BUILD == 'true' && 'arc-keeperhub-build' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'arc-keeperhub-build' || 'ubuntu-latest' }}
     environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
     outputs:
       image_tag: ${{ steps.vars.outputs.sha_short }}
@@ -128,7 +128,7 @@ jobs:
           exit 1
 
       - name: Free runner disk space
-        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.USE_SELF_HOSTED_BUILD != 'true'
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.USE_SELF_HOSTED_RUNNERS != 'true'
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
@@ -140,14 +140,14 @@ jobs:
           swap-storage: false
 
       - name: Set up Docker Buildx (remote)
-        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.USE_SELF_HOSTED_BUILD == 'true'
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.USE_SELF_HOSTED_RUNNERS == 'true'
         uses: docker/setup-buildx-action@v4
         with:
           driver: remote
           endpoint: ${{ vars.BUILDKITD_ENDPOINT }}
 
       - name: Set up Docker Buildx
-        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.USE_SELF_HOSTED_BUILD != 'true'
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.USE_SELF_HOSTED_RUNNERS != 'true'
         uses: docker/setup-buildx-action@v4
 
       - name: Build and push all images to ECR

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -22,10 +22,10 @@ jobs:
     uses: ./.github/workflows/build-images.yml
     secrets: inherit
 
-  # Two e2e paths, selected by branch (see e2e-tests-ephemeral.yml).
-  e2e-tests-staging:
+  # Ephemeral e2e tests.
+  e2e-tests:
     needs: [build-images]
-    if: ${{ github.ref_name != 'prod' && !failure() && !cancelled() }}
+    if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/e2e-tests-ephemeral.yml
     with:
       caller_event: ${{ github.event_name }}
@@ -40,22 +40,7 @@ jobs:
       ecr_region: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.ecr_region || '') || '' }}
     secrets: inherit
 
-  e2e-tests-prod:
-    if: ${{ github.ref_name == 'prod' && !failure() && !cancelled() }}
-    uses: ./.github/workflows/e2e-tests-ephemeral.yml
-    with:
-      caller_event: ${{ github.event_name }}
-      caller_action: ${{ github.event.action }}
-      has_e2e_label: false
-      label_name: ""
-      image_tag: ""
-      ecr_registry: ""
-      ecr_repo: ""
-      ecr_region: ""
-    secrets: inherit
-
-  # Deploy runs after build-images and whichever e2e path ran (staging or prod;
-  # the other is skipped, which still satisfies needs under !failure()).
+  # Deploy runs after build-images and e2e-tests.
   # Blocked if e2e tests fail — no deployment without passing tests.
   # Deploys the whole execution pipeline (app + executor + schedule + block +
   # metrics-collector) as one atomic keeperhub-stack release, so every component
@@ -63,7 +48,7 @@ jobs:
   # metrics-collector deploys and removes the staggered-rollover window that left
   # in-flight executions orphaned mid-deploy.
   deploy:
-    needs: [build-images, e2e-tests-staging, e2e-tests-prod]
+    needs: [build-images, e2e-tests]
     if: ${{ github.event_name != 'pull_request' && !failure() && !cancelled() }}
     uses: ./.github/workflows/deploy-keeperhub.yaml
     with:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1,4 +1,4 @@
-# Type: orchestrator | Coordinates build-images -> e2e-tests -> deploy -> release -> docs-sync
+# Type: orchestrator | Coordinates build-images + e2e-tests -> deploy -> release -> docs-sync
 name: CI Pipeline
 
 on:
@@ -22,36 +22,40 @@ jobs:
     uses: ./.github/workflows/build-images.yml
     secrets: inherit
 
-  # Ephemeral e2e tests run on:
-  # - Push to staging or prod
-  # - PRs with run-e2e-tests-ephemeral label
-  # - Manual workflow_dispatch
-  #
-  # The e2e job always runs under the staging environment (staging creds, test
-  # endpoints). On a prod push, build-images builds and pushes to the prod ECR
-  # repo with prod creds, and the prod image strips test endpoints -- so the
-  # staging-cred e2e job can neither pull that image nor exercise it. Withhold
-  # the ECR coordinates on prod so e2e falls back to its bare-metal source build.
-  e2e-tests:
+  # Two e2e paths, selected by branch (see e2e-tests-ephemeral.yml).
+  e2e-tests-staging:
     needs: [build-images]
-    if: ${{ !failure() && !cancelled() }}
+    if: ${{ github.ref_name != 'prod' && !failure() && !cancelled() }}
     uses: ./.github/workflows/e2e-tests-ephemeral.yml
     with:
       caller_event: ${{ github.event_name }}
       caller_action: ${{ github.event.action }}
       has_e2e_label: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-e2e-tests-ephemeral') || false }}
       label_name: ${{ github.event.label.name || '' }}
-      # Only a staging push reuses the prebuilt ECR image. An empty string is
-      # falsy in Actions expressions, so the value we want to pass through (the
-      # build output) MUST sit on the `&&` side and '' must be the fallthrough;
-      # `cond && '' || build_output` would always yield build_output.
+      # Pass build outputs only on staging; '' must be the `||` fallthrough since
+      # an empty string is falsy (`cond && '' || x` would always yield x).
       image_tag: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.image_tag || '') || '' }}
       ecr_registry: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.ecr_registry || '') || '' }}
       ecr_repo: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.ecr_repo || '') || '' }}
       ecr_region: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.ecr_region || '') || '' }}
     secrets: inherit
 
-  # Deploy runs after build-images and e2e-tests.
+  e2e-tests-prod:
+    if: ${{ github.ref_name == 'prod' && !failure() && !cancelled() }}
+    uses: ./.github/workflows/e2e-tests-ephemeral.yml
+    with:
+      caller_event: ${{ github.event_name }}
+      caller_action: ${{ github.event.action }}
+      has_e2e_label: false
+      label_name: ""
+      image_tag: ""
+      ecr_registry: ""
+      ecr_repo: ""
+      ecr_region: ""
+    secrets: inherit
+
+  # Deploy runs after build-images and whichever e2e path ran (staging or prod;
+  # the other is skipped, which still satisfies needs under !failure()).
   # Blocked if e2e tests fail — no deployment without passing tests.
   # Deploys the whole execution pipeline (app + executor + schedule + block +
   # metrics-collector) as one atomic keeperhub-stack release, so every component
@@ -59,7 +63,7 @@ jobs:
   # metrics-collector deploys and removes the staggered-rollover window that left
   # in-flight executions orphaned mid-deploy.
   deploy:
-    needs: [build-images, e2e-tests]
+    needs: [build-images, e2e-tests-staging, e2e-tests-prod]
     if: ${{ github.event_name != 'pull_request' && !failure() && !cancelled() }}
     uses: ./.github/workflows/deploy-keeperhub.yaml
     with:

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -283,11 +283,10 @@ jobs:
             coverage/
           retention-days: 7
 
-  # Playwright E2E tests (browser-based, single worker, serial)
-  # Runs after Vitest to avoid conflicts on shared external test accounts
-  # DISABLED: ephemeral E2E tests temporarily disabled while KEEP-1351 stabilises auth/rate-limit infrastructure
+  # Playwright E2E tests (browser-based, single worker, serial within the suite).
+  # Runs in parallel with the Vitest job (each has its own ephemeral Postgres).
   e2e-playwright-ephemeral:
-    needs: [should-run, e2e-vitest-ephemeral]
+    needs: [should-run]
     if: ${{ always() && needs.should-run.outputs.run-e2e == 'true' && !failure() }}
     runs-on: ubuntu-latest
     # Always staging: e2e validates against test credentials, never prod.

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -95,7 +95,7 @@ jobs:
   e2e-vitest-ephemeral:
     needs: should-run
     if: ${{ needs.should-run.outputs.run-e2e == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && inputs.caller_event != 'pull_request' && 'arc-keeperhub-build' || 'ubuntu-latest' }}
     # Always staging: e2e validates against test credentials, never prod.
     environment: staging
 
@@ -288,7 +288,7 @@ jobs:
   e2e-playwright-ephemeral:
     needs: [should-run]
     if: ${{ always() && needs.should-run.outputs.run-e2e == 'true' && !failure() }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && inputs.caller_event != 'pull_request' && 'arc-keeperhub-build' || 'ubuntu-latest' }}
     # Always staging: e2e validates against test credentials, never prod.
     environment: staging
 


### PR DESCRIPTION
## What

Two structural CI changes to cut deploy wall-time without changing test scope or coverage.

1. Split `e2e-tests` into `e2e-tests-staging` and `e2e-tests-prod`. The prod path
   always bare-metal builds from source (the prod image strips test endpoints), so it
   never consumed the prebuilt image yet idled ~14 min behind `build-images`. It no
   longer depends on `build-images` and runs concurrently with it. The staging path
   keeps the dependency and still reuses the prebuilt staging image.

2. Run the vitest and playwright e2e jobs in parallel (drop the serial `needs`). Their
   external footprints are disjoint: all on-chain/funder activity is vitest-only, and
   each job has its own ephemeral Postgres. The only shared external is the Turnkey
   parent org, where concurrency can surface as an API rate-limit but never state
   corruption (separate sub-orgs, separate DBs).

## Expected effect

- Staging deploy ~43 -> ~36 min (e2e 16 -> ~10 min via parallelism).
- Prod deploy ~53 -> ~21-24 min (e2e overlaps the build and runs in parallel).
- The dominant remaining cost becomes `build-images` (cold Next.js build cache on
  ephemeral builders), addressed separately.

## Verification

Draft PR with the `run-e2e-tests-ephemeral` label, so the e2e workflow runs via the
pull_request path (parallel, bare-metal) and deploys nothing. Watching for:
- both e2e jobs starting within seconds of each other (parallel),
- a clean pass with the shared Turnkey org (no rate-limit errors),
- wall-time vs the previous serial run.

Validated locally with `actionlint` (clean).
