### PR TITLE
fix: copy scheduler log-facade into dispatcher images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -181,6 +181,7 @@ ENV NODE_ENV=production
 FROM scheduler-base AS schedule-dispatcher
 COPY --link --from=source /app/keeperhub-scheduler/schedule-dispatcher/ ./schedule-dispatcher/
 COPY --link --from=source /app/keeperhub-scheduler/lib/ ./lib/
+COPY --link --from=source /app/keeperhub-scheduler/log-facade.ts ./log-facade.ts
 COPY --link --from=source /app/keeperhub-scheduler/package.json ./keeperhub-scheduler/package.json
 COPY --link --from=source /app/keeperhub-scheduler/tsconfig.json ./keeperhub-scheduler/tsconfig.json
 COPY --link --from=source /app/keeperhub-scheduler/package.json ./package.json
@@ -194,6 +195,7 @@ CMD ["tsx", "schedule-dispatcher/index.ts"]
 FROM scheduler-base AS block-dispatcher
 COPY --link --from=source /app/keeperhub-scheduler/block-dispatcher/ ./block-dispatcher/
 COPY --link --from=source /app/keeperhub-scheduler/lib/ ./lib/
+COPY --link --from=source /app/keeperhub-scheduler/log-facade.ts ./log-facade.ts
 COPY --link --from=source /app/keeperhub-scheduler/package.json ./package.json
 COPY --link --from=source /app/keeperhub-scheduler/tsconfig.json ./tsconfig.json
 RUN chown -R scheduler:scheduler /app


### PR DESCRIPTION
## Summary

The `block-dispatcher` and `schedule-dispatcher` Docker stages copied only their own subdirectory plus `lib/`, omitting the package-root `log-facade.ts` that each entrypoint imports first (`import "../log-facade.js"`). At runtime `tsx` resolved that import to `/app/log-facade.ts`, which did not exist, so both services crashed on startup with `ERR_MODULE_NOT_FOUND`. The Helm `--atomic --wait` deploy then timed out at 15m and rolled back, which had been breaking every staging deploy since the canonical-logging change landed.

This copies `keeperhub-scheduler/log-facade.ts` into both dispatcher stages so the import resolves.

`executor` and `metrics-collector` are unaffected: their facades sit beside `index.ts` and the whole service directory is already copied. `event-tracker` rewrote an existing in-tree logger with no new file.

## Verification

Built the `block-dispatcher` target locally:

- `log-facade.ts` is present in the image at `/app/log-facade.ts`.
- The service boots past the import (no `ERR_MODULE_NOT_FOUND`), emits canonical single-line JSON (confirming the facade is active), and fails only on the expected missing `INTERNAL_SERVICE_HMAC_SECRET`, which staging supplies via Parameter Store.
