### PR TITLE
feat: show analytics success rate to two decimals

### DIFF
--- a/components/analytics/kpi-cards.tsx
+++ b/components/analytics/kpi-cards.tsx
@@ -190,7 +190,7 @@ export function KpiCards(): ReactNode {
         key: "success-rate",
         icon: <CheckCircle2 className="size-5" />,
         label: "Success Rate",
-        value: `${(summary.successRate * 100).toFixed(1)}%`,
+        value: `${(summary.successRate * 100).toFixed(2)}%`,
         delta: successRateDelta,
         invertDeltaColor: false,
         iconClassName: "bg-green-500/10 text-green-600 dark:text-green-400",


### PR DESCRIPTION
## Summary

Higher-precision success rate reporting was requested. The Analytics Success Rate KPI now renders two decimal places instead of one.

## Changes

- `components/analytics/kpi-cards.tsx`: Success Rate value now formats with `toFixed(2)` (e.g. `99.60%`) instead of `toFixed(1)`.

Display-only change. The delta badge and email digest are unaffected.