### PR TITLE
fix: resize page content when nav flyout panels open

### DIFF
--- a/app/hub/page.tsx
+++ b/app/hub/page.tsx
@@ -156,7 +156,7 @@ export default async function HubPage({
 
   return (
     <div className="pointer-events-auto fixed inset-0 overflow-x-hidden overflow-y-auto bg-sidebar [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-      <div className="flex min-h-full flex-col md:ml-[var(--nav-sidebar-width,60px)]">
+      <div className="flex min-h-full flex-col transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-content-offset,var(--nav-sidebar-width,60px))]">
         <div className="container mx-auto max-w-7xl px-6 pb-8 pt-[calc(5rem+var(--app-banner-height,0px))]">
           <HubHero />
           <HubTabsShell

--- a/components/activity/activity-member-preview.tsx
+++ b/components/activity/activity-member-preview.tsx
@@ -99,7 +99,7 @@ export function ActivityMemberPreview(): ReactNode {
 
   return (
     <div className="pointer-events-auto fixed inset-0 flex flex-col overflow-hidden bg-sidebar">
-      <div className="flex min-h-0 flex-1 flex-col transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+      <div className="flex min-h-0 flex-1 flex-col transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-content-offset,var(--nav-sidebar-width,60px))]">
         <div className="flex min-h-0 flex-1 flex-col gap-6 p-6 pt-[calc(5rem+var(--app-banner-height,0px))]">
           <div className="space-y-1">
             <h1 className="font-semibold text-2xl tracking-tight">

--- a/components/activity/activity-page.tsx
+++ b/components/activity/activity-page.tsx
@@ -35,7 +35,7 @@ function ActivityGuestGate(): ReactNode {
   const { openAuthPrompt } = useAuthPrompt();
   return (
     <div className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar">
-      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-content-offset,var(--nav-sidebar-width,60px))]">
         <div className="flex min-h-[80vh] flex-col items-center justify-center gap-6 p-6 text-center">
           <div className="flex size-20 items-center justify-center rounded-2xl bg-muted">
             <LogIn className="size-10 text-muted-foreground" />
@@ -88,7 +88,7 @@ function ActivityAdminView(): ReactNode {
 
   return (
     <div className="pointer-events-auto fixed inset-0 flex flex-col overflow-hidden bg-sidebar">
-      <div className="flex min-h-0 flex-1 flex-col transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+      <div className="flex min-h-0 flex-1 flex-col transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-content-offset,var(--nav-sidebar-width,60px))]">
         <div className="flex min-h-0 flex-1 flex-col gap-6 p-6 pt-[calc(5rem+var(--app-banner-height,0px))]">
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div className="space-y-1">

--- a/components/analytics/analytics-page.tsx
+++ b/components/analytics/analytics-page.tsx
@@ -25,7 +25,7 @@ function AuthGate({ error }: { error: string }): ReactNode {
 
   return (
     <div className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar">
-      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-content-offset,var(--nav-sidebar-width,60px))]">
         <div className="flex min-h-[80vh] flex-col items-center justify-center gap-6 p-6 text-center">
           <div className="flex size-20 items-center justify-center rounded-2xl bg-muted">
             {isAuthRequired ? (
@@ -105,7 +105,7 @@ export function AnalyticsPage(): ReactNode {
   if (hasNoData && !loading) {
     return (
       <div className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar">
-        <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+        <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-content-offset,var(--nav-sidebar-width,60px))]">
           <div className="flex flex-col gap-6 p-6 pt-[calc(5rem+var(--app-banner-height,0px))]">
             <AnalyticsHeader onRefetch={refetch} />
             <EmptyState />
@@ -117,7 +117,7 @@ export function AnalyticsPage(): ReactNode {
 
   return (
     <div className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar">
-      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-content-offset,var(--nav-sidebar-width,60px))]">
         <div className="flex flex-col gap-6 p-6 pt-[calc(5rem+var(--app-banner-height,0px))]">
           <AnalyticsHeader onRefetch={refetch} />
 

--- a/components/billing/billing-page.tsx
+++ b/components/billing/billing-page.tsx
@@ -44,7 +44,7 @@ function AuthGate({
       data-page-state="ready"
       data-testid="billing-page-auth-gate"
     >
-      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-content-offset,var(--nav-sidebar-width,60px))]">
         <div className="flex min-h-[80vh] flex-col items-center justify-center gap-6 p-6 text-center">
           <div className="flex size-20 items-center justify-center rounded-2xl bg-muted">
             {isAuthRequired ? (
@@ -171,7 +171,7 @@ export function BillingPage(): React.ReactElement {
       data-page-state={planLoaded ? "ready" : "loading"}
       data-testid="billing-page"
     >
-      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-content-offset,var(--nav-sidebar-width,60px))]">
         <div className="container mx-auto max-w-7xl space-y-8 px-4 py-8 pt-[calc(5rem+var(--app-banner-height,0px))]">
           <div>
             <h1 className="text-2xl font-bold">Billing</h1>

--- a/components/earnings/earnings-page.tsx
+++ b/components/earnings/earnings-page.tsx
@@ -19,7 +19,7 @@ function AuthGate({ error }: { error: string }): ReactNode {
 
   return (
     <div className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar">
-      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-content-offset,var(--nav-sidebar-width,60px))]">
         <div className="flex min-h-[80vh] flex-col items-center justify-center gap-6 p-6 text-center">
           <div className="flex size-20 items-center justify-center rounded-2xl bg-muted">
             {isAuthRequired ? (
@@ -54,7 +54,7 @@ function AuthGate({ error }: { error: string }): ReactNode {
 function NoListedWorkflowsState(): ReactNode {
   return (
     <div className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar">
-      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-content-offset,var(--nav-sidebar-width,60px))]">
         <div className="flex min-h-[80vh] flex-col items-center justify-center gap-6 p-6 text-center">
           <div className="flex size-20 items-center justify-center rounded-2xl bg-muted">
             <BarChart3 className="size-10 text-muted-foreground" />
@@ -121,7 +121,7 @@ export function EarningsPage(): ReactNode {
 
   return (
     <div className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar">
-      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-content-offset,var(--nav-sidebar-width,60px))]">
         <div className="flex flex-col gap-6 p-6 pt-[calc(5rem+var(--app-banner-height,0px))]">
           <EarningsHeader onRefetch={refetch} />
           <EarningsKpiCards />

--- a/components/hub/protocol-detail-page.tsx
+++ b/components/hub/protocol-detail-page.tsx
@@ -12,7 +12,7 @@ export function ProtocolDetailPage({
 }): React.ReactElement {
   return (
     <div className="pointer-events-auto fixed inset-0 overflow-y-auto bg-sidebar [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-sidebar-width,60px)]">
+      <div className="transition-[margin-left] duration-200 ease-out md:ml-[var(--nav-content-offset,var(--nav-sidebar-width,60px))]">
         <div className="mx-auto w-full max-w-5xl px-4 py-8">
           <Link
             className="mb-6 inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"

--- a/components/navigation-sidebar.tsx
+++ b/components/navigation-sidebar.tsx
@@ -752,7 +752,18 @@ export function NavigationSidebar(): React.ReactNode {
       "--nav-sidebar-width",
       `${currentWidth}px`
     );
-  }, [currentWidth]);
+    // Full left offset including any open/collapsed flyout panels, so pages
+    // that resize their main frame (e.g. analytics) sit beside the panels
+    // instead of being overlapped by them.
+    const { rightEdge } = computePanelOffsets(
+      currentWidth,
+      navState.state.panels
+    );
+    document.documentElement.style.setProperty(
+      "--nav-content-offset",
+      `${rightEdge}px`
+    );
+  }, [currentWidth, navState.state.panels]);
 
   if (isMobile || !navState.hasMounted) {
     return null;


### PR DESCRIPTION
## Summary

The nav flyout panels (Workflows / Projects / Tags) render `position: fixed` and overlay everything to their right. Pages offset their main frame only by the icon-rail width (`--nav-sidebar-width`), so opening a panel covered the page content (e.g. the Analytics header and KPI cards were partially hidden behind the panels).

The sidebar now also publishes the full left offset (icon rail plus any open/collapsed panels) as `--nav-content-offset`. Pages that should reflow consume it and resize their frame to sit beside the panels, animating in sync with the panel transition.

## Changes

- `navigation-sidebar.tsx`: publish `--nav-content-offset` (full left offset including open/collapsed flyout panels), updated on rail width or panel-state change.
- Offset main content by `--nav-content-offset`, falling back to the rail width: analytics, earnings, activity (page + member preview), hub (landing + protocol detail), billing.
- Hub landing also gains the `margin-left` transition so it animates with the panels instead of snapping.

All consumers keep the `var(--nav-content-offset, var(--nav-sidebar-width,60px))` fallback, so the panels-closed, SSR, and mobile cases render exactly as before. The workflows editor is intentionally left overlaid.