### PR TITLE
fix(analytics): eliminate networks-breakdown timeout via denormalised log columns

### DIFF
--- a/drizzle/0117_keep_857_exec_log_network_gas.sql
+++ b/drizzle/0117_keep_857_exec_log_network_gas.sql
@@ -1,0 +1,23 @@
+-- KEEP-857: denormalise per-step network + gas onto workflow_execution_logs.
+--
+-- The /analytics per-network gas breakdown (computeNetworkBreakdown) is the
+-- last reader that still extracts `network` (input) and `gasUsed` (output) from
+-- the double-encoded JSONB on every log row in the window, GROUP BY-ing and
+-- SUM-ing those re-parsed expressions. That is unindexable and, on a large org
+-- over a 30d range, runs past Cloudflare's 100s limit (the networks-endpoint
+-- 524). Run-total gas was already denormalised onto workflow_executions
+-- (KEEP-683); this does the same one level down, per step, because network is a
+-- per-step property.
+--
+-- These columns let the breakdown read first-class columns with no JSONB parse.
+-- network is populated at step start (from input), gas_used_wei at step
+-- complete (from output) by lib/workflow/executor/logging.ts, and historical
+-- rows are filled by scripts/backfill-exec-log-network-gas.ts.
+--
+-- No `-- @requires-db-prep`: ADD COLUMN of a nullable column with no default is
+-- a catalog-only change in PostgreSQL 11+ (momentary ACCESS EXCLUSIVE lock, no
+-- table rewrite), safe inline via the normal migrate path even on the large
+-- prod logs table. The heavy backfill UPDATE runs out-of-band, batched.
+
+ALTER TABLE "workflow_execution_logs" ADD COLUMN IF NOT EXISTS "network" text;--> statement-breakpoint
+ALTER TABLE "workflow_execution_logs" ADD COLUMN IF NOT EXISTS "gas_used_wei" numeric;

--- a/drizzle/0118_keep_857_exec_log_gas_index.sql
+++ b/drizzle/0118_keep_857_exec_log_gas_index.sql
@@ -1,0 +1,16 @@
+-- @requires-db-prep
+-- KEEP-857: supporting index for the per-network gas breakdown.
+--
+-- computeNetworkBreakdown's workflow branch filters
+-- `gas_used_wei IS NOT NULL` over a started_at window, then GROUP BY network.
+-- Gas-bearing step rows (web3 nodes) are a small fraction of all log rows, so a
+-- partial index on started_at keyed to gas-bearing rows turns the window scan
+-- into an index range scan that skips the non-gas majority.
+--
+-- DB-PREP: on prod/staging an operator applies this CONCURRENTLY out-of-band
+-- (`CREATE INDEX CONCURRENTLY IF NOT EXISTS ...`) before merge, so the plain
+-- statement below is a no-op there (IF NOT EXISTS). On dev / PR-env DBs the
+-- table is small, so the plain in-migration build is fine.
+CREATE INDEX IF NOT EXISTS "idx_exec_logs_gas_started_at"
+  ON "workflow_execution_logs" ("started_at")
+  WHERE gas_used_wei IS NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -820,6 +820,20 @@
       "when": 1782648000000,
       "tag": "0116_keep_884_gas_sponsorship_monthly",
       "breakpoints": true
+    },
+    {
+      "idx": 117,
+      "version": "7",
+      "when": 1782648000001,
+      "tag": "0117_keep_857_exec_log_network_gas",
+      "breakpoints": true
+    },
+    {
+      "idx": 118,
+      "version": "7",
+      "when": 1782648000002,
+      "tag": "0118_keep_857_exec_log_gas_index",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -1,6 +1,16 @@
 import "server-only";
 
-import { and, count, desc, eq, gte, inArray, lt, sql } from "drizzle-orm";
+import {
+  and,
+  count,
+  desc,
+  eq,
+  gte,
+  inArray,
+  isNotNull,
+  lt,
+  sql,
+} from "drizzle-orm";
 import { db } from "@/lib/db";
 import { logInputField, logOutputField } from "@/lib/db/execution-log-fields";
 import {
@@ -691,10 +701,16 @@ async function computeNetworkBreakdown(
             )
           )
           .groupBy(directExecutions.network),
+    // Reads the denormalised network / gas_used_wei columns instead of
+    // re-parsing the double-encoded input/output JSONB per row, which is what
+    // pushed this query past the 100s edge timeout on large orgs. The columns
+    // are populated by lib/workflow/executor/logging.ts and backfilled by
+    // scripts/backfill-exec-log-network-gas.ts; they agree value-for-value with
+    // the JSONB extraction the rest of the readers use.
     db
       .select({
-        network: sql<string>`${logInputField("network")}`,
-        totalGasWei: sql<string>`COALESCE(SUM(CAST(${logOutputField("gasUsed")} AS NUMERIC)), 0)::text`,
+        network: workflowExecutionLogs.network,
+        totalGasWei: sql<string>`COALESCE(SUM(${workflowExecutionLogs.gasUsedWei}), 0)::text`,
         executionCount: count(),
         successCount: sql<number>`SUM(CASE WHEN ${workflowExecutionLogs.status} = 'success' THEN 1 ELSE 0 END)`,
         errorCount: sql<number>`SUM(CASE WHEN ${workflowExecutionLogs.status} = 'error' THEN 1 ELSE 0 END)`,
@@ -711,10 +727,10 @@ async function computeNetworkBreakdown(
           projectId ? eq(workflows.projectId, projectId) : undefined,
           gte(workflowExecutionLogs.startedAt, rangeStart),
           lt(workflowExecutionLogs.startedAt, rangeEnd),
-          sql`${logOutputField("gasUsed")} IS NOT NULL`
+          isNotNull(workflowExecutionLogs.gasUsedWei)
         )
       )
-      .groupBy(sql`${logInputField("network")}`),
+      .groupBy(workflowExecutionLogs.network),
   ]);
 
   const networkMap = new Map<string, NetworkBreakdown>();

--- a/lib/db/execution-log-fields.ts
+++ b/lib/db/execution-log-fields.ts
@@ -33,3 +33,44 @@ export function logInputField(field: string): ReturnType<typeof sql> {
     ELSE ${workflowExecutionLogs.input}->>${sql.raw(`'${field}'`)}
   END`;
 }
+
+/**
+ * JS-side counterparts of the SQL extraction above, used by the executor writer
+ * (lib/workflow/executor/logging.ts) to populate the denormalised `network` /
+ * `gas_used_wei` columns at write time. They read the same raw input/output the
+ * `input` / `output` JSONB columns receive, so a writer-populated column agrees
+ * value-for-value with `logInputField`/`logOutputField` and the backfill (which
+ * uses the SQL builders). Mirror the `->>` semantics: only a plain-object source
+ * yields a value, and the result is the scalar's text form.
+ */
+function jsonScalarText(source: unknown, field: string): string | null {
+  if (source === null || typeof source !== "object" || Array.isArray(source)) {
+    return null;
+  }
+  const value = (source as Record<string, unknown>)[field];
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === "object") {
+    return null;
+  }
+  return String(value);
+}
+
+export function extractLogNetwork(input: unknown): string | null {
+  return jsonScalarText(input, "network");
+}
+
+/**
+ * Extract per-step gas as the text of a numeric (the `gas_used_wei` column is
+ * numeric). Returns null for a missing key or a value that is not a finite
+ * numeric string, matching what `CAST(... AS NUMERIC)` would accept from the
+ * SQL extraction.
+ */
+export function extractLogGasUsedWei(output: unknown): string | null {
+  const text = jsonScalarText(output, "gasUsed");
+  if (text === null || text.trim() === "") {
+    return null;
+  }
+  return Number.isFinite(Number(text)) ? text : null;
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -717,6 +717,17 @@ export const workflowExecutionLogs = pgTable(
     timestamp: timestamp("timestamp").notNull().defaultNow(),
     iterationIndex: integer("iteration_index"), // 0-based loop iteration (null for non-loop nodes)
     forEachNodeId: text("for_each_node_id"), // parent For Each node ID (null for non-loop nodes)
+    /**
+     * Per-step network + on-chain gas, denormalised out of the input/output
+     * JSONB so the /analytics per-network gas breakdown can aggregate
+     * first-class columns instead of re-parsing the double-encoded JSONB on
+     * every row (the cost behind the networks-endpoint 524). network is read
+     * from input at step start; gas_used_wei from output at step complete.
+     * Both nullable on legacy rows until backfilled
+     * (scripts/backfill-exec-log-network-gas.ts) and on non-web3 steps.
+     */
+    network: text("network"),
+    gasUsedWei: numeric("gas_used_wei"),
   },
   (table) => [index("idx_exec_logs_started_at").on(table.startedAt)]
 );

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -6,7 +6,11 @@ import "server-only";
 
 import { and, asc, eq, inArray, isNotNull, ne, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { logOutputField } from "@/lib/db/execution-log-fields";
+import {
+  extractLogGasUsedWei,
+  extractLogNetwork,
+  logOutputField,
+} from "@/lib/db/execution-log-fields";
 import {
   organization,
   type TransactionHashEntry,
@@ -441,6 +445,7 @@ export async function logStepStartDb(
       nodeType: params.nodeType,
       status: "running",
       input: toJsonSafe(params.input),
+      network: extractLogNetwork(params.input),
       startedAt: new Date(),
       iterationIndex: params.iterationIndex ?? null,
       forEachNodeId: params.forEachNodeId ?? null,
@@ -500,6 +505,7 @@ export async function logStepCompleteDb(
       status: params.status,
       output: toJsonSafe(params.output),
       outputRaw: toJsonSafe(params.outputRaw),
+      gasUsedWei: extractLogGasUsedWei(params.output),
       error: errorValue,
       completedAt: new Date(),
       duration: duration.toString(),

--- a/scripts/backfill-exec-log-network-gas.ts
+++ b/scripts/backfill-exec-log-network-gas.ts
@@ -8,16 +8,19 @@
  * gas breakdown can move off the per-row input/output JSONB re-parse (the cost
  * behind the networks-endpoint 524) without the breakdown totals changing.
  *
- * Approach: set-based, one UPDATE per keyset batch of log ids (NOT one query
- * per row - this runs over millions of rows on prod). Each batch re-extracts
+ * Scope: only gas-bearing rows. The per-network breakdown reads network and
+ * gas_used_wei exclusively for rows where gas_used_wei IS NOT NULL, so those are
+ * the only historical rows that need denormalising. Gas steps are a tiny
+ * fraction of the table (most rows are reads with no on-chain gas), so this
+ * touches a handful of rows rather than the whole multi-GB table. network on
+ * non-gas rows stays null on purpose; nothing reads it.
+ *
+ * Approach: keyset batches over the gas-bearing rows, each re-extracting
  * network/gasUsed from the JSONB via the shared logInputField/logOutputField
  * builders, the same expressions the executor writer mirrors in JS and the
- * /analytics reads used to use, so all paths agree value-for-value.
- *
- * COALESCE preserves any value the live writer already set (no clobber race on
- * hot recent rows); the WHERE only touches rows that have a JSONB value to fill
- * and a still-null column, so non-web3 rows (no network, no gas) are never
- * written and re-runs are cheap. Idempotent and resumable via --after-id.
+ * /analytics reads used to use, so all paths agree value-for-value. COALESCE
+ * preserves any value the live writer already set (no clobber race on hot
+ * recent rows). Idempotent and resumable via --after-id.
  *
  * A LIVE run against a non-local DB requires --yes; dry-runs and local DBs do
  * not. This is a guard against an accidental prod write, not a security
@@ -88,7 +91,14 @@ function parseArgs(argv: string[]): CliArgs {
   return args;
 }
 
-/** Keyset page of log ids; the cursor for the next batch is the last id. */
+const networkExpr = logInputField("network");
+const gasExpr = logOutputField("gasUsed");
+
+/**
+ * Keyset page of the gas-bearing log ids still needing a backfill; the cursor
+ * for the next batch is the last id. Filtering to gas rows here keeps the walk
+ * over the handful of rows that matter instead of the whole table.
+ */
 async function fetchLogIdBatch(
   afterId: string,
   batchSize: number
@@ -96,27 +106,28 @@ async function fetchLogIdBatch(
   const rows = await db
     .select({ id: workflowExecutionLogs.id })
     .from(workflowExecutionLogs)
-    .where(sql`${workflowExecutionLogs.id} > ${afterId}`)
+    .where(
+      sql`${workflowExecutionLogs.id} > ${afterId} AND ${workflowExecutionLogs.gasUsedWei} IS NULL AND ${gasExpr} IS NOT NULL`
+    )
     .orderBy(workflowExecutionLogs.id)
     .limit(batchSize);
   return rows.map((r) => r.id);
 }
 
-const networkExpr = logInputField("network");
-const gasExpr = logOutputField("gasUsed");
-
 /**
- * Backfill one keyset batch. Re-selects the same batch inside a CTE
- * (deterministic for a fixed cursor) so no id array has to be marshalled into
- * the statement. COALESCE keeps any writer-set value; the WHERE only fills a
- * null column when the JSONB actually carries a value, so non-web3 rows are
- * skipped and re-runs are no-ops. Returns the number of rows written.
+ * Backfill one keyset batch of gas-bearing rows. Re-selects the same batch
+ * inside a CTE (deterministic for a fixed cursor) so no id array has to be
+ * marshalled into the statement. COALESCE keeps any value the live writer
+ * already set; re-runs skip rows whose gas_used_wei is already populated.
+ * Returns the number of rows written.
  */
 async function applyBatch(afterId: string, batchSize: number): Promise<number> {
   const result = await db.execute(sql`
     WITH batch AS (
       SELECT id FROM workflow_execution_logs
       WHERE id > ${afterId}
+        AND gas_used_wei IS NULL
+        AND ${gasExpr} IS NOT NULL
       ORDER BY id
       LIMIT ${batchSize}
     )
@@ -128,30 +139,24 @@ async function applyBatch(afterId: string, batchSize: number): Promise<number> {
         )
     FROM batch
     WHERE workflow_execution_logs.id = batch.id
-      AND (
-        (workflow_execution_logs.network IS NULL AND ${networkExpr} IS NOT NULL)
-        OR (workflow_execution_logs.gas_used_wei IS NULL AND ${gasExpr} IS NOT NULL)
-      )
     RETURNING workflow_execution_logs.id
   `);
   // postgres-js: db.execute resolves to the RETURNING rows array.
   return result.length;
 }
 
-/** Dry-run: count how many rows in the batch WOULD be written. */
+/** Dry-run: count how many gas-bearing rows in the batch WOULD be written. */
 async function countBatch(afterId: string, batchSize: number): Promise<number> {
   const result = await db.execute(sql`
     WITH batch AS (
       SELECT id FROM workflow_execution_logs
       WHERE id > ${afterId}
+        AND gas_used_wei IS NULL
+        AND ${gasExpr} IS NOT NULL
       ORDER BY id
       LIMIT ${batchSize}
     )
-    SELECT COUNT(*) AS n
-    FROM workflow_execution_logs
-    JOIN batch ON batch.id = workflow_execution_logs.id
-    WHERE (workflow_execution_logs.network IS NULL AND ${networkExpr} IS NOT NULL)
-      OR (workflow_execution_logs.gas_used_wei IS NULL AND ${gasExpr} IS NOT NULL)
+    SELECT COUNT(*) AS n FROM batch
   `);
   // postgres-js: db.execute resolves to the rows array.
   return Number(result[0]?.n ?? 0);

--- a/scripts/backfill-exec-log-network-gas.ts
+++ b/scripts/backfill-exec-log-network-gas.ts
@@ -1,0 +1,244 @@
+/**
+ * KEEP-857: one-time backfill of the denormalised `network` / `gas_used_wei`
+ * columns on `workflow_execution_logs`.
+ *
+ * Migration 0117 adds the columns null. New rows are populated at write time by
+ * lib/workflow/executor/logging.ts (network at step start, gas_used_wei at step
+ * complete). This script fills historical rows so the /analytics per-network
+ * gas breakdown can move off the per-row input/output JSONB re-parse (the cost
+ * behind the networks-endpoint 524) without the breakdown totals changing.
+ *
+ * Approach: set-based, one UPDATE per keyset batch of log ids (NOT one query
+ * per row - this runs over millions of rows on prod). Each batch re-extracts
+ * network/gasUsed from the JSONB via the shared logInputField/logOutputField
+ * builders, the same expressions the executor writer mirrors in JS and the
+ * /analytics reads used to use, so all paths agree value-for-value.
+ *
+ * COALESCE preserves any value the live writer already set (no clobber race on
+ * hot recent rows); the WHERE only touches rows that have a JSONB value to fill
+ * and a still-null column, so non-web3 rows (no network, no gas) are never
+ * written and re-runs are cheap. Idempotent and resumable via --after-id.
+ *
+ * A LIVE run against a non-local DB requires --yes; dry-runs and local DBs do
+ * not. This is a guard against an accidental prod write, not a security
+ * boundary.
+ *
+ * Usage:
+ *   pnpm tsx scripts/backfill-exec-log-network-gas.ts --dry-run
+ *   pnpm tsx scripts/backfill-exec-log-network-gas.ts                # local DB
+ *   pnpm tsx scripts/backfill-exec-log-network-gas.ts --yes          # staging/prod
+ *   pnpm tsx scripts/backfill-exec-log-network-gas.ts --yes --batch-size 2000 --after-id <id>
+ *   pnpm tsx scripts/backfill-exec-log-network-gas.ts --dry-run --max-batches 5
+ */
+
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  logInputField,
+  logOutputField,
+} from "@/lib/db/execution-log-fields";
+import { workflowExecutionLogs } from "@/lib/db/schema";
+
+const DEFAULT_BATCH_SIZE = 1000;
+
+type CliArgs = {
+  dryRun: boolean;
+  batchSize: number;
+  afterId: string;
+  maxBatches: number | null;
+  yes: boolean;
+};
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    dryRun: false,
+    batchSize: DEFAULT_BATCH_SIZE,
+    afterId: "",
+    maxBatches: null,
+    yes: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") {
+      args.dryRun = true;
+    } else if (a === "--yes") {
+      args.yes = true;
+    } else if (a === "--batch-size" && argv[i + 1]) {
+      const parsed = Number.parseInt(argv[i + 1], 10);
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        args.batchSize = parsed;
+      }
+      i++;
+    } else if (a === "--after-id" && argv[i + 1]) {
+      args.afterId = argv[i + 1];
+      i++;
+    } else if (a === "--max-batches" && argv[i + 1]) {
+      const parsed = Number.parseInt(argv[i + 1], 10);
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        args.maxBatches = parsed;
+      }
+      i++;
+    } else if (a === "--help" || a === "-h") {
+      console.log(
+        "Usage: pnpm tsx scripts/backfill-exec-log-network-gas.ts [--dry-run] [--batch-size N] [--after-id ID] [--max-batches N] [--yes]"
+      );
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+/** Keyset page of log ids; the cursor for the next batch is the last id. */
+async function fetchLogIdBatch(
+  afterId: string,
+  batchSize: number
+): Promise<string[]> {
+  const rows = await db
+    .select({ id: workflowExecutionLogs.id })
+    .from(workflowExecutionLogs)
+    .where(sql`${workflowExecutionLogs.id} > ${afterId}`)
+    .orderBy(workflowExecutionLogs.id)
+    .limit(batchSize);
+  return rows.map((r) => r.id);
+}
+
+const networkExpr = logInputField("network");
+const gasExpr = logOutputField("gasUsed");
+
+/**
+ * Backfill one keyset batch. Re-selects the same batch inside a CTE
+ * (deterministic for a fixed cursor) so no id array has to be marshalled into
+ * the statement. COALESCE keeps any writer-set value; the WHERE only fills a
+ * null column when the JSONB actually carries a value, so non-web3 rows are
+ * skipped and re-runs are no-ops. Returns the number of rows written.
+ */
+async function applyBatch(afterId: string, batchSize: number): Promise<number> {
+  const result = await db.execute(sql`
+    WITH batch AS (
+      SELECT id FROM workflow_execution_logs
+      WHERE id > ${afterId}
+      ORDER BY id
+      LIMIT ${batchSize}
+    )
+    UPDATE workflow_execution_logs
+    SET network = COALESCE(workflow_execution_logs.network, ${networkExpr}),
+        gas_used_wei = COALESCE(
+          workflow_execution_logs.gas_used_wei,
+          CAST(${gasExpr} AS NUMERIC)
+        )
+    FROM batch
+    WHERE workflow_execution_logs.id = batch.id
+      AND (
+        (workflow_execution_logs.network IS NULL AND ${networkExpr} IS NOT NULL)
+        OR (workflow_execution_logs.gas_used_wei IS NULL AND ${gasExpr} IS NOT NULL)
+      )
+    RETURNING workflow_execution_logs.id
+  `);
+  // postgres-js: db.execute resolves to the RETURNING rows array.
+  return result.length;
+}
+
+/** Dry-run: count how many rows in the batch WOULD be written. */
+async function countBatch(afterId: string, batchSize: number): Promise<number> {
+  const result = await db.execute(sql`
+    WITH batch AS (
+      SELECT id FROM workflow_execution_logs
+      WHERE id > ${afterId}
+      ORDER BY id
+      LIMIT ${batchSize}
+    )
+    SELECT COUNT(*) AS n
+    FROM workflow_execution_logs
+    JOIN batch ON batch.id = workflow_execution_logs.id
+    WHERE (workflow_execution_logs.network IS NULL AND ${networkExpr} IS NOT NULL)
+      OR (workflow_execution_logs.gas_used_wei IS NULL AND ${gasExpr} IS NOT NULL)
+  `);
+  // postgres-js: db.execute resolves to the rows array.
+  return Number(result[0]?.n ?? 0);
+}
+
+function dbHost(): string {
+  try {
+    return new URL(process.env.DATABASE_URL ?? "").host || "(unknown)";
+  } catch {
+    return "(unparseable DATABASE_URL)";
+  }
+}
+
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "db", "postgres"]);
+
+function isLocalDb(): boolean {
+  try {
+    // URL.hostname drops the port; strip the IPv6 brackets it keeps.
+    const hostname = new URL(process.env.DATABASE_URL ?? "").hostname.replace(
+      /^\[|\]$/g,
+      ""
+    );
+    return LOCAL_HOSTS.has(hostname);
+  } catch {
+    return false;
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  console.log(
+    `[backfill-exec-log-network-gas] mode=${args.dryRun ? "DRY-RUN" : "LIVE"} host=${dbHost()} batchSize=${args.batchSize} afterId=${args.afterId || "(start)"} maxBatches=${args.maxBatches ?? "all"}`
+  );
+
+  // A LIVE run against a non-local DB (staging/prod) writes immediately. Require
+  // an explicit --yes so an operator cannot kick one off by reflex. Dry-runs and
+  // local DBs are unguarded.
+  if (!(args.dryRun || args.yes || isLocalDb())) {
+    console.error(
+      `[backfill-exec-log-network-gas] refusing LIVE run against non-local host ${dbHost()} without --yes. Re-run with --yes to confirm, or add --dry-run.`
+    );
+    process.exit(1);
+  }
+
+  let cursor = args.afterId;
+  let batches = 0;
+  let totalScanned = 0;
+  let totalWritten = 0;
+
+  for (;;) {
+    const ids = await fetchLogIdBatch(cursor, args.batchSize);
+    if (ids.length === 0) {
+      break;
+    }
+
+    const written = args.dryRun
+      ? await countBatch(cursor, args.batchSize)
+      : await applyBatch(cursor, args.batchSize);
+
+    batches += 1;
+    totalScanned += ids.length;
+    totalWritten += written;
+    cursor = ids[ids.length - 1];
+
+    console.log(
+      `[backfill-exec-log-network-gas] batch=${batches} scanned=${ids.length} written=${written} cursor=${cursor} cumulative_scanned=${totalScanned} cumulative_written=${totalWritten}`
+    );
+
+    if (ids.length < args.batchSize) {
+      break;
+    }
+    if (args.maxBatches !== null && batches >= args.maxBatches) {
+      console.log(
+        `[backfill-exec-log-network-gas] stopping at --max-batches=${args.maxBatches}; resume with --after-id ${cursor}`
+      );
+      break;
+    }
+  }
+
+  console.log(
+    `[backfill-exec-log-network-gas] done. mode=${args.dryRun ? "DRY-RUN" : "LIVE"} batches=${batches} scanned=${totalScanned} written=${totalWritten} last_cursor=${cursor || "(none)"}`
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("[backfill-exec-log-network-gas] failed:", err);
+    process.exit(1);
+  });

--- a/tests/unit/execution-log-fields.test.ts
+++ b/tests/unit/execution-log-fields.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  extractLogGasUsedWei,
+  extractLogNetwork,
+} from "@/lib/db/execution-log-fields";
+
+describe("extractLogNetwork", () => {
+  it("returns the network string from a plain object", () => {
+    expect(extractLogNetwork({ network: "ethereum" })).toBe("ethereum");
+  });
+
+  it("coerces a non-string scalar to its text form, matching ->>", () => {
+    expect(extractLogNetwork({ network: 1 })).toBe("1");
+  });
+
+  it("returns null when the key is absent", () => {
+    expect(extractLogNetwork({ chainId: 1 })).toBeNull();
+  });
+
+  it("returns null for null / array / primitive sources", () => {
+    expect(extractLogNetwork(null)).toBeNull();
+    expect(extractLogNetwork(["network"])).toBeNull();
+    expect(extractLogNetwork("ethereum")).toBeNull();
+  });
+
+  it("returns null when the value is itself an object", () => {
+    expect(extractLogNetwork({ network: { name: "ethereum" } })).toBeNull();
+  });
+});
+
+describe("extractLogGasUsedWei", () => {
+  it("returns the numeric text from a string gasUsed", () => {
+    expect(extractLogGasUsedWei({ gasUsed: "21000" })).toBe("21000");
+  });
+
+  it("returns the numeric text from a number gasUsed", () => {
+    expect(extractLogGasUsedWei({ gasUsed: 21_000 })).toBe("21000");
+  });
+
+  it("returns null when gasUsed is absent", () => {
+    expect(extractLogGasUsedWei({ network: "ethereum" })).toBeNull();
+  });
+
+  it("returns null for an empty or non-numeric gasUsed", () => {
+    expect(extractLogGasUsedWei({ gasUsed: "" })).toBeNull();
+    expect(extractLogGasUsedWei({ gasUsed: "  " })).toBeNull();
+    expect(extractLogGasUsedWei({ gasUsed: "not-a-number" })).toBeNull();
+  });
+
+  it("returns null for null / array / primitive sources", () => {
+    expect(extractLogGasUsedWei(null)).toBeNull();
+    expect(extractLogGasUsedWei([21_000])).toBeNull();
+    expect(extractLogGasUsedWei(21_000)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

`/api/analytics/networks` is the only analytics endpoint that hits the 100s edge timeout (the 524 in the report); summary, runs, and time-series return fine on the same page. It is the last reader that builds the per-network gas breakdown by extracting `network` and `gasUsed` from the double-encoded `input`/`output` JSONB on `workflow_execution_logs`, then grouping and summing those re-parsed expressions over the whole time window. That expression is unindexable, so for a large org over 30 days Postgres scans and detoasts every log row in the window, which is what crosses 100s. Run-total gas was already denormalised onto `workflow_executions.gas_used_wei` for the same reason; per-step network was deliberately left in JSONB because it is a per-step property.

## Fix

Denormalise the two per-step values onto `workflow_execution_logs`:

- New nullable columns `network` (text) and `gas_used_wei` (numeric), plus a partial index on `started_at` keyed to gas-bearing rows.
- The executor writes them at log time: `network` from input at step start, `gas_used_wei` from output at step complete, via JS extractors that match the SQL extraction value-for-value.
- A batched, idempotent backfill fills historical rows from the existing JSONB.
- The breakdown query reads the columns directly, so it consults only gas-bearing rows via the partial index instead of re-parsing the whole window.

## Rollout

The read keys off the column, so per environment the order is: run the migration, run the backfill to completion, then the breakdown reflects historical rows. New rows are correct immediately via the writer. If the read deploys before the backfill finishes, the breakdown undercounts the oldest in-range rows (no error, self-corrects as the backfill catches up). The partial index is marked `@requires-db-prep` so an operator builds it CONCURRENTLY out of band.

## Validation

Verified against a slice of real data loaded locally:

- Correctness: the new column query returns the per-network gas breakdown value-for-value identical to the old JSONB query (checked across mainnet and testnet rows). Backfill output matches the JSONB extraction with zero mismatches and is idempotent on re-run.
- Performance: at platform scale the 30d window holds ~1.19M log rows, of which ~39 carry gas. The old query reparses all 1.19M to find them (observed exceeding 100s); the new query index-scans only the gas rows. On the local slice the cross-org scan shape went from 90ms (seq scan, ~161k rows reparsed) to 0.13ms (index scan, 23 rows).
- Unit and integration: extractor parity tests, plus the existing executor logging suites (42) green.

Migrations: `0117` (columns), `0118` (partial index). Backfill: `scripts/backfill-exec-log-network-gas.ts`.