### PR TITLE
test(analytics): mirror network and gas columns in analytics seeds

### DIFF
--- a/scripts/seed/seed-analytics-data.ts
+++ b/scripts/seed/seed-analytics-data.ts
@@ -403,10 +403,19 @@ async function createStepLogs(
 
     const isWeb3Write = nodeType === "web3:write-contract";
     const network = isWeb3Write ? randomChoice(NETWORKS) : null;
+    const chainId = isWeb3Write
+      ? network === "ethereum"
+        ? "1"
+        : network === "base"
+          ? "8453"
+          : network === "polygon"
+            ? "137"
+            : "11155111"
+      : null;
 
     const inputData = isWeb3Write
       ? JSON.stringify({
-          network: network === "ethereum" ? "1" : network === "base" ? "8453" : network === "polygon" ? "137" : "11155111",
+          network: chainId,
           contractAddress: `0x${randomHex(40)}`,
           actionType: "web3/write-contract",
           abiFunction: "transfer",
@@ -414,20 +423,28 @@ async function createStepLogs(
         })
       : null;
 
-    const outputData =
+    // Computed once and mirrored into both the output JSONB and the
+    // denormalised gas_used_wei column the analytics network breakdown reads.
+    const gasUsedWei =
       isWeb3Write && stepStatus === "success"
+        ? realisticGasWei(network ?? "ethereum")
+        : null;
+
+    const outputData =
+      gasUsedWei !== null
         ? JSON.stringify({
             success: true,
             transactionHash: `0x${randomHex(64)}`,
-            gasUsed: realisticGasWei(network ?? "ethereum"),
+            gasUsed: gasUsedWei,
           })
         : null;
 
     await sql.unsafe(
       `INSERT INTO workflow_execution_logs (
         id, execution_id, node_id, node_name, node_type, status,
-        started_at, completed_at, duration, error, input, output
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12::jsonb)`,
+        started_at, completed_at, duration, error, input, output,
+        network, gas_used_wei
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12::jsonb, $13, $14)`,
       [
         logId,
         executionId,
@@ -441,6 +458,8 @@ async function createStepLogs(
         errorMsg,
         inputData,
         outputData,
+        chainId,
+        gasUsedWei,
       ]
     );
 

--- a/tests/e2e/playwright/utils/seed.ts
+++ b/tests/e2e/playwright/utils/seed.ts
@@ -388,14 +388,14 @@ function buildStepInput(nodeType: string, chainId: string): string | null {
   });
 }
 
-function buildStepOutput(nodeType: string, stepStatus: string): string | null {
-  if (nodeType !== "web3:write-contract" || stepStatus !== "success") {
+function buildStepOutput(gasUsedWei: string | null): string | null {
+  if (gasUsedWei === null) {
     return null;
   }
   return JSON.stringify({
     success: true,
     transactionHash: `0x${randomHex(64)}`,
-    gasUsed: String(randomInt(21_000, 350_000)),
+    gasUsed: gasUsedWei,
   });
 }
 
@@ -414,17 +414,22 @@ async function seedStepLogs(
     const stepStartedAt = new Date(currentTime);
     const stepStatus = resolveStepStatus(execStatus, s, stepCount);
     const isTerminal = stepStatus === "pending" || stepStatus === "running";
-    const network =
-      nodeType === "web3:write-contract"
-        ? randomChoice(ANALYTICS_NETWORKS)
-        : null;
+    const isWrite = nodeType === "web3:write-contract";
+    const network = isWrite ? randomChoice(ANALYTICS_NETWORKS) : null;
     const chainId = CHAIN_MAP[network ?? "sepolia"] ?? "11155111";
+    // Computed once and mirrored into the output JSONB and the denormalised
+    // gas_used_wei column the analytics network breakdown reads.
+    const gasUsedWei =
+      isWrite && stepStatus === "success"
+        ? String(randomInt(21_000, 350_000))
+        : null;
 
     await sql.unsafe(
       `INSERT INTO workflow_execution_logs (
         id, execution_id, node_id, node_name, node_type, status,
-        started_at, completed_at, duration, error, input, output
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12::jsonb)`,
+        started_at, completed_at, duration, error, input, output,
+        network, gas_used_wei
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12::jsonb, $13, $14)`,
       [
         generateId(),
         execId,
@@ -437,7 +442,9 @@ async function seedStepLogs(
         isTerminal ? null : String(stepDuration),
         stepStatus === "error" ? "Contract call reverted" : null,
         buildStepInput(nodeType, chainId),
-        buildStepOutput(nodeType, stepStatus),
+        buildStepOutput(gasUsedWei),
+        isWrite ? chainId : null,
+        gasUsedWei,
       ]
     );
     currentTime += stepDuration + randomInt(10, 100);


### PR DESCRIPTION
## Problem

After the per-network gas breakdown moved off the input/output JSONB and onto the denormalised `network` / `gas_used_wei` columns, the analytics seeds still only wrote gas into the JSONB. The `analytics-gas` e2e (`network breakdown API includes workflow gas`) then saw no workflow gas via the column-based read and failed. It was the only failing job in the post-merge pipeline.

## Fix

Both analytics seeds now compute the per-step gas once and write it to the column and the JSONB, and set `network` on web3-write rows:

- `tests/e2e/playwright/utils/seed.ts` (the seed the e2e uses)
- `scripts/seed/seed-analytics-data.ts` (the dev seed)

## Verification

Ran the actual e2e seed against an isolated local `keeperhub_test` DB (schema via `db:push`), then ran the exact column-based query `/api/analytics/networks` executes:

- Returns chain IDs `1`, `137`, `8453`, `11155111`, each with non-zero gas (the two assertions the e2e makes).
- Zero rows with gas in the JSONB but a null column.

Lint and type-check pass on both files.