### PR TITLE
ci(e2e): reclaim hosted-runner disk before ephemeral e2e jobs

### DIFF
--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -134,6 +134,18 @@ jobs:
           --health-start-period 15s
 
     steps:
+      # Hosted runners ship ~25GB of preinstalled toolchains (Android, .NET,
+      # Haskell) the e2e job never uses. Reclaiming it avoids the runner filling
+      # its disk mid-run (ENOSPC) under the app build + service containers.
+      - name: Free disk space
+        if: runner.environment == 'github-hosted'
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          large-packages: true
+          swap-storage: true
+          docker-images: false
+
       - name: Checkout code
         uses: actions/checkout@v6
 
@@ -311,6 +323,17 @@ jobs:
           --health-retries 5
 
     steps:
+      # Reclaim the ~25GB of unused preinstalled toolchains on hosted runners so
+      # the app build + Playwright browsers + service containers do not ENOSPC.
+      - name: Free disk space
+        if: runner.environment == 'github-hosted'
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          large-packages: true
+          swap-storage: true
+          docker-images: false
+
       - name: Checkout code
         uses: actions/checkout@v6
 


### PR DESCRIPTION
## Problem

The `e2e-vitest-ephemeral` job intermittently fails with `System.IO.IOException: No space left on device` on the GitHub-hosted runner. It is an infra failure, not a test failure: the runner process crashes writing its own diagnostic log, the failing-step logs are unrecoverable (the disk is full), and the Playwright e2e on the same commit passes. The app build plus the postgres / localstack / sandbox containers exhaust the runner disk.

## Fix

Add a `Free disk space` step as the first step of both ephemeral e2e jobs (vitest and playwright). It reclaims the ~25GB of preinstalled toolchains the jobs never use (Android, .NET, Haskell, large apt packages, swap).

- Guarded with `if: runner.environment == 'github-hosted'`, so it is a no-op on self-hosted ARC runners.
- `docker-images: false` and `tool-cache: false` so nothing the job relies on (the prebuilt image, the Node tool cache) is removed.

## Verification

YAML validated; the `jlumbroso/free-disk-space@v1.3.1` tag is pinned and resolves. This is a CI-only change with no effect on application code.