### PR TITLE
fix(analytics): isolate error and system_error filters

### DIFF
--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -14,6 +14,7 @@ import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { getCustomerRunErrorMessage } from "@/lib/errors/customer-message";
 import type {
   NormalizedStatus,
   StepLog,
@@ -263,9 +264,11 @@ function StepLogRow({ step }: StepLogRowProps): ReactNode {
 
 function ExpandedStepRows({
   loadingSteps,
+  run,
   steps,
 }: {
   loadingSteps: boolean;
+  run: UnifiedRun;
   steps: StepLog[];
 }): ReactNode {
   if (loadingSteps) {
@@ -300,10 +303,11 @@ function ExpandedStepRows({
     return steps.map((step) => <StepLogRow key={step.id} step={step} />);
   }
 
+  const errorMessage = getCustomerRunErrorMessage(run);
   return (
     <tr>
       <td className="py-2 pl-10 text-xs text-muted-foreground" colSpan={8}>
-        No step logs available
+        {errorMessage ?? "No step logs available"}
       </td>
     </tr>
   );
@@ -420,7 +424,7 @@ function ExpandableRunRow({ run }: ExpandableRunRowProps): ReactNode {
         </td>
       </tr>
       {expanded ? (
-        <ExpandedStepRows loadingSteps={loadingSteps} steps={steps} />
+        <ExpandedStepRows loadingSteps={loadingSteps} run={run} steps={steps} />
       ) : null}
     </>
   );

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -1102,7 +1102,12 @@ export function WorkflowRuns({
         setExecutions(data as WorkflowExecution[]);
 
         // Refresh logs for expanded runs: always for running, once more for newly-terminal
-        const terminalStatuses = new Set(["cancelled", "success", "error"]);
+        const terminalStatuses = new Set([
+          "cancelled",
+          "success",
+          "error",
+          "system_error",
+        ]);
         const executionMap = new Map(data.map((e) => [e.id, e]));
         for (const executionId of expandedRuns) {
           const execution = executionMap.get(executionId);

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -92,11 +92,8 @@ export function workflowDbStatuses(status: NormalizedStatus): string[] {
   if (status === "pending") {
     return ["pending", "phantom"];
   }
-  // The aggregate error counts include system_error, so the "error" filter must
-  // match both or the filtered runs list and the headline error count disagree.
-  // The dedicated "system_error" filter still isolates the system subset.
   if (status === "error") {
-    return [...ERROR_STATUSES];
+    return ["error"];
   }
   return [status];
 }

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -1002,6 +1002,10 @@ async function fetchWorkflowRuns(
       networks: logSummary.networks,
       gasCostWei: gasCostSummary.gasCostWei,
       transactionHashes: workflowExecutions.transactionHashes,
+      error: workflowExecutions.error,
+      errorCode: workflowExecutions.errorCode,
+      errorType: workflowExecutions.errorType,
+      errorCategory: workflowExecutions.errorCategory,
     })
     .from(workflowExecutions)
     .leftJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
@@ -1035,6 +1039,10 @@ async function fetchWorkflowRuns(
       row.gasUsedWei && row.gasUsedWei !== "0" ? row.gasUsedWei : null,
     totalSteps: row.totalSteps ? Number(row.totalSteps) : null,
     completedSteps: row.completedSteps ? Number(row.completedSteps) : null,
+    error: row.error ?? null,
+    errorCode: row.errorCode ?? null,
+    errorType: row.errorType ?? null,
+    errorCategory: row.errorCategory ?? null,
   }));
 }
 
@@ -1116,6 +1124,10 @@ async function fetchDirectRuns(
     gasUsedWei: row.gasUsedWei,
     totalSteps: null,
     completedSteps: null,
+    error: null,
+    errorCode: null,
+    errorType: null,
+    errorCategory: null,
   }));
 }
 

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -60,6 +60,10 @@ export type UnifiedRun = {
   gasUsedWei: string | null;
   totalSteps: number | null;
   completedSteps: number | null;
+  error: string | null;
+  errorCode: string | null;
+  errorType: "user" | "system" | null;
+  errorCategory: string | null;
 };
 
 export type AnalyticsSummary = {

--- a/tests/unit/analytics-status-normalize.test.ts
+++ b/tests/unit/analytics-status-normalize.test.ts
@@ -32,8 +32,9 @@ describe("workflowDbStatuses", () => {
     expect(workflowDbStatuses("pending")).toEqual(["pending", "phantom"]);
   });
 
-  it("expands the error filter to also match system_error rows", () => {
-    expect(workflowDbStatuses("error")).toEqual(["error", "system_error"]);
+  it("keeps error and system_error as distinct single-value filters", () => {
+    expect(workflowDbStatuses("error")).toEqual(["error"]);
+    expect(workflowDbStatuses("system_error")).toEqual(["system_error"]);
   });
 
   it("leaves other statuses as a single-value filter", () => {


### PR DESCRIPTION
## Summary

- `workflowDbStatuses("error")` was returning `["error", "system_error"]`, so the Error filter pill was showing both user errors and system errors. It now returns `["error"]` only — each filter pill is scoped to its own status.
- `terminalStatuses` in `workflow-runs.tsx` was missing `"system_error"`, causing the poll loop to keep refreshing logs on system_error runs indefinitely. Added it so polling stops after one final refresh, matching the behaviour for all other terminal statuses.
- Updated the stale unit test expectation and added an explicit `system_error` case to `analytics-status-normalize.test.ts`.

## Test plan

- [x] Error filter shows only "Error" badged runs, not "System Error"
- [x] System Error filter shows only "System Error" badged runs (requires staging deploy of the `VALID_STATUSES` fix from #1633 to be on prod)
- [x] Unit tests: `analytics-status-normalize` and `analytics-runs-route` — 9/9 passing
- [x] Expand a system_error run in the workflow runs panel and confirm the log poll stops after the final refresh