### PR TITLE
docs: fix Direct Execution API curl host (api.keeperhub.com → app.keeperhub.com)

### DIFF
--- a/docs/api/direct-execution.md
+++ b/docs/api/direct-execution.md
@@ -38,7 +38,7 @@ Send an `Idempotency-Key` header to safely retry a request without risking a dou
 Requests without an `Idempotency-Key` behave normally. Read-only and dry-run (`simulate: true`) requests are not affected.
 
 ```bash
-curl -X POST https://api.keeperhub.com/api/execute/transfer \
+curl -X POST https://app.keeperhub.com/api/execute/transfer \
   -H "Authorization: Bearer kh_..." \
   -H "Idempotency-Key: 7c9e6679-7425-40de-944b-e07fc1f90ae7" \
   -H "Content-Type: application/json" \


### PR DESCRIPTION
## What

The Idempotency curl example on the **Direct Execution API** page (`docs/api/direct-execution.md`) posts to `https://api.keeperhub.com/api/execute/transfer`.

`api.keeperhub.com` does not resolve (NXDOMAIN), so a builder copy-pasting the documented command hits a DNS error on their very first call.

## Fix

Point it at `https://app.keeperhub.com`, which is the live API host (a POST there returns a normal `401 {"error":"Unauthorized"}` with an invalid key) and matches the host already used on the Authentication page and by the MCP server.

```
- curl -X POST https://api.keeperhub.com/api/execute/transfer
+ curl -X POST https://app.keeperhub.com/api/execute/transfer
```

One-line docs change; no other occurrences of `api.keeperhub.com` remain under `docs/`.

## Verified

- `curl POST https://app.keeperhub.com/api/execute/transfer` → `401 Unauthorized` (host live).
- `curl POST https://api.keeperhub.com/...` → DNS resolution failure.

Found while building a zero→first-transaction quickstart against the Direct Execution API.