### PR TITLE
build: compile the app once per bake by aligning executor build args

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -202,6 +202,19 @@ target "executor" {
   context    = "."
   dockerfile = "Dockerfile"
   target     = "executor"
+  # Args mirror "app" so BuildKit deduplicates the shared "builder" stage and
+  # runs `pnpm build` once. Divergent args here fork the builder stage into a
+  # second invocation that recompiles from scratch.
+  args = {
+    NEXT_PUBLIC_AUTH_PROVIDERS    = NEXT_PUBLIC_AUTH_PROVIDERS
+    NEXT_PUBLIC_GITHUB_CLIENT_ID = NEXT_PUBLIC_GITHUB_CLIENT_ID
+    NEXT_PUBLIC_GOOGLE_CLIENT_ID = NEXT_PUBLIC_GOOGLE_CLIENT_ID
+    NEXT_PUBLIC_BILLING_ENABLED  = NEXT_PUBLIC_BILLING_ENABLED
+    NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED = NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED
+    NEXT_PUBLIC_TURNSTILE_SITE_KEY = NEXT_PUBLIC_TURNSTILE_SITE_KEY
+    NEXT_PUBLIC_SENTRY_DSN       = NEXT_PUBLIC_SENTRY_DSN
+    INCLUDE_TEST_ENDPOINTS       = INCLUDE_TEST_ENDPOINTS
+  }
   tags = compact([
     "${ECR_REGISTRY}/${EXECUTOR_ECR_REPO}:executor-${IMAGE_TAG}",
     "${ECR_REGISTRY}/${EXECUTOR_ECR_REPO}:executor-latest",


### PR DESCRIPTION
## Problem

The deploy build (`build-images.yml`, bake `targets: pipeline`) compiles the Next.js app **twice** per deploy.

The `executor` target copies codegen registry files from the `builder` stage (`COPY --from=builder`) but passed **no build args**, while `app` and `workflow-runner` pass the full `NEXT_PUBLIC_*` + `INCLUDE_TEST_ENDPOINTS` set. Those values are declared as `ARG` on the `builder` stage, so they are part of its cache key. BuildKit therefore materialises `builder` twice in one bake run - a real-args version (app/workflow-runner) and an empty-args version (executor) - running `next build` in both.

PR checks build only `targets: app`, so this affects **deploys only**, which matches the observed build times.

## Fix

Add an `args` block to the `executor` target identical to `app`/`workflow-runner`. The registry files executor consumes come from `discover-plugins` (arg-independent), so matching the args changes nothing about executor's output - it just collapses the duplicate `builder` node into the single one already built for `app`, so `next build` runs once.

## Validation

- `docker buildx bake -f docker-bake.hcl --print pipeline`: `app`, `workflow-runner`, and `executor` now resolve to identical args, the precondition for BuildKit stage dedup.
- HCL-only change; no TypeScript/lint surface. The `build` job in `pr-checks.yml` exercises the actual image build on this PR.
- Authoritative check post-merge: a staging deploy should show the `next build` compile span **once** in `build-images` (today it appears twice).