### PR TITLE
ci: persist Next.js build cache across runs to warm next build

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -150,6 +150,37 @@ jobs:
         if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.USE_SELF_HOSTED_RUNNERS != 'true'
         uses: docker/setup-buildx-action@v4
 
+      # Persist the Next.js incremental-compile cache (.next/cache) across runs.
+      # BuildKit type=cache mounts are not carried by the registry layer cache,
+      # so on ephemeral runners the mount starts empty and next build runs cold
+      # every time. actions/cache stores the mount contents; buildkit-cache-dance
+      # injects them into the BuildKit builder before the build (and extracts
+      # them again in its post step, before actions/cache saves). Keyed per
+      # environment so staging and prod never share a lineage.
+      - name: Restore Next.js build cache
+        id: next-cache
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.USE_SELF_HOSTED_RUNNERS != 'true'
+        uses: actions/cache@v5
+        with:
+          path: .next-cache
+          key: next-build-cache-${{ env.ENVIRONMENT_TAG }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            next-build-cache-${{ env.ENVIRONMENT_TAG }}-${{ hashFiles('pnpm-lock.yaml') }}-
+            next-build-cache-${{ env.ENVIRONMENT_TAG }}-
+
+      - name: Inject Next.js build cache into BuildKit
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.USE_SELF_HOSTED_RUNNERS != 'true'
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          cache-map: |
+            {
+              ".next-cache": {
+                "target": "/app/.next/cache",
+                "id": "nextjs-build-cache"
+              }
+            }
+          skip-extraction: ${{ steps.next-cache.outputs.cache-hit }}
+
       - name: Build and push all images to ECR
         if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
         uses: docker/bake-action@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,8 +107,9 @@ ENV SANDBOX_URL=http://keeperhub-sandbox-common.keeperhub.svc.cluster.local:8787
 # Cache mount persists .next/cache across builds on the same BuildKit instance,
 # enabling Turbopack's incremental compilation. sharing=locked serialises
 # concurrent builders to prevent racing on Next.js cache writes when bake runs
-# multiple targets that share this stage.
-RUN --mount=type=cache,target=/app/.next/cache,sharing=locked pnpm build
+# multiple targets that share this stage. The stable mount id lets CI persist
+# this cache across ephemeral runners (see build-images.yml).
+RUN --mount=type=cache,id=nextjs-build-cache,target=/app/.next/cache,sharing=locked pnpm build
 
 # Stage 2.5b: Sentry source map upload (side-effect only, not consumed by other stages)
 FROM builder AS sentry-upload


### PR DESCRIPTION
## Problem

`next build`'s incremental-compile cache lives in a BuildKit `type=cache` mount (`Dockerfile` builder stage). That mount is **not** carried by the registry layer cache (`cache-to=type=registry,mode=max` exports image layers only), and each hosted job gets a fresh `setup-buildx-action` BuildKit instance - so the mount starts empty and `next build` runs cold whenever source changes. The registry cache only gives a no-op build when source is unchanged; any real change is a full cold compile.

## Fix

Persist `.next/cache` across runs on the hosted build path:

- Give the cache mount a stable id (`id=nextjs-build-cache`) so it can be addressed deterministically.
- `actions/cache@v5` stores the mount contents host-side; `buildkit-cache-dance@v3` injects them into the BuildKit builder before the bake build and extracts them again in its post step (which runs before actions/cache saves). The bake build and cache-dance share the same builder, hence the same cache store keyed by mount id - which is why this works with `docker buildx bake`, not just `build-push-action`.
- Cache key is environment-scoped (`ENVIRONMENT_TAG`) so staging and prod never share a lineage; the primary key includes the commit SHA with env+lockfile restore-key prefixes, so each deploy saves its updated cache and the next restores the latest (the cache evolves instead of freezing).
- Gated to the hosted path (`USE_SELF_HOSTED_RUNNERS != 'true'`).

## Validation

- **cache-dance mechanism tested locally** with the exact id/target: populate mount (root-owned) -> extract to host (modes preserved) -> prune -> inject -> read back, confirmed root-owned (uid0/gid0, 644/755). No `chown` needed.
- Cache-mount persistence across separate builds confirmed on a `docker-container` builder.
- `actionlint -shellcheck=""` (v1.7.11, matches CI) clean; `hadolint --failure-threshold warning` with repo config exit 0.

## Expected behaviour after merge

- **First deploy = cold prime** (no cache yet): `build-images` unchanged (~15 min); cache-dance only saves the populated cache at the end.
- **Second deploy with a code change = the real test**: `next build` should drop from cold toward incremental. The SSG phase (page-data / static-gen / finalizing) is not cache-warmable, so a floor remains there.
- GHA cache has a ~10GB per-repo cap with LRU eviction; `.next/cache` size and hit rate worth monitoring.