### PR TITLE
fix(condition): quote hex address operands instead of treating them as numbers

### DIFF
--- a/lib/workflow/nodes/condition/expression.ts
+++ b/lib/workflow/nodes/condition/expression.ts
@@ -14,6 +14,11 @@ import type {
 } from "./builder-types";
 import { isConditionGroup } from "./builder-types";
 
+// Decimal grammar the safe-eval tokenizer accepts (integer or fixed-point, optional sign).
+// Excludes hex like 0x... and exponents like 1e5, which Number() treats as numeric but the
+// tokenizer cannot parse, so those stay quoted as string literals.
+const NUMERIC_LITERAL_RE = /^[+-]?\d+(\.\d+)?$/;
+
 // Keep in sync with OPERATOR_METADATA in condition-builder-utils.ts (unary: true entries)
 const UNARY_OPERATORS: ReadonlySet<ConditionOperator> = new Set([
   "isEmpty",
@@ -41,7 +46,7 @@ function wrapOperand(operand: string): string {
     return trimmed;
   }
 
-  if (!Number.isNaN(Number(trimmed))) {
+  if (NUMERIC_LITERAL_RE.test(trimmed)) {
     return trimmed;
   }
 

--- a/tests/unit/condition-builder-utils.test.ts
+++ b/tests/unit/condition-builder-utils.test.ts
@@ -300,6 +300,29 @@ describe("condition-builder-utils", () => {
         expect(visualConditionToExpression(g)).toBe("42 === 3.14");
       });
 
+      it("should pass signed numeric values through", () => {
+        const g = group("AND", [rule("-7", ">", "-12.5")]);
+        expect(visualConditionToExpression(g)).toBe("-7 > -12.5");
+      });
+
+      it("should quote hex addresses instead of treating them as numbers", () => {
+        const g = group("AND", [
+          rule(
+            "{{@n:Get owners.result[0]}}",
+            "==",
+            "0x6924f2737145455bBF5B7412DfaDCB785e26f055"
+          ),
+        ]);
+        expect(visualConditionToExpression(g)).toBe(
+          '{{@n:Get owners.result[0]}} == "0x6924f2737145455bBF5B7412DfaDCB785e26f055"'
+        );
+      });
+
+      it("should quote exponent-style strings instead of treating them as numbers", () => {
+        const g = group("AND", [rule("code", "===", "1e5")]);
+        expect(visualConditionToExpression(g)).toBe('"code" === "1e5"');
+      });
+
       it("should pass boolean literals through", () => {
         const g = group("AND", [rule("true", "===", "false")]);
         expect(visualConditionToExpression(g)).toBe("true === false");


### PR DESCRIPTION
## Problem
Condition nodes comparing a value to an Ethereum address (e.g. a Safe owner check, `{{...result[0]}} == 0x6924...`) failed at execution with:

    Failed to evaluate condition expression: Condition parse error:
    Unexpected token "x6924f2737145455bBF5B7412DfaDCB785e26f055"

## Cause
The expression builder's `wrapOperand` used `Number()` to detect numeric operands that can be emitted unquoted. `Number("0x6924...")` parses hex as a valid number, so the address was left unquoted in the compiled expression. The safe-eval tokenizer only parses decimal numbers, so it read the leading `0` and then failed on the rest of the address as an unexpected identifier. Exponent forms like `1e5` had the same latent issue.

## Fix
Replace the `Number()` check with a decimal-only regex (`^[+-]?\d+(\.\d+)?$`) that matches the grammar the tokenizer actually accepts. Hex- and exponent-like operands now fall through to being quoted as string literals. Added unit tests covering hex addresses, exponent strings, and signed numbers.