### PR TITLE
feat(condition): log resolved expression with substituted values

### DIFF
--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -352,7 +352,26 @@ function replaceTemplateVariable(
 type ConditionEvalResult = {
   result: boolean;
   resolvedValues: Record<string, unknown>;
+  // The expression with each {{...}} reference replaced by its resolved value,
+  // so observability shows what was actually compared (e.g. "0x1..." == "0x6...").
+  resolvedExpression?: string;
 };
+
+// Render a resolved value as it should appear inside the resolved expression:
+// strings quoted, numbers/booleans/null bare, undefined as the keyword.
+function renderConditionLiteral(value: unknown): string {
+  if (value === undefined) {
+    return "undefined";
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
 
 /**
  * Evaluate condition expression with template variable replacement.
@@ -397,6 +416,7 @@ export function evaluateConditionExpression(
     try {
       let evalContext: Record<string, unknown> = {};
       const resolvedValues: Record<string, unknown> = {};
+      const tokenLiterals: Record<string, string> = {};
       let transformedExpression = conditionExpression;
       const templatePattern = /\{\{@([^:]+):([^}]+)\}\}/g;
       const varCounter = { value: 0 };
@@ -420,8 +440,16 @@ export function evaluateConditionExpression(
           resolvedValues[rest] = formatConditionValueForDisplay(
             evalContext[varName]
           );
+          tokenLiterals[match] = renderConditionLiteral(evalContext[varName]);
           return varName;
         }
+      );
+
+      // Mirror the substitution against the original expression so the value
+      // side keeps the author's literals (quotes, operators) intact.
+      const resolvedExpression = conditionExpression.replace(
+        templatePattern,
+        (match: string) => tokenLiterals[match] ?? match
       );
 
       // KEEP-468: any `{{...}}` token left after stored-format substitution
@@ -462,7 +490,7 @@ export function evaluateConditionExpression(
       // Only reads the resolved __v/__b values and applies allowlisted
       // operators and methods.
       const result = safeEvaluateCondition(transformedExpression, evalContext);
-      return { result: Boolean(result), resolvedValues };
+      return { result: Boolean(result), resolvedValues, resolvedExpression };
     } catch (error) {
       // KEEP-1284: Re-throw errors about missing data - these should not be silently swallowed
       if (
@@ -524,6 +552,7 @@ async function executeActionStep(input: {
     // KEEP-1284: Catch evaluation errors and pass to step so it gets logged
     let evaluatedCondition = false;
     let resolvedValues: Record<string, unknown> = {};
+    let resolvedExpression: string | undefined;
     let evaluationError: string | undefined;
 
     try {
@@ -535,6 +564,7 @@ async function executeActionStep(input: {
       );
       evaluatedCondition = result.result;
       resolvedValues = result.resolvedValues;
+      resolvedExpression = result.resolvedExpression;
     } catch (error) {
       evaluationError = error instanceof Error ? error.message : String(error);
     }
@@ -548,6 +578,7 @@ async function executeActionStep(input: {
         !evaluationError && typeof originalExpression === "string"
           ? originalExpression
           : undefined,
+      resolvedExpression: evaluationError ? undefined : resolvedExpression,
       values:
         Object.keys(resolvedValues).length > 0 ? resolvedValues : undefined,
       _evaluationError: evaluationError,

--- a/lib/workflow/nodes/condition/step.ts
+++ b/lib/workflow/nodes/condition/step.ts
@@ -12,6 +12,8 @@ export type ConditionInput = StepInput & {
   condition: boolean;
   /** Original condition expression string for logging (e.g., "{{@nodeId:Label.field}} === 'good'") */
   expression?: string;
+  /** Expression with each reference replaced by its resolved value (e.g., "\"0x1...\" == \"0x6...\"") */
+  resolvedExpression?: string;
   /** Resolved values of template variables for logging (e.g., { "Label.field": "actual_value" }) */
   values?: Record<string, unknown>;
   /** KEEP-1284: Error from condition evaluation - if set, the step will throw */

--- a/tests/unit/condition-executor.test.ts
+++ b/tests/unit/condition-executor.test.ts
@@ -1030,3 +1030,60 @@ describe("A-01: condition expressions cannot execute arbitrary code", () => {
     ).toThrow(FAILED_TO_EVALUATE_RE);
   });
 });
+
+describe("resolvedExpression", () => {
+  it("substitutes resolved values into the expression, quoting strings", () => {
+    const expression =
+      '{{@n:Get owners.result[0]}} == "0x6924f2737145455bBF5B7412DfaDCB785e26f055"';
+    const outputs = {
+      n: {
+        label: "Get owners",
+        data: { result: ["0x1Ec3e8A383Cd2084E8bb404cd8999b393db80D57"] },
+      },
+    };
+
+    const result = evaluateConditionExpression(expression, outputs);
+    expect(result.result).toBe(false);
+    expect(result.resolvedExpression).toBe(
+      '"0x1Ec3e8A383Cd2084E8bb404cd8999b393db80D57" == "0x6924f2737145455bBF5B7412DfaDCB785e26f055"'
+    );
+  });
+
+  it("renders numeric and boolean references without quotes", () => {
+    const expression = "{{@a:A.count}} > 10 && {{@b:B.flag}} === true";
+    const outputs = {
+      a: { label: "A", data: { count: 42 } },
+      b: { label: "B", data: { flag: true } },
+    };
+
+    const result = evaluateConditionExpression(expression, outputs);
+    expect(result.result).toBe(true);
+    expect(result.resolvedExpression).toBe("42 > 10 && true === true");
+  });
+
+  it("is omitted for a boolean expression", () => {
+    const result = evaluateConditionExpression(true, {});
+    expect(result.result).toBe(true);
+    expect(result.resolvedExpression).toBeUndefined();
+  });
+
+  it("renders a genuine null reference as the null keyword", () => {
+    const expression = "{{@n:A.matchCount}} === null";
+    const outputs = { n: { label: "A", data: { matchCount: null } } };
+
+    const result = evaluateConditionExpression(expression, outputs);
+    expect(result.result).toBe(true);
+    expect(result.resolvedExpression).toBe("null === null");
+  });
+
+  it("renders a non-executed reference as the undefined keyword", () => {
+    const nodeMap = new Map<string, unknown>([
+      ["dead", { id: "dead", data: { label: "Dead" } }],
+    ]);
+    const expression = "{{@dead:Dead.matchCount}} === undefined";
+
+    const result = evaluateConditionExpression(expression, {}, nodeMap, {});
+    expect(result.result).toBe(true);
+    expect(result.resolvedExpression).toBe("undefined === undefined");
+  });
+});


### PR DESCRIPTION
## What
Adds a `resolvedExpression` field to the condition node's logged output. It inlines each `{{...}}` reference's resolved value into the expression, so the execution log shows exactly what was compared rather than only the template form plus a separate values map.

Example (a Safe owner check that evaluated to false):

    "0x1Ec3..." == "0x6924..." && "0xfB6d..." == "0xfB6d..." && ...

## Details
- Strings are quoted; numbers, booleans, and null render as bare literals; a reference to a non-executed branch renders as the `undefined` keyword.
- Omitted when evaluation errors, matching the existing `expression` field.
- Surfaces in observability automatically via the step's logged input; no UI change required.
- Unit tests cover hex-address operands, numeric/boolean references, null, and the non-executed (undefined) case.