### PR TITLE
fix(executor): skip all-skip OR-joins and stop masking executed failures

### DIFF
--- a/lib/workflow/executor/convergence-barrier.ts
+++ b/lib/workflow/executor/convergence-barrier.ts
@@ -36,6 +36,36 @@ export function buildEdgesBySource(edges: EdgeLike[]): Map<string, string[]> {
 }
 
 /**
+ * Record one arrival edge into a convergence node. Real arrivals land in
+ * `convergenceArrivals`; skip arrivals land in both maps so the skip count can
+ * be compared against the in-degree to detect an all-skipped join.
+ */
+function recordArrival(
+  nodeId: string,
+  fromSource: string,
+  isSkip: boolean,
+  convergenceArrivals: Map<string, Set<string>>,
+  convergenceSkipArrivals: Map<string, Set<string>>
+): void {
+  let arrivals = convergenceArrivals.get(nodeId);
+  if (arrivals === undefined) {
+    arrivals = new Set<string>();
+    convergenceArrivals.set(nodeId, arrivals);
+  }
+  arrivals.add(fromSource);
+
+  if (!isSkip) {
+    return;
+  }
+  let skipArrivals = convergenceSkipArrivals.get(nodeId);
+  if (skipArrivals === undefined) {
+    skipArrivals = new Set<string>();
+    convergenceSkipArrivals.set(nodeId, skipArrivals);
+  }
+  skipArrivals.add(fromSource);
+}
+
+/**
  * Signal arrival at convergence nodes (nodes with >1 incoming edge) and
  * return the IDs of any that became fully unblocked. Non-convergence nodes
  * in targetNodeIds are ignored.
@@ -104,84 +134,78 @@ export function getReadyDownstreamIds(
 }
 
 /**
- * Propagate skip signals through branches that were not taken by a condition.
- * BFS through the skipped subtree, signaling arrival at convergence nodes.
- * Returns convergence node IDs that became fully unblocked (caller handles
- * execution).
+ * Propagate skip signals from a condition's not-taken branch.
+ *
+ * Records a skip-arrival at every convergence node reached through the
+ * not-taken subtree (kept apart from real arrivals in `convergenceSkipArrivals`)
+ * and BFS-walks through fully-skipped nodes. A convergence node is released to
+ * EXECUTE only once every incoming edge has arrived AND at least one of those
+ * arrivals was a real (executed) node. When every incoming edge is a skip the
+ * node is itself skipped: it is added to `skippedNodes` and the skip continues
+ * to its downstream. This is what stops an OR-join (e.g. an alert step wired to
+ * the `false` handle of several conditions) from firing when every condition
+ * took its other branch.
+ *
+ * `skipFromId` is the node initiating the skip (the condition); it is the
+ * arrival source recorded at each direct not-taken target. Returns the
+ * convergence node IDs that became ready to execute (caller runs them).
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: BFS with convergence detection requires nested branching
 export function propagateConvergenceSkips(
+  skipFromId: string,
   skippedNodeIds: string[],
   edgesBySource: Map<string, string[]>,
   edgesByTarget: Map<string, string[]>,
   convergenceArrivals: Map<string, Set<string>>,
+  convergenceSkipArrivals: Map<string, Set<string>>,
+  skippedNodes: Set<string>,
   visited: Set<string>
 ): string[] {
-  const unblocked: string[] = [];
-  const queue = [...skippedNodeIds];
-  const seen = new Set<string>();
+  const executeReady: string[] = [];
+  const queue: Array<{ id: string; from: string }> = skippedNodeIds.map(
+    (id) => ({ id, from: skipFromId })
+  );
+  const propagated = new Set<string>();
+
+  const continueSkip = (id: string): void => {
+    skippedNodes.add(id);
+    if (propagated.has(id)) {
+      return;
+    }
+    propagated.add(id);
+    for (const downId of edgesBySource.get(id) ?? []) {
+      queue.push({ id: downId, from: id });
+    }
+  };
 
   while (queue.length > 0) {
-    const currentId = queue.shift() as string;
-    if (seen.has(currentId)) {
-      continue;
-    }
-    seen.add(currentId);
-
-    const incomingSources = edgesByTarget.get(currentId);
+    const { id, from } = queue.shift() as { id: string; from: string };
+    const incomingSources = edgesByTarget.get(id);
     const isConvergenceNode =
       incomingSources !== undefined && incomingSources.length > 1;
 
-    if (isConvergenceNode) {
-      for (const src of incomingSources) {
-        if (seen.has(src) || skippedNodeIds.includes(src)) {
-          let arrivals = convergenceArrivals.get(currentId);
-          if (arrivals === undefined) {
-            arrivals = new Set<string>();
-            convergenceArrivals.set(currentId, arrivals);
-          }
-          arrivals.add(src);
-        }
-      }
-
-      if (
-        (convergenceArrivals.get(currentId)?.size ?? 0) >=
-        incomingSources.length
-      ) {
-        // Check if any arrival came from a real (non-skip) execution.
-        // If all arrivals are from the skipped subtree, this node should
-        // also be skipped -- continue BFS instead of executing it.
-        const allFromSkipped = incomingSources.every(
-          (src) => seen.has(src) || skippedNodeIds.includes(src)
-        );
-        if (allFromSkipped) {
-          // Continue propagating skip through this convergence node
-          const downstream = edgesBySource.get(currentId) ?? [];
-          for (const downId of downstream) {
-            if (!seen.has(downId)) {
-              queue.push(downId);
-            }
-          }
-          continue;
-        }
-        if (!visited.has(currentId)) {
-          unblocked.push(currentId);
-        }
-        continue;
-      }
-      // Convergence node not fully resolved: stop BFS here. It is still
-      // awaiting arrivals from the real execution path and should not
-      // propagate skip signals to its downstream.
+    if (!isConvergenceNode) {
+      // Non-convergence node: the skip flows straight through it.
+      continueSkip(id);
       continue;
     }
 
-    const downstream = edgesBySource.get(currentId) ?? [];
-    for (const downId of downstream) {
-      if (!seen.has(downId)) {
-        queue.push(downId);
-      }
+    recordArrival(id, from, true, convergenceArrivals, convergenceSkipArrivals);
+
+    if ((convergenceArrivals.get(id)?.size ?? 0) < incomingSources.length) {
+      // Still awaiting arrivals from the real-execution path; stop here.
+      continue;
+    }
+
+    if (
+      (convergenceSkipArrivals.get(id)?.size ?? 0) >= incomingSources.length
+    ) {
+      // Every incoming edge was skipped: skip this node and keep walking.
+      continueSkip(id);
+    } else if (!visited.has(id)) {
+      // At least one arrival came from a real execution: the node runs.
+      executeReady.push(id);
     }
   }
 
-  return unblocked;
+  return executeReady;
 }

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -76,7 +76,6 @@ import { resolveConditionExpression } from "@/lib/workflow/nodes/condition/resol
 import { safeEvaluateCondition } from "@/lib/workflow/nodes/condition/safe-eval";
 import {
   type ConditionDecision,
-  collectAllSkippedTargets,
   collectSkippedTargets,
 } from "@/lib/workflow/nodes/condition/skipped-branch";
 import {
@@ -1798,6 +1797,13 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
 
   const edgesByTarget = buildEdgesByTarget(edges);
   const convergenceArrivals = new Map<string, Set<string>>();
+  // Skip-arrivals tracked apart from real arrivals so an OR-join whose every
+  // incoming edge was skipped is itself skipped rather than executed.
+  const convergenceSkipArrivals = new Map<string, Set<string>>();
+  // Nodes determined to be genuinely skipped (all incoming paths not taken).
+  // Authoritative input to computeFinalSuccess so a node that actually executed
+  // and failed is never masked as skipped.
+  const skippedNodes = new Set<string>();
 
   // Find trigger nodes
   const nodesWithIncoming = new Set(edges.map((e) => e.target));
@@ -2846,35 +2852,30 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             // nodes downstream receive arrival signals from skipped sources
             const skippedTargets = handleMap.get(notTakenHandle) ?? [];
             if (skippedTargets.length > 0) {
-              // Register the condition's skip-arrival at direct skipped targets
-              // that are themselves convergence nodes. Without this, a pattern
-              // like `Cond -> (skipped) -> nodeB` and `Cond -> (taken) -> X -> nodeB`
-              // stalls nodeB: the condition's not-taken edge never signals
-              // arrival, so nodeB only ever sees X's arrival (1/2).
-              const preSeedUnblocked = signalConvergenceArrival(
-                nodeId,
-                skippedTargets,
-                edgesByTarget,
-                convergenceArrivals,
-                visited
-              );
+              // Walk the not-taken subtree, recording skip-arrivals at
+              // convergence nodes. A convergence node runs only if it also got
+              // a real arrival; if every incoming edge was skipped it is added
+              // to `skippedNodes` and the skip continues downstream. This both
+              // unblocks genuine convergence (e.g. `Cond -> (skipped) -> nodeB`
+              // and `Cond -> (taken) -> X -> nodeB`) and stops an all-skipped
+              // OR-join from firing.
               const unblockedIds = propagateConvergenceSkips(
+                nodeId,
                 skippedTargets,
                 edgesBySource,
                 edgesByTarget,
                 convergenceArrivals,
+                convergenceSkipArrivals,
+                skippedNodes,
                 visited
               );
-              const allUnblocked = [
-                ...new Set([...preSeedUnblocked, ...unblockedIds]),
-              ];
-              if (allUnblocked.length > 0) {
+              if (unblockedIds.length > 0) {
                 const settled = await pendingTasks.track(
                   Promise.allSettled(
-                    allUnblocked.map((id) => executeNode(id, visited))
+                    unblockedIds.map((id) => executeNode(id, visited))
                   )
                 );
-                processSettledResults(settled, allUnblocked);
+                processSettledResults(settled, unblockedIds);
               }
             }
           } else {
@@ -3119,8 +3120,12 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     // drained orphan nodes are reflected here. The pre-drain computation (now
     // unused) only ever saw nodes whose call-stack reached processSettledResults;
     // drained orphans land in `results` while drain awaits them.
-    const allSkippedTargets = collectAllSkippedTargets(conditionDecisions);
-    const finalSuccess = computeFinalSuccess(results, allSkippedTargets);
+    // `skippedNodes` is the authoritative set of genuinely-skipped nodes built
+    // during execution: a node only lands here when every incoming path was
+    // not taken. A node that actually executed (even one wired to a condition's
+    // not-taken handle but reached via a real arrival) is absent, so its
+    // failure is never masked as skipped.
+    const finalSuccess = computeFinalSuccess(results, skippedNodes);
 
     // Surface drained-orphan failures explicitly so prod logs make the
     // SDK-checkpoint-truncation case visible (otherwise the failure looks
@@ -3129,7 +3134,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       (id) => !resultKeysBeforeDrain.has(id)
     );
     const drainedFailures = drainedNodeIds.filter(
-      (id) => !(results[id]?.success || allSkippedTargets.has(id))
+      (id) => !(results[id]?.success || skippedNodes.has(id))
     );
     if (drainedFailures.length > 0) {
       console.log(
@@ -3154,7 +3159,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           conditionDecisions: [...conditionDecisions.entries()].map(
             ([id, d]) => ({ id, ...d })
           ),
-          skippedTargets: [...allSkippedTargets],
+          skippedTargets: [...skippedNodes],
           unexecutedNodes,
         }
       );

--- a/tests/unit/convergence-barrier.test.ts
+++ b/tests/unit/convergence-barrier.test.ts
@@ -10,6 +10,7 @@ import {
   propagateConvergenceSkips,
   signalConvergenceArrival,
 } from "@/lib/workflow/executor/convergence-barrier";
+import { computeFinalSuccess } from "@/lib/workflow/executor/final-success";
 
 describe("convergence barrier", () => {
   describe("basic convergence: A -> [B, C, D] -> E", () => {
@@ -192,12 +193,18 @@ describe("convergence barrier", () => {
       const arrivals = new Map<string, Set<string>>();
       const visited = new Set<string>();
 
+      const skipArrivals = new Map<string, Set<string>>();
+      const skippedNodes = new Set<string>();
+
       // Condition takes true branch (B), skips false branch (C)
       const unblocked = propagateConvergenceSkips(
+        "Cond",
         ["C"],
         sourceMap,
         targetMap,
         arrivals,
+        skipArrivals,
+        skippedNodes,
         visited
       );
 
@@ -205,6 +212,7 @@ describe("convergence barrier", () => {
       expect(unblocked).toEqual([]);
       expect(arrivals.get("E")?.has("C")).toBe(true);
       expect(arrivals.get("E")?.size).toBe(1);
+      expect(skippedNodes.has("C")).toBe(true);
 
       // Now B arrives at E
       const ready = getReadyDownstreamIds(
@@ -233,11 +241,16 @@ describe("convergence barrier", () => {
       expect(arrivals.get("E")?.size).toBe(1);
 
       // C gets skipped and propagation signals its arrival
+      const skipArrivals = new Map<string, Set<string>>();
+      const skippedNodes = new Set<string>();
       const unblocked = propagateConvergenceSkips(
+        "Cond",
         ["C"],
         sourceMap,
         targetMap,
         arrivals,
+        skipArrivals,
+        skippedNodes,
         visited
       );
       expect(unblocked).toEqual(["E"]);
@@ -259,11 +272,16 @@ describe("convergence barrier", () => {
       const visited = new Set<string>();
 
       // Skip C, which chains through D to E
+      const skipArrivals = new Map<string, Set<string>>();
+      const skippedNodes = new Set<string>();
       const unblocked = propagateConvergenceSkips(
+        "Cond",
         ["C"],
         sourceMap,
         targetMap,
         arrivals,
+        skipArrivals,
+        skippedNodes,
         visited
       );
 
@@ -271,6 +289,8 @@ describe("convergence barrier", () => {
       // E gets arrival from D (via skip chain)
       expect(arrivals.get("E")?.has("D")).toBe(true);
       expect(unblocked).toEqual([]);
+      expect(skippedNodes.has("C")).toBe(true);
+      expect(skippedNodes.has("D")).toBe(true);
 
       // B arrives at E, completing the barrier
       const ready = getReadyDownstreamIds(
@@ -303,13 +323,17 @@ describe("convergence barrier", () => {
       const visited = new Set<string>();
 
       // Condition=true: X is taken (runs), nodeB is the direct skipped target.
-      // Caller pre-seeds condition's skip-arrival at direct skipped targets.
-      signalConvergenceArrival("Cond", ["nodeB"], targetMap, arrivals, visited);
+      // propagateConvergenceSkips self-seeds the condition's skip-arrival.
+      const skipArrivals = new Map<string, Set<string>>();
+      const skippedNodes = new Set<string>();
       const unblocked = propagateConvergenceSkips(
+        "Cond",
         ["nodeB"],
         sourceMap,
         targetMap,
         arrivals,
+        skipArrivals,
+        skippedNodes,
         visited
       );
 
@@ -355,15 +379,20 @@ describe("convergence barrier", () => {
       expect(arrivals.get("nodeB")?.size).toBe(1);
 
       // X is skipped; propagation walks X -> nodeB, adds X to arrivals.
-      signalConvergenceArrival("Cond", ["X"], targetMap, arrivals, visited);
+      const skipArrivals = new Map<string, Set<string>>();
+      const skippedNodes = new Set<string>();
       const unblocked = propagateConvergenceSkips(
+        "Cond",
         ["X"],
         sourceMap,
         targetMap,
         arrivals,
+        skipArrivals,
+        skippedNodes,
         visited
       );
       expect(unblocked).toEqual(["nodeB"]);
+      expect(skippedNodes.has("X")).toBe(true);
     });
 
     it("does not corrupt deeper convergence when direct-skip target is still pending", () => {
@@ -386,12 +415,16 @@ describe("convergence barrier", () => {
       const arrivals = new Map<string, Set<string>>();
       const visited = new Set<string>();
 
-      signalConvergenceArrival("Cond", ["nodeB"], targetMap, arrivals, visited);
+      const skipArrivals = new Map<string, Set<string>>();
+      const skippedNodes = new Set<string>();
       propagateConvergenceSkips(
+        "Cond",
         ["nodeB"],
         sourceMap,
         targetMap,
         arrivals,
+        skipArrivals,
+        skippedNodes,
         visited
       );
 
@@ -464,9 +497,9 @@ describe("convergence barrier", () => {
     };
 
     // End-to-end simulator that mirrors the executor's control flow:
-    //   - For condition nodes: signal taken arrival, pre-seed skip arrivals at
-    //     direct skipped convergence targets, propagate skip through not-taken
-    //     subtree.
+    //   - For condition nodes: signal taken arrival, then propagate skip through
+    //     the not-taken subtree (which self-seeds skip arrivals at direct
+    //     skipped convergence targets).
     //   - For non-condition nodes: getReadyDownstreamIds over downstream.
     // Returns the set of executed nodes in discovery order.
     function runSimulatedWorkflow(
@@ -474,8 +507,10 @@ describe("convergence barrier", () => {
       conditions: Map<string, ConditionSpec>,
       edgesBySource: Map<string, string[]>,
       edgesByTarget: Map<string, string[]>
-    ): { executed: string[]; visited: Set<string> } {
+    ): { executed: string[]; visited: Set<string>; skippedNodes: Set<string> } {
       const arrivals = new Map<string, Set<string>>();
+      const skipArrivals = new Map<string, Set<string>>();
+      const skippedNodes = new Set<string>();
       const visited = new Set<string>();
       const executed: string[] = [];
       const queue: string[] = [...triggerReady];
@@ -503,25 +538,17 @@ describe("convergence barrier", () => {
             arrivals,
             visited
           );
-          const preSeed = signalConvergenceArrival(
-            nodeId,
-            skipped,
-            edgesByTarget,
-            arrivals,
-            visited
-          );
           const unblockedFromSkip = propagateConvergenceSkips(
+            nodeId,
             skipped,
             edgesBySource,
             edgesByTarget,
             arrivals,
+            skipArrivals,
+            skippedNodes,
             visited
           );
-          for (const next of [
-            ...readyFromTaken,
-            ...preSeed,
-            ...unblockedFromSkip,
-          ]) {
+          for (const next of [...readyFromTaken, ...unblockedFromSkip]) {
             if (!visited.has(next)) {
               queue.push(next);
             }
@@ -544,7 +571,7 @@ describe("convergence barrier", () => {
         }
       }
 
-      return { executed, visited };
+      return { executed, visited, skippedNodes };
     }
 
     type Scenario = {
@@ -665,16 +692,23 @@ describe("convergence barrier", () => {
       const visited = new Set<string>();
 
       // Skip A (the false branch root)
+      const skipArrivals = new Map<string, Set<string>>();
+      const skippedNodes = new Set<string>();
       const unblocked = propagateConvergenceSkips(
+        "Cond",
         ["A"],
         sourceMap,
         targetMap,
         arrivals,
+        skipArrivals,
+        skippedNodes,
         visited
       );
 
       // D should NOT be unblocked -- all its inputs are from skipped nodes
       expect(unblocked).toEqual([]);
+      // and D is recorded as genuinely skipped.
+      expect(skippedNodes.has("D")).toBe(true);
     });
 
     it("should unblock convergence node when at least one input is from real execution", () => {
@@ -693,16 +727,22 @@ describe("convergence barrier", () => {
       signalConvergenceArrival("X", ["D"], targetMap, arrivals, visited);
 
       // B gets skipped
+      const skipArrivals = new Map<string, Set<string>>();
+      const skippedNodes = new Set<string>();
       const unblocked = propagateConvergenceSkips(
+        "Cond",
         ["B"],
         sourceMap,
         targetMap,
         arrivals,
+        skipArrivals,
+        skippedNodes,
         visited
       );
 
       // D should be unblocked -- X was a real arrival
       expect(unblocked).toEqual(["D"]);
+      expect(skippedNodes.has("D")).toBe(false);
     });
 
     it("should propagate skip through fully-skipped convergence nodes to downstream", () => {
@@ -726,16 +766,24 @@ describe("convergence barrier", () => {
       signalConvergenceArrival("X", ["E"], targetMap, arrivals, visited);
 
       // Skip A -- should propagate through B, C, D (all-skip), then reach E
+      const skipArrivals = new Map<string, Set<string>>();
+      const skippedNodes = new Set<string>();
       const unblocked = propagateConvergenceSkips(
+        "Cond",
         ["A"],
         sourceMap,
         targetMap,
         arrivals,
+        skipArrivals,
+        skippedNodes,
         visited
       );
 
       // E should be unblocked (X was real, D arrival was skip-propagated)
       expect(unblocked).toEqual(["E"]);
+      // D is all-skip so it is recorded skipped; E executed (real X) so it is not.
+      expect(skippedNodes.has("D")).toBe(true);
+      expect(skippedNodes.has("E")).toBe(false);
     });
   });
 
@@ -829,6 +877,186 @@ describe("convergence barrier", () => {
       const condHandles = handleMap.get("Cond");
       expect(condHandles?.get("true")).toEqual(["B"]);
       expect(condHandles?.get("false")).toEqual(["C"]);
+    });
+  });
+
+  describe("alert OR-join wired to several conditions' false handles", () => {
+    // Production shape: five health-check conditions each route their `false`
+    // handle to a single alert step. The alert fires if ANY check fails; when
+    // every check passes the alert must be skipped, and a workflow with no real
+    // failure must report success.
+    const condIds = ["c1", "c2", "c3", "c4", "c5"];
+    const alert = "alert";
+    const edges = condIds.map((id) => ({ source: id, target: alert }));
+
+    // Drive every condition's not-taken (false) branch into the alert and
+    // return the resulting execute-ready list plus the skipped-node set.
+    function runAllConditions(realFromConditions: string[]): {
+      executeReady: string[];
+      skippedNodes: Set<string>;
+      arrivals: Map<string, Set<string>>;
+    } {
+      const sourceMap = buildEdgesBySource(edges);
+      const targetMap = buildEdgesByTarget(edges);
+      const arrivals = new Map<string, Set<string>>();
+      const skipArrivals = new Map<string, Set<string>>();
+      const skippedNodes = new Set<string>();
+      const visited = new Set<string>();
+      const executeReady: string[] = [];
+
+      for (const condId of condIds) {
+        if (realFromConditions.includes(condId)) {
+          // Condition went false: it TAKES the edge to the alert (real arrival).
+          executeReady.push(
+            ...getReadyDownstreamIds(
+              condId,
+              [alert],
+              targetMap,
+              arrivals,
+              visited
+            )
+          );
+        } else {
+          // Condition went true: the alert is on its not-taken handle (skip).
+          executeReady.push(
+            ...propagateConvergenceSkips(
+              condId,
+              [alert],
+              sourceMap,
+              targetMap,
+              arrivals,
+              skipArrivals,
+              skippedNodes,
+              visited
+            )
+          );
+        }
+      }
+      return { executeReady, skippedNodes, arrivals };
+    }
+
+    it("does not execute the alert when every condition passed (all-skip)", () => {
+      const { executeReady, skippedNodes } = runAllConditions([]);
+      expect(executeReady).toEqual([]);
+      expect(skippedNodes.has(alert)).toBe(true);
+    });
+
+    it("reports success when the all-skip alert never ran (no masking needed)", () => {
+      const { skippedNodes } = runAllConditions([]);
+      // The alert never executed, so it is absent from results.
+      const results = {
+        c1: { success: true },
+        c2: { success: true },
+        c3: { success: true },
+        c4: { success: true },
+        c5: { success: true },
+      };
+      expect(computeFinalSuccess(results, skippedNodes)).toBe(true);
+    });
+
+    it("executes the alert once when a single condition failed", () => {
+      const { executeReady, skippedNodes } = runAllConditions(["c3"]);
+      expect(executeReady).toEqual([alert]);
+      // The alert genuinely ran, so it must NOT be recorded as skipped.
+      expect(skippedNodes.has(alert)).toBe(false);
+    });
+
+    it("counts an executed-and-failed alert against final success (no false success)", () => {
+      const { executeReady, skippedNodes } = runAllConditions(["c3"]);
+      expect(executeReady).toEqual([alert]);
+      // The alert ran and failed (e.g. bad webhook payload).
+      const results = {
+        c1: { success: true },
+        c2: { success: true },
+        c3: { success: true },
+        c4: { success: true },
+        c5: { success: true },
+        [alert]: { success: false, error: "HTTP 400: Invalid routing key" },
+      };
+      // Because the alert is not in skippedNodes, its failure is authoritative.
+      expect(computeFinalSuccess(results, skippedNodes)).toBe(false);
+    });
+
+    it("executes the alert when at least one of several failures arrives", () => {
+      const { executeReady, skippedNodes } = runAllConditions(["c1", "c4"]);
+      // Real arrivals from c1 and c4 plus skips from c2/c3/c5 -> one execution.
+      expect(executeReady).toEqual([alert]);
+      expect(skippedNodes.has(alert)).toBe(false);
+    });
+  });
+
+  describe("OR-join with a non-condition predecessor", () => {
+    // J converges a condition's false branch and a plain (always-run) node.
+    // The plain node's real arrival must release J even though the condition
+    // skipped its edge -- a join is skipped only when EVERY input was skipped.
+    const edges = [
+      { source: "Cond", target: "J" },
+      { source: "Plain", target: "J" },
+    ];
+
+    it("executes the join when the plain node arrives after the condition skip", () => {
+      const sourceMap = buildEdgesBySource(edges);
+      const targetMap = buildEdgesByTarget(edges);
+      const arrivals = new Map<string, Set<string>>();
+      const skipArrivals = new Map<string, Set<string>>();
+      const skippedNodes = new Set<string>();
+      const visited = new Set<string>();
+
+      // Condition skips its edge to J first.
+      const afterSkip = propagateConvergenceSkips(
+        "Cond",
+        ["J"],
+        sourceMap,
+        targetMap,
+        arrivals,
+        skipArrivals,
+        skippedNodes,
+        visited
+      );
+      expect(afterSkip).toEqual([]);
+      expect(skippedNodes.has("J")).toBe(false);
+
+      // Plain executes and arrives -> J releases.
+      const afterReal = getReadyDownstreamIds(
+        "Plain",
+        ["J"],
+        targetMap,
+        arrivals,
+        visited
+      );
+      expect(afterReal).toEqual(["J"]);
+      expect(skippedNodes.has("J")).toBe(false);
+    });
+
+    it("executes the join when the plain node arrives before the condition skip", () => {
+      const sourceMap = buildEdgesBySource(edges);
+      const targetMap = buildEdgesByTarget(edges);
+      const arrivals = new Map<string, Set<string>>();
+      const skipArrivals = new Map<string, Set<string>>();
+      const skippedNodes = new Set<string>();
+      const visited = new Set<string>();
+
+      const afterReal = getReadyDownstreamIds(
+        "Plain",
+        ["J"],
+        targetMap,
+        arrivals,
+        visited
+      );
+      expect(afterReal).toEqual([]);
+
+      const afterSkip = propagateConvergenceSkips(
+        "Cond",
+        ["J"],
+        sourceMap,
+        targetMap,
+        arrivals,
+        skipArrivals,
+        skippedNodes,
+        visited
+      );
+      expect(afterSkip).toEqual(["J"]);
+      expect(skippedNodes.has("J")).toBe(false);
     });
   });
 });

--- a/tests/unit/convergence-barrier.test.ts
+++ b/tests/unit/convergence-barrier.test.ts
@@ -1058,5 +1058,63 @@ describe("convergence barrier", () => {
       expect(afterSkip).toEqual(["J"]);
       expect(skippedNodes.has("J")).toBe(false);
     });
+
+    it("runs the join and its continuation when several conditions skip but a normal node arrives", () => {
+      // c1, c2 both route their not-taken handle into Merge; Plain always runs
+      // and also feeds Merge; Merge -> Next continues the workflow. Merge must
+      // run on Plain's real arrival regardless of the two condition skips, and
+      // Next (downstream of Merge) must then run too.
+      const wf = [
+        { source: "c1", target: "Merge" },
+        { source: "c2", target: "Merge" },
+        { source: "Plain", target: "Merge" },
+        { source: "Merge", target: "Next" },
+      ];
+      const sourceMap = buildEdgesBySource(wf);
+      const targetMap = buildEdgesByTarget(wf);
+      const arrivals = new Map<string, Set<string>>();
+      const skipArrivals = new Map<string, Set<string>>();
+      const skippedNodes = new Set<string>();
+      const visited = new Set<string>();
+
+      // Both conditions pass: their edges into Merge are skipped (2/3 arrivals).
+      for (const cond of ["c1", "c2"]) {
+        expect(
+          propagateConvergenceSkips(
+            cond,
+            ["Merge"],
+            sourceMap,
+            targetMap,
+            arrivals,
+            skipArrivals,
+            skippedNodes,
+            visited
+          )
+        ).toEqual([]);
+      }
+      expect(skippedNodes.has("Merge")).toBe(false);
+
+      // Plain runs -> real arrival completes Merge (3/3) and releases it.
+      const readyMerge = getReadyDownstreamIds(
+        "Plain",
+        ["Merge"],
+        targetMap,
+        arrivals,
+        visited
+      );
+      expect(readyMerge).toEqual(["Merge"]);
+
+      // Execute Merge and route downstream: Next (single-incoming) runs.
+      visited.add("Merge");
+      const readyNext = getReadyDownstreamIds(
+        "Merge",
+        ["Next"],
+        targetMap,
+        arrivals,
+        visited
+      );
+      expect(readyNext).toEqual(["Next"]);
+      expect(skippedNodes.has("Next")).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Problem
A workflow whose final alert step is wired to the `false` handle of several condition nodes exposed two branch-convergence defects:

1. When every condition passed, the alert (an OR-join of all those `false` edges) still executed -- a spurious alert on a healthy run.
2. The alert step then failed (bad payload) yet the run reported `success`.

## Cause
1. The skip path counted skip-arrivals the same as real arrivals, so a join whose every incoming edge was a not-taken branch still reached its in-degree and ran.
2. Final-success masked the failure of any node in the skipped-targets set; a node that was both skip-classified and actually executed had its failure swallowed.

## Fix
- `propagateConvergenceSkips` tracks skip-arrivals separately and releases a convergence node only when at least one arrival was a real execution; an all-skipped join is itself skipped and propagates the skip downstream. A real predecessor (including a non-condition node) still releases the join.
- `computeFinalSuccess` consumes the precise genuinely-skipped set, so a node reached by a real arrival is never masked.

## Tests
Barrier-level and executor-simulation tests for the all-skip fan-in, mixed real/skip joins, a non-condition predecessor releasing the join in both arrival orders, a multi-condition join with a normal-node continuation downstream, and the executed-and-failed alert status case.

## Note
Existing affected workflows need their alert node re-saved to recompile the stored expression; the fix changes runtime convergence behavior for new executions.