### PR TITLE
fix: getCurrentNonce RPC operation label write -> read

### DIFF
--- a/lib/web3/transaction-manager.ts
+++ b/lib/web3/transaction-manager.ts
@@ -407,6 +407,6 @@ export async function getCurrentNonce(
   const rpcManager = await getRpcProviderFromUrls(rpcUrl, undefined, chainId);
   return await rpcManager.executeWithFailover(
     (provider) => provider.getTransactionCount(walletAddress, "pending"),
-    "write"
+    "read"
   );
 }


### PR DESCRIPTION
## Summary

`getTransactionCount` is a read-only operation. The second arg to `executeWithFailover` was incorrectly labelled `"write"`, which caused `getCurrentNonce` traffic to be counted under write metrics in Prometheus (`rpcMetrics.primaryAttempts{operation="write"}`, latency, failures, etc.). No functional impact -- failover behaviour is identical regardless of the label.

## Changes

- `lib/web3/transaction-manager.ts`: `"write"` -> `"read"` in `getCurrentNonce`

## Scope check

After KEEP-546 landed (`"write-broadcast"` for actual broadcasts), this was the only remaining `"write"` label in `lib/`. All other `executeWithFailover` call sites use `"read"`, `"preflight"`, `"write-broadcast"`, or omit the arg.

## Test Plan

- [x] No logic change -- metrics-only fix; verify Prometheus `rpcMetrics.*{operation="write"}` no longer includes nonce-query traffic after deploy