### PR TITLE
feat: split reaper error_category by stuck state

### DIFF
--- a/app/api/internal/reaper/route.ts
+++ b/app/api/internal/reaper/route.ts
@@ -99,8 +99,8 @@ export async function GET(request: Request): Promise<NextResponse> {
     );
 
     // KEEP-545: reaped executions are by definition stuck/timed-out, which
-    // classifies as WORKFLOW_ENGINE / system-side. Write the classification
-    // columns and increment the per-org counter per reaped row.
+    // classifies as system-side. Write the classification columns and
+    // increment the per-org counter per reaped row.
     const reaperErrorMessage = `Execution timed out: no progress for ${thresholdMinutes} minutes`;
     const reaperClassification = classifyExecutionError(reaperErrorMessage);
 
@@ -111,12 +111,20 @@ export async function GET(request: Request): Promise<NextResponse> {
         // never-started, SQS-lost), so they carry the system_error status.
         status: "system_error",
         error: reaperErrorMessage,
-        errorCategory: reaperClassification.errorCategory,
+        // KEEP-651: errorCategory is per pre-update status. running -> the
+        // runtime claimed the execution but stopped progressing, which is a
+        // workflow engine failure (workflow_engine). pending/phantom -> the
+        // pod never started or the dispatcher never dequeued -- these are
+        // infrastructure failures (infrastructure), not runtime engine faults,
+        // and must be a distinct metric series so a FailedCreatePodSandBox
+        // burst surfaces separately from ordinary execution timeouts.
+        errorCategory: sql<string>`CASE
+          WHEN ${workflowExecutions.status} = 'running' THEN 'workflow_engine'
+          ELSE 'infrastructure' END`,
         errorType: reaperClassification.errorType,
         // KEEP-693: attribute the code to the pre-update status -- running ->
         // timed out (E-0001), pending -> never started (P-0001), phantom ->
-        // never picked up (P-0005). All three are workflow_engine/system, so the
-        // category/type columns above stay constant for every reaped row.
+        // never picked up (P-0005).
         errorCode: sql<ErrorCode>`CASE
           WHEN ${workflowExecutions.status} = 'pending' THEN 'P-0001'
           WHEN ${workflowExecutions.status} = 'phantom' THEN 'P-0005'
@@ -128,6 +136,7 @@ export async function GET(request: Request): Promise<NextResponse> {
       .returning({
         id: workflowExecutions.id,
         workflowId: workflowExecutions.workflowId,
+        errorCategory: workflowExecutions.errorCategory,
       });
 
     const reapedIds = reaped.map((row) => row.id);
@@ -138,6 +147,7 @@ export async function GET(request: Request): Promise<NextResponse> {
       await recordExecutionErrorFinalized({
         workflowId: row.workflowId,
         errorMessage: reaperErrorMessage,
+        errorCategory: row.errorCategory ?? undefined,
       });
     }
 

--- a/lib/errors/finalize-error.ts
+++ b/lib/errors/finalize-error.ts
@@ -24,11 +24,12 @@ import { ANONYMOUS_ORG_SLUG } from "@/lib/metrics/db-metrics";
 export async function recordExecutionErrorFinalized(args: {
   workflowId: string;
   errorMessage: string | null | undefined;
+  errorCategory?: string;
 }): Promise<void> {
   try {
-    const { errorCategory, errorType } = classifyExecutionError(
-      args.errorMessage
-    );
+    const classification = classifyExecutionError(args.errorMessage);
+    const errorCategory = args.errorCategory ?? classification.errorCategory;
+    const { errorType } = classification;
 
     const row = await db
       .select({ slug: organization.slug })

--- a/tests/e2e/vitest/reaper-codes.test.ts
+++ b/tests/e2e/vitest/reaper-codes.test.ts
@@ -141,14 +141,17 @@ describe.skipIf(SKIP)("reaper error codes", () => {
     const running = await read(`${PREFIX}running`);
     expect(running.status).toBe("system_error");
     expect(running.errorCode).toBe("E-0001");
+    expect(running.errorCategory).toBe("workflow_engine");
 
     const pending = await read(`${PREFIX}pending`);
     expect(pending.status).toBe("system_error");
     expect(pending.errorCode).toBe("P-0001");
+    expect(pending.errorCategory).toBe("infrastructure");
 
     const phantom = await read(`${PREFIX}phantom`);
     expect(phantom.status).toBe("system_error");
     expect(phantom.errorCode).toBe("P-0005");
+    expect(phantom.errorCategory).toBe("infrastructure");
   });
 
   it("leaves a fresh phantom untouched (not yet aged out)", async () => {


### PR DESCRIPTION
## Summary

- Pending/phantom rows reaped with no step logs now write \`error_category='infrastructure'\` instead of \`'workflow_engine'\`
- Running-timeout rows keep \`error_category='workflow_engine'\`
- \`recordExecutionErrorFinalized\` gains an optional \`errorCategory\` override so the reaper forwards the per-row category to the in-process counter without re-classifying from the generic timeout message

## Problem

The TECH-6544 P3 alert fires once per \`error_category\`. Previously, never-started (P-0001) and execution-timeout (E-0001) both produced \`error_category=workflow_engine\`, so a FailedCreatePodSandBox burst was invisible against the always-on background noise from ordinary timeouts. The May 21-22 incident (74 never-started runs across 66 workflows) would not have fired a distinct alert.

## Changes

**\`app/api/internal/reaper/route.ts\`**
- \`errorCategory\` in the bulk UPDATE is now a SQL CASE on pre-update status, same pattern as the existing \`errorCode\` CASE: \`running\` → \`workflow_engine\`, \`pending\`/\`phantom\` → \`infrastructure\`
- \`errorCategory\` added to \`.returning()\` and forwarded per-row to \`recordExecutionErrorFinalized\`

**\`lib/errors/finalize-error.ts\`**
- Accepts optional \`errorCategory\` override; uses it directly when provided, falls back to message classification for all other callers

**\`tests/e2e/vitest/reaper-codes.test.ts\`**
- Extended existing real-DB integration test to assert \`errorCategory\` per stuck state: \`workflow_engine\` for running, \`infrastructure\` for pending and phantom

## Effect on alerting

\`keeperhub_system_errors_by_category{error_category="infrastructure"}\` is now a separate series. The TECH-6544 P3 alert fires one PagerDuty incident per category, so a FailedCreatePodSandBox burst opens its own \`infrastructure\` incident rather than blending into the standing \`workflow_engine\` incident.

## Infra

The Grafana alert query fix (P2 \`status="error"\` → \`status=~"error|system_error"\`) is in https://github.com/techops-services/infrastructure/pull/282.