### PR TITLE
fix(sandbox): sandbox follow-up cleanup and hardening

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -275,6 +275,11 @@ jobs:
       - name: Run sandbox package unit tests
         run: pnpm --filter @keeperhub/sandbox test
 
+      - name: Build sandbox dist and run smoke test
+        run: |
+          pnpm --filter @keeperhub/sandbox build
+          pnpm --filter @keeperhub/sandbox test:smoke
+
       - name: Build sandbox image
         run: docker build -f sandbox/Dockerfile -t keeperhub-sandbox:ci .
 

--- a/.github/workflows/sandbox-escape-matrix.yaml
+++ b/.github/workflows/sandbox-escape-matrix.yaml
@@ -40,6 +40,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  issues: write
 
 concurrency:
   group: sandbox-escape-matrix-${{ inputs.environment || 'staging' }}
@@ -168,3 +169,22 @@ jobs:
             echo ""
             echo "If TEST-06..10 fail: the image/FS/network strand has regressed but the env/SA/IRSA strand is intact. Re-verify the sandbox runtime image is distroless, the NetworkPolicy is applied, and the pod has readOnlyRootFilesystem. SANDBOX_BACKEND rollback is not required unless TEST-01..05 also fail."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open GitHub issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "sandbox-escape-matrix failed on ${{ env.TARGET_ENV }}" \
+            --body "The sandbox-escape-matrix suite failed and needs investigation.
+
+          **Environment**: ${{ env.TARGET_ENV }}
+          **Run**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Triggered by**: ${{ github.event_name }}
+          **Matrix step outcome**: ${{ steps.matrix.outcome }}
+
+          If TEST-01..05 failed: the env/SA/IRSA strand has regressed. Roll the main app back to \`SANDBOX_BACKEND=local\` in Helm values immediately.
+
+          If TEST-06..10 failed: the image/FS/network strand has regressed. Re-verify the sandbox image is distroless, NetworkPolicy is applied, and \`readOnlyRootFilesystem\` is set. No rollback required unless TEST-01..05 also fail."

--- a/.github/workflows/sandbox-escape-matrix.yaml
+++ b/.github/workflows/sandbox-escape-matrix.yaml
@@ -171,7 +171,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Open GitHub issue on failure
-        if: failure()
+        if: steps.matrix.outcome == 'failure'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/deploy/keeperhub-sandbox/prod/values.yaml
+++ b/deploy/keeperhub-sandbox/prod/values.yaml
@@ -38,9 +38,6 @@ serviceAccount:
   create: false
   name: keeperhub-sandbox
 
-podAnnotations:
-  reloader.stakater.com/auto: "true"
-
 resources:
   requests:
     cpu: 100m

--- a/deploy/keeperhub-sandbox/staging/values.yaml
+++ b/deploy/keeperhub-sandbox/staging/values.yaml
@@ -69,9 +69,6 @@ serviceAccount:
   create: false
   name: keeperhub-sandbox
 
-podAnnotations:
-  reloader.stakater.com/auto: "true"
-
 resources:
   requests:
     cpu: 100m

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -768,13 +768,14 @@ async function resolveValidatedAddresses(hostname) {
     };
   }
   const DNS_TIMEOUT_MS = 3000;
-  const dnsTimeoutPromise = new Promise((_, reject) =>
-    setTimeout(() => reject(new Error("DNS lookup timed out")), DNS_TIMEOUT_MS)
-  );
+  let dnsTimer;
+  const dnsTimeoutPromise = new Promise((_, reject) => {
+    dnsTimer = setTimeout(() => reject(new Error("DNS lookup timed out")), DNS_TIMEOUT_MS);
+  });
   const records = await Promise.race([
     dnsPromises.lookup(hostname, { all: true }),
     dnsTimeoutPromise,
-  ]);
+  ]).finally(() => clearTimeout(dnsTimer));
   const validated = [];
   for (const rec of records) {
     const check = isBlockedIp(rec.address);

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -767,7 +767,14 @@ async function resolveValidatedAddresses(hostname) {
       addresses: [{ address: hostname, family: literalFamily }],
     };
   }
-  const records = await dnsPromises.lookup(hostname, { all: true });
+  const DNS_TIMEOUT_MS = 3000;
+  const dnsTimeoutPromise = new Promise((_, reject) =>
+    setTimeout(() => reject(new Error("DNS lookup timed out")), DNS_TIMEOUT_MS)
+  );
+  const records = await Promise.race([
+    dnsPromises.lookup(hostname, { all: true }),
+    dnsTimeoutPromise,
+  ]);
   const validated = [];
   for (const rec of records) {
     const check = isBlockedIp(rec.address);

--- a/plugins/code/steps/run-code.ts
+++ b/plugins/code/steps/run-code.ts
@@ -204,12 +204,18 @@ function outcomeFromReader(reader: SandboxResultReader): ChildOutcome {
   }
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: single cohesive spawner with timeout + stream aggregation + graceful teardown
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: single cohesive spawner with timeout + stream aggregation + graceful teardown + signal wiring
 async function runInChild(
   code: string,
-  timeoutMs: number
+  timeoutMs: number,
+  signal?: AbortSignal
 ): Promise<ChildOutcome> {
   return await new Promise<ChildOutcome>((resolve) => {
+    if (signal?.aborted) {
+      resolve({ ok: false, errorMessage: "ABORTED", logs: [] });
+      return;
+    }
+
     // fd 3 is the dedicated result channel (F-010). stdout/stderr stay
     // user-facing diagnostics and are never deserialized.
     const child = spawn(process.execPath, ["-e", CHILD_SOURCE], {
@@ -227,6 +233,7 @@ async function runInChild(
       }
       settled = true;
       clearTimeout(killTimer);
+      signal?.removeEventListener("abort", onAbort);
       if (!child.killed) {
         try {
           child.kill("SIGKILL");
@@ -240,6 +247,11 @@ async function runInChild(
     const killTimer = setTimeout(() => {
       finish({ ok: false, errorMessage: "WALL_CLOCK_TIMEOUT", logs: [] });
     }, timeoutMs + 1000);
+
+    const onAbort = (): void => {
+      finish({ ok: false, errorMessage: "ABORTED", logs: [] });
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
 
     // Drain stdout so a sandbox escape that writes there cannot fill the pipe
     // and block the child; the bytes are intentionally discarded (never a
@@ -336,9 +348,10 @@ function validateInput(input: RunCodeCoreInput): RunCodeResult | null {
 async function runLocal(
   input: RunCodeCoreInput,
   timeoutSeconds: number,
+  signal?: AbortSignal,
 ): Promise<RunCodeResult> {
   const timeoutMs = timeoutSeconds * 1000;
-  const outcome = await runInChild(input.code, timeoutMs);
+  const outcome = await runInChild(input.code, timeoutMs, signal);
 
   if (outcome.ok) {
     return { success: true, result: outcome.result, logs: outcome.logs };

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node dist/sandbox/src/index.js",
     "build": "tsc && cp ../lib/ssrf-blocklist.json dist/lib/ssrf-blocklist.json",
+    "test:smoke": "SANDBOX_PORT=18787 node dist/sandbox/src/index.js & PID=$!; TRIES=0; until curl -sf http://localhost:18787/healthz; do sleep 1; TRIES=$((TRIES+1)); if [ $TRIES -ge 10 ]; then kill $PID; exit 1; fi; done && kill $PID",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/sandbox/src/index.ts
+++ b/sandbox/src/index.ts
@@ -77,8 +77,7 @@ function getMaxConcurrentRuns(): number {
  * because check-and-increment happens without an intervening await. */
 let inFlightRuns = 0;
 
-/** Test/operational hook to observe current load. */
-export function getInFlightRuns(): number {
+function getInFlightRuns(): number {
   return inFlightRuns;
 }
 
@@ -154,7 +153,6 @@ async function handlePostRun(
     res.end("sandbox at capacity");
     return;
   }
-  inFlightRuns++;
 
   // If the client disconnects before we finish writing the response, we
   // cancel the child so sandbox capacity is not pinned beyond the caller's
@@ -176,6 +174,7 @@ async function handlePostRun(
   res.on("close", onResClose);
 
   try {
+    inFlightRuns++;
     const raw = await readBody(req, getMaxBodyBytes());
     if (raw.length === 0) {
       res.writeHead(400);

--- a/sandbox/src/index.ts
+++ b/sandbox/src/index.ts
@@ -77,10 +77,6 @@ function getMaxConcurrentRuns(): number {
  * because check-and-increment happens without an intervening await. */
 let inFlightRuns = 0;
 
-function getInFlightRuns(): number {
-  return inFlightRuns;
-}
-
 async function readBody(
   req: IncomingMessage,
   maxBytes: number

--- a/tests/unit/sandbox-client.test.ts
+++ b/tests/unit/sandbox-client.test.ts
@@ -466,6 +466,55 @@ describe("lib/sandbox-client runRemote", () => {
       expect(outcome.error).toContain("500");
     }
   });
+
+  it("returns success:false when the server resets the socket mid-response-body", async () => {
+    const resetSockets: IncomingMessage[] = [];
+    const resetServer = createServer(
+      (req: IncomingMessage, res: ServerResponse): void => {
+        resetSockets.push(req);
+        res.writeHead(200, {
+          "Content-Type": "application/json",
+          "X-KH-Sandbox-Wire": SANDBOX_WIRE_VERSION,
+          "Transfer-Encoding": "chunked",
+        });
+        res.write("RESULT{\"ok\":tr");
+        // Destroy the socket before the body is complete.
+        req.socket.destroy();
+      }
+    );
+    await new Promise<void>((resolve, reject) => {
+      resetServer.once("error", reject);
+      resetServer.listen(0, "127.0.0.1", () => {
+        resetServer.off("error", reject);
+        resolve();
+      });
+    });
+    const resetPort = (resetServer.address() as AddressInfo).port;
+    const savedUrl = process.env.SANDBOX_URL;
+    process.env.SANDBOX_URL = `http://127.0.0.1:${resetPort}`;
+    try {
+      vi.resetModules();
+      const { runRemote } = await import("@/lib/sandbox/client");
+      const outcome = await runRemote({ code: "return 1;", timeoutMs: 5000 });
+      expect(outcome.success).toBe(false);
+      if (!outcome.success) {
+        expect(outcome.error).toContain("sandbox client error");
+      }
+    } finally {
+      for (const req of resetSockets) {
+        req.socket.destroy();
+      }
+      if (savedUrl === undefined) {
+        delete process.env.SANDBOX_URL;
+      } else {
+        process.env.SANDBOX_URL = savedUrl;
+      }
+      await new Promise<void>((resolve) => {
+        resetServer.close(() => resolve());
+      });
+      vi.resetModules();
+    }
+  });
 });
 
 describe("lib/sandbox-client runRemote untrusted-shape hardening", () => {


### PR DESCRIPTION
## Summary

- Remove dead `reloader.stakater.com/auto: "true"` annotation from sandbox Helm values (staging + prod). Sandbox has no externalSecrets or ConfigMaps for reloader to watch.
- Move `inFlightRuns++` inside the `try` block in `handlePostRun` so the `finally` decrement is guaranteed to cover every increment path. Unexport `getInFlightRuns` which has no non-test consumer.
- Wire `signal?: AbortSignal` through `runInChild` and `runLocal` in the main-app local runner, closing the asymmetry with the standalone sandbox's `runInChild` which already supported cancellation.
- Add mid-body socket reset test to `sandbox-client.test.ts` (server sends headers + partial body then destroys socket).
- Add a 3s `Promise.race` timeout around `dnsPromises.lookup` in the SSRF guard inside `SANDBOX_CHILD_SOURCE`. A slow resolver could otherwise pin a request slot for the OS default timeout (~30s), soft-DoS-ing the concurrency gate.
- Add `test:smoke` to `sandbox/package.json` and a CI step in `pr-checks.yml` that builds the sandbox dist and hits `/healthz` directly (no Docker) before the Docker image build, catching dist layout regressions one step earlier.
- Add a GitHub issue creation step on failure in `sandbox-escape-matrix.yaml` so a TEST-XX regression is not silently swallowed in the Actions UI.

## Test plan

- [x] `pnpm --filter @keeperhub/sandbox test` passes
- [x] `pnpm --filter @keeperhub/sandbox build && pnpm --filter @keeperhub/sandbox test:smoke` passes locally
- [x] `pnpm test:unit tests/unit/sandbox-client.test.ts` passes (includes new mid-body reset case)
- [ ] Deploy to staging and confirm sandbox healthz still green after reloader annotation removal