### PR TITLE
refactor: extract shared workflow-execution orchestration helpers

### DIFF
--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -5,7 +5,7 @@ import { checkConcurrencyLimit } from "@/app/api/execute/_lib/concurrency-limit"
 import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { priceQualifiesForMarketplaceExemption } from "@/lib/billing/marketplace-billing";
 import { db } from "@/lib/db";
-import { getOrgPlanLabel, getOrgSlug } from "@/lib/db/org-helpers";
+import { resolveExecutionOrgMetadata } from "@/lib/db/org-helpers";
 import {
   organization,
   tags,
@@ -185,10 +185,8 @@ async function startExecutionInBackground(
   body: Record<string, unknown>,
   executionId: string
 ): Promise<void> {
-  const [organizationSlug, organizationPlan] = await Promise.all([
-    getOrgSlug(workflow.organizationId),
-    getOrgPlanLabel(workflow.organizationId),
-  ]);
+  const { slug: organizationSlug, plan: organizationPlan } =
+    await resolveExecutionOrgMetadata(workflow.organizationId);
   start(executeWorkflow, [
     buildExecutorInput(workflow, {
       triggerInput: body,

--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -27,16 +27,12 @@ import {
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
 import { extractActionTypeNodes } from "@/lib/features";
 import { enforceWorkflowFeatures } from "@/lib/features/route-guard";
-import { getOrgPlanLabel, getOrgSlug } from "@/lib/db/org-helpers";
-import {
-  organization,
-  workflowExecutions,
-  workflows,
-} from "@/lib/db/schema";
+import { resolveExecutionOrgMetadata } from "@/lib/db/org-helpers";
+import { workflowExecutions, workflows } from "@/lib/db/schema";
 import { getWorkflowAccess } from "@/lib/workflow/access";
 import { hashWorkflowDefinition } from "@/lib/workflow/content-hash";
-import { getWorkflowExecutability } from "@/lib/workflow/executable";
 import { executeWorkflowInBackground } from "@/lib/workflow/execute-in-background";
+import { loadWorkflowForExecution } from "@/lib/workflow/load-for-execution";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Workflow execution requires complex error handling and validation
@@ -58,10 +54,24 @@ export async function POST(
     const isInternalExecution = internalAuth.authenticated;
 
     let userId: string;
-    let workflow: typeof workflows.$inferSelect | undefined;
     let orgApiKeyId: string | null = null;
     let credentialType: ExecutionCredentialType | null = null;
     let credentialLabel: string | null = null;
+
+    // Load workflow + evaluate lifecycle in one round-trip. requireEnabled maps
+    // to the dispatch context: internal callers (scheduler/executor routing back
+    // through this route) must not run a disabled workflow, but interactive
+    // callers (the editor "Run" button) may test a not-yet-enabled workflow.
+    const loaded = await loadWorkflowForExecution(workflowId, {
+      requireEnabled: isInternalExecution,
+    });
+    if (loaded.status === "not_found" || loaded.status === "not_executable") {
+      return NextResponse.json(
+        { error: "Workflow not found" },
+        { status: HttpStatus.NOT_FOUND }
+      );
+    }
+    const { workflow } = loaded;
 
     if (isInternalExecution) {
       // Internal execution from authenticated service
@@ -72,22 +82,11 @@ export async function POST(
       credentialType = "internal";
       credentialLabel = internalAuth.caller ?? null;
 
-      workflow = await db.query.workflows.findFirst({
-        where: eq(workflows.id, workflowId),
-      });
-
-      if (!workflow) {
-        return NextResponse.json(
-          { error: "Workflow not found" },
-          { status: HttpStatus.NOT_FOUND }
-        );
-      }
-
       // Internal service auth already verified by authenticateInternalService.
       // Org membership check would require organizationId but internal callers
       // have no session org — and all workflows are NOT NULL on organizationId
       // post-migration, so passing null here would always 404. Lifecycle checks
-      // (deleted, deactivated) are handled by getWorkflowExecutability below.
+      // (deleted, deactivated) are handled by loadWorkflowForExecution above.
       userId = workflow.userId;
     } else {
       const authContext = await getDualAuthContext(request);
@@ -116,17 +115,6 @@ export async function POST(
         return scopeError;
       }
 
-      workflow = await db.query.workflows.findFirst({
-        where: eq(workflows.id, workflowId),
-      });
-
-      if (!workflow) {
-        return NextResponse.json(
-          { error: "Workflow not found" },
-          { status: HttpStatus.NOT_FOUND }
-        );
-      }
-
       const access = await getWorkflowAccess(workflow, {
         userId: authContext.userId,
         organizationId: authContext.organizationId,
@@ -152,31 +140,6 @@ export async function POST(
       } else {
         credentialType = "session";
       }
-    }
-
-    // Gate on workflow lifecycle using the shared executability predicate so
-    // this route cannot drift from the scheduler/executor. A soft-deleted or
-    // deactivated-owner workflow is never runnable. The `enabled` flag gates
-    // automated dispatch only: interactive callers (the editor "Run" button)
-    // must still be able to test a not-yet-enabled workflow, so a disabled
-    // workflow is allowed through the dual-auth branch.
-    const [gate] = await db
-      .select({ orgDeactivatedAt: organization.deactivatedAt })
-      .from(workflows)
-      .leftJoin(organization, eq(organization.id, workflows.organizationId))
-      .where(eq(workflows.id, workflow.id))
-      .limit(1);
-    const executability = getWorkflowExecutability({
-      enabled: workflow.enabled,
-      deletedAt: workflow.deletedAt,
-      deactivatedAt: workflow.deactivatedAt,
-      orgDeactivatedAt: gate?.orgDeactivatedAt ?? null,
-    });
-    const blockedByExecutability =
-      !executability.executable &&
-      (isInternalExecution || executability.reason !== "disabled");
-    if (blockedByExecutability) {
-      return NextResponse.json({ error: "Workflow not found" }, { status: HttpStatus.NOT_FOUND });
     }
 
     // Validate integration references as the ORG principal: the org owns the
@@ -349,10 +312,10 @@ export async function POST(
     }
 
     // Resolve org slug + plan for log labels (cached per request)
-    const [organizationSlug, organizationPlan] = await Promise.all([
-      getOrgSlug(workflow.organizationId),
-      getOrgPlanLabel(workflow.organizationId),
-    ]);
+    const {
+      slug: organizationSlug,
+      plan: organizationPlan,
+    } = await resolveExecutionOrgMetadata(workflow.organizationId);
 
     // Execute the workflow in the background (don't await)
     executeWorkflowInBackground(

--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -29,11 +29,10 @@ import {
 } from "@/lib/features/route-guard";
 import {
   apiKeys,
-  organization,
   workflowExecutions,
   workflows,
 } from "@/lib/db/schema";
-import { getOrgPlanLabel, getOrgSlug } from "@/lib/db/org-helpers";
+import { resolveExecutionOrgMetadata } from "@/lib/db/org-helpers";
 import { webhookPayloadSchema } from "@/lib/schemas/webhook";
 import { validateData } from "@/lib/validate-request";
 import { withBackstopCapture } from "@/lib/security/backstop-capture";
@@ -43,8 +42,8 @@ import {
   isUserMemberOfOrganization,
 } from "@/lib/workflow/access";
 import { hashWorkflowDefinition } from "@/lib/workflow/content-hash";
-import { getWorkflowExecutability } from "@/lib/workflow/executable";
 import { executeWorkflowInBackground } from "@/lib/workflow/execute-in-background";
+import { loadWorkflowForExecution } from "@/lib/workflow/load-for-execution";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 type ValidateApiKeyResult = {
   valid: boolean;
@@ -193,38 +192,21 @@ export async function POST(
   try {
     const { workflowId } = await context.params;
 
-    // Get workflow
-    const workflow = await db.query.workflows.findFirst({
-      where: eq(workflows.id, workflowId),
+    // Load workflow + evaluate lifecycle before API-key validation so a
+    // non-executable workflow never triggers an auth round-trip.
+    const loaded = await loadWorkflowForExecution(workflowId, {
+      requireEnabled: true,
     });
-
-    if (!workflow) {
+    if (loaded.status === "not_found") {
       return failResponse(workflowId, timer, HttpStatus.NOT_FOUND, "Workflow not found");
     }
-
-    // Gate on workflow lifecycle (enabled, not soft-deleted, owner active)
-    // using the shared executability predicate, before API-key
-    // validation so a non-executable workflow never triggers an auth round-trip.
-    // A disabled workflow stays a 410; a deleted or deactivated-owner workflow
-    // is reported as gone (404).
-    const [gate] = await db
-      .select({ orgDeactivatedAt: organization.deactivatedAt })
-      .from(workflows)
-      .leftJoin(organization, eq(organization.id, workflows.organizationId))
-      .where(eq(workflows.id, workflow.id))
-      .limit(1);
-    const executability = getWorkflowExecutability({
-      enabled: workflow.enabled,
-      deletedAt: workflow.deletedAt,
-      deactivatedAt: workflow.deactivatedAt,
-      orgDeactivatedAt: gate?.orgDeactivatedAt ?? null,
-    });
-    if (!executability.executable) {
-      if (executability.reason === "disabled") {
+    if (loaded.status === "not_executable") {
+      if (loaded.reason === "disabled") {
         return failResponse(workflowId, timer, HttpStatus.GONE, "Workflow is disabled");
       }
       return failResponse(workflowId, timer, HttpStatus.NOT_FOUND, "Workflow not found");
     }
+    const { workflow } = loaded;
 
     // Validate API key - must belong to the workflow owner
     const authHeader = request.headers.get("Authorization");
@@ -441,10 +423,8 @@ export async function POST(
     });
 
     // Resolve org slug + plan for log labels (cached per request)
-    const [organizationSlug, organizationPlan] = await Promise.all([
-      getOrgSlug(workflow.organizationId),
-      getOrgPlanLabel(workflow.organizationId),
-    ]);
+    const { slug: organizationSlug, plan: organizationPlan } =
+      await resolveExecutionOrgMetadata(workflow.organizationId);
 
     // Execute the workflow in the background (don't await)
     executeWorkflowInBackground(

--- a/keeperhub-executor/in-process.ts
+++ b/keeperhub-executor/in-process.ts
@@ -1,14 +1,12 @@
-import { eq } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { validateWorkflowIntegrations } from "../lib/db/integrations";
-import { organization, workflows } from "../lib/db/schema";
-import { getWorkflowExecutability } from "../lib/workflow/executable";
 import { buildExecutorInput } from "../lib/workflow/executor/build-executor-input";
 import { executeWorkflow } from "../lib/workflow/executor/executor.workflow";
-import { calculateTotalSteps } from "../lib/workflow/executor/progress";
 import type { WorkflowEdge, WorkflowNode } from "../lib/workflow/store";
+import { loadWorkflowForExecution } from "../lib/workflow/load-for-execution";
 import type { DbSchema } from "./lib/db-helpers";
 import {
+  applyExecutionResult,
   initializeExecutionProgress,
   updateExecutionStatus,
   updateScheduleStatus,
@@ -36,47 +34,25 @@ export async function executeInProcess(params: {
   try {
     await updateExecutionStatus(db, executionId, "running");
 
-    const workflow = await db.query.workflows.findFirst({
-      where: eq(workflows.id, workflowId),
-    });
-
-    if (!workflow) {
-      throw new Error(`Workflow not found: ${workflowId}`);
-    }
-
     // Defensive re-check: the dispatcher already gated lifecycle state, but the
     // workflow could have been disabled, soft-deleted, deactivated, or its
     // owning org deactivated between dispatch and execution. Cancel rather than
     // run. The org owns the workflow, so org deactivation is the owner gate.
-    const [org] = await db
-      .select({ deactivatedAt: organization.deactivatedAt })
-      .from(organization)
-      .where(eq(organization.id, workflow.organizationId))
-      .limit(1);
-    const executability = getWorkflowExecutability({
-      enabled: workflow.enabled,
-      deletedAt: workflow.deletedAt,
-      deactivatedAt: workflow.deactivatedAt,
-      orgDeactivatedAt: org?.deactivatedAt ?? null,
+    const loaded = await loadWorkflowForExecution(workflowId, {
+      requireEnabled: true,
     });
-    if (!executability.executable) {
+    if (loaded.status === "not_found") {
+      throw new Error(`Workflow not found: ${workflowId}`);
+    }
+    if (loaded.status === "not_executable") {
       console.log(
-        `[Executor:InProcess] Workflow not executable (${executability.reason}), skipping: ${workflowId}`
+        `[Executor:InProcess] Workflow not executable (${loaded.reason}), skipping: ${workflowId}`
       );
       await updateExecutionStatus(db, executionId, "cancelled");
       return;
     }
 
-    let organizationName: string | undefined;
-    if (workflow.organizationId) {
-      const [org] = await db
-        .select({ name: organization.name })
-        .from(organization)
-        .where(eq(organization.id, workflow.organizationId))
-        .limit(1);
-      organizationName = org?.name;
-    }
-
+    const { workflow, organizationName } = loaded;
     const nodes = workflow.nodes as WorkflowNode[];
     const edges = workflow.edges as WorkflowEdge[];
     const validation = await validateWorkflowIntegrations(
@@ -90,8 +66,7 @@ export async function executeInProcess(params: {
       );
     }
 
-    const totalSteps = calculateTotalSteps(nodes, edges);
-    await initializeExecutionProgress(db, executionId, totalSteps);
+    await initializeExecutionProgress(db, executionId, nodes, edges);
 
     console.log("[Executor:InProcess] Executing workflow...");
     // Intentional direct call (not start() from workflow/api): the executor and
@@ -112,39 +87,17 @@ export async function executeInProcess(params: {
     console.log(`[Executor:InProcess] Completed in ${duration}ms`);
 
     // executeWorkflow is the authoritative writer of the terminal status (with
-    // reconciliation and richer fields). These updateExecutionStatus calls are
-    // a guarded backstop: the WHERE clause in updateExecutionStatus makes them
-    // a no-op once the engine's own write landed, and only closes the row if
+    // reconciliation and richer fields). applyExecutionResult is a guarded
+    // backstop: the WHERE clause in updateExecutionStatus makes its writes a
+    // no-op once the engine's own write landed, and only closes the row if
     // that write was lost - so a finished run is never left stuck "running".
-    if (result.success) {
-      await updateExecutionStatus(db, executionId, "success", {
-        output: result.outputs,
-      });
-
-      if (scheduleId) {
-        await updateScheduleStatus(db, scheduleId, "success");
-      }
-
-      console.log("[Executor:InProcess] Execution completed successfully");
+    const { errorMessage } = await applyExecutionResult(db, executionId, result, {
+      scheduleId,
+    });
+    if (errorMessage) {
+      console.error("[Executor:InProcess] Workflow execution failed:", errorMessage);
     } else {
-      const errorMessage =
-        result.error ||
-        Object.values(result.results || {}).find((r) => !r.success)?.error ||
-        "Unknown error";
-
-      await updateExecutionStatus(db, executionId, "error", {
-        error: errorMessage,
-        output: result.outputs,
-      });
-
-      if (scheduleId) {
-        await updateScheduleStatus(db, scheduleId, "error", errorMessage);
-      }
-
-      console.error(
-        "[Executor:InProcess] Workflow execution failed:",
-        errorMessage
-      );
+      console.log("[Executor:InProcess] Execution completed successfully");
     }
   } catch (error) {
     const duration = Date.now() - startTime;

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -35,7 +35,6 @@ import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import {
-  organization,
   workflowExecutions,
   workflowSchedules,
   workflows,
@@ -47,7 +46,7 @@ import { buildAttribution } from "../lib/security/request-attribution";
 import { generateId } from "../lib/utils/id";
 import { checkConcurrencyLimit } from "../lib/workflow/concurrency";
 import { hashWorkflowDefinition } from "../lib/workflow/content-hash";
-import { getWorkflowExecutability } from "../lib/workflow/executable";
+import { loadWorkflowForExecution } from "../lib/workflow/load-for-execution";
 import type { WorkflowNode } from "../lib/workflow/store";
 import { type ApiExecuteTriggerType, executeViaApi } from "./api-execute";
 import { checkExecutionLimitForExecutor } from "./billing-guard";
@@ -246,39 +245,28 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
     `[Executor] Processing ${triggerType} trigger for workflow ${workflowId}`
   );
 
-  // Load the workflow and its owning org's deactivation state in one round-trip.
-  const [row] = await db
-    .select()
-    .from(workflows)
-    .leftJoin(organization, eq(organization.id, workflows.organizationId))
-    .where(eq(workflows.id, workflowId))
-    .limit(1);
-  const workflow = row?.workflows;
-
-  if (!workflow) {
-    console.error(`[Executor] Workflow not found: ${workflowId}`);
-    await discardPhantomRow(db, message.executionId);
-    return;
-  }
-
+  // Load the workflow and evaluate its lifecycle state in one round-trip.
   // A soft-deleted, disabled, or deactivated workflow - or one whose owning
   // org is deactivated - must never execute, even if a stale schedule or
   // queued message still references it. The block_executions DB trigger is the
   // INSERT-time backstop; this skips the work before it gets that far. The org
   // owns the workflow, so org deactivation is the owner gate.
-  const executability = getWorkflowExecutability({
-    enabled: workflow.enabled,
-    deletedAt: workflow.deletedAt,
-    deactivatedAt: workflow.deactivatedAt,
-    orgDeactivatedAt: row?.organization?.deactivatedAt ?? null,
+  const loaded = await loadWorkflowForExecution(workflowId, {
+    requireEnabled: true,
   });
-  if (!executability.executable) {
+  if (loaded.status === "not_found") {
+    console.error(`[Executor] Workflow not found: ${workflowId}`);
+    await discardPhantomRow(db, message.executionId);
+    return;
+  }
+  if (loaded.status === "not_executable") {
     console.log(
-      `[Executor] Workflow not executable (${executability.reason}), skipping: ${workflowId}`
+      `[Executor] Workflow not executable (${loaded.reason}), skipping: ${workflowId}`
     );
     await discardPhantomRow(db, message.executionId);
     return;
   }
+  const { workflow } = loaded;
 
   if (triggerType === "schedule") {
     const valid = await validateSchedule(

--- a/keeperhub-executor/lib/db-helpers.ts
+++ b/keeperhub-executor/lib/db-helpers.ts
@@ -7,6 +7,9 @@ import {
   type workflows,
 } from "../../lib/db/schema";
 import type { ErrorCode } from "../../lib/errors/error-codes";
+import { calculateTotalSteps } from "../../lib/workflow/executor/progress";
+import type { WorkflowEdge, WorkflowNode } from "../../lib/workflow/store";
+import type { executeWorkflow } from "../../lib/workflow/executor/executor.workflow";
 import { toJsonSafe } from "./serialize";
 
 export type DbSchema = {
@@ -193,8 +196,10 @@ export async function resolvePhantomToError(
 export async function initializeExecutionProgress(
   db: PostgresJsDatabase<DbSchema>,
   executionId: string,
-  totalSteps: number
+  nodes: WorkflowNode[],
+  edges: WorkflowEdge[]
 ): Promise<void> {
+  const totalSteps = calculateTotalSteps(nodes, edges);
   await db
     .update(workflowExecutions)
     .set({
@@ -207,6 +212,47 @@ export async function initializeExecutionProgress(
       lastSuccessfulNodeName: null,
     })
     .where(eq(workflowExecutions.id, executionId));
+}
+
+type ExecuteWorkflowResult = Awaited<ReturnType<typeof executeWorkflow>>;
+
+/**
+ * Write the terminal execution status (success or error) and optionally update
+ * the associated schedule row. Replaces the identical if/else block that
+ * workflow-runner.ts and in-process.ts both maintained after executeWorkflow().
+ *
+ * Returns the error message string on failure (null on success) so callers can
+ * use it for their own logging without re-deriving it.
+ */
+export async function applyExecutionResult(
+  db: PostgresJsDatabase<DbSchema>,
+  executionId: string,
+  result: ExecuteWorkflowResult,
+  opts: { scheduleId?: string }
+): Promise<{ errorMessage: string | null }> {
+  if (result.success) {
+    await updateExecutionStatus(db, executionId, "success", {
+      output: result.outputs,
+    });
+    if (opts.scheduleId) {
+      await updateScheduleStatus(db, opts.scheduleId, "success");
+    }
+    return { errorMessage: null };
+  }
+
+  const errorMessage =
+    result.error ||
+    Object.values(result.results || {}).find((r) => !r.success)?.error ||
+    "Unknown error";
+
+  await updateExecutionStatus(db, executionId, "error", {
+    error: errorMessage,
+    output: result.outputs,
+  });
+  if (opts.scheduleId) {
+    await updateScheduleStatus(db, opts.scheduleId, "error", errorMessage);
+  }
+  return { errorMessage };
 }
 
 export function computeNextRunTime(

--- a/keeperhub-executor/workflow-runner.ts
+++ b/keeperhub-executor/workflow-runner.ts
@@ -23,23 +23,21 @@
  *   + system credentials from runner-env.ts (ETHERSCAN_API_KEY, etc.)
  */
 
-import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { validateWorkflowIntegrations } from "../lib/db/integrations";
 import {
-  organization,
   workflowExecutions,
   workflowSchedules,
   workflows,
 } from "../lib/db/schema";
-import { getWorkflowExecutability } from "../lib/workflow/executable";
 import { buildExecutorInput } from "../lib/workflow/executor/build-executor-input";
 import { executeWorkflow } from "../lib/workflow/executor/executor.workflow";
-import { calculateTotalSteps } from "../lib/workflow/executor/progress";
 import { SHUTDOWN_TIMEOUT_MS } from "../lib/workflow/executor/runner-constants";
 import type { WorkflowEdge, WorkflowNode } from "../lib/workflow/store";
+import { loadWorkflowForExecution } from "../lib/workflow/load-for-execution";
 import {
+  applyExecutionResult,
   initializeExecutionProgress,
   updateExecutionStatus,
   updateScheduleStatus,
@@ -176,48 +174,26 @@ async function main(): Promise<void> {
 
     await updateExecutionStatus(db, executionId, "running");
 
-    const workflow = await db.query.workflows.findFirst({
-      where: eq(workflows.id, workflowId),
-    });
-
-    if (!workflow) {
-      throw new Error(`Workflow not found: ${workflowId}`);
-    }
-
     // Defensive re-check: the dispatcher already gated lifecycle state, but the
     // workflow could have been disabled, soft-deleted, deactivated, or its
     // owning org deactivated between dispatch and pod startup. Cancel rather
     // than run. The org owns the workflow, so org deactivation is the owner gate.
-    const [org] = await db
-      .select({ deactivatedAt: organization.deactivatedAt })
-      .from(organization)
-      .where(eq(organization.id, workflow.organizationId))
-      .limit(1);
-    const executability = getWorkflowExecutability({
-      enabled: workflow.enabled,
-      deletedAt: workflow.deletedAt,
-      deactivatedAt: workflow.deactivatedAt,
-      orgDeactivatedAt: org?.deactivatedAt ?? null,
+    const loaded = await loadWorkflowForExecution(workflowId, {
+      requireEnabled: true,
     });
-    if (!executability.executable) {
+    if (loaded.status === "not_found") {
+      throw new Error(`Workflow not found: ${workflowId}`);
+    }
+    if (loaded.status === "not_executable") {
       console.log(
-        `[Runner] Workflow not executable (${executability.reason}), skipping execution: ${workflowId}`
+        `[Runner] Workflow not executable (${loaded.reason}), skipping execution: ${workflowId}`
       );
       await updateExecutionStatus(db, executionId, "cancelled");
       return;
     }
 
+    const { workflow, organizationName } = loaded;
     console.log(`[Runner] Loaded workflow: ${workflow.name || workflowId}`);
-
-    let organizationName: string | undefined;
-    if (workflow.organizationId) {
-      const [org] = await db
-        .select({ name: organization.name })
-        .from(organization)
-        .where(eq(organization.id, workflow.organizationId))
-        .limit(1);
-      organizationName = org?.name;
-    }
 
     const nodes = workflow.nodes as WorkflowNode[];
     const edges = workflow.edges as WorkflowEdge[];
@@ -232,9 +208,8 @@ async function main(): Promise<void> {
       );
     }
 
-    const totalSteps = calculateTotalSteps(nodes, edges);
-    console.log(`[Runner] Total steps: ${totalSteps}`);
-    await initializeExecutionProgress(db, executionId, totalSteps);
+    await initializeExecutionProgress(db, executionId, nodes, edges);
+    console.log(`[Runner] Initialized execution progress`);
 
     if (isShuttingDown) {
       console.log("[Runner] Shutdown requested, aborting before execution");
@@ -261,38 +236,18 @@ async function main(): Promise<void> {
     console.log(`[Runner] Success: ${result.success}`);
 
     // executeWorkflow is the authoritative writer of the terminal status (with
-    // reconciliation and richer fields). These updateExecutionStatus calls are
-    // a guarded backstop: the WHERE clause in updateExecutionStatus makes them
-    // a no-op once the engine's own write landed, and only closes the row if
+    // reconciliation and richer fields). applyExecutionResult is a guarded
+    // backstop: the WHERE clause in updateExecutionStatus makes its writes a
+    // no-op once the engine's own write landed, and only closes the row if
     // that write was lost - so a finished run is never left stuck "running".
-    if (result.success) {
-      await updateExecutionStatus(db, executionId, "success", {
-        output: result.outputs,
-      });
-
-      if (scheduleId) {
-        await updateScheduleStatus(db, scheduleId, "success");
-      }
-
-      currentExecutionId = null;
-      console.log("[Runner] Execution completed successfully");
-    } else {
-      const errorMessage =
-        result.error ||
-        Object.values(result.results || {}).find((r) => !r.success)?.error ||
-        "Unknown error";
-
-      await updateExecutionStatus(db, executionId, "error", {
-        error: errorMessage,
-        output: result.outputs,
-      });
-
-      if (scheduleId) {
-        await updateScheduleStatus(db, scheduleId, "error", errorMessage);
-      }
-
-      currentExecutionId = null;
+    const { errorMessage } = await applyExecutionResult(db, executionId, result, {
+      scheduleId,
+    });
+    currentExecutionId = null;
+    if (errorMessage) {
       console.error("[Runner] Workflow execution failed:", errorMessage);
+    } else {
+      console.log("[Runner] Execution completed successfully");
     }
   } catch (error) {
     const duration = Date.now() - startTime;

--- a/lib/db/org-helpers.ts
+++ b/lib/db/org-helpers.ts
@@ -89,6 +89,25 @@ export const getOrgPlanLabel = cache(
 );
 
 /**
+ * Resolve org slug, display name, and plan label in parallel for use as
+ * execution log labels. Replaces the repeated `Promise.all([getOrgSlug,
+ * getOrgPlanLabel])` pattern across the three HTTP-path entry points.
+ * Best-effort: any failed lookup yields undefined for that field.
+ */
+export async function resolveExecutionOrgMetadata(
+  orgId: string | null | undefined
+): Promise<{ slug?: string; name?: string; plan?: string }> {
+  if (!orgId) {
+    return {};
+  }
+  const [identity, plan] = await Promise.all([
+    getOrgIdentity(orgId),
+    getOrgPlanLabel(orgId),
+  ]);
+  return { slug: identity.slug, name: identity.name, plan };
+}
+
+/**
  * Convenience for direct-execute API routes (e.g.
  * /api/execute/check-and-execute) that bypass the workflow executor and
  * therefore don't get its ALS scope. Resolves the org slug and plan and

--- a/lib/workflow/load-for-execution.ts
+++ b/lib/workflow/load-for-execution.ts
@@ -1,0 +1,73 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { organization, workflows } from "@/lib/db/schema";
+import { getWorkflowExecutability } from "@/lib/workflow/executable";
+
+export type LoadWorkflowForExecutionResult =
+  | { status: "not_found" }
+  | {
+      status: "not_executable";
+      reason: "deleted" | "deactivated" | "org_deactivated" | "disabled";
+    }
+  | {
+      status: "ok";
+      workflow: typeof workflows.$inferSelect;
+      organizationName: string | undefined;
+    };
+
+/**
+ * Load a workflow by id and evaluate its lifecycle state in a single round-trip.
+ * Replaces the repeated pattern of findFirst + separate org-deactivation join +
+ * getWorkflowExecutability() that each entry point re-implemented independently.
+ *
+ * `requireEnabled: true` — blocks disabled workflows (automated triggers: webhook,
+ * executor). `requireEnabled: false` — lets disabled through (interactive execute
+ * route, where the editor "Run" button must still work on not-yet-enabled workflows).
+ *
+ * Uses @/lib/db internally (same pattern as validateWorkflowIntegrations, which
+ * the executor already imports). Safe to call from both Next.js routes and the
+ * standalone executor process.
+ */
+export async function loadWorkflowForExecution(
+  id: string,
+  opts: { requireEnabled: boolean }
+): Promise<LoadWorkflowForExecutionResult> {
+  const [row] = await db
+    .select({
+      workflow: workflows,
+      orgDeactivatedAt: organization.deactivatedAt,
+      organizationName: organization.name,
+    })
+    .from(workflows)
+    .leftJoin(organization, eq(organization.id, workflows.organizationId))
+    .where(eq(workflows.id, id))
+    .limit(1);
+
+  if (!row?.workflow) {
+    return { status: "not_found" };
+  }
+
+  const executability = getWorkflowExecutability({
+    enabled: row.workflow.enabled,
+    deletedAt: row.workflow.deletedAt,
+    deactivatedAt: row.workflow.deactivatedAt,
+    orgDeactivatedAt: row.orgDeactivatedAt ?? null,
+  });
+
+  if (!executability.executable) {
+    if (!opts.requireEnabled && executability.reason === "disabled") {
+      return {
+        status: "ok",
+        workflow: row.workflow,
+        organizationName: row.organizationName ?? undefined,
+      };
+    }
+    return { status: "not_executable", reason: executability.reason };
+  }
+
+  return {
+    status: "ok",
+    workflow: row.workflow,
+    organizationName: row.organizationName ?? undefined,
+  };
+}

--- a/tests/integration/execute-route-integration-authz.test.ts
+++ b/tests/integration/execute-route-integration-authz.test.ts
@@ -93,7 +93,9 @@ describe("execute route - per-integration authorization", () => {
       error: "Unauthorized",
       status: 401,
     });
-    mockFindWorkflow.mockResolvedValue(workflow);
+    mockOwnerLimit.mockResolvedValue([
+      { workflow, orgDeactivatedAt: null, organizationName: null },
+    ]);
     mockGetWorkflowAccess.mockResolvedValue({
       isCreatorWithCurrentAccess: false,
       isSameOrg: true,
@@ -153,14 +155,15 @@ describe("execute route - lifecycle executability gate", () => {
       error: "Unauthorized",
       status: 401,
     });
-    mockFindWorkflow.mockResolvedValue(workflow);
+    mockOwnerLimit.mockResolvedValue([
+      { workflow, orgDeactivatedAt: null, organizationName: null },
+    ]);
     mockGetWorkflowAccess.mockResolvedValue({
       isCreatorWithCurrentAccess: false,
       isSameOrg: true,
       hasFullAccess: true,
       isDeleted: false,
     });
-    mockOwnerLimit.mockResolvedValue([{ orgDeactivatedAt: null }]);
     mockGetDualAuthContext.mockResolvedValue({
       userId: "owner_a",
       organizationId: "org_1",
@@ -176,7 +179,9 @@ describe("execute route - lifecycle executability gate", () => {
       caller: "scheduler",
       scheme: "hmac",
     });
-    mockFindWorkflow.mockResolvedValue({ ...workflow, enabled: false });
+    mockOwnerLimit.mockResolvedValue([
+      { workflow: { ...workflow, enabled: false }, orgDeactivatedAt: null, organizationName: null },
+    ]);
 
     const response = await callExecute();
 
@@ -186,7 +191,9 @@ describe("execute route - lifecycle executability gate", () => {
   });
 
   it("allows a disabled workflow on the interactive path (editor test run)", async () => {
-    mockFindWorkflow.mockResolvedValue({ ...workflow, enabled: false });
+    mockOwnerLimit.mockResolvedValue([
+      { workflow: { ...workflow, enabled: false }, orgDeactivatedAt: null, organizationName: null },
+    ]);
     // Force a 403 downstream so we can prove the disabled gate did NOT short
     // -circuit: reaching the integration check means the workflow passed.
     mockValidateWorkflowIntegrations.mockResolvedValue({
@@ -201,7 +208,9 @@ describe("execute route - lifecycle executability gate", () => {
   });
 
   it("blocks a soft-deleted workflow on the interactive path with 404", async () => {
-    mockFindWorkflow.mockResolvedValue({ ...workflow, deletedAt: new Date() });
+    mockOwnerLimit.mockResolvedValue([
+      { workflow: { ...workflow, deletedAt: new Date() }, orgDeactivatedAt: null, organizationName: null },
+    ]);
 
     const response = await callExecute();
 
@@ -210,7 +219,9 @@ describe("execute route - lifecycle executability gate", () => {
   });
 
   it("blocks a deactivated-owner workflow on the interactive path with 404", async () => {
-    mockOwnerLimit.mockResolvedValue([{ orgDeactivatedAt: new Date() }]);
+    mockOwnerLimit.mockResolvedValue([
+      { workflow, orgDeactivatedAt: new Date(), organizationName: null },
+    ]);
 
     const response = await callExecute();
 

--- a/tests/integration/webhook-route.test.ts
+++ b/tests/integration/webhook-route.test.ts
@@ -200,13 +200,14 @@ function createContext(workflowId: string): {
 }
 
 function setupHappyPath(): void {
-  mockWorkflowsFindFirst.mockResolvedValue(webhookWorkflow);
+  mockOrgGateLimit.mockResolvedValue([
+    { workflow: webhookWorkflow, orgDeactivatedAt: null, organizationName: null },
+  ]);
   mockApiKeysFindFirst.mockResolvedValue({
     id: "key-1",
     userId: OWNER_USER_ID,
     keyHash: VALID_KEY_HASH,
   });
-  mockOrgGateLimit.mockResolvedValue([{ orgDeactivatedAt: null }]);
   mockMemberLimit.mockResolvedValue([{ id: "member-1" }]);
   mockValidateIntegrations.mockResolvedValue({ valid: true });
   mockEnforceExecutionLimit.mockResolvedValue({ blocked: false });
@@ -219,13 +220,19 @@ function setupHappyPath(): void {
 describe("POST /api/workflows/:workflowId/webhook", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockOrgGateLimit.mockResolvedValue([{ orgDeactivatedAt: null }]);
+    // loadWorkflowForExecution now returns the workflow + org data in a single
+    // left-join query (db.select().from(workflows).leftJoin(organization)).
+    // The mock for that chain is mockOrgGateLimit; it must include the workflow
+    // field so the helper recognises a found row.
+    mockOrgGateLimit.mockResolvedValue([
+      { workflow: webhookWorkflow, orgDeactivatedAt: null, organizationName: null },
+    ]);
     mockMemberLimit.mockResolvedValue([{ id: "member-1" }]);
   });
 
   describe("workflow lookup", () => {
     it("should return 404 when workflow not found", async () => {
-      mockWorkflowsFindFirst.mockResolvedValue(null);
+      mockOrgGateLimit.mockResolvedValue([]);
 
       const response = await POST(
         createWebhookRequest(VALID_API_KEY),
@@ -239,7 +246,9 @@ describe("POST /api/workflows/:workflowId/webhook", () => {
 
   describe("disabled workflow", () => {
     it("should return 410 Gone when workflow.enabled is false", async () => {
-      mockWorkflowsFindFirst.mockResolvedValue(disabledWebhookWorkflow);
+      mockOrgGateLimit.mockResolvedValue([
+        { workflow: disabledWebhookWorkflow, orgDeactivatedAt: null, organizationName: null },
+      ]);
 
       const response = await POST(
         createWebhookRequest(VALID_API_KEY),
@@ -251,7 +260,9 @@ describe("POST /api/workflows/:workflowId/webhook", () => {
     });
 
     it("should not validate API key for a disabled workflow", async () => {
-      mockWorkflowsFindFirst.mockResolvedValue(disabledWebhookWorkflow);
+      mockOrgGateLimit.mockResolvedValue([
+        { workflow: disabledWebhookWorkflow, orgDeactivatedAt: null, organizationName: null },
+      ]);
 
       await POST(
         createWebhookRequest(VALID_API_KEY),
@@ -264,10 +275,10 @@ describe("POST /api/workflows/:workflowId/webhook", () => {
 
   describe("deactivated owner", () => {
     it("should return 404 when the workflow owner is deactivated", async () => {
-      mockWorkflowsFindFirst.mockResolvedValue(webhookWorkflow);
-      // The org gate is the first db.select() the route makes; return a
-      // deactivated org so the executability gate rejects before auth.
-      mockOrgGateLimit.mockResolvedValue([{ orgDeactivatedAt: new Date() }]);
+      // Return a deactivated org so the executability gate rejects before auth.
+      mockOrgGateLimit.mockResolvedValue([
+        { workflow: webhookWorkflow, orgDeactivatedAt: new Date(), organizationName: null },
+      ]);
 
       const response = await POST(
         createWebhookRequest(VALID_API_KEY),
@@ -382,7 +393,9 @@ describe("POST /api/workflows/:workflowId/webhook", () => {
 
   describe("webhook trigger validation", () => {
     it("should return 400 when workflow is not webhook-triggered", async () => {
-      mockWorkflowsFindFirst.mockResolvedValue(manualWorkflow);
+      mockOrgGateLimit.mockResolvedValue([
+        { workflow: manualWorkflow, orgDeactivatedAt: null, organizationName: null },
+      ]);
       mockApiKeysFindFirst.mockResolvedValue({
         id: "key-1",
         userId: OWNER_USER_ID,

--- a/tests/unit/apply-execution-result.test.ts
+++ b/tests/unit/apply-execution-result.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../lib/db/schema", () => ({
+  workflows: {},
+  workflowExecutions: {
+    id: "workflowExecutions.id",
+    status: "workflowExecutions.status",
+  },
+  workflowSchedules: {
+    id: "workflowSchedules.id",
+    intervalSeconds: "workflowSchedules.intervalSeconds",
+    anchorAt: "workflowSchedules.anchorAt",
+    cronExpression: "workflowSchedules.cronExpression",
+    timezone: "workflowSchedules.timezone",
+    runCount: "workflowSchedules.runCount",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: () => ({}),
+  and: () => ({}),
+  ne: () => ({}),
+  inArray: () => ({}),
+}));
+
+vi.mock("cron-parser", () => ({
+  CronExpressionParser: {
+    parse: vi.fn().mockReturnValue({
+      next: vi.fn().mockReturnValue({
+        toDate: vi.fn().mockReturnValue(new Date("2025-06-01T00:00:00Z")),
+      }),
+    }),
+  },
+}));
+
+vi.mock("../../lib/workflow/executor/progress", () => ({
+  calculateTotalSteps: vi.fn().mockReturnValue(3),
+}));
+
+vi.mock("../../lib/workflow/store", () => ({}));
+
+vi.mock("../../lib/errors/error-codes", () => ({}));
+
+vi.mock("../../keeperhub-executor/lib/serialize", () => ({
+  toJsonSafe: (v: unknown) => v,
+}));
+
+import { applyExecutionResult } from "../../keeperhub-executor/lib/db-helpers";
+import type { DbSchema } from "../../keeperhub-executor/lib/db-helpers";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+
+function makeMockDb(
+  scheduleRow?: object | null
+): PostgresJsDatabase<DbSchema> {
+  const mockWhere = vi.fn().mockResolvedValue([]);
+  const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
+  const mockUpdate = vi.fn().mockReturnValue({ set: mockSet });
+  const mockFindFirst = vi.fn().mockResolvedValue(
+    scheduleRow !== undefined
+      ? scheduleRow
+      : {
+          id: "sched-1",
+          cronExpression: "0 * * * *",
+          timezone: "UTC",
+          intervalSeconds: null,
+          anchorAt: null,
+          runCount: "5",
+        }
+  );
+
+  return {
+    update: mockUpdate,
+    query: {
+      workflowSchedules: { findFirst: mockFindFirst },
+    },
+  } as unknown as PostgresJsDatabase<DbSchema>;
+}
+
+type MockDb = ReturnType<typeof makeMockDb> & {
+  query: { workflowSchedules: { findFirst: ReturnType<typeof vi.fn> } };
+};
+
+const SUCCESS_RESULT = {
+  success: true,
+  results: {},
+  outputs: { "step-1": { label: "Result", data: "done" } },
+} as unknown as Awaited<ReturnType<typeof import("../../lib/workflow/executor/executor.workflow").executeWorkflow>>;
+
+const FAILURE_RESULT = {
+  success: false,
+  results: {},
+  outputs: {},
+  error: "Step failed: timeout",
+} as unknown as Awaited<ReturnType<typeof import("../../lib/workflow/executor/executor.workflow").executeWorkflow>>;
+
+const FAILURE_RESULT_FROM_STEP = {
+  success: false,
+  results: {
+    "step-1": { success: false, error: "Contract reverted" },
+    "step-2": { success: true },
+  },
+  outputs: {},
+} as unknown as Awaited<ReturnType<typeof import("../../lib/workflow/executor/executor.workflow").executeWorkflow>>;
+
+describe("applyExecutionResult", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("successful execution", () => {
+    it("returns null errorMessage on success", async () => {
+      const db = makeMockDb(null);
+      const result = await applyExecutionResult(db, "exec-1", SUCCESS_RESULT, {});
+      expect(result.errorMessage).toBeNull();
+    });
+
+    it("does not call updateScheduleStatus when no scheduleId", async () => {
+      const db = makeMockDb(null) as MockDb;
+      await applyExecutionResult(db, "exec-1", SUCCESS_RESULT, {});
+      expect(db.query.workflowSchedules.findFirst).not.toHaveBeenCalled();
+    });
+
+    it("calls updateScheduleStatus when scheduleId is provided", async () => {
+      const db = makeMockDb() as MockDb;
+      await applyExecutionResult(db, "exec-1", SUCCESS_RESULT, {
+        scheduleId: "sched-1",
+      });
+      expect(db.query.workflowSchedules.findFirst).toHaveBeenCalled();
+    });
+  });
+
+  describe("failed execution", () => {
+    it("returns the top-level error message from result.error", async () => {
+      const db = makeMockDb(null);
+      const result = await applyExecutionResult(db, "exec-1", FAILURE_RESULT, {});
+      expect(result.errorMessage).toBe("Step failed: timeout");
+    });
+
+    it("falls back to step-level error when result.error is absent", async () => {
+      const db = makeMockDb(null);
+      const result = await applyExecutionResult(
+        db,
+        "exec-1",
+        FAILURE_RESULT_FROM_STEP,
+        {}
+      );
+      expect(result.errorMessage).toBe("Contract reverted");
+    });
+
+    it("falls back to 'Unknown error' when no error field is present", async () => {
+      const db = makeMockDb(null);
+      const noErrorResult = {
+        success: false,
+        results: {},
+        outputs: {},
+      } as unknown as Awaited<ReturnType<typeof import("../../lib/workflow/executor/executor.workflow").executeWorkflow>>;
+      const result = await applyExecutionResult(db, "exec-1", noErrorResult, {});
+      expect(result.errorMessage).toBe("Unknown error");
+    });
+
+    it("calls updateScheduleStatus when scheduleId is provided on failure", async () => {
+      const db = makeMockDb() as MockDb;
+      await applyExecutionResult(db, "exec-1", FAILURE_RESULT, {
+        scheduleId: "sched-1",
+      });
+      expect(db.query.workflowSchedules.findFirst).toHaveBeenCalled();
+    });
+
+    it("does not call updateScheduleStatus when scheduleId is absent on failure", async () => {
+      const db = makeMockDb(null) as MockDb;
+      await applyExecutionResult(db, "exec-1", FAILURE_RESULT, {});
+      expect(db.query.workflowSchedules.findFirst).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/load-for-execution.test.ts
+++ b/tests/unit/load-for-execution.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let mockDbRows: unknown[] = [];
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        leftJoin: () => ({
+          where: () => ({
+            limit: () => Promise.resolve(mockDbRows),
+          }),
+        }),
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflows: {
+    id: "workflows.id",
+    organizationId: "workflows.organizationId",
+  },
+  organization: {
+    id: "organization.id",
+    deactivatedAt: "organization.deactivatedAt",
+    name: "organization.name",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: () => ({}),
+}));
+
+const mockGetWorkflowExecutability = vi.fn();
+vi.mock("@/lib/workflow/executable", () => ({
+  getWorkflowExecutability: (...args: unknown[]) =>
+    mockGetWorkflowExecutability(...args),
+}));
+
+import { loadWorkflowForExecution } from "@/lib/workflow/load-for-execution";
+
+const WORKFLOW = {
+  id: "wf-1",
+  enabled: true,
+  deletedAt: null,
+  deactivatedAt: null,
+  organizationId: "org-1",
+  userId: "user-1",
+  name: "Test Workflow",
+  nodes: [],
+  edges: [],
+  chain: null,
+};
+
+beforeEach(() => {
+  mockDbRows = [];
+  vi.clearAllMocks();
+});
+
+describe("loadWorkflowForExecution", () => {
+  it("returns not_found when db returns no row", async () => {
+    mockDbRows = [];
+    const result = await loadWorkflowForExecution("wf-1", {
+      requireEnabled: true,
+    });
+    expect(result).toEqual({ status: "not_found" });
+  });
+
+  it("returns not_found when row has no workflow (null left-join result)", async () => {
+    mockDbRows = [{ workflow: null, orgDeactivatedAt: null, organizationName: null }];
+    const result = await loadWorkflowForExecution("wf-1", {
+      requireEnabled: true,
+    });
+    expect(result).toEqual({ status: "not_found" });
+  });
+
+  it("returns ok with workflow and organizationName when executable", async () => {
+    mockDbRows = [
+      { workflow: WORKFLOW, orgDeactivatedAt: null, organizationName: "Test Org" },
+    ];
+    mockGetWorkflowExecutability.mockReturnValue({ executable: true });
+    const result = await loadWorkflowForExecution("wf-1", {
+      requireEnabled: true,
+    });
+    expect(result).toEqual({
+      status: "ok",
+      workflow: WORKFLOW,
+      organizationName: "Test Org",
+    });
+  });
+
+  it("returns ok with undefined organizationName when org name is null", async () => {
+    mockDbRows = [
+      { workflow: WORKFLOW, orgDeactivatedAt: null, organizationName: null },
+    ];
+    mockGetWorkflowExecutability.mockReturnValue({ executable: true });
+    const result = await loadWorkflowForExecution("wf-1", {
+      requireEnabled: true,
+    });
+    expect(result).toEqual({
+      status: "ok",
+      workflow: WORKFLOW,
+      organizationName: undefined,
+    });
+  });
+
+  it("returns not_executable with reason deleted", async () => {
+    mockDbRows = [
+      { workflow: WORKFLOW, orgDeactivatedAt: null, organizationName: null },
+    ];
+    mockGetWorkflowExecutability.mockReturnValue({
+      executable: false,
+      reason: "deleted",
+    });
+    const result = await loadWorkflowForExecution("wf-1", {
+      requireEnabled: true,
+    });
+    expect(result).toEqual({ status: "not_executable", reason: "deleted" });
+  });
+
+  it("returns not_executable with reason deactivated", async () => {
+    mockDbRows = [
+      { workflow: WORKFLOW, orgDeactivatedAt: null, organizationName: null },
+    ];
+    mockGetWorkflowExecutability.mockReturnValue({
+      executable: false,
+      reason: "deactivated",
+    });
+    const result = await loadWorkflowForExecution("wf-1", {
+      requireEnabled: true,
+    });
+    expect(result).toEqual({ status: "not_executable", reason: "deactivated" });
+  });
+
+  it("returns not_executable with reason org_deactivated", async () => {
+    mockDbRows = [
+      {
+        workflow: WORKFLOW,
+        orgDeactivatedAt: new Date(),
+        organizationName: null,
+      },
+    ];
+    mockGetWorkflowExecutability.mockReturnValue({
+      executable: false,
+      reason: "org_deactivated",
+    });
+    const result = await loadWorkflowForExecution("wf-1", {
+      requireEnabled: true,
+    });
+    expect(result).toEqual({
+      status: "not_executable",
+      reason: "org_deactivated",
+    });
+  });
+
+  describe("disabled workflow", () => {
+    beforeEach(() => {
+      mockDbRows = [
+        { workflow: WORKFLOW, orgDeactivatedAt: null, organizationName: "Org" },
+      ];
+      mockGetWorkflowExecutability.mockReturnValue({
+        executable: false,
+        reason: "disabled",
+      });
+    });
+
+    it("returns not_executable when requireEnabled is true (automated trigger)", async () => {
+      const result = await loadWorkflowForExecution("wf-1", {
+        requireEnabled: true,
+      });
+      expect(result).toEqual({ status: "not_executable", reason: "disabled" });
+    });
+
+    it("returns ok when requireEnabled is false (interactive editor run)", async () => {
+      const result = await loadWorkflowForExecution("wf-1", {
+        requireEnabled: false,
+      });
+      expect(result).toEqual({
+        status: "ok",
+        workflow: WORKFLOW,
+        organizationName: "Org",
+      });
+    });
+  });
+
+  it("passes orgDeactivatedAt from the left-join row to getWorkflowExecutability", async () => {
+    const orgDeactivatedAt = new Date("2025-01-01");
+    mockDbRows = [
+      { workflow: WORKFLOW, orgDeactivatedAt, organizationName: null },
+    ];
+    mockGetWorkflowExecutability.mockReturnValue({ executable: true });
+    await loadWorkflowForExecution("wf-1", { requireEnabled: true });
+    expect(mockGetWorkflowExecutability).toHaveBeenCalledWith(
+      expect.objectContaining({ orgDeactivatedAt })
+    );
+  });
+
+  it("coerces null orgDeactivatedAt to null in the executability call", async () => {
+    mockDbRows = [
+      { workflow: WORKFLOW, orgDeactivatedAt: null, organizationName: null },
+    ];
+    mockGetWorkflowExecutability.mockReturnValue({ executable: true });
+    await loadWorkflowForExecution("wf-1", { requireEnabled: true });
+    expect(mockGetWorkflowExecutability).toHaveBeenCalledWith(
+      expect.objectContaining({ orgDeactivatedAt: null })
+    );
+  });
+});

--- a/tests/unit/org-helpers-resolve-metadata.test.ts
+++ b/tests/unit/org-helpers-resolve-metadata.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// cache() from React relies on AsyncLocalStorage context that doesn't exist
+// in Vitest. Replace with a plain identity wrapper so the cached functions
+// behave as regular async functions here.
+vi.mock("react", () => ({
+  cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
+}));
+
+let mockSelectRows: unknown[] = [];
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve(mockSelectRows),
+        }),
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  organization: {
+    id: "organization.id",
+    slug: "organization.slug",
+    name: "organization.name",
+    deactivatedAt: "organization.deactivatedAt",
+  },
+  organizationSubscriptions: {
+    organizationId: "organizationSubscriptions.organizationId",
+    plan: "organizationSubscriptions.plan",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: () => ({}),
+}));
+
+vi.mock("@/lib/errors/workflow-error-context", () => ({
+  enterWorkflowErrorContext: vi.fn(),
+}));
+
+import { resolveExecutionOrgMetadata } from "@/lib/db/org-helpers";
+
+beforeEach(() => {
+  mockSelectRows = [];
+  vi.clearAllMocks();
+});
+
+describe("resolveExecutionOrgMetadata", () => {
+  it("returns empty object when orgId is null", async () => {
+    const result = await resolveExecutionOrgMetadata(null);
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object when orgId is undefined", async () => {
+    const result = await resolveExecutionOrgMetadata(undefined);
+    expect(result).toEqual({});
+  });
+
+  it("returns slug, name, and plan when all fields are present", async () => {
+    mockSelectRows = [
+      { slug: "my-org", name: "My Organization", plan: "pro" },
+    ];
+    const result = await resolveExecutionOrgMetadata("org-1");
+    expect(result.slug).toBe("my-org");
+    expect(result.name).toBe("My Organization");
+    expect(result.plan).toBe("pro");
+  });
+
+  it("returns undefined slug/name and 'free' plan when db returns no row", async () => {
+    mockSelectRows = [];
+    const result = await resolveExecutionOrgMetadata("org-1");
+    // getOrgIdentity yields {} (no row), getOrgPlanLabel yields "free" (no subscription defaults to free)
+    expect(result).toEqual({ slug: undefined, name: undefined, plan: "free" });
+  });
+
+  it("returns partial result when only some fields are populated", async () => {
+    mockSelectRows = [{ slug: "partial-org", name: null, plan: null }];
+    const result = await resolveExecutionOrgMetadata("org-1");
+    expect(result.slug).toBe("partial-org");
+  });
+
+  it("does not throw when the underlying db query rejects", async () => {
+    const { db } = await import("@/lib/db");
+    vi.spyOn(db, "select").mockImplementationOnce(() => {
+      throw new Error("db error");
+    });
+    const result = await resolveExecutionOrgMetadata("org-1");
+    expect(result).toMatchObject({});
+  });
+});


### PR DESCRIPTION
## Summary

Eliminates the duplicated orchestration shell each execution entry point re-implemented around the shared `executeWorkflow` engine. Four composable helpers extracted — each independently testable — consumed by all relevant entry points in their own call sequence.

## Changes

- **`lib/workflow/load-for-execution.ts`** (new) — `loadWorkflowForExecution(id, { requireEnabled })`: single left-join query replacing the repeated `findFirst` + separate org-deactivation join + `getWorkflowExecutability()` pattern across 5 entry points. `requireEnabled: false` lets disabled workflows through for interactive editor runs; `true` blocks them for automated triggers.

- **`lib/db/org-helpers.ts`** — new `resolveExecutionOrgMetadata(orgId)` export replacing the identical `Promise.all([getOrgSlug, getOrgPlanLabel])` pattern in 3 HTTP routes. Also surfaces `organizationName` via `getOrgIdentity` at no extra round-trip.

- **`keeperhub-executor/lib/db-helpers.ts`** — `initializeExecutionProgress` signature updated to accept `(nodes, edges)` directly (absorbs `calculateTotalSteps` internally); new `applyExecutionResult` export replacing the identical success/error DB-write if/else block in the two direct-invocation paths.

- **Entry points updated** (no behavior change):
  - `app/api/workflow/[workflowId]/execute/route.ts` — helpers 1 + 2
  - `app/api/workflows/[workflowId]/webhook/route.ts` — helpers 1 + 2
  - `app/api/mcp/workflows/[slug]/call/route.ts` — helper 2 (`startExecutionInBackground`)
  - `keeperhub-executor/workflow-runner.ts` — helpers 1 + 3 + 4
  - `keeperhub-executor/in-process.ts` — helpers 1 + 3 + 4 (also fixes missing `updateScheduleStatus` import in catch block)
  - `keeperhub-executor/index.ts` — helper 1

- **Tests** — 25 new unit tests across 3 files: `load-for-execution`, `apply-execution-result`, `org-helpers-resolve-metadata`.

## Test Plan

- [x] `pnpm type-check` — no errors in modified files
- [x] `pnpm test tests/unit/load-for-execution.test.ts tests/unit/apply-execution-result.test.ts tests/unit/org-helpers-resolve-metadata.test.ts` — 25/25 pass
- [x] Full unit suite (`pnpm test tests/unit/`) — no regressions
- [x] `pnpm test tests/integration/workflow-runner.test.ts` — 18/18 pass