### PR TITLE
ci: remove self-hosted runner path from image build

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && 'arc-keeperhub-build' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
     outputs:
       image_tag: ${{ steps.vars.outputs.sha_short }}
@@ -131,7 +131,7 @@ jobs:
           exit 1
 
       - name: Free runner disk space
-        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.USE_SELF_HOSTED_RUNNERS != 'true'
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
@@ -142,15 +142,8 @@ jobs:
           docker-images: false
           swap-storage: false
 
-      - name: Set up Docker Buildx (remote)
-        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.USE_SELF_HOSTED_RUNNERS == 'true'
-        uses: docker/setup-buildx-action@v4
-        with:
-          driver: remote
-          endpoint: ${{ vars.BUILDKITD_ENDPOINT }}
-
       - name: Set up Docker Buildx
-        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.USE_SELF_HOSTED_RUNNERS != 'true'
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
         uses: docker/setup-buildx-action@v4
 
       # Persist the Next.js incremental-compile cache (.next/cache) across runs.
@@ -162,7 +155,7 @@ jobs:
       # environment so staging and prod never share a lineage.
       - name: Restore Next.js build cache
         id: next-cache
-        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.USE_SELF_HOSTED_RUNNERS != 'true'
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
         uses: actions/cache@v5
         with:
           path: .next-cache
@@ -172,7 +165,7 @@ jobs:
             next-build-cache-${{ env.ENVIRONMENT_TAG }}-
 
       - name: Inject Next.js build cache into BuildKit
-        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && vars.USE_SELF_HOSTED_RUNNERS != 'true'
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
         uses: reproducible-containers/buildkit-cache-dance@v3
         with:
           cache-map: |


### PR DESCRIPTION
## What

The self-hosted ARC runners and the warm in-cluster buildkitd remote builder on techops-staging have been torn down. This removes the now-dead path from the image build workflow.

## Changes (`build-images.yml`)
- `runs-on` pinned to `ubuntu-latest` (was a `USE_SELF_HOSTED_RUNNERS` ternary).
- Removed the `Set up Docker Buildx (remote)` step (remote buildkitd endpoint).
- Dropped the `USE_SELF_HOSTED_RUNNERS != 'true'` guard from the free-disk and Next.js cache steps - they always run on the GitHub-hosted path now.

## Kept
The GitHub-hosted optimizations stay: free runner disk space, persisted Next.js `.next/cache` (actions/cache + buildkit-cache-dance), and compile-once via the shared bake builder.

`actionlint` passes clean. No application code touched.