### PR TITLE
ci: migrate AWS authentication from static keys to OIDC

### DIFF
--- a/.github/workflows/build-docs-image.yml
+++ b/.github/workflows/build-docs-image.yml
@@ -21,6 +21,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build:
@@ -54,8 +55,7 @@ jobs:
         if: ${{ inputs.push }}
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
       - name: Login to AWS ECR

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build:
@@ -75,8 +76,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
       - name: Login to AWS ECR

--- a/.github/workflows/cleanup-pr-environment.yaml
+++ b/.github/workflows/cleanup-pr-environment.yaml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   check-cleanup:
@@ -42,6 +43,7 @@ jobs:
   cleanup:
     permissions:
       contents: read
+      id-token: write
       pull-requests: write # actions/github-script posts PR comments
     needs: check-cleanup
     if: needs.check-cleanup.outputs.should-cleanup == 'true'
@@ -57,8 +59,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
       - name: Configure kubectl

--- a/.github/workflows/deploy-events.yaml
+++ b/.github/workflows/deploy-events.yaml
@@ -51,8 +51,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
       - name: Login to AWS ECR

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -17,6 +17,10 @@ on:
 
 name: deploy-keeperhub
 
+permissions:
+  contents: read
+  id-token: write
+
 # Serialize app deploys per target so two near-simultaneous pushes to the same
 # branch never run `helm upgrade` against the same release at once. Without this
 # the second run fails with "another operation (install/upgrade/rollback) is in
@@ -54,8 +58,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
       - name: Login to AWS ECR
@@ -191,9 +194,6 @@ jobs:
             --region us-east-2)
           echo "::add-mask::$TEST_API_KEY"
           echo "TEST_API_KEY=$TEST_API_KEY" >> "$GITHUB_ENV"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
 
       - name: Wait for deployment to be ready
         run: |

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   check-labels:
@@ -195,8 +196,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
       - name: Login to AWS ECR
@@ -273,8 +273,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
       - name: Login to AWS ECR
@@ -325,8 +324,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
       - name: Login to AWS ECR
@@ -398,8 +396,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
       - name: Login to AWS ECR
@@ -448,6 +445,7 @@ jobs:
   deploy:
     permissions:
       contents: read
+      id-token: write
       pull-requests: write # actions/github-script posts PR comments
     needs:
       [
@@ -490,8 +488,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
       - name: Login to AWS ECR
@@ -990,8 +987,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
       - name: Login to AWS ECR
@@ -1067,8 +1063,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
       - name: Configure kubectl
@@ -1167,6 +1162,7 @@ jobs:
   e2e-playwright-remote:
     permissions:
       contents: read
+      id-token: write
       pull-requests: write # actions/github-script posts PR comments
     needs: [check-labels, deploy]
     if: >-
@@ -1197,8 +1193,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
       - name: Configure kubectl

--- a/.github/workflows/deploy-sandbox.yaml
+++ b/.github/workflows/deploy-sandbox.yaml
@@ -60,8 +60,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
       - name: Login to AWS ECR

--- a/.github/workflows/sandbox-escape-matrix.yaml
+++ b/.github/workflows/sandbox-escape-matrix.yaml
@@ -84,8 +84,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
       - name: Configure kubectl


### PR DESCRIPTION
## Summary

- Replaces `TO_AWS_ACCESS_KEY_ID` / `TO_AWS_SECRET_ACCESS_KEY` static credential pairs in all 8 deploy and build workflows with `role-to-assume: ${{ vars.AWS_ROLE_ARN }}`
- Adds `id-token: write` permission where absent (`build-docs-image.yml`, `build-images.yml`, `deploy-keeperhub.yaml`, `deploy-pr-environment.yaml`, `cleanup-pr-environment.yaml`)
- The `AWS_ROLE_ARN` repository variable must be set to the IAM role ARN from the companion infrastructure PR before any workflow run will succeed

## Workflows changed

- `build-docs-image.yml`
- `build-images.yml`
- `deploy-keeperhub.yaml`
- `deploy-events.yaml`
- `deploy-sandbox.yaml`
- `sandbox-escape-matrix.yaml`
- `deploy-pr-environment.yaml`
- `cleanup-pr-environment.yaml`

## Prerequisites

1. Merge and apply the companion infrastructure PR (creates the OIDC provider + IAM role)
2. Set `AWS_ROLE_ARN` as a repository Actions variable in `KeeperHub/keeperhub` pointing to the `github_oidc_eks_keeperhub_arn` output

## Test plan

- After prerequisites are met, push to `staging` and confirm the `Configure AWS credentials` step logs `Assuming role with OIDC` instead of `Configuring credentials from environment`
- Verify a full deploy to staging completes successfully
- Open a PR with the `deploy-pr-environment` label to test the PR environment path
