### PR TITLE
ci: migrate remaining workflows to OIDC authentication

### DIFF
--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -21,12 +21,8 @@ inputs:
     description: 'AWS region for ECR'
     required: false
     default: ''
-  aws_access_key_id:
-    description: 'AWS access key ID (for ECR login)'
-    required: false
-    default: ''
-  aws_secret_access_key:
-    description: 'AWS secret access key (for ECR login)'
+  role_arn:
+    description: 'IAM role ARN to assume via OIDC (for ECR login)'
     required: false
     default: ''
   database_url:
@@ -104,8 +100,7 @@ runs:
       if: inputs.image_tag != ''
       uses: aws-actions/configure-aws-credentials@v6
       with:
-        aws-access-key-id: ${{ inputs.aws_access_key_id }}
-        aws-secret-access-key: ${{ inputs.aws_secret_access_key }}
+        role-to-assume: ${{ inputs.role_arn }}
         aws-region: ${{ inputs.ecr_region }}
 
     - name: Login to AWS ECR

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -18,6 +18,7 @@ name: deploy-keeperhub-docs
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build:
@@ -45,8 +46,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
       - name: Replace variables in the Helm values file

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -48,6 +48,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   should-run:
@@ -198,8 +199,7 @@ jobs:
           ecr_registry: ${{ inputs.ecr_registry }}
           ecr_repo: ${{ inputs.ecr_repo }}
           ecr_region: ${{ inputs.ecr_region }}
-          aws_access_key_id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          role_arn: ${{ vars.AWS_ROLE_ARN }}
           database_url: postgresql://postgres:postgres@localhost:5432/keeperhub_test
           better_auth_secret: ${{ secrets.BETTER_AUTH_SECRET }}
           test_api_key: ${{ secrets.TEST_API_KEY }}
@@ -343,8 +343,7 @@ jobs:
           ecr_registry: ${{ inputs.ecr_registry }}
           ecr_repo: ${{ inputs.ecr_repo }}
           ecr_region: ${{ inputs.ecr_region }}
-          aws_access_key_id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          role_arn: ${{ vars.AWS_ROLE_ARN }}
           database_url: postgresql://postgres:postgres@localhost:5432/keeperhub_test
           better_auth_secret: ${{ secrets.BETTER_AUTH_SECRET }}
           test_api_key: ${{ secrets.TEST_API_KEY }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  id-token: write
 
 jobs:
   migrate-check:
@@ -213,8 +214,7 @@ jobs:
         if: steps.changes.outputs.relevant == 'true' && github.actor != 'dependabot[bot]'
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.TO_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TO_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.TO_REGION }}
 
       - name: Login to AWS ECR


### PR DESCRIPTION
Completes the OIDC migration started in #1658. Some workflows and the `start-app` composite action were intentionally missed in the initial pass.

After this PR there are zero references to `TO_AWS_ACCESS_KEY_ID` or `TO_AWS_SECRET_ACCESS_KEY` anywhere in `.github/`.