### PR TITLE
fix: handle-aware routing for recovered condition nodes in parallel OR-joins

### DIFF
--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -2499,8 +2499,74 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     }
   }
 
+  /**
+   * Continue execution downstream of a condition node, honoring the taken
+   * handle and propagating skips on the not-taken handle. Shared by the normal
+   * post-step path and the spurious-completion recovery path so a recovered
+   * condition routes exactly like one that completed normally. Routing a
+   * condition through `edgesBySource` instead fires the not-taken edge (e.g. a
+   * `false`-handle OR-join) on a branch that should have been skipped.
+   */
+  async function continueFromCondition(
+    nodeId: string,
+    conditionResult: boolean | undefined,
+    visited: Set<string>
+  ): Promise<void> {
+    const handleMap = edgesBySourceHandle.get(nodeId);
+    if (!handleMap) {
+      // Legacy fallback: no sourceHandle on edges, use old gate behavior
+      if (conditionResult === true) {
+        const nextNodes = edgesBySource.get(nodeId) ?? [];
+        await executeReadyDownstream(nodeId, nextNodes, visited);
+      }
+      return;
+    }
+
+    // Handle-aware routing: use the taken handle to determine targets
+    const handleId = conditionResult === true ? "true" : "false";
+    const notTakenHandle = conditionResult === true ? "false" : "true";
+    const handleTargets = handleMap.get(handleId) ?? [];
+
+    // Record decision for branch-aware finalSuccess
+    conditionDecisions.set(nodeId, {
+      taken: handleId,
+      skippedTargets: collectSkippedTargets(
+        nodeId,
+        notTakenHandle,
+        edgesBySourceHandle
+      ),
+      takenTargets: handleTargets,
+    });
+    await executeReadyDownstream(nodeId, handleTargets, visited);
+
+    // Propagate skip signals for the not-taken branch so convergence nodes
+    // downstream receive arrival signals from skipped sources. A convergence
+    // node runs only if it also got a real arrival; if every incoming edge was
+    // skipped it is added to `skippedNodes` and the skip continues downstream.
+    // This both unblocks genuine convergence and stops an all-skipped OR-join
+    // from firing.
+    const skippedTargets = handleMap.get(notTakenHandle) ?? [];
+    if (skippedTargets.length > 0) {
+      const unblockedIds = propagateConvergenceSkips(
+        nodeId,
+        skippedTargets,
+        edgesBySource,
+        edgesByTarget,
+        convergenceArrivals,
+        convergenceSkipArrivals,
+        skippedNodes,
+        visited
+      );
+      if (unblockedIds.length > 0) {
+        const settled = await pendingTasks.track(
+          Promise.allSettled(unblockedIds.map((id) => executeNode(id, visited)))
+        );
+        processSettledResults(settled, unblockedIds);
+      }
+    }
+  }
+
   // Helper to execute a single node
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Node execution requires type checking and error handling
   async function executeNode(nodeId: string, visited: Set<string> = new Set()) {
     console.log("[Workflow Executor] Executing node:", nodeId);
 
@@ -2856,63 +2922,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           // For condition nodes, route to true/false handle targets
           const conditionResult = (result.data as { condition?: boolean })
             ?.condition;
-
-          const handleMap = edgesBySourceHandle.get(nodeId);
-          if (handleMap) {
-            // Handle-aware routing: use sourceHandle to determine targets
-            const handleId = conditionResult === true ? "true" : "false";
-            const notTakenHandle = conditionResult === true ? "false" : "true";
-            const handleTargets = handleMap.get(handleId) ?? [];
-
-            // Record decision for branch-aware finalSuccess
-            conditionDecisions.set(nodeId, {
-              taken: handleId,
-              skippedTargets: collectSkippedTargets(
-                nodeId,
-                notTakenHandle,
-                edgesBySourceHandle
-              ),
-              takenTargets: handleTargets,
-            });
-            await executeReadyDownstream(nodeId, handleTargets, visited);
-
-            // Propagate skip signals for the not-taken branch so convergence
-            // nodes downstream receive arrival signals from skipped sources
-            const skippedTargets = handleMap.get(notTakenHandle) ?? [];
-            if (skippedTargets.length > 0) {
-              // Walk the not-taken subtree, recording skip-arrivals at
-              // convergence nodes. A convergence node runs only if it also got
-              // a real arrival; if every incoming edge was skipped it is added
-              // to `skippedNodes` and the skip continues downstream. This both
-              // unblocks genuine convergence (e.g. `Cond -> (skipped) -> nodeB`
-              // and `Cond -> (taken) -> X -> nodeB`) and stops an all-skipped
-              // OR-join from firing.
-              const unblockedIds = propagateConvergenceSkips(
-                nodeId,
-                skippedTargets,
-                edgesBySource,
-                edgesByTarget,
-                convergenceArrivals,
-                convergenceSkipArrivals,
-                skippedNodes,
-                visited
-              );
-              if (unblockedIds.length > 0) {
-                const settled = await pendingTasks.track(
-                  Promise.allSettled(
-                    unblockedIds.map((id) => executeNode(id, visited))
-                  )
-                );
-                processSettledResults(settled, unblockedIds);
-              }
-            }
-          } else {
-            // Legacy fallback: no sourceHandle on edges, use old gate behavior
-            if (conditionResult === true) {
-              const nextNodes = edgesBySource.get(nodeId) ?? [];
-              await executeReadyDownstream(nodeId, nextNodes, visited);
-            }
-          }
+          await continueFromCondition(nodeId, conditionResult, visited);
         } else {
           // For non-condition nodes, execute all next nodes in parallel
           const nextNodes = edgesBySource.get(nodeId) || [];
@@ -2993,8 +3003,24 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           label: getNodeName(node),
           data: recordedOutput,
         };
-        const nextNodes = edgesBySource.get(nodeId) ?? [];
-        await executeReadyDownstream(nodeId, nextNodes, visited);
+        // A recovered condition must route by handle, exactly like the normal
+        // path. Continuing through the handle-agnostic `edgesBySource` here
+        // fires the not-taken edge (e.g. a `false`-handle OR-join) on a branch
+        // that should have been skipped, which is what caused the join to run
+        // even though every condition evaluated true.
+        const recoveredActionType =
+          node.data.type === "action"
+            ? (node.data.config?.actionType as string | undefined)
+            : undefined;
+        if (recoveredActionType === "Condition") {
+          const recoveredCondition = (
+            recordedOutput as { condition?: boolean } | undefined
+          )?.condition;
+          await continueFromCondition(nodeId, recoveredCondition, visited);
+        } else {
+          const nextNodes = edgesBySource.get(nodeId) ?? [];
+          await executeReadyDownstream(nodeId, nextNodes, visited);
+        }
         return;
       }
 
@@ -3057,19 +3083,33 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       // Signal arrival at downstream convergence nodes to prevent deadlocks.
       // If this failure was the last arrival, execute the convergence node
       // with partial data rather than hanging forever.
-      const nextNodes = edgesBySource.get(nodeId) ?? [];
-      const unblockedIds = signalConvergenceArrival(
-        nodeId,
-        nextNodes,
-        edgesByTarget,
-        convergenceArrivals,
-        visited
-      );
-      if (unblockedIds.length > 0) {
-        const settled = await Promise.allSettled(
-          unblockedIds.map((id) => executeNode(id, visited))
+      //
+      // A genuinely-failed condition is the exception: it has no taken handle,
+      // and signaling a real arrival through the handle-agnostic `edgesBySource`
+      // would fire a not-taken OR-join (e.g. an alert on the `false` handle) on
+      // a branch that never produced a decision. Skip the signal for condition
+      // nodes; the run is already marked failed and the join is left unrun
+      // rather than mis-fired. Non-condition merges still signal so a
+      // partial-data join does not hang.
+      const failedActionType =
+        node.data.type === "action"
+          ? (node.data.config?.actionType as string | undefined)
+          : undefined;
+      if (failedActionType !== "Condition") {
+        const nextNodes = edgesBySource.get(nodeId) ?? [];
+        const unblockedIds = signalConvergenceArrival(
+          nodeId,
+          nextNodes,
+          edgesByTarget,
+          convergenceArrivals,
+          visited
         );
-        processSettledResults(settled, unblockedIds);
+        if (unblockedIds.length > 0) {
+          const settled = await Promise.allSettled(
+            unblockedIds.map((id) => executeNode(id, visited))
+          );
+          processSettledResults(settled, unblockedIds);
+        }
       }
     }
   }

--- a/tests/unit/convergence-barrier.test.ts
+++ b/tests/unit/convergence-barrier.test.ts
@@ -983,6 +983,31 @@ describe("convergence barrier", () => {
       expect(executeReady).toEqual([alert]);
       expect(skippedNodes.has(alert)).toBe(false);
     });
+
+    // KEEP-895: a condition that evaluates `true` must contribute a SKIP to the
+    // OR-join even when it completes through the spurious-completion recovery
+    // path (lost `step_completed` event under heavy fan-in -> re-fire ->
+    // exceeded-max-retries -> recover). The bug was that the recovery path
+    // continued downstream through the handle-agnostic `edgesBySource`, which
+    // routes the not-taken `false` edge as a REAL arrival -- modeled here by
+    // putting a passing condition into `realFromConditions`. That single
+    // mis-routed arrival fires the alert even though every condition passed.
+    it("a true condition routed via the skip primitive keeps the alert skipped", () => {
+      // Post-fix: the recovery path routes a true condition exactly like the
+      // normal path -- propagateConvergenceSkips -- so all five are skips.
+      const { executeReady, skippedNodes } = runAllConditions([]);
+      expect(executeReady).toEqual([]);
+      expect(skippedNodes.has(alert)).toBe(true);
+    });
+
+    it("regression: routing one passing condition as a real arrival wrongly fires the alert", () => {
+      // Pin the exact pre-fix failure mode: c3 passed (its output was
+      // `condition: true`) but was mis-routed as a real arrival. The four
+      // genuine skips plus that one bogus real arrival fire the alert.
+      const { executeReady, skippedNodes } = runAllConditions(["c3"]);
+      expect(executeReady).toEqual([alert]);
+      expect(skippedNodes.has(alert)).toBe(false);
+    });
   });
 
   describe("OR-join with a non-condition predecessor", () => {
@@ -1115,6 +1140,164 @@ describe("convergence barrier", () => {
       );
       expect(readyNext).toEqual(["Next"]);
       expect(skippedNodes.has("Next")).toBe(false);
+    });
+  });
+
+  describe("OR-join: a plain node parallel to all-false conditions whose taken branch is a dead end", () => {
+    // Topology: each condition feeds the join J on its `true` handle; the
+    // condition's `false` handle (the branch TAKEN when it evaluates false) has
+    // no edge -- a dead end. A plain, always-run node also feeds J. So a
+    // condition that goes false never reaches J through the dead-end handle; it
+    // instead skips its not-taken `true` edge into J. J is an OR-join: it runs
+    // once if any real arrival lands (the plain node, or a condition that went
+    // true) and is skipped only when EVERY incoming edge was a skip.
+    const condIds = ["c1", "c2", "c3"];
+    const plain = "Plain";
+    const join = "J";
+
+    type Barrier = {
+      arrivals: Map<string, Set<string>>;
+      skipArrivals: Map<string, Set<string>>;
+      skippedNodes: Set<string>;
+      visited: Set<string>;
+    };
+
+    function freshBarrier(): Barrier {
+      return {
+        arrivals: new Map<string, Set<string>>(),
+        skipArrivals: new Map<string, Set<string>>(),
+        skippedNodes: new Set<string>(),
+        visited: new Set<string>(),
+      };
+    }
+
+    function withPlainEdges(): { source: string; target: string }[] {
+      return [
+        ...condIds.map((id) => ({ source: id, target: join })),
+        { source: plain, target: join },
+      ];
+    }
+
+    function condOnlyEdges(): { source: string; target: string }[] {
+      return condIds.map((id) => ({ source: id, target: join }));
+    }
+
+    // A false condition takes its disconnected `false` handle (nothing happens
+    // downstream) and skips its not-taken `true` edge into J. A true condition
+    // takes the connected `true` edge -> real arrival.
+    function driveCondition(
+      condId: string,
+      truthy: boolean,
+      edges: { source: string; target: string }[],
+      b: Barrier
+    ): string[] {
+      const sourceMap = buildEdgesBySource(edges);
+      const targetMap = buildEdgesByTarget(edges);
+      if (truthy) {
+        return getReadyDownstreamIds(
+          condId,
+          [join],
+          targetMap,
+          b.arrivals,
+          b.visited
+        );
+      }
+      return propagateConvergenceSkips(
+        condId,
+        [join],
+        sourceMap,
+        targetMap,
+        b.arrivals,
+        b.skipArrivals,
+        b.skippedNodes,
+        b.visited
+      );
+    }
+
+    function drivePlain(
+      edges: { source: string; target: string }[],
+      b: Barrier
+    ): string[] {
+      const targetMap = buildEdgesByTarget(edges);
+      return getReadyDownstreamIds(
+        plain,
+        [join],
+        targetMap,
+        b.arrivals,
+        b.visited
+      );
+    }
+
+    it("fires the join once via the plain node when every condition went false", () => {
+      const b = freshBarrier();
+      const edges = withPlainEdges();
+      const ready: string[] = [];
+      for (const c of condIds) {
+        ready.push(...driveCondition(c, false, edges, b));
+      }
+      // Three skips, no real arrival yet: J is neither released nor skipped
+      // because the plain edge has not landed.
+      expect(ready).toEqual([]);
+      expect(b.skippedNodes.has(join)).toBe(false);
+
+      // The plain node arrives -> real arrival completes the OR-join (4/4) and
+      // runs it exactly once.
+      expect(drivePlain(edges, b)).toEqual([join]);
+      expect(b.skippedNodes.has(join)).toBe(false);
+    });
+
+    it("fires the join once when the plain node arrives before the false conditions", () => {
+      const b = freshBarrier();
+      const edges = withPlainEdges();
+      // Plain lands first (1/4) -> not enough arrivals yet.
+      expect(drivePlain(edges, b)).toEqual([]);
+
+      const releases: string[] = [];
+      for (const c of condIds) {
+        releases.push(...driveCondition(c, false, edges, b));
+      }
+      // The last skip completes 4/4 with a real arrival already present, so the
+      // join releases exactly once and is not marked skipped.
+      expect(releases).toEqual([join]);
+      expect(b.skippedNodes.has(join)).toBe(false);
+    });
+
+    it("skips the join when all-false conditions have a dead-end branch and there is no plain node", () => {
+      const b = freshBarrier();
+      const edges = condOnlyEdges();
+      const ready: string[] = [];
+      for (const c of condIds) {
+        ready.push(...driveCondition(c, false, edges, b));
+      }
+      // Every incoming edge was a skip -> the join is skipped, never executed.
+      expect(ready).toEqual([]);
+      expect(b.skippedNodes.has(join)).toBe(true);
+    });
+
+    it("fires the join once when a condition goes true alongside the plain node", () => {
+      const b = freshBarrier();
+      const edges = withPlainEdges();
+      const ready: string[] = [];
+      ready.push(...driveCondition("c1", false, edges, b)); // skip 1/4
+      ready.push(...driveCondition("c2", true, edges, b)); // real 2/4
+      ready.push(...driveCondition("c3", false, edges, b)); // skip 3/4
+      ready.push(...drivePlain(edges, b)); // real 4/4 -> release
+      expect(ready).toEqual([join]);
+      expect(b.skippedNodes.has(join)).toBe(false);
+    });
+
+    it("does not double-fire the join when both a true condition and the plain node real-arrive", () => {
+      const b = freshBarrier();
+      const edges = withPlainEdges();
+      const ready: string[] = [];
+      ready.push(...driveCondition("c1", false, edges, b)); // skip 1/4
+      ready.push(...driveCondition("c2", false, edges, b)); // skip 2/4
+      ready.push(...drivePlain(edges, b)); // real 3/4, still pending
+      expect(ready).toEqual([]);
+      ready.push(...driveCondition("c3", true, edges, b)); // real 4/4 -> release
+      // The join appears exactly once in the ready list across all arrivals.
+      expect(ready).toEqual([join]);
+      expect(b.skippedNodes.has(join)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Problem

A workflow with parallel branches that converge on a single node wired to the `false` handle of every condition (an OR-join, for example an alert step) intermittently executes that join even when every condition evaluates true and takes its other branch. The join should be skipped in that case.

Observed on a Safe-monitoring workflow: five parallel reads, each into a Condition, all five `false` handles wired into one alert node. In the failing runs all five conditions logged `condition: true` and succeeded, yet the join still ran. It reproduced on manual runs (tighter concurrency); scheduled runs were clean across the sample window.

## Root cause

1. `conditionStep.maxRetries = 0`.
2. Under heavy fan-in the Workflow DevKit occasionally loses a step's `step_completed` event and re-fires the step. With `maxRetries=0` the framework throws "exceeded max retries", which lands in the executor catch block.
3. The catch recognizes this as a spurious failure, recovers the real output (`condition: true`), then continued downstream using `edgesBySource.get(nodeId)`.
4. `edgesBySource` is handle-agnostic: for a condition it returns all targets including the not-taken `false` edge into the join, which records a real convergence arrival via `signalConvergenceArrival`.
5. The join then sees N-1 skip arrivals plus one real arrival and fires, even though every condition was true.

The same handle-blind continuation existed in the catch fall-through that signals convergence arrival on genuine failure.

## Fix

Extract the normal condition routing into `continueFromCondition` and reuse it from the spurious-completion recovery path, so a recovered condition routes only its taken handle and propagates a skip on its not-taken handle, exactly like a condition that completed normally. The catch fall-through no longer real-signals a failed condition's not-taken OR-join; non-condition merges still signal to avoid a deadlock.

Both the manual run path (`execute-in-background`, MCP call route) and the executor service (`keeperhub-executor`) call this shared `executeWorkflow`, so the fix covers both.

## Tests

- `convergence-barrier.test.ts`: a spurious-recovery regression that pins the OR-join contract (a passing condition must contribute a skip, never a real arrival), plus a new block for a non-condition node running in parallel with all-false conditions whose taken branch is a dead end (all-skip vs plain-node real arrival, ordering, and no double-fire).
- Full executor and convergence suites pass; type-check and lint clean on the changed files.

Verified locally across the full handle/value matrix (all-true, one-false, mixed, true-handle-connected, false-handle-connected, with and without a parallel plain node): the join fires exactly once when it should and never when every condition takes its not-taken branch.
