### PR TITLE
fix(metrics): scope getWorkflowStatsFromDb to 30-day window, drop offset from alerts (TECH-56)

### DIFF
--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -116,7 +116,7 @@ function getOrCreateGauge(
 const workflowExecutionsTotal = getOrCreateGauge(
   dbRegistry,
   "keeperhub_workflow_executions_total",
-  "Total workflow executions by status, broken down by org_slug and error_type (all-time)",
+  "Workflow executions by status, broken down by org_slug and error_type (rolling 30-day window)",
   ["status", "org_slug", "error_type"]
 );
 
@@ -1525,7 +1525,7 @@ async function refreshDbMetricsNow(): Promise<void> {
     workflowDurationBucket.set(
       { le: "+Inf" },
       workflowStats.durationBuckets[WORKFLOW_DURATION_BUCKETS.length] ??
-        workflowStats.durationCount
+      workflowStats.durationCount
     );
 
     // Update workflow duration sum and count
@@ -1560,7 +1560,7 @@ async function refreshDbMetricsNow(): Promise<void> {
     stepDurationBucket.set(
       { le: "+Inf" },
       stepStats.durationBuckets[STEP_DURATION_BUCKETS.length] ??
-        stepStats.durationCount
+      stepStats.durationCount
     );
 
     // Update step duration sum and count

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -139,8 +139,13 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
     // SELECT-side expressions render those groups as ANONYMOUS_ORG_SLUG /
     // "unknown" / "na" as appropriate.
     //
-    // Bounded to startedAt >= now() - 1h. startedAt is used instead of
-    // completedAt so in-flight running/pending rows are included.
+    // Bounded to startedAt >= now() - 30 days so the query is an index range
+    // scan rather than a full-table scan that trips the 8s metrics
+    // statement_timeout. startedAt is used instead of completedAt so in-flight
+    // running/pending executions started within the window are included. The
+    // 30-day window matches what the Grafana managed-client and system-error
+    // alerts expect: both read keeperhub_workflow_executions_total directly
+    // (no offset subtraction) as their 30-day volume denominator.
     const breakdown = await db
       .select({
         status: workflowExecutions.status,
@@ -156,7 +161,7 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
       .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
       .leftJoin(organization, eq(workflows.organizationId, organization.id))
       .where(
-        gte(workflowExecutions.startedAt, sql`now() - interval '1 hour'`)
+        gte(workflowExecutions.startedAt, sql`now() - interval '30 days'`)
       )
       .groupBy(
         workflowExecutions.status,
@@ -215,7 +220,7 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
         and(
           sql`${workflowExecutions.status} IN ('success', 'error', 'system_error')`,
           sql`${workflowExecutions.duration} IS NOT NULL`,
-          gte(workflowExecutions.startedAt, sql`now() - interval '1 hour'`)
+          gte(workflowExecutions.startedAt, sql`now() - interval '30 days'`)
         )
       );
 


### PR DESCRIPTION
The prior fix (PR #1622) bounded it to 1 hour, which broke the 30-day volume denominator used by the Managed Client Error and Keeperhub System Error alerts: those alerts computed the 30-day execution volume via snapshot subtraction (`value_now - value_offset_30d`), a pattern that is only valid when the gauge is an all-time cumulative — with a 1-hour window the two endpoints cover unrelated 1-hour slices 30 days apart, collapsing the denominator to near-zero and triggering spurious critical fires. This change scopes both queries in `getWorkflowStatsFromDb` to `startedAt >= now() - interval '30 days'`, making the gauge a rolling 30-day count.

The alert's code (infra repo) also has to be updated because of this, so I'll be applying the changes one after the other, as close together as possible. I'll silence the alerts during that process to avoid false positives.