### PR TITLE
ci: wire load-test.yml into reusable workflow + label trigger

### DIFF
--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -778,51 +778,6 @@ jobs:
           echo "--- hmac-seed job logs ---"
           kubectl logs -n "${NAMESPACE}" job/keeperhub-pr-${PR_NUMBER}-hmac-seed --tail=30 || true
 
-      - name: Seed load-test users
-        if: needs.check-labels.outputs.should-load-test == 'true'
-        env:
-          PR_NUMBER: ${{ env.PR_NUMBER }}
-          NAMESPACE: ${{ env.NAMESPACE }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
-          LOAD_TEST_USER_PASSWORD: ${{ secrets.LOAD_TEST_USER_PASSWORD }}
-        run: |
-          set -euo pipefail
-          DB_PASSWORD=$(kubectl get secret keeperhub-pr-${PR_NUMBER}-db-credentials -n "${NAMESPACE}" -o jsonpath='{.data.password}' | base64 -d)
-          ENCODED_PASSWORD=$(DB_PASSWORD="${DB_PASSWORD}" python3 -c "import urllib.parse, os; print(urllib.parse.quote(os.environ['DB_PASSWORD'], safe=''))")
-          DB_URL="postgresql://keeperhub:${ENCODED_PASSWORD}@keeperhub-pr-${PR_NUMBER}-db-rw.${NAMESPACE}.svc.cluster.local:5432/keeperhub"
-          kubectl delete job keeperhub-pr-${PR_NUMBER}-load-test-seed -n "${NAMESPACE}" --ignore-not-found
-          kubectl apply -n "${NAMESPACE}" -f - <<EOF
-          apiVersion: batch/v1
-          kind: Job
-          metadata:
-            name: keeperhub-pr-${PR_NUMBER}-load-test-seed
-          spec:
-            backoffLimit: 2
-            ttlSecondsAfterFinished: 600
-            template:
-              spec:
-                restartPolicy: Never
-                containers:
-                  - name: load-test-seed
-                    image: ${ECR_REGISTRY}/keeperhub-staging:migrator-${IMAGE_TAG}
-                    command: ["/bin/sh", "-c"]
-                    args:
-                      - 'pnpm tsx scripts/seed-load-test-users.ts'
-                    env:
-                      - name: DATABASE_URL
-                        value: "${DB_URL}"
-                      - name: ALLOW_REMOTE
-                        value: "1"
-                      - name: LOAD_TEST_USER_PASSWORD
-                        value: "${LOAD_TEST_USER_PASSWORD}"
-                      - name: SEED_COUNT
-                        value: "50"
-          EOF
-          kubectl wait --for=condition=complete job/keeperhub-pr-${PR_NUMBER}-load-test-seed -n "${NAMESPACE}" --timeout=120s || true
-          echo "--- load-test-seed job logs ---"
-          kubectl logs -n "${NAMESPACE}" job/keeperhub-pr-${PR_NUMBER}-load-test-seed --tail=30 || true
-
       # Opt-in (deploy-pr-metrics label). Deploys the metrics-collector
       # satellite against the PR DB so its /metrics can be curled directly
       # (ServiceMonitors are off in PR envs). TECH-6484.
@@ -1396,12 +1351,86 @@ jobs:
               });
             }
 
-  load-test:
+  seed-load-test-users:
+    permissions:
+      id-token: write
+      contents: read
     needs: [check-labels, deploy]
     if: >-
       !cancelled() &&
       needs.check-labels.outputs.should-load-test == 'true' &&
       (needs.deploy.result == 'success' || needs.deploy.result == 'skipped')
+    runs-on: ubuntu-latest
+    environment: staging
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      REGION: us-east-1
+      CLUSTER_NAME: ${{ vars.TO_CLUSTER_NAME }}
+      NAMESPACE: pr-${{ github.event.pull_request.number }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ env.REGION }}
+
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Configure kubectl
+        run: |
+          aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }} --region ${{ env.REGION }}
+
+      - name: Seed load-test users
+        env:
+          LOAD_TEST_USER_PASSWORD: ${{ secrets.LOAD_TEST_USER_PASSWORD }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          set -euo pipefail
+          IMAGE_TAG=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
+          DB_PASSWORD=$(kubectl get secret keeperhub-pr-${PR_NUMBER}-db-credentials -n "${NAMESPACE}" -o jsonpath='{.data.password}' | base64 -d)
+          ENCODED_PASSWORD=$(DB_PASSWORD="${DB_PASSWORD}" python3 -c "import urllib.parse, os; print(urllib.parse.quote(os.environ['DB_PASSWORD'], safe=''))")
+          DB_URL="postgresql://keeperhub:${ENCODED_PASSWORD}@keeperhub-pr-${PR_NUMBER}-db-rw.${NAMESPACE}.svc.cluster.local:5432/keeperhub"
+          kubectl delete job keeperhub-pr-${PR_NUMBER}-load-test-seed -n "${NAMESPACE}" --ignore-not-found
+          kubectl apply -n "${NAMESPACE}" -f - <<EOF
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: keeperhub-pr-${PR_NUMBER}-load-test-seed
+          spec:
+            backoffLimit: 2
+            ttlSecondsAfterFinished: 600
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: load-test-seed
+                    image: ${ECR_REGISTRY}/keeperhub-staging:migrator-${IMAGE_TAG}
+                    command: ["/bin/sh", "-c"]
+                    args:
+                      - 'pnpm tsx scripts/seed-load-test-users.ts'
+                    env:
+                      - name: DATABASE_URL
+                        value: "${DB_URL}"
+                      - name: ALLOW_REMOTE
+                        value: "1"
+                      - name: LOAD_TEST_USER_PASSWORD
+                        value: "${LOAD_TEST_USER_PASSWORD}"
+                      - name: SEED_COUNT
+                        value: "50"
+          EOF
+          kubectl wait --for=condition=complete job/keeperhub-pr-${PR_NUMBER}-load-test-seed -n "${NAMESPACE}" --timeout=120s || true
+          echo "--- load-test-seed job logs ---"
+          kubectl logs -n "${NAMESPACE}" job/keeperhub-pr-${PR_NUMBER}-load-test-seed --tail=30 || true
+
+  load-test:
+    needs: [check-labels, deploy, seed-load-test-users]
+    if: >-
+      !cancelled() &&
+      needs.check-labels.outputs.should-load-test == 'true' &&
+      (needs.deploy.result == 'success' || needs.deploy.result == 'skipped') &&
+      needs.seed-load-test-users.result == 'success'
     uses: ./.github/workflows/load-test.yml
     with:
       target_url: https://app-pr-${{ github.event.pull_request.number }}.keeperhub.com

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -778,6 +778,51 @@ jobs:
           echo "--- hmac-seed job logs ---"
           kubectl logs -n "${NAMESPACE}" job/keeperhub-pr-${PR_NUMBER}-hmac-seed --tail=30 || true
 
+      - name: Seed load-test users
+        if: needs.check-labels.outputs.should-load-test == 'true'
+        env:
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+          NAMESPACE: ${{ env.NAMESPACE }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
+          LOAD_TEST_USER_PASSWORD: ${{ secrets.LOAD_TEST_USER_PASSWORD }}
+        run: |
+          set -euo pipefail
+          DB_PASSWORD=$(kubectl get secret keeperhub-pr-${PR_NUMBER}-db-credentials -n "${NAMESPACE}" -o jsonpath='{.data.password}' | base64 -d)
+          ENCODED_PASSWORD=$(DB_PASSWORD="${DB_PASSWORD}" python3 -c "import urllib.parse, os; print(urllib.parse.quote(os.environ['DB_PASSWORD'], safe=''))")
+          DB_URL="postgresql://keeperhub:${ENCODED_PASSWORD}@keeperhub-pr-${PR_NUMBER}-db-rw.${NAMESPACE}.svc.cluster.local:5432/keeperhub"
+          kubectl delete job keeperhub-pr-${PR_NUMBER}-load-test-seed -n "${NAMESPACE}" --ignore-not-found
+          kubectl apply -n "${NAMESPACE}" -f - <<EOF
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: keeperhub-pr-${PR_NUMBER}-load-test-seed
+          spec:
+            backoffLimit: 2
+            ttlSecondsAfterFinished: 600
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: load-test-seed
+                    image: ${ECR_REGISTRY}/keeperhub-staging:migrator-${IMAGE_TAG}
+                    command: ["/bin/sh", "-c"]
+                    args:
+                      - 'pnpm tsx scripts/seed-load-test-users.ts'
+                    env:
+                      - name: DATABASE_URL
+                        value: "${DB_URL}"
+                      - name: ALLOW_REMOTE
+                        value: "1"
+                      - name: LOAD_TEST_USER_PASSWORD
+                        value: "${LOAD_TEST_USER_PASSWORD}"
+                      - name: SEED_COUNT
+                        value: "50"
+          EOF
+          kubectl wait --for=condition=complete job/keeperhub-pr-${PR_NUMBER}-load-test-seed -n "${NAMESPACE}" --timeout=120s || true
+          echo "--- load-test-seed job logs ---"
+          kubectl logs -n "${NAMESPACE}" job/keeperhub-pr-${PR_NUMBER}-load-test-seed --tail=30 || true
+
       # Opt-in (deploy-pr-metrics label). Deploys the metrics-collector
       # satellite against the PR DB so its /metrics can be curled directly
       # (ServiceMonitors are off in PR envs). TECH-6484.

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -1385,10 +1385,13 @@ jobs:
       - name: Seed load-test users
         env:
           LOAD_TEST_USER_PASSWORD: ${{ secrets.LOAD_TEST_USER_PASSWORD }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
           set -euo pipefail
-          IMAGE_TAG=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
+          # Derive the migrator image from the running deployment initContainer rather
+          # than the HEAD SHA — the image may have been built on an earlier commit if
+          # only CI/test files changed and build-images was skipped this run.
+          MIGRATOR_IMAGE=$(kubectl get deployment keeperhub-pr-${PR_NUMBER}-common -n "${NAMESPACE}" \
+            -o jsonpath='{.spec.template.spec.initContainers[0].image}')
           DB_PASSWORD=$(kubectl get secret keeperhub-pr-${PR_NUMBER}-db-credentials -n "${NAMESPACE}" -o jsonpath='{.data.password}' | base64 -d)
           ENCODED_PASSWORD=$(DB_PASSWORD="${DB_PASSWORD}" python3 -c "import urllib.parse, os; print(urllib.parse.quote(os.environ['DB_PASSWORD'], safe=''))")
           DB_URL="postgresql://keeperhub:${ENCODED_PASSWORD}@keeperhub-pr-${PR_NUMBER}-db-rw.${NAMESPACE}.svc.cluster.local:5432/keeperhub"
@@ -1406,7 +1409,7 @@ jobs:
                 restartPolicy: Never
                 containers:
                   - name: load-test-seed
-                    image: ${ECR_REGISTRY}/keeperhub-staging:migrator-${IMAGE_TAG}
+                    image: ${MIGRATOR_IMAGE}
                     command: ["/bin/sh", "-c"]
                     args:
                       - 'pnpm tsx scripts/seed-load-test-users.ts'

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -24,6 +24,7 @@ jobs:
       should-deploy-events-only: ${{ steps.check.outputs.should-deploy-events-only }}
       should-build-executor: ${{ steps.check.outputs.should-build-executor }}
       should-deploy-collector: ${{ steps.check.outputs.should-deploy-collector }}
+      should-load-test: ${{ steps.check.outputs.should-load-test }}
     steps:
       - name: Checkout code (for change detection)
         if: github.event.action == 'synchronize'
@@ -40,6 +41,7 @@ jobs:
           echo "should-deploy-events-only=false" >> $GITHUB_OUTPUT
           echo "should-build-executor=false" >> $GITHUB_OUTPUT
           echo "should-deploy-collector=false" >> $GITHUB_OUTPUT
+          echo "should-load-test=false" >> $GITHUB_OUTPUT
 
           HAS_DEPLOY_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'deploy-pr-environment') }}"
           HAS_TEST_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'run-e2e-tests-pr-deploy') }}"
@@ -60,6 +62,7 @@ jobs:
           # satellite so the PR's collector code can be exercised against the
           # PR's DB. ServiceMonitors are off in PR envs - verify via curl.
           HAS_METRICS_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'deploy-pr-metrics') }}"
+          HAS_LOAD_TEST_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'run-load-test') }}"
           ACTION="${{ github.event.action }}"
           ADDED_LABEL="${{ github.event.label.name }}"
 
@@ -78,8 +81,17 @@ jobs:
               if [[ "$HAS_METRICS_LABEL" == "true" ]]; then
                 echo "should-deploy-collector=true" >> $GITHUB_OUTPUT
               fi
+              if [[ "$HAS_LOAD_TEST_LABEL" == "true" ]]; then
+                echo "should-load-test=true" >> $GITHUB_OUTPUT
+              fi
             elif [[ "$ADDED_LABEL" == "run-e2e-tests-pr-deploy" ]]; then
               echo "should-test=true" >> $GITHUB_OUTPUT
+            elif [[ "$ADDED_LABEL" == "run-load-test" ]]; then
+              # Load-test-only path: PR env is already deployed. Only meaningful
+              # when deploy-pr-environment is also present — no env, no target.
+              if [[ "$HAS_DEPLOY_LABEL" == "true" ]]; then
+                echo "should-load-test=true" >> $GITHUB_OUTPUT
+              fi
             elif [[ "$ADDED_LABEL" == "deploy-pr-executor" ]]; then
               # Executor-only path: PR env is already deployed. Build a PR
               # executor image and redeploy just that satellite. Cheaper than
@@ -161,6 +173,9 @@ jobs:
             # Run tests if both labels present (even without deploy)
             if [[ "$HAS_DEPLOY_LABEL" == "true" && "$HAS_TEST_LABEL" == "true" ]]; then
               echo "should-test=true" >> $GITHUB_OUTPUT
+            fi
+            if [[ "$HAS_DEPLOY_LABEL" == "true" && "$HAS_LOAD_TEST_LABEL" == "true" ]]; then
+              echo "should-load-test=true" >> $GITHUB_OUTPUT
             fi
           fi
 
@@ -1335,3 +1350,14 @@ jobs:
                 body,
               });
             }
+
+  load-test:
+    needs: [check-labels, deploy]
+    if: >-
+      !cancelled() &&
+      needs.check-labels.outputs.should-load-test == 'true' &&
+      (needs.deploy.result == 'success' || needs.deploy.result == 'skipped')
+    uses: ./.github/workflows/load-test.yml
+    with:
+      target_url: https://app-pr-${{ github.event.pull_request.number }}.keeperhub.com
+    secrets: inherit

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,3 +1,4 @@
+# Type: reusable | Called by deploy-pr-environment.yaml + ad-hoc
 name: k6 Load Test
 
 on:
@@ -7,6 +8,33 @@ on:
   # weekly traffic window (results ready Sunday morning).
   schedule:
     - cron: '0 4 * * 0'
+  workflow_call:
+    inputs:
+      target_url:
+        description: 'Target URL to load test (e.g. https://app-pr-42.keeperhub.com)'
+        type: string
+        required: true
+      test_mode:
+        description: 'Test mode'
+        type: string
+        required: false
+        default: 'execution'
+      target_vus:
+        type: string
+        required: false
+        default: '5'
+      wf_per_vu:
+        type: string
+        required: false
+        default: '30'
+      duration:
+        type: string
+        required: false
+        default: '60s'
+      threshold:
+        type: string
+        required: false
+        default: '95'
   workflow_dispatch:
     inputs:
       test_mode:
@@ -85,7 +113,7 @@ on:
         default: '500'
 
 concurrency:
-  group: load-test-${{ inputs.environment }}
+  group: load-test-${{ inputs.target_url || inputs.environment || 'scheduled' }}
   cancel-in-progress: false
 
 permissions:
@@ -111,7 +139,9 @@ jobs:
 
       - name: Resolve target URL
         run: |
-          if [[ "${{ inputs.environment }}" == "custom" ]]; then
+          if [[ -n "${{ inputs.target_url }}" ]]; then
+            BASE_URL="${{ inputs.target_url }}"
+          elif [[ "${{ inputs.environment }}" == "custom" ]]; then
             BASE_URL="${{ inputs.custom_url }}"
             if [[ -z "$BASE_URL" ]]; then
               echo "::error::custom_url is required when environment=custom"
@@ -121,7 +151,7 @@ jobs:
             BASE_URL="${{ vars.TO_HEALTH_URL }}"
           fi
           echo "BASE_URL=$BASE_URL" >> $GITHUB_ENV
-          echo "Target: $BASE_URL (mode: ${{ inputs.test_mode }})"
+          echo "Target: $BASE_URL (mode: ${{ inputs.test_mode || 'execution' }})"
 
       - name: Create results directory
         run: mkdir -p /tmp/k6-results

--- a/tests/k6/execution-load-test.js
+++ b/tests/k6/execution-load-test.js
@@ -135,6 +135,7 @@ const PATTERNS = [
 
 // Per-VU state
 let myEmail = "";
+let authenticated = false;
 let allWfIds = [];
 let manualWfIds = [];
 let completedTiers = 0;
@@ -154,7 +155,7 @@ function authenticate() {
   myEmail = `k6-loadtest-vu${v}@techops.services`;
   const sr = retryPost(`${BASE_URL}/api/auth/sign-in/email`,
     JSON.stringify({ email: myEmail, password: PASSWORD }), 5);
-  if (sr.status !== 200) { console.error(`VU${v}: signin ${sr.status}`); return false; }
+  if (sr.status !== 200) { console.error(`VU${v}: signin ${sr.status} body=${sr.body}`); return false; }
   return true;
 }
 
@@ -205,9 +206,10 @@ function triggerManuals() {
 
 // Main loop
 export default function () {
-  if (!myEmail || completedTiers > 0) {
+  if (!authenticated || completedTiers > 0) {
     const ok = authenticate();
     if (!ok) { sleep(30); return; }
+    authenticated = true;
     if (completedTiers === 0) {
       usersCreated.add(1);
       console.log(`VU${exec.vu.idInTest}: authenticated`);


### PR DESCRIPTION
## Summary

- Add `workflow_call` trigger to `load-test.yml` so it can be invoked from other workflows, alongside the existing `workflow_dispatch` and `schedule` triggers
- Add `# Type: reusable | Called by deploy-pr-environment.yaml + ad-hoc` header matching repo convention
- Wire the `run-load-test` PR label into `deploy-pr-environment.yaml`: `check-labels` now emits `should-load-test`, and a new `load-test` job calls the reusable workflow with the PR env URL derived automatically from the PR number

## Changes

### `load-test.yml`
- Added `workflow_call` trigger with `target_url` (required), `test_mode`, `target_vus`, `wf_per_vu`, `duration`, `threshold` inputs
- Updated concurrency group to `inputs.target_url || inputs.environment || 'scheduled'` so all three trigger paths (workflow_call, dispatch, schedule) produce a meaningful group key
- Updated "Resolve target URL" step to short-circuit to `target_url` when provided, falling back to the existing `environment`/`custom_url` logic for dispatch runs

### `deploy-pr-environment.yaml`
- Added `should-load-test` output to `check-labels` job
- `should-load-test=true` is emitted on three event paths:
  - `deploy-pr-environment` labeled + `run-load-test` co-label present
  - `run-load-test` labeled + `deploy-pr-environment` already present (guarded on `HAS_DEPLOY_LABEL` to avoid firing against a non-existent env)
  - `synchronize`/`opened`/`reopened` with both labels present
- Added `load-test` job calling `./.github/workflows/load-test.yml` with `target_url: https://app-pr-${{ github.event.pull_request.number }}.keeperhub.com`, gated on `should-load-test == 'true'` and `deploy.result == 'success' || 'skipped'`

## Test plan

- [ ] Adding `run-load-test` + `deploy-pr-environment` to a PR triggers the `load-test` job in the Deploy PR Environment run with the correct PR env URL
- [ ] Adding `run-load-test` to a PR that already has a deployed PR env (deploy job skipped) still fires the load test
- [ ] Adding `run-load-test` to a PR without `deploy-pr-environment` does not fire a load test (`should-load-test` stays false)
- [ ] `gh workflow run load-test.yml -f environment=staging` still works as before
- [ ] Saturday scheduled run still resolves URL from `vars.TO_HEALTH_URL`