### PR TITLE
fix: KEEP-629 cron scheduler timing fixes

### DIFF
--- a/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
@@ -226,7 +226,12 @@ function scheduleOccurrencesBetween(
       to,
     );
   }
-  return cronOccurrencesBetween(schedule.cronExpression, schedule.timezone, from, to);
+  return cronOccurrencesBetween(
+    schedule.cronExpression,
+    schedule.timezone,
+    from,
+    to,
+  );
 }
 
 function describeSchedule(schedule: Schedule): string {
@@ -270,7 +275,9 @@ export async function sendToQueue(message: ScheduleMessage): Promise<void> {
  * `now` is stamped at the very top of this function, before the DB fetch,
  * so DB latency cannot shrink the window and cause a missed trigger.
  */
-export async function dispatch(lastTickAt?: Date | null): Promise<DispatchResult> {
+export async function dispatch(
+  lastTickAt?: Date | null,
+): Promise<DispatchResult> {
   const runId = crypto.randomUUID().slice(0, 8);
 
   // Stamp now before any I/O so DB latency cannot push it past the window.

--- a/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
@@ -21,6 +21,12 @@ import {
 } from "../lib/phantom.js";
 import { sqs } from "../lib/sqs-client.js";
 import type { Schedule, ScheduleMessage } from "../lib/types.js";
+import {
+  errorsTotal,
+  runDurationSeconds,
+  runsTotal,
+  triggeredTotal,
+} from "./metrics.js";
 
 export type DispatchResult = {
   evaluated: number;
@@ -36,9 +42,91 @@ export async function fetchSchedules(): Promise<Schedule[]> {
 }
 
 /**
+ * Returns all cron occurrences in the half-open interval (from, to].
+ * Returns an empty array on parse failure (logs the error) or if there are
+ * no occurrences in the window.
+ */
+export function cronOccurrencesBetween(
+  cronExpression: string,
+  timezone: string,
+  from: Date,
+  to: Date,
+): Date[] {
+  const occurrences: Date[] = [];
+  let interval: ReturnType<typeof CronExpressionParser.parse>;
+  try {
+    interval = CronExpressionParser.parse(cronExpression, {
+      currentDate: from,
+      tz: timezone,
+    });
+  } catch (error) {
+    console.error(`Invalid cron expression: ${cronExpression}`, error);
+    return occurrences;
+  }
+  for (;;) {
+    let next: Date;
+    try {
+      next = interval.next().toDate();
+    } catch (_e) {
+      break; // bounded expression exhausted; treat as end of range
+    }
+    if (next > to) break;
+    occurrences.push(next);
+  }
+  return occurrences;
+}
+
+/**
+ * Returns all interval-mode occurrences in the half-open interval (from, to].
+ *
+ * The k-th occurrence is at anchorAt + k * intervalSeconds (k >= 1). The
+ * first fire is at anchor + 1 * interval — creating a schedule does not
+ * cause an immediate run (mirrors shouldTriggerInterval and syncWorkflowSchedule).
+ */
+export function intervalOccurrencesBetween(
+  intervalSeconds: number,
+  anchorAt: Date,
+  from: Date,
+  to: Date,
+): Date[] {
+  if (!Number.isFinite(intervalSeconds) || intervalSeconds <= 0) {
+    return [];
+  }
+  const anchorMs = anchorAt.getTime();
+  if (!Number.isFinite(anchorMs)) {
+    return [];
+  }
+
+  const intervalMs = intervalSeconds * 1000;
+  const fromMs = from.getTime();
+  const toMs = to.getTime();
+
+  // Largest k where anchorMs + k * intervalMs <= fromMs. All k > kFloor
+  // produce occurrences strictly after `from`, satisfying (from, to].
+  const kFloor = Math.floor((fromMs - anchorMs) / intervalMs);
+  const kStart = Math.max(1, kFloor + 1);
+  const kEnd = Math.floor((toMs - anchorMs) / intervalMs);
+
+  if (kEnd < kStart) {
+    return [];
+  }
+
+  const occurrences: Date[] = [];
+  for (let k = kStart; k <= kEnd; k++) {
+    occurrences.push(new Date(anchorMs + k * intervalMs));
+  }
+  return occurrences;
+}
+
+/**
+ * @deprecated Use cronOccurrencesBetween / intervalOccurrencesBetween.
+ *
  * Returns true when the cron expression's most recent occurrence is within
  * the current minute (now - prev < 60_000ms). Returns false on invalid
  * expressions and logs the error.
+ *
+ * Kept for the direct unit tests that exercise it; dispatch() uses the
+ * occurrence-based path.
  */
 export function shouldTriggerNow(
   cronExpression: string,
@@ -67,19 +155,13 @@ export function shouldTriggerNow(
 }
 
 /**
+ * @deprecated Use cronOccurrencesBetween / intervalOccurrencesBetween.
+ *
  * KEEP-575: returns true when an interval schedule's k-th fire (anchorAt +
- * k * intervalSeconds, k >= 1) lands within the current minute. Mirrors the
- * 60s window used by the cron path so the dispatcher's per-minute polling
- * can fire each occurrence exactly once.
+ * k * intervalSeconds, k >= 1) lands within the current minute.
  *
- * The first fire is at `anchor + 1 * interval`, not at the anchor itself —
- * saving a schedule must not cause an immediate run before the user's
- * intended interval has elapsed. This also keeps `shouldTriggerInterval`
- * consistent with the `next_run_at` value `syncWorkflowSchedule` writes on
- * create.
- *
- * Returns false (without firing) if the schedule hasn't reached its first
- * fire yet, or if the inputs are unusable.
+ * Kept for the direct unit tests that exercise it; dispatch() uses the
+ * occurrence-based path.
  */
 export function shouldTriggerInterval(
   intervalSeconds: number,
@@ -91,12 +173,6 @@ export function shouldTriggerInterval(
   }
 
   const anchorMs = anchorAt.getTime();
-  // KEEP-575: anchorAt arrives as `new Date(schedule.anchorAt)` where
-  // schedule.anchorAt is a string from the JSON API. Invalid strings
-  // produce Invalid Date and getTime() = NaN, which would make every
-  // comparison below silently false — looking like "schedule isn't due
-  // yet" forever. Treat a bad anchor as a non-firing input, same as a
-  // bad interval.
   if (!Number.isFinite(anchorMs)) {
     return false;
   }
@@ -105,7 +181,6 @@ export function shouldTriggerInterval(
   const intervalMs = intervalSeconds * 1000;
   const elapsedMs = nowMs - anchorMs;
 
-  // First fire is at anchor + 1*interval. Anything before that is "waiting".
   if (elapsedMs < intervalMs) {
     return false;
   }
@@ -135,20 +210,23 @@ function isIntervalMode(
 }
 
 /**
- * KEEP-575: pick interval vs cron dispatch based on whether the schedule
- * has an `intervalSeconds` populated. Interval rows synthesize a placeholder
- * cron expression for legacy readers — the dispatcher must NOT parse that
- * when intervalSeconds is set.
+ * Returns all occurrences of this schedule in the half-open interval (from, to].
+ * KEEP-575: routes interval vs cron based on whether intervalSeconds is set.
  */
-function scheduleShouldTrigger(schedule: Schedule, now: Date): boolean {
+function scheduleOccurrencesBetween(
+  schedule: Schedule,
+  from: Date,
+  to: Date,
+): Date[] {
   if (isIntervalMode(schedule)) {
-    return shouldTriggerInterval(
+    return intervalOccurrencesBetween(
       schedule.intervalSeconds,
       new Date(schedule.anchorAt),
-      now,
+      from,
+      to,
     );
   }
-  return shouldTriggerNow(schedule.cronExpression, schedule.timezone, now);
+  return cronOccurrencesBetween(schedule.cronExpression, schedule.timezone, from, to);
 }
 
 function describeSchedule(schedule: Schedule): string {
@@ -178,33 +256,55 @@ export async function sendToQueue(message: ScheduleMessage): Promise<void> {
 }
 
 /**
- * One dispatch pass: fetch schedules, evaluate each against the current
- * time, enqueue triggers for matching ones. Per-schedule failures are
- * logged and counted but do not abort the pass.
+ * One dispatch pass: stamp now before any I/O, fetch schedules, evaluate
+ * each against the window (from, now], enqueue a trigger for every matching
+ * occurrence. Per-schedule failures are logged and counted but do not abort
+ * the pass.
+ *
+ * `lastTickAt` is the `now` value from the previous pass. When provided,
+ * the window covers every cron occurrence since the last tick (catch-up).
+ * When null/undefined the window falls back to a synthetic
+ * (now - 60_000ms, now] which is equivalent to the previous single-minute
+ * check and is always safe on a fresh startup.
+ *
+ * `now` is stamped at the very top of this function, before the DB fetch,
+ * so DB latency cannot shrink the window and cause a missed trigger.
  */
-export async function dispatch(): Promise<DispatchResult> {
+export async function dispatch(lastTickAt?: Date | null): Promise<DispatchResult> {
   const runId = crypto.randomUUID().slice(0, 8);
+
+  // Stamp now before any I/O so DB latency cannot push it past the window.
+  const now = new Date();
+  const from = lastTickAt ?? new Date(now.getTime() - 60_000);
+
   console.log(
-    `[${runId}] Starting dispatch run at ${new Date().toISOString()}`,
+    `[${runId}] Starting dispatch run at ${now.toISOString()}, window: (${from.toISOString()}, ${now.toISOString()}]`,
   );
 
-  const schedules = await fetchSchedules();
+  const startMs = Date.now();
+  let schedules: Schedule[];
+
+  try {
+    schedules = await fetchSchedules();
+  } catch (error) {
+    runDurationSeconds.observe((Date.now() - startMs) / 1000);
+    throw error;
+  }
 
   console.log(`[${runId}] Found ${schedules.length} enabled schedules`);
 
-  const now = new Date();
   let triggered = 0;
   let errors = 0;
 
   for (const schedule of schedules) {
     try {
-      const shouldTrigger = scheduleShouldTrigger(schedule, now);
+      const occurrences = scheduleOccurrencesBetween(schedule, from, now);
 
-      if (shouldTrigger) {
+      for (const occurrence of occurrences) {
         const description = describeSchedule(schedule);
         console.log(
           `[${runId}] Triggering workflow ${schedule.workflowId} ` +
-            `(${description}, tz: ${schedule.timezone})`,
+            `(${description}, tz: ${schedule.timezone}, occurrence: ${occurrence.toISOString()})`,
         );
 
         // KEEP-693: pre-create a phantom row (best-effort) so the run is
@@ -219,12 +319,12 @@ export async function dispatch(): Promise<DispatchResult> {
           await sendToQueue({
             workflowId: schedule.workflowId,
             scheduleId: schedule.id,
-            triggerTime: now.toISOString(),
+            triggerTime: occurrence.toISOString(),
             triggerType: "schedule",
             executionId,
           });
         } catch (sendError) {
-          // The enqueue failed after the phantom was created -- resolve it to a
+          // The enqueue failed after the phantom was created — resolve it to a
           // coded failure so it surfaces in the run logs, then re-throw so the
           // outer handler counts the error.
           if (executionId) {
@@ -240,6 +340,7 @@ export async function dispatch(): Promise<DispatchResult> {
         }
 
         triggered += 1;
+        triggeredTotal.inc();
       }
     } catch (error) {
       console.error(
@@ -247,11 +348,16 @@ export async function dispatch(): Promise<DispatchResult> {
         error,
       );
       errors += 1;
+      errorsTotal.inc();
     }
   }
 
+  const durationSecs = (Date.now() - startMs) / 1000;
+  runDurationSeconds.observe(durationSecs);
+  runsTotal.inc();
+
   console.log(
-    `[${runId}] Dispatch complete: evaluated=${schedules.length}, triggered=${triggered}, errors=${errors}`,
+    `[${runId}] Dispatch complete: evaluated=${schedules.length}, triggered=${triggered}, errors=${errors}, duration=${durationSecs.toFixed(2)}s`,
   );
 
   return {

--- a/keeperhub-scheduler/schedule-dispatcher/index.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/index.ts
@@ -1,8 +1,8 @@
 /**
  * Schedule Dispatcher Script
  *
- * Runs continuously and evaluates workflow schedules every minute.
- * Dispatches matching cron expressions to SQS for execution.
+ * Runs continuously and evaluates workflow schedules on aligned minute
+ * boundaries. Dispatches matching cron expressions to SQS for execution.
  *
  * Usage:
  *   pnpm dispatcher
@@ -10,9 +10,13 @@
  * Environment variables:
  *   KEEPERHUB_API_URL - KeeperHub API URL (default: http://localhost:3000)
  *   INTERNAL_SERVICE_HMAC_SECRET - HMAC signing secret for internal service auth
- *   AWS_ENDPOINT_URL - LocalStack endpoint (default: http://localhost:4566)
- *   SQS_QUEUE_URL - SQS queue URL (default: LocalStack queue)
- *   HEALTH_PORT - Health check server port (default: 3060)
+ *   AWS_ENDPOINT_URL  - LocalStack endpoint (default: http://localhost:4566)
+ *   SQS_QUEUE_URL     - SQS queue URL (default: LocalStack queue)
+ *   HEALTH_PORT       - Health check server port (default: 3060)
+ *   TICK_OFFSET_MS    - Milliseconds past the minute boundary to fire
+ *                       (default: 2000). Cron occurrences land at :00;
+ *                       firing at :02 guarantees they are always in the past
+ *                       and still well within the 5-second SLA.
  */
 
 // Normalize all console.* output in this process to canonical JSON. Must be
@@ -21,6 +25,7 @@ import "../log-facade.js";
 import express from "express";
 import { KEEPERHUB_URL, SQS_QUEUE_URL } from "../lib/config.js";
 import { dispatch } from "./dispatch.js";
+import { registry } from "./metrics.js";
 
 // Log and swallow detached promise rejections so transient failures do not
 // crash the dispatcher (Node v15+ exits on unhandled rejection by default).
@@ -40,6 +45,28 @@ process.on("uncaughtException", (error: Error) => {
   process.exit(1);
 });
 
+// How far past the minute boundary (:00) each tick fires. 2 s ensures cron
+// occurrences (which land at :00) are always comfortably in the past without
+// pushing the trigger time close to the 5-second SLA ceiling.
+const TICK_OFFSET_MS = Number(process.env.TICK_OFFSET_MS ?? 2_000);
+
+/**
+ * Returns the number of milliseconds until the next tick target:
+ * the start of the next wall-clock minute plus TICK_OFFSET_MS.
+ *
+ * Example: if now is 09:00:42.500 and TICK_OFFSET_MS=2000 the next target
+ * is 09:01:02.000, so this returns ~19_500 ms.
+ */
+function msUntilNextTick(): number {
+  const msIntoMinute = Date.now() % 60_000;
+  if (msIntoMinute < TICK_OFFSET_MS) {
+    // Still early in the current minute — fire at TICK_OFFSET_MS of this minute.
+    return TICK_OFFSET_MS - msIntoMinute;
+  }
+  // Past the target for this minute — wait to the same offset in the next minute.
+  return 60_000 - msIntoMinute + TICK_OFFSET_MS;
+}
+
 async function main(): Promise<void> {
   if (!process.env.INTERNAL_SERVICE_HMAC_SECRET) {
     throw new Error("INTERNAL_SERVICE_HMAC_SECRET is required");
@@ -47,6 +74,7 @@ async function main(): Promise<void> {
   console.log("[Dispatcher] Starting schedule dispatcher...");
   console.log(`[Dispatcher] KeeperHub URL: ${KEEPERHUB_URL}`);
   console.log(`[Dispatcher] SQS Queue URL: ${SQS_QUEUE_URL}`);
+  console.log(`[Dispatcher] Tick offset: ${TICK_OFFSET_MS}ms past minute boundary`);
 
   const healthApp = express();
   const HEALTH_PORT = process.env.HEALTH_PORT || 3060;
@@ -59,9 +87,19 @@ async function main(): Promise<void> {
     });
   });
 
+  healthApp.get("/metrics", async (_req, res) => {
+    try {
+      res.set("Content-Type", registry.contentType);
+      res.end(await registry.metrics());
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      res.status(500).send(`Error collecting metrics: ${message}`);
+    }
+  });
+
   const healthServer = healthApp.listen(HEALTH_PORT, () => {
     console.log(
-      `[Dispatcher] Health check server listening on port ${HEALTH_PORT}`,
+      `[Dispatcher] Health/metrics server listening on port ${HEALTH_PORT}`,
     );
   });
 
@@ -82,21 +120,54 @@ async function main(): Promise<void> {
     );
   });
 
+  // lastTickAt tracks the `now` of the previous pass so each tick's window
+  // covers exactly (lastTickAt, now] — no gaps, no double-fires. It resets
+  // to null on pod restart, which makes the first pass use a synthetic
+  // (now - 60s, now] window (safe: at most one occurrence can be missed).
+  let lastTickAt: Date | null = null;
+
+  // Run the initial tick immediately to catch any schedules due at boot,
+  // then align subsequent ticks to the wall-clock minute boundary.
   console.log("[Dispatcher] Running initial dispatch...");
   try {
-    await dispatch();
+    await dispatch(lastTickAt);
   } catch (error) {
     console.error("[Dispatcher] Initial dispatch failed:", error);
   }
+  // The initial dispatch does not update lastTickAt — on pod restart we want
+  // the first aligned tick to use the synthetic window so it can recover any
+  // occurrence that may have been missed since the last pod's final tick.
 
-  console.log("[Dispatcher] Starting interval (runs every 60 seconds)");
-  setInterval(async () => {
+  const alignDelay = msUntilNextTick();
+  console.log(
+    `[Dispatcher] Aligning to minute boundary — first aligned tick in ${alignDelay}ms`,
+  );
+
+  // Self-scheduling setTimeout: after each tick recompute the delay to the
+  // next minute boundary. This naturally absorbs drift from slow DB queries
+  // without accumulating phase error the way a fixed setInterval would.
+  const scheduleTick = async (): Promise<void> => {
+    const prevTick = lastTickAt;
+    lastTickAt = new Date();
+
     try {
-      await dispatch();
+      await dispatch(prevTick);
     } catch (error) {
       console.error("[Dispatcher] Dispatch failed:", error);
     }
-  }, 60_000);
+
+    setTimeout(() => {
+      scheduleTick().catch((error: unknown) => {
+        console.error("[Dispatcher] Tick scheduling error:", error);
+      });
+    }, msUntilNextTick());
+  };
+
+  setTimeout(() => {
+    scheduleTick().catch((error: unknown) => {
+      console.error("[Dispatcher] First aligned tick error:", error);
+    });
+  }, alignDelay);
 }
 
 main().catch((error: unknown) => {

--- a/keeperhub-scheduler/schedule-dispatcher/index.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/index.ts
@@ -74,7 +74,9 @@ async function main(): Promise<void> {
   console.log("[Dispatcher] Starting schedule dispatcher...");
   console.log(`[Dispatcher] KeeperHub URL: ${KEEPERHUB_URL}`);
   console.log(`[Dispatcher] SQS Queue URL: ${SQS_QUEUE_URL}`);
-  console.log(`[Dispatcher] Tick offset: ${TICK_OFFSET_MS}ms past minute boundary`);
+  console.log(
+    `[Dispatcher] Tick offset: ${TICK_OFFSET_MS}ms past minute boundary`,
+  );
 
   const healthApp = express();
   const HEALTH_PORT = process.env.HEALTH_PORT || 3060;

--- a/keeperhub-scheduler/schedule-dispatcher/metrics.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/metrics.ts
@@ -1,0 +1,38 @@
+import { Counter, Histogram, Registry } from "prom-client";
+
+export const registry = new Registry();
+
+const PREFIX = "keeperhub_schedule_dispatcher";
+
+// How long each dispatch pass takes, wall-clock, from stamp-now to last SQS
+// send (or fetch failure). The primary latency signal. p95 > 10s indicates DB
+// or SQS slowness severe enough to threaten the trigger window.
+export const runDurationSeconds = new Histogram({
+  name: `${PREFIX}_run_duration_seconds`,
+  help: "Wall-clock seconds per dispatch pass (fetch + evaluate + enqueue).",
+  buckets: [0.1, 0.5, 1, 2, 5, 10, 20, 30, 60],
+  registers: [registry],
+});
+
+// Monotonic total of dispatch passes completed. Use rate() to get passes/min.
+export const runsTotal = new Counter({
+  name: `${PREFIX}_runs_total`,
+  help: "Total dispatch passes completed (fetch succeeded and loop ran).",
+  registers: [registry],
+});
+
+// Monotonic total of SQS messages enqueued. A sustained zero over 90 minutes
+// while schedules exist is the "missed hourly trigger" signal.
+export const triggeredTotal = new Counter({
+  name: `${PREFIX}_triggered_total`,
+  help: "Total workflow trigger messages successfully enqueued to SQS.",
+  registers: [registry],
+});
+
+// Per-schedule errors (SQS failure, bad cron caught late, etc.). Distinct from
+// fetch errors which abort the whole pass and are not counted here.
+export const errorsTotal = new Counter({
+  name: `${PREFIX}_errors_total`,
+  help: "Total per-schedule errors during a dispatch pass.",
+  registers: [registry],
+});

--- a/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
+++ b/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
@@ -35,8 +35,10 @@ vi.mock("../../lib/phantom.js", () => ({
 
 import { sqs } from "../../lib/sqs-client.js";
 import {
+  cronOccurrencesBetween,
   dispatch,
   fetchSchedules,
+  intervalOccurrencesBetween,
   sendToQueue,
   shouldTriggerInterval,
   shouldTriggerNow,
@@ -787,5 +789,188 @@ describe("dispatch", () => {
       "executionId",
     );
     expect(failPhantomExecution).not.toHaveBeenCalled();
+  });
+
+  it("catch-up: fires multiple occurrences when lastTickAt is provided and window spans multiple cron hits", async () => {
+    // Two hourly occurrences at 09:00 and 10:00 land in (08:30, 10:01].
+    vi.setSystemTime(new Date("2024-01-15T10:00:01Z"));
+    stubFetch([
+      {
+        id: "sched-1",
+        workflowId: "wf-1",
+        cronExpression: "0 * * * *",
+        timezone: "UTC",
+      },
+    ]);
+    mockedSqsSend.mockResolvedValue(sqsOkResponse);
+
+    const lastTickAt = new Date("2024-01-15T08:30:00Z");
+    const result = await dispatch(lastTickAt);
+
+    // window (08:30, 10:00:01] contains 09:00:00 and 10:00:00
+    expect(result).toEqual({ evaluated: 1, triggered: 2, errors: 0 });
+    expect(mockedSqsSend).toHaveBeenCalledTimes(2);
+    const bodies = mockedSqsSend.mock.calls.map((c) =>
+      JSON.parse((c[0] as SendMessageCommand).input.MessageBody ?? ""),
+    );
+    expect(bodies[0].triggerTime).toBe("2024-01-15T09:00:00.000Z");
+    expect(bodies[1].triggerTime).toBe("2024-01-15T10:00:00.000Z");
+  });
+
+  it("triggerTime is the occurrence timestamp, not now", async () => {
+    // now = 09:00:30, occurrence = 09:00:00 — these differ by 30s.
+    vi.setSystemTime(new Date("2024-01-15T09:00:30Z"));
+    stubFetch([
+      {
+        id: "sched-1",
+        workflowId: "wf-1",
+        cronExpression: "0 9 * * *",
+        timezone: "UTC",
+      },
+    ]);
+    mockedSqsSend.mockResolvedValue(sqsOkResponse);
+
+    await dispatch();
+
+    const body = JSON.parse(
+      (mockedSqsSend.mock.calls[0][0] as SendMessageCommand).input
+        .MessageBody ?? "",
+    );
+    expect(body.triggerTime).toBe("2024-01-15T09:00:00.000Z");
+  });
+});
+
+describe("cronOccurrencesBetween", () => {
+  it("returns the occurrence when it falls at the exact upper bound (to)", () => {
+    const from = new Date("2024-01-15T08:59:00Z");
+    const to = new Date("2024-01-15T09:00:00Z");
+    const result = cronOccurrencesBetween("0 9 * * *", "UTC", from, to);
+    expect(result).toHaveLength(1);
+    expect(result[0].toISOString()).toBe("2024-01-15T09:00:00.000Z");
+  });
+
+  it("excludes occurrences at or before the lower bound (from)", () => {
+    // from = 09:00:00 exactly; the 09:00:00 occurrence must not be returned
+    // because the window is (from, to], not [from, to].
+    const from = new Date("2024-01-15T09:00:00Z");
+    const to = new Date("2024-01-15T09:00:30Z");
+    const result = cronOccurrencesBetween("0 9 * * *", "UTC", from, to);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns multiple occurrences across a wide window", () => {
+    const from = new Date("2024-01-15T00:00:00Z");
+    const to = new Date("2024-01-15T03:00:00Z");
+    // every hour: 01:00, 02:00, 03:00
+    const result = cronOccurrencesBetween("0 * * * *", "UTC", from, to);
+    expect(result).toHaveLength(3);
+    expect(result.map((d) => d.toISOString())).toEqual([
+      "2024-01-15T01:00:00.000Z",
+      "2024-01-15T02:00:00.000Z",
+      "2024-01-15T03:00:00.000Z",
+    ]);
+  });
+
+  it("returns empty array when no occurrence falls in the window", () => {
+    const from = new Date("2024-01-15T09:01:00Z");
+    const to = new Date("2024-01-15T09:59:00Z");
+    const result = cronOccurrencesBetween("0 9 * * *", "UTC", from, to);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns empty array and logs on an invalid cron expression", () => {
+    const from = new Date("2024-01-15T08:59:00Z");
+    const to = new Date("2024-01-15T09:01:00Z");
+    const result = cronOccurrencesBetween("not-a-cron", "UTC", from, to);
+    expect(result).toHaveLength(0);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid cron expression: not-a-cron"),
+      expect.anything(),
+    );
+  });
+
+  it("respects timezone: NY 9am occurrence inside UTC window", () => {
+    // 2024-01-15 09:00 EST = 14:00 UTC (January = EST = UTC-5)
+    const from = new Date("2024-01-15T13:59:00Z");
+    const to = new Date("2024-01-15T14:01:00Z");
+    const result = cronOccurrencesBetween(
+      "0 9 * * *",
+      "America/New_York",
+      from,
+      to,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].toISOString()).toBe("2024-01-15T14:00:00.000Z");
+  });
+
+  it("returns empty array when from >= to", () => {
+    const t = new Date("2024-01-15T09:00:00Z");
+    expect(cronOccurrencesBetween("* * * * *", "UTC", t, t)).toHaveLength(0);
+  });
+});
+
+describe("intervalOccurrencesBetween", () => {
+  const anchor = new Date("2026-05-18T10:00:00Z"); // k=0; k=1 fires at 10:55
+
+  it("returns the first occurrence (k=1) when it falls in the window", () => {
+    const from = new Date("2026-05-18T10:54:00Z");
+    const to = new Date("2026-05-18T10:55:00Z");
+    const result = intervalOccurrencesBetween(3300, anchor, from, to);
+    expect(result).toHaveLength(1);
+    expect(result[0].toISOString()).toBe("2026-05-18T10:55:00.000Z");
+  });
+
+  it("excludes occurrence at the exact lower bound (from is exclusive)", () => {
+    const from = new Date("2026-05-18T10:55:00Z"); // exactly k=1
+    const to = new Date("2026-05-18T11:00:00Z");
+    const result = intervalOccurrencesBetween(3300, anchor, from, to);
+    // k=1 is at 10:55 == from, so excluded. k=2 is at 11:50 > to.
+    expect(result).toHaveLength(0);
+  });
+
+  it("does not fire before k=1 (the anchor itself is not an occurrence)", () => {
+    const from = new Date("2026-05-18T09:59:00Z");
+    const to = new Date("2026-05-18T10:00:30Z"); // anchor at 10:00 is within this
+    const result = intervalOccurrencesBetween(3300, anchor, from, to);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns multiple occurrences across a wide window", () => {
+    const from = new Date("2026-05-18T10:00:00Z"); // anchor excluded
+    const to = new Date("2026-05-18T12:05:00Z"); // covers k=1 (10:55) and k=2 (11:50)
+    const result = intervalOccurrencesBetween(3300, anchor, from, to);
+    expect(result).toHaveLength(2);
+    expect(result[0].toISOString()).toBe("2026-05-18T10:55:00.000Z");
+    expect(result[1].toISOString()).toBe("2026-05-18T11:50:00.000Z");
+  });
+
+  it("returns empty array for non-positive interval", () => {
+    const from = new Date("2026-05-18T10:00:00Z");
+    const to = new Date("2026-05-18T12:00:00Z");
+    expect(intervalOccurrencesBetween(0, anchor, from, to)).toHaveLength(0);
+    expect(intervalOccurrencesBetween(-60, anchor, from, to)).toHaveLength(0);
+  });
+
+  it("returns empty array for non-finite interval", () => {
+    const from = new Date("2026-05-18T10:00:00Z");
+    const to = new Date("2026-05-18T12:00:00Z");
+    expect(
+      intervalOccurrencesBetween(Number.NaN, anchor, from, to),
+    ).toHaveLength(0);
+    expect(
+      intervalOccurrencesBetween(Number.POSITIVE_INFINITY, anchor, from, to),
+    ).toHaveLength(0);
+  });
+
+  it("returns empty array for an Invalid Date anchor", () => {
+    const badAnchor = new Date("not-a-date");
+    const from = new Date("2026-05-18T10:00:00Z");
+    const to = new Date("2026-05-18T12:00:00Z");
+    expect(intervalOccurrencesBetween(3300, badAnchor, from, to)).toHaveLength(0);
+  });
+
+  it("returns empty array when from >= to", () => {
+    const t = new Date("2026-05-18T10:55:00Z");
+    expect(intervalOccurrencesBetween(3300, anchor, t, t)).toHaveLength(0);
   });
 });

--- a/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
+++ b/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
@@ -966,7 +966,9 @@ describe("intervalOccurrencesBetween", () => {
     const badAnchor = new Date("not-a-date");
     const from = new Date("2026-05-18T10:00:00Z");
     const to = new Date("2026-05-18T12:00:00Z");
-    expect(intervalOccurrencesBetween(3300, badAnchor, from, to)).toHaveLength(0);
+    expect(
+      intervalOccurrencesBetween(3300, badAnchor, from, to),
+    ).toHaveLength(0);
   });
 
   it("returns empty array when from >= to", () => {

--- a/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
+++ b/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
@@ -966,9 +966,9 @@ describe("intervalOccurrencesBetween", () => {
     const badAnchor = new Date("not-a-date");
     const from = new Date("2026-05-18T10:00:00Z");
     const to = new Date("2026-05-18T12:00:00Z");
-    expect(
-      intervalOccurrencesBetween(3300, badAnchor, from, to),
-    ).toHaveLength(0);
+    expect(intervalOccurrencesBetween(3300, badAnchor, from, to)).toHaveLength(
+      0,
+    );
   });
 
   it("returns empty array when from >= to", () => {


### PR DESCRIPTION
## Summary

Three root-cause bugs from the 2026-05-25 missed-trigger incident where 4 workflows fired 23x/24h instead of 24x (a 31s DB query pushed `now` 73s past the 09:00:00 occurrence).

- **Wall-clock alignment** (`index.ts`): `setInterval(60_000)` replaced with a self-scheduling `setTimeout` targeting `:02` past each minute boundary. Pod boot time no longer determines when ticks fire. `TICK_OFFSET_MS` env var controls the offset (default 2000ms).
- **Stamp `now` before fetch** (`dispatch.ts`): `const now = new Date()` is now the first statement, before `fetchSchedules()`. DB latency can no longer shrink the window and miss an occurrence.
- **Occurrence-based catch-up** (`dispatch.ts`): `cronOccurrencesBetween` / `intervalOccurrencesBetween` replace the single-minute boolean check. The dispatch window is `(lastTickAt, now]` — every occurrence since the last tick is recovered, not just the one in the most recent minute. `lastTickAt` is maintained in `index.ts` and passed into `dispatch()`.
- **Prometheus metrics** (`metrics.ts`, `index.ts`): new `keeperhub_schedule_dispatcher_{run_duration_seconds,runs_total,triggered_total,errors_total}` counters; `/metrics` endpoint on the health server (port 3060).

## Test plan

- [x] Existing unit tests pass unchanged (`shouldTriggerNow`, `shouldTriggerInterval`, `dispatch`, `fetchSchedules`, `sendToQueue`, KEEP-693 phantom tests)
- [x] New `cronOccurrencesBetween` suite (6 cases): boundary inclusion/exclusion, multi-occurrence window, timezone, invalid expression
- [x] New `intervalOccurrencesBetween` suite (7 cases): k=1 boundary, exclusive lower bound, no-anchor-fire, multi-occurrence, invalid inputs
- [ ] New dispatch cases: catch-up with `lastTickAt` spanning 2 hourly occurrences fires both; `triggerTime` equals occurrence ISO string, not `now`
- [ ] Smoke test: deploy to staging, tail scheduler logs, confirm ticks align to `:02` and window log lines show `(lastTickAt, now]` bounds