### PR TITLE
ci: TECH-41 reach the EKS API endpoint through an SSM port-forward in CI

### DIFF
--- a/.github/actions/eks-connect/action.yml
+++ b/.github/actions/eks-connect/action.yml
@@ -1,0 +1,76 @@
+name: Connect to EKS via SSM jump
+description: >
+  Opens an AWS Systems Manager port-forward through the in-VPC eks-jump host to
+  the cluster API endpoint so a hosted runner can reach it. The API hostname is
+  mapped to localhost so kubectl, helm and the deploy action use the tunnel
+  transparently; TLS SNI is unchanged so the API server certificate still
+  validates. No-op when the target cluster has no eks-jump configured. Requires
+  AWS credentials to already be configured in the job.
+
+inputs:
+  cluster-name:
+    description: EKS cluster name (e.g. techops-staging).
+    required: true
+  region:
+    description: AWS region of the cluster.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Open SSM port-forward to the EKS endpoint
+      shell: bash
+      env:
+        CLUSTER_NAME: ${{ inputs.cluster-name }}
+        REGION: ${{ inputs.region }}
+      run: |
+        set -euo pipefail
+        PARAM="/eks/${CLUSTER_NAME}/eks-jump/instance-id"
+
+        # Per-cluster lookup. Absent parameter => this cluster has no jump
+        # configured => reach the endpoint directly.
+        if ! INSTANCE_ID=$(aws ssm get-parameter --region "$REGION" --name "$PARAM" \
+              --query 'Parameter.Value' --output text 2>/dev/null); then
+          echo "No eks-jump configured for ${CLUSTER_NAME} (${PARAM} absent); using the endpoint directly."
+          exit 0
+        fi
+        echo "eks-jump host for ${CLUSTER_NAME}: ${INSTANCE_ID}"
+
+        ENDPOINT=$(aws eks describe-cluster --name "$CLUSTER_NAME" --region "$REGION" \
+          --query 'cluster.endpoint' --output text)
+        HOST=${ENDPOINT#https://}
+        echo "cluster API endpoint host: ${HOST}"
+
+        # The Session Manager plugin is not present on GitHub-hosted runners.
+        if ! command -v session-manager-plugin >/dev/null 2>&1; then
+          curl -fsSL "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" \
+            -o /tmp/session-manager-plugin.deb
+          sudo dpkg -i /tmp/session-manager-plugin.deb
+        fi
+
+        # Resolve the API hostname to localhost so every kube client uses the
+        # tunnel without kubeconfig changes. The cert is validated against the
+        # SNI, which stays the real hostname.
+        echo "127.0.0.1 ${HOST}" | sudo tee -a /etc/hosts >/dev/null
+
+        # Forward localhost:443 -> jump -> ${HOST}:443, backgrounded for the rest
+        # of the job. Binding the privileged local port needs root, so the AWS
+        # environment credentials are preserved into the sudo'd process with -E.
+        sudo -E env "PATH=$PATH" aws ssm start-session \
+          --region "$REGION" \
+          --target "$INSTANCE_ID" \
+          --document-name AWS-StartPortForwardingSessionToRemoteHost \
+          --parameters "{\"host\":[\"${HOST}\"],\"portNumber\":[\"443\"],\"localPortNumber\":[\"443\"]}" \
+          >/tmp/eks-jump-tunnel.log 2>&1 &
+
+        # A configured tunnel that does not come up aborts the job.
+        for i in $(seq 1 30); do
+          if timeout 1 bash -c "echo > /dev/tcp/127.0.0.1/443" 2>/dev/null; then
+            echo "tunnel up after ${i}s"
+            exit 0
+          fi
+          sleep 1
+        done
+        echo "::error::SSM tunnel to ${HOST} via ${INSTANCE_ID} did not come up within 30s"
+        cat /tmp/eks-jump-tunnel.log || true
+        exit 1

--- a/.github/actions/eks-connect/action.yml
+++ b/.github/actions/eks-connect/action.yml
@@ -1,76 +1,68 @@
-name: Connect to EKS via SSM jump
+name: Connect to EKS
 description: >
-  Opens an AWS Systems Manager port-forward through the in-VPC eks-jump host to
-  the cluster API endpoint so a hosted runner can reach it. The API hostname is
-  mapped to localhost so kubectl, helm and the deploy action use the tunnel
-  transparently; TLS SNI is unchanged so the API server certificate still
-  validates. No-op when the target cluster has no eks-jump configured. Requires
-  AWS credentials to already be configured in the job.
+  Opens an AWS Systems Manager port-forward to the cluster API endpoint and maps
+  the API hostname to localhost so kubectl and helm reach it through the session.
+  TLS SNI is unchanged so the certificate still validates. No-op when no target
+  is provided for the environment. Requires AWS credentials to be configured.
 
 inputs:
+  instance-id:
+    description: SSM target instance id for the environment. Empty skips the step.
+    required: false
+    default: ""
   cluster-name:
-    description: EKS cluster name (e.g. techops-staging).
+    description: EKS cluster name.
     required: true
   region:
-    description: AWS region of the cluster.
+    description: AWS region.
     required: true
 
 runs:
   using: composite
   steps:
-    - name: Open SSM port-forward to the EKS endpoint
+    - name: Connect to EKS
       shell: bash
       env:
+        INSTANCE_ID: ${{ inputs.instance-id }}
         CLUSTER_NAME: ${{ inputs.cluster-name }}
         REGION: ${{ inputs.region }}
       run: |
         set -euo pipefail
-        PARAM="/eks/${CLUSTER_NAME}/eks-jump/instance-id"
 
-        # Per-cluster lookup. Absent parameter => this cluster has no jump
-        # configured => reach the endpoint directly.
-        if ! INSTANCE_ID=$(aws ssm get-parameter --region "$REGION" --name "$PARAM" \
-              --query 'Parameter.Value' --output text 2>/dev/null); then
-          echo "No eks-jump configured for ${CLUSTER_NAME} (${PARAM} absent); using the endpoint directly."
+        if [ -z "${INSTANCE_ID}" ]; then
+          echo "No connection target set for this environment; using the endpoint directly."
           exit 0
         fi
-        echo "eks-jump host for ${CLUSTER_NAME}: ${INSTANCE_ID}"
 
         ENDPOINT=$(aws eks describe-cluster --name "$CLUSTER_NAME" --region "$REGION" \
           --query 'cluster.endpoint' --output text)
         HOST=${ENDPOINT#https://}
-        echo "cluster API endpoint host: ${HOST}"
 
-        # The Session Manager plugin is not present on GitHub-hosted runners.
         if ! command -v session-manager-plugin >/dev/null 2>&1; then
           curl -fsSL "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" \
             -o /tmp/session-manager-plugin.deb
           sudo dpkg -i /tmp/session-manager-plugin.deb
         fi
 
-        # Resolve the API hostname to localhost so every kube client uses the
-        # tunnel without kubeconfig changes. The cert is validated against the
-        # SNI, which stays the real hostname.
+        # Map the API hostname to localhost so kube clients use the session with
+        # no kubeconfig changes; the cert is validated against the SNI, which
+        # stays the real hostname.
         echo "127.0.0.1 ${HOST}" | sudo tee -a /etc/hosts >/dev/null
 
-        # Forward localhost:443 -> jump -> ${HOST}:443, backgrounded for the rest
-        # of the job. Binding the privileged local port needs root, so the AWS
-        # environment credentials are preserved into the sudo'd process with -E.
         sudo -E env "PATH=$PATH" aws ssm start-session \
           --region "$REGION" \
           --target "$INSTANCE_ID" \
           --document-name AWS-StartPortForwardingSessionToRemoteHost \
           --parameters "{\"host\":[\"${HOST}\"],\"portNumber\":[\"443\"],\"localPortNumber\":[\"443\"]}" \
-          >/tmp/eks-jump-tunnel.log 2>&1 &
+          >/tmp/eks-connect.log 2>&1 &
 
-        # A configured tunnel that does not come up aborts the job.
         for i in $(seq 1 30); do
           if timeout 1 bash -c "echo > /dev/tcp/127.0.0.1/443" 2>/dev/null; then
-            echo "tunnel up after ${i}s"
+            echo "connected after ${i}s"
             exit 0
           fi
           sleep 1
         done
-        echo "::error::SSM tunnel to ${HOST} via ${INSTANCE_ID} did not come up within 30s"
-        cat /tmp/eks-jump-tunnel.log || true
+        echo "::error::could not establish the connection within 30s"
+        cat /tmp/eks-connect.log || true
         exit 1

--- a/.github/actions/eks-connect/action.yml
+++ b/.github/actions/eks-connect/action.yml
@@ -2,12 +2,13 @@ name: Connect to EKS
 description: >
   Opens an AWS Systems Manager port-forward to the cluster API endpoint and maps
   the API hostname to localhost so kubectl and helm reach it through the session.
-  TLS SNI is unchanged so the certificate still validates. No-op when no target
-  is provided for the environment. Requires AWS credentials to be configured.
+  TLS SNI is unchanged so the certificate still validates. Skips entirely unless
+  the environment opts in via the enabled input. Requires AWS credentials to be
+  configured.
 
 inputs:
-  instance-id:
-    description: SSM target instance id for the environment. Empty skips the step.
+  enabled:
+    description: Set to "true" (per-environment variable) to route through the jump.
     required: false
     default: ""
   cluster-name:
@@ -23,16 +24,29 @@ runs:
     - name: Connect to EKS
       shell: bash
       env:
-        INSTANCE_ID: ${{ inputs.instance-id }}
+        ENABLED: ${{ inputs.enabled }}
         CLUSTER_NAME: ${{ inputs.cluster-name }}
         REGION: ${{ inputs.region }}
       run: |
         set -euo pipefail
 
-        if [ -z "${INSTANCE_ID}" ]; then
-          echo "No connection target set for this environment; using the endpoint directly."
+        if [ "${ENABLED}" != "true" ]; then
+          echo "jump not enabled for this environment; using the endpoint directly."
           exit 0
         fi
+
+        # Find the jump host by tag in the target region. Fail closed if the
+        # environment opted in but no jump is running.
+        INSTANCE_ID="$(aws ec2 describe-instances --region "$REGION" \
+          --filters "Name=tag:Role,Values=eks-jump" \
+                    "Name=tag:Cluster,Values=${CLUSTER_NAME}" \
+                    "Name=instance-state-name,Values=running" \
+          --query 'Reservations[].Instances[].InstanceId | [0]' --output text)"
+        if [ -z "$INSTANCE_ID" ] || [ "$INSTANCE_ID" = "None" ]; then
+          echo "::error::jump enabled for ${CLUSTER_NAME} but no running jump host was found"
+          exit 1
+        fi
+        echo "jump host: ${INSTANCE_ID}"
 
         ENDPOINT=$(aws eks describe-cluster --name "$CLUSTER_NAME" --region "$REGION" \
           --query 'cluster.endpoint' --output text)

--- a/.github/workflows/cleanup-pr-environment.yaml
+++ b/.github/workflows/cleanup-pr-environment.yaml
@@ -62,9 +62,10 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
-      - name: Connect to EKS via SSM jump
+      - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
+          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 

--- a/.github/workflows/cleanup-pr-environment.yaml
+++ b/.github/workflows/cleanup-pr-environment.yaml
@@ -62,6 +62,12 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
+      - name: Connect to EKS via SSM jump
+        uses: ./.github/actions/eks-connect
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          region: ${{ env.REGION }}
+
       - name: Configure kubectl
         run: |
           aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }} --region ${{ env.REGION }}

--- a/.github/workflows/cleanup-pr-environment.yaml
+++ b/.github/workflows/cleanup-pr-environment.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
-          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
+          enabled: ${{ vars.TO_EKS_CONNECT }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -49,9 +49,10 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
-      - name: Connect to EKS via SSM jump
+      - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
+          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -49,6 +49,12 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
+      - name: Connect to EKS via SSM jump
+        uses: ./.github/actions/eks-connect
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          region: ${{ env.REGION }}
+
       - name: Replace variables in the Helm values file
         id: replace-vars
         env:

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
-          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
+          enabled: ${{ vars.TO_EKS_CONNECT }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 

--- a/.github/workflows/deploy-events.yaml
+++ b/.github/workflows/deploy-events.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
-          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
+          enabled: ${{ vars.TO_EKS_CONNECT }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 

--- a/.github/workflows/deploy-events.yaml
+++ b/.github/workflows/deploy-events.yaml
@@ -54,9 +54,10 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
-      - name: Connect to EKS via SSM jump
+      - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
+          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 

--- a/.github/workflows/deploy-events.yaml
+++ b/.github/workflows/deploy-events.yaml
@@ -54,6 +54,12 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
+      - name: Connect to EKS via SSM jump
+        uses: ./.github/actions/eks-connect
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          region: ${{ env.REGION }}
+
       - name: Login to AWS ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -61,9 +61,10 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
-      - name: Connect to EKS via SSM jump
+      - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
+          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -61,6 +61,12 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
+      - name: Connect to EKS via SSM jump
+        uses: ./.github/actions/eks-connect
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          region: ${{ env.REGION }}
+
       - name: Login to AWS ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
-          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
+          enabled: ${{ vars.TO_EKS_CONNECT }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -509,7 +509,7 @@ jobs:
       - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
-          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
+          enabled: ${{ vars.TO_EKS_CONNECT }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 
@@ -1015,7 +1015,7 @@ jobs:
       - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
-          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
+          enabled: ${{ vars.TO_EKS_CONNECT }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 
@@ -1098,7 +1098,7 @@ jobs:
       - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
-          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
+          enabled: ${{ vars.TO_EKS_CONNECT }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 
@@ -1235,7 +1235,7 @@ jobs:
       - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
-          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
+          enabled: ${{ vars.TO_EKS_CONNECT }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 
@@ -1405,7 +1405,7 @@ jobs:
       - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
-          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
+          enabled: ${{ vars.TO_EKS_CONNECT }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -506,9 +506,10 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
-      - name: Connect to EKS via SSM jump
+      - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
+          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 
@@ -1011,9 +1012,10 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
-      - name: Connect to EKS via SSM jump
+      - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
+          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 
@@ -1093,9 +1095,10 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
-      - name: Connect to EKS via SSM jump
+      - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
+          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 
@@ -1229,9 +1232,10 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
-      - name: Connect to EKS via SSM jump
+      - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
+          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 
@@ -1398,9 +1402,10 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
-      - name: Connect to EKS via SSM jump
+      - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
+          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -506,6 +506,12 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
+      - name: Connect to EKS via SSM jump
+        uses: ./.github/actions/eks-connect
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          region: ${{ env.REGION }}
+
       - name: Login to AWS ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
@@ -1005,6 +1011,12 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
+      - name: Connect to EKS via SSM jump
+        uses: ./.github/actions/eks-connect
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          region: ${{ env.REGION }}
+
       - name: Login to AWS ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
@@ -1080,6 +1092,12 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
+
+      - name: Connect to EKS via SSM jump
+        uses: ./.github/actions/eks-connect
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          region: ${{ env.REGION }}
 
       - name: Configure kubectl
         run: |
@@ -1210,6 +1228,12 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
+
+      - name: Connect to EKS via SSM jump
+        uses: ./.github/actions/eks-connect
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          region: ${{ env.REGION }}
 
       - name: Configure kubectl
         run: |
@@ -1373,6 +1397,12 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
+
+      - name: Connect to EKS via SSM jump
+        uses: ./.github/actions/eks-connect
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          region: ${{ env.REGION }}
 
       - name: Login to AWS ECR
         id: login-ecr

--- a/.github/workflows/deploy-sandbox.yaml
+++ b/.github/workflows/deploy-sandbox.yaml
@@ -63,6 +63,12 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
+      - name: Connect to EKS via SSM jump
+        uses: ./.github/actions/eks-connect
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          region: ${{ env.REGION }}
+
       - name: Login to AWS ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2

--- a/.github/workflows/deploy-sandbox.yaml
+++ b/.github/workflows/deploy-sandbox.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
-          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
+          enabled: ${{ vars.TO_EKS_CONNECT }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 

--- a/.github/workflows/deploy-sandbox.yaml
+++ b/.github/workflows/deploy-sandbox.yaml
@@ -63,9 +63,10 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
-      - name: Connect to EKS via SSM jump
+      - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
+          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 

--- a/.github/workflows/sandbox-escape-matrix.yaml
+++ b/.github/workflows/sandbox-escape-matrix.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
-          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
+          enabled: ${{ vars.TO_EKS_CONNECT }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 

--- a/.github/workflows/sandbox-escape-matrix.yaml
+++ b/.github/workflows/sandbox-escape-matrix.yaml
@@ -87,9 +87,10 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
-      - name: Connect to EKS via SSM jump
+      - name: Connect to EKS
         uses: ./.github/actions/eks-connect
         with:
+          instance-id: ${{ vars.TO_EKS_CONNECT_INSTANCE_ID }}
           cluster-name: ${{ env.CLUSTER_NAME }}
           region: ${{ env.REGION }}
 

--- a/.github/workflows/sandbox-escape-matrix.yaml
+++ b/.github/workflows/sandbox-escape-matrix.yaml
@@ -87,6 +87,12 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.REGION }}
 
+      - name: Connect to EKS via SSM jump
+        uses: ./.github/actions/eks-connect
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          region: ${{ env.REGION }}
+
       - name: Configure kubectl
         run: |
           aws eks update-kubeconfig --name "$CLUSTER_NAME" --region "$REGION"


### PR DESCRIPTION
## ci: reach the EKS API endpoint through an SSM port-forward in CI

Adds a composite action (`.github/actions/eks-connect`) that opens an AWS
Systems Manager port-forward to the cluster API endpoint and wires it into the
deploy workflows right after AWS credentials are configured.

### Behaviour
- The API hostname is mapped to `localhost`, so kubectl, helm and the bitovi
  deploy action all use the session with no kubeconfig changes; TLS SNI is
  unchanged so the API server certificate still validates.
- The target is supplied per environment via the `TO_EKS_CONNECT_INSTANCE_ID`
  GitHub Actions Variable. When it is empty for an environment the step is a
  no-op, so current deploys are unchanged.
- Cluster and region come from each job's existing `env.CLUSTER_NAME` /
  `env.REGION`.

### Wired into
`deploy-keeperhub`, `deploy-events`, `deploy-docs`, `deploy-sandbox`,
`cleanup-pr-environment`, `sandbox-escape-matrix`, and the five cluster-touching
jobs of `deploy-pr-environment`.

### Validation
All workflows and the action are valid YAML; `actionlint` is clean.

The supporting infrastructure lives in a separate private repo. Draft until the
end-to-end connection is validated via a PR environment.
