### PR TITLE
refactor: migrate compound-v3 and safe to defineAbiProtocol

### DIFF
--- a/protocols/compound-v3.ts
+++ b/protocols/compound-v3.ts
@@ -1,6 +1,6 @@
-import { defineProtocol } from "@/lib/protocol-registry";
+import { defineAbiProtocol } from "@/lib/protocol-registry";
 
-export default defineProtocol({
+export default defineAbiProtocol({
   name: "Compound V3",
   slug: "compound",
   description:
@@ -12,18 +12,11 @@ export default defineProtocol({
     comet: {
       label: "Comet Market",
       userSpecifiedAddress: true,
-      // Reference addresses (USDC market per chain) for chain-availability metadata.
-      // Runtime address comes from user input via the contractAddress config field,
-      // since each Comet market (USDC, USDT, WETH) is a separate contract.
       addresses: {
-        // Ethereum Mainnet (USDC market)
         "1": "0xc3d688B66703497DAA19211EEdff47f25384cdc3",
-        // Base (USDC market)
         "8453": "0xb125E6687d4313864e53df431d5425969c15Eb2F",
-        // Arbitrum One (USDC market)
         "42161": "0x9c4ec768c28520B50860ea7a15bd7213a9fF58bf",
       },
-      // Inline ABI -- Comet is a proxy; block explorer auto-fetch fails on Base/Arbitrum
       abi: JSON.stringify([
         {
           type: "function",
@@ -122,229 +115,131 @@ export default defineProtocol({
           outputs: [{ name: "", type: "uint8" }],
         },
       ]),
+      overrides: {
+        supply: {
+          label: "Supply Asset",
+          description:
+            "Supply base or collateral assets to a Compound V3 Comet market. Requires prior ERC-20 approval for the Comet contract.",
+          inputs: {
+            asset: { label: "Asset Token Address" },
+            amount: { label: "Amount (wei)" },
+          },
+        },
+        withdraw: {
+          label: "Withdraw Asset",
+          description:
+            "Withdraw base or collateral assets from a Compound V3 Comet market",
+          inputs: {
+            asset: { label: "Asset Token Address" },
+            amount: { label: "Amount (wei)" },
+          },
+        },
+        balanceOf: {
+          slug: "get-balance",
+          label: "Get Base Balance",
+          description:
+            "Get the balance of the base asset (e.g. USDC) for an account in a Comet market",
+          inputs: {
+            account: { label: "Account Address" },
+          },
+          outputs: {
+            result: { name: "balance", label: "Base Asset Balance" },
+          },
+        },
+        userCollateral: {
+          slug: "get-collateral-balance",
+          label: "Get Collateral Balance",
+          description:
+            "Get the collateral balance of a specific asset for an account in a Comet market",
+          inputs: {
+            account: { label: "Account Address" },
+            asset: { label: "Collateral Asset Address" },
+          },
+          outputs: {
+            balance: { label: "Collateral Balance" },
+          },
+        },
+        borrowBalanceOf: {
+          slug: "get-borrow-balance",
+          label: "Get Borrow Balance",
+          description:
+            "Get the borrow balance of the base asset for an account in a Comet market",
+          inputs: {
+            account: { label: "Account Address" },
+          },
+          outputs: {
+            result: { name: "balance", label: "Borrow Balance" },
+          },
+        },
+        getUtilization: {
+          label: "Get Utilization",
+          description:
+            "Get the current utilization rate of a Comet market (ratio of borrows to supply, scaled to 1e18)",
+          outputs: {
+            result: { name: "utilization", label: "Utilization Rate", decimals: 18 },
+          },
+        },
+        getSupplyRate: {
+          label: "Get Supply Rate",
+          description:
+            "Get the per-second supply rate for a given utilization level. Multiply by seconds in a year (31536000) for APR.",
+          inputs: {
+            utilization: { label: "Utilization (from Get Utilization)" },
+          },
+          outputs: {
+            result: { name: "rate", label: "Supply Rate Per Second" },
+          },
+        },
+        getBorrowRate: {
+          label: "Get Borrow Rate",
+          description:
+            "Get the per-second borrow rate for a given utilization level. Multiply by seconds in a year (31536000) for APR.",
+          inputs: {
+            utilization: { label: "Utilization (from Get Utilization)" },
+          },
+          outputs: {
+            result: { name: "rate", label: "Borrow Rate Per Second" },
+          },
+        },
+        totalSupply: {
+          slug: "get-total-supply",
+          label: "Get Total Supply",
+          description:
+            "Get the total base asset supplied to a Comet market across all users",
+          outputs: {
+            result: { name: "totalSupply", label: "Total Supply" },
+          },
+        },
+        totalBorrow: {
+          slug: "get-total-borrow",
+          label: "Get Total Borrow",
+          description:
+            "Get the total base asset borrowed from a Comet market across all users",
+          outputs: {
+            result: { name: "totalBorrow", label: "Total Borrow" },
+          },
+        },
+        isLiquidatable: {
+          label: "Is Liquidatable",
+          description:
+            "Check if an account is currently liquidatable in a Comet market",
+          inputs: {
+            account: { label: "Account Address" },
+          },
+          outputs: {
+            result: { name: "isLiquidatable", label: "Is Liquidatable" },
+          },
+        },
+        numAssets: {
+          slug: "get-num-assets",
+          label: "Get Number of Assets",
+          description:
+            "Get the number of collateral assets supported by a Comet market",
+          outputs: {
+            result: { name: "numAssets", label: "Number of Collateral Assets" },
+          },
+        },
+      },
     },
   },
-
-  actions: [
-    // Supply / Withdraw
-
-    {
-      slug: "supply",
-      label: "Supply Asset",
-      description:
-        "Supply base or collateral assets to a Compound V3 Comet market. Requires prior ERC-20 approval for the Comet contract.",
-      type: "write",
-      contract: "comet",
-      function: "supply",
-      inputs: [
-        { name: "asset", type: "address", label: "Asset Token Address" },
-        { name: "amount", type: "uint256", label: "Amount (wei)" },
-      ],
-    },
-    {
-      slug: "withdraw",
-      label: "Withdraw Asset",
-      description:
-        "Withdraw base or collateral assets from a Compound V3 Comet market",
-      type: "write",
-      contract: "comet",
-      function: "withdraw",
-      inputs: [
-        { name: "asset", type: "address", label: "Asset Token Address" },
-        { name: "amount", type: "uint256", label: "Amount (wei)" },
-      ],
-    },
-
-    // Read Actions
-
-    {
-      slug: "get-balance",
-      label: "Get Base Balance",
-      description:
-        "Get the balance of the base asset (e.g. USDC) for an account in a Comet market",
-      type: "read",
-      contract: "comet",
-      function: "balanceOf",
-      inputs: [{ name: "account", type: "address", label: "Account Address" }],
-      outputs: [
-        {
-          name: "balance",
-          type: "uint256",
-          label: "Base Asset Balance",
-        },
-      ],
-    },
-    {
-      slug: "get-collateral-balance",
-      label: "Get Collateral Balance",
-      description:
-        "Get the collateral balance of a specific asset for an account in a Comet market",
-      type: "read",
-      contract: "comet",
-      function: "userCollateral",
-      inputs: [
-        { name: "account", type: "address", label: "Account Address" },
-        { name: "asset", type: "address", label: "Collateral Asset Address" },
-      ],
-      outputs: [
-        {
-          name: "balance",
-          type: "uint128",
-          label: "Collateral Balance",
-        },
-      ],
-    },
-    {
-      slug: "get-borrow-balance",
-      label: "Get Borrow Balance",
-      description:
-        "Get the borrow balance of the base asset for an account in a Comet market",
-      type: "read",
-      contract: "comet",
-      function: "borrowBalanceOf",
-      inputs: [{ name: "account", type: "address", label: "Account Address" }],
-      outputs: [
-        {
-          name: "balance",
-          type: "uint256",
-          label: "Borrow Balance",
-        },
-      ],
-    },
-
-    // Market analytics
-
-    {
-      slug: "get-utilization",
-      label: "Get Utilization",
-      description:
-        "Get the current utilization rate of a Comet market (ratio of borrows to supply, scaled to 1e18)",
-      type: "read",
-      contract: "comet",
-      function: "getUtilization",
-      inputs: [],
-      outputs: [
-        {
-          name: "utilization",
-          type: "uint256",
-          label: "Utilization Rate",
-          decimals: 18,
-        },
-      ],
-    },
-    {
-      slug: "get-supply-rate",
-      label: "Get Supply Rate",
-      description:
-        "Get the per-second supply rate for a given utilization level. Multiply by seconds in a year (31536000) for APR.",
-      type: "read",
-      contract: "comet",
-      function: "getSupplyRate",
-      inputs: [
-        {
-          name: "utilization",
-          type: "uint256",
-          label: "Utilization (from Get Utilization)",
-        },
-      ],
-      outputs: [
-        {
-          name: "rate",
-          type: "uint64",
-          label: "Supply Rate Per Second",
-        },
-      ],
-    },
-    {
-      slug: "get-borrow-rate",
-      label: "Get Borrow Rate",
-      description:
-        "Get the per-second borrow rate for a given utilization level. Multiply by seconds in a year (31536000) for APR.",
-      type: "read",
-      contract: "comet",
-      function: "getBorrowRate",
-      inputs: [
-        {
-          name: "utilization",
-          type: "uint256",
-          label: "Utilization (from Get Utilization)",
-        },
-      ],
-      outputs: [
-        {
-          name: "rate",
-          type: "uint64",
-          label: "Borrow Rate Per Second",
-        },
-      ],
-    },
-    {
-      slug: "get-total-supply",
-      label: "Get Total Supply",
-      description:
-        "Get the total base asset supplied to a Comet market across all users",
-      type: "read",
-      contract: "comet",
-      function: "totalSupply",
-      inputs: [],
-      outputs: [
-        {
-          name: "totalSupply",
-          type: "uint256",
-          label: "Total Supply",
-        },
-      ],
-    },
-    {
-      slug: "get-total-borrow",
-      label: "Get Total Borrow",
-      description:
-        "Get the total base asset borrowed from a Comet market across all users",
-      type: "read",
-      contract: "comet",
-      function: "totalBorrow",
-      inputs: [],
-      outputs: [
-        {
-          name: "totalBorrow",
-          type: "uint256",
-          label: "Total Borrow",
-        },
-      ],
-    },
-    {
-      slug: "is-liquidatable",
-      label: "Is Liquidatable",
-      description:
-        "Check if an account is currently liquidatable in a Comet market",
-      type: "read",
-      contract: "comet",
-      function: "isLiquidatable",
-      inputs: [{ name: "account", type: "address", label: "Account Address" }],
-      outputs: [
-        {
-          name: "isLiquidatable",
-          type: "bool",
-          label: "Is Liquidatable",
-        },
-      ],
-    },
-    {
-      slug: "get-num-assets",
-      label: "Get Number of Assets",
-      description:
-        "Get the number of collateral assets supported by a Comet market",
-      type: "read",
-      contract: "comet",
-      function: "numAssets",
-      inputs: [],
-      outputs: [
-        {
-          name: "numAssets",
-          type: "uint8",
-          label: "Number of Collateral Assets",
-        },
-      ],
-    },
-  ],
 });

--- a/protocols/compound-v3.ts
+++ b/protocols/compound-v3.ts
@@ -53,10 +53,7 @@ export default defineAbiProtocol({
             { name: "account", type: "address" },
             { name: "asset", type: "address" },
           ],
-          outputs: [
-            { name: "balance", type: "uint128" },
-            { name: "_reserved", type: "uint128" },
-          ],
+          outputs: [{ name: "balance", type: "uint128" }],
         },
         {
           type: "function",

--- a/protocols/safe.ts
+++ b/protocols/safe.ts
@@ -1,6 +1,134 @@
-import { defineProtocol } from "@/lib/protocol-registry";
+import { defineAbiProtocol } from "@/lib/protocol-registry";
 
-export default defineProtocol({
+const SAFE_ABI = JSON.stringify([
+  // Functions
+  {
+    type: "function",
+    name: "getOwners",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address[]" }],
+  },
+  {
+    type: "function",
+    name: "getThreshold",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "isOwner",
+    stateMutability: "view",
+    inputs: [{ name: "owner", type: "address" }],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "nonce",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "isModuleEnabled",
+    stateMutability: "view",
+    inputs: [{ name: "module", type: "address" }],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "getModulesPaginated",
+    stateMutability: "view",
+    inputs: [
+      { name: "start", type: "address" },
+      { name: "pageSize", type: "uint256" },
+    ],
+    outputs: [
+      { name: "array", type: "address[]" },
+      { name: "next", type: "address" },
+    ],
+  },
+  // Events
+  {
+    type: "event",
+    name: "AddedOwner",
+    inputs: [{ name: "owner", type: "address", indexed: true }],
+  },
+  {
+    type: "event",
+    name: "RemovedOwner",
+    inputs: [{ name: "owner", type: "address", indexed: true }],
+  },
+  {
+    type: "event",
+    name: "ChangedThreshold",
+    inputs: [{ name: "threshold", type: "uint256", indexed: false }],
+  },
+  {
+    type: "event",
+    name: "EnabledModule",
+    inputs: [{ name: "module", type: "address", indexed: true }],
+  },
+  {
+    type: "event",
+    name: "DisabledModule",
+    inputs: [{ name: "module", type: "address", indexed: true }],
+  },
+  {
+    type: "event",
+    name: "ChangedGuard",
+    inputs: [{ name: "guard", type: "address", indexed: false }],
+  },
+  {
+    type: "event",
+    name: "ExecutionSuccess",
+    inputs: [
+      { name: "txHash", type: "bytes32", indexed: false },
+      { name: "payment", type: "uint256", indexed: false },
+    ],
+  },
+  {
+    type: "event",
+    name: "ExecutionFailure",
+    inputs: [
+      { name: "txHash", type: "bytes32", indexed: false },
+      { name: "payment", type: "uint256", indexed: false },
+    ],
+  },
+  {
+    type: "event",
+    name: "ApproveHash",
+    inputs: [
+      { name: "approvedHash", type: "bytes32", indexed: true },
+      { name: "owner", type: "address", indexed: true },
+    ],
+  },
+  {
+    type: "event",
+    name: "SignMsg",
+    inputs: [{ name: "msgHash", type: "bytes32", indexed: true }],
+  },
+  {
+    type: "event",
+    name: "ChangedFallbackHandler",
+    inputs: [{ name: "handler", type: "address", indexed: false }],
+  },
+  {
+    type: "event",
+    name: "SafeSetup",
+    inputs: [
+      { name: "initiator", type: "address", indexed: true },
+      { name: "owners", type: "address[]", indexed: false },
+      { name: "threshold", type: "uint256", indexed: false },
+      { name: "initializer", type: "address", indexed: false },
+      { name: "fallbackHandler", type: "address", indexed: false },
+    ],
+  },
+]);
+
+export default defineAbiProtocol({
   name: "Safe",
   slug: "safe",
   description:
@@ -12,259 +140,136 @@ export default defineProtocol({
     safe: {
       label: "Safe Multisig",
       userSpecifiedAddress: true,
-      // Reference addresses (Safe v1.4.1 Singleton) for chain-availability metadata.
-      // Runtime address comes from user input via the contractAddress config field.
       addresses: {
-        // Ethereum Mainnet
         "1": "0x41675C099F32341bf84BFc5382aF534df5C7461a",
-        // Base
         "8453": "0x41675C099F32341bf84BFc5382aF534df5C7461a",
-        // Arbitrum One
         "42161": "0x41675C099F32341bf84BFc5382aF534df5C7461a",
-        // Optimism
         "10": "0x41675C099F32341bf84BFc5382aF534df5C7461a",
+      },
+      abi: SAFE_ABI,
+      overrides: {
+        getOwners: {
+          label: "Get Owners",
+          description: "Get the list of owner addresses for a Safe multisig",
+          outputs: {
+            result: { name: "owners", label: "Owner Addresses" },
+          },
+        },
+        getThreshold: {
+          label: "Get Threshold",
+          description:
+            "Get the number of required confirmations for a Safe transaction",
+          outputs: {
+            result: { name: "threshold", label: "Required Confirmations" },
+          },
+        },
+        isOwner: {
+          label: "Is Owner",
+          description: "Check if an address is an owner of the Safe multisig",
+          inputs: {
+            owner: { label: "Address to Check" },
+          },
+          outputs: {
+            result: { name: "isOwner", label: "Is Owner" },
+          },
+        },
+        nonce: {
+          slug: "get-nonce",
+          label: "Get Nonce",
+          description: "Get the current transaction nonce of the Safe multisig",
+          outputs: {
+            result: { name: "nonce", label: "Current Nonce" },
+          },
+        },
+        isModuleEnabled: {
+          label: "Is Module Enabled",
+          description: "Check if a module is enabled on the Safe multisig",
+          inputs: {
+            module: { label: "Module Address" },
+          },
+          outputs: {
+            result: { name: "isEnabled", label: "Module Enabled" },
+          },
+        },
+        getModulesPaginated: {
+          label: "Get Modules Paginated",
+          description:
+            "Get a paginated list of enabled modules on the Safe multisig",
+          inputs: {
+            start: {
+              label: "Start Address",
+              default: "0x0000000000000000000000000000000000000001",
+            },
+            pageSize: { label: "Page Size", default: "10" },
+          },
+          outputs: {
+            array: { label: "Module Addresses" },
+            next: { label: "Next Pagination Address" },
+          },
+        },
+      },
+      events: {
+        AddedOwner: {
+          slug: "added-owner",
+          label: "Owner Added",
+          description: "Fires when a new owner is added to the Safe",
+        },
+        RemovedOwner: {
+          slug: "removed-owner",
+          label: "Owner Removed",
+          description: "Fires when an owner is removed from the Safe",
+        },
+        ChangedThreshold: {
+          slug: "changed-threshold",
+          label: "Threshold Changed",
+          description: "Fires when the confirmation threshold is changed",
+        },
+        EnabledModule: {
+          slug: "enabled-module",
+          label: "Module Enabled",
+          description: "Fires when a module is enabled on the Safe",
+        },
+        DisabledModule: {
+          slug: "disabled-module",
+          label: "Module Disabled",
+          description: "Fires when a module is disabled on the Safe",
+        },
+        ChangedGuard: {
+          slug: "changed-guard",
+          label: "Guard Changed",
+          description: "Fires when the transaction guard is changed",
+        },
+        ExecutionSuccess: {
+          slug: "execution-success",
+          label: "Transaction Executed (Success)",
+          description: "Fires when a Safe transaction is executed successfully",
+        },
+        ExecutionFailure: {
+          slug: "execution-failure",
+          label: "Transaction Executed (Failure)",
+          description: "Fires when a Safe transaction execution fails",
+        },
+        ApproveHash: {
+          slug: "approve-hash",
+          label: "Hash Approved",
+          description: "Fires when an owner approves a transaction hash",
+        },
+        SignMsg: {
+          slug: "sign-msg",
+          label: "Message Signed",
+          description: "Fires when a message is signed by the Safe",
+        },
+        ChangedFallbackHandler: {
+          slug: "changed-fallback-handler",
+          label: "Fallback Handler Changed",
+          description: "Fires when the fallback handler is changed",
+        },
+        SafeSetup: {
+          slug: "safe-setup",
+          label: "Safe Setup",
+          description: "Fires when a new Safe is initialized",
+        },
       },
     },
   },
-
-  events: [
-    {
-      slug: "added-owner",
-      label: "Owner Added",
-      description: "Fires when a new owner is added to the Safe",
-      eventName: "AddedOwner",
-      contract: "safe",
-      inputs: [{ name: "owner", type: "address", indexed: true }],
-    },
-    {
-      slug: "removed-owner",
-      label: "Owner Removed",
-      description: "Fires when an owner is removed from the Safe",
-      eventName: "RemovedOwner",
-      contract: "safe",
-      inputs: [{ name: "owner", type: "address", indexed: true }],
-    },
-    {
-      slug: "changed-threshold",
-      label: "Threshold Changed",
-      description: "Fires when the confirmation threshold is changed",
-      eventName: "ChangedThreshold",
-      contract: "safe",
-      inputs: [{ name: "threshold", type: "uint256", indexed: false }],
-    },
-    {
-      slug: "enabled-module",
-      label: "Module Enabled",
-      description: "Fires when a module is enabled on the Safe",
-      eventName: "EnabledModule",
-      contract: "safe",
-      inputs: [{ name: "module", type: "address", indexed: true }],
-    },
-    {
-      slug: "disabled-module",
-      label: "Module Disabled",
-      description: "Fires when a module is disabled on the Safe",
-      eventName: "DisabledModule",
-      contract: "safe",
-      inputs: [{ name: "module", type: "address", indexed: true }],
-    },
-    {
-      slug: "changed-guard",
-      label: "Guard Changed",
-      description: "Fires when the transaction guard is changed",
-      eventName: "ChangedGuard",
-      contract: "safe",
-      inputs: [{ name: "guard", type: "address", indexed: false }],
-    },
-    {
-      slug: "execution-success",
-      label: "Transaction Executed (Success)",
-      description: "Fires when a Safe transaction is executed successfully",
-      eventName: "ExecutionSuccess",
-      contract: "safe",
-      inputs: [
-        { name: "txHash", type: "bytes32", indexed: false },
-        { name: "payment", type: "uint256", indexed: false },
-      ],
-    },
-    {
-      slug: "execution-failure",
-      label: "Transaction Executed (Failure)",
-      description: "Fires when a Safe transaction execution fails",
-      eventName: "ExecutionFailure",
-      contract: "safe",
-      inputs: [
-        { name: "txHash", type: "bytes32", indexed: false },
-        { name: "payment", type: "uint256", indexed: false },
-      ],
-    },
-    {
-      slug: "approve-hash",
-      label: "Hash Approved",
-      description: "Fires when an owner approves a transaction hash",
-      eventName: "ApproveHash",
-      contract: "safe",
-      inputs: [
-        { name: "approvedHash", type: "bytes32", indexed: true },
-        { name: "owner", type: "address", indexed: true },
-      ],
-    },
-    {
-      slug: "sign-msg",
-      label: "Message Signed",
-      description: "Fires when a message is signed by the Safe",
-      eventName: "SignMsg",
-      contract: "safe",
-      inputs: [{ name: "msgHash", type: "bytes32", indexed: true }],
-    },
-    {
-      slug: "changed-fallback-handler",
-      label: "Fallback Handler Changed",
-      description: "Fires when the fallback handler is changed",
-      eventName: "ChangedFallbackHandler",
-      contract: "safe",
-      inputs: [{ name: "handler", type: "address", indexed: false }],
-    },
-    {
-      slug: "safe-setup",
-      label: "Safe Setup",
-      description: "Fires when a new Safe is initialized",
-      eventName: "SafeSetup",
-      contract: "safe",
-      inputs: [
-        { name: "initiator", type: "address", indexed: true },
-        { name: "owners", type: "address[]", indexed: false },
-        { name: "threshold", type: "uint256", indexed: false },
-        { name: "initializer", type: "address", indexed: false },
-        { name: "fallbackHandler", type: "address", indexed: false },
-      ],
-    },
-  ],
-
-  actions: [
-    // Ownership
-
-    {
-      slug: "get-owners",
-      label: "Get Owners",
-      description: "Get the list of owner addresses for a Safe multisig",
-      type: "read",
-      contract: "safe",
-      function: "getOwners",
-      inputs: [],
-      outputs: [
-        {
-          name: "owners",
-          type: "address[]",
-          label: "Owner Addresses",
-        },
-      ],
-    },
-    {
-      slug: "get-threshold",
-      label: "Get Threshold",
-      description:
-        "Get the number of required confirmations for a Safe transaction",
-      type: "read",
-      contract: "safe",
-      function: "getThreshold",
-      inputs: [],
-      outputs: [
-        {
-          name: "threshold",
-          type: "uint256",
-          label: "Required Confirmations",
-        },
-      ],
-    },
-    {
-      slug: "is-owner",
-      label: "Is Owner",
-      description: "Check if an address is an owner of the Safe multisig",
-      type: "read",
-      contract: "safe",
-      function: "isOwner",
-      inputs: [{ name: "owner", type: "address", label: "Address to Check" }],
-      outputs: [
-        {
-          name: "isOwner",
-          type: "bool",
-          label: "Is Owner",
-        },
-      ],
-    },
-
-    // Transaction State
-
-    {
-      slug: "get-nonce",
-      label: "Get Nonce",
-      description: "Get the current transaction nonce of the Safe multisig",
-      type: "read",
-      contract: "safe",
-      function: "nonce",
-      inputs: [],
-      outputs: [
-        {
-          name: "nonce",
-          type: "uint256",
-          label: "Current Nonce",
-        },
-      ],
-    },
-
-    // Modules
-
-    {
-      slug: "is-module-enabled",
-      label: "Is Module Enabled",
-      description: "Check if a module is enabled on the Safe multisig",
-      type: "read",
-      contract: "safe",
-      function: "isModuleEnabled",
-      inputs: [{ name: "module", type: "address", label: "Module Address" }],
-      outputs: [
-        {
-          name: "isEnabled",
-          type: "bool",
-          label: "Module Enabled",
-        },
-      ],
-    },
-    {
-      slug: "get-modules-paginated",
-      label: "Get Modules Paginated",
-      description:
-        "Get a paginated list of enabled modules on the Safe multisig",
-      type: "read",
-      contract: "safe",
-      function: "getModulesPaginated",
-      inputs: [
-        {
-          name: "start",
-          type: "address",
-          label: "Start Address",
-          default: "0x0000000000000000000000000000000000000001",
-        },
-        {
-          name: "pageSize",
-          type: "uint256",
-          label: "Page Size",
-          default: "10",
-        },
-      ],
-      outputs: [
-        {
-          name: "array",
-          type: "address[]",
-          label: "Module Addresses",
-        },
-        {
-          name: "next",
-          type: "address",
-          label: "Next Pagination Address",
-        },
-      ],
-    },
-  ],
 });


### PR DESCRIPTION
## Summary

- Migrates compound-v3 and safe from `defineProtocol` to `defineAbiProtocol` with inline ABIs and full override sets
- Compound-v3: 12 functions with slug renames for 6 ABI names that differed from existing kebab slugs (e.g. `balanceOf` → `get-balance`)
- Safe: minimal 6-function + 12-event ABI constructed from the Safe contract interface; single slug rename (`nonce` → `get-nonce`)

15 remaining protocols are documented exceptions in the commit — blocked by `erc4626VaultActions` spread, per-feed slug factories, `abi-cache`, Vyper snake_case, or multi-contract complexity that `defineAbiProtocol` cannot represent cleanly.

## Test plan

- [ ] Unit tests pass: `pnpm vitest run tests/unit/protocol-compound-v3.test.ts tests/unit/protocol-safe.test.ts`
- [ ] No action slug or label regressions vs prior definitions