### PR TITLE
feat(metrics): add fast zero-finished-executions monitoring

### DIFF
--- a/drizzle/0119_keep_855_finished_completed_at_index.sql
+++ b/drizzle/0119_keep_855_finished_completed_at_index.sql
@@ -1,0 +1,19 @@
+-- @requires-db-prep
+-- KEEP-855: supporting index for the fast "zero finished executions" alert.
+--
+-- getLastFinishedExecutionAgeSecondsFromDb runs on every /api/metrics/db scrape
+-- and computes max(completed_at) over workflow_executions where completed_at
+-- IS NOT NULL. The existing partial index on completed_at only covers
+-- status = 'error', so a max() over ALL finished rows has no usable index and
+-- Postgres would scan the whole multi-million-row table on every scrape, risking
+-- the 8s metrics statement_timeout (Postgres 57014). A partial index on
+-- completed_at (completed_at IS NOT NULL) turns max() into a single-row backward
+-- index scan that finishes in microseconds.
+--
+-- DB-PREP: on prod/staging an operator applies this CONCURRENTLY out-of-band
+-- (`CREATE INDEX CONCURRENTLY IF NOT EXISTS ...`) before merge, so the plain
+-- statement below is a no-op there (IF NOT EXISTS). On dev / PR-env DBs the
+-- table is small, so the plain in-migration build is fine.
+CREATE INDEX IF NOT EXISTS "idx_workflow_executions_completed_at"
+  ON "workflow_executions" ("completed_at")
+  WHERE completed_at IS NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -834,6 +834,13 @@
       "when": 1782648000002,
       "tag": "0118_keep_857_exec_log_gas_index",
       "breakpoints": true
+    },
+    {
+      "idx": 119,
+      "version": "7",
+      "when": 1782648000003,
+      "tag": "0119_keep_855_finished_completed_at_index",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -161,6 +161,21 @@ const systemErrorsByCategory = getOrCreateGauge(
   ["error_category", "error_type"]
 );
 
+// KEEP-855: seconds since the most recent execution reached a terminal state
+// (non-NULL completed_at), across all trigger types and chains. Powers the fast
+// "zero finished executions" alert: it sits well under a minute under normal
+// load and climbs without bound if the whole pipeline stops finishing work.
+// DB-sourced (see getLastFinishedExecutionAgeSecondsFromDb) so it is correct no
+// matter which short-lived pod finalized the execution. No labels - this is a
+// single global freshness signal. No `_total` suffix: it is a gauge, not a
+// counter (see the KEEP-545 note below).
+const workflowExecutionsFinishedAgeSeconds = getOrCreateGauge(
+  dbRegistry,
+  "keeperhub_workflow_executions_finished_age_seconds",
+  "Seconds since the most recent workflow execution reached a terminal state (success/error/cancelled), across all trigger types and chains",
+  []
+);
+
 // KEEP-545: the previous DB-sourced gauge `keeperhub_workflow_execution_errors_total`
 // has been removed. It was named with the `_total` counter suffix but was
 // actually a poll-driven gauge that overwrote itself on every scrape with the
@@ -1417,6 +1432,7 @@ async function refreshDbMetricsNow(): Promise<void> {
     // Dynamic import to avoid circular dependencies
     const {
       getWorkflowStatsFromDb,
+      getLastFinishedExecutionAgeSecondsFromDb,
       getWorkflowErrorsByWorkflowFromDb,
       getSystemErrorsByCategoryFromDb,
       getStepStatsFromDb,
@@ -1434,6 +1450,7 @@ async function refreshDbMetricsNow(): Promise<void> {
     } = await import("../db-metrics");
     const [
       workflowStats,
+      lastFinishedAgeSeconds,
       errorsByWorkflow,
       systemErrorsByCategoryRows,
       stepStats,
@@ -1450,6 +1467,7 @@ async function refreshDbMetricsNow(): Promise<void> {
       billingStats,
     ] = await Promise.all([
       getWorkflowStatsFromDb(),
+      getLastFinishedExecutionAgeSecondsFromDb(),
       getWorkflowErrorsByWorkflowFromDb(),
       getSystemErrorsByCategoryFromDb(),
       getStepStatsFromDb(),
@@ -1479,6 +1497,13 @@ async function refreshDbMetricsNow(): Promise<void> {
         },
         row.count
       );
+    }
+
+    // KEEP-855: only set the finished-age gauge when we have a real value.
+    // On null (empty table or query error) leave it untouched so Prometheus
+    // staleness / the alert's no_data_state governs instead of a misleading 0.
+    if (lastFinishedAgeSeconds !== null) {
+      workflowExecutionsFinishedAgeSeconds.set(lastFinishedAgeSeconds);
     }
 
     // KEEP-545: the per-org error gauge that used to live here was removed.

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -263,6 +263,53 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
   }
 }
 
+/**
+ * Seconds since the most recent workflow execution reached a terminal state
+ * (anything with a non-NULL completed_at: success / error / cancelled), across
+ * ALL trigger types and chains.
+ *
+ * Value = EXTRACT(EPOCH FROM now() - max(completed_at)). This is the freshness
+ * signal behind the fast "zero finished executions" alert: under normal load
+ * something finishes every few seconds, so the value sits well under a minute;
+ * if the whole pipeline stalls (executor wedged, runner Jobs hanging, DB writes
+ * failing) nothing updates completed_at and the value climbs without bound.
+ *
+ * Sourced from the DB so it is authoritative regardless of which (often
+ * short-lived) pod finalized the execution - the same reason the rest of this
+ * module reads the DB instead of per-pod counters. `completed_at IS NOT NULL`
+ * matches the partial index idx_workflow_executions_completed_at, so this is an
+ * index scan for max() rather than a full-table scan that would trip the 8s
+ * metrics statement_timeout.
+ *
+ * Returns null when the table has no finished executions yet (max is NULL) or
+ * on query error; the caller leaves the gauge unset in that case so Prometheus
+ * staleness / the alert's no_data_state governs rather than a misleading 0.
+ */
+export async function getLastFinishedExecutionAgeSecondsFromDb(): Promise<
+  number | null
+> {
+  try {
+    const rows = await db
+      .select({
+        ageSeconds: sql<
+          number | null
+        >`EXTRACT(EPOCH FROM (now() - max(${workflowExecutions.completedAt})))`,
+      })
+      .from(workflowExecutions)
+      .where(sql`${workflowExecutions.completedAt} IS NOT NULL`);
+
+    const raw = rows[0]?.ageSeconds;
+    return raw == null ? null : Number(raw);
+  } catch (error) {
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[Metrics] Failed to query last finished execution age from DB",
+      error
+    );
+    return null;
+  }
+}
+
 // One cumulative all-time error count per (workflow_id, org_slug, error_type)
 // for managed orgs. Mirrors the gauge semantics of
 // executionsByStatusAndOrgSlug: a point-in-time snapshot the alert reads as

--- a/tests/unit/db-metrics-cache.test.ts
+++ b/tests/unit/db-metrics-cache.test.ts
@@ -26,6 +26,7 @@ const DEFAULT_DB_RETURNS: Record<string, unknown> = {
     durationSum: 0,
     durationCount: 0,
   },
+  getLastFinishedExecutionAgeSecondsFromDb: null,
   getWorkflowErrorsByWorkflowFromDb: [],
   getSystemErrorsByCategoryFromDb: [],
   getStepStatsFromDb: {
@@ -148,6 +149,13 @@ const ERRORS_BY_CATEGORY_SYSTEM_RE =
   /keeperhub_system_errors_by_category\{[^}]*error_category="network_rpc"[^}]*error_type="system"[^}]*\}\s+5/;
 const ERRORS_BY_CATEGORY_UNKNOWN_RE =
   /keeperhub_system_errors_by_category\{[^}]*error_category="unknown"[^}]*error_type="user"[^}]*\}\s+3/;
+// Unlabeled gauge: name followed by the value, no `{...}` block.
+const FINISHED_AGE_42_RE =
+  /keeperhub_workflow_executions_finished_age_seconds\s+42(\s|$)/m;
+const FINISHED_AGE_17_RE =
+  /keeperhub_workflow_executions_finished_age_seconds\s+17(\s|$)/m;
+const FINISHED_AGE_ZERO_RE =
+  /keeperhub_workflow_executions_finished_age_seconds\s+0(\s|$)/m;
 
 describe("updateDbMetrics TTL cache", () => {
   const originalTtl = process.env.DB_METRICS_CACHE_TTL_MS;
@@ -488,5 +496,59 @@ describe("keeperhub_system_errors_by_category gauge", () => {
     dbMocks.getSystemErrorsByCategoryFromDb.mockResolvedValue([]);
     await updateDbMetrics();
     expect(await getDbMetrics()).not.toContain('error_category="billing"');
+  });
+});
+
+// KEEP-855: the finished-age gauge powers the fast "zero finished executions"
+// alert. It must be DB-sourced, populated on the metrics scrape, and -
+// critically - must NOT report a misleading 0 when the query can't produce a
+// value (empty table / query error), which would mask a real stall. On null it
+// holds the previous value so Prometheus staleness / the alert's no_data_state
+// governs instead.
+describe("keeperhub_workflow_executions_finished_age_seconds gauge", () => {
+  const originalTtl = process.env.DB_METRICS_CACHE_TTL_MS;
+
+  beforeEach(() => {
+    __resetDbMetricsCacheForTest();
+    for (const fn of Object.values(dbMocks)) {
+      fn.mockReset();
+    }
+    rebindDefaultDbMockImplementations();
+    // No caching so each updateDbMetrics() re-reads the (overridden) mocks.
+    process.env.DB_METRICS_CACHE_TTL_MS = "0";
+  });
+
+  afterEach(() => {
+    if (originalTtl === undefined) {
+      // biome-ignore lint/performance/noDelete: must truly unset the env var to restore the unset state; assigning "" or undefined changes cache-TTL semantics
+      delete process.env.DB_METRICS_CACHE_TTL_MS;
+    } else {
+      process.env.DB_METRICS_CACHE_TTL_MS = originalTtl;
+    }
+  });
+
+  it("emits the age in seconds returned by the DB query", async () => {
+    dbMocks.getLastFinishedExecutionAgeSecondsFromDb.mockResolvedValue(42);
+
+    await updateDbMetrics();
+    const out = await getDbMetrics();
+
+    expect(out).toMatch(FINISHED_AGE_42_RE);
+  });
+
+  it("holds the last value (not 0) when the query returns null", async () => {
+    // First scrape: real value populates the gauge.
+    dbMocks.getLastFinishedExecutionAgeSecondsFromDb.mockResolvedValue(17);
+    await updateDbMetrics();
+    expect(await getDbMetrics()).toMatch(FINISHED_AGE_17_RE);
+
+    // Second scrape: query returns null (empty table or error). The gauge must
+    // retain 17 rather than resetting to 0, so the alert never sees a false
+    // "just finished" signal during a metrics-DB hiccup.
+    dbMocks.getLastFinishedExecutionAgeSecondsFromDb.mockResolvedValue(null);
+    await updateDbMetrics();
+    const out = await getDbMetrics();
+    expect(out).toMatch(FINISHED_AGE_17_RE);
+    expect(out).not.toMatch(FINISHED_AGE_ZERO_RE);
   });
 });


### PR DESCRIPTION
## What

Adds a fast, global "nothing is finishing" signal and the alert that pages on it.

New DB-sourced gauge `keeperhub_workflow_executions_finished_age_seconds` = seconds since the most recent workflow execution reached a terminal state (`completed_at` not null: success/error/cancelled), across all trigger types and chains. The matching Grafana alert (in the `infrastructure` repo) fires when this exceeds 120s.

## Why

The existing zero-executions alert family counts executions that **started**, per `(trigger_type, chain)`, over 30-minute windows. That catches a single path going silent but cannot catch the whole platform starting work and then never **finishing** it (executor wedged, runner Jobs hanging, terminal DB writes failing), and a global stall can take up to ~30 min to page. This gauge is the freshness signal for a ~2-3 min detector.

Why a gauge and not a counter: the only existing finish-time metric (the duration histogram) is app-pod-only and sparse - 9.4% of 2-minute windows read zero over 14 days, so it would false-page constantly. The DB is the one place every finish is recorded regardless of which (often short-lived) pod finalized the run, so a DB-sourced signal is complete by construction.

Threshold safety: over the last 14 days prod had 478,684 finishes and the longest gap between consecutive completions was 47.5s, so 120s has ~2.5x headroom and would not have false-fired.

## Changes

- `lib/metrics/db-metrics.ts` - `getLastFinishedExecutionAgeSecondsFromDb()` (computes `max(completed_at)`; returns null on empty table / query error).
- `lib/metrics/collectors/prometheus.ts` - registers the gauge on the dbRegistry and sets it on each scrape; on null it holds the last value rather than reporting a misleading 0.
- `drizzle/0119_*.sql` - partial index `idx_workflow_executions_completed_at` so `max(completed_at)` is an index scan. Tagged `@requires-db-prep`; apply `CREATE INDEX CONCURRENTLY IF NOT EXISTS ...` out-of-band before merge and add the `db-prepped-staging` label.
- `tests/unit/db-metrics-cache.test.ts` - covers the emit and the hold-last-value-on-null behaviour.

## Testing

- `pnpm type-check`, `pnpm check`: green.
- `pnpm test tests/unit/db-metrics-cache.test.ts`: 14/14 pass (2 new).
- Migration DDL applied against a local DB: index created and valid.

## Deploy order

This PR (the gauge) merges to `staging` first so the metric exists before the alert evaluates, then promotes to `prod`. The `infrastructure` alert PR (prod P2 + staging P3 twin) applies after the gauge is live.
