### PR TITLE
fix: route dev-min executions through standalone executor to unblock workflow execution

### DIFF
--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -440,7 +440,8 @@ export async function POST(
       workflow.organizationId,
       workflow.userId,
       organizationSlug,
-      organizationPlan
+      organizationPlan,
+      "webhook"
     );
 
     await recordWebhookMetrics({

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -214,6 +214,15 @@ services:
       # all workflow runs sit at status=pending until the worker hits its
       # 5-minute timeout. Pinning to the IPv4 loopback bypasses DNS.
       WORKFLOW_LOCAL_BASE_URL: "http://127.0.0.1:3000"
+      # Route UI-triggered executions through the standalone executor via SQS
+      # so /.well-known/workflow/v1/step is never compiled in dev. The executor
+      # runs all steps in-process (tsc-compiled, no turbopack), bypassing the
+      # DevKit's embedded graphile worker which deadlocks on the 91-step bundle.
+      WORKFLOW_DISPATCH_VIA_EXECUTOR: "1"
+      # Override the minikube-targeted anchor URLs with the in-container hostnames
+      # so the SQS client can reach localstack from within the app-dev container.
+      AWS_ENDPOINT_URL: http://localstack:4566
+      SQS_QUEUE_URL: http://localstack:4566/000000000000/keeperhub-workflow-queue
     deploy:
       resources:
         limits:
@@ -334,6 +343,10 @@ services:
       TURNKEY_API_PUBLIC_KEY: ${TURNKEY_API_PUBLIC_KEY:-}
       TURNKEY_API_PRIVATE_KEY: ${TURNKEY_API_PRIVATE_KEY:-}
       TURNKEY_ORGANIZATION_ID: ${TURNKEY_ORGANIZATION_ID:-}
+      # Run steps directly in the executor process instead of K8s Jobs.
+      # In dev there is no Kubernetes; in-process bypasses the isolation overhead
+      # and lets the executor run on a plain Docker Compose stack.
+      EXECUTION_MODE: in-process
     depends_on:
       db:
         condition: service_healthy
@@ -343,6 +356,7 @@ services:
         condition: service_started
     profiles:
       - dev
+      - dev-min
 
   # ===========================================================================
   # Internal-service HMAC secret seeder (one-shot)
@@ -373,6 +387,7 @@ services:
       pnpm tsx scripts/seed-internal-service-hmac.ts || true"
     profiles:
       - dev
+      - dev-min
       - minikube
 
   # ===========================================================================

--- a/keeperhub-executor/config.ts
+++ b/keeperhub-executor/config.ts
@@ -1,4 +1,4 @@
-export type ExecutionMode = "isolated" | "process" | "complex";
+export type ExecutionMode = "isolated" | "process" | "complex" | "in-process";
 
 export const CONFIG = {
   executionMode: (process.env.EXECUTION_MODE || "isolated") as ExecutionMode,

--- a/keeperhub-executor/execution-mode.ts
+++ b/keeperhub-executor/execution-mode.ts
@@ -11,6 +11,7 @@ import type { DispatchTarget } from "./types";
  * - "process": Always call the KeeperHub API endpoint (no isolation)
  * - "complex": Inspect workflow nodes at runtime — K8s Job for web3 writes,
  *              in-process for everything else
+ * - "in-process": Always run steps directly in the executor process (dev/docker-compose)
  */
 export function resolveDispatchTarget(nodes: WorkflowNode[]): DispatchTarget {
   switch (CONFIG.executionMode) {
@@ -20,6 +21,8 @@ export function resolveDispatchTarget(nodes: WorkflowNode[]): DispatchTarget {
       return "api";
     case "complex":
       return hasWeb3Writes(nodes) ? "k8s-job" : "in-process";
+    case "in-process":
+      return "in-process";
     default: {
       const _exhaustive: never = CONFIG.executionMode;
       throw new Error(`Unknown EXECUTION_MODE: ${_exhaustive}`);

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -143,6 +143,8 @@ function buildInput(message: ExecutorMessage): Record<string, unknown> {
       };
     case "manual":
       return { triggerType: "manual" as const, ...message.input };
+    case "webhook":
+      return { triggerType: "webhook" as const, ...message.input };
     default: {
       const _exhaustive: never = message;
       throw new Error(
@@ -389,10 +391,10 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
     );
   }
 
-  // Manual triggers: the API pre-created the execution row as 'pending' before
-  // enqueueing. Skip phantom handling entirely and dispatch directly. All
-  // billing/feature/concurrency guards above still run.
-  if (message.triggerType === "manual") {
+  // Manual and webhook triggers: the API pre-created the execution row as
+  // 'pending' before enqueueing. Skip phantom handling entirely and dispatch
+  // directly. All billing/feature/concurrency guards above still run.
+  if (message.triggerType === "manual" || message.triggerType === "webhook") {
     const nodes = workflow.nodes as WorkflowNode[];
     const target = resolveDispatchTarget(nodes);
     if (target === "api") {

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -395,6 +395,16 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
   if (message.triggerType === "manual") {
     const nodes = workflow.nodes as WorkflowNode[];
     const target = resolveDispatchTarget(nodes);
+    if (target === "api") {
+      // EXECUTION_MODE=process routes dispatch back to the app's execute route,
+      // which calls executeWorkflowInBackground, which (if
+      // WORKFLOW_DISPATCH_VIA_EXECUTOR=1 is set) re-enqueues to SQS — loop.
+      throw new Error(
+        "EXECUTION_MODE=process is incompatible with WORKFLOW_DISPATCH_VIA_EXECUTOR: " +
+          "it routes manual executions back to the API which re-enqueues to SQS. " +
+          "Use EXECUTION_MODE=in-process instead."
+      );
+    }
     console.log(
       `[Executor] Manual trigger dispatch target: ${target} (mode: ${CONFIG.executionMode})`
     );

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -142,7 +142,7 @@ function buildInput(message: ExecutorMessage): Record<string, unknown> {
         ...message.triggerData,
       };
     case "manual":
-      return message.input;
+      return { triggerType: "manual" as const, ...message.input };
     default: {
       const _exhaustive: never = message;
       throw new Error(

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -31,7 +31,7 @@ import {
   ReceiveMessageCommand,
   SQSClient,
 } from "@aws-sdk/client-sqs";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import {
@@ -323,10 +323,12 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
     const blockedUserId =
       "userId" in message ? message.userId : workflow.userId;
 
-    // KEEP-693: if a phantom row was pre-created for this trigger, resolve it
-    // in place to the blocked (billing/user) state rather than inserting a
-    // second row -- and so the reaper does not later age the orphaned phantom
-    // to a system P-code. Falls through to an insert when there is no phantom.
+    // KEEP-693: if a pre-created row exists for this trigger, resolve it in
+    // place to the blocked (billing/user) state rather than inserting a second
+    // row -- and so the reaper does not later age the orphan to a system P-code.
+    // Matches both 'phantom' (scheduler/event-tracker pre-created) and 'pending'
+    // (API pre-created for manual triggers). Falls through to an insert when
+    // there is no executionId (legacy messages or no pre-create).
     let blockedResolved = false;
     if (message.executionId) {
       const resolved = await db
@@ -342,7 +344,7 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
         .where(
           and(
             eq(workflowExecutions.id, message.executionId),
-            eq(workflowExecutions.status, "phantom")
+            inArray(workflowExecutions.status, ["phantom", "pending"])
           )
         )
         .returning({ id: workflowExecutions.id });

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -141,6 +141,8 @@ function buildInput(message: ExecutorMessage): Record<string, unknown> {
         triggerType: "event",
         ...message.triggerData,
       };
+    case "manual":
+      return message.input;
     default: {
       const _exhaustive: never = message;
       throw new Error(
@@ -383,6 +385,26 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
     throw new RequeueSignal(
       `Concurrency limit reached (${concurrency.running}/${concurrency.limit}); requeueing workflow ${workflowId}`
     );
+  }
+
+  // Manual triggers: the API pre-created the execution row as 'pending' before
+  // enqueueing. Skip phantom handling entirely and dispatch directly. All
+  // billing/feature/concurrency guards above still run.
+  if (message.triggerType === "manual") {
+    const nodes = workflow.nodes as WorkflowNode[];
+    const target = resolveDispatchTarget(nodes);
+    console.log(
+      `[Executor] Manual trigger dispatch target: ${target} (mode: ${CONFIG.executionMode})`
+    );
+    await dispatchExecution({
+      target,
+      workflowId,
+      executionId: message.executionId,
+      input: message.input,
+      triggerType: "manual",
+      scheduleId: undefined,
+    });
+    return;
   }
 
   const input = buildInput(message);

--- a/keeperhub-executor/lib/db-helpers.ts
+++ b/keeperhub-executor/lib/db-helpers.ts
@@ -138,12 +138,15 @@ export async function upgradePhantomToPending(
 }
 
 /**
- * KEEP-693: delete a pre-created phantom row when the executor intentionally
- * skips the trigger (workflow not found / not executable / schedule invalid).
- * The trigger correctly did not run, so there is no failure to surface and the
- * reaper must not later age the orphan to a system P-code. The compare-and-set
- * on status='phantom' makes it a no-op when there is no id or the row already
- * advanced past phantom (e.g. a duplicate delivery upgraded it).
+ * KEEP-693: delete a pre-created phantom or pending row when the executor
+ * intentionally skips the trigger (workflow not found / not executable /
+ * schedule invalid). The trigger correctly did not run, so there is no failure
+ * to surface and the reaper must not later age the orphan to a system P-code.
+ * The compare-and-set on status IN ('phantom', 'pending') makes it a no-op
+ * when there is no id or the row already advanced past these states.
+ *
+ * Matches 'pending' in addition to 'phantom' because manual-trigger executions
+ * are pre-created by the API as 'pending' before being enqueued.
  */
 export async function discardPhantomRow(
   db: PostgresJsDatabase<DbSchema>,
@@ -157,7 +160,7 @@ export async function discardPhantomRow(
     .where(
       and(
         eq(workflowExecutions.id, executionId),
-        eq(workflowExecutions.status, "phantom")
+        inArray(workflowExecutions.status, ["phantom", "pending"])
       )
     );
 }

--- a/keeperhub-executor/lib/db-helpers.ts
+++ b/keeperhub-executor/lib/db-helpers.ts
@@ -163,10 +163,13 @@ export async function discardPhantomRow(
 }
 
 /**
- * KEEP-693: resolve a pre-created phantom row to a user-actionable error (e.g. a
- * billing block) rather than leaving it for the reaper to mis-code as a system
- * failure. Compare-and-set on status='phantom' so a row that already advanced
- * is left untouched.
+ * KEEP-693: resolve a pre-created phantom or pending row to a user-actionable
+ * error (e.g. a billing block) rather than leaving it for the reaper to
+ * mis-code as a system failure. Compare-and-set on status IN ('phantom',
+ * 'pending') so a row that already advanced is left untouched.
+ *
+ * Matches 'pending' in addition to 'phantom' because manual-trigger executions
+ * are pre-created by the API as 'pending' (not 'phantom') before being enqueued.
  */
 export async function resolvePhantomToError(
   db: PostgresJsDatabase<DbSchema>,
@@ -188,7 +191,7 @@ export async function resolvePhantomToError(
     .where(
       and(
         eq(workflowExecutions.id, executionId),
-        eq(workflowExecutions.status, "phantom")
+        inArray(workflowExecutions.status, ["phantom", "pending"])
       )
     );
 }

--- a/keeperhub-executor/types.ts
+++ b/keeperhub-executor/types.ts
@@ -49,7 +49,7 @@ export type ManualMessage = {
   workflowId: string;
   userId: string;
   organizationId?: string;
-  triggerType: "manual";
+  triggerType: "manual" | "webhook";
   input: Record<string, unknown>;
 };
 

--- a/keeperhub-executor/types.ts
+++ b/keeperhub-executor/types.ts
@@ -43,7 +43,21 @@ export type EventMessage = {
   };
 };
 
-export type ExecutorMessage = ScheduleMessage | BlockMessage | EventMessage;
+export type ManualMessage = {
+  // Always present: the API pre-creates this row as 'pending' before enqueueing.
+  executionId: string;
+  workflowId: string;
+  userId: string;
+  organizationId?: string;
+  triggerType: "manual";
+  input: Record<string, unknown>;
+};
+
+export type ExecutorMessage =
+  | ScheduleMessage
+  | BlockMessage
+  | EventMessage
+  | ManualMessage;
 
 export type DispatchTarget = "k8s-job" | "in-process" | "api";
 

--- a/lib/workflow/execute-in-background.ts
+++ b/lib/workflow/execute-in-background.ts
@@ -59,7 +59,8 @@ export async function executeWorkflowInBackground(
   organizationId?: string | null,
   createdBy?: string,
   organizationSlug?: string,
-  organizationPlan?: string
+  organizationPlan?: string,
+  triggerType: "manual" | "webhook" = "manual"
 ): Promise<void> {
   try {
     console.log(`${context.logPrefix} Starting execution:`, executionId);
@@ -79,7 +80,7 @@ export async function executeWorkflowInBackground(
             workflowId,
             userId: createdBy ?? "",
             organizationId: organizationId ?? undefined,
-            triggerType: "manual",
+            triggerType,
             input,
           }),
         })

--- a/lib/workflow/execute-in-background.ts
+++ b/lib/workflow/execute-in-background.ts
@@ -1,3 +1,4 @@
+import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
 import { and, eq } from "drizzle-orm";
 import { start } from "workflow/api";
 import { db } from "@/lib/db";
@@ -11,6 +12,25 @@ import { recordExecutionErrorFinalized } from "@/lib/errors/finalize-error";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { executeWorkflow } from "@/lib/workflow/executor/executor.workflow";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
+
+let _sqsClient: SQSClient | null = null;
+function getSqsClient(): SQSClient {
+  if (!_sqsClient) {
+    _sqsClient = new SQSClient({
+      region: process.env.AWS_REGION ?? "us-east-1",
+      ...(process.env.AWS_ENDPOINT_URL
+        ? {
+            endpoint: process.env.AWS_ENDPOINT_URL,
+            credentials: {
+              accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? "test",
+              secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? "test",
+            },
+          }
+        : {}),
+    });
+  }
+  return _sqsClient;
+}
 
 type BackgroundLogContext = {
   /** Prefix for console logs, e.g. "[Workflow Execute]" or "[Webhook]". */
@@ -43,6 +63,33 @@ export async function executeWorkflowInBackground(
 ): Promise<void> {
   try {
     console.log(`${context.logPrefix} Starting execution:`, executionId);
+
+    // When WORKFLOW_DISPATCH_VIA_EXECUTOR is set, route execution through the
+    // standalone keeperhub-executor (in-process mode) via SQS instead of the
+    // DevKit's embedded graphile worker. This bypasses /.well-known/workflow/v1/step
+    // compilation, which deadlocks on the full 91-step bundle in dev.
+    // The executor transitions the row from 'pending' -> 'running' -> terminal
+    // directly, so we do not pre-lift the status here.
+    if (process.env.WORKFLOW_DISPATCH_VIA_EXECUTOR === "1") {
+      await getSqsClient().send(
+        new SendMessageCommand({
+          QueueUrl: process.env.SQS_QUEUE_URL,
+          MessageBody: JSON.stringify({
+            executionId,
+            workflowId,
+            userId: createdBy ?? "",
+            organizationId: organizationId ?? undefined,
+            triggerType: "manual",
+            input,
+          }),
+        })
+      );
+      console.log(
+        `${context.logPrefix} Dispatched to executor via SQS:`,
+        executionId
+      );
+      return;
+    }
 
     // Flip the pre-created row from "pending" to "running" so every execution
     // path shares the same pending -> running -> terminal lifecycle. Guarded on


### PR DESCRIPTION
## Problem

\`/.well-known/workflow/v1/step\` deadlocks in dev under memory pressure. Turbopack tries to bundle all 91 step files and their transitive deps (ethers, viem, AI SDKs, chain adapters) into a single esbuild pass, saturating the 6 GB V8 heap. The DevKit's embedded graphile worker calls this route for every step in every workflow run — so every run stalls at \`pending\` indefinitely and the 5-minute timeout fires before any step executes.

\`lazyDiscovery: true\` (already merged) fixed the directory scan (126s → 7s) but not the compile-graph size for the \`/step\` bundle.

## Solution

Add a \`ManualMessage\` SQS type. When \`WORKFLOW_DISPATCH_VIA_EXECUTOR=1\`, the app sends a manual message to SQS instead of calling the DevKit \`start()\`. The standalone \`keeperhub-executor\` picks it up and runs all steps in-process via tsc-compiled code — no turbopack, no HTTP dispatch, no \`/.well-known/workflow/v1/step\`.

Enable this across all dev profiles in docker-compose, and add \`executor\` and \`hmac-seed\` to the \`dev-min\` profile so \`docker compose --profile dev-min up\` supports end-to-end workflow execution without minikube.

## Changes

- \`keeperhub-executor/types.ts\`: add \`ManualMessage\` (\`triggerType: "manual" | "webhook"\`, carries pre-created \`executionId\`)
- \`keeperhub-executor/config.ts\`: add \`"in-process"\` to \`ExecutionMode\` union
- \`keeperhub-executor/execution-mode.ts\`: add \`"in-process"\` case to \`resolveDispatchTarget\`
- \`keeperhub-executor/index.ts\`: handle \`"manual"\` and \`"webhook"\` triggers — skip phantom handling, run all guards with \`inArray(status, ["phantom","pending"])\` CAS, dispatch to \`executeInProcess\`; guard against \`EXECUTION_MODE=process\` infinite SQS loop
- \`keeperhub-executor/lib/db-helpers.ts\`: extend \`resolvePhantomToError\` and \`discardPhantomRow\` CAS to match \`"pending"\` rows in addition to \`"phantom"\`
- \`lib/workflow/execute-in-background.ts\`: when \`WORKFLOW_DISPATCH_VIA_EXECUTOR=1\`, send \`ManualMessage\` to SQS and return (no \`start()\`, no status pre-lift); accept \`triggerType\` parameter for webhook callers
- \`app/api/workflows/[workflowId]/webhook/route.ts\`: pass \`"webhook"\` as \`triggerType\` to \`executeWorkflowInBackground\`
- \`docker-compose.yml\`: \`executor\` and \`hmac-seed\` added to \`dev-min\`; executor gets \`EXECUTION_MODE=in-process\`; \`app-dev\` gets \`WORKFLOW_DISPATCH_VIA_EXECUTOR=1\` + localstack SQS overrides

## Execution row lifecycle

```
API route: INSERT status='pending'
execute-in-background: enqueue ManualMessage (no status change)
executor: billing/feature/concurrency guards pass (CAS on phantom|pending)
executor: dispatchExecution -> executeInProcess
executeInProcess: UPDATE pending->running -> runs steps -> terminal state
```

## Test plan

Verified locally with direct SQS injection:

```
[Executor] Received 1 messages
[Executor] Processing manual trigger for workflow wf-test-533
[Executor] Manual trigger dispatch target: in-process (mode: in-process)
[Executor:InProcess] Starting workflow execution
[Workflow Executor] Workflow execution completed: {"success":true,"duration":67}
[Executor:InProcess] Completed in 137ms
[Executor] Message deleted for workflow wf-test-533
```

Execution row transitioned from \`pending\` → \`success\` with \`completed_at\` set. No \`/.well-known/workflow/v1/step\` compilation triggered.

To test against the full dev stack:

```bash
docker compose --profile dev-min up -d
# trigger a workflow from the UI
docker logs -f keeperhub-executor   # expect [Executor:InProcess] Starting workflow execution
docker logs app-dev | grep "Compiling /.well-known/workflow/v1/step"  # expect no output
```