### PR TITLE
fix(address-book): return curated errors instead of raw DB errors

### DIFF
--- a/app/api/address-book/[entryId]/route.ts
+++ b/app/api/address-book/[entryId]/route.ts
@@ -3,6 +3,7 @@ import { ethers } from "ethers";
 import { NextResponse } from "next/server";
 import { normalizeAddressForStorage } from "@/lib/address-utils";
 import { db } from "@/lib/db";
+import { isUniqueViolation } from "@/lib/db/errors";
 import { addressBookEntry } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
@@ -137,6 +138,12 @@ export async function PATCH(
 
     return NextResponse.json(updatedEntry);
   } catch (error) {
+    if (isUniqueViolation(error)) {
+      return NextResponse.json(
+        { error: "This address is already in your address book." },
+        { status: 409 }
+      );
+    }
     logSystemError(
       ErrorCategory.DATABASE,
       "[Address Book] Failed to update entry",
@@ -144,12 +151,7 @@ export async function PATCH(
       { endpoint: "/api/address-book/[entryId]", operation: "update" }
     );
     return NextResponse.json(
-      {
-        error:
-          error instanceof Error
-            ? error.message
-            : "Failed to update address book entry",
-      },
+      { error: "Failed to update address book entry" },
       { status: 500 }
     );
   }
@@ -206,12 +208,7 @@ export async function DELETE(
       { endpoint: "/api/address-book/[entryId]", operation: "delete" }
     );
     return NextResponse.json(
-      {
-        error:
-          error instanceof Error
-            ? error.message
-            : "Failed to delete address book entry",
-      },
+      { error: "Failed to delete address book entry" },
       { status: 500 }
     );
   }

--- a/app/api/address-book/[entryId]/route.ts
+++ b/app/api/address-book/[entryId]/route.ts
@@ -3,7 +3,7 @@ import { ethers } from "ethers";
 import { NextResponse } from "next/server";
 import { normalizeAddressForStorage } from "@/lib/address-utils";
 import { db } from "@/lib/db";
-import { isUniqueViolation } from "@/lib/db/errors";
+import { curateDbError } from "@/lib/db/errors";
 import { addressBookEntry } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
@@ -138,21 +138,21 @@ export async function PATCH(
 
     return NextResponse.json(updatedEntry);
   } catch (error) {
-    if (isUniqueViolation(error)) {
-      return NextResponse.json(
-        { error: "This address is already in your address book." },
-        { status: 409 }
+    const curated = curateDbError(error, {
+      messages: { "23505": "This address is already in your address book." },
+      fallback: "Failed to update address book entry",
+    });
+    if (curated.status >= 500) {
+      logSystemError(
+        ErrorCategory.DATABASE,
+        "[Address Book] Failed to update entry",
+        error,
+        { endpoint: "/api/address-book/[entryId]", operation: "update" }
       );
     }
-    logSystemError(
-      ErrorCategory.DATABASE,
-      "[Address Book] Failed to update entry",
-      error,
-      { endpoint: "/api/address-book/[entryId]", operation: "update" }
-    );
     return NextResponse.json(
-      { error: "Failed to update address book entry" },
-      { status: 500 }
+      { error: curated.message },
+      { status: curated.status }
     );
   }
 }
@@ -207,9 +207,12 @@ export async function DELETE(
       error,
       { endpoint: "/api/address-book/[entryId]", operation: "delete" }
     );
+    const curated = curateDbError(error, {
+      fallback: "Failed to delete address book entry",
+    });
     return NextResponse.json(
-      { error: "Failed to delete address book entry" },
-      { status: 500 }
+      { error: curated.message },
+      { status: curated.status }
     );
   }
 }

--- a/app/api/address-book/route.ts
+++ b/app/api/address-book/route.ts
@@ -3,7 +3,7 @@ import { ethers } from "ethers";
 import { NextResponse } from "next/server";
 import { normalizeAddressForStorage } from "@/lib/address-utils";
 import { db } from "@/lib/db";
-import { isUniqueViolation } from "@/lib/db/errors";
+import { curateDbError } from "@/lib/db/errors";
 import { addressBookEntry, users } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
@@ -69,9 +69,12 @@ export async function GET(request: Request) {
       error,
       { endpoint: "/api/address-book", operation: "list" }
     );
+    const curated = curateDbError(error, {
+      fallback: "Failed to list address book entries",
+    });
     return NextResponse.json(
-      { error: "Failed to list address book entries" },
-      { status: 500 }
+      { error: curated.message },
+      { status: curated.status }
     );
   }
 }
@@ -136,21 +139,21 @@ export async function POST(request: Request) {
 
     return NextResponse.json(newEntry, { status: 201 });
   } catch (error) {
-    if (isUniqueViolation(error)) {
-      return NextResponse.json(
-        { error: "This address is already in your address book." },
-        { status: 409 }
+    const curated = curateDbError(error, {
+      messages: { "23505": "This address is already in your address book." },
+      fallback: "Failed to create address book entry",
+    });
+    if (curated.status >= 500) {
+      logSystemError(
+        ErrorCategory.DATABASE,
+        "[Address Book] Failed to create entry",
+        error,
+        { endpoint: "/api/address-book", operation: "create" }
       );
     }
-    logSystemError(
-      ErrorCategory.DATABASE,
-      "[Address Book] Failed to create entry",
-      error,
-      { endpoint: "/api/address-book", operation: "create" }
-    );
     return NextResponse.json(
-      { error: "Failed to create address book entry" },
-      { status: 500 }
+      { error: curated.message },
+      { status: curated.status }
     );
   }
 }

--- a/app/api/address-book/route.ts
+++ b/app/api/address-book/route.ts
@@ -3,6 +3,7 @@ import { ethers } from "ethers";
 import { NextResponse } from "next/server";
 import { normalizeAddressForStorage } from "@/lib/address-utils";
 import { db } from "@/lib/db";
+import { isUniqueViolation } from "@/lib/db/errors";
 import { addressBookEntry, users } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
@@ -69,12 +70,7 @@ export async function GET(request: Request) {
       { endpoint: "/api/address-book", operation: "list" }
     );
     return NextResponse.json(
-      {
-        error:
-          error instanceof Error
-            ? error.message
-            : "Failed to list address book entries",
-      },
+      { error: "Failed to list address book entries" },
       { status: 500 }
     );
   }
@@ -140,6 +136,12 @@ export async function POST(request: Request) {
 
     return NextResponse.json(newEntry, { status: 201 });
   } catch (error) {
+    if (isUniqueViolation(error)) {
+      return NextResponse.json(
+        { error: "This address is already in your address book." },
+        { status: 409 }
+      );
+    }
     logSystemError(
       ErrorCategory.DATABASE,
       "[Address Book] Failed to create entry",
@@ -147,12 +149,7 @@ export async function POST(request: Request) {
       { endpoint: "/api/address-book", operation: "create" }
     );
     return NextResponse.json(
-      {
-        error:
-          error instanceof Error
-            ? error.message
-            : "Failed to create address book entry",
-      },
+      { error: "Failed to create address book entry" },
       { status: 500 }
     );
   }

--- a/lib/db/errors.ts
+++ b/lib/db/errors.ts
@@ -1,0 +1,21 @@
+/**
+ * Helpers for classifying Postgres errors surfaced through Drizzle.
+ *
+ * Drizzle wraps the driver error, so the SQLSTATE code can live either on the
+ * thrown error or on its `cause`. Check both.
+ */
+
+const PG_UNIQUE_VIOLATION = "23505";
+
+function pgErrorCode(err: unknown): string | undefined {
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+  const e = err as { code?: string; cause?: { code?: string } };
+  return e.cause?.code ?? e.code;
+}
+
+/** True when the error is a Postgres unique-constraint violation (SQLSTATE 23505). */
+export function isUniqueViolation(err: unknown): boolean {
+  return pgErrorCode(err) === PG_UNIQUE_VIOLATION;
+}

--- a/lib/db/errors.ts
+++ b/lib/db/errors.ts
@@ -1,11 +1,14 @@
 /**
- * Helpers for classifying Postgres errors surfaced through Drizzle.
+ * Curate Postgres errors surfaced through Drizzle into safe, user-facing
+ * messages. Raw driver errors (which embed SQL fragments and column names)
+ * must never reach the client -- always run a caught DB error through
+ * `curateDbError` and return the curated message instead of `error.message`.
  *
  * Drizzle wraps the driver error, so the SQLSTATE code can live either on the
  * thrown error or on its `cause`. Check both.
  */
 
-const PG_UNIQUE_VIOLATION = "23505";
+export type CuratedDbError = { message: string; status: number };
 
 function pgErrorCode(err: unknown): string | undefined {
   if (!err || typeof err !== "object") {
@@ -15,7 +18,46 @@ function pgErrorCode(err: unknown): string | undefined {
   return e.cause?.code ?? e.code;
 }
 
-/** True when the error is a Postgres unique-constraint violation (SQLSTATE 23505). */
-export function isUniqueViolation(err: unknown): boolean {
-  return pgErrorCode(err) === PG_UNIQUE_VIOLATION;
+/** Default curated response per Postgres SQLSTATE code. */
+const PG_CODE_DEFAULTS: Record<string, CuratedDbError> = {
+  "23505": { message: "This record already exists.", status: 409 },
+  "23503": {
+    message: "A related record is missing or still in use.",
+    status: 409,
+  },
+  "23502": { message: "A required field is missing.", status: 400 },
+  "23514": { message: "One or more values are invalid.", status: 400 },
+};
+
+const GENERIC_DB_ERROR: CuratedDbError = {
+  message: "Something went wrong. Please try again.",
+  status: 500,
+};
+
+/**
+ * Map a caught DB error to a curated `{ message, status }`. Known SQLSTATE
+ * codes get a friendly default; anything else falls back to a generic message.
+ * Pass `messages` to override the copy for a specific code (e.g. a
+ * domain-specific duplicate message) and `fallback` for the generic case.
+ * The raw error message is never returned.
+ */
+export function curateDbError(
+  err: unknown,
+  options?: {
+    messages?: Record<string, string>;
+    fallback?: string;
+  }
+): CuratedDbError {
+  const code = pgErrorCode(err);
+  const known = code ? PG_CODE_DEFAULTS[code] : undefined;
+  if (known) {
+    return {
+      message: (code ? options?.messages?.[code] : undefined) ?? known.message,
+      status: known.status,
+    };
+  }
+  return {
+    message: options?.fallback ?? GENERIC_DB_ERROR.message,
+    status: GENERIC_DB_ERROR.status,
+  };
 }


### PR DESCRIPTION
## Summary

Adding an address that already exists in the org address book failed with the raw Postgres error (`insert into address_book_entry ...`) surfaced straight to the UI, so users could not tell a duplicate apart from a permissions or backend failure.

The unique `(organization_id, address)` index is intentional and load-bearing (it's what keeps `record-wallet` idempotent when a Safe is reconciled on a second chain), so this keeps the constraint and curates the error instead.

## Changes

- Add `lib/db/errors.ts` with `curateDbError`, a single curation layer that maps any Postgres error to a safe `{ message, status }` and never returns the raw driver message. Known SQLSTATE codes (unique / foreign-key / not-null / check violations) get friendly defaults; anything unrecognised gets a generic message.
- Route every address-book handler (list / create / update / delete) through `curateDbError`. Duplicate inserts and updates now return `409 "This address is already in your address book."`; all other failures return curated copy with no DB internals.
- System errors are only logged to Sentry when the curated status is `5xx`, so expected user conditions (duplicates) no longer create noise.

All curated messages flow through the existing client toasts (`addressBookApi` -> `ApiError.message`), so no client changes were needed.