### PR TITLE
fix: show two decimals in analytics KPI change deltas

### DIFF
--- a/components/analytics/kpi-cards.tsx
+++ b/components/analytics/kpi-cards.tsx
@@ -88,7 +88,7 @@ function DeltaDisplay({
       )}
     >
       <Icon className="size-3" />
-      {Math.abs(delta).toFixed(1)}%
+      {Math.abs(delta).toFixed(2)}%
     </span>
   );
 }


### PR DESCRIPTION
The period-over-period change ratio on the analytics KPI cards rounded to one decimal (e.g. `4.2%`). This bumps it to two decimals (`4.20%`) to match the Success Rate value formatting.