### PR TITLE
fix: KEEP-602 connect directly to postgres for mainnet fork DB patch

### DIFF
--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -262,9 +262,11 @@ jobs:
           # Patch the test DB so chain 1's primaryRpc points at the local fork.
           # Without this the app (which reads CHAIN_RPC_CONFIG) would submit
           # transactions to a real mainnet node rather than the anvil fork.
-          DB_CONTAINER=$(docker ps --filter "name=keeperhub-db" --filter "status=running" \
-            --format '{{.Names}}' | grep -vi 'test' | head -n1)
-          docker exec "$DB_CONTAINER" psql -U postgres keeperhub_test \
+          # Postgres runs as a GitHub Actions `services:` container (see
+          # postgres: above), not a docker-compose service, so there is no
+          # "keeperhub-db"-named container to docker exec into -- connect
+          # directly on localhost:5432, same as "Wait for services" above.
+          PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d keeperhub_test \
             -c "UPDATE chains SET default_primary_rpc = 'http://localhost:8548' WHERE chain_id = 1"
 
       - name: Start code-execution sandbox


### PR DESCRIPTION
## Summary

- The anvil Ethereum mainnet fork step in `e2e-tests-ephemeral.yml` (added by the KEEP-602 harness) patched chain 1's RPC by looking up a `keeperhub-db`-named container via `docker ps` and `docker exec`-ing into it.
- In the `e2e-vitest-ephemeral` job, postgres runs as a GitHub Actions `services:` container on `localhost:5432`, not a docker-compose service - no `keeperhub-db` container exists, so `DB_CONTAINER` resolved to an empty string and `docker exec ""` failed with `invalid container name or ID: value is empty`, failing the job right after the fork itself came up healthy.
- Connect directly via `psql -h localhost -p 5432` instead, matching the pattern the same job already uses in its "Wait for services" step.

Seen failing on the staging->prod release PR: https://github.com/KeeperHub/keeperhub/actions/runs/28495654544/job/84463252945?pr=1685

## Test plan

- [ ] `e2e-tests / e2e-vitest-ephemeral` passes the "Start anvil Ethereum mainnet fork for protocol-coverage tests" step
- [ ] `chains.default_primary_rpc` for chain 1 is patched to `http://localhost:8548` in the test DB