### PR TITLE
feat: KEEP-602 wire protocol-coverage tests into e2e-vitest-ephemeral

### DIFF
--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -138,6 +138,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      # ubuntu-latest ships several GB of preinstalled toolchains this job
+      # never touches (Android SDK, .NET, Haskell/GHC). This job now runs
+      # two anvil forks, a sandbox container, and the protocol-coverage
+      # suite on top of the base e2e stack -- free the unused space up
+      # front rather than risk "no space left on device" mid-job.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          df -h /
+
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -300,6 +300,28 @@ jobs:
           # SSRF (dev/CI-only opt-in) to reach the localhost anvil fork.
           SAFE_FETCH_SHADOW: "true"
 
+      - name: Run protocol-coverage tests
+        run: pnpm test:protocol
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/keeperhub_test
+          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+          WORKFLOW_TARGET_WORLD: "@workflow/world-postgres"
+          AWS_ENDPOINT_URL: http://localhost:4566
+          AWS_ACCESS_KEY_ID: test
+          AWS_SECRET_ACCESS_KEY: test
+          AWS_REGION: us-east-1
+          TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
+          CHAIN_RPC_CONFIG: ${{ secrets.CHAIN_RPC_CONFIG }}
+          # Funder EOA for protocol-coverage suites' ensureNativeGas top-up
+          # on testnet chains (aave-v3, superfluid, chronicle). When unset
+          # those suites skip cleanly (see coverage.test.ts gate).
+          TESTNET_FUNDER_PK: ${{ secrets.TESTNET_FUNDER_PK }}
+          # Archive-node URL for the Ethereum mainnet anvil fork started
+          # above. When set, protocol-coverage suites for chain 1 (morpho,
+          # wrapped, lido, ethena, curve, chainlink, spark, yearn, uniswap,
+          # pendle, sky) run for real. When unset those suites skip cleanly.
+          ANVIL_FORK_MAINNET_URL: ${{ secrets.ANVIL_FORK_MAINNET_URL }}
+
       - name: Dump app container logs
         if: failure() && inputs.image_tag != ''
         run: docker logs keeperhub-app 2>&1 | tail -200

--- a/lib/test-data/chain-test-data.ts
+++ b/lib/test-data/chain-test-data.ts
@@ -226,10 +226,18 @@ export const FORK_WHALES: Record<
  * ~0.0012 ETH; coverage suites run multiple writes per CI run, sometimes
  * concurrently across protocols sharing one wallet via NonceManager).
  * Fork-mode chains get a generous floor since anvil_setBalance is free.
+ *
+ * Chain 8453 (Base) is real mainnet, not a fork or testnet -- ajna is the
+ * only protocol-coverage suite on it, and every write action it has is
+ * marked skipped in TEST_DATA, so this floor is never actually spent on
+ * gas; it just needs to exist for the preflight to proceed. 0.01 ETH
+ * matches the "read-only test execution" floor documented in
+ * tests/e2e/vitest/protocol-coverage/ajna/base/coverage.test.ts.
  */
 export const MIN_NATIVE_BALANCE_WEI_BY_CHAIN: Record<string, bigint> = {
   "1": BigInt("1000000000000000000"), // 1 ETH (fork mode, free via anvil_setBalance)
   "11155111": BigInt("10000000000000000"), // 0.01 ETH
+  "8453": BigInt("10000000000000000"), // 0.01 ETH real Base mainnet ETH
 };
 
 /**
@@ -244,8 +252,13 @@ export const MIN_NATIVE_BALANCE_WEI_BY_CHAIN: Record<string, bigint> = {
  * The shared TESTNET_FUNDER_PK wallet on Sepolia was topped up to ~0.15 ETH
  * on 2026-07-01 after briefly running dry mid-debug; re-top-up via a faucet
  * if this starts throwing "funder has X; need >= Y" again.
+ *
+ * Chain 8453 (Base) is real mainnet ETH, unlike the fork/testnet entries
+ * above -- kept modest since ajna's write actions are all skipped, so this
+ * balance is never actually spent, only held as the preflight floor.
  */
 export const FUND_NATIVE_AMOUNT_WEI_BY_CHAIN: Record<string, bigint> = {
   "1": BigInt("10000000000000000000"), // 10 ETH (fork mode)
   "11155111": BigInt("30000000000000000"), // 0.03 ETH
+  "8453": BigInt("15000000000000000"), // 0.015 ETH real Base mainnet ETH
 };

--- a/lib/test-data/chain-test-data.ts
+++ b/lib/test-data/chain-test-data.ts
@@ -227,17 +227,15 @@ export const FORK_WHALES: Record<
  * concurrently across protocols sharing one wallet via NonceManager).
  * Fork-mode chains get a generous floor since anvil_setBalance is free.
  *
- * Chain 8453 (Base) is real mainnet, not a fork or testnet -- ajna is the
- * only protocol-coverage suite on it, and every write action it has is
- * marked skipped in TEST_DATA, so this floor is never actually spent on
- * gas; it just needs to exist for the preflight to proceed. 0.01 ETH
- * matches the "read-only test execution" floor documented in
- * tests/e2e/vitest/protocol-coverage/ajna/base/coverage.test.ts.
+ * No entry for chain 8453 (Base): ajna is the only protocol-coverage suite
+ * on it, every write action it has is marked skipped in TEST_DATA, and
+ * runSetup() only calls ensureNativeGas when a chain actually has a
+ * transaction to sign -- reads are free, so no real Base mainnet ETH is
+ * ever required.
  */
 export const MIN_NATIVE_BALANCE_WEI_BY_CHAIN: Record<string, bigint> = {
   "1": BigInt("1000000000000000000"), // 1 ETH (fork mode, free via anvil_setBalance)
   "11155111": BigInt("10000000000000000"), // 0.01 ETH
-  "8453": BigInt("10000000000000000"), // 0.01 ETH real Base mainnet ETH
 };
 
 /**
@@ -252,10 +250,6 @@ export const MIN_NATIVE_BALANCE_WEI_BY_CHAIN: Record<string, bigint> = {
  * The shared TESTNET_FUNDER_PK wallet on Sepolia was topped up to ~0.15 ETH
  * on 2026-07-01 after briefly running dry mid-debug; re-top-up via a faucet
  * if this starts throwing "funder has X; need >= Y" again.
- *
- * Chain 8453 (Base) is real mainnet ETH, unlike the fork/testnet entries
- * above -- kept modest since ajna's write actions are all skipped, so this
- * balance is never actually spent, only held as the preflight floor.
  */
 export const FUND_NATIVE_AMOUNT_WEI_BY_CHAIN: Record<string, bigint> = {
   "1": BigInt("10000000000000000000"), // 10 ETH (fork mode)

--- a/lib/test-data/chain-test-data.ts
+++ b/lib/test-data/chain-test-data.ts
@@ -233,18 +233,19 @@ export const MIN_NATIVE_BALANCE_WEI_BY_CHAIN: Record<string, bigint> = {
 };
 
 /**
- * How much native to send when topping up. Aim for ~10x the per-tx cost so
- * a single top-up survives a full suite run without re-checking mid-flight.
+ * How much native to send when topping up. Aim for ~25x the per-tx cost so
+ * a single top-up survives a full suite run without re-checking mid-flight,
+ * including a multi-tx setup sequence (e.g. superfluid: faucet mint +
+ * approve + wrap in setup, then ~7 more writes in the coverage phase --
+ * observed to need ~0.012-0.013 ETH total end to end) plus headroom for
+ * concurrent NonceManager usage across protocols sharing one wallet.
  * Fork-mode: set once via anvil_setBalance to 10 ETH and never re-top-up.
  *
- * Sepolia is sized to the shared TESTNET_FUNDER_PK wallet's actual balance
- * (~0.0117 ETH as of 2026-07-01) rather than the original 0.02 ETH target --
- * still ~9x the per-tx cost, but the funder no longer holds enough to send
- * 0.02 ETH per top-up. Sepolia ETH has no real value, so this is a safe
- * adaptation; it is not a substitute for topping up the funder wallet via a
- * faucet, which remains necessary as the balance keeps draining over time.
+ * The shared TESTNET_FUNDER_PK wallet on Sepolia was topped up to ~0.15 ETH
+ * on 2026-07-01 after briefly running dry mid-debug; re-top-up via a faucet
+ * if this starts throwing "funder has X; need >= Y" again.
  */
 export const FUND_NATIVE_AMOUNT_WEI_BY_CHAIN: Record<string, bigint> = {
   "1": BigInt("10000000000000000000"), // 10 ETH (fork mode)
-  "11155111": BigInt("11000000000000000"), // 0.011 ETH
+  "11155111": BigInt("30000000000000000"), // 0.03 ETH
 };

--- a/lib/test-data/chain-test-data.ts
+++ b/lib/test-data/chain-test-data.ts
@@ -236,8 +236,15 @@ export const MIN_NATIVE_BALANCE_WEI_BY_CHAIN: Record<string, bigint> = {
  * How much native to send when topping up. Aim for ~10x the per-tx cost so
  * a single top-up survives a full suite run without re-checking mid-flight.
  * Fork-mode: set once via anvil_setBalance to 10 ETH and never re-top-up.
+ *
+ * Sepolia is sized to the shared TESTNET_FUNDER_PK wallet's actual balance
+ * (~0.0117 ETH as of 2026-07-01) rather than the original 0.02 ETH target --
+ * still ~9x the per-tx cost, but the funder no longer holds enough to send
+ * 0.02 ETH per top-up. Sepolia ETH has no real value, so this is a safe
+ * adaptation; it is not a substitute for topping up the funder wallet via a
+ * faucet, which remains necessary as the balance keeps draining over time.
  */
 export const FUND_NATIVE_AMOUNT_WEI_BY_CHAIN: Record<string, bigint> = {
   "1": BigInt("10000000000000000000"), // 10 ETH (fork mode)
-  "11155111": BigInt("20000000000000000"), // 0.02 ETH
+  "11155111": BigInt("11000000000000000"), // 0.011 ETH
 };

--- a/protocols/ajna.ts
+++ b/protocols/ajna.ts
@@ -14,7 +14,6 @@ const TEST_DATA: ProtocolTestData = {
       "get-pool-htp": { ajnaPool_: contract("pool1") },
       "price-to-index": { price: native("1") },
       "index-to-price": { index_: "5000" },
-      "get-deposit-index": { ajnaPool_: contract("pool1"), debt_: native("1") },
       "get-auction-status": { ajnaPool_: contract("pool1"), borrower_: wallet() },
       "get-borrower-info": { ajnaPool_: contract("pool1"), borrower_: wallet() },
       "pool1-inflator-info": {},
@@ -26,6 +25,9 @@ const TEST_DATA: ProtocolTestData = {
       "pool1-settle": { borrowerAddress_: wallet() },
       "pool1-withdraw-bonds": { recipient_: wallet() },
       "pool1-update-interest": {},
+      // depositIndex is a pool-level function (IPoolDerivedState.sol), not
+      // a PoolInfoUtils function -- it takes only debt_, no pool address.
+      "pool1-deposit-index": { debt_: native("1") },
       "pool2-inflator-info": {},
       "pool2-bucket-info": { index_: "5000" },
       "pool2-kicker-info": { kicker_: wallet() },
@@ -35,6 +37,7 @@ const TEST_DATA: ProtocolTestData = {
       "pool2-settle": { borrowerAddress_: wallet() },
       "pool2-withdraw-bonds": { recipient_: wallet() },
       "pool2-update-interest": {},
+      "pool2-deposit-index": { debt_: native("1") },
       "vault1-is-paused": {},
       "vault1-get-buckets": {},
       "vault1-total-assets": {},
@@ -158,16 +161,6 @@ const POOL_INFO_UTILS_ABI = JSON.stringify([
     inputs: [{ name: "index_", type: "uint256" }],
     outputs: [{ name: "price", type: "uint256" }],
   },
-  {
-    type: "function",
-    name: "depositIndex",
-    stateMutability: "view",
-    inputs: [
-      { name: "ajnaPool_", type: "address" },
-      { name: "debt_", type: "uint256" },
-    ],
-    outputs: [{ name: "index", type: "uint256" }],
-  },
 ]);
 
 const POOL_ABI = JSON.stringify([
@@ -269,6 +262,15 @@ const POOL_ABI = JSON.stringify([
     stateMutability: "nonpayable",
     inputs: [],
     outputs: [],
+  },
+  {
+    // Pool-level function per IPoolDerivedState.sol -- NOT a PoolInfoUtils
+    // function. Takes only debt_ (the pool itself is the call target).
+    type: "function",
+    name: "depositIndex",
+    stateMutability: "view",
+    inputs: [{ name: "debt_", type: "uint256" }],
+    outputs: [{ name: "index", type: "uint256" }],
   },
 ]);
 
@@ -470,6 +472,17 @@ function poolOverrides(
       slug: `${slugPrefix}-update-interest`,
       label: `${pairLabel} Update Interest`,
       description: `Update interest rate for the ${pairLabel} pool`,
+    },
+    depositIndex: {
+      slug: `${slugPrefix}-deposit-index`,
+      label: `${pairLabel} Deposit Index`,
+      description: `Get the bucket index containing a given amount of deposit in the ${pairLabel} pool`,
+      inputs: {
+        debt_: { label: "Debt Amount (WAD)" },
+      },
+      outputs: {
+        index: { label: "Deposit Bucket Index" },
+      },
     },
   };
 }
@@ -707,19 +720,6 @@ export default defineAbiProtocol({
           },
           outputs: {
             price: { label: "Price (WAD)", decimals: 18 },
-          },
-        },
-        depositIndex: {
-          slug: "get-deposit-index",
-          label: "Get Deposit Index",
-          description:
-            "Get the bucket index containing a given amount of deposit for an Ajna pool",
-          inputs: {
-            ajnaPool_: { label: "Pool Address" },
-            debt_: { label: "Debt Amount (WAD)" },
-          },
-          outputs: {
-            index: { label: "Deposit Bucket Index" },
           },
         },
       },

--- a/protocols/chronicle.ts
+++ b/protocols/chronicle.ts
@@ -54,10 +54,14 @@ const TEST_DATA: ProtocolTestData = {
       "usdt-usd-read-with-age": {},
       "link-usd-read": {},
       "link-usd-read-with-age": {},
-      read: {},
-      "try-read": {},
-      "read-with-age": {},
-      "try-read-with-age": {},
+      // customOracle is userSpecifiedAddress; point the generic read actions
+      // at the ETH/USD oracle the setup workflow already self-kissed above,
+      // so read/readWithAge (which require whitelisting) succeed too, not
+      // just tryRead/tryReadWithAge.
+      read: { contractAddress: contract("ethUsd") },
+      "try-read": { contractAddress: contract("ethUsd") },
+      "read-with-age": { contractAddress: contract("ethUsd") },
+      "try-read-with-age": { contractAddress: contract("ethUsd") },
       "self-kiss": { oracle: contract("ethUsd") },
     },
     skipped: {

--- a/tests/e2e/vitest/protocol-coverage/_shared/setup.ts
+++ b/tests/e2e/vitest/protocol-coverage/_shared/setup.ts
@@ -82,13 +82,32 @@ export async function runSetup(opts: {
   }
   const walletAddress = ctx.walletAddress;
 
-  await ensureNativeGas(chainId, walletAddress);
-
   const protocolDef = getProtocol(protocol);
-  const setupSpec = protocolDef?.testData?.[chainId]?.setup;
+  const chainData = protocolDef?.testData?.[chainId];
+  const setupSpec = chainData?.setup;
   if (!setupSpec) {
     throw new Error(`No setup spec for ${protocol} on chain ${chainId}.`);
   }
+
+  // Native gas is only needed if the wallet will actually sign a
+  // transaction: a setup approval, a setup protocol step, or a write
+  // action that isn't skipped. A protocol whose coverage on this chain is
+  // 100% reads (e.g. ajna on Base mainnet) never submits anything, so
+  // skip the funder/balance preflight entirely rather than requiring a
+  // funded wallet for gas that will never be spent.
+  const needsGas =
+    setupSpec.approvals.length > 0 ||
+    (setupSpec.protocolSteps?.length ?? 0) > 0 ||
+    (protocolDef?.actions.some(
+      (action) =>
+        action.type === "write" &&
+        chainData?.skipped?.[action.slug] === undefined
+    ) ??
+      false);
+  if (needsGas) {
+    await ensureNativeGas(chainId, walletAddress);
+  }
+
   for (const required of setupSpec.requiredTokens) {
     await ensureErc20Acquired(
       chainId,

--- a/tests/unit/protocol-ajna.test.ts
+++ b/tests/unit/protocol-ajna.test.ts
@@ -64,7 +64,7 @@ describe("Ajna Protocol Definition", () => {
   });
 
   it("has expected action count", () => {
-    expect(ajnaProtocol.actions.length).toBe(48);
+    expect(ajnaProtocol.actions.length).toBe(49);
   });
 
   it("has expected contract count", () => {
@@ -89,10 +89,10 @@ describe("Ajna Protocol Definition", () => {
     }
   });
 
-  it("has 30 read actions and 18 write actions", () => {
+  it("has 31 read actions and 18 write actions", () => {
     const readActions = ajnaProtocol.actions.filter((a) => a.type === "read");
     const writeActions = ajnaProtocol.actions.filter((a) => a.type === "write");
-    expect(readActions).toHaveLength(30);
+    expect(readActions).toHaveLength(31);
     expect(writeActions).toHaveLength(18);
   });
 


### PR DESCRIPTION
## Summary

- `pnpm test:protocol` (the dedicated protocol-coverage suite covering morpho, wrapped, and 13 other protocols) was never invoked by any CI workflow. The anvil mainnet-fork infra this job sets up (fixed in #1686) existed but had nothing wired to actually run against it, and `test:e2e:vitest` explicitly excludes `**/protocol-coverage/**`.
- Add a "Run protocol-coverage tests" step running `pnpm test:protocol` with the same env the main e2e step already uses.
- Blocking: if this step fails, `e2e-tests-ephemeral` fails, same as the main e2e suite.

## Current behavior with existing secrets

- Mainnet-fork suites (morpho, wrapped, lido, ethena, curve, chainlink, spark, yearn, uniswap, pendle, sky) skip cleanly - no `ANVIL_FORK_MAINNET_URL` secret configured yet.
- Testnet suites (superfluid, chronicle, ajna) run for real via the configured `TESTNET_FUNDER_PK` - first time any of these run in this job.
- aave-v3 stays disabled via its existing `describe.skip` (prior Sepolia CI flakes: setup workflow timeout, intermittent Etherscan ABI fetch failure).

## Test plan

- [x] Apply `run-e2e-tests-ephemeral` label to trigger the ephemeral e2e workflow on this PR
- [x] `e2e-tests / e2e-vitest-ephemeral` passes with the new "Run protocol-coverage tests" step showing superfluid/chronicle/ajna executing (not skipped) and the rest skipping cleanly