### PR TITLE
fix(docs-site): raise container memory limit to 512Mi

### DIFF
--- a/deploy/docs-site/prod/values.yaml
+++ b/deploy/docs-site/prod/values.yaml
@@ -41,7 +41,7 @@ podAnnotations:
 
 resources:
   limits:
-    memory: 256Mi
+    memory: 512Mi
   requests:
     cpu: 10m
     memory: 128Mi

--- a/deploy/docs-site/staging/values.yaml
+++ b/deploy/docs-site/staging/values.yaml
@@ -41,7 +41,7 @@ podAnnotations:
 
 resources:
   limits:
-    memory: 256Mi
+    memory: 512Mi
   requests:
     cpu: 10m
     memory: 128Mi


### PR DESCRIPTION
## What

Raise the `keeperhub-docs-common` container memory limit from `256Mi` to `512Mi` in both prod and staging docs-site Helm values.

## Why

The docs container leaks memory steadily in prod: working-set grows roughly `+18 MiB/day` from a `~123 MiB` fresh baseline and crosses `~90%` of the `256Mi` limit within about six days when the pod is not redeployed, triggering the `KeeperHub High Memory Usage` alert and risking an OOMKill. This fired a P2 page today (both replicas were at 90% and 84%).

A rolling restart already cleared the immediate alert (pods reset to ~40 MiB). This change raises the limit to give real headroom (~2 weeks at the current leak rate) while the underlying leak is investigated as a follow-up. `requests` stays at `128Mi` since fresh usage is only ~40-46 MiB.

## Notes

- Active prod deploy uses `deploy/docs-site/prod/values.yaml`; staging uses `deploy/docs-site/staging/values.yaml`. Both updated for parity.
- `deploy/docs-site/techops-prod/` holds an identical but unreferenced copy that looks stale; left untouched here, worth a separate cleanup.

## Validation

`helm template` against the `common` chart renders cleanly with `memory: 512Mi`.
