### PR TITLE
fix(docs-site): cap Node old-space heap to bound memory growth

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'docs/**'
       - 'docs-site/**'
+      - 'deploy/docs-site/**'
       - '.github/workflows/build-docs-image.yml'
       - '.github/workflows/deploy-docs.yaml'
   workflow_dispatch:

--- a/deploy/docs-site/prod/values.yaml
+++ b/deploy/docs-site/prod/values.yaml
@@ -53,6 +53,9 @@ env:
   HOSTNAME:
     type: kv
     value: "0.0.0.0"
+  NODE_OPTIONS:
+    type: kv
+    value: "--max-old-space-size=350"
 
 livenessProbe:
   initialDelaySeconds: 5

--- a/deploy/docs-site/staging/values.yaml
+++ b/deploy/docs-site/staging/values.yaml
@@ -53,6 +53,9 @@ env:
   HOSTNAME:
     type: kv
     value: "0.0.0.0"
+  NODE_OPTIONS:
+    type: kv
+    value: "--max-old-space-size=350"
 
 livenessProbe:
   initialDelaySeconds: 5


### PR DESCRIPTION
## What

1. Add `NODE_OPTIONS=--max-old-space-size=350` to the docs-site container env in prod and staging.
2. Add `deploy/docs-site/**` to the `deploy-docs.yaml` push path filter so values-only changes actually trigger a deploy.

## Why - heap cap

The docs-site runs a standalone Next.js Node server whose working set climbs steadily (~18 MiB/day) until it nears the container limit and risks OOMKill (this paged a P2 earlier).

Root cause of the climb-to-limit: inside the pod, `v8.getHeapStatistics().heap_size_limit` is `259 MiB` against the `256Mi` cgroup - Node auto-tuned V8's heap ceiling to ~100% of the container, leaving no headroom for non-heap RSS (runtime, code, buffers, native). With its ceiling set that high V8 has no memory-pressure signal, defers major GC, and lets working set march into the cgroup limit, which OOMKills the process before V8 would collect.

Capping old-space at `350` (against the now-`512Mi` limit) forces V8 to GC at a bounded ceiling with ~160 MiB left for non-heap RSS, so working set plateaus instead of climbing.

This is a stopgap. The real fix is to serve the docs as static files (the site is fully SSG; only a redundant `middleware.ts` forces the Node server) - tracked as the follow-up on KEEP-910.

## Why - path filter

`deploy-docs.yaml` only watched `docs/**` and `docs-site/**` (the source content), so changes to the Helm values under `deploy/docs-site/**` (like the limit and env in this PR) did not trigger a deploy - they would only apply on the next docs content push or a manual `workflow_dispatch`. The other deploy workflows (`deploy-scheduler`, `deploy-events`, `deploy-sandbox`) already watch their `deploy/<component>/**` path; this brings docs in line so values-only changes deploy on their own.

## Notes

- Env applies to both `deploy/docs-site/prod/values.yaml` and `deploy/docs-site/staging/values.yaml`.
- Effectiveness of the heap cap depends on the growth being in the V8 heap. If working set does not plateau after this ships, the growth is in external/native memory and the static-hosting fix is required.

## Validation

`helm template` against the `common` chart renders `NODE_OPTIONS=--max-old-space-size=350` as a container env var alongside the `512Mi` limit.
