### PR TITLE
ci: forward sandbox config to app container in vitest e2e job

### DIFF
--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -222,6 +222,12 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           ai_model: claude-3-5-haiku-20241022
           safe_fetch_shadow: "true"
+          # Forward sandbox config to the app container so the production build
+          # does not throw at run-code module load. The protocol-coverage setup
+          # workflows execute steps through the app, which dispatches code steps
+          # to the sandbox started below.
+          sandbox_backend: remote
+          sandbox_url: http://localhost:8787
 
       - name: Start anvil Sepolia fork for orchestrator integration tests
         run: |


### PR DESCRIPTION
## Problem

The `e2e-vitest-ephemeral` job starts the app image without `SANDBOX_BACKEND` / `SANDBOX_URL`. Under `NODE_ENV=production`, the top-level guard in `plugins/code/steps/run-code.ts` throws at module import, so every `workflow_steps` execution returns 500 (`[postgres world] Queue execution failed (500)`).

The protocol-coverage setup workflows run their steps through the app, so they never reach `success` and all suites time out after 180s (`ajna/8453`, `chronicle/11155111`, `superfluid/11155111`).

## Cause

On the Docker image path, `start-app` only forwards the sandbox env when the inputs are set. The playwright job passes `sandbox_backend` / `sandbox_url`, but the vitest job did not, so the app container booted unconfigured. The `SANDBOX_BACKEND` env on the test step itself only applies to the vitest process, not the app container that executes the steps.

## Fix

Pass `sandbox_backend: remote` and `sandbox_url: http://localhost:8787` to the vitest job's `Start application` step, matching the playwright job.