### PR TITLE
test(analytics): tolerate zero-gas networks in gas breakdown assertion

### DIFF
--- a/tests/e2e/playwright/analytics-gas.test.ts
+++ b/tests/e2e/playwright/analytics-gas.test.ts
@@ -103,10 +103,22 @@ test.describe("Analytics Gas Tracking", () => {
     );
     expect(hasWorkflowNetwork).toBe(true);
 
-    // All networks should have non-zero gas
+    // Gas is recorded only when an execution completes, so networks that saw
+    // only failed or pending runs legitimately report zero gas (matches the
+    // production write path). Assert gas is attributed overall, and that any
+    // network with successful executions carries non-zero gas.
+    let totalGasAcrossNetworks = BigInt(0);
     for (const network of data.networks) {
-      expect(BigInt(network.totalGasWei)).toBeGreaterThan(BigInt(0));
+      const gas = BigInt(network.totalGasWei);
+      totalGasAcrossNetworks += gas;
+      if (network.successCount > 0) {
+        expect(
+          gas,
+          `network ${network.network} has successful executions but zero gas`
+        ).toBeGreaterThan(BigInt(0));
+      }
     }
+    expect(totalGasAcrossNetworks).toBeGreaterThan(BigInt(0));
   });
 
   test("workflow runs API attaches gas to the returned page", async ({


### PR DESCRIPTION
## Problem

`analytics-gas.test.ts` ("network breakdown API includes workflow gas") flakes with:

```
expect(BigInt(network.totalGasWei)).toBeGreaterThan(BigInt(0)) // Received: 0n
```

## Cause

The per-network loop asserted **every** network has non-zero gas. That is not a real invariant:

- Gas is recorded only when an execution completes (`completeExecution` sets `gasUsedWei`; `createExecution` sets `network` up front). So a failed/pending execution has a network but no gas — in production too.
- The direct-executions branch of `getNetworkBreakdown` groups by `network` with `COALESCE(SUM(gas),0)` and **no** null-gas filter, so a network whose runs all failed shows `totalGasWei = "0"`.
- The seed (`tests/e2e/playwright/utils/seed.ts`) assigns a random network to all 40 direct executions but gas only to the ~75% completed ones. When a network randomly lands only failed/pending runs, the assertion fails.

## Fix

Assert the true invariant: gas is attributed overall (sum across networks > 0), and any network **with successful executions** carries non-zero gas. Networks with only failed/pending runs are allowed to report zero.

## Verification

Reproduced against `keeperhub_test` by running the real `getNetworkBreakdown` over a controlled seed (ethereum: completed, base: mixed, polygon: only failed):

```
polygon -> totalGasWei 0, successCount 0   # old assertion FAILS here
OLD assertion (every network gas>0): FAIL
NEW assertion (successCount>0 => gas>0, total>0): PASS
```