### PR TITLE
fix: enforce daily spend cap on value moved, not gas

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -177,3 +177,10 @@ REGISTRATION_PRIVATE_KEY=
 # runtime gate automatically, so ALLOW_TEST_ENDPOINTS is not needed locally).
 # INCLUDE_TEST_ENDPOINTS=true
 # TEST_API_KEY=
+
+# Direct execution API (/api/execute/*) controls
+# Per-org daily value caps are set by org admins/owners (stored in
+# organization_spend_caps.daily_value_cap_wei); there is no env-level default.
+# Max in-flight direct executions (pending+running) before the execute write
+# routes return 429. Defaults to 100.
+# MAX_CONCURRENT_DIRECT_EXECUTIONS=100

--- a/app/api/analytics/spend-cap/route.ts
+++ b/app/api/analytics/spend-cap/route.ts
@@ -2,7 +2,14 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { getSpendCapData } from "@/lib/analytics/queries";
 import { apiError } from "@/lib/api-error";
-import { requireOrganization } from "@/lib/middleware/require-org";
+import { db } from "@/lib/db";
+import { organizationSpendCaps } from "@/lib/db/schema";
+import {
+  requireOrganization,
+  requirePermission,
+} from "@/lib/middleware/require-org";
+
+const NON_NEGATIVE_INTEGER = /^\d+$/;
 
 export const GET = requireOrganization(
   async (_req: NextRequest, context): Promise<Response> => {
@@ -20,5 +27,65 @@ export const GET = requireOrganization(
     } catch (error: unknown) {
       return apiError(error, "Failed to fetch spend cap data");
     }
+  }
+);
+
+/**
+ * Set or clear the organization's daily value cap (native wei).
+ *
+ * Gated by `organization:update` (admin/owner) over the session. A leaked `kh_`
+ * API key or MCP OAuth token -- the KEEP-911 threat -- authenticates a different
+ * layer and never satisfies the org session context, so it cannot raise its own
+ * ceiling. A null `dailyValueCapWei` clears the cap (unlimited).
+ */
+export const PUT = requirePermission(
+  "organization",
+  ["update"],
+  async (req: NextRequest, context): Promise<Response> => {
+    const organizationId = context.organization?.id;
+    if (!organizationId) {
+      return NextResponse.json(
+        { error: "Organization not found" },
+        { status: 403 }
+      );
+    }
+
+    let body: { dailyValueCapWei?: unknown };
+    try {
+      body = (await req.json()) as { dailyValueCapWei?: unknown };
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const raw = body.dailyValueCapWei;
+    let dailyValueCapWei: string | null;
+    if (raw === null) {
+      dailyValueCapWei = null;
+    } else if (typeof raw === "string" && NON_NEGATIVE_INTEGER.test(raw)) {
+      dailyValueCapWei = raw;
+    } else {
+      return NextResponse.json(
+        {
+          error:
+            "dailyValueCapWei must be a non-negative integer wei string, or null to clear the cap",
+          field: "dailyValueCapWei",
+        },
+        { status: 400 }
+      );
+    }
+
+    try {
+      await db
+        .insert(organizationSpendCaps)
+        .values({ organizationId, dailyValueCapWei })
+        .onConflictDoUpdate({
+          target: organizationSpendCaps.organizationId,
+          set: { dailyValueCapWei, updatedAt: new Date() },
+        });
+    } catch (error: unknown) {
+      return apiError(error, "Failed to update spend cap");
+    }
+
+    return NextResponse.json({ dailyValueCapWei }, { status: 200 });
   }
 );

--- a/app/api/analytics/spend-cap/route.ts
+++ b/app/api/analytics/spend-cap/route.ts
@@ -34,9 +34,9 @@ export const GET = requireOrganization(
  * Set or clear the organization's daily value cap (native wei).
  *
  * Gated by `organization:update` (admin/owner) over the session. A leaked `kh_`
- * API key or MCP OAuth token -- the KEEP-911 threat -- authenticates a different
- * layer and never satisfies the org session context, so it cannot raise its own
- * ceiling. A null `dailyValueCapWei` clears the cap (unlimited).
+ * API key or MCP OAuth token authenticates a different layer and never satisfies
+ * the org session context, so a compromised key cannot raise its own ceiling.
+ * A null `dailyValueCapWei` clears the cap (unlimited).
  */
 export const PUT = requirePermission(
   "organization",

--- a/app/api/execute/[...slug]/route.ts
+++ b/app/api/execute/[...slug]/route.ts
@@ -29,6 +29,7 @@ import {
   writeContractCore,
 } from "@/plugins/web3/steps/write-contract-core";
 import { validateApiKey } from "../_lib/auth";
+import { enforceDirectExecutionConcurrency } from "../_lib/concurrency-limit";
 import {
   completeExecution,
   failExecution,
@@ -37,6 +38,7 @@ import {
   withRejectedSignerOverride,
 } from "../_lib/execution-service";
 import { checkRateLimit } from "../_lib/rate-limit";
+import { parseNativeValueWei } from "../_lib/reserved-value";
 import { checkAndReserveExecution } from "../_lib/spending-cap";
 import { requireWallet } from "../_lib/wallet-check";
 
@@ -224,9 +226,28 @@ async function executeProtocolAction(
     return recordIdempotentResponse(idem, executionGuard.response, "release");
   }
 
+  const concurrency = await enforceDirectExecutionConcurrency();
+  if (concurrency) {
+    return recordIdempotentResponse(idem, concurrency, "release");
+  }
+
   const walletError = await requireWallet(organizationId);
   if (walletError) {
     return recordIdempotentResponse(idem, walletError, "release");
+  }
+
+  const ethValue = body.ethValue ? String(body.ethValue) : undefined;
+  // Charge any native value forwarded by the protocol write against the cap.
+  const parsedValue = parseNativeValueWei(ethValue);
+  if (!parsedValue.ok) {
+    return recordIdempotentResponse(
+      idem,
+      NextResponse.json(
+        { success: false, error: parsedValue.error },
+        { status: HttpStatus.BAD_REQUEST }
+      ),
+      "release"
+    );
   }
 
   const reserve = await checkAndReserveExecution({
@@ -235,6 +256,7 @@ async function executeProtocolAction(
     type: "protocol-action",
     network,
     input: redactInput(withRejectedSignerOverride(body, body)),
+    reservedValueWei: parsedValue.valueWei,
   });
   if (!reserve.allowed) {
     return recordIdempotentResponse(
@@ -249,7 +271,6 @@ async function executeProtocolAction(
   const { executionId } = reserve;
   await markRunning(executionId);
 
-  const ethValue = body.ethValue ? String(body.ethValue) : undefined;
   const coreInput: WriteContractCoreInput = {
     contractAddress,
     network,

--- a/app/api/execute/[...slug]/route.ts
+++ b/app/api/execute/[...slug]/route.ts
@@ -226,7 +226,7 @@ async function executeProtocolAction(
     return recordIdempotentResponse(idem, executionGuard.response, "release");
   }
 
-  const concurrency = await enforceDirectExecutionConcurrency();
+  const concurrency = await enforceDirectExecutionConcurrency(organizationId);
   if (concurrency) {
     return recordIdempotentResponse(idem, concurrency, "release");
   }

--- a/app/api/execute/_lib/concurrency-limit.ts
+++ b/app/api/execute/_lib/concurrency-limit.ts
@@ -1,12 +1,18 @@
 import "server-only";
 
+import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
+import { HttpStatus } from "@/lib/http-status";
+import { applyRateLimitHeaders } from "@/lib/rate-limit-headers";
 import {
-  checkConcurrencyLimit as checkConcurrencyLimitCore,
   type ConcurrencyLimitResult,
+  checkConcurrencyLimit as checkConcurrencyLimitCore,
+  checkDirectExecutionConcurrency as checkDirectExecutionConcurrencyCore,
 } from "@/lib/workflow/concurrency";
 
-export type { ConcurrencyLimitResult };
+export type { ConcurrencyLimitResult } from "@/lib/workflow/concurrency";
+
+const RETRY_AFTER_SECONDS = 30;
 
 /**
  * Route-side concurrency check, bound to the app db. Shares its implementation
@@ -14,4 +20,41 @@ export type { ConcurrencyLimitResult };
  */
 export function checkConcurrencyLimit(): Promise<ConcurrencyLimitResult> {
   return checkConcurrencyLimitCore(db);
+}
+
+/**
+ * Back-pressure for the direct execution write routes, bound to the app db.
+ * Counts in-flight direct executions (not workflow executions).
+ */
+export function checkDirectExecutionConcurrency(): Promise<ConcurrencyLimitResult> {
+  return checkDirectExecutionConcurrencyCore(db);
+}
+
+/**
+ * Enforce direct-execution back-pressure at the top of a write route. Returns a
+ * 429 response (with Retry-After) when the in-flight cap is hit, or null to
+ * proceed. Mirrors the workflow routes' concurrency 429 shape.
+ */
+export async function enforceDirectExecutionConcurrency(): Promise<NextResponse | null> {
+  const check = await checkDirectExecutionConcurrency();
+  if (check.allowed) {
+    return null;
+  }
+
+  return applyRateLimitHeaders(
+    NextResponse.json(
+      {
+        error: "Too many concurrent executions",
+        running: check.running,
+        limit: check.limit,
+      },
+      { status: HttpStatus.TOO_MANY_REQUESTS }
+    ),
+    {
+      limit: check.limit,
+      remaining: 0,
+      reset: Math.ceil(Date.now() / 1000) + RETRY_AFTER_SECONDS,
+      retryAfter: RETRY_AFTER_SECONDS,
+    }
+  );
 }

--- a/app/api/execute/_lib/concurrency-limit.ts
+++ b/app/api/execute/_lib/concurrency-limit.ts
@@ -24,19 +24,23 @@ export function checkConcurrencyLimit(): Promise<ConcurrencyLimitResult> {
 
 /**
  * Back-pressure for the direct execution write routes, bound to the app db.
- * Counts in-flight direct executions (not workflow executions).
+ * Counts the org's in-flight direct executions (not workflow executions).
  */
-export function checkDirectExecutionConcurrency(): Promise<ConcurrencyLimitResult> {
-  return checkDirectExecutionConcurrencyCore(db);
+export function checkDirectExecutionConcurrency(
+  organizationId: string
+): Promise<ConcurrencyLimitResult> {
+  return checkDirectExecutionConcurrencyCore(db, organizationId);
 }
 
 /**
  * Enforce direct-execution back-pressure at the top of a write route. Returns a
- * 429 response (with Retry-After) when the in-flight cap is hit, or null to
- * proceed. Mirrors the workflow routes' concurrency 429 shape.
+ * 429 response (with Retry-After) when the org's in-flight cap is hit, or null
+ * to proceed. Mirrors the workflow routes' concurrency 429 shape.
  */
-export async function enforceDirectExecutionConcurrency(): Promise<NextResponse | null> {
-  const check = await checkDirectExecutionConcurrency();
+export async function enforceDirectExecutionConcurrency(
+  organizationId: string
+): Promise<NextResponse | null> {
+  const check = await checkDirectExecutionConcurrency(organizationId);
   if (check.allowed) {
     return null;
   }

--- a/app/api/execute/_lib/reserved-value.ts
+++ b/app/api/execute/_lib/reserved-value.ts
@@ -1,0 +1,69 @@
+import "server-only";
+
+import { ethers } from "ethers";
+
+export type ReservedValue =
+  | { ok: true; valueWei: string }
+  | { ok: false; error: string };
+
+/**
+ * Native notional value (in wei) a direct execution will move, used by the
+ * per-org daily spending cap. Parses a human-decimal ETH amount (e.g. "1.5")
+ * the same way the web3 cores do (`ethers.parseEther`).
+ *
+ * An absent/empty amount reserves "0". Only native value is counted today;
+ * ERC-20 token amounts are not yet priced into the cap, so token-only transfers
+ * pass "0" directly rather than calling this.
+ *
+ * Malformed amounts return `{ ok: false }` so the caller can reject with 400
+ * instead of silently under-reserving (which would weaken the cap). Negative
+ * amounts are rejected too: `ethers.parseEther("-5")` yields a negative BigInt
+ * (it does not throw), and a negative reservation would lower the day's SUM and
+ * bank credit against the cap.
+ */
+export function parseNativeValueWei(
+  rawAmount: string | undefined | null
+): ReservedValue {
+  if (rawAmount === undefined || rawAmount === null || rawAmount === "") {
+    return { ok: true, valueWei: "0" };
+  }
+
+  let parsed: bigint;
+  try {
+    parsed = ethers.parseEther(rawAmount);
+  } catch {
+    return { ok: false, error: `Invalid value amount: ${rawAmount}` };
+  }
+
+  if (parsed < BigInt(0)) {
+    return {
+      ok: false,
+      error: `Value amount must not be negative: ${rawAmount}`,
+    };
+  }
+
+  return { ok: true, valueWei: parsed.toString() };
+}
+
+/**
+ * Native value (wei) reserved for a generic node execution, keyed by the
+ * resolved step function. Only actions that broadcast native ETH value are
+ * charged against the cap: a native transfer (`amount`) or a contract write
+ * that forwards value (`ethValue`). Token transfers/approvals and off-chain
+ * steps move no native value and reserve "0".
+ *
+ * Keyed on the step function so a newly-added value-bearing action must opt in
+ * here rather than silently reserving 0 (which would be a cap bypass).
+ */
+export function parseNodeNativeValueWei(
+  stepFunction: string,
+  config: Record<string, unknown>
+): ReservedValue {
+  let raw: string | undefined;
+  if (stepFunction === "transferFundsStep") {
+    raw = typeof config.amount === "string" ? config.amount : undefined;
+  } else if (stepFunction === "writeContractStep") {
+    raw = typeof config.ethValue === "string" ? config.ethValue : undefined;
+  }
+  return parseNativeValueWei(raw);
+}

--- a/app/api/execute/_lib/reserved-value.ts
+++ b/app/api/execute/_lib/reserved-value.ts
@@ -46,24 +46,26 @@ export function parseNativeValueWei(
 }
 
 /**
- * Native value (wei) reserved for a generic node execution, keyed by the
- * resolved step function. Only actions that broadcast native ETH value are
- * charged against the cap: a native transfer (`amount`) or a contract write
- * that forwards value (`ethValue`). Token transfers/approvals and off-chain
- * steps move no native value and reserve "0".
+ * Native value (wei) reserved for a generic node execution.
  *
- * Keyed on the step function so a newly-added value-bearing action must opt in
- * here rather than silently reserving 0 (which would be a cap bypass).
+ * A native transfer forwards `amount`; every contract-write-style action
+ * forwards native value via `ethValue`. Charging `ethValue` on the field name
+ * (not the step name) means a future value-forwarding action is charged
+ * automatically rather than silently reserving 0 (a cap bypass). Token
+ * transfers/approvals and off-chain steps have neither field and correctly
+ * reserve "0". `value` is deliberately NOT read -- it names non-broadcasting
+ * inputs on other steps (e.g. risk analysis), so charging it would be wrong.
  */
 export function parseNodeNativeValueWei(
   stepFunction: string,
   config: Record<string, unknown>
 ): ReservedValue {
-  let raw: string | undefined;
   if (stepFunction === "transferFundsStep") {
-    raw = typeof config.amount === "string" ? config.amount : undefined;
-  } else if (stepFunction === "writeContractStep") {
-    raw = typeof config.ethValue === "string" ? config.ethValue : undefined;
+    return parseNativeValueWei(
+      typeof config.amount === "string" ? config.amount : undefined
+    );
   }
-  return parseNativeValueWei(raw);
+  return parseNativeValueWei(
+    typeof config.ethValue === "string" ? config.ethValue : undefined
+  );
 }

--- a/app/api/execute/_lib/reserved-value.ts
+++ b/app/api/execute/_lib/reserved-value.ts
@@ -1,10 +1,14 @@
 import "server-only";
 
-import { parseNativeValueWei } from "@/lib/execute/native-value";
+import {
+  parseNativeValueWei,
+  type ReservedValue,
+} from "@/lib/execute/native-value";
 
 // parseNativeValueWei lives in lib/execute so both the direct-execution routes
 // (here) and the workflow step wrappers can charge native value against the
-// same cap. Re-exported for the routes/tests that import it from this path.
+// same cap. Imported above for local use (parseNodeNativeValueWei), and
+// re-exported for the routes/tests that import it from this path.
 export {
   parseNativeValueWei,
   type ReservedValue,

--- a/app/api/execute/_lib/reserved-value.ts
+++ b/app/api/execute/_lib/reserved-value.ts
@@ -1,49 +1,14 @@
 import "server-only";
 
-import { ethers } from "ethers";
+import { parseNativeValueWei } from "@/lib/execute/native-value";
 
-export type ReservedValue =
-  | { ok: true; valueWei: string }
-  | { ok: false; error: string };
-
-/**
- * Native notional value (in wei) a direct execution will move, used by the
- * per-org daily spending cap. Parses a human-decimal ETH amount (e.g. "1.5")
- * the same way the web3 cores do (`ethers.parseEther`).
- *
- * An absent/empty amount reserves "0". Only native value is counted today;
- * ERC-20 token amounts are not yet priced into the cap, so token-only transfers
- * pass "0" directly rather than calling this.
- *
- * Malformed amounts return `{ ok: false }` so the caller can reject with 400
- * instead of silently under-reserving (which would weaken the cap). Negative
- * amounts are rejected too: `ethers.parseEther("-5")` yields a negative BigInt
- * (it does not throw), and a negative reservation would lower the day's SUM and
- * bank credit against the cap.
- */
-export function parseNativeValueWei(
-  rawAmount: string | undefined | null
-): ReservedValue {
-  if (rawAmount === undefined || rawAmount === null || rawAmount === "") {
-    return { ok: true, valueWei: "0" };
-  }
-
-  let parsed: bigint;
-  try {
-    parsed = ethers.parseEther(rawAmount);
-  } catch {
-    return { ok: false, error: `Invalid value amount: ${rawAmount}` };
-  }
-
-  if (parsed < BigInt(0)) {
-    return {
-      ok: false,
-      error: `Value amount must not be negative: ${rawAmount}`,
-    };
-  }
-
-  return { ok: true, valueWei: parsed.toString() };
-}
+// parseNativeValueWei lives in lib/execute so both the direct-execution routes
+// (here) and the workflow step wrappers can charge native value against the
+// same cap. Re-exported for the routes/tests that import it from this path.
+export {
+  parseNativeValueWei,
+  type ReservedValue,
+} from "@/lib/execute/native-value";
 
 /**
  * Native value (wei) reserved for a generic node execution.

--- a/app/api/execute/_lib/spending-cap.ts
+++ b/app/api/execute/_lib/spending-cap.ts
@@ -84,7 +84,14 @@ export async function checkAndReserveExecution(
         and(
           eq(directExecutions.organizationId, params.organizationId),
           ne(directExecutions.status, "failed"),
-          gte(directExecutions.createdAt, todayStart)
+          gte(directExecutions.createdAt, todayStart),
+          // Exclude stale in-flight reservations: a pending/running row from a
+          // crashed pod or a throwing core would otherwise hold its reserved
+          // value against the cap for the rest of the UTC day. Completed rows
+          // always count; pending/running only within a 15m window (matches the
+          // concurrency limiter's stale window). Legitimate in-flight requests
+          // settle in seconds, so this never drops a real concurrent reservation.
+          sql`(${directExecutions.status} = 'completed' OR ${directExecutions.createdAt} > now() - interval '15 minutes')`
         )
       )
       .then((rows) => rows[0]);

--- a/app/api/execute/_lib/spending-cap.ts
+++ b/app/api/execute/_lib/spending-cap.ts
@@ -1,8 +1,9 @@
 import "server-only";
 
-import { and, eq, gte, ne, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { directExecutions, organizationSpendCaps } from "@/lib/db/schema";
+import { sumOrgValueTodayWei } from "@/lib/execute/value-ledger";
 import { generateId } from "@/lib/utils/id";
 
 export type SpendCapResult =
@@ -72,31 +73,11 @@ export async function checkAndReserveExecution(
       return { allowed: true, executionId: id } as const;
     }
 
-    const todayStart = new Date();
-    todayStart.setUTCHours(0, 0, 0, 0);
-
-    const result = await tx
-      .select({
-        totalWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.valueWei} AS NUMERIC)), 0)::text`,
-      })
-      .from(directExecutions)
-      .where(
-        and(
-          eq(directExecutions.organizationId, params.organizationId),
-          ne(directExecutions.status, "failed"),
-          gte(directExecutions.createdAt, todayStart),
-          // Exclude stale in-flight reservations: a pending/running row from a
-          // crashed pod or a throwing core would otherwise hold its reserved
-          // value against the cap for the rest of the UTC day. Completed rows
-          // always count; pending/running only within a 15m window (matches the
-          // concurrency limiter's stale window). Legitimate in-flight requests
-          // settle in seconds, so this never drops a real concurrent reservation.
-          sql`(${directExecutions.status} = 'completed' OR ${directExecutions.createdAt} > now() - interval '15 minutes')`
-        )
-      )
-      .then((rows) => rows[0]);
-
-    const totalWei = BigInt(result?.totalWei ?? "0");
+    // Sum today's value across BOTH stores (direct executions AND the workflow/
+    // protocol value ledger) so a direct-API request is charged against value
+    // moved by workflow runs too, and cannot exceed the cap by racing them.
+    // Runs inside this FOR UPDATE tx, so it is consistent under concurrency.
+    const totalWei = await sumOrgValueTodayWei(tx, params.organizationId);
     const reservedWei = BigInt(params.reservedValueWei);
     const dailyCap = BigInt(cap.dailyValueCapWei);
 

--- a/app/api/execute/_lib/spending-cap.ts
+++ b/app/api/execute/_lib/spending-cap.ts
@@ -16,6 +16,9 @@ type ReserveExecutionParams = {
   network?: string;
   // biome-ignore lint/suspicious/noExplicitAny: jsonb column accepts arbitrary serializable data
   input: any;
+  // Native notional value (wei) this execution moves. "0" for token-only or
+  // no-value calls. Charged against the org's daily value cap at reservation.
+  reservedValueWei: string;
 };
 
 type ReserveResult =
@@ -23,30 +26,26 @@ type ReserveResult =
   | { allowed: false; reason: string };
 
 /**
- * Atomically check the spending cap and create the execution record.
+ * Atomically check the daily value cap and create the execution record.
  *
- * Uses SELECT FOR UPDATE on the cap row to serialize concurrent requests
- * for the same organization. The execution record is inserted inside the
- * same transaction so no gap exists between the cap check and the record
- * that represents in-flight spend.
+ * The cap bounds the native notional VALUE moved per org per day, not gas.
+ * `reservedValueWei` (known at request time) is charged against
+ * `organizationSpendCaps.dailyValueCapWei` inside a SELECT FOR UPDATE on the
+ * cap row, which serializes concurrent requests for the same organization. The
+ * execution record is inserted in the same transaction carrying its
+ * `valueWei`, so the reserved value is immediately visible to subsequent
+ * callers -- closing the TOCTOU that the old gas-based cap had (pending/running
+ * rows had null gasUsedWei and contributed 0 to the SUM).
  *
- * The SUM includes all non-failed executions (pending, running, completed)
- * so that serialized-but-not-yet-completed requests are visible to
- * subsequent callers once their gas totals are recorded.
- *
- * Residual race window: pending/running records have null gasUsedWei so
- * they contribute 0 to the SUM. Two sequential requests can both pass the
- * cap check while the first is still executing. Full elimination would
- * require estimating gas at reservation time (not available pre-execution)
- * or holding the lock through execution (unacceptable for long-running txs).
- * At typical org concurrency this is acceptable.
+ * The cap is the org's `dailyValueCapWei`, set by org admins/owners. When no
+ * cap row exists, or it is null, value spending is unlimited.
  */
 export async function checkAndReserveExecution(
   params: ReserveExecutionParams
 ): Promise<ReserveResult> {
   return await db.transaction(async (tx) => {
     const caps = await tx
-      .select({ dailyCapWei: organizationSpendCaps.dailyCapWei })
+      .select({ dailyValueCapWei: organizationSpendCaps.dailyValueCapWei })
       .from(organizationSpendCaps)
       .where(eq(organizationSpendCaps.organizationId, params.organizationId))
       .for("update")
@@ -55,16 +54,21 @@ export async function checkAndReserveExecution(
     const cap = caps[0];
     const id = generateId();
 
-    if (!cap) {
-      await tx.insert(directExecutions).values({
+    const insertReservation = () =>
+      tx.insert(directExecutions).values({
         id,
         organizationId: params.organizationId,
         apiKeyId: params.apiKeyId,
         type: params.type,
         network: params.network ?? null,
         input: params.input,
+        valueWei: params.reservedValueWei,
         status: "pending",
       });
+
+    // No cap configured (no row, or value cap unset) -> unlimited.
+    if (!cap || cap.dailyValueCapWei === null) {
+      await insertReservation();
       return { allowed: true, executionId: id } as const;
     }
 
@@ -73,7 +77,7 @@ export async function checkAndReserveExecution(
 
     const result = await tx
       .select({
-        totalWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.gasUsedWei} AS NUMERIC)), 0)::text`,
+        totalWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.valueWei} AS NUMERIC)), 0)::text`,
       })
       .from(directExecutions)
       .where(
@@ -86,21 +90,15 @@ export async function checkAndReserveExecution(
       .then((rows) => rows[0]);
 
     const totalWei = BigInt(result?.totalWei ?? "0");
-    const dailyCap = BigInt(cap.dailyCapWei);
+    const reservedWei = BigInt(params.reservedValueWei);
+    const dailyCap = BigInt(cap.dailyValueCapWei);
 
-    if (totalWei >= dailyCap) {
+    // Pre-charge: deny if this request would push the day's total over the cap.
+    if (totalWei + reservedWei > dailyCap) {
       return { allowed: false, reason: "Daily spending cap exceeded" } as const;
     }
 
-    await tx.insert(directExecutions).values({
-      id,
-      organizationId: params.organizationId,
-      apiKeyId: params.apiKeyId,
-      type: params.type,
-      network: params.network ?? null,
-      input: params.input,
-      status: "pending",
-    });
+    await insertReservation();
 
     return { allowed: true, executionId: id } as const;
   });

--- a/app/api/execute/check-and-execute/route.ts
+++ b/app/api/execute/check-and-execute/route.ts
@@ -365,7 +365,9 @@ export async function POST(request: Request): Promise<NextResponse> {
   // Concurrency back-pressure: gate the broadcasting write path only (reads and
   // simulations already returned above). Before reserving the idempotency key so
   // a 429 leaves no key to release.
-  const concurrency = await enforceDirectExecutionConcurrency();
+  const concurrency = await enforceDirectExecutionConcurrency(
+    apiKeyCtx.organizationId
+  );
   if (concurrency) {
     return concurrency;
   }

--- a/app/api/execute/check-and-execute/route.ts
+++ b/app/api/execute/check-and-execute/route.ts
@@ -20,6 +20,7 @@ import { getErrorMessage } from "@/lib/utils";
 import { readContractCore } from "@/plugins/web3/steps/read-contract-core";
 import { writeContractCore } from "@/plugins/web3/steps/write-contract-core";
 import { validateApiKey } from "../_lib/auth";
+import { enforceDirectExecutionConcurrency } from "../_lib/concurrency-limit";
 import type { ConditionInput, ConditionResult } from "../_lib/condition";
 import { evaluateCondition } from "../_lib/condition";
 import {
@@ -144,6 +145,9 @@ async function executeConditionalWrite(
     type: "check-and-execute",
     network,
     input: redactedInput,
+    // The conditional write never forwards native value (writeContractCore is
+    // called without ethValue), so nothing is charged to the value cap here.
+    reservedValueWei: "0",
   });
   if (!reserve.allowed) {
     return recordIdempotentResponse(
@@ -356,6 +360,14 @@ export async function POST(request: Request): Promise<NextResponse> {
       ),
       rateLimit
     );
+  }
+
+  // Concurrency back-pressure: gate the broadcasting write path only (reads and
+  // simulations already returned above). Before reserving the idempotency key so
+  // a 429 leaves no key to release.
+  const concurrency = await enforceDirectExecutionConcurrency();
+  if (concurrency) {
+    return concurrency;
   }
 
   // Idempotency applies only to the broadcasting write path.

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -322,7 +322,9 @@ export async function POST(request: Request): Promise<NextResponse> {
   // Concurrency back-pressure: gate the state-changing write path only (reads
   // and simulations already returned above). Before reserving the idempotency
   // key so a 429 leaves no key to release.
-  const concurrency = await enforceDirectExecutionConcurrency();
+  const concurrency = await enforceDirectExecutionConcurrency(
+    apiKeyCtx.organizationId
+  );
   if (concurrency) {
     return concurrency;
   }

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -21,6 +21,7 @@ import { getErrorMessage } from "@/lib/utils";
 import { readContractCore } from "@/plugins/web3/steps/read-contract-core";
 import { writeContractCore } from "@/plugins/web3/steps/write-contract-core";
 import { validateApiKey } from "../_lib/auth";
+import { enforceDirectExecutionConcurrency } from "../_lib/concurrency-limit";
 import {
   completeExecution,
   failExecution,
@@ -29,6 +30,7 @@ import {
   withRejectedSignerOverride,
 } from "../_lib/execution-service";
 import { checkRateLimit } from "../_lib/rate-limit";
+import { parseNativeValueWei } from "../_lib/reserved-value";
 import { parseSimulateFlag } from "../_lib/simulate-flag";
 import { checkAndReserveExecution } from "../_lib/spending-cap";
 import { validateContractCallInput } from "../_lib/validate";
@@ -144,12 +146,25 @@ async function handleWriteCall(
   }
 
   const redactedInput = redactInput(withRejectedSignerOverride(body, body));
+  // Charge any native ETH value sent with the call against the daily value cap.
+  const parsedValue = parseNativeValueWei(body.value as string | undefined);
+  if (!parsedValue.ok) {
+    return recordIdempotentResponse(
+      idem,
+      NextResponse.json(
+        { error: parsedValue.error, field: "value" },
+        { status: HttpStatus.BAD_REQUEST }
+      ),
+      "release"
+    );
+  }
   const reserve = await checkAndReserveExecution({
     organizationId,
     apiKeyId,
     type: "contract-call",
     network: body.network as string,
     input: redactedInput,
+    reservedValueWei: parsedValue.valueWei,
   });
   if (!reserve.allowed) {
     return recordIdempotentResponse(
@@ -302,6 +317,14 @@ export async function POST(request: Request): Promise<NextResponse> {
       await handleSimulateCall(body, resolvedAbi, apiKeyCtx.organizationId),
       rateLimit
     );
+  }
+
+  // Concurrency back-pressure: gate the state-changing write path only (reads
+  // and simulations already returned above). Before reserving the idempotency
+  // key so a 429 leaves no key to release.
+  const concurrency = await enforceDirectExecutionConcurrency();
+  if (concurrency) {
+    return concurrency;
   }
 
   // Idempotency applies only to the state-changing write path.

--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -578,7 +578,9 @@ export async function POST(request: Request): Promise<NextResponse> {
 
     // Concurrency back-pressure before broadcasting. Release the idempotency
     // key on a 429 so a retry is not blocked by a stale in-progress record.
-    const concurrency = await enforceDirectExecutionConcurrency();
+    const concurrency = await enforceDirectExecutionConcurrency(
+      apiKeyCtx.organizationId
+    );
     if (concurrency) {
       return recordIdempotentResponse(idem, concurrency, "release");
     }

--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -384,6 +384,11 @@ async function executeNode(
       nodeName: resolved.label,
       nodeType: "action",
       organizationId: apiKeyCtx.organizationId,
+      // A pre-created execution id means the caller already reserved this
+      // execution's value against the cap (checkAndReserveExecution, in the
+      // networked branch below). Flag it so a value-moving step wrapper does
+      // not reserve a second time and double-charge the cap.
+      valueCapReserved: Boolean(preCreatedExecutionId),
     },
   };
 

--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -23,6 +23,7 @@ import type { ResolvedAction } from "../_lib/action-resolver";
 import { resolveAction } from "../_lib/action-resolver";
 import type { ApiKeyContext } from "../_lib/auth";
 import { validateApiKey } from "../_lib/auth";
+import { enforceDirectExecutionConcurrency } from "../_lib/concurrency-limit";
 import {
   completeExecution,
   createExecution,
@@ -33,6 +34,7 @@ import {
   withRejectedSignerOverride,
 } from "../_lib/execution-service";
 import { checkRateLimit } from "../_lib/rate-limit";
+import { parseNodeNativeValueWei } from "../_lib/reserved-value";
 import {
   DEFAULT_TIMEOUT_MS as DEFAULT_RETRY_TIMEOUT_MS,
   executeWithRetry,
@@ -574,6 +576,31 @@ export async function POST(request: Request): Promise<NextResponse> {
       return recordIdempotentResponse(idem, walletError, "release");
     }
 
+    // Concurrency back-pressure before broadcasting. Release the idempotency
+    // key on a 429 so a retry is not blocked by a stale in-progress record.
+    const concurrency = await enforceDirectExecutionConcurrency();
+    if (concurrency) {
+      return recordIdempotentResponse(idem, concurrency, "release");
+    }
+
+    // Charge native value moved against the daily cap: transfer-funds forwards
+    // `amount`, a contract write forwards `ethValue`. Other actions (token
+    // transfer/approve, off-chain steps) move no native value.
+    const parsedValue = parseNodeNativeValueWei(
+      resolved.importer.stepFunction,
+      validation.data.config
+    );
+    if (!parsedValue.ok) {
+      return recordIdempotentResponse(
+        idem,
+        NextResponse.json(
+          { error: parsedValue.error },
+          { status: HttpStatus.BAD_REQUEST }
+        ),
+        "release"
+      );
+    }
+
     // Strip the same reserved keys executeNode removes so the persisted audit
     // input matches what the step actually received (see stripReservedConfig),
     // but preserve a non-honored web3Connection under _rejectedConfig so the
@@ -593,6 +620,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       type: resolved.actionType,
       network: effectiveNetwork,
       input: redactedInput,
+      reservedValueWei: parsedValue.valueWei,
     });
     if (!reserve.allowed) {
       return applyRateLimitHeaders(

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -160,7 +160,9 @@ export async function POST(request: Request): Promise<NextResponse> {
   // 5.55 Concurrency back-pressure: gate the state-changing write path only
   // (reads/simulations/replays are not throttled). Checked before reserving the
   // idempotency key so a 429 leaves no key to release.
-  const concurrency = await enforceDirectExecutionConcurrency();
+  const concurrency = await enforceDirectExecutionConcurrency(
+    apiKeyCtx.organizationId
+  );
   if (concurrency) {
     return concurrency;
   }

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -20,6 +20,7 @@ import { applyRateLimitHeaders } from "@/lib/rate-limit-headers";
 import { transferFundsCore } from "@/plugins/web3/steps/transfer-funds-core";
 import { transferTokenCore } from "@/plugins/web3/steps/transfer-token-core";
 import { validateApiKey } from "../_lib/auth";
+import { enforceDirectExecutionConcurrency } from "../_lib/concurrency-limit";
 import {
   completeExecution,
   failExecution,
@@ -28,6 +29,7 @@ import {
   withRejectedSignerOverride,
 } from "../_lib/execution-service";
 import { checkRateLimit } from "../_lib/rate-limit";
+import { parseNativeValueWei } from "../_lib/reserved-value";
 import { parseSimulateFlag } from "../_lib/simulate-flag";
 import { checkAndReserveExecution } from "../_lib/spending-cap";
 import { validateTokenFields, validateTransferInput } from "../_lib/validate";
@@ -155,6 +157,14 @@ export async function POST(request: Request): Promise<NextResponse> {
     });
   }
 
+  // 5.55 Concurrency back-pressure: gate the state-changing write path only
+  // (reads/simulations/replays are not throttled). Checked before reserving the
+  // idempotency key so a 429 leaves no key to release.
+  const concurrency = await enforceDirectExecutionConcurrency();
+  if (concurrency) {
+    return concurrency;
+  }
+
   // 5.6 Idempotency: an Idempotency-Key lets clients retry a broadcast safely.
   // Reserve the key (per-org, across direct-execution endpoints) before doing
   // any state-changing work; a replay/conflict/in-progress short-circuits here.
@@ -174,14 +184,35 @@ export async function POST(request: Request): Promise<NextResponse> {
     }
   }
 
-  // 6. Spending cap + create execution atomically
+  // 6. Spending cap + create execution atomically. Native transfers charge
+  // their ETH value against the daily value cap; ERC-20 transfers move no
+  // native value (token value is not yet priced into the cap) so reserve 0.
   const redactedInput = redactInput(withRejectedSignerOverride(body, body));
+  let reservedValueWei = "0";
+  if (!isTokenTransfer) {
+    const parsedValue = parseNativeValueWei(amount);
+    if (!parsedValue.ok) {
+      return applyRateLimitHeaders(
+        await recordIdempotentResponse(
+          idem,
+          NextResponse.json(
+            { error: parsedValue.error, field: "amount" },
+            { status: HttpStatus.BAD_REQUEST }
+          ),
+          "release"
+        ),
+        rateLimit
+      );
+    }
+    reservedValueWei = parsedValue.valueWei;
+  }
   const reserve = await checkAndReserveExecution({
     organizationId: apiKeyCtx.organizationId,
     apiKeyId: apiKeyCtx.apiKeyId,
     type: "transfer",
     network,
     input: redactedInput,
+    reservedValueWei,
   });
   if (!reserve.allowed) {
     // Pre-broadcast gating failure: release so the same key can be retried.

--- a/components/organization/manage-orgs-modal.tsx
+++ b/components/organization/manage-orgs-modal.tsx
@@ -19,6 +19,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ExecutionDigestSection } from "@/components/organization/execution-digest-section";
 import { MemberSessionsDialog } from "@/components/organization/member-sessions-dialog";
+import { SpendCapSection } from "@/components/organization/spend-cap-section";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -1320,7 +1321,7 @@ export function ManageOrgsModal({
             onValueChange={setActiveTab}
             value={activeTab}
           >
-            <TabsList className="grid w-full grid-cols-3">
+            <TabsList className="grid w-full grid-cols-4">
               <TabsTrigger value="organizations">Organizations</TabsTrigger>
               <TabsTrigger value="invitations">
                 Invitations
@@ -1331,6 +1332,7 @@ export function ManageOrgsModal({
                 )}
               </TabsTrigger>
               <TabsTrigger value="notifications">Notifications</TabsTrigger>
+              <TabsTrigger value="limits">Limits</TabsTrigger>
             </TabsList>
 
             <TabsContent className="space-y-4" value="organizations">
@@ -1707,6 +1709,25 @@ export function ManageOrgsModal({
               ) : (
                 <div className="py-8 text-center text-muted-foreground">
                   Only organization owners and admins can manage notifications.
+                </div>
+              )}
+            </TabsContent>
+
+            <TabsContent className="space-y-4" value="limits">
+              {organization && (isActiveOrgOwner || isActiveOrgAdmin) ? (
+                <>
+                  <p className="text-muted-foreground text-sm">
+                    Settings for{" "}
+                    <span className="font-medium text-foreground">
+                      {organization.name}
+                    </span>
+                  </p>
+                  <SpendCapSection key={organization.id} />
+                </>
+              ) : (
+                <div className="py-8 text-center text-muted-foreground">
+                  Only organization owners and admins can manage spending
+                  limits.
                 </div>
               )}
             </TabsContent>

--- a/components/organization/spend-cap-section.tsx
+++ b/components/organization/spend-cap-section.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ethers } from "ethers";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -11,33 +12,27 @@ type SpendCapResponse = {
   dailyUsedWei: string;
 };
 
-const WEI_PER_ETH = BigInt(10) ** BigInt(18);
-const ETH_AMOUNT = /^\d+(\.\d{1,18})?$/;
-const TRAILING_ZEROS = /0+$/;
-
 function formatWeiToEth(wei: string): string {
-  let value: bigint;
   try {
-    value = BigInt(wei);
+    return ethers.formatEther(wei);
   } catch {
     return "0";
   }
-  const whole = value / WEI_PER_ETH;
-  const frac = (value % WEI_PER_ETH)
-    .toString()
-    .padStart(18, "0")
-    .replace(TRAILING_ZEROS, "");
-  return frac ? `${whole}.${frac}` : whole.toString();
 }
 
 function parseEthToWei(input: string): string | null {
   const trimmed = input.trim();
-  if (!ETH_AMOUNT.test(trimmed)) {
+  if (trimmed === "") {
     return null;
   }
-  const [whole, frac = ""] = trimmed.split(".");
-  const fracPadded = (frac + "0".repeat(18)).slice(0, 18);
-  return (BigInt(whole) * WEI_PER_ETH + BigInt(fracPadded)).toString();
+  try {
+    const wei = ethers.parseEther(trimmed);
+    // ethers.parseEther("-5") yields a negative BigInt without throwing; the
+    // cap must be non-negative (the server also rejects it).
+    return wei < BigInt(0) ? null : wei.toString();
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/components/organization/spend-cap-section.tsx
+++ b/components/organization/spend-cap-section.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type SpendCapResponse = {
+  dailyCapWei: string | null;
+  dailyUsedWei: string;
+};
+
+const WEI_PER_ETH = BigInt(10) ** BigInt(18);
+const ETH_AMOUNT = /^\d+(\.\d{1,18})?$/;
+const TRAILING_ZEROS = /0+$/;
+
+function formatWeiToEth(wei: string): string {
+  let value: bigint;
+  try {
+    value = BigInt(wei);
+  } catch {
+    return "0";
+  }
+  const whole = value / WEI_PER_ETH;
+  const frac = (value % WEI_PER_ETH)
+    .toString()
+    .padStart(18, "0")
+    .replace(TRAILING_ZEROS, "");
+  return frac ? `${whole}.${frac}` : whole.toString();
+}
+
+function parseEthToWei(input: string): string | null {
+  const trimmed = input.trim();
+  if (!ETH_AMOUNT.test(trimmed)) {
+    return null;
+  }
+  const [whole, frac = ""] = trimmed.split(".");
+  const fracPadded = (frac + "0".repeat(18)).slice(0, 18);
+  return (BigInt(whole) * WEI_PER_ETH + BigInt(fracPadded)).toString();
+}
+
+/**
+ * Organization daily value-cap control. Reads and writes the active org's
+ * `daily_value_cap_wei` via /api/analytics/spend-cap; the PUT is gated server
+ * side by `organization:update` (owner/admin) over the session, so this only
+ * mounts inside an admin-gated surface.
+ */
+export function SpendCapSection(): React.ReactElement {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [capWei, setCapWei] = useState<string | null>(null);
+  const [usedWei, setUsedWei] = useState("0");
+  const [input, setInput] = useState("");
+
+  const load = useCallback(() => {
+    setLoading(true);
+    fetch("/api/analytics/spend-cap")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: SpendCapResponse | null) => {
+        if (!data) {
+          return;
+        }
+        setCapWei(data.dailyCapWei);
+        setUsedWei(data.dailyUsedWei);
+        setInput(data.dailyCapWei ? formatWeiToEth(data.dailyCapWei) : "");
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const save = useCallback(async (dailyValueCapWei: string | null) => {
+    setSaving(true);
+    try {
+      const res = await fetch("/api/analytics/spend-cap", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ dailyValueCapWei }),
+      });
+      if (res.ok) {
+        setCapWei(dailyValueCapWei);
+        setInput(dailyValueCapWei ? formatWeiToEth(dailyValueCapWei) : "");
+        toast.success(
+          dailyValueCapWei ? "Daily value cap saved" : "Daily value cap cleared"
+        );
+      } else if (res.status === 403) {
+        toast.error("Only organization owners and admins can change the cap");
+      } else {
+        toast.error("Could not save the cap");
+      }
+    } catch {
+      toast.error("Could not save the cap");
+    } finally {
+      setSaving(false);
+    }
+  }, []);
+
+  const handleSave = useCallback(() => {
+    const wei = parseEthToWei(input);
+    if (wei === null) {
+      toast.error("Enter a valid ETH amount (up to 18 decimals)");
+      return;
+    }
+    save(wei);
+  }, [input, save]);
+
+  const usedEth = formatWeiToEth(usedWei);
+
+  return (
+    <div className="space-y-3">
+      <h4 className="font-medium text-muted-foreground text-sm">
+        Daily value cap
+      </h4>
+      <p className="text-muted-foreground text-xs">
+        Limits the total native value (ETH) that direct execution API calls can
+        move per day for this organization. Leave empty for no cap.
+      </p>
+
+      <div className="space-y-2">
+        <Label className="text-sm" htmlFor="daily-value-cap">
+          Cap (ETH per day)
+        </Label>
+        <Input
+          disabled={loading || saving}
+          id="daily-value-cap"
+          inputMode="decimal"
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="e.g. 1.5"
+          value={input}
+        />
+        <p className="text-muted-foreground text-xs">
+          {capWei
+            ? `Current cap: ${formatWeiToEth(capWei)} ETH/day - used ${usedEth} ETH today`
+            : `No cap set - used ${usedEth} ETH today`}
+        </p>
+      </div>
+
+      <div className="flex gap-2">
+        <Button
+          className="flex-1"
+          disabled={loading || saving}
+          onClick={handleSave}
+          size="sm"
+          variant="outline"
+        >
+          {saving ? "Saving..." : "Save cap"}
+        </Button>
+        <Button
+          disabled={loading || saving || !capWei}
+          onClick={() => save(null)}
+          size="sm"
+          variant="ghost"
+        >
+          Clear
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/organization/spend-cap-section.tsx
+++ b/components/organization/spend-cap-section.tsx
@@ -60,6 +60,9 @@ export function SpendCapSection(): React.ReactElement {
         setUsedWei(data.dailyUsedWei);
         setInput(data.dailyCapWei ? formatWeiToEth(data.dailyCapWei) : "");
       })
+      .catch(() => {
+        toast.error("Could not load the spend cap");
+      })
       .finally(() => setLoading(false));
   }, []);
 
@@ -94,6 +97,11 @@ export function SpendCapSection(): React.ReactElement {
   }, []);
 
   const handleSave = useCallback(() => {
+    // An empty field clears the cap, matching the "Leave empty for no cap" hint.
+    if (input.trim() === "") {
+      save(null);
+      return;
+    }
     const wei = parseEthToWei(input);
     if (wei === null) {
       toast.error("Enter a valid ETH amount (up to 18 decimals)");

--- a/drizzle/0121_keep_911_daily_value_cap.sql
+++ b/drizzle/0121_keep_911_daily_value_cap.sql
@@ -1,0 +1,18 @@
+-- KEEP-911: cap the notional VALUE moved (not gas) per org per day.
+--
+-- direct_executions.value_wei holds the native value (wei) reserved for each
+-- execution at request time; spending-cap enforcement sums it per org per day.
+-- organization_spend_caps.daily_value_cap_wei is the enforced limit (native
+-- value); the pre-existing daily_cap_wei stays as a legacy gas-denominated
+-- figure for the analytics gauge. Both new columns are nullable (a null
+-- value_wei counts as 0; a null daily_value_cap_wei means no value cap).
+--
+-- No lock-free prep needed: ADD COLUMN of a nullable column with no default is
+-- a catalog-only change in PostgreSQL 11+ (momentary ACCESS EXCLUSIVE lock, no
+-- table rewrite), safe inline via the normal migrate path.
+
+ALTER TABLE "direct_executions" ADD COLUMN IF NOT EXISTS "value_wei" text;--> statement-breakpoint
+ALTER TABLE "organization_spend_caps" ADD COLUMN IF NOT EXISTS "daily_value_cap_wei" text;--> statement-breakpoint
+-- daily_cap_wei is legacy (gas-denominated, no longer enforced); make it
+-- nullable so an admin-set value-only cap row can be created without it.
+ALTER TABLE "organization_spend_caps" ALTER COLUMN "daily_cap_wei" DROP NOT NULL;

--- a/drizzle/0122_keep_933_org_value_reservations.sql
+++ b/drizzle/0122_keep_933_org_value_reservations.sql
@@ -1,0 +1,28 @@
+-- KEEP-933: close the workflow/protocol value-cap bypass.
+--
+-- The KEEP-911 daily value cap is only charged by the direct-execution API
+-- routes (direct_executions.value_wei). Value moved by a workflow run or a
+-- protocol write goes through the same value-moving cores but never touches
+-- direct_executions, so an authenticated key could create+trigger a workflow to
+-- exceed the cap. This ledger records reservations from those other entrances;
+-- the cap SUM now unions both stores, so every value-moving path is bounded by
+-- the same per-org daily cap.
+--
+-- status: reserved (in-flight) | settled (broadcast succeeded, counts all day) |
+-- released (denied/failed, drops out of the SUM). Native value only, in wei.
+--
+-- Plain CREATE TABLE + CREATE INDEX on a brand-new (empty) table takes no
+-- meaningful lock, so no lock-free prep is required.
+
+CREATE TABLE IF NOT EXISTS "org_value_reservations" (
+    "id" text PRIMARY KEY NOT NULL,
+    "organization_id" text NOT NULL,
+    "value_wei" text NOT NULL,
+    "status" text DEFAULT 'reserved' NOT NULL,
+    "source" text,
+    "ref" text,
+    "created_at" timestamp DEFAULT now() NOT NULL,
+    "updated_at" timestamp DEFAULT now() NOT NULL,
+    CONSTRAINT "org_value_reservations_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE no action ON UPDATE no action
+);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_org_value_reservations_org_created" ON "org_value_reservations" ("organization_id","created_at");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -855,6 +855,13 @@
       "when": 1782765380001,
       "tag": "0121_keep_911_daily_value_cap",
       "breakpoints": true
+    },
+    {
+      "idx": 122,
+      "version": "7",
+      "when": 1782765380002,
+      "tag": "0122_keep_933_org_value_reservations",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -848,6 +848,13 @@
       "when": 1782765380000,
       "tag": "0120_api_key_scope",
       "breakpoints": true
+    },
+    {
+      "idx": 121,
+      "version": "7",
+      "when": 1782765380001,
+      "tag": "0121_keep_911_daily_value_cap",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -9,7 +9,6 @@ import {
   inArray,
   isNotNull,
   lt,
-  ne,
   sql,
 } from "drizzle-orm";
 import { db } from "@/lib/db";
@@ -25,6 +24,7 @@ import {
   organizationSpendCaps,
 } from "@/lib/db/schema-extensions";
 import { ERROR_STATUSES } from "@/lib/errors/execution-status";
+import { sumOrgValueTodayWei } from "@/lib/execute/value-ledger";
 import { analyticsCacheKey, cachedAnalytics } from "./cache";
 import {
   getBucketInterval,
@@ -1293,35 +1293,23 @@ export async function getSpendCapData(organizationId: string): Promise<{
   dailyCapWei: string | null;
   dailyUsedWei: string;
 }> {
-  const todayStart = new Date();
-  todayStart.setUTCHours(0, 0, 0, 0);
-
   // Mirror spending-cap enforcement exactly: the notional VALUE moved per org
-  // per day (SUM value_wei over non-failed direct executions -- pending/running
-  // reservations included) against the org's daily value cap.
-  const [capResult, usageResult] = await Promise.all([
+  // per day, summed across BOTH stores (direct executions AND the workflow/
+  // protocol value ledger, with the same stale-window aging), against the org's
+  // daily value cap. Using the shared SUM keeps the gauge honest -- it shows the
+  // same number enforcement checks, so workflow spend counts too.
+  const [capResult, dailyUsedWei] = await Promise.all([
     db
       .select({ dailyValueCapWei: organizationSpendCaps.dailyValueCapWei })
       .from(organizationSpendCaps)
       .where(eq(organizationSpendCaps.organizationId, organizationId))
       .limit(1),
-    db
-      .select({
-        totalWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.valueWei} AS NUMERIC)), 0)::text`,
-      })
-      .from(directExecutions)
-      .where(
-        and(
-          eq(directExecutions.organizationId, organizationId),
-          ne(directExecutions.status, "failed"),
-          gte(directExecutions.createdAt, todayStart)
-        )
-      ),
+    sumOrgValueTodayWei(db, organizationId),
   ]);
 
   return {
     dailyCapWei: capResult[0]?.dailyValueCapWei ?? null,
-    dailyUsedWei: usageResult[0]?.totalWei ?? "0",
+    dailyUsedWei: dailyUsedWei.toString(),
   };
 }
 

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -9,6 +9,7 @@ import {
   inArray,
   isNotNull,
   lt,
+  ne,
   sql,
 } from "drizzle-orm";
 import { db } from "@/lib/db";
@@ -1295,51 +1296,32 @@ export async function getSpendCapData(organizationId: string): Promise<{
   const todayStart = new Date();
   todayStart.setUTCHours(0, 0, 0, 0);
 
-  const [capResult, directUsageResult, workflowUsageResult] = await Promise.all(
-    [
-      db
-        .select({ dailyCapWei: organizationSpendCaps.dailyCapWei })
-        .from(organizationSpendCaps)
-        .where(eq(organizationSpendCaps.organizationId, organizationId))
-        .limit(1),
-      db
-        .select({
-          totalWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.gasUsedWei} AS NUMERIC)), 0)::text`,
-        })
-        .from(directExecutions)
-        .where(
-          and(
-            eq(directExecutions.organizationId, organizationId),
-            eq(directExecutions.status, "completed"),
-            gte(directExecutions.createdAt, todayStart)
-          )
-        ),
-      db
-        // Same denormalised-column read as getWorkflowGasTotal: today's run
-        // gas straight off workflow_executions, no logs JSONB scan. gas_used_wei
-        // already reflects only gas-bearing (success) step output, so the
-        // previous log status='success' filter is subsumed. Windowed by run
-        // start rather than per-step time (see getWorkflowGasTotal).
-        .select({
-          totalWei: sql<string>`COALESCE(SUM(CAST(${workflowExecutions.gasUsedWei} AS NUMERIC)), 0)::text`,
-        })
-        .from(workflowExecutions)
-        .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
-        .where(
-          and(
-            eq(workflows.organizationId, organizationId),
-            gte(workflowExecutions.startedAt, todayStart)
-          )
-        ),
-    ]
-  );
+  // Mirror spending-cap enforcement exactly: the notional VALUE moved per org
+  // per day (SUM value_wei over non-failed direct executions -- pending/running
+  // reservations included) against the org's daily value cap.
+  const [capResult, usageResult] = await Promise.all([
+    db
+      .select({ dailyValueCapWei: organizationSpendCaps.dailyValueCapWei })
+      .from(organizationSpendCaps)
+      .where(eq(organizationSpendCaps.organizationId, organizationId))
+      .limit(1),
+    db
+      .select({
+        totalWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.valueWei} AS NUMERIC)), 0)::text`,
+      })
+      .from(directExecutions)
+      .where(
+        and(
+          eq(directExecutions.organizationId, organizationId),
+          ne(directExecutions.status, "failed"),
+          gte(directExecutions.createdAt, todayStart)
+        )
+      ),
+  ]);
 
   return {
-    dailyCapWei: capResult[0]?.dailyCapWei ?? null,
-    dailyUsedWei: addBigIntStrings(
-      directUsageResult[0]?.totalWei ?? "0",
-      workflowUsageResult[0]?.totalWei ?? "0"
-    ),
+    dailyCapWei: capResult[0]?.dailyValueCapWei ?? null,
+    dailyUsedWei: usageResult[0]?.totalWei ?? "0",
   };
 }
 

--- a/lib/db/schema-extensions.ts
+++ b/lib/db/schema-extensions.ts
@@ -628,6 +628,11 @@ export const directExecutions = pgTable(
     error: text("error"),
     gasUsedWei: text("gas_used_wei"),
     gasPriceWei: text("gas_price_wei"),
+    // Native notional value (wei) this execution moves, reserved at request time
+    // and summed per org per day by spending-cap enforcement. Null for executions
+    // that move no native value (treated as 0). ERC-20 token value is not yet
+    // priced into this figure.
+    valueWei: text("value_wei"),
     // Populated by a future price-oracle integration; null until then
     estimatedCostUsd: text("estimated_cost_usd"),
     retryCount: integer("retry_count").notNull().default(0),
@@ -697,9 +702,15 @@ export type NewIdempotencyRecord = typeof idempotencyRecords.$inferInsert;
  *
  * Per-organization daily spending limits for the direct execution API.
  * One row per organization (enforced by unique constraint on organizationId).
- * dailyCapWei is stored as text for BigInt compatibility.
+ * Wei amounts are stored as text for BigInt compatibility.
  *
- * When no row exists for an org, spending is unlimited (no cap enforced).
+ * `dailyValueCapWei` caps the native notional value moved per org per day and is
+ * the enforced limit, set by org admins/owners. `dailyCapWei` is a legacy
+ * gas-denominated figure, no longer enforced or displayed; nullable so a
+ * value-only cap row can be created without it.
+ *
+ * When no row exists for an org, or `dailyValueCapWei` is null, value spending
+ * is unlimited (no cap enforced).
  */
 export const organizationSpendCaps = pgTable("organization_spend_caps", {
   id: text("id")
@@ -709,7 +720,8 @@ export const organizationSpendCaps = pgTable("organization_spend_caps", {
     .notNull()
     .unique()
     .references(() => organization.id),
-  dailyCapWei: text("daily_cap_wei").notNull(),
+  dailyCapWei: text("daily_cap_wei"),
+  dailyValueCapWei: text("daily_value_cap_wei"),
   createdAt: timestamp("created_at").notNull().defaultNow(),
   updatedAt: timestamp("updated_at").notNull().defaultNow(),
 });

--- a/lib/db/schema-extensions.ts
+++ b/lib/db/schema-extensions.ts
@@ -731,6 +731,46 @@ export type OrganizationSpendCap = typeof organizationSpendCaps.$inferSelect;
 export type NewOrganizationSpendCap = typeof organizationSpendCaps.$inferInsert;
 
 /**
+ * Organization Value Reservations ledger
+ *
+ * Unified per-org record of native value moved by execution so the daily value
+ * cap covers every path -- direct API, workflow steps, and protocol writes --
+ * rather than only the direct-execution routes. Every value-moving core reserves
+ * a row before broadcast and settles or releases it afterward.
+ *
+ * status: `reserved` (in-flight) -> `settled` (broadcast succeeded) | `released`
+ * (denied or failed; excluded from the cap SUM). Wei stored as text for BigInt.
+ */
+export const orgValueReservations = pgTable(
+  "org_value_reservations",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => generateId()),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id),
+    valueWei: text("value_wei").notNull(),
+    status: text("status").notNull().default("reserved"), // reserved | settled | released
+    // Origin of the value-moving execution, for audit only.
+    source: text("source"), // direct | workflow | protocol
+    // Correlation id (executionId when available), for audit only.
+    ref: text("ref"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_org_value_reservations_org_created").on(
+      table.organizationId,
+      table.createdAt
+    ),
+  ]
+);
+
+export type OrgValueReservation = typeof orgValueReservations.$inferSelect;
+export type NewOrgValueReservation = typeof orgValueReservations.$inferInsert;
+
+/**
  * Overage Billing Records table
  *
  * Tracks overage charges applied at the end of each billing period.

--- a/lib/execute/native-value.ts
+++ b/lib/execute/native-value.ts
@@ -1,0 +1,47 @@
+import "server-only";
+
+import { ethers } from "ethers";
+
+export type ReservedValue =
+  | { ok: true; valueWei: string }
+  | { ok: false; error: string };
+
+/**
+ * Native notional value (in wei) an execution will move, used by the per-org
+ * daily spending cap. Parses a human-decimal ETH amount (e.g. "1.5") the same
+ * way the web3 cores do (`ethers.parseEther`).
+ *
+ * An absent/empty amount reserves "0". Only native value is counted today;
+ * ERC-20 token amounts are not yet priced into the cap, so token-only transfers
+ * pass "0" directly rather than calling this.
+ *
+ * Malformed amounts return `{ ok: false }` so the caller can decide (the direct
+ * routes reject with 400; the workflow wrapper reserves 0 and lets the core's
+ * own validation surface the canonical error). Negative amounts are rejected
+ * too: `ethers.parseEther("-5")` yields a negative BigInt (it does not throw),
+ * and a negative reservation would lower the day's SUM and bank credit against
+ * the cap.
+ */
+export function parseNativeValueWei(
+  rawAmount: string | undefined | null
+): ReservedValue {
+  if (rawAmount === undefined || rawAmount === null || rawAmount === "") {
+    return { ok: true, valueWei: "0" };
+  }
+
+  let parsed: bigint;
+  try {
+    parsed = ethers.parseEther(rawAmount);
+  } catch {
+    return { ok: false, error: `Invalid value amount: ${rawAmount}` };
+  }
+
+  if (parsed < BigInt(0)) {
+    return {
+      ok: false,
+      error: `Value amount must not be negative: ${rawAmount}`,
+    };
+  }
+
+  return { ok: true, valueWei: parsed.toString() };
+}

--- a/lib/execute/value-ledger.ts
+++ b/lib/execute/value-ledger.ts
@@ -212,6 +212,9 @@ type StepValueCapArgs = {
   // Correlation id for audit; the workflow execution id when available.
   executionId?: string;
   source?: string;
+  // True when a direct-execution route already reserved this execution's value
+  // (see StepContext.valueCapReserved); the step must not reserve again.
+  valueCapReserved?: boolean;
 };
 
 /**
@@ -230,7 +233,9 @@ export function withStepValueCap<T extends { success: boolean }>(
   const parsed = parseNativeValueWei(args.amountEth);
   const valueWei = parsed.ok ? parsed.valueWei : "0";
 
-  if (!args.organizationId || valueWei === "0") {
+  // Skip when the caller already reserved (direct-execution route), when there
+  // is no org to charge, or when no native value moves.
+  if (args.valueCapReserved || !args.organizationId || valueWei === "0") {
     return run();
   }
 

--- a/lib/execute/value-ledger.ts
+++ b/lib/execute/value-ledger.ts
@@ -1,0 +1,246 @@
+import "server-only";
+
+import { and, eq, gte, ne, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  directExecutions,
+  organizationSpendCaps,
+  orgValueReservations,
+} from "@/lib/db/schema-extensions";
+import { parseNativeValueWei } from "@/lib/execute/native-value";
+
+// In-flight rows older than this are treated as stale (crashed pod / lost
+// process) and drop out of the cap SUM, matching the direct-execution
+// concurrency limiter, so a stuck reservation cannot hold the cap all day.
+const STALE_INFLIGHT_MINUTES = 15;
+
+// biome-ignore lint/suspicious/noExplicitAny: accept either the app db or a tx
+type Executor = any;
+
+/**
+ * Total native value (wei) an org has moved / has in-flight today, summed across
+ * BOTH stores so every path counts against the same cap: direct-execution rows
+ * (`direct_executions.value_wei`, set by the direct API routes) and the value
+ * ledger (`org_value_reservations`, set by workflow + protocol executions).
+ *
+ * Settled/completed rows count for the whole UTC day; in-flight (pending/running
+ * or reserved) rows only within the stale window, so a stuck row ages out.
+ * Runs inside the caller's transaction so it is consistent with the FOR UPDATE.
+ */
+export async function sumOrgValueTodayWei(
+  executor: Executor,
+  organizationId: string
+): Promise<bigint> {
+  const todayStart = new Date();
+  todayStart.setUTCHours(0, 0, 0, 0);
+
+  const directRows = await executor
+    .select({
+      totalWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.valueWei} AS NUMERIC)), 0)::text`,
+    })
+    .from(directExecutions)
+    .where(
+      and(
+        eq(directExecutions.organizationId, organizationId),
+        ne(directExecutions.status, "failed"),
+        gte(directExecutions.createdAt, todayStart),
+        sql`(${directExecutions.status} = 'completed' OR ${directExecutions.createdAt} > now() - interval '${sql.raw(String(STALE_INFLIGHT_MINUTES))} minutes')`
+      )
+    );
+
+  const ledgerRows = await executor
+    .select({
+      totalWei: sql<string>`COALESCE(SUM(CAST(${orgValueReservations.valueWei} AS NUMERIC)), 0)::text`,
+    })
+    .from(orgValueReservations)
+    .where(
+      and(
+        eq(orgValueReservations.organizationId, organizationId),
+        ne(orgValueReservations.status, "released"),
+        gte(orgValueReservations.createdAt, todayStart),
+        sql`(${orgValueReservations.status} = 'settled' OR ${orgValueReservations.createdAt} > now() - interval '${sql.raw(String(STALE_INFLIGHT_MINUTES))} minutes')`
+      )
+    );
+
+  const direct = BigInt(directRows[0]?.totalWei ?? "0");
+  const ledger = BigInt(ledgerRows[0]?.totalWei ?? "0");
+  return direct + ledger;
+}
+
+/**
+ * The org's total value moved today (wei) across both stores, for read-only
+ * surfaces (the dashboard gauge). Uses the app db, not a transaction.
+ */
+export function getOrgValueUsedTodayWei(
+  organizationId: string
+): Promise<bigint> {
+  return sumOrgValueTodayWei(db, organizationId);
+}
+
+export type ReserveResult =
+  | { allowed: true; reservationId: string }
+  | { allowed: false; reason: string };
+
+type ReserveParams = {
+  organizationId: string;
+  // Native value being moved, in wei.
+  valueWei: string;
+  // Origin of the execution and a correlation id, for audit only.
+  source?: string;
+  ref?: string;
+};
+
+/**
+ * Atomically check the org's daily value cap and reserve `valueWei` against it,
+ * recording into the value ledger. Shared by the value-moving paths that are not
+ * the direct-execution API (workflow steps, protocol writes) so the cap cannot
+ * be bypassed by using a different entrance.
+ *
+ * A `SELECT ... FOR UPDATE` on the cap row serializes per org (the same row the
+ * direct routes lock, so direct + workflow reservations serialize together); the
+ * day's value across BOTH stores is summed; the request is denied if it would
+ * push the total over the cap; otherwise a `reserved` ledger row is inserted so
+ * concurrent callers see it (closing the TOCTOU). When the org has no cap,
+ * nothing is recorded (unlimited) and the empty reservationId makes settle/
+ * release a no-op.
+ */
+export async function reserveOrgValue(
+  params: ReserveParams
+): Promise<ReserveResult> {
+  return await db.transaction(async (tx) => {
+    const caps = await tx
+      .select({ dailyValueCapWei: organizationSpendCaps.dailyValueCapWei })
+      .from(organizationSpendCaps)
+      .where(eq(organizationSpendCaps.organizationId, params.organizationId))
+      .for("update")
+      .limit(1);
+
+    const cap = caps[0];
+
+    // No cap configured -> unlimited; record nothing.
+    if (!cap || cap.dailyValueCapWei === null) {
+      return { allowed: true, reservationId: "" } as const;
+    }
+
+    const totalWei = await sumOrgValueTodayWei(tx, params.organizationId);
+    const reservedWei = BigInt(params.valueWei);
+    const dailyCap = BigInt(cap.dailyValueCapWei);
+
+    if (totalWei + reservedWei > dailyCap) {
+      return { allowed: false, reason: "Daily spending cap exceeded" } as const;
+    }
+
+    const [row] = await tx
+      .insert(orgValueReservations)
+      .values({
+        organizationId: params.organizationId,
+        valueWei: params.valueWei,
+        status: "reserved",
+        source: params.source ?? null,
+        ref: params.ref ?? null,
+      })
+      .returning({ id: orgValueReservations.id });
+
+    return { allowed: true, reservationId: row.id } as const;
+  });
+}
+
+/** Mark a reservation as settled (broadcast succeeded); it counts all day. */
+export async function settleReservation(reservationId: string): Promise<void> {
+  if (!reservationId) {
+    return;
+  }
+  await db
+    .update(orgValueReservations)
+    .set({ status: "settled", updatedAt: new Date() })
+    .where(eq(orgValueReservations.id, reservationId));
+}
+
+/** Release a reservation (denied or failed); it drops out of the cap SUM. */
+export async function releaseReservation(reservationId: string): Promise<void> {
+  if (!reservationId) {
+    return;
+  }
+  await db
+    .update(orgValueReservations)
+    .set({ status: "released", updatedAt: new Date() })
+    .where(eq(orgValueReservations.id, reservationId));
+}
+
+/**
+ * Wrap a value-moving execution so it is charged against the org's daily cap.
+ * Reserves `valueWei` before running `run`, then settles on a successful result
+ * or releases on a failed result or a thrown error. A zero value skips the cap.
+ * Returns the run result, or a cap-exceeded failure without running.
+ */
+export async function withValueCap<T extends { success: boolean }>(
+  params: ReserveParams,
+  run: () => Promise<T>
+): Promise<T | { success: false; error: string }> {
+  if (params.valueWei === "0" || BigInt(params.valueWei) <= BigInt(0)) {
+    return await run();
+  }
+
+  const reservation = await reserveOrgValue(params);
+  if (!reservation.allowed) {
+    return { success: false, error: reservation.reason };
+  }
+
+  let result: T;
+  try {
+    result = await run();
+  } catch (error) {
+    await releaseReservation(reservation.reservationId);
+    throw error;
+  }
+
+  if (result.success) {
+    await settleReservation(reservation.reservationId);
+  } else {
+    await releaseReservation(reservation.reservationId);
+  }
+  return result;
+}
+
+type StepValueCapArgs = {
+  // The workflow's owning org (the credential authority). Absent for
+  // org-less workflows -> no org cap applies, so the run is not charged.
+  organizationId?: string;
+  // Human-decimal native amount the step moves (e.g. "1.5"); undefined/"0"
+  // for token-only or off-chain steps.
+  amountEth?: string | null;
+  // Correlation id for audit; the workflow execution id when available.
+  executionId?: string;
+  source?: string;
+};
+
+/**
+ * Charge a workflow/protocol step's native value against the org's daily cap.
+ * Thin front door over `withValueCap` for the step wrappers: parses the human
+ * ETH amount, skips the cap when there is no org or no native value, and treats
+ * an unparseable amount as 0 (the core's own validation surfaces the real
+ * error; a parse quirk here must never block a valid call or bank negative
+ * credit). Direct-execution API routes do NOT use this -- they reserve via
+ * `checkAndReserveExecution`, and the cap SUM unions both stores.
+ */
+export function withStepValueCap<T extends { success: boolean }>(
+  args: StepValueCapArgs,
+  run: () => Promise<T>
+): Promise<T | { success: false; error: string }> {
+  const parsed = parseNativeValueWei(args.amountEth);
+  const valueWei = parsed.ok ? parsed.valueWei : "0";
+
+  if (!args.organizationId || valueWei === "0") {
+    return run();
+  }
+
+  return withValueCap(
+    {
+      organizationId: args.organizationId,
+      valueWei,
+      source: args.source ?? "workflow",
+      ref: args.executionId,
+    },
+    run
+  );
+}

--- a/lib/workflow/concurrency.ts
+++ b/lib/workflow/concurrency.ts
@@ -1,6 +1,6 @@
-import { eq, sql } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
-import { workflowExecutions } from "@/lib/db/schema";
+import { directExecutions, workflowExecutions } from "@/lib/db/schema";
 
 /**
  * Shared concurrency back-pressure check. Server-only-free and db-agnostic so
@@ -9,6 +9,7 @@ import { workflowExecutions } from "@/lib/db/schema";
  */
 
 const DEFAULT_LIMIT = 500;
+const DEFAULT_DIRECT_LIMIT = 100;
 
 export function resolveMaxConcurrent(): number {
   const envValue = process.env.MAX_CONCURRENT_WORKFLOW_EXECUTIONS;
@@ -17,6 +18,15 @@ export function resolveMaxConcurrent(): number {
   }
   const parsed = Number.parseInt(envValue, 10);
   return Number.isNaN(parsed) ? DEFAULT_LIMIT : parsed;
+}
+
+export function resolveMaxConcurrentDirect(): number {
+  const envValue = process.env.MAX_CONCURRENT_DIRECT_EXECUTIONS;
+  if (!envValue) {
+    return DEFAULT_DIRECT_LIMIT;
+  }
+  const parsed = Number.parseInt(envValue, 10);
+  return Number.isNaN(parsed) ? DEFAULT_DIRECT_LIMIT : parsed;
 }
 
 export type ConcurrencyLimitResult =
@@ -28,7 +38,9 @@ export type ConcurrencyLimitResult =
  * concurrent callers may all pass before any new execution is inserted. The
  * goal is back-pressure, not a hard guarantee.
  */
-export async function checkConcurrencyLimit<TSchema extends Record<string, unknown>>(
+export async function checkConcurrencyLimit<
+  TSchema extends Record<string, unknown>,
+>(
   db: PostgresJsDatabase<TSchema>,
   limit: number = resolveMaxConcurrent()
 ): Promise<ConcurrencyLimitResult> {
@@ -36,6 +48,32 @@ export async function checkConcurrencyLimit<TSchema extends Record<string, unkno
     .select({ count: sql<number>`COUNT(*)::int` })
     .from(workflowExecutions)
     .where(eq(workflowExecutions.status, "running"));
+
+  const running = result?.count ?? 0;
+
+  if (running >= limit) {
+    return { allowed: false, running, limit };
+  }
+
+  return { allowed: true };
+}
+
+/**
+ * Back-pressure for the direct execution API. Counts in-flight direct
+ * executions (pending/running) rather than workflow executions, so the
+ * /api/execute/* write routes throttle on their own load. Same soft-cap
+ * caveat as checkConcurrencyLimit: count-then-admit is not atomic.
+ */
+export async function checkDirectExecutionConcurrency<
+  TSchema extends Record<string, unknown>,
+>(
+  db: PostgresJsDatabase<TSchema>,
+  limit: number = resolveMaxConcurrentDirect()
+): Promise<ConcurrencyLimitResult> {
+  const [result] = await db
+    .select({ count: sql<number>`COUNT(*)::int` })
+    .from(directExecutions)
+    .where(inArray(directExecutions.status, ["pending", "running"]));
 
   const running = result?.count ?? 0;
 

--- a/lib/workflow/concurrency.ts
+++ b/lib/workflow/concurrency.ts
@@ -1,4 +1,4 @@
-import { eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, sql } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { directExecutions, workflowExecutions } from "@/lib/db/schema";
 
@@ -10,6 +10,11 @@ import { directExecutions, workflowExecutions } from "@/lib/db/schema";
 
 const DEFAULT_LIMIT = 500;
 const DEFAULT_DIRECT_LIMIT = 100;
+// In-flight rows older than this are treated as stale (crashed pod / lost
+// process) and excluded from the count, so a stuck row cannot permanently
+// consume a slot. On-chain broadcast + confirmation is seconds to a couple of
+// minutes; 15m is a comfortable upper bound for a legitimate in-flight row.
+const DIRECT_STALE_MINUTES = 15;
 
 export function resolveMaxConcurrent(): number {
   const envValue = process.env.MAX_CONCURRENT_WORKFLOW_EXECUTIONS;
@@ -59,21 +64,33 @@ export async function checkConcurrencyLimit<
 }
 
 /**
- * Back-pressure for the direct execution API. Counts in-flight direct
- * executions (pending/running) rather than workflow executions, so the
- * /api/execute/* write routes throttle on their own load. Same soft-cap
- * caveat as checkConcurrencyLimit: count-then-admit is not atomic.
+ * Back-pressure for the direct execution API, scoped to one organization so a
+ * single org's burst cannot throttle other tenants. Counts that org's in-flight
+ * on-chain direct executions (pending/running with a network, created within the
+ * stale window). The network filter matches what the write routes gate (off-chain
+ * node executions are not gated, so they must not consume slots either), and the
+ * time window means a crashed/stuck row ages out instead of holding a slot
+ * forever. Same soft-cap caveat as checkConcurrencyLimit: count-then-admit is not
+ * atomic.
  */
 export async function checkDirectExecutionConcurrency<
   TSchema extends Record<string, unknown>,
 >(
   db: PostgresJsDatabase<TSchema>,
+  organizationId: string,
   limit: number = resolveMaxConcurrentDirect()
 ): Promise<ConcurrencyLimitResult> {
   const [result] = await db
     .select({ count: sql<number>`COUNT(*)::int` })
     .from(directExecutions)
-    .where(inArray(directExecutions.status, ["pending", "running"]));
+    .where(
+      and(
+        eq(directExecutions.organizationId, organizationId),
+        isNotNull(directExecutions.network),
+        inArray(directExecutions.status, ["pending", "running"]),
+        sql`${directExecutions.createdAt} > now() - interval '${sql.raw(String(DIRECT_STALE_MINUTES))} minutes'`
+      )
+    );
 
   const running = result?.count ?? 0;
 

--- a/lib/workflow/executor/step-handler.ts
+++ b/lib/workflow/executor/step-handler.ts
@@ -33,6 +33,13 @@ export type StepContext = {
   iterationIndex?: number;
   forEachNodeId?: string;
   organizationId?: string;
+  // Set by direct-execution routes that already reserved this execution's
+  // native value against the daily cap (checkAndReserveExecution). Tells a
+  // value-moving step wrapper not to reserve again, so /api/execute/node -
+  // which dispatches the step wrappers, unlike the sibling routes that call the
+  // cores directly - is charged once, not twice. The workflow executor never
+  // sets it, so workflow-triggered steps still reserve via withStepValueCap.
+  valueCapReserved?: boolean;
   // Identifiers attached to every workflow error log line
   orgSlug?: string;
   createdBy?: string;

--- a/plugins/protocol/steps/protocol-write.ts
+++ b/plugins/protocol/steps/protocol-write.ts
@@ -305,6 +305,7 @@ export async function protocolWriteStep(
         amountEth: ethValue,
         executionId: input._context?.executionId,
         source: "protocol",
+        valueCapReserved: input._context?.valueCapReserved,
       },
       () => writeContractCore(coreInput)
     );

--- a/plugins/protocol/steps/protocol-write.ts
+++ b/plugins/protocol/steps/protocol-write.ts
@@ -9,6 +9,7 @@ import {
 } from "@/plugins/web3/steps/write-contract-core";
 import { resolveAbi } from "@/lib/abi/cache";
 import { type AbiItem, findAbiFunction } from "@/lib/abi/utils";
+import { withStepValueCap } from "@/lib/execute/value-ledger";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getProtocol, resolveContractAddress } from "@/lib/protocol-registry";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
@@ -295,7 +296,18 @@ export async function protocolWriteStep(
         : undefined,
     };
 
-    return await writeContractCore(coreInput);
+    // Charge the payable value against the org's daily cap. `ethValue` is the
+    // resolved native value forwarded to writeContractCore; a non-payable /
+    // absent value reserves nothing.
+    return await withStepValueCap(
+      {
+        organizationId: input._context?.organizationId,
+        amountEth: ethValue,
+        executionId: input._context?.executionId,
+        source: "protocol",
+      },
+      () => writeContractCore(coreInput)
+    );
   });
 }
 

--- a/plugins/web3/steps/transfer-funds.ts
+++ b/plugins/web3/steps/transfer-funds.ts
@@ -64,6 +64,7 @@ export async function transferFundsStep(
             organizationId: input._context?.organizationId,
             amountEth: input.amount,
             executionId: input._context?.executionId,
+            valueCapReserved: input._context?.valueCapReserved,
           },
           () => transferFundsCore(input)
         )

--- a/plugins/web3/steps/transfer-funds.ts
+++ b/plugins/web3/steps/transfer-funds.ts
@@ -5,6 +5,7 @@ import { db } from "@/lib/db";
 import { explorerConfigs } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import { withStepValueCap } from "@/lib/execute/value-ledger";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import type {
@@ -56,7 +57,17 @@ export async function transferFundsStep(
       actionName: "transfer-funds",
       executionId: input._context?.executionId,
     },
-    () => withStepLogging(enrichedInput, () => transferFundsCore(input))
+    () =>
+      withStepLogging(enrichedInput, () =>
+        withStepValueCap(
+          {
+            organizationId: input._context?.organizationId,
+            amountEth: input.amount,
+            executionId: input._context?.executionId,
+          },
+          () => transferFundsCore(input)
+        )
+      )
   );
 }
 

--- a/plugins/web3/steps/write-contract.ts
+++ b/plugins/web3/steps/write-contract.ts
@@ -5,6 +5,7 @@ import { db } from "@/lib/db";
 import { explorerConfigs } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import { withStepValueCap } from "@/lib/execute/value-ledger";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import {
@@ -51,7 +52,17 @@ export async function writeContractStep(
       actionName: "write-contract",
       executionId: input._context?.executionId,
     },
-    () => withStepLogging(enrichedInput, () => writeContractCore(input))
+    () =>
+      withStepLogging(enrichedInput, () =>
+        withStepValueCap(
+          {
+            organizationId: input._context?.organizationId,
+            amountEth: input.ethValue,
+            executionId: input._context?.executionId,
+          },
+          () => writeContractCore(input)
+        )
+      )
   );
 }
 

--- a/plugins/web3/steps/write-contract.ts
+++ b/plugins/web3/steps/write-contract.ts
@@ -59,6 +59,7 @@ export async function writeContractStep(
             organizationId: input._context?.organizationId,
             amountEth: input.ethValue,
             executionId: input._context?.executionId,
+            valueCapReserved: input._context?.valueCapReserved,
           },
           () => writeContractCore(input)
         )

--- a/tests/integration/direct-execution-api.test.ts
+++ b/tests/integration/direct-execution-api.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   validateApiKey: vi.fn(),
   checkRateLimit: vi.fn(),
   checkAndReserveExecution: vi.fn(),
+  enforceDirectExecutionConcurrency: vi.fn(),
   markRunning: vi.fn(),
   completeExecution: vi.fn(),
   failExecution: vi.fn(),
@@ -32,6 +33,10 @@ vi.mock("@/app/api/execute/_lib/rate-limit", () => ({
 
 vi.mock("@/app/api/execute/_lib/spending-cap", () => ({
   checkAndReserveExecution: mocks.checkAndReserveExecution,
+}));
+
+vi.mock("@/app/api/execute/_lib/concurrency-limit", () => ({
+  enforceDirectExecutionConcurrency: mocks.enforceDirectExecutionConcurrency,
 }));
 
 vi.mock("@/app/api/execute/_lib/execution-service", async (importActual) => {
@@ -179,6 +184,7 @@ function setupPassingGuards(): void {
     allowed: true,
     executionId: "exec_1",
   });
+  mocks.enforceDirectExecutionConcurrency.mockResolvedValue(null);
   mocks.redactInput.mockImplementation(
     (input: Record<string, unknown>) => input
   );
@@ -208,7 +214,10 @@ describe("Direct Execution API", () => {
     };
 
     it("returns 401 when auth fails", async () => {
-      mocks.validateApiKey.mockResolvedValue({ error: "Unauthorized", status: 401 });
+      mocks.validateApiKey.mockResolvedValue({
+        error: "Unauthorized",
+        status: 401,
+      });
 
       const response = await transferPOST(postRequest("/transfer", validBody));
 
@@ -325,6 +334,71 @@ describe("Direct Execution API", () => {
       expect(mocks.transferFundsCore).not.toHaveBeenCalled();
     });
 
+    it("charges the native amount (wei) against the value cap", async () => {
+      setupPassingGuards();
+      mocks.transferFundsCore.mockResolvedValue({
+        success: true,
+        transactionHash: "0xabc",
+      });
+
+      await transferPOST(postRequest("/transfer", validBody));
+
+      expect(mocks.checkAndReserveExecution).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "transfer",
+          reservedValueWei: "1000000000000000000",
+        })
+      );
+    });
+
+    it("reserves 0 native value for an ERC-20 transfer", async () => {
+      setupPassingGuards();
+      mocks.transferTokenCore.mockResolvedValue({
+        success: true,
+        transactionHash: "0xdef",
+      });
+
+      await transferPOST(
+        postRequest("/transfer", {
+          ...validBody,
+          tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        })
+      );
+
+      expect(mocks.checkAndReserveExecution).toHaveBeenCalledWith(
+        expect.objectContaining({ reservedValueWei: "0" })
+      );
+    });
+
+    it("returns 400 for an unparseable native amount before reserving", async () => {
+      setupPassingGuards();
+
+      const response = await transferPOST(
+        postRequest("/transfer", { ...validBody, amount: "not-a-number" })
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.field).toBe("amount");
+      expect(mocks.checkAndReserveExecution).not.toHaveBeenCalled();
+    });
+
+    it("returns 429 when direct-execution concurrency is exceeded", async () => {
+      setupPassingGuards();
+      const { NextResponse } = await import("next/server");
+      mocks.enforceDirectExecutionConcurrency.mockResolvedValue(
+        NextResponse.json(
+          { error: "Too many concurrent executions", running: 100, limit: 100 },
+          { status: 429 }
+        )
+      );
+
+      const response = await transferPOST(postRequest("/transfer", validBody));
+
+      expect(response.status).toBe(429);
+      expect(mocks.checkAndReserveExecution).not.toHaveBeenCalled();
+    });
+
     it("returns 202 with failed status when transfer fails", async () => {
       setupPassingGuards();
       mocks.transferFundsCore.mockResolvedValue({
@@ -393,7 +467,10 @@ describe("Direct Execution API", () => {
     };
 
     it("returns 401 when auth fails", async () => {
-      mocks.validateApiKey.mockResolvedValue({ error: "Unauthorized", status: 401 });
+      mocks.validateApiKey.mockResolvedValue({
+        error: "Unauthorized",
+        status: 401,
+      });
 
       const response = await contractCallPOST(
         postRequest("/contract-call", validReadBody)
@@ -611,7 +688,10 @@ describe("Direct Execution API", () => {
     };
 
     it("returns 401 when auth fails", async () => {
-      mocks.validateApiKey.mockResolvedValue({ error: "Unauthorized", status: 401 });
+      mocks.validateApiKey.mockResolvedValue({
+        error: "Unauthorized",
+        status: 401,
+      });
 
       const response = await checkAndExecutePOST(
         postRequest("/check-and-execute", validBody)
@@ -733,7 +813,10 @@ describe("Direct Execution API", () => {
   // ==========================================================================
   describe("GET /api/execute/{id}/status", () => {
     it("returns 401 when auth fails", async () => {
-      mocks.validateApiKey.mockResolvedValue({ error: "Unauthorized", status: 401 });
+      mocks.validateApiKey.mockResolvedValue({
+        error: "Unauthorized",
+        status: 401,
+      });
 
       const response = await statusGET(getRequest("/exec_1/status"), {
         params: Promise.resolve({ executionId: "exec_1" }),
@@ -830,7 +913,10 @@ describe("Direct Execution API", () => {
     });
 
     it("returns 401 when auth fails", async () => {
-      mocks.validateApiKey.mockResolvedValue({ error: "Unauthorized", status: 401 });
+      mocks.validateApiKey.mockResolvedValue({
+        error: "Unauthorized",
+        status: 401,
+      });
 
       const response = await swapPOST(
         postRequest("/swap", { fromToken: "ETH" })

--- a/tests/integration/execute-node-reserved-fields.test.ts
+++ b/tests/integration/execute-node-reserved-fields.test.ts
@@ -45,6 +45,10 @@ vi.mock("@/app/api/execute/_lib/spending-cap", () => ({
   checkAndReserveExecution: mocks.checkAndReserveExecution,
 }));
 
+vi.mock("@/app/api/execute/_lib/concurrency-limit", () => ({
+  enforceDirectExecutionConcurrency: vi.fn().mockResolvedValue(null),
+}));
+
 vi.mock("@/app/api/execute/_lib/wallet-check", () => ({
   requireWallet: mocks.requireWallet,
 }));

--- a/tests/integration/execute-node-reserved-fields.test.ts
+++ b/tests/integration/execute-node-reserved-fields.test.ts
@@ -195,6 +195,12 @@ describe("POST /api/execute/node reserved-field gating", () => {
       (mocks.capturedInput?._context as { organizationId: string })
         .organizationId
     ).toBe("org_a");
+    // The route reserved the value itself, so the step wrapper is told not to
+    // reserve again (prevents the node route double-charging the cap).
+    expect(
+      (mocks.capturedInput?._context as { valueCapReserved: boolean })
+        .valueCapReserved
+    ).toBe(true);
   });
 
   it("ignores a caller-supplied _context and always sets the trusted org", async () => {

--- a/tests/integration/execute-scope-enforcement.test.ts
+++ b/tests/integration/execute-scope-enforcement.test.ts
@@ -36,6 +36,10 @@ vi.mock("@/app/api/execute/_lib/spending-cap", () => ({
   checkAndReserveExecution: mocks.checkAndReserveExecution,
 }));
 
+vi.mock("@/app/api/execute/_lib/concurrency-limit", () => ({
+  enforceDirectExecutionConcurrency: vi.fn().mockResolvedValue(null),
+}));
+
 vi.mock("@/app/api/execute/_lib/execution-service", async (importActual) => {
   const actual =
     await importActual<

--- a/tests/integration/execute-simulate-route.test.ts
+++ b/tests/integration/execute-simulate-route.test.ts
@@ -67,6 +67,10 @@ vi.mock("../../app/api/execute/_lib/spending-cap", () => ({
   checkAndReserveExecution: spies.checkAndReserveExecution,
 }));
 
+vi.mock("../../app/api/execute/_lib/concurrency-limit", () => ({
+  enforceDirectExecutionConcurrency: vi.fn().mockResolvedValue(null),
+}));
+
 vi.mock("../../app/api/execute/_lib/execution-service", async (importActual) => {
   const actual =
     await importActual<

--- a/tests/integration/spend-cap-setter-route.test.ts
+++ b/tests/integration/spend-cap-setter-route.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  getOrgContext: vi.fn(),
+  hasPermission: vi.fn(),
+  upsertValues: vi.fn(),
+  upsertConflict: vi.fn(),
+}));
+
+vi.mock("@/lib/middleware/org-context", () => ({
+  getOrgContext: (...args: unknown[]) => mocks.getOrgContext(...args),
+  getActiveOrgId: vi.fn(),
+  hasPermission: (...args: unknown[]) => mocks.hasPermission(...args),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    insert: () => ({
+      values: (v: unknown) => {
+        mocks.upsertValues(v);
+        return {
+          onConflictDoUpdate: (c: unknown) => {
+            mocks.upsertConflict(c);
+            return Promise.resolve(undefined);
+          },
+        };
+      },
+    }),
+  },
+}));
+
+import { PUT } from "@/app/api/analytics/spend-cap/route";
+
+const ORG_ID = "org-1";
+
+function putRequest(body: unknown): Parameters<typeof PUT>[0] {
+  return new Request("http://localhost/api/analytics/spend-cap", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  }) as Parameters<typeof PUT>[0];
+}
+
+function authedContext(role = "admin"): Record<string, unknown> {
+  return {
+    user: { id: "user-1", email: "a@example.com", name: "A", image: null },
+    organization: { id: ORG_ID, name: "Org", createdAt: new Date() },
+    member: {
+      id: "m-1",
+      organizationId: ORG_ID,
+      userId: "user-1",
+      role,
+      createdAt: new Date(),
+    },
+    isAnonymous: false,
+    needsOrganization: false,
+  };
+}
+
+describe("PUT /api/analytics/spend-cap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getOrgContext.mockResolvedValue(authedContext());
+    mocks.hasPermission.mockResolvedValue(true);
+  });
+
+  it("returns 401 for an anonymous session", async () => {
+    mocks.getOrgContext.mockResolvedValue({
+      user: null,
+      organization: null,
+      member: null,
+      isAnonymous: true,
+      needsOrganization: false,
+    });
+
+    const res = await PUT(putRequest({ dailyValueCapWei: "1000" }));
+
+    expect(res.status).toBe(401);
+    expect(mocks.upsertValues).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the caller lacks organization:update (e.g. a member)", async () => {
+    mocks.getOrgContext.mockResolvedValue(authedContext("member"));
+    mocks.hasPermission.mockResolvedValue(false);
+
+    const res = await PUT(putRequest({ dailyValueCapWei: "1000" }));
+
+    expect(res.status).toBe(403);
+    expect(mocks.hasPermission).toHaveBeenCalledWith("organization", [
+      "update",
+    ]);
+    expect(mocks.upsertValues).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-integer / negative cap with 400", async () => {
+    for (const bad of ["-5", "1.5", "abc", 1000]) {
+      const res = await PUT(putRequest({ dailyValueCapWei: bad }));
+      expect(res.status).toBe(400);
+    }
+    expect(mocks.upsertValues).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an invalid JSON body", async () => {
+    const res = await PUT(putRequest("{not json"));
+    expect(res.status).toBe(400);
+    expect(mocks.upsertValues).not.toHaveBeenCalled();
+  });
+
+  it("upserts the org's value cap and returns 200", async () => {
+    const res = await PUT(
+      putRequest({ dailyValueCapWei: "1000000000000000000" })
+    );
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({ dailyValueCapWei: "1000000000000000000" });
+    expect(mocks.upsertValues).toHaveBeenCalledWith({
+      organizationId: ORG_ID,
+      dailyValueCapWei: "1000000000000000000",
+    });
+    expect(mocks.upsertConflict).toHaveBeenCalledWith(
+      expect.objectContaining({
+        set: expect.objectContaining({
+          dailyValueCapWei: "1000000000000000000",
+        }),
+      })
+    );
+  });
+
+  it("clears the cap when dailyValueCapWei is null", async () => {
+    const res = await PUT(putRequest({ dailyValueCapWei: null }));
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({ dailyValueCapWei: null });
+    expect(mocks.upsertValues).toHaveBeenCalledWith({
+      organizationId: ORG_ID,
+      dailyValueCapWei: null,
+    });
+  });
+});

--- a/tests/unit/check-and-execute-routing.test.ts
+++ b/tests/unit/check-and-execute-routing.test.ts
@@ -62,6 +62,10 @@ vi.mock("@/app/api/execute/_lib/spending-cap", () => ({
     mockCheckAndReserveExecution(...args),
 }));
 
+vi.mock("@/app/api/execute/_lib/concurrency-limit", () => ({
+  enforceDirectExecutionConcurrency: vi.fn().mockResolvedValue(null),
+}));
+
 const mockValidateCheckAndExecuteInput = vi.fn();
 vi.mock("@/app/api/execute/_lib/validate", () => ({
   validateCheckAndExecuteInput: (...args: unknown[]) =>

--- a/tests/unit/concurrency-limit.test.ts
+++ b/tests/unit/concurrency-limit.test.ts
@@ -20,6 +20,9 @@ vi.mock("@/lib/db/schema", () => ({
   },
   directExecutions: {
     status: "status",
+    organizationId: "organization_id",
+    network: "network",
+    createdAt: "created_at",
   },
 }));
 
@@ -122,18 +125,18 @@ describe("checkDirectExecutionConcurrency", () => {
     Reflect.deleteProperty(process.env, "MAX_CONCURRENT_DIRECT_EXECUTIONS");
   });
 
-  it("allows when in-flight count is below the default limit", async () => {
+  it("allows when the org's in-flight count is below the default limit", async () => {
     mockRunningCount = 99;
 
-    const result = await checkDirectExecutionConcurrency();
+    const result = await checkDirectExecutionConcurrency("org_1");
 
     expect(result).toEqual({ allowed: true });
   });
 
-  it("rejects when in-flight count meets the default limit", async () => {
+  it("rejects when the org's in-flight count meets the default limit", async () => {
     mockRunningCount = 100;
 
-    const result = await checkDirectExecutionConcurrency();
+    const result = await checkDirectExecutionConcurrency("org_1");
 
     expect(result).toEqual({ allowed: false, running: 100, limit: 100 });
   });
@@ -146,7 +149,7 @@ describe("checkDirectExecutionConcurrency", () => {
     );
     mockRunningCount = 5;
 
-    const result = await freshCheck();
+    const result = await freshCheck("org_1");
 
     expect(result).toEqual({ allowed: false, running: 5, limit: 5 });
   });

--- a/tests/unit/concurrency-limit.test.ts
+++ b/tests/unit/concurrency-limit.test.ts
@@ -18,9 +18,15 @@ vi.mock("@/lib/db/schema", () => ({
   workflowExecutions: {
     status: "status",
   },
+  directExecutions: {
+    status: "status",
+  },
 }));
 
-import { checkConcurrencyLimit } from "@/app/api/execute/_lib/concurrency-limit";
+import {
+  checkConcurrencyLimit,
+  checkDirectExecutionConcurrency,
+} from "@/app/api/execute/_lib/concurrency-limit";
 
 describe("checkConcurrencyLimit", () => {
   beforeEach(() => {
@@ -102,5 +108,46 @@ describe("checkConcurrencyLimit", () => {
     const result = await freshCheck();
 
     expect(result).toEqual({ allowed: true });
+  });
+});
+
+describe("checkDirectExecutionConcurrency", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRunningCount = 0;
+    Reflect.deleteProperty(process.env, "MAX_CONCURRENT_DIRECT_EXECUTIONS");
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(process.env, "MAX_CONCURRENT_DIRECT_EXECUTIONS");
+  });
+
+  it("allows when in-flight count is below the default limit", async () => {
+    mockRunningCount = 99;
+
+    const result = await checkDirectExecutionConcurrency();
+
+    expect(result).toEqual({ allowed: true });
+  });
+
+  it("rejects when in-flight count meets the default limit", async () => {
+    mockRunningCount = 100;
+
+    const result = await checkDirectExecutionConcurrency();
+
+    expect(result).toEqual({ allowed: false, running: 100, limit: 100 });
+  });
+
+  it("uses a custom limit from MAX_CONCURRENT_DIRECT_EXECUTIONS", async () => {
+    process.env.MAX_CONCURRENT_DIRECT_EXECUTIONS = "5";
+    vi.resetModules();
+    const { checkDirectExecutionConcurrency: freshCheck } = await import(
+      "@/app/api/execute/_lib/concurrency-limit"
+    );
+    mockRunningCount = 5;
+
+    const result = await freshCheck();
+
+    expect(result).toEqual({ allowed: false, running: 5, limit: 5 });
   });
 });

--- a/tests/unit/execute-protocol-execution-guards.test.ts
+++ b/tests/unit/execute-protocol-execution-guards.test.ts
@@ -79,6 +79,10 @@ vi.mock("../../app/api/execute/_lib/spending-cap", () => ({
     checkAndReserveExecutionMock(params),
 }));
 
+vi.mock("../../app/api/execute/_lib/concurrency-limit", () => ({
+  enforceDirectExecutionConcurrency: vi.fn().mockResolvedValue(null),
+}));
+
 const markRunningMock = vi.fn();
 const completeExecutionMock = vi.fn();
 const failExecutionMock = vi.fn();

--- a/tests/unit/execute-protocol-idempotency-disposition.test.ts
+++ b/tests/unit/execute-protocol-idempotency-disposition.test.ts
@@ -78,6 +78,10 @@ vi.mock("../../app/api/execute/_lib/spending-cap", () => ({
     checkAndReserveExecutionMock(params),
 }));
 
+vi.mock("../../app/api/execute/_lib/concurrency-limit", () => ({
+  enforceDirectExecutionConcurrency: vi.fn().mockResolvedValue(null),
+}));
+
 vi.mock("../../app/api/execute/_lib/execution-service", () => ({
   markRunning: vi.fn(),
   completeExecution: vi.fn(),

--- a/tests/unit/execute-protocol-route-chain-resolution.test.ts
+++ b/tests/unit/execute-protocol-route-chain-resolution.test.ts
@@ -87,6 +87,10 @@ vi.mock("../../app/api/execute/_lib/spending-cap", () => ({
     .fn()
     .mockResolvedValue({ allowed: true, executionId: "exec_1" }),
 }));
+
+vi.mock("../../app/api/execute/_lib/concurrency-limit", () => ({
+  enforceDirectExecutionConcurrency: vi.fn().mockResolvedValue(null),
+}));
 vi.mock("../../app/api/execute/_lib/execution-service", () => ({
   markRunning: vi.fn().mockResolvedValue(undefined),
   completeExecution: vi.fn().mockResolvedValue(undefined),

--- a/tests/unit/reserved-value.test.ts
+++ b/tests/unit/reserved-value.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  parseNativeValueWei,
+  parseNodeNativeValueWei,
+} from "@/app/api/execute/_lib/reserved-value";
+
+describe("parseNativeValueWei", () => {
+  it("parses a decimal ETH amount to wei", () => {
+    expect(parseNativeValueWei("1.5")).toEqual({
+      ok: true,
+      valueWei: "1500000000000000000",
+    });
+  });
+
+  it("treats undefined/null/empty as 0", () => {
+    expect(parseNativeValueWei(undefined)).toEqual({ ok: true, valueWei: "0" });
+    expect(parseNativeValueWei(null)).toEqual({ ok: true, valueWei: "0" });
+    expect(parseNativeValueWei("")).toEqual({ ok: true, valueWei: "0" });
+  });
+
+  it("rejects a non-numeric amount", () => {
+    expect(parseNativeValueWei("abc").ok).toBe(false);
+  });
+
+  it("rejects a negative amount (would bank credit against the cap)", () => {
+    // ethers.parseEther("-5") returns a negative BigInt without throwing.
+    expect(parseNativeValueWei("-5").ok).toBe(false);
+  });
+
+  it("rejects more than 18 decimals", () => {
+    expect(parseNativeValueWei("1.0000000000000000001").ok).toBe(false);
+  });
+});
+
+describe("parseNodeNativeValueWei", () => {
+  it("charges a native transfer's amount", () => {
+    expect(
+      parseNodeNativeValueWei("transferFundsStep", { amount: "2" })
+    ).toEqual({ ok: true, valueWei: "2000000000000000000" });
+  });
+
+  it("charges a contract write's ethValue", () => {
+    expect(
+      parseNodeNativeValueWei("writeContractStep", { ethValue: "0.1" })
+    ).toEqual({ ok: true, valueWei: "100000000000000000" });
+  });
+
+  it("ignores a token transfer's amount (no native value moved)", () => {
+    expect(
+      parseNodeNativeValueWei("transferTokenStep", { amount: "1000000" })
+    ).toEqual({ ok: true, valueWei: "0" });
+  });
+
+  it("reserves 0 for off-chain / unrecognized steps", () => {
+    expect(parseNodeNativeValueWei("httpRequestStep", { amount: "5" })).toEqual(
+      { ok: true, valueWei: "0" }
+    );
+  });
+
+  it("propagates a parse failure for a value-bearing step", () => {
+    expect(
+      parseNodeNativeValueWei("transferFundsStep", { amount: "-5" }).ok
+    ).toBe(false);
+  });
+});

--- a/tests/unit/reserved-value.test.ts
+++ b/tests/unit/reserved-value.test.ts
@@ -54,10 +54,18 @@ describe("parseNodeNativeValueWei", () => {
     ).toEqual({ ok: true, valueWei: "0" });
   });
 
-  it("reserves 0 for off-chain / unrecognized steps", () => {
+  it("reserves 0 for off-chain / unrecognized steps with no ethValue", () => {
     expect(parseNodeNativeValueWei("httpRequestStep", { amount: "5" })).toEqual(
       { ok: true, valueWei: "0" }
     );
+  });
+
+  it("charges any step that forwards ethValue, not just writeContractStep", () => {
+    // A future value-forwarding action reserves its ethValue instead of
+    // silently bypassing the cap with "0".
+    expect(
+      parseNodeNativeValueWei("someFutureWriteStep", { ethValue: "0.25" })
+    ).toEqual({ ok: true, valueWei: "250000000000000000" });
   });
 
   it("propagates a parse failure for a value-bearing step", () => {

--- a/tests/unit/spending-cap.test.ts
+++ b/tests/unit/spending-cap.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/utils/id", () => ({ generateId: () => "exec_test" }));
+
+// Hoisted state the fake tx reads from / writes to, set per test.
+const state = vi.hoisted(() => ({
+  caps: [] as Array<{ dailyValueCapWei: string | null }>,
+  sumRows: [] as Array<{ totalWei: string }>,
+  inserted: [] as Record<string, unknown>[],
+}));
+
+// Fake db.transaction whose tx supports what the reservation uses: the cap
+// FOR UPDATE lookup (.for().limit()), the value SUM (a thenable .where()), and
+// the reservation insert.
+vi.mock("@/lib/db", () => ({
+  db: {
+    transaction: (cb: (tx: unknown) => unknown) => {
+      let selectCall = 0;
+      const tx = {
+        select: () => {
+          selectCall += 1;
+          if (selectCall === 1) {
+            return {
+              from: () => ({
+                where: () => ({
+                  for: () => ({
+                    limit: () => Promise.resolve(state.caps),
+                  }),
+                }),
+              }),
+            };
+          }
+          return {
+            from: () => ({
+              where: () => Promise.resolve(state.sumRows),
+            }),
+          };
+        },
+        insert: () => ({
+          values: (v: Record<string, unknown>) => {
+            state.inserted.push(v);
+            return Promise.resolve(undefined);
+          },
+        }),
+      };
+      return cb(tx);
+    },
+  },
+}));
+
+import { checkAndReserveExecution } from "@/app/api/execute/_lib/spending-cap";
+
+const baseParams = {
+  organizationId: "org_1",
+  apiKeyId: "key_1",
+  type: "transfer",
+  network: "1",
+  input: { foo: "bar" },
+};
+
+beforeEach(() => {
+  state.caps = [];
+  state.sumRows = [{ totalWei: "0" }];
+  state.inserted = [];
+});
+
+describe("checkAndReserveExecution value cap", () => {
+  it("allows and records the reserved value when no cap row exists (unlimited)", async () => {
+    state.caps = [];
+
+    const result = await checkAndReserveExecution({
+      ...baseParams,
+      reservedValueWei: "5",
+    });
+
+    expect(result).toEqual({ allowed: true, executionId: "exec_test" });
+    expect(state.inserted).toHaveLength(1);
+    expect(state.inserted[0]).toMatchObject({
+      valueWei: "5",
+      status: "pending",
+    });
+  });
+
+  it("treats a null dailyValueCapWei as unlimited", async () => {
+    state.caps = [{ dailyValueCapWei: null }];
+
+    const result = await checkAndReserveExecution({
+      ...baseParams,
+      reservedValueWei: "999",
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(state.inserted).toHaveLength(1);
+  });
+
+  it("allows when the day's total plus this reservation stays within the cap", async () => {
+    state.caps = [{ dailyValueCapWei: "1000" }];
+    state.sumRows = [{ totalWei: "600" }];
+
+    const result = await checkAndReserveExecution({
+      ...baseParams,
+      reservedValueWei: "400",
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(state.inserted[0]).toMatchObject({ valueWei: "400" });
+  });
+
+  it("denies when the reservation would push the day's total over the cap", async () => {
+    state.caps = [{ dailyValueCapWei: "1000" }];
+    state.sumRows = [{ totalWei: "600" }];
+
+    const result = await checkAndReserveExecution({
+      ...baseParams,
+      reservedValueWei: "500",
+    });
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: "Daily spending cap exceeded",
+    });
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("blocks a single wallet-draining reservation even with a zero recorded total (TOCTOU closed)", async () => {
+    // The reservation alone (5 ETH) exceeds a 1 ETH cap although the recorded
+    // day total is still 0 -- value is known up front, unlike gas.
+    state.caps = [{ dailyValueCapWei: "1000000000000000000" }];
+    state.sumRows = [{ totalWei: "0" }];
+
+    const result = await checkAndReserveExecution({
+      ...baseParams,
+      reservedValueWei: "5000000000000000000",
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(state.inserted).toHaveLength(0);
+  });
+});

--- a/tests/unit/spending-cap.test.ts
+++ b/tests/unit/spending-cap.test.ts
@@ -7,12 +7,14 @@ vi.mock("@/lib/utils/id", () => ({ generateId: () => "exec_test" }));
 const state = vi.hoisted(() => ({
   caps: [] as Array<{ dailyValueCapWei: string | null }>,
   sumRows: [] as Array<{ totalWei: string }>,
+  ledgerRows: [] as Array<{ totalWei: string }>,
   inserted: [] as Record<string, unknown>[],
 }));
 
 // Fake db.transaction whose tx supports what the reservation uses: the cap
-// FOR UPDATE lookup (.for().limit()), the value SUM (a thenable .where()), and
-// the reservation insert.
+// FOR UPDATE lookup (.for().limit()), the value SUM -- now two thenable
+// .where() selects (direct executions, then the value ledger) via
+// sumOrgValueTodayWei -- and the reservation insert.
 vi.mock("@/lib/db", () => ({
   db: {
     transaction: (cb: (tx: unknown) => unknown) => {
@@ -31,9 +33,11 @@ vi.mock("@/lib/db", () => ({
               }),
             };
           }
+          // select #2 = direct-executions SUM, select #3 = ledger SUM.
+          const rows = selectCall === 2 ? state.sumRows : state.ledgerRows;
           return {
             from: () => ({
-              where: () => Promise.resolve(state.sumRows),
+              where: () => Promise.resolve(rows),
             }),
           };
         },
@@ -62,6 +66,7 @@ const baseParams = {
 beforeEach(() => {
   state.caps = [];
   state.sumRows = [{ totalWei: "0" }];
+  state.ledgerRows = [{ totalWei: "0" }];
   state.inserted = [];
 });
 
@@ -120,6 +125,23 @@ describe("checkAndReserveExecution value cap", () => {
       allowed: false,
       reason: "Daily spending cap exceeded",
     });
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("counts workflow/protocol value (the ledger) against a direct reservation", async () => {
+    // Direct spend 600 + ledger (workflow) spend 300 = 900; a further 200
+    // direct reservation would reach 1100 > 1000 -> denied. Without the ledger
+    // in the SUM this would wrongly pass (600 + 200 = 800).
+    state.caps = [{ dailyValueCapWei: "1000" }];
+    state.sumRows = [{ totalWei: "600" }];
+    state.ledgerRows = [{ totalWei: "300" }];
+
+    const result = await checkAndReserveExecution({
+      ...baseParams,
+      reservedValueWei: "200",
+    });
+
+    expect(result.allowed).toBe(false);
     expect(state.inserted).toHaveLength(0);
   });
 

--- a/tests/unit/value-ledger.test.ts
+++ b/tests/unit/value-ledger.test.ts
@@ -300,4 +300,27 @@ describe("withStepValueCap", () => {
       expect.objectContaining({ status: "settled" }),
     ]);
   });
+
+  it("does not reserve when the caller already reserved (valueCapReserved)", async () => {
+    // /api/execute/node dispatches the step wrappers but has already reserved
+    // this execution's value via checkAndReserveExecution. The step must not
+    // reserve a second time, or a single node-route transfer double-charges.
+    state.caps = [{ dailyValueCapWei: ONE_ETH_WEI }];
+    const run = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await withStepValueCap(
+      {
+        organizationId: "org_1",
+        amountEth: "0.5",
+        executionId: "exec_1",
+        valueCapReserved: true,
+      },
+      run
+    );
+
+    expect(run).toHaveBeenCalledOnce();
+    expect(result).toEqual({ success: true });
+    expect(state.inserted).toHaveLength(0);
+    expect(state.updates).toHaveLength(0);
+  });
 });

--- a/tests/unit/value-ledger.test.ts
+++ b/tests/unit/value-ledger.test.ts
@@ -1,0 +1,303 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/utils/id", () => ({ generateId: () => "res_gen" }));
+
+// Hoisted state the fake db reads from / writes to, set per test.
+const state = vi.hoisted(() => ({
+  caps: [] as Array<{ dailyValueCapWei: string | null }>,
+  directSum: [{ totalWei: "0" }] as Array<{ totalWei: string }>,
+  ledgerSum: [{ totalWei: "0" }] as Array<{ totalWei: string }>,
+  inserted: [] as Record<string, unknown>[],
+  updates: [] as Record<string, unknown>[],
+  returningId: "res_1",
+}));
+
+// Fake db: transaction whose tx serves the cap FOR UPDATE lookup, then the two
+// SUM selects (direct executions, then the value ledger) that
+// sumOrgValueTodayWei runs, then the reservation insert (.returning). update()
+// records the settle/release status.
+vi.mock("@/lib/db", () => ({
+  db: {
+    transaction: (cb: (tx: unknown) => unknown) => {
+      let selectCall = 0;
+      const tx = {
+        select: () => {
+          selectCall += 1;
+          if (selectCall === 1) {
+            return {
+              from: () => ({
+                where: () => ({
+                  for: () => ({
+                    limit: () => Promise.resolve(state.caps),
+                  }),
+                }),
+              }),
+            };
+          }
+          const rows = selectCall === 2 ? state.directSum : state.ledgerSum;
+          return {
+            from: () => ({ where: () => Promise.resolve(rows) }),
+          };
+        },
+        insert: () => ({
+          values: (v: Record<string, unknown>) => {
+            state.inserted.push(v);
+            return {
+              returning: () => Promise.resolve([{ id: state.returningId }]),
+            };
+          },
+        }),
+      };
+      return cb(tx);
+    },
+    update: () => ({
+      set: (s: Record<string, unknown>) => ({
+        where: () => {
+          state.updates.push(s);
+          return Promise.resolve(undefined);
+        },
+      }),
+    }),
+  },
+}));
+
+import {
+  reserveOrgValue,
+  withStepValueCap,
+  withValueCap,
+} from "@/lib/execute/value-ledger";
+
+const ONE_ETH_WEI = "1000000000000000000";
+
+beforeEach(() => {
+  state.caps = [];
+  state.directSum = [{ totalWei: "0" }];
+  state.ledgerSum = [{ totalWei: "0" }];
+  state.inserted = [];
+  state.updates = [];
+  state.returningId = "res_1";
+});
+
+describe("reserveOrgValue", () => {
+  it("is unlimited (records nothing) when no cap row exists", async () => {
+    state.caps = [];
+
+    const result = await reserveOrgValue({
+      organizationId: "org_1",
+      valueWei: "500",
+    });
+
+    expect(result).toEqual({ allowed: true, reservationId: "" });
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("treats a null daily value cap as unlimited", async () => {
+    state.caps = [{ dailyValueCapWei: null }];
+
+    const result = await reserveOrgValue({
+      organizationId: "org_1",
+      valueWei: ONE_ETH_WEI,
+    });
+
+    expect(result).toEqual({ allowed: true, reservationId: "" });
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("allows and inserts a reserved row within the cap", async () => {
+    state.caps = [{ dailyValueCapWei: "1000" }];
+    state.directSum = [{ totalWei: "600" }];
+
+    const result = await reserveOrgValue({
+      organizationId: "org_1",
+      valueWei: "300",
+      source: "workflow",
+      ref: "exec_1",
+    });
+
+    expect(result).toEqual({ allowed: true, reservationId: "res_1" });
+    expect(state.inserted).toHaveLength(1);
+    expect(state.inserted[0]).toMatchObject({
+      valueWei: "300",
+      status: "reserved",
+      source: "workflow",
+      ref: "exec_1",
+    });
+  });
+
+  it("denies (no insert) when the reservation would exceed the cap", async () => {
+    state.caps = [{ dailyValueCapWei: "1000" }];
+    state.directSum = [{ totalWei: "600" }];
+
+    const result = await reserveOrgValue({
+      organizationId: "org_1",
+      valueWei: "500",
+    });
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: "Daily spending cap exceeded",
+    });
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("counts prior direct-execution spend in its own SUM", async () => {
+    // 900 already spent via the direct API (directSum) leaves only 100 room;
+    // a 200 workflow reservation is denied. Proves the ledger path sees direct
+    // spend, the mirror of the direct path seeing ledger spend.
+    state.caps = [{ dailyValueCapWei: "1000" }];
+    state.directSum = [{ totalWei: "900" }];
+
+    const result = await reserveOrgValue({
+      organizationId: "org_1",
+      valueWei: "200",
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(state.inserted).toHaveLength(0);
+  });
+});
+
+describe("withValueCap", () => {
+  it("skips the cap and runs when the value is zero", async () => {
+    const run = vi.fn().mockResolvedValue({ success: true, id: "ran" });
+
+    const result = await withValueCap(
+      { organizationId: "org_1", valueWei: "0" },
+      run
+    );
+
+    expect(run).toHaveBeenCalledOnce();
+    expect(result).toEqual({ success: true, id: "ran" });
+    expect(state.inserted).toHaveLength(0);
+    expect(state.updates).toHaveLength(0);
+  });
+
+  it("reserves then settles on a successful result", async () => {
+    state.caps = [{ dailyValueCapWei: "1000" }];
+    const run = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await withValueCap(
+      { organizationId: "org_1", valueWei: "100" },
+      run
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(state.inserted).toHaveLength(1);
+    expect(state.updates).toEqual([
+      expect.objectContaining({ status: "settled" }),
+    ]);
+  });
+
+  it("reserves then releases on a failed result", async () => {
+    state.caps = [{ dailyValueCapWei: "1000" }];
+    const run = vi.fn().mockResolvedValue({ success: false, error: "boom" });
+
+    const result = await withValueCap(
+      { organizationId: "org_1", valueWei: "100" },
+      run
+    );
+
+    expect(result).toEqual({ success: false, error: "boom" });
+    expect(state.inserted).toHaveLength(1);
+    expect(state.updates).toEqual([
+      expect.objectContaining({ status: "released" }),
+    ]);
+  });
+
+  it("releases and rethrows when the run throws", async () => {
+    state.caps = [{ dailyValueCapWei: "1000" }];
+    const run = vi.fn().mockRejectedValue(new Error("kaboom"));
+
+    await expect(
+      withValueCap({ organizationId: "org_1", valueWei: "100" }, run)
+    ).rejects.toThrow("kaboom");
+
+    expect(state.inserted).toHaveLength(1);
+    expect(state.updates).toEqual([
+      expect.objectContaining({ status: "released" }),
+    ]);
+  });
+
+  it("denies without running when over the cap", async () => {
+    state.caps = [{ dailyValueCapWei: "100" }];
+    const run = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await withValueCap(
+      { organizationId: "org_1", valueWei: "500" },
+      run
+    );
+
+    expect(run).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      success: false,
+      error: "Daily spending cap exceeded",
+    });
+    expect(state.updates).toHaveLength(0);
+  });
+});
+
+describe("withStepValueCap", () => {
+  it("runs without a cap check when the workflow has no organization", async () => {
+    const run = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await withStepValueCap({ amountEth: "1" }, run);
+
+    expect(run).toHaveBeenCalledOnce();
+    expect(result).toEqual({ success: true });
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("runs without a cap check when the step moves no native value", async () => {
+    state.caps = [{ dailyValueCapWei: "1" }];
+    const run = vi.fn().mockResolvedValue({ success: true });
+
+    await withStepValueCap({ organizationId: "org_1", amountEth: "0" }, run);
+    await withStepValueCap(
+      { organizationId: "org_1", amountEth: undefined },
+      run
+    );
+
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("blocks the value-moving core when a workflow step exceeds the cap", async () => {
+    // The KEEP-933 fix: a 5 ETH transfer triggered from a workflow (not the
+    // direct API) is now bounded by the same 1 ETH org cap. The core never runs.
+    state.caps = [{ dailyValueCapWei: ONE_ETH_WEI }];
+    const run = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await withStepValueCap(
+      { organizationId: "org_1", amountEth: "5", executionId: "exec_1" },
+      run
+    );
+
+    expect(run).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      success: false,
+      error: "Daily spending cap exceeded",
+    });
+  });
+
+  it("runs and settles a workflow step within the cap", async () => {
+    state.caps = [{ dailyValueCapWei: ONE_ETH_WEI }];
+    const run = vi.fn().mockResolvedValue({ success: true, hash: "0xabc" });
+
+    const result = await withStepValueCap(
+      { organizationId: "org_1", amountEth: "0.5", executionId: "exec_1" },
+      run
+    );
+
+    expect(run).toHaveBeenCalledOnce();
+    expect(result).toEqual({ success: true, hash: "0xabc" });
+    expect(state.inserted[0]).toMatchObject({
+      valueWei: "500000000000000000",
+      source: "workflow",
+      ref: "exec_1",
+    });
+    expect(state.updates).toEqual([
+      expect.objectContaining({ status: "settled" }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem

The per-org daily spending cap enforced the wrong quantity: it summed `gasUsedWei` (gas used) rather than the notional value transferred, comparing that gas total against `dailyCapWei`. A native transfer costs ~21k gas, so the gas total stays far below any reasonable cap while the `amount`/`value` actually moved was never summed or bounded.

Impact: an authenticated API key (or MCP OAuth token) could `POST /api/execute/transfer` with `amount` set to the wallet's entire balance and drain it in a single in-spec call. For Turnkey-EOA orgs with no on-chain Safe/Zodiac-Roles policy, this cap is the only server-side value control.

Two secondary issues in the same path: a reservation TOCTOU (in-flight rows had null gas, so concurrent requests all read the same pre-execution total), and no concurrency back-pressure on the execute write routes.

## Change

**Enforcement**
- The cap now bounds the native notional value moved per org per day. Each execution reserves its `value_wei` inside the same `SELECT ... FOR UPDATE` transaction and is denied when `today_total + reserved > cap`. The reserved value is written on the pending row, so concurrent in-flight requests see it, closing the TOCTOU (value is known up front, unlike gas).
- Native value is parsed per write route (transfer / contract-call / check-and-execute / node / protocol) via a shared helper that rejects malformed and negative amounts. ERC-20 token value is not yet priced into the cap (tracked separately); token-only transfers reserve 0.
- Added an execute-scoped concurrency limiter that counts in-flight direct executions and returns 429 on the write routes.

**Ownership**
- Caps are set by org admins/owners and stored in `organization_spend_caps.daily_value_cap_wei`. `PUT /api/analytics/spend-cap` is gated by the `organization:update` permission over the session, so a leaked API key or MCP token cannot raise its own ceiling (it authenticates a different layer and never satisfies the org session context).
- A new admin-gated "Limits" tab in the org settings modal sets/clears the cap; the dashboard gauge now reflects value used vs the value cap.

## Migration

Adds `direct_executions.value_wei` and `organization_spend_caps.daily_value_cap_wei`, and makes the legacy `daily_cap_wei` nullable so a value-only cap row can be created. All are nullable / ADD COLUMN / DROP NOT NULL changes (catalog-only), so no lock-free db-prep directive is required.

## Testing

- Unit: reservation value math and TOCTOU (`checkAndReserveExecution`), native-value parsing, concurrency counter.
- Integration: full-balance transfer rejected when a cap is set; concurrency 429; setter route authz (401 / 403 / 400 / 200 set / 200 clear, gated on `organization:update`).
- Full type-check, lint, and design-system token audit pass with no new findings (existing token-audit errors are in unrelated files).

## Follow-ups (not in this PR)

- USD-normalized cap covering ERC-20 value (needs a token price oracle).
- Playwright E2E for the Limits settings tab.
