### PR TITLE
fix: sign and validate SQS workflow-trigger messages

### DIFF
--- a/keeperhub-events/event-tracker/lib/sqs-message-auth.ts
+++ b/keeperhub-events/event-tracker/lib/sqs-message-auth.ts
@@ -22,23 +22,25 @@ export const SQS_CALLER_ATTR = "X-KH-Caller";
 
 function computeSqsSignature(
   secret: string,
+  queueUrl: string,
   caller: string,
   body: string,
   timestamp: string,
 ): string {
   const bodyDigest = createHash("sha256").update(body).digest("hex");
-  const signingString = `sqs\n${caller}\n${bodyDigest}\n${timestamp}`;
+  const signingString = `sqs\n${queueUrl}\n${caller}\n${bodyDigest}\n${timestamp}`;
   return createHmac("sha256", secret).update(signingString).digest("hex");
 }
 
 export function signSqsMessageAttributes(
   caller: SqsHmacCaller,
+  queueUrl: string,
   body: string,
   nowSeconds: number = Math.floor(Date.now() / 1000),
 ): Record<string, MessageAttributeValue> {
   const secret = process.env.INTERNAL_SERVICE_HMAC_SECRET ?? "";
   const timestamp = String(nowSeconds);
-  const signature = computeSqsSignature(secret, caller, body, timestamp);
+  const signature = computeSqsSignature(secret, queueUrl, caller, body, timestamp);
   return {
     [SQS_CALLER_ATTR]: { DataType: "String", StringValue: caller },
     [SQS_TIMESTAMP_ATTR]: { DataType: "String", StringValue: timestamp },

--- a/keeperhub-events/event-tracker/lib/sqs-message-auth.ts
+++ b/keeperhub-events/event-tracker/lib/sqs-message-auth.ts
@@ -47,7 +47,13 @@ export function signSqsMessageAttributes(
     );
   }
   const timestamp = String(nowSeconds);
-  const signature = computeSqsSignature(secret, queueUrl, caller, body, timestamp);
+  const signature = computeSqsSignature(
+    secret,
+    queueUrl,
+    caller,
+    body,
+    timestamp,
+  );
   return {
     [SQS_CALLER_ATTR]: { DataType: "String", StringValue: caller },
     [SQS_TIMESTAMP_ATTR]: { DataType: "String", StringValue: timestamp },

--- a/keeperhub-events/event-tracker/lib/sqs-message-auth.ts
+++ b/keeperhub-events/event-tracker/lib/sqs-message-auth.ts
@@ -38,7 +38,14 @@ export function signSqsMessageAttributes(
   body: string,
   nowSeconds: number = Math.floor(Date.now() / 1000),
 ): Record<string, MessageAttributeValue> {
-  const secret = process.env.INTERNAL_SERVICE_HMAC_SECRET ?? "";
+  const secret = process.env.INTERNAL_SERVICE_HMAC_SECRET;
+  // Fail loud rather than sign with "" (see lib/sqs-message-auth.ts): a
+  // ""-signed message is dropped by the verifier in enforce mode.
+  if (!secret) {
+    throw new Error(
+      "INTERNAL_SERVICE_HMAC_SECRET is not set; refusing to enqueue an unsigned SQS message",
+    );
+  }
   const timestamp = String(nowSeconds);
   const signature = computeSqsSignature(secret, queueUrl, caller, body, timestamp);
   return {

--- a/keeperhub-events/event-tracker/lib/sqs-message-auth.ts
+++ b/keeperhub-events/event-tracker/lib/sqs-message-auth.ts
@@ -1,0 +1,47 @@
+import { createHash, createHmac } from "node:crypto";
+import type { MessageAttributeValue } from "@aws-sdk/client-sqs";
+
+/**
+ * SQS message signing for the event-tracker.
+ *
+ * SIGN-ONLY copy of the shared scheme in the app's lib/sqs-message-auth.ts. The
+ * event-tracker is an isolated package (separate build + Docker context) that
+ * cannot import root lib/, so the signing logic is duplicated here (same
+ * convention as this package's logger and fetch-utils signHmacHeaders). The
+ * executor holds the verify half.
+ *
+ * Keep the signing string, attribute names, and caller set identical to
+ * lib/sqs-message-auth.ts - the shared anti-drift test vector guards this.
+ */
+
+export type SqsHmacCaller = "scheduler" | "events" | "app";
+
+export const SQS_SIGNATURE_ATTR = "X-KH-Signature";
+export const SQS_TIMESTAMP_ATTR = "X-KH-Timestamp";
+export const SQS_CALLER_ATTR = "X-KH-Caller";
+
+function computeSqsSignature(
+  secret: string,
+  caller: string,
+  body: string,
+  timestamp: string,
+): string {
+  const bodyDigest = createHash("sha256").update(body).digest("hex");
+  const signingString = `sqs\n${caller}\n${bodyDigest}\n${timestamp}`;
+  return createHmac("sha256", secret).update(signingString).digest("hex");
+}
+
+export function signSqsMessageAttributes(
+  caller: SqsHmacCaller,
+  body: string,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): Record<string, MessageAttributeValue> {
+  const secret = process.env.INTERNAL_SERVICE_HMAC_SECRET ?? "";
+  const timestamp = String(nowSeconds);
+  const signature = computeSqsSignature(secret, caller, body, timestamp);
+  return {
+    [SQS_CALLER_ATTR]: { DataType: "String", StringValue: caller },
+    [SQS_TIMESTAMP_ATTR]: { DataType: "String", StringValue: timestamp },
+    [SQS_SIGNATURE_ATTR]: { DataType: "String", StringValue: signature },
+  };
+}

--- a/keeperhub-events/event-tracker/lib/workflow-sqs.ts
+++ b/keeperhub-events/event-tracker/lib/workflow-sqs.ts
@@ -1,4 +1,5 @@
 import { type SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
+import { signSqsMessageAttributes } from "./sqs-message-auth";
 
 /**
  * Shape of every event-trigger message the tracker enqueues to SQS. Kept
@@ -24,7 +25,7 @@ export async function enqueueWorkflowEventTrigger(
   queueUrl: string,
   trigger: WorkflowEventTrigger,
 ): Promise<void> {
-  const body = {
+  const payload = {
     // undefined is dropped by JSON.stringify, so legacy messages stay identical.
     executionId: trigger.executionId,
     workflowId: trigger.workflowId,
@@ -32,16 +33,18 @@ export async function enqueueWorkflowEventTrigger(
     triggerType: "event" as const,
     triggerData: trigger.triggerData,
   };
+  const body = JSON.stringify(payload);
   await client.send(
     new SendMessageCommand({
       QueueUrl: queueUrl,
-      MessageBody: JSON.stringify(body),
+      MessageBody: body,
       MessageAttributes: {
         TriggerType: { DataType: "String", StringValue: "event" },
         WorkflowId: {
           DataType: "String",
           StringValue: trigger.workflowId,
         },
+        ...signSqsMessageAttributes("events", body),
       },
     }),
   );

--- a/keeperhub-events/event-tracker/lib/workflow-sqs.ts
+++ b/keeperhub-events/event-tracker/lib/workflow-sqs.ts
@@ -44,7 +44,7 @@ export async function enqueueWorkflowEventTrigger(
           DataType: "String",
           StringValue: trigger.workflowId,
         },
-        ...signSqsMessageAttributes("events", body),
+        ...signSqsMessageAttributes("events", queueUrl, body),
       },
     }),
   );

--- a/keeperhub-events/event-tracker/tests/unit/sqs-message-auth.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/sqs-message-auth.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  SQS_SIGNATURE_ATTR,
+  signSqsMessageAttributes,
+} from "../../lib/sqs-message-auth";
+
+// Shared anti-drift vector. These exact inputs must produce this exact
+// signature here, in the app's lib/sqs-message-auth.ts, and in the scheduler
+// copy. A mismatch means a copy drifted from the scheme and the executor would
+// reject this producer's messages.
+const FIXED_SECRET = "test-shared-secret";
+const FIXED_BODY = JSON.stringify({
+  workflowId: "wf_1",
+  scheduleId: "sch_1",
+  triggerTime: "2026-01-01T00:00:00.000Z",
+  triggerType: "schedule",
+});
+const FIXED_TS = 1_700_000_000;
+const FIXED_SIG =
+  "f508ed8e583f7d2f61341526a735cefe45a4aa83d0befcb761ad5953fc48fca2";
+
+let savedSecret: string | undefined;
+
+beforeEach(() => {
+  savedSecret = process.env.INTERNAL_SERVICE_HMAC_SECRET;
+  process.env.INTERNAL_SERVICE_HMAC_SECRET = FIXED_SECRET;
+});
+
+afterEach(() => {
+  process.env.INTERNAL_SERVICE_HMAC_SECRET = savedSecret;
+});
+
+describe("event-tracker sqs-message-auth", () => {
+  it("matches the shared anti-drift signature vector", () => {
+    const attrs = signSqsMessageAttributes("scheduler", FIXED_BODY, FIXED_TS);
+    expect(attrs[SQS_SIGNATURE_ATTR].StringValue).toBe(FIXED_SIG);
+  });
+});

--- a/keeperhub-events/event-tracker/tests/unit/sqs-message-auth.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/sqs-message-auth.test.ts
@@ -9,6 +9,8 @@ import {
 // copy. A mismatch means a copy drifted from the scheme and the executor would
 // reject this producer's messages.
 const FIXED_SECRET = "test-shared-secret";
+const FIXED_QUEUE_URL =
+  "https://sqs.us-east-1.amazonaws.com/123456789012/keeperhub-workflow-queue-test";
 const FIXED_BODY = JSON.stringify({
   workflowId: "wf_1",
   scheduleId: "sch_1",
@@ -17,7 +19,7 @@ const FIXED_BODY = JSON.stringify({
 });
 const FIXED_TS = 1_700_000_000;
 const FIXED_SIG =
-  "f508ed8e583f7d2f61341526a735cefe45a4aa83d0befcb761ad5953fc48fca2";
+  "52a1fbfe8524879f745928cde4565fb86bbe4e00c75f3ad9f4935e633c7e7328";
 
 let savedSecret: string | undefined;
 
@@ -32,7 +34,12 @@ afterEach(() => {
 
 describe("event-tracker sqs-message-auth", () => {
   it("matches the shared anti-drift signature vector", () => {
-    const attrs = signSqsMessageAttributes("scheduler", FIXED_BODY, FIXED_TS);
+    const attrs = signSqsMessageAttributes(
+      "scheduler",
+      FIXED_QUEUE_URL,
+      FIXED_BODY,
+      FIXED_TS,
+    );
     expect(attrs[SQS_SIGNATURE_ATTR].StringValue).toBe(FIXED_SIG);
   });
 });

--- a/keeperhub-events/event-tracker/vitest.config.mts
+++ b/keeperhub-events/event-tracker/vitest.config.mts
@@ -13,6 +13,9 @@ export default defineConfig({
     testTimeout: 60_000,
     hookTimeout: 60_000,
     fileParallelism: false,
+    // Producers now require a signing secret (SQS message HMAC); provide a test
+    // value so enqueue paths exercise real signing instead of throwing.
+    env: { INTERNAL_SERVICE_HMAC_SECRET: "test-hmac-secret" },
   },
   resolve: {
     alias: {

--- a/keeperhub-executor/config.ts
+++ b/keeperhub-executor/config.ts
@@ -8,6 +8,17 @@ function parseSqsHmacMode(value: string | undefined): SqsHmacMode {
   return value === "off" || value === "enforce" ? value : "warn";
 }
 
+// Parse a non-negative integer env var, falling back on unset/blank/non-numeric.
+// Unlike `Number(x) || fallback`, this honours an explicit 0 rather than
+// treating it as falsy.
+function parseNonNegativeInt(value: string | undefined, fallback: number): number {
+  if (value === undefined || value.trim() === "") {
+    return fallback;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
 export const CONFIG = {
   executionMode: (process.env.EXECUTION_MODE || "isolated") as ExecutionMode,
 
@@ -54,15 +65,19 @@ export const CONFIG = {
 
   // SQS trigger-message HMAC verification mode. "warn" (default)
   // verifies + records metrics but never drops a message, so shipping the
-  // executor change alone cannot reject live traffic; flip to "enforce" via env
-  // (no redeploy) once rollout metrics show every producer is signing. "off"
-  // skips the checks entirely.
+  // executor change alone cannot reject live traffic; flip to "enforce" once
+  // rollout metrics show every producer is signing. Read once at process start,
+  // so changing it takes an env update + pod restart (no code deploy needed).
+  // "off" skips the checks entirely.
   sqsHmacMode: parseSqsHmacMode(process.env.SQS_HMAC_MODE),
   // Advisory freshness threshold (seconds) for a validly-signed message. Beyond
   // it a metric + warn is emitted, but the message is still processed - a queue
   // backlog can legitimately hold old messages, so age alone never drops a
   // trigger.
-  sqsHmacMaxAgeSeconds: Number(process.env.SQS_HMAC_MAX_AGE_SECONDS) || 900,
+  sqsHmacMaxAgeSeconds: parseNonNegativeInt(
+    process.env.SQS_HMAC_MAX_AGE_SECONDS,
+    900
+  ),
 
   visibilityTimeout: 300,
   waitTimeSeconds: 20,

--- a/keeperhub-executor/config.ts
+++ b/keeperhub-executor/config.ts
@@ -1,5 +1,13 @@
 export type ExecutionMode = "isolated" | "process" | "complex" | "in-process";
 
+export type SqsHmacMode = "off" | "warn" | "enforce";
+
+// Anything other than an explicit "off"/"enforce" falls back to "warn" so a
+// typo can never silently disable verification (fail-safe default).
+function parseSqsHmacMode(value: string | undefined): SqsHmacMode {
+  return value === "off" || value === "enforce" ? value : "warn";
+}
+
 export const CONFIG = {
   executionMode: (process.env.EXECUTION_MODE || "isolated") as ExecutionMode,
 
@@ -43,6 +51,18 @@ export const CONFIG = {
 
   workflowRunnerCollectMonitoring:
     process.env.WORKFLOW_RUNNER_COLLECT_MONITORING !== "false",
+
+  // SQS trigger-message HMAC verification mode. "warn" (default)
+  // verifies + records metrics but never drops a message, so shipping the
+  // executor change alone cannot reject live traffic; flip to "enforce" via env
+  // (no redeploy) once rollout metrics show every producer is signing. "off"
+  // skips the checks entirely.
+  sqsHmacMode: parseSqsHmacMode(process.env.SQS_HMAC_MODE),
+  // Advisory freshness threshold (seconds) for a validly-signed message. Beyond
+  // it a metric + warn is emitted, but the message is still processed - a queue
+  // backlog can legitimately hold old messages, so age alone never drops a
+  // trigger.
+  sqsHmacMaxAgeSeconds: Number(process.env.SQS_HMAC_MAX_AGE_SECONDS) || 900,
 
   visibilityTimeout: 300,
   waitTimeSeconds: 20,

--- a/keeperhub-executor/config.ts
+++ b/keeperhub-executor/config.ts
@@ -78,6 +78,11 @@ export const CONFIG = {
     process.env.SQS_HMAC_MAX_AGE_SECONDS,
     900
   ),
+  // When true, a validly-signed message older than sqsHmacMaxAgeSeconds is
+  // rejected in enforce mode, bounding replay to the freshness window. Default
+  // false keeps freshness advisory so a queue backlog never drops real triggers;
+  // enable once backlog behaviour is understood.
+  sqsHmacMaxAgeEnforce: process.env.SQS_HMAC_MAX_AGE_ENFORCE === "true",
 
   visibilityTimeout: 300,
   waitTimeSeconds: 20,

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -558,7 +558,7 @@ export function evaluateSqsMessageAuth(
     | null;
   stale: boolean;
 } {
-  const sig = verifySqsMessageSignature(rawBody, attributes);
+  const sig = verifySqsMessageSignature(CONFIG.sqsQueueUrl, rawBody, attributes);
   if (!sig.ok) {
     return { failure: sig.reason, stale: false };
   }

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -614,14 +614,20 @@ export async function processMessage(
       [LabelKeys.AUTH_RESULT]: result,
       [LabelKeys.MODE]: CONFIG.sqsHmacMode,
     });
-    if (auth.stale) {
+
+    // Staleness is advisory unless SQS_HMAC_MAX_AGE_ENFORCE is set, in which case
+    // an over-age message becomes a hard failure (bounds replay to the window).
+    const staleRejected = auth.stale && CONFIG.sqsHmacMaxAgeEnforce;
+    if (auth.stale && !staleRejected) {
       console.warn(
         `[Executor] SQS message older than ${CONFIG.sqsHmacMaxAgeSeconds}s (advisory) for workflow ${body.workflowId}`
       );
     }
-    if (auth.failure) {
+
+    const failure = auth.failure ?? (staleRejected ? "stale" : null);
+    if (failure) {
       console.warn(
-        `[Executor] SQS message failed auth (${auth.failure}, mode=${CONFIG.sqsHmacMode}) for workflow ${body.workflowId}`
+        `[Executor] SQS message rejected (${failure}, mode=${CONFIG.sqsHmacMode}) for workflow ${body.workflowId}`
       );
       if (CONFIG.sqsHmacMode === "enforce") {
         await sqs.send(

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -28,6 +28,7 @@ import { createServer, type IncomingMessage } from "node:http";
 import {
   DeleteMessageCommand,
   type Message,
+  type MessageAttributeValue,
   ReceiveMessageCommand,
   SQSClient,
 } from "@aws-sdk/client-sqs";
@@ -43,6 +44,7 @@ import { getMetricsCollector } from "../lib/metrics";
 import { LabelKeys, MetricNames } from "../lib/metrics/types";
 import { withBackstopCapture } from "../lib/security/backstop-capture";
 import { buildAttribution } from "../lib/security/request-attribution";
+import { verifySqsMessageSignature } from "../lib/sqs-message-auth";
 import { generateId } from "../lib/utils/id";
 import { checkConcurrencyLimit } from "../lib/workflow/concurrency";
 import { hashWorkflowDefinition } from "../lib/workflow/content-hash";
@@ -63,6 +65,7 @@ import {
 } from "./lib/db-helpers";
 import { applyCounterDeltas, isIngestPayload } from "./lib/metrics-shipping";
 import { toJsonSafe } from "./lib/serialize";
+import { executorMessageSchema } from "./message-schema";
 import {
   assertHmacSecretSet,
   assertTurnkeyEnvForActiveWallets,
@@ -535,6 +538,38 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
   }
 }
 
+/**
+ * Verify a trigger message's HMAC signature and validate its shape
+ * before it can drive an execution. Returns the first hard failure (or null),
+ * plus whether a validly-signed message is older than the advisory freshness
+ * threshold. Freshness never produces a failure - a backlog can legitimately
+ * hold old messages, so age alone must not drop a real trigger.
+ */
+export function evaluateSqsMessageAuth(
+  rawBody: string,
+  attributes: Record<string, MessageAttributeValue> | undefined,
+  body: ExecutorMessage
+): {
+  failure:
+    | "unsigned"
+    | "unknown_caller"
+    | "bad_signature"
+    | "invalid_schema"
+    | null;
+  stale: boolean;
+} {
+  const sig = verifySqsMessageSignature(rawBody, attributes);
+  if (!sig.ok) {
+    return { failure: sig.reason, stale: false };
+  }
+  const stale = Math.abs(sig.ageSeconds) > CONFIG.sqsHmacMaxAgeSeconds;
+  const parsed = executorMessageSchema.safeParse(body);
+  if (!parsed.success) {
+    return { failure: "invalid_schema", stale };
+  }
+  return { failure: null, stale };
+}
+
 export async function processMessage(
   message: Message,
   // The message processor is injectable so tests can drive the success and
@@ -558,6 +593,52 @@ export async function processMessage(
       })
     );
     return;
+  }
+
+  // Authenticate + validate the message before it can drive a
+  // fund-moving execution. In "warn" mode we record metrics but still process
+  // (so shipping this ahead of every producer signing cannot cause an outage);
+  // in "enforce" mode a hard failure drops the message (no DLQ configured, and a
+  // forged/corrupt message cannot be made valid by redelivery).
+  if (CONFIG.sqsHmacMode !== "off") {
+    const auth = evaluateSqsMessageAuth(
+      message.Body,
+      message.MessageAttributes,
+      body
+    );
+    const collector = getMetricsCollector();
+    if (auth.stale) {
+      collector.incrementCounter(MetricNames.SQS_MESSAGE_AUTH, {
+        [LabelKeys.AUTH_RESULT]: "stale",
+        [LabelKeys.MODE]: CONFIG.sqsHmacMode,
+      });
+      console.warn(
+        `[Executor] SQS message older than ${CONFIG.sqsHmacMaxAgeSeconds}s (advisory) for workflow ${body.workflowId}`
+      );
+    }
+    if (auth.failure) {
+      collector.incrementCounter(MetricNames.SQS_MESSAGE_AUTH, {
+        [LabelKeys.AUTH_RESULT]: auth.failure,
+        [LabelKeys.MODE]: CONFIG.sqsHmacMode,
+      });
+      console.warn(
+        `[Executor] SQS message failed auth (${auth.failure}, mode=${CONFIG.sqsHmacMode}) for workflow ${body.workflowId}`
+      );
+      if (CONFIG.sqsHmacMode === "enforce") {
+        await sqs.send(
+          new DeleteMessageCommand({
+            QueueUrl: CONFIG.sqsQueueUrl,
+            ReceiptHandle: message.ReceiptHandle,
+          })
+        );
+        return;
+      }
+    } else {
+      collector.incrementCounter(MetricNames.SQS_MESSAGE_AUTH, {
+        [LabelKeys.AUTH_RESULT]: "valid",
+        [LabelKeys.MODE]: CONFIG.sqsHmacMode,
+      });
+    }
   }
 
   try {

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -606,21 +606,20 @@ export async function processMessage(
       message.MessageAttributes,
       body
     );
-    const collector = getMetricsCollector();
+    // Exactly one auth_result per message (a failure outranks stale, stale
+    // outranks valid) so the metric's total across labels equals messages
+    // processed - the rollout gate reads these series.
+    const result = auth.failure ?? (auth.stale ? "stale" : "valid");
+    getMetricsCollector().incrementCounter(MetricNames.SQS_MESSAGE_AUTH, {
+      [LabelKeys.AUTH_RESULT]: result,
+      [LabelKeys.MODE]: CONFIG.sqsHmacMode,
+    });
     if (auth.stale) {
-      collector.incrementCounter(MetricNames.SQS_MESSAGE_AUTH, {
-        [LabelKeys.AUTH_RESULT]: "stale",
-        [LabelKeys.MODE]: CONFIG.sqsHmacMode,
-      });
       console.warn(
         `[Executor] SQS message older than ${CONFIG.sqsHmacMaxAgeSeconds}s (advisory) for workflow ${body.workflowId}`
       );
     }
     if (auth.failure) {
-      collector.incrementCounter(MetricNames.SQS_MESSAGE_AUTH, {
-        [LabelKeys.AUTH_RESULT]: auth.failure,
-        [LabelKeys.MODE]: CONFIG.sqsHmacMode,
-      });
       console.warn(
         `[Executor] SQS message failed auth (${auth.failure}, mode=${CONFIG.sqsHmacMode}) for workflow ${body.workflowId}`
       );
@@ -633,11 +632,6 @@ export async function processMessage(
         );
         return;
       }
-    } else {
-      collector.incrementCounter(MetricNames.SQS_MESSAGE_AUTH, {
-        [LabelKeys.AUTH_RESULT]: "valid",
-        [LabelKeys.MODE]: CONFIG.sqsHmacMode,
-      });
     }
   }
 

--- a/keeperhub-executor/message-auth.test.ts
+++ b/keeperhub-executor/message-auth.test.ts
@@ -14,6 +14,8 @@ import { executorMessageSchema } from "./message-schema";
 // divergence in any copy fails CI.
 const FIXED_SECRET = "test-shared-secret";
 const FIXED_CALLER = "scheduler";
+const FIXED_QUEUE_URL =
+  "https://sqs.us-east-1.amazonaws.com/123456789012/keeperhub-workflow-queue-test";
 const FIXED_BODY = JSON.stringify({
   workflowId: "wf_1",
   scheduleId: "sch_1",
@@ -22,7 +24,10 @@ const FIXED_BODY = JSON.stringify({
 });
 const FIXED_TS = 1_700_000_000;
 const FIXED_SIG =
-  "f508ed8e583f7d2f61341526a735cefe45a4aa83d0befcb761ad5953fc48fca2";
+  "52a1fbfe8524879f745928cde4565fb86bbe4e00c75f3ad9f4935e633c7e7328";
+
+// Queue URL used for the round-trip tests below.
+const QUEUE = "https://sqs.us-east-1.amazonaws.com/000000000000/local-queue";
 
 let savedSecret: string | undefined;
 let savedPrevious: string | undefined;
@@ -50,7 +55,12 @@ afterEach(() => {
 describe("sqs-message-auth signing", () => {
   it("matches the shared anti-drift vector", () => {
     process.env.INTERNAL_SERVICE_HMAC_SECRET = FIXED_SECRET;
-    const attrs = signSqsMessageAttributes(FIXED_CALLER, FIXED_BODY, FIXED_TS);
+    const attrs = signSqsMessageAttributes(
+      FIXED_CALLER,
+      FIXED_QUEUE_URL,
+      FIXED_BODY,
+      FIXED_TS
+    );
     expect(attrs[SQS_SIGNATURE_ATTR].StringValue).toBe(FIXED_SIG);
     expect(attrs[SQS_CALLER_ATTR].StringValue).toBe(FIXED_CALLER);
     expect(attrs[SQS_TIMESTAMP_ATTR].StringValue).toBe(String(FIXED_TS));
@@ -58,8 +68,8 @@ describe("sqs-message-auth signing", () => {
 
   it("verifies a freshly signed message", () => {
     const body = JSON.stringify({ workflowId: "wf1", triggerType: "schedule" });
-    const attrs = signSqsMessageAttributes("scheduler", body);
-    const result = verifySqsMessageSignature(body, attrs);
+    const attrs = signSqsMessageAttributes("scheduler", QUEUE, body);
+    const result = verifySqsMessageSignature(QUEUE, body, attrs);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.caller).toBe("scheduler");
@@ -71,33 +81,42 @@ describe("sqs-message-auth signing", () => {
 describe("sqs-message-auth verification failures", () => {
   it("rejects a tampered body", () => {
     const body = JSON.stringify({ workflowId: "wf1", triggerType: "schedule" });
-    const attrs = signSqsMessageAttributes("scheduler", body);
+    const attrs = signSqsMessageAttributes("scheduler", QUEUE, body);
     const tampered = JSON.stringify({
       workflowId: "victim",
       triggerType: "schedule",
     });
-    const result = verifySqsMessageSignature(tampered, attrs);
+    const result = verifySqsMessageSignature(QUEUE, tampered, attrs);
+    expect(result).toEqual({ ok: false, reason: "bad_signature" });
+  });
+
+  it("rejects a message signed for a different queue (cross-environment replay)", () => {
+    const body = JSON.stringify({ workflowId: "wf1", triggerType: "schedule" });
+    const attrs = signSqsMessageAttributes("scheduler", QUEUE, body);
+    const otherQueue =
+      "https://sqs.us-east-1.amazonaws.com/999999999999/other-queue";
+    const result = verifySqsMessageSignature(otherQueue, body, attrs);
     expect(result).toEqual({ ok: false, reason: "bad_signature" });
   });
 
   it("rejects a message with no signature attributes", () => {
-    const result = verifySqsMessageSignature("{}", undefined);
+    const result = verifySqsMessageSignature(QUEUE, "{}", undefined);
     expect(result).toEqual({ ok: false, reason: "unsigned" });
   });
 
   it("rejects an unknown caller", () => {
     const body = "{}";
-    const attrs = signSqsMessageAttributes("scheduler", body);
+    const attrs = signSqsMessageAttributes("scheduler", QUEUE, body);
     attrs[SQS_CALLER_ATTR].StringValue = "attacker";
-    const result = verifySqsMessageSignature(body, attrs);
+    const result = verifySqsMessageSignature(QUEUE, body, attrs);
     expect(result).toEqual({ ok: false, reason: "unknown_caller" });
   });
 
   it("rejects a malformed (non 64-hex) signature", () => {
     const body = "{}";
-    const attrs = signSqsMessageAttributes("scheduler", body);
+    const attrs = signSqsMessageAttributes("scheduler", QUEUE, body);
     attrs[SQS_SIGNATURE_ATTR].StringValue = "deadbeef";
-    const result = verifySqsMessageSignature(body, attrs);
+    const result = verifySqsMessageSignature(QUEUE, body, attrs);
     expect(result).toEqual({ ok: false, reason: "bad_signature" });
   });
 
@@ -105,18 +124,18 @@ describe("sqs-message-auth verification failures", () => {
     const body = JSON.stringify({ workflowId: "wf1", triggerType: "schedule" });
     // Producer still signs with the old secret.
     process.env.INTERNAL_SERVICE_HMAC_SECRET = "old-secret";
-    const attrs = signSqsMessageAttributes("scheduler", body);
+    const attrs = signSqsMessageAttributes("scheduler", QUEUE, body);
     // Executor has rotated: new secret is primary, old is retained as previous.
     process.env.INTERNAL_SERVICE_HMAC_SECRET = "new-secret";
     process.env.INTERNAL_SERVICE_HMAC_SECRET_PREVIOUS = "old-secret";
-    expect(verifySqsMessageSignature(body, attrs).ok).toBe(true);
+    expect(verifySqsMessageSignature(QUEUE, body, attrs).ok).toBe(true);
   });
 
   it("reports a large positive age for an old timestamp", () => {
     const body = JSON.stringify({ workflowId: "wf1", triggerType: "schedule" });
     const oldTs = Math.floor(Date.now() / 1000) - 10_000;
-    const attrs = signSqsMessageAttributes("scheduler", body, oldTs);
-    const result = verifySqsMessageSignature(body, attrs);
+    const attrs = signSqsMessageAttributes("scheduler", QUEUE, body, oldTs);
+    const result = verifySqsMessageSignature(QUEUE, body, attrs);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.ageSeconds).toBeGreaterThan(9_000);
@@ -132,6 +151,22 @@ describe("executorMessageSchema", () => {
         workflowId: "wf1",
         scheduleId: "s1",
         triggerTime: "2026-01-01T00:00:00.000Z",
+      }).success
+    ).toBe(true);
+  });
+
+  it("accepts a valid block message", () => {
+    expect(
+      executorMessageSchema.safeParse({
+        triggerType: "block",
+        workflowId: "wf1",
+        userId: "u1",
+        triggerData: {
+          blockNumber: 1,
+          blockHash: "0xhash",
+          blockTimestamp: 1,
+          parentHash: "0xparent",
+        },
       }).success
     ).toBe(true);
   });

--- a/keeperhub-executor/message-auth.test.ts
+++ b/keeperhub-executor/message-auth.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  SQS_CALLER_ATTR,
+  SQS_SIGNATURE_ATTR,
+  SQS_TIMESTAMP_ATTR,
+  signSqsMessageAttributes,
+  verifySqsMessageSignature,
+} from "../lib/sqs-message-auth";
+import { executorMessageSchema } from "./message-schema";
+
+// Shared anti-drift vector: the scheduler and event-tracker keep byte-identical
+// SIGN-only copies of the scheme. These exact inputs must produce this exact
+// signature in all three packages (mirrored in their own unit suites), so a
+// divergence in any copy fails CI.
+const FIXED_SECRET = "test-shared-secret";
+const FIXED_CALLER = "scheduler";
+const FIXED_BODY = JSON.stringify({
+  workflowId: "wf_1",
+  scheduleId: "sch_1",
+  triggerTime: "2026-01-01T00:00:00.000Z",
+  triggerType: "schedule",
+});
+const FIXED_TS = 1_700_000_000;
+const FIXED_SIG =
+  "f508ed8e583f7d2f61341526a735cefe45a4aa83d0befcb761ad5953fc48fca2";
+
+let savedSecret: string | undefined;
+let savedPrevious: string | undefined;
+
+function setEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
+beforeEach(() => {
+  savedSecret = process.env.INTERNAL_SERVICE_HMAC_SECRET;
+  savedPrevious = process.env.INTERNAL_SERVICE_HMAC_SECRET_PREVIOUS;
+  process.env.INTERNAL_SERVICE_HMAC_SECRET = "unit-secret";
+  delete process.env.INTERNAL_SERVICE_HMAC_SECRET_PREVIOUS;
+});
+
+afterEach(() => {
+  setEnv("INTERNAL_SERVICE_HMAC_SECRET", savedSecret);
+  setEnv("INTERNAL_SERVICE_HMAC_SECRET_PREVIOUS", savedPrevious);
+});
+
+describe("sqs-message-auth signing", () => {
+  it("matches the shared anti-drift vector", () => {
+    process.env.INTERNAL_SERVICE_HMAC_SECRET = FIXED_SECRET;
+    const attrs = signSqsMessageAttributes(FIXED_CALLER, FIXED_BODY, FIXED_TS);
+    expect(attrs[SQS_SIGNATURE_ATTR].StringValue).toBe(FIXED_SIG);
+    expect(attrs[SQS_CALLER_ATTR].StringValue).toBe(FIXED_CALLER);
+    expect(attrs[SQS_TIMESTAMP_ATTR].StringValue).toBe(String(FIXED_TS));
+  });
+
+  it("verifies a freshly signed message", () => {
+    const body = JSON.stringify({ workflowId: "wf1", triggerType: "schedule" });
+    const attrs = signSqsMessageAttributes("scheduler", body);
+    const result = verifySqsMessageSignature(body, attrs);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.caller).toBe("scheduler");
+      expect(Math.abs(result.ageSeconds)).toBeLessThan(5);
+    }
+  });
+});
+
+describe("sqs-message-auth verification failures", () => {
+  it("rejects a tampered body", () => {
+    const body = JSON.stringify({ workflowId: "wf1", triggerType: "schedule" });
+    const attrs = signSqsMessageAttributes("scheduler", body);
+    const tampered = JSON.stringify({
+      workflowId: "victim",
+      triggerType: "schedule",
+    });
+    const result = verifySqsMessageSignature(tampered, attrs);
+    expect(result).toEqual({ ok: false, reason: "bad_signature" });
+  });
+
+  it("rejects a message with no signature attributes", () => {
+    const result = verifySqsMessageSignature("{}", undefined);
+    expect(result).toEqual({ ok: false, reason: "unsigned" });
+  });
+
+  it("rejects an unknown caller", () => {
+    const body = "{}";
+    const attrs = signSqsMessageAttributes("scheduler", body);
+    attrs[SQS_CALLER_ATTR].StringValue = "attacker";
+    const result = verifySqsMessageSignature(body, attrs);
+    expect(result).toEqual({ ok: false, reason: "unknown_caller" });
+  });
+
+  it("rejects a malformed (non 64-hex) signature", () => {
+    const body = "{}";
+    const attrs = signSqsMessageAttributes("scheduler", body);
+    attrs[SQS_SIGNATURE_ATTR].StringValue = "deadbeef";
+    const result = verifySqsMessageSignature(body, attrs);
+    expect(result).toEqual({ ok: false, reason: "bad_signature" });
+  });
+
+  it("accepts a signature made with the previous secret during rotation", () => {
+    const body = JSON.stringify({ workflowId: "wf1", triggerType: "schedule" });
+    // Producer still signs with the old secret.
+    process.env.INTERNAL_SERVICE_HMAC_SECRET = "old-secret";
+    const attrs = signSqsMessageAttributes("scheduler", body);
+    // Executor has rotated: new secret is primary, old is retained as previous.
+    process.env.INTERNAL_SERVICE_HMAC_SECRET = "new-secret";
+    process.env.INTERNAL_SERVICE_HMAC_SECRET_PREVIOUS = "old-secret";
+    expect(verifySqsMessageSignature(body, attrs).ok).toBe(true);
+  });
+
+  it("reports a large positive age for an old timestamp", () => {
+    const body = JSON.stringify({ workflowId: "wf1", triggerType: "schedule" });
+    const oldTs = Math.floor(Date.now() / 1000) - 10_000;
+    const attrs = signSqsMessageAttributes("scheduler", body, oldTs);
+    const result = verifySqsMessageSignature(body, attrs);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.ageSeconds).toBeGreaterThan(9_000);
+    }
+  });
+});
+
+describe("executorMessageSchema", () => {
+  it("accepts a valid schedule message", () => {
+    expect(
+      executorMessageSchema.safeParse({
+        triggerType: "schedule",
+        workflowId: "wf1",
+        scheduleId: "s1",
+        triggerTime: "2026-01-01T00:00:00.000Z",
+      }).success
+    ).toBe(true);
+  });
+
+  it("accepts a valid event message with arbitrary triggerData", () => {
+    expect(
+      executorMessageSchema.safeParse({
+        triggerType: "event",
+        workflowId: "wf1",
+        userId: "u1",
+        triggerData: { contractAddress: "0xabc", anything: [1, 2, 3] },
+      }).success
+    ).toBe(true);
+  });
+
+  it("accepts valid manual and webhook messages", () => {
+    const base = {
+      workflowId: "wf1",
+      userId: "u1",
+      executionId: "e1",
+      input: { foo: "bar" },
+    };
+    expect(
+      executorMessageSchema.safeParse({ ...base, triggerType: "manual" }).success
+    ).toBe(true);
+    expect(
+      executorMessageSchema.safeParse({ ...base, triggerType: "webhook" })
+        .success
+    ).toBe(true);
+  });
+
+  it("rejects a missing workflowId", () => {
+    expect(
+      executorMessageSchema.safeParse({
+        triggerType: "schedule",
+        scheduleId: "s1",
+        triggerTime: "t",
+      }).success
+    ).toBe(false);
+  });
+
+  it("rejects an unknown triggerType", () => {
+    expect(
+      executorMessageSchema.safeParse({
+        triggerType: "attacker",
+        workflowId: "wf1",
+      }).success
+    ).toBe(false);
+  });
+
+  it("rejects a manual message without an executionId", () => {
+    expect(
+      executorMessageSchema.safeParse({
+        triggerType: "manual",
+        workflowId: "wf1",
+        userId: "u1",
+        input: {},
+      }).success
+    ).toBe(false);
+  });
+});

--- a/keeperhub-executor/message-auth.test.ts
+++ b/keeperhub-executor/message-auth.test.ts
@@ -76,6 +76,13 @@ describe("sqs-message-auth signing", () => {
       expect(Math.abs(result.ageSeconds)).toBeLessThan(5);
     }
   });
+
+  it("throws when the signing secret is unset (fails loud, not silent)", () => {
+    delete process.env.INTERNAL_SERVICE_HMAC_SECRET;
+    expect(() => signSqsMessageAttributes("scheduler", QUEUE, "{}")).toThrow(
+      /INTERNAL_SERVICE_HMAC_SECRET/
+    );
+  });
 });
 
 describe("sqs-message-auth verification failures", () => {

--- a/keeperhub-executor/message-schema.ts
+++ b/keeperhub-executor/message-schema.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+
+/**
+ * Runtime validation for SQS trigger message bodies, mirroring the TypeScript
+ * union in ./types.ts (ExecutorMessage). The consumer previously cast the
+ * JSON.parse result straight to ExecutorMessage with no shape check; this gates
+ * the parsed body before any workflow load/dispatch.
+ *
+ * Identity fields (workflowId, triggerType, and executionId where the producer
+ * always sends one) are strict. Free-form payloads (triggerData / input) are
+ * left permissive on purpose so a legitimate producer payload is never rejected
+ * - the security-relevant fields are the identity ones. Unknown extra top-level
+ * keys are stripped by default (not an error).
+ *
+ * Keep in sync with ./types.ts.
+ */
+
+const workflowId = z.string().min(1);
+const payload = z.record(z.string(), z.unknown());
+
+const scheduleMessageSchema = z.object({
+  triggerType: z.literal("schedule"),
+  workflowId,
+  scheduleId: z.string().min(1),
+  triggerTime: z.string(),
+  executionId: z.string().optional(),
+});
+
+const blockMessageSchema = z.object({
+  triggerType: z.literal("block"),
+  workflowId,
+  userId: z.string(),
+  executionId: z.string().optional(),
+  triggerData: z.object({
+    blockNumber: z.number(),
+    blockHash: z.string(),
+    blockTimestamp: z.number(),
+    parentHash: z.string(),
+  }),
+});
+
+const eventMessageSchema = z.object({
+  triggerType: z.literal("event"),
+  workflowId,
+  userId: z.string(),
+  executionId: z.string().optional(),
+  triggerData: payload,
+});
+
+// manual and webhook share a shape but are separate literal branches so the
+// discriminated union stays on a single literal discriminator per branch.
+const manualFields = {
+  workflowId,
+  userId: z.string(),
+  executionId: z.string().min(1),
+  organizationId: z.string().optional(),
+  input: payload,
+};
+const manualMessageSchema = z.object({
+  triggerType: z.literal("manual"),
+  ...manualFields,
+});
+const webhookMessageSchema = z.object({
+  triggerType: z.literal("webhook"),
+  ...manualFields,
+});
+
+export const executorMessageSchema = z.discriminatedUnion("triggerType", [
+  scheduleMessageSchema,
+  blockMessageSchema,
+  eventMessageSchema,
+  manualMessageSchema,
+  webhookMessageSchema,
+]);

--- a/keeperhub-executor/message-schema.ts
+++ b/keeperhub-executor/message-schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { ExecutorMessage } from "./types";
 
 /**
  * Runtime validation for SQS trigger message bodies, mirroring the TypeScript
@@ -44,7 +45,10 @@ const eventMessageSchema = z.object({
   workflowId,
   userId: z.string(),
   executionId: z.string().optional(),
-  triggerData: payload,
+  // The event producer types triggerData as `unknown` (workflow-sqs.ts) and
+  // passes decoded event data through verbatim; keep this permissive so a
+  // non-object payload never fails an already-authenticated message.
+  triggerData: z.unknown(),
 });
 
 // manual and webhook share a shape but are separate literal branches so the
@@ -72,3 +76,14 @@ export const executorMessageSchema = z.discriminatedUnion("triggerType", [
   manualMessageSchema,
   webhookMessageSchema,
 ]);
+
+// Compile-time drift guard binding this schema to ExecutorMessage in ./types.ts
+// (the "Keep in sync" comment above is otherwise unenforced). If a new trigger
+// type or a new required field is added to ExecutorMessage without a matching
+// schema branch/field, every message of that shape would be dropped as
+// invalid_schema in enforce mode - so instead this stops compiling: each
+// ExecutorMessage variant must be a valid input to the schema.
+type Assert<T extends true> = T;
+type _SchemaCoversExecutorMessage = Assert<
+  ExecutorMessage extends z.input<typeof executorMessageSchema> ? true : false
+>;

--- a/keeperhub-executor/process-message-auth.test.ts
+++ b/keeperhub-executor/process-message-auth.test.ts
@@ -48,19 +48,41 @@ function unsigned(body: unknown): Message {
 }
 
 let savedMode: typeof CONFIG.sqsHmacMode;
+let savedMaxAgeEnforce: boolean;
+let savedMaxAgeSeconds: number;
 let savedSecret: string | undefined;
 
 beforeEach(() => {
   sendMock.mockReset();
   savedMode = CONFIG.sqsHmacMode;
+  savedMaxAgeEnforce = CONFIG.sqsHmacMaxAgeEnforce;
+  savedMaxAgeSeconds = CONFIG.sqsHmacMaxAgeSeconds;
   savedSecret = process.env.INTERNAL_SERVICE_HMAC_SECRET;
   process.env.INTERNAL_SERVICE_HMAC_SECRET = "test-secret";
 });
 
 afterEach(() => {
   CONFIG.sqsHmacMode = savedMode;
+  CONFIG.sqsHmacMaxAgeEnforce = savedMaxAgeEnforce;
+  CONFIG.sqsHmacMaxAgeSeconds = savedMaxAgeSeconds;
   process.env.INTERNAL_SERVICE_HMAC_SECRET = savedSecret;
 });
+
+// A validly-signed message stamped `ageSeconds` in the past.
+function signedStale(ageSeconds: number): Message {
+  const str = JSON.stringify(VALID);
+  const ts = Math.floor(Date.now() / 1000) - ageSeconds;
+  return {
+    Body: str,
+    ReceiptHandle: "rh-1",
+    MessageAttributes: signSqsMessageAttributes(
+      "scheduler",
+      CONFIG.sqsQueueUrl,
+      str,
+      ts
+    ),
+  } as Message;
+}
 
 describe("processMessage HMAC gating", () => {
   it("off mode processes an unsigned, schema-invalid message", async () => {
@@ -118,6 +140,26 @@ describe("processMessage HMAC gating", () => {
     const run = vi.fn().mockResolvedValue(undefined);
     // Signature is valid over this body, but it fails the schema.
     await processMessage(signed({ triggerType: "schedule", workflowId: "wf1" }), run);
+    expect(run).not.toHaveBeenCalled();
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("processes a stale message when max-age enforcement is off (advisory)", async () => {
+    CONFIG.sqsHmacMode = "enforce";
+    CONFIG.sqsHmacMaxAgeEnforce = false;
+    CONFIG.sqsHmacMaxAgeSeconds = 60;
+    const run = vi.fn().mockResolvedValue(undefined);
+    await processMessage(signedStale(3600), run);
+    expect(run).toHaveBeenCalledOnce();
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("enforce mode drops a stale message when max-age enforcement is on", async () => {
+    CONFIG.sqsHmacMode = "enforce";
+    CONFIG.sqsHmacMaxAgeEnforce = true;
+    CONFIG.sqsHmacMaxAgeSeconds = 60;
+    const run = vi.fn().mockResolvedValue(undefined);
+    await processMessage(signedStale(3600), run);
     expect(run).not.toHaveBeenCalled();
     expect(sendMock).toHaveBeenCalledTimes(1);
   });

--- a/keeperhub-executor/process-message-auth.test.ts
+++ b/keeperhub-executor/process-message-auth.test.ts
@@ -1,0 +1,123 @@
+import type { Message } from "@aws-sdk/client-sqs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Same lightweight harness as process-message.test.ts: capture SQS sends and
+// stub the heavy dispatch submodules so importing index.ts stays cheap.
+const { sendMock } = vi.hoisted(() => ({ sendMock: vi.fn() }));
+
+vi.mock("server-only", () => ({}));
+vi.mock("./in-process", () => ({ executeInProcess: vi.fn() }));
+vi.mock("./k8s-job", () => ({ createWorkflowJob: vi.fn() }));
+vi.mock("./api-execute", () => ({ executeViaApi: vi.fn() }));
+vi.mock("./execution-mode", () => ({ resolveDispatchTarget: vi.fn() }));
+vi.mock("./billing-guard", () => ({ checkExecutionLimitForExecutor: vi.fn() }));
+vi.mock("./feature-guard", () => ({
+  checkWorkflowFeaturesForExecutor: vi.fn(),
+}));
+vi.mock("@aws-sdk/client-sqs", () => ({
+  SQSClient: class {
+    send = sendMock;
+  },
+  DeleteMessageCommand: class {},
+  ReceiveMessageCommand: class {},
+}));
+
+import { signSqsMessageAttributes } from "../lib/sqs-message-auth";
+import { CONFIG } from "./config";
+import { processMessage } from "./index";
+
+const VALID = {
+  triggerType: "schedule",
+  workflowId: "wf1",
+  scheduleId: "s1",
+  triggerTime: "2026-01-01T00:00:00.000Z",
+};
+
+function signed(body: unknown, caller: "scheduler" | "events" | "app" = "scheduler"): Message {
+  const str = JSON.stringify(body);
+  return {
+    Body: str,
+    ReceiptHandle: "rh-1",
+    MessageAttributes: signSqsMessageAttributes(caller, str),
+  } as Message;
+}
+
+function unsigned(body: unknown): Message {
+  return { Body: JSON.stringify(body), ReceiptHandle: "rh-1" } as Message;
+}
+
+let savedMode: typeof CONFIG.sqsHmacMode;
+let savedSecret: string | undefined;
+
+beforeEach(() => {
+  sendMock.mockReset();
+  savedMode = CONFIG.sqsHmacMode;
+  savedSecret = process.env.INTERNAL_SERVICE_HMAC_SECRET;
+  process.env.INTERNAL_SERVICE_HMAC_SECRET = "test-secret";
+});
+
+afterEach(() => {
+  CONFIG.sqsHmacMode = savedMode;
+  process.env.INTERNAL_SERVICE_HMAC_SECRET = savedSecret;
+});
+
+describe("processMessage HMAC gating", () => {
+  it("off mode processes an unsigned, schema-invalid message", async () => {
+    CONFIG.sqsHmacMode = "off";
+    const run = vi.fn().mockResolvedValue(undefined);
+    await processMessage(unsigned({ workflowId: "wf1" }), run);
+    expect(run).toHaveBeenCalledOnce();
+    expect(sendMock).toHaveBeenCalledTimes(1); // delete after success
+  });
+
+  it("warn mode still processes an unsigned message", async () => {
+    CONFIG.sqsHmacMode = "warn";
+    const run = vi.fn().mockResolvedValue(undefined);
+    await processMessage(unsigned(VALID), run);
+    expect(run).toHaveBeenCalledOnce();
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("warn mode still processes a schema-invalid message", async () => {
+    CONFIG.sqsHmacMode = "warn";
+    const run = vi.fn().mockResolvedValue(undefined);
+    await processMessage(signed({ triggerType: "schedule", workflowId: "wf1" }), run);
+    expect(run).toHaveBeenCalledOnce();
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("enforce mode drops an unsigned message without running it", async () => {
+    CONFIG.sqsHmacMode = "enforce";
+    const run = vi.fn().mockResolvedValue(undefined);
+    await processMessage(unsigned(VALID), run);
+    expect(run).not.toHaveBeenCalled();
+    expect(sendMock).toHaveBeenCalledTimes(1); // the enforce drop-delete
+  });
+
+  it("enforce mode processes a validly signed message", async () => {
+    CONFIG.sqsHmacMode = "enforce";
+    const run = vi.fn().mockResolvedValue(undefined);
+    await processMessage(signed(VALID), run);
+    expect(run).toHaveBeenCalledOnce();
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("enforce mode drops a signed-but-tampered message", async () => {
+    CONFIG.sqsHmacMode = "enforce";
+    const run = vi.fn().mockResolvedValue(undefined);
+    const msg = signed(VALID);
+    msg.Body = JSON.stringify({ ...VALID, workflowId: "victim" });
+    await processMessage(msg, run);
+    expect(run).not.toHaveBeenCalled();
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("enforce mode drops a validly-signed but schema-invalid message", async () => {
+    CONFIG.sqsHmacMode = "enforce";
+    const run = vi.fn().mockResolvedValue(undefined);
+    // Signature is valid over this body, but it fails the schema.
+    await processMessage(signed({ triggerType: "schedule", workflowId: "wf1" }), run);
+    expect(run).not.toHaveBeenCalled();
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/keeperhub-executor/process-message-auth.test.ts
+++ b/keeperhub-executor/process-message-auth.test.ts
@@ -38,7 +38,8 @@ function signed(body: unknown, caller: "scheduler" | "events" | "app" = "schedul
   return {
     Body: str,
     ReceiptHandle: "rh-1",
-    MessageAttributes: signSqsMessageAttributes(caller, str),
+    // Sign against the queue the executor verifies with (CONFIG.sqsQueueUrl).
+    MessageAttributes: signSqsMessageAttributes(caller, CONFIG.sqsQueueUrl, str),
   } as Message;
 }
 

--- a/keeperhub-scheduler/block-dispatcher/sqs-enqueue.ts
+++ b/keeperhub-scheduler/block-dispatcher/sqs-enqueue.ts
@@ -30,7 +30,7 @@ export async function enqueueBlockTrigger(
           DataType: "String",
           StringValue: message.workflowId,
         },
-        ...signSqsMessageAttributes("scheduler", body),
+        ...signSqsMessageAttributes("scheduler", SQS_QUEUE_URL, body),
       },
     }),
   );

--- a/keeperhub-scheduler/block-dispatcher/sqs-enqueue.ts
+++ b/keeperhub-scheduler/block-dispatcher/sqs-enqueue.ts
@@ -6,6 +6,7 @@
 
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
 import { SQS_QUEUE_URL } from "../lib/config.js";
+import { signSqsMessageAttributes } from "../lib/sqs-message-auth.js";
 import { sqs } from "../lib/sqs-client.js";
 import type { BlockMessage } from "../lib/types.js";
 
@@ -15,10 +16,11 @@ export async function enqueueBlockTrigger(
   console.log(
     `[SQS] Enqueuing block trigger: workflow=${message.workflowId}, block=${message.triggerData.blockNumber}`,
   );
+  const body = JSON.stringify(message);
   await sqs.send(
     new SendMessageCommand({
       QueueUrl: SQS_QUEUE_URL,
-      MessageBody: JSON.stringify(message),
+      MessageBody: body,
       MessageAttributes: {
         TriggerType: {
           DataType: "String",
@@ -28,6 +30,7 @@ export async function enqueueBlockTrigger(
           DataType: "String",
           StringValue: message.workflowId,
         },
+        ...signSqsMessageAttributes("scheduler", body),
       },
     }),
   );

--- a/keeperhub-scheduler/block-dispatcher/sqs-enqueue.ts
+++ b/keeperhub-scheduler/block-dispatcher/sqs-enqueue.ts
@@ -6,8 +6,8 @@
 
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
 import { SQS_QUEUE_URL } from "../lib/config.js";
-import { signSqsMessageAttributes } from "../lib/sqs-message-auth.js";
 import { sqs } from "../lib/sqs-client.js";
+import { signSqsMessageAttributes } from "../lib/sqs-message-auth.js";
 import type { BlockMessage } from "../lib/types.js";
 
 export async function enqueueBlockTrigger(

--- a/keeperhub-scheduler/lib/sqs-message-auth.ts
+++ b/keeperhub-scheduler/lib/sqs-message-auth.ts
@@ -37,7 +37,14 @@ export function signSqsMessageAttributes(
   body: string,
   nowSeconds: number = Math.floor(Date.now() / 1000),
 ): Record<string, MessageAttributeValue> {
-  const secret = process.env.INTERNAL_SERVICE_HMAC_SECRET ?? "";
+  const secret = process.env.INTERNAL_SERVICE_HMAC_SECRET;
+  // Fail loud rather than sign with "" (see lib/sqs-message-auth.ts): a
+  // ""-signed message is dropped by the verifier in enforce mode.
+  if (!secret) {
+    throw new Error(
+      "INTERNAL_SERVICE_HMAC_SECRET is not set; refusing to enqueue an unsigned SQS message",
+    );
+  }
   const timestamp = String(nowSeconds);
   const signature = computeSqsSignature(secret, queueUrl, caller, body, timestamp);
   return {

--- a/keeperhub-scheduler/lib/sqs-message-auth.ts
+++ b/keeperhub-scheduler/lib/sqs-message-auth.ts
@@ -21,23 +21,25 @@ export const SQS_CALLER_ATTR = "X-KH-Caller";
 
 function computeSqsSignature(
   secret: string,
+  queueUrl: string,
   caller: string,
   body: string,
   timestamp: string,
 ): string {
   const bodyDigest = createHash("sha256").update(body).digest("hex");
-  const signingString = `sqs\n${caller}\n${bodyDigest}\n${timestamp}`;
+  const signingString = `sqs\n${queueUrl}\n${caller}\n${bodyDigest}\n${timestamp}`;
   return createHmac("sha256", secret).update(signingString).digest("hex");
 }
 
 export function signSqsMessageAttributes(
   caller: SqsHmacCaller,
+  queueUrl: string,
   body: string,
   nowSeconds: number = Math.floor(Date.now() / 1000),
 ): Record<string, MessageAttributeValue> {
   const secret = process.env.INTERNAL_SERVICE_HMAC_SECRET ?? "";
   const timestamp = String(nowSeconds);
-  const signature = computeSqsSignature(secret, caller, body, timestamp);
+  const signature = computeSqsSignature(secret, queueUrl, caller, body, timestamp);
   return {
     [SQS_CALLER_ATTR]: { DataType: "String", StringValue: caller },
     [SQS_TIMESTAMP_ATTR]: { DataType: "String", StringValue: timestamp },

--- a/keeperhub-scheduler/lib/sqs-message-auth.ts
+++ b/keeperhub-scheduler/lib/sqs-message-auth.ts
@@ -46,7 +46,13 @@ export function signSqsMessageAttributes(
     );
   }
   const timestamp = String(nowSeconds);
-  const signature = computeSqsSignature(secret, queueUrl, caller, body, timestamp);
+  const signature = computeSqsSignature(
+    secret,
+    queueUrl,
+    caller,
+    body,
+    timestamp,
+  );
   return {
     [SQS_CALLER_ATTR]: { DataType: "String", StringValue: caller },
     [SQS_TIMESTAMP_ATTR]: { DataType: "String", StringValue: timestamp },

--- a/keeperhub-scheduler/lib/sqs-message-auth.ts
+++ b/keeperhub-scheduler/lib/sqs-message-auth.ts
@@ -1,0 +1,46 @@
+import { createHash, createHmac } from "node:crypto";
+import type { MessageAttributeValue } from "@aws-sdk/client-sqs";
+
+/**
+ * SQS message signing for the scheduler (block + schedule dispatchers).
+ *
+ * SIGN-ONLY copy of the shared scheme in the app's lib/sqs-message-auth.ts. The
+ * scheduler is an isolated package that cannot import root lib/, so the signing
+ * logic is duplicated here (same convention as this package's log-facade.ts and
+ * http-client.ts signHmacHeaders). The executor holds the verify half.
+ *
+ * Keep the signing string, attribute names, and caller set identical to
+ * lib/sqs-message-auth.ts - the shared anti-drift test vector guards this.
+ */
+
+export type SqsHmacCaller = "scheduler" | "events" | "app";
+
+export const SQS_SIGNATURE_ATTR = "X-KH-Signature";
+export const SQS_TIMESTAMP_ATTR = "X-KH-Timestamp";
+export const SQS_CALLER_ATTR = "X-KH-Caller";
+
+function computeSqsSignature(
+  secret: string,
+  caller: string,
+  body: string,
+  timestamp: string,
+): string {
+  const bodyDigest = createHash("sha256").update(body).digest("hex");
+  const signingString = `sqs\n${caller}\n${bodyDigest}\n${timestamp}`;
+  return createHmac("sha256", secret).update(signingString).digest("hex");
+}
+
+export function signSqsMessageAttributes(
+  caller: SqsHmacCaller,
+  body: string,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): Record<string, MessageAttributeValue> {
+  const secret = process.env.INTERNAL_SERVICE_HMAC_SECRET ?? "";
+  const timestamp = String(nowSeconds);
+  const signature = computeSqsSignature(secret, caller, body, timestamp);
+  return {
+    [SQS_CALLER_ATTR]: { DataType: "String", StringValue: caller },
+    [SQS_TIMESTAMP_ATTR]: { DataType: "String", StringValue: timestamp },
+    [SQS_SIGNATURE_ATTR]: { DataType: "String", StringValue: signature },
+  };
+}

--- a/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
@@ -256,7 +256,7 @@ export async function sendToQueue(message: ScheduleMessage): Promise<void> {
         DataType: "String",
         StringValue: message.workflowId,
       },
-      ...signSqsMessageAttributes("scheduler", body),
+      ...signSqsMessageAttributes("scheduler", SQS_QUEUE_URL, body),
     },
   });
 

--- a/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
@@ -20,6 +20,7 @@ import {
   failPhantomExecution,
 } from "../lib/phantom.js";
 import { sqs } from "../lib/sqs-client.js";
+import { signSqsMessageAttributes } from "../lib/sqs-message-auth.js";
 import type { Schedule, ScheduleMessage } from "../lib/types.js";
 import {
   errorsTotal,
@@ -242,9 +243,10 @@ function describeSchedule(schedule: Schedule): string {
 }
 
 export async function sendToQueue(message: ScheduleMessage): Promise<void> {
+  const body = JSON.stringify(message);
   const command = new SendMessageCommand({
     QueueUrl: SQS_QUEUE_URL,
-    MessageBody: JSON.stringify(message),
+    MessageBody: body,
     MessageAttributes: {
       TriggerType: {
         DataType: "String",
@@ -254,6 +256,7 @@ export async function sendToQueue(message: ScheduleMessage): Promise<void> {
         DataType: "String",
         StringValue: message.workflowId,
       },
+      ...signSqsMessageAttributes("scheduler", body),
     },
   });
 

--- a/keeperhub-scheduler/tests/unit/sqs-message-auth.test.ts
+++ b/keeperhub-scheduler/tests/unit/sqs-message-auth.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  SQS_SIGNATURE_ATTR,
+  signSqsMessageAttributes,
+} from "../../lib/sqs-message-auth.js";
+
+// Shared anti-drift vector. These exact inputs must produce this exact
+// signature here, in the app's lib/sqs-message-auth.ts, and in the
+// event-tracker copy. A mismatch means a copy drifted from the scheme and the
+// executor would reject this producer's messages.
+const FIXED_SECRET = "test-shared-secret";
+const FIXED_BODY = JSON.stringify({
+  workflowId: "wf_1",
+  scheduleId: "sch_1",
+  triggerTime: "2026-01-01T00:00:00.000Z",
+  triggerType: "schedule",
+});
+const FIXED_TS = 1_700_000_000;
+const FIXED_SIG =
+  "f508ed8e583f7d2f61341526a735cefe45a4aa83d0befcb761ad5953fc48fca2";
+
+let savedSecret: string | undefined;
+
+beforeEach(() => {
+  savedSecret = process.env.INTERNAL_SERVICE_HMAC_SECRET;
+  process.env.INTERNAL_SERVICE_HMAC_SECRET = FIXED_SECRET;
+});
+
+afterEach(() => {
+  process.env.INTERNAL_SERVICE_HMAC_SECRET = savedSecret;
+});
+
+describe("scheduler sqs-message-auth", () => {
+  it("matches the shared anti-drift signature vector", () => {
+    const attrs = signSqsMessageAttributes("scheduler", FIXED_BODY, FIXED_TS);
+    expect(attrs[SQS_SIGNATURE_ATTR].StringValue).toBe(FIXED_SIG);
+  });
+});

--- a/keeperhub-scheduler/tests/unit/sqs-message-auth.test.ts
+++ b/keeperhub-scheduler/tests/unit/sqs-message-auth.test.ts
@@ -9,6 +9,8 @@ import {
 // event-tracker copy. A mismatch means a copy drifted from the scheme and the
 // executor would reject this producer's messages.
 const FIXED_SECRET = "test-shared-secret";
+const FIXED_QUEUE_URL =
+  "https://sqs.us-east-1.amazonaws.com/123456789012/keeperhub-workflow-queue-test";
 const FIXED_BODY = JSON.stringify({
   workflowId: "wf_1",
   scheduleId: "sch_1",
@@ -17,7 +19,7 @@ const FIXED_BODY = JSON.stringify({
 });
 const FIXED_TS = 1_700_000_000;
 const FIXED_SIG =
-  "f508ed8e583f7d2f61341526a735cefe45a4aa83d0befcb761ad5953fc48fca2";
+  "52a1fbfe8524879f745928cde4565fb86bbe4e00c75f3ad9f4935e633c7e7328";
 
 let savedSecret: string | undefined;
 
@@ -32,7 +34,12 @@ afterEach(() => {
 
 describe("scheduler sqs-message-auth", () => {
   it("matches the shared anti-drift signature vector", () => {
-    const attrs = signSqsMessageAttributes("scheduler", FIXED_BODY, FIXED_TS);
+    const attrs = signSqsMessageAttributes(
+      "scheduler",
+      FIXED_QUEUE_URL,
+      FIXED_BODY,
+      FIXED_TS,
+    );
     expect(attrs[SQS_SIGNATURE_ATTR].StringValue).toBe(FIXED_SIG);
   });
 });

--- a/keeperhub-scheduler/vitest.config.ts
+++ b/keeperhub-scheduler/vitest.config.ts
@@ -7,5 +7,8 @@ export default defineConfig({
     include: ["tests/**/*.test.ts"],
     exclude: ["node_modules", "dist"],
     testTimeout: 10_000,
+    // Producers now require a signing secret (SQS message HMAC); provide a test
+    // value so enqueue paths exercise real signing instead of throwing.
+    env: { INTERNAL_SERVICE_HMAC_SECRET: "test-hmac-secret" },
   },
 });

--- a/lib/metrics/types.ts
+++ b/lib/metrics/types.ts
@@ -187,6 +187,12 @@ export const MetricNames = {
   // often the policy-bypass window opens before deciding whether to
   // hard-fail the resolver vs keep the current silent-downgrade behavior.
   SIGNER_PROBE_FAILURE: "signer_probe.failure.total",
+
+  // SQS trigger-message authentication. One counter labelled by
+  // auth_result (valid | unsigned | unknown_caller | bad_signature |
+  // invalid_schema | stale) and mode (warn | enforce). Drives the rollout gate:
+  // flip the executor to enforce only once unsigned/invalid series hit zero.
+  SQS_MESSAGE_AUTH: "sqs.message.auth.total",
 } as const;
 
 /**
@@ -216,6 +222,8 @@ export const LabelKeys = {
   ERROR_CONTEXT: "error_context",
   BILLING_STATUS: "billing_status",
   TIER: "tier",
+  AUTH_RESULT: "auth_result",
+  MODE: "mode",
 } as const;
 
 /**

--- a/lib/sqs-message-auth.ts
+++ b/lib/sqs-message-auth.ts
@@ -78,7 +78,13 @@ export function signSqsMessageAttributes(
     );
   }
   const timestamp = String(nowSeconds);
-  const signature = computeSqsSignature(secret, queueUrl, caller, body, timestamp);
+  const signature = computeSqsSignature(
+    secret,
+    queueUrl,
+    caller,
+    body,
+    timestamp
+  );
   return {
     [SQS_CALLER_ATTR]: { DataType: "String", StringValue: caller },
     [SQS_TIMESTAMP_ATTR]: { DataType: "String", StringValue: timestamp },

--- a/lib/sqs-message-auth.ts
+++ b/lib/sqs-message-auth.ts
@@ -11,9 +11,12 @@ import type { MessageAttributeValue } from "@aws-sdk/client-sqs";
  *
  * Scheme mirrors the HTTP signer (lib/internal-service-auth.ts computeSignature)
  * minus the HTTP method/path, with a fixed "sqs" domain-separation prefix so an
- * HTTP signature can never be replayed as an SQS one and vice versa:
+ * HTTP signature can never be replayed as an SQS one, and the destination queue
+ * URL bound in so a signature minted for one environment's queue (staging and
+ * every pr-N share the same INTERNAL_SERVICE_HMAC_SECRET) can never be replayed
+ * into another's:
  *
- *   signingString = "sqs\n<caller>\n<sha256hex(body)>\n<unixSeconds>"
+ *   signingString = "sqs\n<queueUrl>\n<caller>\n<sha256hex(body)>\n<unixSeconds>"
  *   signature     = hex(hmac_sha256(secret, signingString))
  *
  * The proof travels as SQS MessageAttributes (X-KH-Caller / X-KH-Timestamp /
@@ -39,28 +42,30 @@ const SIGNATURE_HEX_LENGTH = 64; // sha256 hex
 
 function computeSqsSignature(
   secret: string,
+  queueUrl: string,
   caller: string,
   body: string,
   timestamp: string
 ): string {
   const bodyDigest = createHash("sha256").update(body).digest("hex");
-  const signingString = `sqs\n${caller}\n${bodyDigest}\n${timestamp}`;
+  const signingString = `sqs\n${queueUrl}\n${caller}\n${bodyDigest}\n${timestamp}`;
   return createHmac("sha256", secret).update(signingString).digest("hex");
 }
 
 /**
  * Build the signed SQS MessageAttributes for `body`. Merge the result into the
  * producer's existing attributes (TriggerType / WorkflowId). Sign the exact
- * string passed as MessageBody.
+ * string passed as MessageBody, bound to the destination `queueUrl`.
  */
 export function signSqsMessageAttributes(
   caller: SqsHmacCaller,
+  queueUrl: string,
   body: string,
   nowSeconds: number = Math.floor(Date.now() / 1000)
 ): Record<string, MessageAttributeValue> {
   const secret = process.env.INTERNAL_SERVICE_HMAC_SECRET ?? "";
   const timestamp = String(nowSeconds);
-  const signature = computeSqsSignature(secret, caller, body, timestamp);
+  const signature = computeSqsSignature(secret, queueUrl, caller, body, timestamp);
   return {
     [SQS_CALLER_ATTR]: { DataType: "String", StringValue: caller },
     [SQS_TIMESTAMP_ATTR]: { DataType: "String", StringValue: timestamp },
@@ -92,6 +97,7 @@ function activeSecrets(): string[] {
  * triggers during an executor outage).
  */
 export function verifySqsMessageSignature(
+  queueUrl: string,
   body: string,
   attributes: Record<string, MessageAttributeValue> | undefined
 ): SqsVerifyResult {
@@ -113,7 +119,13 @@ export function verifySqsMessageSignature(
 
   const providedBuf = Buffer.from(signature, "hex");
   for (const secret of activeSecrets()) {
-    const expected = computeSqsSignature(secret, caller, body, timestamp);
+    const expected = computeSqsSignature(
+      secret,
+      queueUrl,
+      caller,
+      body,
+      timestamp
+    );
     const expectedBuf = Buffer.from(expected, "hex");
     if (
       providedBuf.length === expectedBuf.length &&

--- a/lib/sqs-message-auth.ts
+++ b/lib/sqs-message-auth.ts
@@ -1,0 +1,130 @@
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+import type { MessageAttributeValue } from "@aws-sdk/client-sqs";
+
+/**
+ * HMAC signing and verification for SQS workflow-trigger messages.
+ *
+ * The executor consumes fund-moving trigger messages off SQS. The HTTP path to
+ * the same executor is HMAC-protected (lib/internal-service-auth.ts); this
+ * brings the SQS path to parity so a principal that can only sqs:SendMessage
+ * cannot forge a trigger for an arbitrary workflow.
+ *
+ * Scheme mirrors the HTTP signer (lib/internal-service-auth.ts computeSignature)
+ * minus the HTTP method/path, with a fixed "sqs" domain-separation prefix so an
+ * HTTP signature can never be replayed as an SQS one and vice versa:
+ *
+ *   signingString = "sqs\n<caller>\n<sha256hex(body)>\n<unixSeconds>"
+ *   signature     = hex(hmac_sha256(secret, signingString))
+ *
+ * The proof travels as SQS MessageAttributes (X-KH-Caller / X-KH-Timestamp /
+ * X-KH-Signature), leaving the message body byte-for-byte unchanged.
+ *
+ * NOTE: the scheduler and event-tracker are isolated packages that cannot import
+ * root lib/, so the SIGN half of this module is copied verbatim into
+ * keeperhub-scheduler/lib/sqs-message-auth.ts and
+ * keeperhub-events/event-tracker/lib/sqs-message-auth.ts (same pattern as the
+ * per-service signHmacHeaders / log-facade copies). Keep the signing string,
+ * attribute names, and caller set in sync across all three files - the shared
+ * anti-drift test vector guards this.
+ */
+
+export const SQS_HMAC_CALLERS = ["scheduler", "events", "app"] as const;
+export type SqsHmacCaller = (typeof SQS_HMAC_CALLERS)[number];
+
+export const SQS_SIGNATURE_ATTR = "X-KH-Signature";
+export const SQS_TIMESTAMP_ATTR = "X-KH-Timestamp";
+export const SQS_CALLER_ATTR = "X-KH-Caller";
+
+const SIGNATURE_HEX_LENGTH = 64; // sha256 hex
+
+function computeSqsSignature(
+  secret: string,
+  caller: string,
+  body: string,
+  timestamp: string
+): string {
+  const bodyDigest = createHash("sha256").update(body).digest("hex");
+  const signingString = `sqs\n${caller}\n${bodyDigest}\n${timestamp}`;
+  return createHmac("sha256", secret).update(signingString).digest("hex");
+}
+
+/**
+ * Build the signed SQS MessageAttributes for `body`. Merge the result into the
+ * producer's existing attributes (TriggerType / WorkflowId). Sign the exact
+ * string passed as MessageBody.
+ */
+export function signSqsMessageAttributes(
+  caller: SqsHmacCaller,
+  body: string,
+  nowSeconds: number = Math.floor(Date.now() / 1000)
+): Record<string, MessageAttributeValue> {
+  const secret = process.env.INTERNAL_SERVICE_HMAC_SECRET ?? "";
+  const timestamp = String(nowSeconds);
+  const signature = computeSqsSignature(secret, caller, body, timestamp);
+  return {
+    [SQS_CALLER_ATTR]: { DataType: "String", StringValue: caller },
+    [SQS_TIMESTAMP_ATTR]: { DataType: "String", StringValue: timestamp },
+    [SQS_SIGNATURE_ATTR]: { DataType: "String", StringValue: signature },
+  };
+}
+
+export type SqsVerifyResult =
+  | { ok: true; caller: SqsHmacCaller; ageSeconds: number }
+  | { ok: false; reason: "unsigned" | "unknown_caller" | "bad_signature" };
+
+/**
+ * Current signing secret plus an optional previous secret, so a secret rotation
+ * can flip producers and the executor independently without dropping in-flight
+ * messages during the changeover. Empty secrets are ignored.
+ */
+function activeSecrets(): string[] {
+  return [
+    process.env.INTERNAL_SERVICE_HMAC_SECRET,
+    process.env.INTERNAL_SERVICE_HMAC_SECRET_PREVIOUS,
+  ].filter((secret): secret is string => Boolean(secret));
+}
+
+/**
+ * Verify an SQS message's signature against `body` (the raw MessageBody string).
+ * Freshness is NOT enforced here - the age since signing is returned so the
+ * caller can treat it as advisory (a legitimately-signed message can sit in the
+ * queue for a long time during a backlog, so dropping on age would lose real
+ * triggers during an executor outage).
+ */
+export function verifySqsMessageSignature(
+  body: string,
+  attributes: Record<string, MessageAttributeValue> | undefined
+): SqsVerifyResult {
+  const caller = attributes?.[SQS_CALLER_ATTR]?.StringValue;
+  const timestamp = attributes?.[SQS_TIMESTAMP_ATTR]?.StringValue;
+  const signature = attributes?.[SQS_SIGNATURE_ATTR]?.StringValue;
+
+  if (!(caller && timestamp && signature)) {
+    return { ok: false, reason: "unsigned" };
+  }
+  if (!SQS_HMAC_CALLERS.includes(caller as SqsHmacCaller)) {
+    return { ok: false, reason: "unknown_caller" };
+  }
+  // A sha256-hex signature is always 64 chars; anything else is malformed and
+  // would throw in Buffer length handling below. Length is not secret.
+  if (signature.length !== SIGNATURE_HEX_LENGTH) {
+    return { ok: false, reason: "bad_signature" };
+  }
+
+  const providedBuf = Buffer.from(signature, "hex");
+  for (const secret of activeSecrets()) {
+    const expected = computeSqsSignature(secret, caller, body, timestamp);
+    const expectedBuf = Buffer.from(expected, "hex");
+    if (
+      providedBuf.length === expectedBuf.length &&
+      timingSafeEqual(providedBuf, expectedBuf)
+    ) {
+      const ts = Number.parseInt(timestamp, 10);
+      const ageSeconds = Number.isFinite(ts)
+        ? Math.floor(Date.now() / 1000) - ts
+        : 0;
+      return { ok: true, caller: caller as SqsHmacCaller, ageSeconds };
+    }
+  }
+  return { ok: false, reason: "bad_signature" };
+}

--- a/lib/sqs-message-auth.ts
+++ b/lib/sqs-message-auth.ts
@@ -63,7 +63,16 @@ export function signSqsMessageAttributes(
   body: string,
   nowSeconds: number = Math.floor(Date.now() / 1000)
 ): Record<string, MessageAttributeValue> {
-  const secret = process.env.INTERNAL_SERVICE_HMAC_SECRET ?? "";
+  const secret = process.env.INTERNAL_SERVICE_HMAC_SECRET;
+  // Fail loud rather than sign with "". The verifier ignores the empty secret,
+  // so a silently ""-signed message would be dropped in enforce mode with only
+  // a warn log - a hard-to-diagnose partial outage. Throwing surfaces the
+  // misconfiguration at the producer, which resolves the phantom row to an error.
+  if (!secret) {
+    throw new Error(
+      "INTERNAL_SERVICE_HMAC_SECRET is not set; refusing to enqueue an unsigned SQS message"
+    );
+  }
   const timestamp = String(nowSeconds);
   const signature = computeSqsSignature(secret, queueUrl, caller, body, timestamp);
   return {

--- a/lib/sqs-message-auth.ts
+++ b/lib/sqs-message-auth.ts
@@ -34,6 +34,10 @@ import type { MessageAttributeValue } from "@aws-sdk/client-sqs";
 export const SQS_HMAC_CALLERS = ["scheduler", "events", "app"] as const;
 export type SqsHmacCaller = (typeof SQS_HMAC_CALLERS)[number];
 
+// Only these attributes plus the MessageBody are covered by the signature. Any
+// other MessageAttribute a producer attaches (TriggerType, WorkflowId) is an
+// unauthenticated routing hint: consumers MUST derive security-relevant fields
+// (workflowId, triggerType, userId) from the signed body, never from attributes.
 export const SQS_SIGNATURE_ATTR = "X-KH-Signature";
 export const SQS_TIMESTAMP_ATTR = "X-KH-Timestamp";
 export const SQS_CALLER_ATTR = "X-KH-Caller";
@@ -90,6 +94,13 @@ export type SqsVerifyResult =
  * Current signing secret plus an optional previous secret, so a secret rotation
  * can flip producers and the executor independently without dropping in-flight
  * messages during the changeover. Empty secrets are ignored.
+ *
+ * OPERATOR NOTE: this SQS path uses env vars, NOT the DB-backed rotating store
+ * (internal_service_hmac_secrets) that the HTTP verifier in
+ * lib/internal-service-auth.ts reads. So when rotating the shared secret, set
+ * the executor's INTERNAL_SERVICE_HMAC_SECRET_PREVIOUS to the outgoing secret
+ * for the grace window; otherwise, in enforce mode, messages still signed by
+ * not-yet-rotated producers are dropped.
  */
 function activeSecrets(): string[] {
   return [

--- a/lib/workflow/execute-in-background.ts
+++ b/lib/workflow/execute-in-background.ts
@@ -86,7 +86,11 @@ export async function executeWorkflowInBackground(
         new SendMessageCommand({
           QueueUrl: queueUrl,
           MessageBody: body,
-          MessageAttributes: signSqsMessageAttributes("app", queueUrl ?? "", body),
+          MessageAttributes: signSqsMessageAttributes(
+            "app",
+            queueUrl ?? "",
+            body
+          ),
         })
       );
       console.log(

--- a/lib/workflow/execute-in-background.ts
+++ b/lib/workflow/execute-in-background.ts
@@ -81,11 +81,12 @@ export async function executeWorkflowInBackground(
         triggerType,
         input,
       });
+      const queueUrl = process.env.SQS_QUEUE_URL;
       await getSqsClient().send(
         new SendMessageCommand({
-          QueueUrl: process.env.SQS_QUEUE_URL,
+          QueueUrl: queueUrl,
           MessageBody: body,
-          MessageAttributes: signSqsMessageAttributes("app", body),
+          MessageAttributes: signSqsMessageAttributes("app", queueUrl ?? "", body),
         })
       );
       console.log(

--- a/lib/workflow/execute-in-background.ts
+++ b/lib/workflow/execute-in-background.ts
@@ -10,6 +10,7 @@ import {
 import { statusForErrorType } from "@/lib/errors/execution-status";
 import { recordExecutionErrorFinalized } from "@/lib/errors/finalize-error";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { signSqsMessageAttributes } from "@/lib/sqs-message-auth";
 import { executeWorkflow } from "@/lib/workflow/executor/executor.workflow";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 
@@ -72,17 +73,19 @@ export async function executeWorkflowInBackground(
     // The executor transitions the row from 'pending' -> 'running' -> terminal
     // directly, so we do not pre-lift the status here.
     if (process.env.WORKFLOW_DISPATCH_VIA_EXECUTOR === "1") {
+      const body = JSON.stringify({
+        executionId,
+        workflowId,
+        userId: createdBy ?? "",
+        organizationId: organizationId ?? undefined,
+        triggerType,
+        input,
+      });
       await getSqsClient().send(
         new SendMessageCommand({
           QueueUrl: process.env.SQS_QUEUE_URL,
-          MessageBody: JSON.stringify({
-            executionId,
-            workflowId,
-            userId: createdBy ?? "",
-            organizationId: organizationId ?? undefined,
-            triggerType,
-            input,
-          }),
+          MessageBody: body,
+          MessageAttributes: signSqsMessageAttributes("app", body),
         })
       );
       console.log(


### PR DESCRIPTION
## Summary

The async trigger pipeline drives fund-moving workflow executions off SQS messages carrying `workflowId` / `userId` / `executionId` / `triggerData` as plaintext JSON with no signature, schema validation, or replay protection - the only control is queue IAM. The HTTP internal API to the same executor is HMAC-protected, so SQS was an unauthenticated parallel channel: any principal that can `sqs:SendMessage` could make the executor load and run an arbitrary user's workflow under the owner's signing keys.

This brings the SQS trust boundary to parity with the HTTP one: producers sign, the executor verifies + validates before anything runs.

## Changes

- **`lib/sqs-message-auth.ts`** - canonical HMAC signer/verifier. Signs `sqs\n<queueUrl>\n<caller>\n<sha256(body)>\n<ts>` (domain-separated from the HTTP HMAC and bound to the destination queue), carried in `X-KH-Caller` / `X-KH-Timestamp` / `X-KH-Signature` SQS MessageAttributes so the body is byte-unchanged. Constant-time compare; accepts `INTERNAL_SERVICE_HMAC_SECRET` plus optional `INTERNAL_SERVICE_HMAC_SECRET_PREVIOUS` for rotation; throws rather than signing with an empty secret.
- **Sign-only copies** in `keeperhub-scheduler/lib/` and `keeperhub-events/event-tracker/lib/` (those packages cannot import root `lib/`, matching the existing per-service `signHmacHeaders` convention), guarded by a shared fixed-vector anti-drift test in all three packages.
- **All four producers sign**: block dispatcher, schedule dispatcher, event tracker, and the in-app manual/webhook path.
- **Executor gate** (`processMessage`): signature verification + zod schema validation (`keeperhub-executor/message-schema.ts`, a discriminated union bound to `types.ts` by a compile-time guard), gated by `SQS_HMAC_MODE` (`off` | `warn` | `enforce`, default `warn`), emitting one `sqs.message.auth.total` result per message.

## Replay & rollout

- **Cross-environment replay is closed** by binding the destination queue URL into the signature: staging and every pr-N share one `INTERNAL_SERVICE_HMAC_SECRET`, but their queue URLs differ, so a signature minted for one environment's queue no longer verifies against another's.
- **Same-environment replay**: freshness is advisory by default (a queue backlog legitimately holds old messages, so age never drops a trigger). `SQS_HMAC_MAX_AGE_ENFORCE=true` promotes over-age messages to a hard drop in enforce mode, bounding replay to the freshness window when operators are ready.
- **Known limitation (follow-up):** signing prevents forgery, but replay is not yet idempotent - a replayed schedule/block/event message whose phantom row was already consumed falls through to a fresh execution insert and re-runs. Hardening that at-least-once path is tracked as a separate ticket.
- **Rollout**: ship producers signing first; run executor in `warn` until the auth metric shows all traffic signed and the queue has drained; then set `SQS_HMAC_MODE=enforce` (env change + pod restart, no code deploy). Secret rotation must also set the executor's `INTERNAL_SERVICE_HMAC_SECRET_PREVIOUS` for the grace window (the SQS path uses env secrets, not the DB-backed store the HTTP verifier reads).
- **Out of scope (follow-up):** queue IAM currently uses one shared ServiceAccount for all producers and the executor with no queue resource policy; per-producer send-scoping needs a role split first.

## Test Plan

- [x] Executor suite: 9 files / 84 tests, incl. sign/verify, cross-queue rejection, empty-secret throw, off/warn/enforce matrix, and stale advisory-vs-enforced.
- [x] Anti-drift signature vector asserted identically in the executor, scheduler, and event-tracker packages.
- [x] `type-check` clean (incl. the schema<->types compile-time guard); lint clean.
- [ ] Verify on staging in `warn` mode (auth metric all-signed) before flipping to `enforce`.