### PR TITLE
ci: forward SAFE_FETCH_SHADOW to the app container on the Docker path

### DIFF
--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -124,6 +124,7 @@ runs:
         TURNKEY_ORGANIZATION_ID: ${{ inputs.turnkey_organization_id }}
         ALLOW_TEST_ENDPOINTS: ${{ inputs.allow_test_endpoints }}
         LOAD_TEST_BYPASS_TOKEN: ${{ inputs.load_test_bypass_token }}
+        SAFE_FETCH_SHADOW: ${{ inputs.safe_fetch_shadow }}
         SANDBOX_BACKEND: ${{ inputs.sandbox_backend }}
         SANDBOX_URL: ${{ inputs.sandbox_url }}
       run: |
@@ -164,7 +165,11 @@ runs:
         # opt-in for testEndpointsEnabled, gating the admin OTP endpoint +
         # rate-limit bypass) and LOAD_TEST_BYPASS_TOKEN (MFA-enrollment bypass,
         # verified in proxy.ts) are required for the Playwright auth setup -
-        # the bare-metal path already sets them.
+        # the bare-metal path already sets them. SAFE_FETCH_SHADOW puts the
+        # app's safeFetch into shadow mode so the protocol-coverage setup
+        # workflows can reach the localhost anvil fork (chain 11155111 -> :8547);
+        # it takes effect under NODE_ENV=production because the container is
+        # CI-exempt (CI=true). Empty in other jobs keeps SSRF fully enforced.
         docker run -d --name keeperhub-app --network host \
           --env-file /tmp/keeperhub-app.env \
           -e "CHAIN_RPC_CONFIG=${CHAIN_RPC_CONFIG}" \
@@ -174,6 +179,7 @@ runs:
           -e "TURNKEY_ORGANIZATION_ID=${TURNKEY_ORGANIZATION_ID}" \
           -e "ALLOW_TEST_ENDPOINTS=${ALLOW_TEST_ENDPOINTS}" \
           -e "LOAD_TEST_BYPASS_TOKEN=${LOAD_TEST_BYPASS_TOKEN}" \
+          -e "SAFE_FETCH_SHADOW=${SAFE_FETCH_SHADOW}" \
           "${IMAGE}"
 
         for i in $(seq 1 30); do


### PR DESCRIPTION
## Problem

The `e2e-vitest-ephemeral` job fails on staging pushes at the protocol-coverage step:

```
setup workflow failed for superfluid/11155111: error - RPC failed on primary endpoint:
Outbound request to localhost blocked by SSRF policy (blocked-host).
```

The superfluid protocol-coverage suite runs against a local anvil Sepolia fork: CI repoints chain `11155111`'s primary RPC to `http://localhost:8547`. The setup workflow's `web3/approve-token` step runs inside the app container and its RPC call routes through `lib/rpc/safe-ethers-fetch.ts` -> `safeFetch`, which blocks `localhost` unless shadow mode is active.

`isShadowMode()` requires `SAFE_FETCH_SHADOW=true` (and, under `NODE_ENV=production`, the container to be CI-exempt via `CI=true`). The app container had `CI=true` but not `SAFE_FETCH_SHADOW`.

## Root cause

`.github/actions/start-app/action.yml` forwards `SAFE_FETCH_SHADOW` on the bare-metal path but not the Docker path. PRs use the bare-metal path (no `image_tag`) and pass; only staging pushes get an ECR `image_tag`, take the Docker path, and fail. The gap was latent until the fork-backed suite landed.

## Fix

Forward `SAFE_FETCH_SHADOW` to the container on the Docker path, mirroring the existing `ALLOW_TEST_ENDPOINTS` pattern (env block + `-e` flag).

## Safety

- Only the `e2e-vitest-ephemeral` job passes `safe_fetch_shadow: "true"`; other jobs leave it empty, keeping SSRF fully enforced.
- No effect on real production, which never sets `CI=true` and so is never shadow-exempt.
- YAML-only change; validated by inspection against the proven bare-metal path (the Docker path cannot be reproduced locally without the ECR image + CI infra). The real confirmation is the next staging-push CI run.