### PR TITLE
fix(web3): querying different RPCs returns different head blocks

### DIFF
--- a/plugins/web3/steps/query-events-core.ts
+++ b/plugins/web3/steps/query-events-core.ts
@@ -4,6 +4,17 @@ import { getErrorMessage } from "@/lib/utils";
 
 export type AbiEntry = { type: string; name: string };
 
+export type BatchQueryResult = {
+  events: (ethers.Log | ethers.EventLog)[];
+  // The block actually scanned up to. Equal to the requested `end` for a
+  // non-tip batch. For the tip batch it is the head observed by the
+  // parallel getBlockNumber() call in fetchTipBatch, which is purely
+  // informational and can differ from what was originally planned -- the
+  // caller's reported `toBlock` must use this, not the originally requested
+  // `end`, or it will misstate what was actually queried.
+  actualEnd: number;
+};
+
 // A single batch can transiently time out on both RPC endpoints during a long
 // scan (e.g. 30-60 day event ranges). Rather than failing the whole node (and
 // having the durable engine replay the entire multi-minute scan), retry the
@@ -17,33 +28,95 @@ function delay(ms: number): Promise<void> {
   });
 }
 
+function resolveEventFilter(
+  contract: ethers.Contract,
+  eventName: string
+): ethers.DeferredTopicFilter {
+  const eventFilter = contract.filters[eventName]?.();
+  if (eventFilter === undefined || eventFilter === null) {
+    throw new Error(`Could not create filter for event '${eventName}'`);
+  }
+  return eventFilter;
+}
+
+async function fetchFixedBatch(
+  provider: ethers.JsonRpcProvider,
+  contractAddress: string,
+  parsedAbi: AbiEntry[],
+  eventName: string,
+  start: number,
+  end: number
+): Promise<BatchQueryResult> {
+  const contract = new ethers.Contract(contractAddress, parsedAbi, provider);
+  const eventFilter = resolveEventFilter(contract, eventName);
+  const events = await contract.queryFilter(eventFilter, start, end);
+  return { events, actualEnd: end };
+}
+
+// The tip batch of a "latest"-resolved range is the only one at risk of
+// asking for a block a node hasn't caught up to yet: a load-balanced RPC
+// endpoint can route an earlier head-check and this batch's eth_getLogs to
+// two different backend replicas that have not converged (a fast replica
+// answers the check, a slower one serves the query). Passing the literal
+// block tag "latest" to eth_getLogs instead of a previously-resolved number
+// eliminates that race entirely -- whichever replica serves this call
+// resolves "latest" against its own head, so it can never reject its own
+// answer as beyond its own head. The block-number fetch alongside it is
+// purely informational (for the caller's reported `toBlock`) and runs in
+// parallel since the query no longer depends on it for correctness.
+async function fetchTipBatch(
+  provider: ethers.JsonRpcProvider,
+  contractAddress: string,
+  parsedAbi: AbiEntry[],
+  eventName: string,
+  start: number
+): Promise<BatchQueryResult> {
+  const contract = new ethers.Contract(contractAddress, parsedAbi, provider);
+  const eventFilter = resolveEventFilter(contract, eventName);
+
+  const [events, head] = await Promise.all([
+    contract.queryFilter(eventFilter, start, "latest"),
+    provider.getBlockNumber(),
+  ]);
+
+  return { events, actualEnd: head };
+}
+
 // Query a single block range, failing over between RPC endpoints AND retrying
 // the batch with a backoff (at least MAX_BATCH_RETRIES attempts) before giving
 // up. A timed-out batch is the common transient failure on long scans; this
 // keeps it from sinking the whole node.
+//
+// `isTipBatch` marks the final batch of a range whose end we resolved
+// ourselves (see query-events.ts's `toBlockIsLatest`). Only that batch
+// queries against "latest" directly; an explicit user-provided toBlock is
+// always queried as a fixed number, so a real user misconfiguration still
+// surfaces as an error instead of being silently reinterpreted.
 export async function queryBatchWithRetry(
   rpcManager: RpcProviderManager,
   contractAddress: string,
   parsedAbi: AbiEntry[],
   eventName: string,
   start: number,
-  end: number
-): Promise<(ethers.Log | ethers.EventLog)[]> {
+  end: number,
+  isTipBatch: boolean
+): Promise<BatchQueryResult> {
   let lastError: unknown;
+
   for (let attempt = 1; attempt <= MAX_BATCH_RETRIES; attempt++) {
     try {
-      return await rpcManager.executeWithFailover(async (provider) => {
-        const contract = new ethers.Contract(
-          contractAddress,
-          parsedAbi,
-          provider
-        );
-        const eventFilter = contract.filters[eventName]?.();
-        if (eventFilter === undefined || eventFilter === null) {
-          throw new Error(`Could not create filter for event '${eventName}'`);
-        }
-        return await contract.queryFilter(eventFilter, start, end);
-      });
+      return await rpcManager.executeWithFailover((provider) =>
+        isTipBatch
+          ? fetchTipBatch(provider, contractAddress, parsedAbi, eventName, start)
+          : fetchFixedBatch(
+              provider,
+              contractAddress,
+              parsedAbi,
+              eventName,
+              start,
+              end
+            )
+      );
     } catch (error) {
       lastError = error;
       console.log(

--- a/plugins/web3/steps/query-events-core.ts
+++ b/plugins/web3/steps/query-events-core.ts
@@ -7,11 +7,11 @@ export type AbiEntry = { type: string; name: string };
 export type BatchQueryResult = {
   events: (ethers.Log | ethers.EventLog)[];
   // The block actually scanned up to. Equal to the requested `end` for a
-  // non-tip batch. For the tip batch it is the head observed by the
-  // parallel getBlockNumber() call in fetchTipBatch, which is purely
-  // informational and can differ from what was originally planned -- the
-  // caller's reported `toBlock` must use this, not the originally requested
-  // `end`, or it will misstate what was actually queried.
+  // non-tip batch. For the tip batch it is derived from the query result
+  // itself (see fetchTipBatch) rather than a separate RPC call, since only
+  // the exact call that served the query can vouch for what it covered --
+  // the caller's reported `toBlock` must use this, not the originally
+  // requested `end`, or it will misstate what was actually queried.
   actualEnd: number;
 };
 
@@ -61,9 +61,16 @@ async function fetchFixedBatch(
 // block tag "latest" to eth_getLogs instead of a previously-resolved number
 // eliminates that race entirely -- whichever replica serves this call
 // resolves "latest" against its own head, so it can never reject its own
-// answer as beyond its own head. The block-number fetch alongside it is
-// purely informational (for the caller's reported `toBlock`) and runs in
-// parallel since the query no longer depends on it for correctness.
+// answer as beyond its own head.
+//
+// A separate getBlockNumber() call is deliberately NOT used to report
+// `actualEnd`: even issued against the same `provider` object, a concurrent
+// request isn't guaranteed to land on the same backend replica as the
+// queryFilter call, so it could report a head more advanced than what this
+// call's replica actually resolved "latest" to -- overstating what was
+// scanned and, if a caller checkpoints off `toBlock`, risking a skipped
+// range on the next run. The highest event block actually returned is the
+// only value this exact call can vouch for.
 async function fetchTipBatch(
   provider: ethers.JsonRpcProvider,
   contractAddress: string,
@@ -73,13 +80,14 @@ async function fetchTipBatch(
 ): Promise<BatchQueryResult> {
   const contract = new ethers.Contract(contractAddress, parsedAbi, provider);
   const eventFilter = resolveEventFilter(contract, eventName);
+  const events = await contract.queryFilter(eventFilter, start, "latest");
 
-  const [events, head] = await Promise.all([
-    contract.queryFilter(eventFilter, start, "latest"),
-    provider.getBlockNumber(),
-  ]);
+  const actualEnd =
+    events.length > 0
+      ? Math.max(...events.map((event) => event.blockNumber))
+      : start - 1;
 
-  return { events, actualEnd: head };
+  return { events, actualEnd };
 }
 
 // Query a single block range, failing over between RPC endpoints AND retrying

--- a/plugins/web3/steps/query-events-core.ts
+++ b/plugins/web3/steps/query-events-core.ts
@@ -82,10 +82,10 @@ async function fetchTipBatch(
   const eventFilter = resolveEventFilter(contract, eventName);
   const events = await contract.queryFilter(eventFilter, start, "latest");
 
-  const actualEnd =
-    events.length > 0
-      ? Math.max(...events.map((event) => event.blockNumber))
-      : start - 1;
+  const actualEnd = events.reduce(
+    (max, event) => Math.max(max, event.blockNumber),
+    start - 1
+  );
 
   return { events, actualEnd };
 }

--- a/plugins/web3/steps/query-events-core.ts
+++ b/plugins/web3/steps/query-events-core.ts
@@ -22,6 +22,28 @@ export type BatchQueryResult = {
 export const MAX_BATCH_RETRIES = 3;
 export const RETRY_BASE_DELAY_MS = 2000;
 
+// A batch is also at risk of the cross-replica race described below even if
+// it isn't the literal final batch of a "latest"-resolved range: when the
+// range length leaves a small remainder over the batch size, the batch
+// immediately before the tip can end within a handful of blocks of the
+// resolved-latest estimate -- close enough for a lagging replica to reject
+// it with the same "block range extends beyond current head" error. This
+// margin widens tip-batch treatment to any batch ending this close to the
+// estimate, not just the one landing exactly on it.
+export const TIP_SAFETY_MARGIN_BLOCKS = 5;
+
+// Whether a batch ending at `batchEnd` should be queried as a tip batch
+// (against the literal "latest" tag) rather than a fixed numeric end. Only
+// relevant for ranges whose end we resolved ourselves (`toBlockIsLatest`) --
+// an explicit user-provided toBlock is always a fixed query.
+export function isNearHeadBatch(
+  batchEnd: number,
+  toBlock: number,
+  toBlockIsLatest: boolean
+): boolean {
+  return toBlockIsLatest && toBlock - batchEnd < TIP_SAFETY_MARGIN_BLOCKS;
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);

--- a/plugins/web3/steps/query-events.ts
+++ b/plugins/web3/steps/query-events.ts
@@ -13,6 +13,7 @@ import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-ha
 import { getErrorMessage } from "@/lib/utils";
 import {
   type AbiEntry,
+  isNearHeadBatch,
   queryBatchWithRetry,
 } from "./query-events-core";
 
@@ -235,7 +236,7 @@ async function queryEventBatches(
     start += batchSize
   ) {
     const end = Math.min(start + batchSize - 1, range.toBlock);
-    const isTipBatch = range.toBlockIsLatest && end === range.toBlock;
+    const isTipBatch = isNearHeadBatch(end, range.toBlock, range.toBlockIsLatest);
     console.log(`[Query Events] Querying batch: blocks ${start} to ${end}`);
 
     const { events: batchEvents, actualEnd } = await queryBatchWithRetry(
@@ -260,6 +261,12 @@ async function queryEventBatches(
     }
 
     actualToBlock = actualEnd;
+
+    // A tip batch already queried through to the real head via "latest" --
+    // there is no fixed-range batch left to run after it.
+    if (isTipBatch) {
+      break;
+    }
     // The batch could not vouch for scanning all the way to its planned end
     // -- later batches would target blocks even further out, so there is
     // nothing left to gain by continuing.

--- a/plugins/web3/steps/query-events.ts
+++ b/plugins/web3/steps/query-events.ts
@@ -260,9 +260,9 @@ async function queryEventBatches(
     }
 
     actualToBlock = actualEnd;
-    // The head was clamped below this batch's planned end -- later batches
-    // would target blocks even further out, so there is nothing left to gain
-    // by continuing.
+    // The batch could not vouch for scanning all the way to its planned end
+    // -- later batches would target blocks even further out, so there is
+    // nothing left to gain by continuing.
     if (actualEnd < end) {
       break;
     }

--- a/plugins/web3/steps/query-events.ts
+++ b/plugins/web3/steps/query-events.ts
@@ -64,7 +64,12 @@ export type QueryEventsCoreInput = {
 
 export type QueryEventsInput = StepInput & QueryEventsCoreInput;
 
-type BlockRange = { fromBlock: number; toBlock: number };
+// `toBlockIsLatest` marks a range whose end was resolved by us (from an empty
+// or "latest" input) rather than given explicitly by the user. Only that case
+// is safe to re-verify/clamp against a fresher head at query time -- an
+// explicit user-provided toBlock must surface a real error if it turns out to
+// be beyond the chain, not get silently truncated.
+type BlockRange = { fromBlock: number; toBlock: number; toBlockIsLatest: boolean };
 
 function serializeBigInts(value: unknown): unknown {
   return JSON.parse(
@@ -172,8 +177,13 @@ async function resolveBlockRange(
 > {
   const toBlockStr = toBlockInput?.toString().trim() ?? "";
   let resolvedToBlock: number;
+  const toBlockIsLatest =
+    toBlockStr === "" || toBlockStr.toLowerCase() === "latest";
 
-  if (toBlockStr === "" || toBlockStr.toLowerCase() === "latest") {
+  if (toBlockIsLatest) {
+    // This is a planning estimate only -- how many batches to run and where
+    // `fromBlock` starts. It is NOT the authoritative bound used for the
+    // final eth_getLogs call; see queryBatchWithRetry's tip-batch handling.
     resolvedToBlock = await provider.getBlockNumber();
     console.log("[Query Events] Resolved latest block:", resolvedToBlock);
   } else {
@@ -197,9 +207,15 @@ async function resolveBlockRange(
 
   return {
     success: true,
-    range: { fromBlock: fromBlockResult.value, toBlock: resolvedToBlock },
+    range: {
+      fromBlock: fromBlockResult.value,
+      toBlock: resolvedToBlock,
+      toBlockIsLatest,
+    },
   };
 }
+
+type EventBatchesResult = { events: DecodedEvent[]; actualToBlock: number };
 
 async function queryEventBatches(
   rpcManager: RpcProviderManager,
@@ -208,9 +224,10 @@ async function queryEventBatches(
   eventName: string,
   eventFragment: ethers.EventFragment,
   range: BlockRange
-): Promise<DecodedEvent[]> {
+): Promise<EventBatchesResult> {
   const batchSize = DEFAULT_BATCH_SIZE;
   const allEvents: DecodedEvent[] = [];
+  let actualToBlock = range.fromBlock - 1;
 
   for (
     let start = range.fromBlock;
@@ -218,15 +235,17 @@ async function queryEventBatches(
     start += batchSize
   ) {
     const end = Math.min(start + batchSize - 1, range.toBlock);
+    const isTipBatch = range.toBlockIsLatest && end === range.toBlock;
     console.log(`[Query Events] Querying batch: blocks ${start} to ${end}`);
 
-    const batchEvents = await queryBatchWithRetry(
+    const { events: batchEvents, actualEnd } = await queryBatchWithRetry(
       rpcManager,
       contractAddress,
       parsedAbi,
       eventName,
       start,
-      end
+      end,
+      isTipBatch
     );
 
     for (const event of batchEvents) {
@@ -239,9 +258,17 @@ async function queryEventBatches(
         });
       }
     }
+
+    actualToBlock = actualEnd;
+    // The head was clamped below this batch's planned end -- later batches
+    // would target blocks even further out, so there is nothing left to gain
+    // by continuing.
+    if (actualEnd < end) {
+      break;
+    }
   }
 
-  return allEvents;
+  return { events: allEvents, actualToBlock };
 }
 
 async function stepHandler(
@@ -335,7 +362,7 @@ async function stepHandler(
   // Query events (each batch fails over between endpoints and retries with a
   // backoff, so a transient timeout on one batch does not fail the whole node).
   try {
-    const events = await queryEventBatches(
+    const { events, actualToBlock } = await queryEventBatches(
       rpcManager,
       contractAddress,
       abiResult.parsed,
@@ -350,7 +377,7 @@ async function stepHandler(
       success: true as const,
       events,
       fromBlock: range.fromBlock,
-      toBlock: range.toBlock,
+      toBlock: actualToBlock,
       eventCount: events.length,
     };
   } catch (error) {

--- a/tests/unit/query-events-core.test.ts
+++ b/tests/unit/query-events-core.test.ts
@@ -183,3 +183,86 @@ describe("queryBatchWithRetry", () => {
     );
   });
 });
+
+describe("cross-replica head divergence (regression coverage)", () => {
+  // A pooled RPC endpoint load-balances each call independently: a fast
+  // replica and a slower, not-yet-synced replica can each end up serving
+  // one of two calls that a caller assumes are consistent with each other.
+  const FAST_REPLICA_HEAD = 205;
+  const SLOW_REPLICA_SYNCED_HEAD = 203;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockQueryFilter.mockReset();
+    mockQueryFilter.mockImplementation(
+      (_filter: unknown, _start: number, end: number | string) => {
+        if (end === "latest") {
+          // Whichever replica serves this call resolves "latest" against
+          // its own head, so it can never ask itself for a range beyond
+          // what it has.
+          return Promise.resolve([{ blockNumber: SLOW_REPLICA_SYNCED_HEAD }]);
+        }
+        if (typeof end === "number" && end > SLOW_REPLICA_SYNCED_HEAD) {
+          return Promise.reject(
+            new Error(
+              "could not coalesce error: -32602 block range extends beyond current head"
+            )
+          );
+        }
+        return Promise.resolve([{ blockNumber: end }]);
+      }
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("regression: a fixed toBlock (isTipBatch: false) resolved from one replica gets rejected by a slower replica serving the eth_getLogs call", async () => {
+    const executeWithFailover = vi.fn((operation) => operation(fakeProvider()));
+
+    const promise = queryBatchWithRetry(
+      mockRpc(executeWithFailover),
+      "0xabc",
+      [],
+      "Lift",
+      200,
+      FAST_REPLICA_HEAD, // resolved by an earlier, separate call that hit the fast replica
+      false // fixed toBlock -- see fetchFixedBatch in query-events-core.ts
+    );
+    const expectation = expect(promise).rejects.toThrow(
+      /block range extends beyond current head/
+    );
+    await vi.runAllTimersAsync();
+    await expectation;
+
+    expect(executeWithFailover).toHaveBeenCalledTimes(MAX_BATCH_RETRIES);
+  });
+
+  it("the tip batch (isTipBatch: true), queried against the literal 'latest' tag, survives the same lagging replica that just rejected the fixed-toBlock query above", async () => {
+    const executeWithFailover = vi.fn((operation) => operation(fakeProvider()));
+
+    const promise = queryBatchWithRetry(
+      mockRpc(executeWithFailover),
+      "0xabc",
+      [],
+      "Lift",
+      200,
+      200, // ignored for a tip batch
+      true
+    );
+    const expectation = expect(promise).resolves.toEqual({
+      events: [{ blockNumber: SLOW_REPLICA_SYNCED_HEAD }],
+      actualEnd: SLOW_REPLICA_SYNCED_HEAD,
+    });
+    await vi.runAllTimersAsync();
+    await expectation;
+
+    expect(mockQueryFilter).toHaveBeenCalledWith(
+      expect.anything(),
+      200,
+      "latest"
+    );
+    expect(executeWithFailover).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/query-events-core.test.ts
+++ b/tests/unit/query-events-core.test.ts
@@ -28,8 +28,8 @@ function mockRpc(
   return { executeWithFailover } as unknown as RpcProviderManager;
 }
 
-function fakeProvider(head: number): { getBlockNumber: () => Promise<number> } {
-  return { getBlockNumber: () => Promise.resolve(head) };
+function fakeProvider(): Record<string, never> {
+  return {};
 }
 
 describe("queryBatchWithRetry", () => {
@@ -45,9 +45,7 @@ describe("queryBatchWithRetry", () => {
   it("returns on the first attempt without retrying (non-tip batch)", async () => {
     const events = [{ blockNumber: 1 }];
     mockQueryFilter.mockResolvedValue(events);
-    const executeWithFailover = vi.fn((operation) =>
-      operation(fakeProvider(999))
-    );
+    const executeWithFailover = vi.fn((operation) => operation(fakeProvider()));
 
     const promise = queryBatchWithRetry(
       mockRpc(executeWithFailover),
@@ -116,12 +114,14 @@ describe("queryBatchWithRetry", () => {
     expect(executeWithFailover).toHaveBeenCalledTimes(MAX_BATCH_RETRIES);
   });
 
-  it("queries a tip batch against the literal 'latest' tag and reports the parallel head fetch as actualEnd", async () => {
-    const events = [{ blockNumber: 205 }];
+  it("queries a tip batch against the literal 'latest' tag and derives actualEnd from the highest returned event", async () => {
+    const events = [
+      { blockNumber: 201 },
+      { blockNumber: 205 },
+      { blockNumber: 199 },
+    ];
     mockQueryFilter.mockResolvedValue(events);
-    const executeWithFailover = vi.fn((operation) =>
-      operation(fakeProvider(205))
-    );
+    const executeWithFailover = vi.fn((operation) => operation(fakeProvider()));
 
     const promise = queryBatchWithRetry(
       mockRpc(executeWithFailover),
@@ -141,7 +141,9 @@ describe("queryBatchWithRetry", () => {
 
     // The literal "latest" tag, not a previously-resolved number, is what
     // makes this immune to the fast-replica/slow-replica race: whichever
-    // node answers resolves "latest" against its own head.
+    // node answers resolves "latest" against its own head. actualEnd must
+    // come from the events this exact call returned (max, not last), not a
+    // separate getBlockNumber() call that could hit a different replica.
     expect(mockQueryFilter).toHaveBeenCalledWith(
       expect.anything(),
       200,
@@ -150,16 +152,13 @@ describe("queryBatchWithRetry", () => {
     expect(executeWithFailover).toHaveBeenCalledTimes(1);
   });
 
-  it("reports actualEnd from the head fetch even when it disagrees with the originally planned end", async () => {
-    // The planned `end` (200) is only used for the outer batch loop's
-    // bookkeeping; the tip batch's actual query and its reported actualEnd
-    // are both driven by the live head, which can have moved past (or, in
-    // this case, sit below) that original estimate without causing an error.
+  it("reports no forward progress when a tip batch's latest query returns no events", async () => {
+    // With nothing returned, there is no value this call can vouch for as
+    // actually scanned -- reporting start - 1 means a future run re-checks
+    // the same window instead of risking a skipped range.
     const events: unknown[] = [];
     mockQueryFilter.mockResolvedValue(events);
-    const executeWithFailover = vi.fn((operation) =>
-      operation(fakeProvider(150))
-    );
+    const executeWithFailover = vi.fn((operation) => operation(fakeProvider()));
 
     const promise = queryBatchWithRetry(
       mockRpc(executeWithFailover),
@@ -172,9 +171,15 @@ describe("queryBatchWithRetry", () => {
     );
     const expectation = expect(promise).resolves.toEqual({
       events,
-      actualEnd: 150,
+      actualEnd: 99,
     });
     await vi.runAllTimersAsync();
     await expectation;
+
+    expect(mockQueryFilter).toHaveBeenCalledWith(
+      expect.anything(),
+      100,
+      "latest"
+    );
   });
 });

--- a/tests/unit/query-events-core.test.ts
+++ b/tests/unit/query-events-core.test.ts
@@ -1,6 +1,22 @@
-import type { ethers } from "ethers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
+
+const mockQueryFilter = vi.fn();
+
+vi.mock("ethers", async () => {
+  const actual = await vi.importActual<typeof import("ethers")>("ethers");
+  return {
+    ...actual,
+    ethers: {
+      ...actual.ethers,
+      Contract: class MockContract {
+        filters = { Lift: () => ({ topics: [] }) };
+        queryFilter = mockQueryFilter;
+      },
+    },
+  };
+});
+
 import {
   MAX_BATCH_RETRIES,
   queryBatchWithRetry,
@@ -12,18 +28,26 @@ function mockRpc(
   return { executeWithFailover } as unknown as RpcProviderManager;
 }
 
+function fakeProvider(head: number): { getBlockNumber: () => Promise<number> } {
+  return { getBlockNumber: () => Promise.resolve(head) };
+}
+
 describe("queryBatchWithRetry", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    mockQueryFilter.mockReset();
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it("returns on the first attempt without retrying", async () => {
-    const events = [{ blockNumber: 1 } as unknown as ethers.EventLog];
-    const executeWithFailover = vi.fn().mockResolvedValue(events);
+  it("returns on the first attempt without retrying (non-tip batch)", async () => {
+    const events = [{ blockNumber: 1 }];
+    mockQueryFilter.mockResolvedValue(events);
+    const executeWithFailover = vi.fn((operation) =>
+      operation(fakeProvider(999))
+    );
 
     const promise = queryBatchWithRetry(
       mockRpc(executeWithFailover),
@@ -31,22 +55,27 @@ describe("queryBatchWithRetry", () => {
       [],
       "Lift",
       0,
-      100
+      100,
+      false
     );
-    const expectation = expect(promise).resolves.toBe(events);
+    const expectation = expect(promise).resolves.toEqual({
+      events,
+      actualEnd: 100,
+    });
     await vi.runAllTimersAsync();
     await expectation;
 
+    expect(mockQueryFilter).toHaveBeenCalledWith(expect.anything(), 0, 100);
     expect(executeWithFailover).toHaveBeenCalledTimes(1);
   });
 
   it("retries a transiently failing batch and returns once an attempt succeeds", async () => {
-    const events = [{ blockNumber: 2 } as unknown as ethers.EventLog];
+    const events = [{ blockNumber: 2 }];
     const executeWithFailover = vi
       .fn()
       .mockRejectedValueOnce(new Error("RPC failed: Timeout after 30000ms"))
       .mockRejectedValueOnce(new Error("RPC failed: Timeout after 30000ms"))
-      .mockResolvedValueOnce(events);
+      .mockResolvedValueOnce({ events, actualEnd: 100 });
 
     const promise = queryBatchWithRetry(
       mockRpc(executeWithFailover),
@@ -54,9 +83,13 @@ describe("queryBatchWithRetry", () => {
       [],
       "Lift",
       0,
-      100
+      100,
+      false
     );
-    const expectation = expect(promise).resolves.toBe(events);
+    const expectation = expect(promise).resolves.toEqual({
+      events,
+      actualEnd: 100,
+    });
     await vi.runAllTimersAsync();
     await expectation;
 
@@ -73,12 +106,75 @@ describe("queryBatchWithRetry", () => {
       [],
       "Lift",
       0,
-      100
+      100,
+      false
     );
     const expectation = expect(promise).rejects.toBe(lastError);
     await vi.runAllTimersAsync();
     await expectation;
 
     expect(executeWithFailover).toHaveBeenCalledTimes(MAX_BATCH_RETRIES);
+  });
+
+  it("queries a tip batch against the literal 'latest' tag and reports the parallel head fetch as actualEnd", async () => {
+    const events = [{ blockNumber: 205 }];
+    mockQueryFilter.mockResolvedValue(events);
+    const executeWithFailover = vi.fn((operation) =>
+      operation(fakeProvider(205))
+    );
+
+    const promise = queryBatchWithRetry(
+      mockRpc(executeWithFailover),
+      "0xabc",
+      [],
+      "Lift",
+      200,
+      200,
+      true
+    );
+    const expectation = expect(promise).resolves.toEqual({
+      events,
+      actualEnd: 205,
+    });
+    await vi.runAllTimersAsync();
+    await expectation;
+
+    // The literal "latest" tag, not a previously-resolved number, is what
+    // makes this immune to the fast-replica/slow-replica race: whichever
+    // node answers resolves "latest" against its own head.
+    expect(mockQueryFilter).toHaveBeenCalledWith(
+      expect.anything(),
+      200,
+      "latest"
+    );
+    expect(executeWithFailover).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports actualEnd from the head fetch even when it disagrees with the originally planned end", async () => {
+    // The planned `end` (200) is only used for the outer batch loop's
+    // bookkeeping; the tip batch's actual query and its reported actualEnd
+    // are both driven by the live head, which can have moved past (or, in
+    // this case, sit below) that original estimate without causing an error.
+    const events: unknown[] = [];
+    mockQueryFilter.mockResolvedValue(events);
+    const executeWithFailover = vi.fn((operation) =>
+      operation(fakeProvider(150))
+    );
+
+    const promise = queryBatchWithRetry(
+      mockRpc(executeWithFailover),
+      "0xabc",
+      [],
+      "Lift",
+      100,
+      200,
+      true
+    );
+    const expectation = expect(promise).resolves.toEqual({
+      events,
+      actualEnd: 150,
+    });
+    await vi.runAllTimersAsync();
+    await expectation;
   });
 });

--- a/tests/unit/query-events-core.test.ts
+++ b/tests/unit/query-events-core.test.ts
@@ -3,6 +3,8 @@ import type { RpcProviderManager } from "@/lib/rpc/providers";
 
 const mockQueryFilter = vi.fn();
 
+const BLOCK_RANGE_BEYOND_HEAD_ERROR = /block range extends beyond current head/;
+
 vi.mock("ethers", async () => {
   const actual = await vi.importActual<typeof import("ethers")>("ethers");
   return {
@@ -18,8 +20,10 @@ vi.mock("ethers", async () => {
 });
 
 import {
+  isNearHeadBatch,
   MAX_BATCH_RETRIES,
   queryBatchWithRetry,
+  TIP_SAFETY_MARGIN_BLOCKS,
 } from "@/plugins/web3/steps/query-events-core";
 
 function mockRpc(
@@ -231,7 +235,7 @@ describe("cross-replica head divergence (regression coverage)", () => {
       false // fixed toBlock -- see fetchFixedBatch in query-events-core.ts
     );
     const expectation = expect(promise).rejects.toThrow(
-      /block range extends beyond current head/
+      BLOCK_RANGE_BEYOND_HEAD_ERROR
     );
     await vi.runAllTimersAsync();
     await expectation;
@@ -264,5 +268,31 @@ describe("cross-replica head divergence (regression coverage)", () => {
       "latest"
     );
     expect(executeWithFailover).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("isNearHeadBatch", () => {
+  it("treats the batch landing exactly on toBlock as a tip batch", () => {
+    expect(isNearHeadBatch(4999, 4999, true)).toBe(true);
+  });
+
+  it("treats a batch ending within the safety margin of toBlock as a tip batch, not just the exact final one", () => {
+    // Reproduces a small remainder over the batch size: fromBlock=1000,
+    // toBlock=5001 (batchSize=2000) produces batches [1000,2999],
+    // [3000,4999], [5000,5001] -- the second batch ends only 2 blocks
+    // before toBlock, close enough to race a lagging replica the same way
+    // the exact tip batch does.
+    const batchEnd = 4999;
+    const toBlock = 5001;
+    expect(toBlock - batchEnd).toBeLessThan(TIP_SAFETY_MARGIN_BLOCKS);
+    expect(isNearHeadBatch(batchEnd, toBlock, true)).toBe(true);
+  });
+
+  it("does not treat a batch well short of toBlock as a tip batch", () => {
+    expect(isNearHeadBatch(2999, 5001, true)).toBe(false);
+  });
+
+  it("never treats any batch as a tip batch when toBlock was explicitly provided by the user", () => {
+    expect(isNearHeadBatch(5001, 5001, false)).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes a bug in the "Query Contract Events" web3 step where a resolved (non-user-specified) `toBlock` was computed once via a standalone `eth_blockNumber` call and then reused for a later `eth_getLogs` call. Because the RPC provider's endpoint is a load-balanced pool of backend nodes that do not sync in unison, the two calls could land on different endpoints, and if the log query landed on a slightly slower endpoint than the one that answered the head check, it would reject the range with `-32602 block range extends beyond current head`.

This was discovered when an unrelated issue caused it to surface during the debugging session (see [this PM doc](https://docs.google.com/document/d/1cNdU5ixrAF3F098FqqPl7IhZG2RLYvDBj2gKLS0NJv0)).

The step's reported `toBlock` output is derived only from that same query's results (the highest block among the returned events, or no forward progress if none) rather than a separate `getBlockNumber()` call, since a second call could itself land on a different, more-advanced replica and overstate what was actually scanned. An explicit user-provided `toBlock` is left untouched so a genuine misconfiguration still surfaces as an error. Unit tests cover the retry/failover wiring and the tip-batch query against a mocked contract, verifying the `"latest"` tag, the max-of-events derivation, and the no-events fallback.

Opening as draft since I wanna test it in a PR env.