### PR TITLE
fix(event-tracker): reconnect chains whose block stream silently stalls

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -97,6 +97,17 @@
         "instrumentation.ts"
       ],
       "linter": { "rules": { "suspicious": { "noConsole": "off" } } }
+    },
+    {
+      // The protocol on-chain tests declare cases via `itOnchain` (a custom
+      // wrapper around `it` in tests/integration/_shared/onchain-rpc.ts that
+      // retries RPC-infrastructure faults). noMisplacedAssertion only knows
+      // it/test/Deno.test, so it flags every expect() inside an itOnchain
+      // body as misplaced. Scope just that rule off for these files.
+      "includes": ["tests/integration/*onchain*.test.ts"],
+      "linter": {
+        "rules": { "suspicious": { "noMisplacedAssertion": "off" } }
+      }
     }
   ]
 }

--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -37,6 +37,19 @@ const GETLOGS_ADDRESS_BATCH = 500;
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const HEARTBEAT_TIMEOUT_MS = 10_000;
+/**
+ * Ceiling on the gap between delivered blocks before a subscribed chain's
+ * connection is treated as dead. The heartbeat pings `eth_blockNumber`, a
+ * request/response RPC call that stays healthy even when the `newHeads` push
+ * subscription has silently stopped delivering blocks - so a stalled
+ * subscription passes the heartbeat forever. Block-staleness is the only
+ * signal that catches that state. Checked on each heartbeat tick, so
+ * effective detection latency is this value plus up to one
+ * HEARTBEAT_INTERVAL_MS. Defaults well above any supported chain's block
+ * time so a slow-but-healthy chain is never reconnected for a normal
+ * inter-block gap; overridable per-manager for tests.
+ */
+const BLOCK_STALENESS_TIMEOUT_MS = 120_000;
 const INITIAL_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 60_000;
 const MAX_RECONNECT_ATTEMPTS = 10;
@@ -67,7 +80,8 @@ export type ProviderFactory = (wssUrl: string) => ethers.WebSocketProvider;
 export type DisconnectReason =
   | "provider_error"
   | "heartbeat_failure"
-  | "heartbeat_timeout";
+  | "heartbeat_timeout"
+  | "block_staleness";
 
 export interface DisconnectEvent {
   chainId: number;
@@ -122,6 +136,12 @@ export interface SubscribeOptions {
 export interface ChainProviderManagerOptions {
   factory?: ProviderFactory;
   onPermanentFailure?: (chainId: number) => void;
+  /**
+   * Override the block-staleness ceiling (defaults to
+   * BLOCK_STALENESS_TIMEOUT_MS). Tests set a small value to exercise the
+   * watchdog without advancing timers past the production threshold.
+   */
+  blockStalenessTimeoutMs?: number;
 }
 
 interface Subscriber {
@@ -166,6 +186,14 @@ interface ChainEntry {
   heartbeatTimer: ReturnType<typeof setInterval> | null;
   isReconnecting: boolean;
   lastBlockAt: number | null;
+  /**
+   * When the current block listener was attached. Baseline for the
+   * block-staleness watchdog before the first block arrives, so a
+   * connection that never delivers a single block (subscription that
+   * silently failed to establish) is still caught. Null while no block
+   * listener is attached.
+   */
+  blockListenerAttachedAt: number | null;
   /**
    * Populated when `createProvider` rejects (most often the
    * subscription probe). Cleared on the next successful creation.
@@ -240,6 +268,7 @@ export class ChainProviderManager {
   private readonly chains = new Map<number, ChainEntry>();
   private readonly factory: ProviderFactory;
   private readonly onPermanentFailure: (chainId: number) => void;
+  private readonly blockStalenessTimeoutMs: number;
   private isDestroyed = false;
   // Wake-up signal for in-flight reconnect sleeps: `destroy()` resolves
   // this promise, racing any pending backoff sleep so the reconnect loop
@@ -255,6 +284,8 @@ export class ChainProviderManager {
     this.factory = opts.factory ?? defaultFactory;
     this.onPermanentFailure =
       opts.onPermanentFailure ?? defaultOnPermanentFailure;
+    this.blockStalenessTimeoutMs =
+      opts.blockStalenessTimeoutMs ?? BLOCK_STALENESS_TIMEOUT_MS;
     let resolve!: () => void;
     const promise = new Promise<void>((r) => {
       resolve = r;
@@ -505,6 +536,7 @@ export class ChainProviderManager {
       heartbeatTimer: null,
       isReconnecting: false,
       lastBlockAt: null,
+      blockListenerAttachedAt: null,
       lastCreateError: null,
       disconnectHandlers: new Set(),
     };
@@ -693,10 +725,15 @@ export class ChainProviderManager {
       await this.processBlock(entry, blockNumber);
     };
     entry.blockListener = listener;
+    // Baseline for the block-staleness watchdog: until the first block
+    // arrives, staleness is measured from attach time so a subscription that
+    // never delivers a block is still caught.
+    entry.blockListenerAttachedAt = Date.now();
     entry.provider.on("block", listener);
   }
 
   private detachBlockListener(entry: ChainEntry): void {
+    entry.blockListenerAttachedAt = null;
     if (!(entry.provider && entry.blockListener)) {
       entry.blockListener = null;
       return;
@@ -766,7 +803,58 @@ export class ChainProviderManager {
         `[ChainProviderManager] chain=${entry.chainId} heartbeat failed: ${message}`,
       );
       this.triggerReconnect(entry, reason, message);
+      return;
     }
+
+    // The heartbeat succeeded, so the RPC is answering. That does not prove
+    // the newHeads subscription is still delivering blocks - a silently
+    // dropped subscription passes the heartbeat forever. Block-staleness is
+    // the only signal that catches it.
+    this.checkBlockStaleness(entry);
+  }
+
+  /**
+   * Reconnect a chain whose connection is answering the heartbeat but has
+   * stopped delivering blocks past `blockStalenessTimeoutMs`. Runs on each
+   * heartbeat tick (after a successful ping) so it inherits the heartbeat's
+   * subscriber-scoped lifecycle. Measures staleness from the last delivered
+   * block, or - before any block has arrived - from when the block listener
+   * attached, so a subscription that never delivers is also caught.
+   */
+  private checkBlockStaleness(entry: ChainEntry): void {
+    if (this.isDestroyed || entry.isReconnecting || !entry.provider) {
+      return;
+    }
+    // Blocks are only expected while a subscriber (and thus a block
+    // listener) is attached; an idle provider is legitimately silent.
+    if (entry.subscribers.size === 0) {
+      return;
+    }
+    // Measure from the most recent of the last delivered block and the
+    // current block-listener attach time. After a reconnect, lastBlockAt
+    // still holds the pre-drop timestamp, so folding in the fresh attach
+    // time gives the new connection a full window to deliver its first
+    // block instead of tripping again immediately. Real timestamps are
+    // always > 0, so 0 means neither is set.
+    const reference = Math.max(
+      entry.lastBlockAt ?? 0,
+      entry.blockListenerAttachedAt ?? 0,
+    );
+    if (reference === 0) {
+      return;
+    }
+    const age = Date.now() - reference;
+    if (age <= this.blockStalenessTimeoutMs) {
+      return;
+    }
+    logger.warn(
+      `[ChainProviderManager] chain=${entry.chainId} no block for ${age}ms while heartbeat passing; treating subscription as dead and reconnecting`,
+    );
+    this.triggerReconnect(
+      entry,
+      "block_staleness",
+      `no block received for ${age}ms while heartbeat passing`,
+    );
   }
 
   private triggerReconnect(

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -1337,6 +1337,125 @@ describe("ChainProviderManager", () => {
     });
   });
 
+  describe("block-staleness watchdog", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    // A short staleness ceiling so the watchdog trips within a couple of
+    // heartbeat ticks under fake timers, without advancing past the
+    // production threshold.
+    function makeStalenessManager(
+      timeoutMs: number,
+    ): ReturnType<typeof makeFactory> & { mgr: ChainProviderManager } {
+      const bundle = makeFactory();
+      const mgr = new ChainProviderManager({
+        factory: bundle.factory,
+        onPermanentFailure,
+        blockStalenessTimeoutMs: timeoutMs,
+      });
+      return { ...bundle, mgr };
+    }
+
+    it("reconnects when the heartbeat passes but no block arrives (silent subscription drop)", async () => {
+      const { created, mgr } = makeStalenessManager(60_000);
+      await mgr.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      const reasons: string[] = [];
+      mgr.onDisconnect(CHAIN_A, (ev) => {
+        reasons.push(ev.reason);
+      });
+
+      // Deliver one block, then go silent while the heartbeat keeps
+      // answering (MockProvider.eth_blockNumber returns a value by default).
+      await created[0].emitBlock(1000);
+
+      // Advance past the 60s ceiling (trips at the 90s heartbeat) plus the
+      // reconnect backoff so the replacement provider is created.
+      await vi.advanceTimersByTimeAsync(92_100);
+
+      expect(reasons).toContain("block_staleness");
+      // A fresh provider was created by the reconnect.
+      expect(created.length).toBeGreaterThanOrEqual(2);
+      await mgr.destroy();
+    });
+
+    it("does not reconnect while blocks keep arriving within the ceiling", async () => {
+      const { created, mgr } = makeStalenessManager(60_000);
+      await mgr.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      const reasons: string[] = [];
+      mgr.onDisconnect(CHAIN_A, (ev) => {
+        reasons.push(ev.reason);
+      });
+
+      // Emit a block every 30s for 2 minutes - each within the 60s ceiling.
+      for (let i = 0; i < 4; i++) {
+        await vi.advanceTimersByTimeAsync(30_000);
+        await created[0].emitBlock(2000 + i);
+      }
+
+      expect(reasons).not.toContain("block_staleness");
+      expect(created).toHaveLength(1);
+      await mgr.destroy();
+    });
+
+    it("does not run the staleness check when there are no subscribers", async () => {
+      const { created, mgr } = makeStalenessManager(60_000);
+      // Provider created but never subscribed: no block listener, so the
+      // provider is legitimately silent and must not be reconnected.
+      await mgr.getOrCreateProvider(CHAIN_A, "ws://a");
+      const reasons: string[] = [];
+      mgr.onDisconnect(CHAIN_A, (ev) => {
+        reasons.push(ev.reason);
+      });
+
+      await vi.advanceTimersByTimeAsync(120_000);
+
+      expect(reasons).toEqual([]);
+      expect(created).toHaveLength(1);
+      await mgr.destroy();
+    });
+
+    it("gives a reconnected provider a fresh window instead of tripping immediately", async () => {
+      const { created, mgr } = makeStalenessManager(60_000);
+      await mgr.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+
+      await created[0].emitBlock(3000);
+      // Trip the watchdog: silence past the ceiling plus reconnect backoff
+      // forces a reconnect and a fresh provider.
+      await vi.advanceTimersByTimeAsync(92_100);
+      expect(created.length).toBeGreaterThanOrEqual(2);
+
+      const afterReconnect = created.length;
+      // The new provider has not delivered a block yet, but its attach time
+      // is fresh. One more heartbeat tick within the ceiling must NOT spawn
+      // yet another reconnect.
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(created).toHaveLength(afterReconnect);
+      await mgr.destroy();
+    });
+  });
+
   describe("destroy", () => {
     it("tears down every chain's provider and clears subscriber state", async () => {
       await manager.subscribeToLogs({

--- a/tests/integration/_shared/onchain-rpc.ts
+++ b/tests/integration/_shared/onchain-rpc.ts
@@ -1,0 +1,156 @@
+/**
+ * Shared RPC-resilience helpers for the protocol on-chain integration tests.
+ *
+ * These tests make real `eth_call`s against deployed mainnet contracts to
+ * prove our ABI-driven calldata matches the deployed bytecode. Their value
+ * is catching ABI/dispatch regressions - not measuring the uptime of a busy
+ * RPC endpoint. But a live call can fail for two very different reasons:
+ *
+ *   1. The deployed bytecode rejected our calldata (real regression) -
+ *      surfaces as an ABI/decode error (BAD_DATA, INVALID_ARGUMENT,
+ *      BUFFER_OVERRUN) or a revert that carries data. These MUST fail
+ *      immediately.
+ *   2. The RPC endpoint could not service the call - rate limiting (429), a
+ *      node error, a timeout, a dropped connection, or an `eth_call` that
+ *      came back with no execution data at all ("missing revert data").
+ *      These are transient infrastructure faults, not code defects.
+ *
+ * `isRpcInfraError` classifies (2). `itOnchain` runs an on-chain test body
+ * and, when it fails with an infra fault, retries with exponential backoff
+ * (which lets a rate-limit window reset) before giving up. The test still
+ * fails if the fault persists across every attempt - we do not skip or
+ * swallow it - and a real assertion or ABI/decode failure fails on the first
+ * attempt with no retry.
+ */
+
+import { it } from "vitest";
+
+interface EthersLikeError {
+  code?: string;
+  data?: unknown;
+  reason?: unknown;
+}
+
+function asEthersError(err: unknown): EthersLikeError | null {
+  if (typeof err === "object" && err !== null) {
+    return err as EthersLikeError;
+  }
+  return null;
+}
+
+function messageOf(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return typeof err === "string" ? err : "";
+}
+
+// ethers v6 error codes for anything that is not the contract itself
+// responding: network drop, HTTP error (rate-limit 429, 5xx), timeout, or a
+// generic JSON-RPC error passthrough.
+const NETWORK_ERROR_CODES = new Set([
+  "NETWORK_ERROR",
+  "SERVER_ERROR",
+  "TIMEOUT",
+  "UNKNOWN_ERROR",
+]);
+
+// RpcProviderManager.executeWithFailover rethrows transport failures wrapped
+// in a plain Error that drops the ethers `code`, so we also match on the
+// wrapper prefixes and the underlying connection strings it carries. Keep in
+// sync with lib/rpc/providers RPC_CONNECTION_ERROR_PATTERNS and the throw
+// sites there.
+const TRANSPORT_MESSAGE_MARKERS: readonly string[] = [
+  "RPC failed on both endpoints",
+  "RPC failed on primary endpoint",
+  "Timeout after ",
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "fetch failed",
+];
+
+/**
+ * True for transport/endpoint faults that mean the RPC could not service the
+ * request, whether the raw ethers error surfaced (has a `code`) or the
+ * failover manager wrapped it in a message-only Error.
+ */
+export function isRpcNetworkError(err: unknown): boolean {
+  const e = asEthersError(err);
+  if (e?.code && NETWORK_ERROR_CODES.has(e.code)) {
+    return true;
+  }
+  const msg = messageOf(err);
+  return TRANSPORT_MESSAGE_MARKERS.some((marker) => msg.includes(marker));
+}
+
+/**
+ * True for any RPC-infrastructure fault worth retrying an on-chain read on.
+ * Superset of `isRpcNetworkError` that also covers a `CALL_EXCEPTION` with no
+ * execution data ("missing revert data"): a plain view function on a
+ * known-good contract does not revert, so a data-less call exception here
+ * means the endpoint returned an error rather than the contract rejecting the
+ * calldata. A genuine ABI mismatch surfaces instead as BAD_DATA /
+ * INVALID_ARGUMENT / BUFFER_OVERRUN, or as a revert carrying data - none of
+ * which match here, so those fail immediately without retry.
+ */
+export function isRpcInfraError(err: unknown): boolean {
+  if (isRpcNetworkError(err)) {
+    return true;
+  }
+  const e = asEthersError(err);
+  if (!e) {
+    return false;
+  }
+  return e.code === "CALL_EXCEPTION" && e.data == null && e.reason == null;
+}
+
+// Retry policy for infra faults. Delays are 750ms, 1.5s, 3s between the four
+// attempts - enough for a provider's per-second rate-limit window to reset
+// without stretching a healthy test.
+const MAX_ATTEMPTS = 4;
+const BASE_DELAY_MS = 750;
+// Headroom added to each test's own timeout to cover the retry backoff so a
+// retried-but-healthy test does not trip the per-test deadline.
+const RETRY_BUDGET_MS = 30_000;
+const DEFAULT_TEST_TIMEOUT_MS = 15_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+type OnchainBody = () => Promise<void> | void;
+
+/**
+ * `it` for on-chain tests that hit a live RPC. A transient RPC-infrastructure
+ * fault is retried with exponential backoff so a rate-limited or briefly
+ * unreachable endpoint does not flake the suite. A real assertion or
+ * ABI/decode failure fails on the first attempt, and an infra fault that
+ * persists across every attempt still fails the test - nothing is skipped.
+ */
+export function itOnchain(
+  name: string,
+  body: OnchainBody,
+  timeout?: number
+): void {
+  it(
+    name,
+    async () => {
+      let lastErr: unknown;
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        try {
+          await body();
+          return;
+        } catch (err) {
+          lastErr = err;
+          if (!isRpcInfraError(err) || attempt === MAX_ATTEMPTS) {
+            throw err;
+          }
+          await sleep(BASE_DELAY_MS * 2 ** (attempt - 1));
+        }
+      }
+      throw lastErr;
+    },
+    (timeout ?? DEFAULT_TEST_TIMEOUT_MS) + RETRY_BUDGET_MS
+  );
+}

--- a/tests/integration/protocol-aave-v4-onchain.test.ts
+++ b/tests/integration/protocol-aave-v4-onchain.test.ts
@@ -17,7 +17,7 @@
  */
 
 import { ethers } from "ethers";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, vi } from "vitest";
 
 // `lib/rpc/providers` transitively imports `lib/safe-fetch` (via the
 // safe-ethers adapter), which declares `import "server-only"` and would
@@ -33,11 +33,13 @@ import {
 } from "@/lib/rpc/rpc-config";
 import aaveV4Def from "@/protocols/aave-v4";
 import { buildCalldata } from "./_shared/build-calldata";
+import { isRpcNetworkError, itOnchain } from "./_shared/onchain-rpc";
 
 const CHAIN_ID = "1";
 const MAINNET_CHAIN_ID = 1;
 const TEST_ADDRESS = "0x0000000000000000000000000000000000000001";
 const CORE_HUB = "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9";
+const HEX_PREFIX = /^0x/;
 
 // Resolve Ethereum mainnet RPC URLs via the shared config pipeline:
 // CHAIN_RPC_CONFIG first, individual env vars second, public default last.
@@ -57,10 +59,11 @@ const MAINNET_FALLBACK_URL = resolveRpcUrl(
 );
 
 // Assertion model:
-//  - Read tests: let the RPC call fail loudly. A success path asserts the
-//    decoded return has the expected shape; anything else (network error,
-//    ABI mismatch, decode failure) surfaces as a real test failure instead
-//    of being swallowed.
+//  - Read tests: a success path asserts the decoded return has the expected
+//    shape. An ABI mismatch or decode failure fails the test. A transient
+//    RPC-infrastructure fault (rate limit, node error, missing revert data)
+//    is retried with backoff by itOnchain, so a rate-limit blip does not
+//    flake the suite; a persistent fault still fails.
 //  - Write tests: use provider.call (not estimateGas) against a zero-balance
 //    TEST_ADDRESS. The contract should either (a) revert with CALL_EXCEPTION
 //    on business logic, or (b) succeed and return "0x" for void functions.
@@ -84,113 +87,140 @@ describe("Aave V4 Lido Spoke on-chain integration", () => {
     );
   });
 
-  it("getReserveId: eth_call returns a decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata({
-      protocol: aaveV4Def,
-      actionSlug: "get-reserve-id",
-      sampleInputs: { hub: CORE_HUB, assetId: "0" },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "getReserveId: eth_call returns a decodable uint256",
+    async () => {
+      const { to, data, contract } = buildCalldata({
+        protocol: aaveV4Def,
+        actionSlug: "get-reserve-id",
+        sampleInputs: { hub: CORE_HUB, assetId: "0" },
+        chainId: CHAIN_ID,
+      });
 
-    const result = await manager.executeWithFailover((p) =>
-      p.call({ to, data })
-    );
-    const abi = JSON.parse(contract.abi as string);
-    const iface = new ethers.Interface(abi);
-    const decoded = iface.decodeFunctionResult("getReserveId", result);
-    expect(decoded).toBeDefined();
-    expect(typeof decoded[0]).toBe("bigint");
-  }, 15_000);
+      const result = await manager.executeWithFailover((p) =>
+        p.call({ to, data })
+      );
+      const abi = JSON.parse(contract.abi as string);
+      const iface = new ethers.Interface(abi);
+      const decoded = iface.decodeFunctionResult("getReserveId", result);
+      expect(decoded).toBeDefined();
+      expect(typeof decoded[0]).toBe("bigint");
+    },
+    15_000
+  );
 
-  it("getUserSuppliedAssets: eth_call returns a decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata({
-      protocol: aaveV4Def,
-      actionSlug: "get-user-supplied-assets",
-      sampleInputs: { reserveId: "0", user: TEST_ADDRESS },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "getUserSuppliedAssets: eth_call returns a decodable uint256",
+    async () => {
+      const { to, data, contract } = buildCalldata({
+        protocol: aaveV4Def,
+        actionSlug: "get-user-supplied-assets",
+        sampleInputs: { reserveId: "0", user: TEST_ADDRESS },
+        chainId: CHAIN_ID,
+      });
 
-    const result = await manager.executeWithFailover((p) =>
-      p.call({ to, data })
-    );
-    const abi = JSON.parse(contract.abi as string);
-    const iface = new ethers.Interface(abi);
-    const decoded = iface.decodeFunctionResult("getUserSuppliedAssets", result);
-    expect(decoded).toBeDefined();
-    expect(typeof decoded[0]).toBe("bigint");
-  }, 15_000);
+      const result = await manager.executeWithFailover((p) =>
+        p.call({ to, data })
+      );
+      const abi = JSON.parse(contract.abi as string);
+      const iface = new ethers.Interface(abi);
+      const decoded = iface.decodeFunctionResult(
+        "getUserSuppliedAssets",
+        result
+      );
+      expect(decoded).toBeDefined();
+      expect(typeof decoded[0]).toBe("bigint");
+    },
+    15_000
+  );
 
-  it("getUserDebt: eth_call returns two decodable uint256 values", async () => {
-    const { to, data, contract } = buildCalldata({
-      protocol: aaveV4Def,
-      actionSlug: "get-user-debt",
-      sampleInputs: { reserveId: "0", user: TEST_ADDRESS },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "getUserDebt: eth_call returns two decodable uint256 values",
+    async () => {
+      const { to, data, contract } = buildCalldata({
+        protocol: aaveV4Def,
+        actionSlug: "get-user-debt",
+        sampleInputs: { reserveId: "0", user: TEST_ADDRESS },
+        chainId: CHAIN_ID,
+      });
 
-    const result = await manager.executeWithFailover((p) =>
-      p.call({ to, data })
-    );
-    const abi = JSON.parse(contract.abi as string);
-    const iface = new ethers.Interface(abi);
-    const decoded = iface.decodeFunctionResult("getUserDebt", result);
-    expect(decoded).toBeDefined();
-    expect(decoded.length).toBeGreaterThanOrEqual(2);
-    expect(typeof decoded[0]).toBe("bigint");
-    expect(typeof decoded[1]).toBe("bigint");
-  }, 15_000);
+      const result = await manager.executeWithFailover((p) =>
+        p.call({ to, data })
+      );
+      const abi = JSON.parse(contract.abi as string);
+      const iface = new ethers.Interface(abi);
+      const decoded = iface.decodeFunctionResult("getUserDebt", result);
+      expect(decoded).toBeDefined();
+      expect(decoded.length).toBeGreaterThanOrEqual(2);
+      expect(typeof decoded[0]).toBe("bigint");
+      expect(typeof decoded[1]).toBe("bigint");
+    },
+    15_000
+  );
 
-  it("getUserAccountData: eth_call returns a decodable struct with named fields", async () => {
-    const { to, data, contract } = buildCalldata({
-      protocol: aaveV4Def,
-      actionSlug: "get-user-account-data",
-      sampleInputs: { user: TEST_ADDRESS },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "getUserAccountData: eth_call returns a decodable struct with named fields",
+    async () => {
+      const { to, data, contract } = buildCalldata({
+        protocol: aaveV4Def,
+        actionSlug: "get-user-account-data",
+        sampleInputs: { user: TEST_ADDRESS },
+        chainId: CHAIN_ID,
+      });
 
-    const result = await manager.executeWithFailover((p) =>
-      p.call({ to, data })
-    );
-    const abi = JSON.parse(contract.abi as string);
-    const iface = new ethers.Interface(abi);
-    const decoded = iface.decodeFunctionResult("getUserAccountData", result);
-    expect(decoded).toBeDefined();
-    const struct = decoded[0];
-    expect(typeof struct.healthFactor).toBe("bigint");
-    expect(typeof struct.totalCollateralValue).toBe("bigint");
-    expect(typeof struct.riskPremium).toBe("bigint");
-    expect(typeof struct.borrowCount).toBe("bigint");
-  }, 15_000);
+      const result = await manager.executeWithFailover((p) =>
+        p.call({ to, data })
+      );
+      const abi = JSON.parse(contract.abi as string);
+      const iface = new ethers.Interface(abi);
+      const decoded = iface.decodeFunctionResult("getUserAccountData", result);
+      expect(decoded).toBeDefined();
+      const struct = decoded[0];
+      expect(typeof struct.healthFactor).toBe("bigint");
+      expect(typeof struct.totalCollateralValue).toBe("bigint");
+      expect(typeof struct.riskPremium).toBe("bigint");
+      expect(typeof struct.borrowCount).toBe("bigint");
+    },
+    15_000
+  );
 
-  it("supply: deployed bytecode accepts the calldata", async () => {
-    const { to, data } = buildCalldata({
-      protocol: aaveV4Def,
-      actionSlug: "supply",
-      sampleInputs: {
-        reserveId: "0",
-        amount: "1000000000000000000",
-        onBehalfOf: TEST_ADDRESS,
-      },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "supply: deployed bytecode accepts the calldata",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: aaveV4Def,
+        actionSlug: "supply",
+        sampleInputs: {
+          reserveId: "0",
+          amount: "1000000000000000000",
+          onBehalfOf: TEST_ADDRESS,
+        },
+        chainId: CHAIN_ID,
+      });
 
-    await expectCallAcceptedByBytecode(manager, { to, data });
-  }, 15_000);
+      await expectCallAcceptedByBytecode(manager, { to, data });
+    },
+    15_000
+  );
 
-  it("setUsingAsCollateral: deployed bytecode accepts the calldata", async () => {
-    const { to, data } = buildCalldata({
-      protocol: aaveV4Def,
-      actionSlug: "set-collateral",
-      sampleInputs: {
-        reserveId: "0",
-        usingAsCollateral: "true",
-        onBehalfOf: TEST_ADDRESS,
-      },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "setUsingAsCollateral: deployed bytecode accepts the calldata",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: aaveV4Def,
+        actionSlug: "set-collateral",
+        sampleInputs: {
+          reserveId: "0",
+          usingAsCollateral: "true",
+          onBehalfOf: TEST_ADDRESS,
+        },
+        chainId: CHAIN_ID,
+      });
 
-    await expectCallAcceptedByBytecode(manager, { to, data });
-  }, 15_000);
+      await expectCallAcceptedByBytecode(manager, { to, data });
+    },
+    15_000
+  );
 });
 
 /**
@@ -208,8 +238,14 @@ async function expectCallAcceptedByBytecode(
     const result = await manager.executeWithFailover((p) =>
       p.call({ ...tx, from: TEST_ADDRESS })
     );
-    expect(result).toMatch(/^0x/);
+    expect(result).toMatch(HEX_PREFIX);
   } catch (err: unknown) {
+    // A transport fault (rate limit, node error, timeout) is not evidence
+    // about the calldata; let itOnchain retry it. A CALL_EXCEPTION is the
+    // deployed bytecode reverting, which is a passing outcome here.
+    if (isRpcNetworkError(err)) {
+      throw err;
+    }
     expect(err).toMatchObject({ code: "CALL_EXCEPTION" });
   }
 }

--- a/tests/integration/protocol-chainlink-onchain.test.ts
+++ b/tests/integration/protocol-chainlink-onchain.test.ts
@@ -21,7 +21,7 @@
  */
 
 import { ethers } from "ethers";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, vi } from "vitest";
 
 // `lib/rpc/providers` transitively imports `lib/safe-fetch` (via the
 // safe-ethers adapter), which declares `import "server-only"` and would
@@ -36,6 +36,7 @@ import {
 } from "@/lib/rpc/rpc-config";
 import chainlinkDef from "@/protocols/chainlink";
 import { buildCalldata } from "./_shared/build-calldata";
+import { itOnchain } from "./_shared/onchain-rpc";
 
 const CHAIN_ID = "11155111"; // Sepolia
 const CHAIN_ID_NUMBER = 11_155_111;
@@ -84,147 +85,171 @@ describe("Chainlink CCIP on-chain integration (Sepolia)", () => {
       "Sepolia (CCIP integration test)"
     );
 
-  it("ccip-get-fee: eth_call returns decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata({
-      protocol: chainlinkDef,
-      actionSlug: "ccip-get-fee",
-      sampleInputs: CCIP_MESSAGE_SAMPLE,
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "ccip-get-fee: eth_call returns decodable uint256",
+    async () => {
+      const { to, data, contract } = buildCalldata({
+        protocol: chainlinkDef,
+        actionSlug: "ccip-get-fee",
+        sampleInputs: CCIP_MESSAGE_SAMPLE,
+        chainId: CHAIN_ID,
+      });
 
-    const provider = await makeProvider();
-    try {
+      const provider = await makeProvider();
+      try {
+        const result = await provider.executeWithFailover(
+          async (p) => await p.call({ to, data })
+        );
+        const abi = JSON.parse(contract.abi as string);
+        const iface = new ethers.Interface(abi);
+        const decoded = iface.decodeFunctionResult("getFee", result);
+        expect(decoded).toBeDefined();
+        expect(typeof decoded[0]).toBe("bigint");
+      } catch (error) {
+        // getFee can revert for business reasons (e.g. unsupported lane),
+        // but the error must not be an ABI-level encoding/decoding failure.
+        const msg = String(error);
+        expect(msg).not.toContain("INVALID_ARGUMENT");
+        expect(msg).not.toContain("could not decode");
+        expect(msg).not.toContain("invalid function");
+      }
+    },
+    30_000
+  );
+
+  itOnchain(
+    "ccip-check-bridge-balance: eth_call returns decodable uint256",
+    async () => {
+      const { to, data, contract } = buildCalldata({
+        protocol: chainlinkDef,
+        actionSlug: "ccip-check-bridge-balance",
+        sampleInputs: { account: TEST_ADDRESS },
+        chainId: CHAIN_ID,
+        toOverride: CCIP_BNM_SEPOLIA,
+      });
+
+      const provider = await makeProvider();
       const result = await provider.executeWithFailover(
         async (p) => await p.call({ to, data })
       );
       const abi = JSON.parse(contract.abi as string);
       const iface = new ethers.Interface(abi);
-      const decoded = iface.decodeFunctionResult("getFee", result);
+      const decoded = iface.decodeFunctionResult("balanceOf", result);
       expect(decoded).toBeDefined();
       expect(typeof decoded[0]).toBe("bigint");
-    } catch (error) {
-      // getFee can revert for business reasons (e.g. unsupported lane),
-      // but the error must not be an ABI-level encoding/decoding failure.
-      const msg = String(error);
-      expect(msg).not.toContain("INVALID_ARGUMENT");
-      expect(msg).not.toContain("could not decode");
-      expect(msg).not.toContain("invalid function");
-    }
-  }, 30_000);
+    },
+    30_000
+  );
 
-  it("ccip-check-bridge-balance: eth_call returns decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata({
-      protocol: chainlinkDef,
-      actionSlug: "ccip-check-bridge-balance",
-      sampleInputs: { account: TEST_ADDRESS },
-      chainId: CHAIN_ID,
-      toOverride: CCIP_BNM_SEPOLIA,
-    });
+  itOnchain(
+    "ccip-check-bridge-allowance: eth_call returns decodable uint256",
+    async () => {
+      const { to, data, contract } = buildCalldata({
+        protocol: chainlinkDef,
+        actionSlug: "ccip-check-bridge-allowance",
+        sampleInputs: { owner: TEST_ADDRESS, spender: ethers.ZeroAddress },
+        chainId: CHAIN_ID,
+        toOverride: CCIP_BNM_SEPOLIA,
+      });
 
-    const provider = await makeProvider();
-    const result = await provider.executeWithFailover(
-      async (p) => await p.call({ to, data })
-    );
-    const abi = JSON.parse(contract.abi as string);
-    const iface = new ethers.Interface(abi);
-    const decoded = iface.decodeFunctionResult("balanceOf", result);
-    expect(decoded).toBeDefined();
-    expect(typeof decoded[0]).toBe("bigint");
-  }, 30_000);
-
-  it("ccip-check-bridge-allowance: eth_call returns decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata({
-      protocol: chainlinkDef,
-      actionSlug: "ccip-check-bridge-allowance",
-      sampleInputs: { owner: TEST_ADDRESS, spender: ethers.ZeroAddress },
-      chainId: CHAIN_ID,
-      toOverride: CCIP_BNM_SEPOLIA,
-    });
-
-    const provider = await makeProvider();
-    const result = await provider.executeWithFailover(
-      async (p) => await p.call({ to, data })
-    );
-    const abi = JSON.parse(contract.abi as string);
-    const iface = new ethers.Interface(abi);
-    const decoded = iface.decodeFunctionResult("allowance", result);
-    expect(decoded).toBeDefined();
-    expect(typeof decoded[0]).toBe("bigint");
-  }, 30_000);
-
-  it("ccip-approve-bridge-token: calldata encodes (business revert expected)", async () => {
-    const { to, data } = buildCalldata({
-      protocol: chainlinkDef,
-      actionSlug: "ccip-approve-bridge-token",
-      sampleInputs: {
-        spender: ethers.ZeroAddress,
-        amount: "1000000000000000000",
-      },
-      chainId: CHAIN_ID,
-      toOverride: CCIP_BNM_SEPOLIA,
-    });
-
-    const provider = await makeProvider();
-    try {
-      await provider.executeWithFailover(
-        async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
+      const provider = await makeProvider();
+      const result = await provider.executeWithFailover(
+        async (p) => await p.call({ to, data })
       );
-    } catch (error) {
-      const msg = String(error);
-      expect(msg).not.toContain("INVALID_ARGUMENT");
-      expect(msg).not.toContain("could not decode");
-      expect(msg).not.toContain("invalid function");
-    }
-  }, 30_000);
+      const abi = JSON.parse(contract.abi as string);
+      const iface = new ethers.Interface(abi);
+      const decoded = iface.decodeFunctionResult("allowance", result);
+      expect(decoded).toBeDefined();
+      expect(typeof decoded[0]).toBe("bigint");
+    },
+    30_000
+  );
 
-  it("ccip-send: calldata encodes (business revert expected)", async () => {
-    const { to, data } = buildCalldata({
-      protocol: chainlinkDef,
-      actionSlug: "ccip-send",
-      sampleInputs: CCIP_MESSAGE_SAMPLE,
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "ccip-approve-bridge-token: calldata encodes (business revert expected)",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: chainlinkDef,
+        actionSlug: "ccip-approve-bridge-token",
+        sampleInputs: {
+          spender: ethers.ZeroAddress,
+          amount: "1000000000000000000",
+        },
+        chainId: CHAIN_ID,
+        toOverride: CCIP_BNM_SEPOLIA,
+      });
 
-    const provider = await makeProvider();
-    try {
-      await provider.executeWithFailover(
-        async (p) =>
-          await p.estimateGas({
-            to,
-            data,
-            // Pay native for fee; any non-zero value is fine - estimateGas
-            // will revert for real-world reasons (fee mismatch, no balance)
-            // but the calldata itself must be ABI-valid.
-            value: ethers.parseEther("0.01"),
-            from: TEST_ADDRESS,
-          })
-      );
-    } catch (error) {
-      const msg = String(error);
-      expect(msg).not.toContain("INVALID_ARGUMENT");
-      expect(msg).not.toContain("could not decode");
-      expect(msg).not.toContain("invalid function");
-    }
-  }, 30_000);
+      const provider = await makeProvider();
+      try {
+        await provider.executeWithFailover(
+          async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
+        );
+      } catch (error) {
+        const msg = String(error);
+        expect(msg).not.toContain("INVALID_ARGUMENT");
+        expect(msg).not.toContain("could not decode");
+        expect(msg).not.toContain("invalid function");
+      }
+    },
+    30_000
+  );
 
-  it("ccip-bnm-drip: calldata encodes (business revert expected)", async () => {
-    const { to, data } = buildCalldata({
-      protocol: chainlinkDef,
-      actionSlug: "ccip-bnm-drip",
-      sampleInputs: { to: TEST_ADDRESS },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "ccip-send: calldata encodes (business revert expected)",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: chainlinkDef,
+        actionSlug: "ccip-send",
+        sampleInputs: CCIP_MESSAGE_SAMPLE,
+        chainId: CHAIN_ID,
+      });
 
-    const provider = await makeProvider();
-    try {
-      await provider.executeWithFailover(
-        async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
-      );
-    } catch (error) {
-      const msg = String(error);
-      expect(msg).not.toContain("INVALID_ARGUMENT");
-      expect(msg).not.toContain("could not decode");
-      expect(msg).not.toContain("invalid function");
-    }
-  }, 30_000);
+      const provider = await makeProvider();
+      try {
+        await provider.executeWithFailover(
+          async (p) =>
+            await p.estimateGas({
+              to,
+              data,
+              // Pay native for fee; any non-zero value is fine - estimateGas
+              // will revert for real-world reasons (fee mismatch, no balance)
+              // but the calldata itself must be ABI-valid.
+              value: ethers.parseEther("0.01"),
+              from: TEST_ADDRESS,
+            })
+        );
+      } catch (error) {
+        const msg = String(error);
+        expect(msg).not.toContain("INVALID_ARGUMENT");
+        expect(msg).not.toContain("could not decode");
+        expect(msg).not.toContain("invalid function");
+      }
+    },
+    30_000
+  );
+
+  itOnchain(
+    "ccip-bnm-drip: calldata encodes (business revert expected)",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: chainlinkDef,
+        actionSlug: "ccip-bnm-drip",
+        sampleInputs: { to: TEST_ADDRESS },
+        chainId: CHAIN_ID,
+      });
+
+      const provider = await makeProvider();
+      try {
+        await provider.executeWithFailover(
+          async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
+        );
+      } catch (error) {
+        const msg = String(error);
+        expect(msg).not.toContain("INVALID_ARGUMENT");
+        expect(msg).not.toContain("could not decode");
+        expect(msg).not.toContain("invalid function");
+      }
+    },
+    30_000
+  );
 });

--- a/tests/integration/protocol-frax-ether-v2-onchain.test.ts
+++ b/tests/integration/protocol-frax-ether-v2-onchain.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { ethers } from "ethers";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, vi } from "vitest";
 
 // `lib/rpc/providers` transitively imports `lib/safe-fetch` (via the
 // safe-ethers adapter), which declares `import "server-only"` and would
@@ -34,6 +34,7 @@ import {
 } from "@/lib/rpc/rpc-config";
 import fraxEtherV2Def from "@/protocols/frax-ether-v2";
 import { buildCalldata } from "./_shared/build-calldata";
+import { itOnchain } from "./_shared/onchain-rpc";
 
 const CHAIN_ID = "1";
 const MAINNET_CHAIN_ID = 1;
@@ -124,55 +125,71 @@ describe("Frax Ether V2 minter on-chain integration", () => {
     }
   }
 
-  it("mintFrxEthPaused: eth_call returns a decodable bool", async () => {
-    const { to, data, contract } = buildCalldata({
-      protocol: fraxEtherV2Def,
-      actionSlug: "mint-paused",
-      sampleInputs: {},
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "mintFrxEthPaused: eth_call returns a decodable bool",
+    async () => {
+      const { to, data, contract } = buildCalldata({
+        protocol: fraxEtherV2Def,
+        actionSlug: "mint-paused",
+        sampleInputs: {},
+        chainId: CHAIN_ID,
+      });
 
-    const result = await manager.executeWithFailover((p) =>
-      p.call({ to, data })
-    );
+      const result = await manager.executeWithFailover((p) =>
+        p.call({ to, data })
+      );
 
-    const abi = JSON.parse(contract.abi as string);
-    const iface = new ethers.Interface(abi);
-    const decoded = iface.decodeFunctionResult("mintFrxEthPaused", result);
-    expect(decoded).toBeDefined();
-    expect(typeof decoded[0]).toBe("boolean");
-  }, 15_000);
+      const abi = JSON.parse(contract.abi as string);
+      const iface = new ethers.Interface(abi);
+      const decoded = iface.decodeFunctionResult("mintFrxEthPaused", result);
+      expect(decoded).toBeDefined();
+      expect(typeof decoded[0]).toBe("boolean");
+    },
+    15_000
+  );
 
-  it("mintFrxEth: deployed bytecode accepts the calldata", async () => {
-    const { to, data } = buildCalldata({
-      protocol: fraxEtherV2Def,
-      actionSlug: "mint",
-      sampleInputs: {},
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "mintFrxEth: deployed bytecode accepts the calldata",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: fraxEtherV2Def,
+        actionSlug: "mint",
+        sampleInputs: {},
+        chainId: CHAIN_ID,
+      });
 
-    await expect(simulateBytecodeCall({ to, data })).resolves.toBeUndefined();
-  }, 15_000);
+      await expect(simulateBytecodeCall({ to, data })).resolves.toBeUndefined();
+    },
+    15_000
+  );
 
-  it("mintFrxEthAndGive: deployed bytecode accepts the calldata", async () => {
-    const { to, data } = buildCalldata({
-      protocol: fraxEtherV2Def,
-      actionSlug: "mint-and-give",
-      sampleInputs: { recipient: TEST_ADDRESS },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "mintFrxEthAndGive: deployed bytecode accepts the calldata",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: fraxEtherV2Def,
+        actionSlug: "mint-and-give",
+        sampleInputs: { recipient: TEST_ADDRESS },
+        chainId: CHAIN_ID,
+      });
 
-    await expect(simulateBytecodeCall({ to, data })).resolves.toBeUndefined();
-  }, 15_000);
+      await expect(simulateBytecodeCall({ to, data })).resolves.toBeUndefined();
+    },
+    15_000
+  );
 
-  it("submitAndDeposit: deployed bytecode accepts the calldata", async () => {
-    const { to, data } = buildCalldata({
-      protocol: fraxEtherV2Def,
-      actionSlug: "mint-and-stake",
-      sampleInputs: { recipient: TEST_ADDRESS },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "submitAndDeposit: deployed bytecode accepts the calldata",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: fraxEtherV2Def,
+        actionSlug: "mint-and-stake",
+        sampleInputs: { recipient: TEST_ADDRESS },
+        chainId: CHAIN_ID,
+      });
 
-    await expect(simulateBytecodeCall({ to, data })).resolves.toBeUndefined();
-  }, 15_000);
+      await expect(simulateBytecodeCall({ to, data })).resolves.toBeUndefined();
+    },
+    15_000
+  );
 });

--- a/tests/integration/protocol-rocket-pool-onchain.test.ts
+++ b/tests/integration/protocol-rocket-pool-onchain.test.ts
@@ -21,7 +21,7 @@
  */
 
 import { ethers } from "ethers";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, vi } from "vitest";
 
 // `lib/rpc/providers` transitively imports `lib/safe-fetch` (via the
 // safe-ethers adapter), which declares `import "server-only"` and would
@@ -37,10 +37,12 @@ import {
 } from "@/lib/rpc/rpc-config";
 import rocketPoolDef from "@/protocols/rocket-pool";
 import { buildCalldata } from "./_shared/build-calldata";
+import { isRpcNetworkError, itOnchain } from "./_shared/onchain-rpc";
 
 const CHAIN_ID = "1";
 const MAINNET_CHAIN_ID = 1;
 const TEST_ADDRESS = "0x0000000000000000000000000000000000000001";
+const HEX_PREFIX = /^0x/;
 
 // Resolve Ethereum mainnet RPC URLs via the shared config pipeline:
 // CHAIN_RPC_CONFIG first, individual env vars second, public default last.
@@ -60,10 +62,11 @@ const MAINNET_FALLBACK_URL = resolveRpcUrl(
 );
 
 // Assertion model:
-//  - Read tests: let the RPC call fail loudly. A success path asserts the
-//    decoded return has the expected shape; anything else (network error,
-//    ABI mismatch, decode failure) surfaces as a real test failure instead
-//    of being swallowed.
+//  - Read tests: a success path asserts the decoded return has the expected
+//    shape. An ABI mismatch or decode failure fails the test. A transient
+//    RPC-infrastructure fault (rate limit, node error, missing revert data)
+//    is retried with backoff by itOnchain, so a rate-limit blip does not
+//    flake the suite; a persistent fault still fails.
 //  - Write tests: use provider.call against a zero-balance TEST_ADDRESS.
 //    The contract should either (a) revert with CALL_EXCEPTION on business
 //    logic (insufficient balance for burn, deposit pool not accepting
@@ -86,99 +89,123 @@ describe("Rocket Pool on-chain integration", () => {
     );
   });
 
-  it("getExchangeRate: eth_call returns a decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata({
-      protocol: rocketPoolDef,
-      actionSlug: "get-exchange-rate",
-      sampleInputs: {},
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "getExchangeRate: eth_call returns a decodable uint256",
+    async () => {
+      const { to, data, contract } = buildCalldata({
+        protocol: rocketPoolDef,
+        actionSlug: "get-exchange-rate",
+        sampleInputs: {},
+        chainId: CHAIN_ID,
+      });
 
-    const result = await manager.executeWithFailover((p) =>
-      p.call({ to, data })
-    );
-    const abi = JSON.parse(contract.abi as string);
-    const iface = new ethers.Interface(abi);
-    const decoded = iface.decodeFunctionResult("getExchangeRate", result);
-    expect(decoded).toBeDefined();
-    expect(typeof decoded[0]).toBe("bigint");
-  }, 15_000);
+      const result = await manager.executeWithFailover((p) =>
+        p.call({ to, data })
+      );
+      const abi = JSON.parse(contract.abi as string);
+      const iface = new ethers.Interface(abi);
+      const decoded = iface.decodeFunctionResult("getExchangeRate", result);
+      expect(decoded).toBeDefined();
+      expect(typeof decoded[0]).toBe("bigint");
+    },
+    15_000
+  );
 
-  it("balanceOf: eth_call returns a decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata({
-      protocol: rocketPoolDef,
-      actionSlug: "balance-of",
-      sampleInputs: { account: TEST_ADDRESS },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "balanceOf: eth_call returns a decodable uint256",
+    async () => {
+      const { to, data, contract } = buildCalldata({
+        protocol: rocketPoolDef,
+        actionSlug: "balance-of",
+        sampleInputs: { account: TEST_ADDRESS },
+        chainId: CHAIN_ID,
+      });
 
-    const result = await manager.executeWithFailover((p) =>
-      p.call({ to, data })
-    );
-    const abi = JSON.parse(contract.abi as string);
-    const iface = new ethers.Interface(abi);
-    const decoded = iface.decodeFunctionResult("balanceOf", result);
-    expect(decoded).toBeDefined();
-    expect(typeof decoded[0]).toBe("bigint");
-  }, 15_000);
+      const result = await manager.executeWithFailover((p) =>
+        p.call({ to, data })
+      );
+      const abi = JSON.parse(contract.abi as string);
+      const iface = new ethers.Interface(abi);
+      const decoded = iface.decodeFunctionResult("balanceOf", result);
+      expect(decoded).toBeDefined();
+      expect(typeof decoded[0]).toBe("bigint");
+    },
+    15_000
+  );
 
-  it("totalSupply: eth_call returns a decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata({
-      protocol: rocketPoolDef,
-      actionSlug: "total-supply",
-      sampleInputs: {},
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "totalSupply: eth_call returns a decodable uint256",
+    async () => {
+      const { to, data, contract } = buildCalldata({
+        protocol: rocketPoolDef,
+        actionSlug: "total-supply",
+        sampleInputs: {},
+        chainId: CHAIN_ID,
+      });
 
-    const result = await manager.executeWithFailover((p) =>
-      p.call({ to, data })
-    );
-    const abi = JSON.parse(contract.abi as string);
-    const iface = new ethers.Interface(abi);
-    const decoded = iface.decodeFunctionResult("totalSupply", result);
-    expect(decoded).toBeDefined();
-    expect(typeof decoded[0]).toBe("bigint");
-  }, 15_000);
+      const result = await manager.executeWithFailover((p) =>
+        p.call({ to, data })
+      );
+      const abi = JSON.parse(contract.abi as string);
+      const iface = new ethers.Interface(abi);
+      const decoded = iface.decodeFunctionResult("totalSupply", result);
+      expect(decoded).toBeDefined();
+      expect(typeof decoded[0]).toBe("bigint");
+    },
+    15_000
+  );
 
-  it("getTotalCollateral: eth_call returns a decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata({
-      protocol: rocketPoolDef,
-      actionSlug: "get-total-collateral",
-      sampleInputs: {},
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "getTotalCollateral: eth_call returns a decodable uint256",
+    async () => {
+      const { to, data, contract } = buildCalldata({
+        protocol: rocketPoolDef,
+        actionSlug: "get-total-collateral",
+        sampleInputs: {},
+        chainId: CHAIN_ID,
+      });
 
-    const result = await manager.executeWithFailover((p) =>
-      p.call({ to, data })
-    );
-    const abi = JSON.parse(contract.abi as string);
-    const iface = new ethers.Interface(abi);
-    const decoded = iface.decodeFunctionResult("getTotalCollateral", result);
-    expect(decoded).toBeDefined();
-    expect(typeof decoded[0]).toBe("bigint");
-  }, 15_000);
+      const result = await manager.executeWithFailover((p) =>
+        p.call({ to, data })
+      );
+      const abi = JSON.parse(contract.abi as string);
+      const iface = new ethers.Interface(abi);
+      const decoded = iface.decodeFunctionResult("getTotalCollateral", result);
+      expect(decoded).toBeDefined();
+      expect(typeof decoded[0]).toBe("bigint");
+    },
+    15_000
+  );
 
-  it("deposit: deployed bytecode accepts the calldata", async () => {
-    const { to, data } = buildCalldata({
-      protocol: rocketPoolDef,
-      actionSlug: "deposit",
-      sampleInputs: {},
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "deposit: deployed bytecode accepts the calldata",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: rocketPoolDef,
+        actionSlug: "deposit",
+        sampleInputs: {},
+        chainId: CHAIN_ID,
+      });
 
-    await expectCallAcceptedByBytecode(manager, { to, data });
-  }, 15_000);
+      await expectCallAcceptedByBytecode(manager, { to, data });
+    },
+    15_000
+  );
 
-  it("burn: deployed bytecode accepts the calldata", async () => {
-    const { to, data } = buildCalldata({
-      protocol: rocketPoolDef,
-      actionSlug: "burn",
-      sampleInputs: { amount: "1000000000000000000" },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "burn: deployed bytecode accepts the calldata",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: rocketPoolDef,
+        actionSlug: "burn",
+        sampleInputs: { amount: "1000000000000000000" },
+        chainId: CHAIN_ID,
+      });
 
-    await expectCallAcceptedByBytecode(manager, { to, data });
-  }, 15_000);
+      await expectCallAcceptedByBytecode(manager, { to, data });
+    },
+    15_000
+  );
 });
 
 /**
@@ -196,8 +223,14 @@ async function expectCallAcceptedByBytecode(
     const result = await manager.executeWithFailover((p) =>
       p.call({ ...tx, from: TEST_ADDRESS })
     );
-    expect(result).toMatch(/^0x/);
+    expect(result).toMatch(HEX_PREFIX);
   } catch (err: unknown) {
+    // A transport fault (rate limit, node error, timeout) is not evidence
+    // about the calldata; let itOnchain retry it. A CALL_EXCEPTION is the
+    // deployed bytecode reverting, which is a passing outcome here.
+    if (isRpcNetworkError(err)) {
+      throw err;
+    }
     expect(err).toMatchObject({ code: "CALL_EXCEPTION" });
   }
 }

--- a/tests/integration/protocol-superfluid-onchain.test.ts
+++ b/tests/integration/protocol-superfluid-onchain.test.ts
@@ -21,7 +21,7 @@
  */
 
 import { ethers } from "ethers";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, vi } from "vitest";
 
 // `lib/rpc/providers` transitively imports `lib/safe-fetch` (via the
 // safe-ethers adapter), which declares `import "server-only"` and would
@@ -41,6 +41,7 @@ import superfluidDef, {
   GDA_FORWARDER_ADDRESS,
 } from "@/protocols/superfluid";
 import { buildCalldata } from "./_shared/build-calldata";
+import { itOnchain } from "./_shared/onchain-rpc";
 
 const CHAIN_ID = "11155111";
 const SEPOLIA_CHAIN_ID = 11_155_111;
@@ -170,258 +171,329 @@ describe("Superfluid on-chain integration", () => {
 
   // -- CFA reads -----------------------------------------------------------
 
-  it("get-flow: returns the four expected CFA flow-info outputs", async () => {
-    const { decoded, to } = await callAndDecode("get-flow", {
-      token: SEPOLIA_FUSDCX,
-      sender: TEST_ADDRESS,
-      receiver: TEST_ADDRESS,
-    });
-    expect(to).toBe(CFA_FORWARDER_ADDRESS);
-    expect(decoded).toHaveLength(4);
-  }, 15_000);
+  itOnchain(
+    "get-flow: returns the four expected CFA flow-info outputs",
+    async () => {
+      const { decoded, to } = await callAndDecode("get-flow", {
+        token: SEPOLIA_FUSDCX,
+        sender: TEST_ADDRESS,
+        receiver: TEST_ADDRESS,
+      });
+      expect(to).toBe(CFA_FORWARDER_ADDRESS);
+      expect(decoded).toHaveLength(4);
+    },
+    15_000
+  );
 
-  it("get-cfa-net-flow: dispatches to cfaForwarder.getAccountFlowrate", async () => {
-    const { decoded, to } = await callAndDecode("get-cfa-net-flow", {
-      token: SEPOLIA_FUSDCX,
-      account: TEST_ADDRESS,
-    });
-    expect(to).toBe(CFA_FORWARDER_ADDRESS);
-    expect(typeof decoded[0]).toBe("bigint");
-  }, 15_000);
+  itOnchain(
+    "get-cfa-net-flow: dispatches to cfaForwarder.getAccountFlowrate",
+    async () => {
+      const { decoded, to } = await callAndDecode("get-cfa-net-flow", {
+        token: SEPOLIA_FUSDCX,
+        account: TEST_ADDRESS,
+      });
+      expect(to).toBe(CFA_FORWARDER_ADDRESS);
+      expect(typeof decoded[0]).toBe("bigint");
+    },
+    15_000
+  );
 
   // -- GDA reads -----------------------------------------------------------
 
-  it("get-net-flow: dispatches to gdaForwarder.getNetFlow (combined CFA+GDA)", async () => {
-    const { decoded, to } = await callAndDecode("get-net-flow", {
-      token: SEPOLIA_FUSDCX,
-      account: TEST_ADDRESS,
-    });
-    expect(to).toBe(GDA_FORWARDER_ADDRESS);
-    expect(typeof decoded[0]).toBe("bigint");
-  }, 15_000);
+  itOnchain(
+    "get-net-flow: dispatches to gdaForwarder.getNetFlow (combined CFA+GDA)",
+    async () => {
+      const { decoded, to } = await callAndDecode("get-net-flow", {
+        token: SEPOLIA_FUSDCX,
+        account: TEST_ADDRESS,
+      });
+      expect(to).toBe(GDA_FORWARDER_ADDRESS);
+      expect(typeof decoded[0]).toBe("bigint");
+    },
+    15_000
+  );
 
   // -- SuperToken reads (userSpecifiedAddress) -----------------------------
 
-  it("get-super-token-balance: dispatches to the user-supplied SuperToken", async () => {
-    const { decoded } = await callAndDecode(
-      "get-super-token-balance",
-      { account: TEST_ADDRESS },
-      SEPOLIA_FUSDCX
-    );
-    expect(typeof decoded[0]).toBe("bigint");
-  }, 15_000);
+  itOnchain(
+    "get-super-token-balance: dispatches to the user-supplied SuperToken",
+    async () => {
+      const { decoded } = await callAndDecode(
+        "get-super-token-balance",
+        { account: TEST_ADDRESS },
+        SEPOLIA_FUSDCX
+      );
+      expect(typeof decoded[0]).toBe("bigint");
+    },
+    15_000
+  );
 
-  it("get-underlying-token: returns the fUSDC underlying for fUSDCx", async () => {
-    const { decoded } = await callAndDecode(
-      "get-underlying-token",
-      {},
-      SEPOLIA_FUSDCX
-    );
-    expect((decoded[0] as string).toLowerCase()).toBe(
-      SEPOLIA_FUSDC.toLowerCase()
-    );
-  }, 15_000);
+  itOnchain(
+    "get-underlying-token: returns the fUSDC underlying for fUSDCx",
+    async () => {
+      const { decoded } = await callAndDecode(
+        "get-underlying-token",
+        {},
+        SEPOLIA_FUSDCX
+      );
+      expect((decoded[0] as string).toLowerCase()).toBe(
+        SEPOLIA_FUSDC.toLowerCase()
+      );
+    },
+    15_000
+  );
 
   // -- CFA writes ----------------------------------------------------------
 
-  it("create-flow: encodes against cfaForwarder.createFlow", async () => {
-    const msg = await estimateGasError("create-flow", {
-      token: SEPOLIA_FUSDCX,
-      sender: TEST_ADDRESS,
-      receiver: TEST_ADDRESS,
-      flowRate: DUMMY_FLOW_RATE,
-      userData: DUMMY_BYTES,
-    });
-    expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
-  }, 15_000);
+  itOnchain(
+    "create-flow: encodes against cfaForwarder.createFlow",
+    async () => {
+      const msg = await estimateGasError("create-flow", {
+        token: SEPOLIA_FUSDCX,
+        sender: TEST_ADDRESS,
+        receiver: TEST_ADDRESS,
+        flowRate: DUMMY_FLOW_RATE,
+        userData: DUMMY_BYTES,
+      });
+      expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
+    },
+    15_000
+  );
 
-  it("update-flow: encodes against cfaForwarder.updateFlow", async () => {
-    const msg = await estimateGasError("update-flow", {
-      token: SEPOLIA_FUSDCX,
-      sender: TEST_ADDRESS,
-      receiver: TEST_ADDRESS,
-      flowRate: DUMMY_FLOW_RATE,
-      userData: DUMMY_BYTES,
-    });
-    expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
-  }, 15_000);
+  itOnchain(
+    "update-flow: encodes against cfaForwarder.updateFlow",
+    async () => {
+      const msg = await estimateGasError("update-flow", {
+        token: SEPOLIA_FUSDCX,
+        sender: TEST_ADDRESS,
+        receiver: TEST_ADDRESS,
+        flowRate: DUMMY_FLOW_RATE,
+        userData: DUMMY_BYTES,
+      });
+      expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
+    },
+    15_000
+  );
 
-  it("delete-flow: encodes against cfaForwarder.deleteFlow", async () => {
-    const msg = await estimateGasError("delete-flow", {
-      token: SEPOLIA_FUSDCX,
-      sender: TEST_ADDRESS,
-      receiver: TEST_ADDRESS,
-      userData: DUMMY_BYTES,
-    });
-    expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
-  }, 15_000);
+  itOnchain(
+    "delete-flow: encodes against cfaForwarder.deleteFlow",
+    async () => {
+      const msg = await estimateGasError("delete-flow", {
+        token: SEPOLIA_FUSDCX,
+        sender: TEST_ADDRESS,
+        receiver: TEST_ADDRESS,
+        userData: DUMMY_BYTES,
+      });
+      expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
+    },
+    15_000
+  );
 
   // -- GDA writes ----------------------------------------------------------
 
-  it("create-pool: simulates successfully against gdaForwarder.createPool", async () => {
-    // GDA createPool only writes pool metadata -- no sender balance, no
-    // pre-existing state required. We can assert positive simulation
-    // success, which (unlike the loose .not.toMatch guard) catches the
-    // class of routing bug KEEP-456 surfaced.
-    const msg = await estimateGasError("create-pool", {
-      token: SEPOLIA_FUSDCX,
-      admin: TEST_ADDRESS,
-      transferabilityForUnitsOwner: "false",
-      distributionFromAnyAddress: "false",
-    });
-    expect(msg).toBe("");
-  }, 15_000);
+  itOnchain(
+    "create-pool: simulates successfully against gdaForwarder.createPool",
+    async () => {
+      // GDA createPool only writes pool metadata -- no sender balance, no
+      // pre-existing state required. We can assert positive simulation
+      // success, which (unlike the loose .not.toMatch guard) catches the
+      // class of routing bug KEEP-456 surfaced.
+      const msg = await estimateGasError("create-pool", {
+        token: SEPOLIA_FUSDCX,
+        admin: TEST_ADDRESS,
+        transferabilityForUnitsOwner: "false",
+        distributionFromAnyAddress: "false",
+      });
+      expect(msg).toBe("");
+    },
+    15_000
+  );
 
-  it("update-member-units: encodes against gdaForwarder.updateMemberUnits", async () => {
-    const msg = await estimateGasError("update-member-units", {
-      pool: TEST_ADDRESS,
-      member: TEST_ADDRESS,
-      units: DUMMY_UNITS,
-      userData: DUMMY_BYTES,
-    });
-    expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
-  }, 15_000);
+  itOnchain(
+    "update-member-units: encodes against gdaForwarder.updateMemberUnits",
+    async () => {
+      const msg = await estimateGasError("update-member-units", {
+        pool: TEST_ADDRESS,
+        member: TEST_ADDRESS,
+        units: DUMMY_UNITS,
+        userData: DUMMY_BYTES,
+      });
+      expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
+    },
+    15_000
+  );
 
-  it("distribute: encodes against gdaForwarder.distribute", async () => {
-    const msg = await estimateGasError("distribute", {
-      token: SEPOLIA_FUSDCX,
-      from: TEST_ADDRESS,
-      pool: TEST_ADDRESS,
-      amount: DUMMY_AMOUNT_WEI,
-      userData: DUMMY_BYTES,
-    });
-    expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
-  }, 15_000);
+  itOnchain(
+    "distribute: encodes against gdaForwarder.distribute",
+    async () => {
+      const msg = await estimateGasError("distribute", {
+        token: SEPOLIA_FUSDCX,
+        from: TEST_ADDRESS,
+        pool: TEST_ADDRESS,
+        amount: DUMMY_AMOUNT_WEI,
+        userData: DUMMY_BYTES,
+      });
+      expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
+    },
+    15_000
+  );
 
-  it("distribute-flow: encodes int96 flowRate against gdaForwarder.distributeFlow", async () => {
-    const msg = await estimateGasError("distribute-flow", {
-      token: SEPOLIA_FUSDCX,
-      from: TEST_ADDRESS,
-      pool: TEST_ADDRESS,
-      flowRate: DUMMY_FLOW_RATE,
-      userData: DUMMY_BYTES,
-    });
-    expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
-  }, 15_000);
+  itOnchain(
+    "distribute-flow: encodes int96 flowRate against gdaForwarder.distributeFlow",
+    async () => {
+      const msg = await estimateGasError("distribute-flow", {
+        token: SEPOLIA_FUSDCX,
+        from: TEST_ADDRESS,
+        pool: TEST_ADDRESS,
+        flowRate: DUMMY_FLOW_RATE,
+        userData: DUMMY_BYTES,
+      });
+      expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
+    },
+    15_000
+  );
 
-  it("connect-pool: encodes against gdaForwarder.connectPool", async () => {
-    // Not convertible to toBe(""): the GDA host dispatches into the pool
-    // address as a contract call during connectPool, and TEST_ADDRESS has
-    // no deployed code -- so estimateGas reverts with `CallUtils: target
-    // revert()`. That is not a routing/ABI failure (the revert *does*
-    // have data, just from a different source), so it correctly does not
-    // match DISPATCH_FAILURE_RE. Strengthening to toBe("") would need a
-    // deployed contract at the pool address that implements the expected
-    // pool interface (any Superfluid pool would do); out of scope for
-    // "no on-chain state dependency" tests.
-    const msg = await estimateGasError("connect-pool", {
-      pool: TEST_ADDRESS,
-      userData: DUMMY_BYTES,
-    });
-    expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
-  }, 15_000);
+  itOnchain(
+    "connect-pool: encodes against gdaForwarder.connectPool",
+    async () => {
+      // Not convertible to toBe(""): the GDA host dispatches into the pool
+      // address as a contract call during connectPool, and TEST_ADDRESS has
+      // no deployed code -- so estimateGas reverts with `CallUtils: target
+      // revert()`. That is not a routing/ABI failure (the revert *does*
+      // have data, just from a different source), so it correctly does not
+      // match DISPATCH_FAILURE_RE. Strengthening to toBe("") would need a
+      // deployed contract at the pool address that implements the expected
+      // pool interface (any Superfluid pool would do); out of scope for
+      // "no on-chain state dependency" tests.
+      const msg = await estimateGasError("connect-pool", {
+        pool: TEST_ADDRESS,
+        userData: DUMMY_BYTES,
+      });
+      expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
+    },
+    15_000
+  );
 
   // -- SuperToken writes (userSpecifiedAddress) ----------------------------
 
-  it("wrap: encodes uint256 amount against superToken.upgrade", async () => {
-    const msg = await estimateGasError(
-      "wrap",
-      { amount: DUMMY_AMOUNT_WEI },
-      SEPOLIA_FUSDCX
-    );
-    expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
-  }, 15_000);
+  itOnchain(
+    "wrap: encodes uint256 amount against superToken.upgrade",
+    async () => {
+      const msg = await estimateGasError(
+        "wrap",
+        { amount: DUMMY_AMOUNT_WEI },
+        SEPOLIA_FUSDCX
+      );
+      expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
+    },
+    15_000
+  );
 
-  it("unwrap: encodes uint256 amount against superToken.downgrade", async () => {
-    const msg = await estimateGasError(
-      "unwrap",
-      { amount: DUMMY_AMOUNT_WEI },
-      SEPOLIA_FUSDCX
-    );
-    expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
-  }, 15_000);
+  itOnchain(
+    "unwrap: encodes uint256 amount against superToken.downgrade",
+    async () => {
+      const msg = await estimateGasError(
+        "unwrap",
+        { amount: DUMMY_AMOUNT_WEI },
+        SEPOLIA_FUSDCX
+      );
+      expect(msg).not.toMatch(DISPATCH_FAILURE_RE);
+    },
+    15_000
+  );
 
-  it("grant-flow-operator: simulates successfully against cfaForwarder.updateFlowOperatorPermissions", async () => {
-    // KEEP-456: routed through the CFAv1Forwarder, not the SuperToken proxy.
-    // Asserts the call actually simulates (estimateGas returns) -- the previous
-    // "tolerate any revert" pattern hid a routing bug because the SuperToken's
-    // proxy reverts on the Sepolia fUSDCx test token. The CFAv1Forwarder is
-    // the canonical entry point and works for any registered SuperToken.
-    //
-    // Note: this on-chain test is gated on INTEGRATION_TEST_RPC_URL and
-    // skipped in CI. The CI-side regression guard for the routing change
-    // lives in tests/unit/superfluid-protocol.test.ts ("grant-flow-operator
-    // action" describe block, asserting `contract === "cfaForwarder"`).
-    const msg = await estimateGasError("grant-flow-operator", {
-      token: SEPOLIA_FUSDCX,
-      flowOperator: TEST_OPERATOR,
-      permissions: DUMMY_PERMISSIONS_ALL,
-      flowRateAllowance: DUMMY_FLOW_RATE,
-    });
-    expect(msg).toBe("");
-  }, 15_000);
-
-  // -- Reroute regression --------------------------------------------------
-
-  it("reroute regression: misdispatched calldata triggers DISPATCH_FAILURE_RE", async () => {
-    // Acceptance criterion #2 of KEEP-459: "no test passes when its
-    // action is silently re-routed to a non-existent contract method."
-    //
-    // Reproduces the KEEP-456 failure mode end-to-end against the live
-    // Sepolia RPC: take a currently-passing action (grant-flow-operator,
-    // which routes correctly to the CFAv1Forwarder), then override its
-    // destination to SEPOLIA_FUSDC -- a real ERC20 contract that exists
-    // on chain but has no Superfluid methods. The EVM returns from the
-    // dispatch with empty revert data (no fallback, no matching selector),
-    // and ethers surfaces it as `missing revert data ... code=CALL_EXCEPTION`.
-    //
-    // If DISPATCH_FAILURE_RE is ever weakened or removed, this test fails
-    // -- which is the whole point. This is the load-bearing assertion of
-    // the hardening, validated against a real RPC rather than a regex
-    // shape sample.
-    const msg = await estimateGasError(
-      "grant-flow-operator",
-      {
+  itOnchain(
+    "grant-flow-operator: simulates successfully against cfaForwarder.updateFlowOperatorPermissions",
+    async () => {
+      // KEEP-456: routed through the CFAv1Forwarder, not the SuperToken proxy.
+      // Asserts the call actually simulates (estimateGas returns) -- the previous
+      // "tolerate any revert" pattern hid a routing bug because the SuperToken's
+      // proxy reverts on the Sepolia fUSDCx test token. The CFAv1Forwarder is
+      // the canonical entry point and works for any registered SuperToken.
+      //
+      // Note: this on-chain test is gated on INTEGRATION_TEST_RPC_URL and
+      // skipped in CI. The CI-side regression guard for the routing change
+      // lives in tests/unit/superfluid-protocol.test.ts ("grant-flow-operator
+      // action" describe block, asserting `contract === "cfaForwarder"`).
+      const msg = await estimateGasError("grant-flow-operator", {
         token: SEPOLIA_FUSDCX,
         flowOperator: TEST_OPERATOR,
         permissions: DUMMY_PERMISSIONS_ALL,
         flowRateAllowance: DUMMY_FLOW_RATE,
-      },
-      SEPOLIA_FUSDC
-    );
-    // Sanity: must not be the empty-string "simulated" case.
-    expect(msg).not.toBe("");
-    // The actual guard: a real misroute must surface as a dispatch failure.
-    expect(msg).toMatch(DISPATCH_FAILURE_RE);
-  }, 15_000);
+      });
+      expect(msg).toBe("");
+    },
+    15_000
+  );
+
+  // -- Reroute regression --------------------------------------------------
+
+  itOnchain(
+    "reroute regression: misdispatched calldata triggers DISPATCH_FAILURE_RE",
+    async () => {
+      // Acceptance criterion #2 of KEEP-459: "no test passes when its
+      // action is silently re-routed to a non-existent contract method."
+      //
+      // Reproduces the KEEP-456 failure mode end-to-end against the live
+      // Sepolia RPC: take a currently-passing action (grant-flow-operator,
+      // which routes correctly to the CFAv1Forwarder), then override its
+      // destination to SEPOLIA_FUSDC -- a real ERC20 contract that exists
+      // on chain but has no Superfluid methods. The EVM returns from the
+      // dispatch with empty revert data (no fallback, no matching selector),
+      // and ethers surfaces it as `missing revert data ... code=CALL_EXCEPTION`.
+      //
+      // If DISPATCH_FAILURE_RE is ever weakened or removed, this test fails
+      // -- which is the whole point. This is the load-bearing assertion of
+      // the hardening, validated against a real RPC rather than a regex
+      // shape sample.
+      const msg = await estimateGasError(
+        "grant-flow-operator",
+        {
+          token: SEPOLIA_FUSDCX,
+          flowOperator: TEST_OPERATOR,
+          permissions: DUMMY_PERMISSIONS_ALL,
+          flowRateAllowance: DUMMY_FLOW_RATE,
+        },
+        SEPOLIA_FUSDC
+      );
+      // Sanity: must not be the empty-string "simulated" case.
+      expect(msg).not.toBe("");
+      // The actual guard: a real misroute must surface as a dispatch failure.
+      expect(msg).toMatch(DISPATCH_FAILURE_RE);
+    },
+    15_000
+  );
 
   // -- Coverage check ------------------------------------------------------
 
-  it("every declared action has at least one dispatch test in this file", () => {
-    const declared = new Set(superfluidDef.actions.map((a) => a.slug));
-    const tested = new Set([
-      "get-flow",
-      "get-cfa-net-flow",
-      "get-net-flow",
-      "get-super-token-balance",
-      "get-underlying-token",
-      "create-flow",
-      "update-flow",
-      "delete-flow",
-      "create-pool",
-      "update-member-units",
-      "distribute",
-      "distribute-flow",
-      "connect-pool",
-      "wrap",
-      "unwrap",
-      "grant-flow-operator",
-    ]);
-    const missing = [...declared].filter((s) => !tested.has(s));
-    const stale = [...tested].filter((s) => !declared.has(s));
-    expect(missing).toEqual([]);
-    expect(stale).toEqual([]);
-  });
+  itOnchain(
+    "every declared action has at least one dispatch test in this file",
+    () => {
+      const declared = new Set(superfluidDef.actions.map((a) => a.slug));
+      const tested = new Set([
+        "get-flow",
+        "get-cfa-net-flow",
+        "get-net-flow",
+        "get-super-token-balance",
+        "get-underlying-token",
+        "create-flow",
+        "update-flow",
+        "delete-flow",
+        "create-pool",
+        "update-member-units",
+        "distribute",
+        "distribute-flow",
+        "connect-pool",
+        "wrap",
+        "unwrap",
+        "grant-flow-operator",
+      ]);
+      const missing = [...declared].filter((s) => !tested.has(s));
+      const stale = [...tested].filter((s) => !declared.has(s));
+      expect(missing).toEqual([]);
+      expect(stale).toEqual([]);
+    }
+  );
 });
 
 // Not gated on RPC: validates the regex shape that the on-chain block above
@@ -438,7 +510,7 @@ describe("DISPATCH_FAILURE_RE shape (synthesized ethers errors)", () => {
     return String(err);
   }
 
-  it("matches `missing revert data` (revert: null branch)", () => {
+  itOnchain("matches `missing revert data` (revert: null branch)", () => {
     const err = ethers.makeError("missing revert data", "CALL_EXCEPTION", {
       action: "estimateGas",
       data: null,
@@ -450,33 +522,43 @@ describe("DISPATCH_FAILURE_RE shape (synthesized ethers errors)", () => {
     expect(asMessage(err)).toMatch(DISPATCH_FAILURE_RE);
   });
 
-  it('matches empty revert data="0x" (proxy returned no revert data)', () => {
-    const err = ethers.makeError("execution reverted", "CALL_EXCEPTION", {
-      action: "estimateGas",
-      data: "0x",
-      reason: null,
-      transaction: { data: "0xdeadbeef", to: TEST_ADDRESS },
-      invocation: null,
-      revert: null,
-    });
-    expect(asMessage(err)).toMatch(DISPATCH_FAILURE_RE);
-  });
+  itOnchain(
+    'matches empty revert data="0x" (proxy returned no revert data)',
+    () => {
+      const err = ethers.makeError("execution reverted", "CALL_EXCEPTION", {
+        action: "estimateGas",
+        data: "0x",
+        reason: null,
+        transaction: { data: "0xdeadbeef", to: TEST_ADDRESS },
+        invocation: null,
+        revert: null,
+      });
+      expect(asMessage(err)).toMatch(DISPATCH_FAILURE_RE);
+    }
+  );
 
-  it('does NOT misfire on data="0x..." with actual revert payload', () => {
-    // Guards against the obvious regression of writing `/data="0x/`
-    // (no closing quote), which would match every revert.
-    const err = ethers.makeError('execution reverted: "X"', "CALL_EXCEPTION", {
-      action: "estimateGas",
-      data: "0x08c379a0deadbeef",
-      reason: "X",
-      transaction: { data: "0xdeadbeef", to: TEST_ADDRESS },
-      invocation: null,
-      revert: { args: ["X"], name: "Error", signature: "Error(string)" },
-    });
-    expect(asMessage(err)).not.toMatch(DISPATCH_FAILURE_RE);
-  });
+  itOnchain(
+    'does NOT misfire on data="0x..." with actual revert payload',
+    () => {
+      // Guards against the obvious regression of writing `/data="0x/`
+      // (no closing quote), which would match every revert.
+      const err = ethers.makeError(
+        'execution reverted: "X"',
+        "CALL_EXCEPTION",
+        {
+          action: "estimateGas",
+          data: "0x08c379a0deadbeef",
+          reason: "X",
+          transaction: { data: "0xdeadbeef", to: TEST_ADDRESS },
+          invocation: null,
+          revert: { args: ["X"], name: "Error", signature: "Error(string)" },
+        }
+      );
+      expect(asMessage(err)).not.toMatch(DISPATCH_FAILURE_RE);
+    }
+  );
 
-  it("matches ABI encoding errors (INVALID_ARGUMENT)", () => {
+  itOnchain("matches ABI encoding errors (INVALID_ARGUMENT)", () => {
     const err = ethers.makeError(
       "invalid BigNumberish value",
       "INVALID_ARGUMENT",
@@ -485,46 +567,56 @@ describe("DISPATCH_FAILURE_RE shape (synthesized ethers errors)", () => {
     expect(asMessage(err)).toMatch(DISPATCH_FAILURE_RE);
   });
 
-  it('does NOT misfire when only the nested transaction.data is "0x"', () => {
-    // Defense-in-depth: confirms the `,\s*data="0x"` anchor distinguishes
-    // top-level CALL_EXCEPTION fields (key=value) from nested JSON
-    // (`"key": value`). If a future ethers version (or a quirky calldata)
-    // ever produced a transaction object whose data was literally "0x"
-    // while the top-level data was populated, the old `data="0x"` pattern
-    // would have false-positived. The anchor prevents that.
-    const err = ethers.makeError('execution reverted: "X"', "CALL_EXCEPTION", {
-      action: "estimateGas",
-      data: "0x08c379a0deadbeef",
-      reason: "X",
-      // Nested transaction with empty data (hypothetical fallback call):
-      transaction: { data: "0x", to: TEST_ADDRESS },
-      invocation: null,
-      revert: { args: ["X"], name: "Error", signature: "Error(string)" },
-    });
-    expect(asMessage(err)).not.toMatch(DISPATCH_FAILURE_RE);
-  });
+  itOnchain(
+    'does NOT misfire when only the nested transaction.data is "0x"',
+    () => {
+      // Defense-in-depth: confirms the `,\s*data="0x"` anchor distinguishes
+      // top-level CALL_EXCEPTION fields (key=value) from nested JSON
+      // (`"key": value`). If a future ethers version (or a quirky calldata)
+      // ever produced a transaction object whose data was literally "0x"
+      // while the top-level data was populated, the old `data="0x"` pattern
+      // would have false-positived. The anchor prevents that.
+      const err = ethers.makeError(
+        'execution reverted: "X"',
+        "CALL_EXCEPTION",
+        {
+          action: "estimateGas",
+          data: "0x08c379a0deadbeef",
+          reason: "X",
+          // Nested transaction with empty data (hypothetical fallback call):
+          transaction: { data: "0x", to: TEST_ADDRESS },
+          invocation: null,
+          revert: { args: ["X"], name: "Error", signature: "Error(string)" },
+        }
+      );
+      expect(asMessage(err)).not.toMatch(DISPATCH_FAILURE_RE);
+    }
+  );
 
-  it("does NOT match a normal business revert with populated revert data", () => {
-    // Models the real connect-pool revert against an EOA "pool": the GDA
-    // dispatches into the address and gets `CallUtils: target revert()`.
-    // Contract was reached, revert has data -- tolerate, do not flag as
-    // a routing/dispatch bug.
-    const err = ethers.makeError(
-      'execution reverted: "CallUtils: target revert()"',
-      "CALL_EXCEPTION",
-      {
-        action: "estimateGas",
-        data: "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001a43616c6c5574696c733a20746172676574207265766572742829000000000000",
-        reason: "CallUtils: target revert()",
-        transaction: { data: "0xdeadbeef", to: TEST_ADDRESS },
-        invocation: null,
-        revert: {
-          args: ["CallUtils: target revert()"],
-          name: "Error",
-          signature: "Error(string)",
-        },
-      }
-    );
-    expect(asMessage(err)).not.toMatch(DISPATCH_FAILURE_RE);
-  });
+  itOnchain(
+    "does NOT match a normal business revert with populated revert data",
+    () => {
+      // Models the real connect-pool revert against an EOA "pool": the GDA
+      // dispatches into the address and gets `CallUtils: target revert()`.
+      // Contract was reached, revert has data -- tolerate, do not flag as
+      // a routing/dispatch bug.
+      const err = ethers.makeError(
+        'execution reverted: "CallUtils: target revert()"',
+        "CALL_EXCEPTION",
+        {
+          action: "estimateGas",
+          data: "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001a43616c6c5574696c733a20746172676574207265766572742829000000000000",
+          reason: "CallUtils: target revert()",
+          transaction: { data: "0xdeadbeef", to: TEST_ADDRESS },
+          invocation: null,
+          revert: {
+            args: ["CallUtils: target revert()"],
+            name: "Error",
+            signature: "Error(string)",
+          },
+        }
+      );
+      expect(asMessage(err)).not.toMatch(DISPATCH_FAILURE_RE);
+    }
+  );
 });

--- a/tests/integration/protocol-uniswap-onchain.test.ts
+++ b/tests/integration/protocol-uniswap-onchain.test.ts
@@ -25,7 +25,7 @@
  */
 
 import { ethers } from "ethers";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, vi } from "vitest";
 
 // `lib/rpc/providers` transitively imports `lib/safe-fetch` (via the
 // safe-ethers adapter), which declares `import "server-only"` and would
@@ -40,6 +40,7 @@ import {
 } from "@/lib/rpc/rpc-config";
 import uniswapDef from "@/protocols/uniswap-v3";
 import { buildCalldata } from "./_shared/build-calldata";
+import { itOnchain } from "./_shared/onchain-rpc";
 
 const CHAIN_ID = "11155111"; // Sepolia
 const CHAIN_ID_NUMBER = 11_155_111;
@@ -83,267 +84,311 @@ describe("Uniswap V3 on-chain integration (Sepolia)", () => {
 
   // -- factory ---------------------------------------------------------------
 
-  it("get-pool: eth_call returns a decodable address", async () => {
-    const { to, data, contract } = buildCalldata({
-      protocol: uniswapDef,
-      actionSlug: "get-pool",
-      sampleInputs: {
-        tokenA: SEPOLIA_WETH,
-        tokenB: SEPOLIA_USDC,
-        fee: FEE_TIER_030,
-      },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "get-pool: eth_call returns a decodable address",
+    async () => {
+      const { to, data, contract } = buildCalldata({
+        protocol: uniswapDef,
+        actionSlug: "get-pool",
+        sampleInputs: {
+          tokenA: SEPOLIA_WETH,
+          tokenB: SEPOLIA_USDC,
+          fee: FEE_TIER_030,
+        },
+        chainId: CHAIN_ID,
+      });
 
-    const provider = await makeProvider();
-    const result = await provider.executeWithFailover(
-      async (p) => await p.call({ to, data })
-    );
-    const iface = new ethers.Interface(JSON.parse(contract.abi as string));
-    const decoded = iface.decodeFunctionResult("getPool", result);
-    expect(decoded).toBeDefined();
-    expect(typeof decoded[0]).toBe("string");
-    expect(decoded[0]).toMatch(HEX_ADDRESS_REGEX);
-  }, 30_000);
+      const provider = await makeProvider();
+      const result = await provider.executeWithFailover(
+        async (p) => await p.call({ to, data })
+      );
+      const iface = new ethers.Interface(JSON.parse(contract.abi as string));
+      const decoded = iface.decodeFunctionResult("getPool", result);
+      expect(decoded).toBeDefined();
+      expect(typeof decoded[0]).toBe("string");
+      expect(decoded[0]).toMatch(HEX_ADDRESS_REGEX);
+    },
+    30_000
+  );
 
   // -- positionManager -------------------------------------------------------
 
-  it("balance-of: eth_call returns a decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata({
-      protocol: uniswapDef,
-      actionSlug: "balance-of",
-      sampleInputs: { owner: TEST_ADDRESS },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "balance-of: eth_call returns a decodable uint256",
+    async () => {
+      const { to, data, contract } = buildCalldata({
+        protocol: uniswapDef,
+        actionSlug: "balance-of",
+        sampleInputs: { owner: TEST_ADDRESS },
+        chainId: CHAIN_ID,
+      });
 
-    const provider = await makeProvider();
-    const result = await provider.executeWithFailover(
-      async (p) => await p.call({ to, data })
-    );
-    const iface = new ethers.Interface(JSON.parse(contract.abi as string));
-    const decoded = iface.decodeFunctionResult("balanceOf", result);
-    expect(decoded).toBeDefined();
-    expect(typeof decoded[0]).toBe("bigint");
-  }, 30_000);
-
-  it("owner-of: calldata encodes (business revert expected for invalid tokenId)", async () => {
-    const { to, data } = buildCalldata({
-      protocol: uniswapDef,
-      actionSlug: "owner-of",
-      sampleInputs: { tokenId: "1" },
-      chainId: CHAIN_ID,
-    });
-
-    const provider = await makeProvider();
-    try {
-      await provider.executeWithFailover(
+      const provider = await makeProvider();
+      const result = await provider.executeWithFailover(
         async (p) => await p.call({ to, data })
       );
-    } catch (error) {
-      const msg = String(error);
-      expect(msg).not.toContain("INVALID_ARGUMENT");
-      expect(msg).not.toContain("could not decode");
-      expect(msg).not.toContain("invalid function");
-    }
-  }, 30_000);
+      const iface = new ethers.Interface(JSON.parse(contract.abi as string));
+      const decoded = iface.decodeFunctionResult("balanceOf", result);
+      expect(decoded).toBeDefined();
+      expect(typeof decoded[0]).toBe("bigint");
+    },
+    30_000
+  );
 
-  it("get-position: calldata encodes (business revert expected for invalid tokenId)", async () => {
-    const { to, data } = buildCalldata({
-      protocol: uniswapDef,
-      actionSlug: "get-position",
-      sampleInputs: { tokenId: "1" },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "owner-of: calldata encodes (business revert expected for invalid tokenId)",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: uniswapDef,
+        actionSlug: "owner-of",
+        sampleInputs: { tokenId: "1" },
+        chainId: CHAIN_ID,
+      });
 
-    const provider = await makeProvider();
-    try {
-      await provider.executeWithFailover(
-        async (p) => await p.call({ to, data })
-      );
-    } catch (error) {
-      const msg = String(error);
-      expect(msg).not.toContain("INVALID_ARGUMENT");
-      expect(msg).not.toContain("could not decode");
-      expect(msg).not.toContain("invalid function");
-    }
-  }, 30_000);
+      const provider = await makeProvider();
+      try {
+        await provider.executeWithFailover(
+          async (p) => await p.call({ to, data })
+        );
+      } catch (error) {
+        const msg = String(error);
+        expect(msg).not.toContain("INVALID_ARGUMENT");
+        expect(msg).not.toContain("could not decode");
+        expect(msg).not.toContain("invalid function");
+      }
+    },
+    30_000
+  );
 
-  it("approve-position: estimateGas calldata is valid (business revert expected)", async () => {
-    const { to, data } = buildCalldata({
-      protocol: uniswapDef,
-      actionSlug: "approve-position",
-      sampleInputs: { to: TEST_ADDRESS, tokenId: "1" },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "get-position: calldata encodes (business revert expected for invalid tokenId)",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: uniswapDef,
+        actionSlug: "get-position",
+        sampleInputs: { tokenId: "1" },
+        chainId: CHAIN_ID,
+      });
 
-    const provider = await makeProvider();
-    try {
-      await provider.executeWithFailover(
-        async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
-      );
-    } catch (error) {
-      const msg = String(error);
-      expect(msg).not.toContain("INVALID_ARGUMENT");
-      expect(msg).not.toContain("could not decode");
-      expect(msg).not.toContain("invalid function");
-    }
-  }, 30_000);
+      const provider = await makeProvider();
+      try {
+        await provider.executeWithFailover(
+          async (p) => await p.call({ to, data })
+        );
+      } catch (error) {
+        const msg = String(error);
+        expect(msg).not.toContain("INVALID_ARGUMENT");
+        expect(msg).not.toContain("could not decode");
+        expect(msg).not.toContain("invalid function");
+      }
+    },
+    30_000
+  );
 
-  it("transfer-position: estimateGas calldata is valid (business revert expected)", async () => {
-    const { to, data } = buildCalldata({
-      protocol: uniswapDef,
-      actionSlug: "transfer-position",
-      sampleInputs: { from: TEST_ADDRESS, to: TEST_ADDRESS, tokenId: "1" },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "approve-position: estimateGas calldata is valid (business revert expected)",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: uniswapDef,
+        actionSlug: "approve-position",
+        sampleInputs: { to: TEST_ADDRESS, tokenId: "1" },
+        chainId: CHAIN_ID,
+      });
 
-    const provider = await makeProvider();
-    try {
-      await provider.executeWithFailover(
-        async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
-      );
-    } catch (error) {
-      const msg = String(error);
-      expect(msg).not.toContain("INVALID_ARGUMENT");
-      expect(msg).not.toContain("could not decode");
-      expect(msg).not.toContain("invalid function");
-    }
-  }, 30_000);
+      const provider = await makeProvider();
+      try {
+        await provider.executeWithFailover(
+          async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
+        );
+      } catch (error) {
+        const msg = String(error);
+        expect(msg).not.toContain("INVALID_ARGUMENT");
+        expect(msg).not.toContain("could not decode");
+        expect(msg).not.toContain("invalid function");
+      }
+    },
+    30_000
+  );
 
-  it("burn-position: estimateGas calldata is valid (business revert expected)", async () => {
-    const { to, data } = buildCalldata({
-      protocol: uniswapDef,
-      actionSlug: "burn-position",
-      sampleInputs: { tokenId: "1" },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "transfer-position: estimateGas calldata is valid (business revert expected)",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: uniswapDef,
+        actionSlug: "transfer-position",
+        sampleInputs: { from: TEST_ADDRESS, to: TEST_ADDRESS, tokenId: "1" },
+        chainId: CHAIN_ID,
+      });
 
-    const provider = await makeProvider();
-    try {
-      await provider.executeWithFailover(
-        async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
-      );
-    } catch (error) {
-      const msg = String(error);
-      expect(msg).not.toContain("INVALID_ARGUMENT");
-      expect(msg).not.toContain("could not decode");
-      expect(msg).not.toContain("invalid function");
-    }
-  }, 30_000);
+      const provider = await makeProvider();
+      try {
+        await provider.executeWithFailover(
+          async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
+        );
+      } catch (error) {
+        const msg = String(error);
+        expect(msg).not.toContain("INVALID_ARGUMENT");
+        expect(msg).not.toContain("could not decode");
+        expect(msg).not.toContain("invalid function");
+      }
+    },
+    30_000
+  );
+
+  itOnchain(
+    "burn-position: estimateGas calldata is valid (business revert expected)",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: uniswapDef,
+        actionSlug: "burn-position",
+        sampleInputs: { tokenId: "1" },
+        chainId: CHAIN_ID,
+      });
+
+      const provider = await makeProvider();
+      try {
+        await provider.executeWithFailover(
+          async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
+        );
+      } catch (error) {
+        const msg = String(error);
+        expect(msg).not.toContain("INVALID_ARGUMENT");
+        expect(msg).not.toContain("could not decode");
+        expect(msg).not.toContain("invalid function");
+      }
+    },
+    30_000
+  );
 
   // -- quoter (tuple-flattened inputs) ---------------------------------------
 
-  it("quote-exact-input: calldata encodes (business revert OK if pool lacks liquidity)", async () => {
-    const { to, data } = buildCalldata({
-      protocol: uniswapDef,
-      actionSlug: "quote-exact-input",
-      sampleInputs: {
-        tokenIn: SEPOLIA_WETH,
-        tokenOut: SEPOLIA_USDC,
-        amountIn: ONE_ETH,
-        fee: FEE_TIER_030,
-        sqrtPriceLimitX96: "0",
-      },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "quote-exact-input: calldata encodes (business revert OK if pool lacks liquidity)",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: uniswapDef,
+        actionSlug: "quote-exact-input",
+        sampleInputs: {
+          tokenIn: SEPOLIA_WETH,
+          tokenOut: SEPOLIA_USDC,
+          amountIn: ONE_ETH,
+          fee: FEE_TIER_030,
+          sqrtPriceLimitX96: "0",
+        },
+        chainId: CHAIN_ID,
+      });
 
-    const provider = await makeProvider();
-    try {
-      await provider.executeWithFailover(
-        async (p) => await p.call({ to, data })
-      );
-    } catch (error) {
-      const msg = String(error);
-      expect(msg).not.toContain("INVALID_ARGUMENT");
-      expect(msg).not.toContain("could not decode");
-      expect(msg).not.toContain("invalid function");
-    }
-  }, 30_000);
+      const provider = await makeProvider();
+      try {
+        await provider.executeWithFailover(
+          async (p) => await p.call({ to, data })
+        );
+      } catch (error) {
+        const msg = String(error);
+        expect(msg).not.toContain("INVALID_ARGUMENT");
+        expect(msg).not.toContain("could not decode");
+        expect(msg).not.toContain("invalid function");
+      }
+    },
+    30_000
+  );
 
-  it("quote-exact-output: calldata encodes (business revert OK if pool lacks liquidity)", async () => {
-    const { to, data } = buildCalldata({
-      protocol: uniswapDef,
-      actionSlug: "quote-exact-output",
-      sampleInputs: {
-        tokenIn: SEPOLIA_WETH,
-        tokenOut: SEPOLIA_USDC,
-        amount: ONE_ETH,
-        fee: FEE_TIER_030,
-        sqrtPriceLimitX96: "0",
-      },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "quote-exact-output: calldata encodes (business revert OK if pool lacks liquidity)",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: uniswapDef,
+        actionSlug: "quote-exact-output",
+        sampleInputs: {
+          tokenIn: SEPOLIA_WETH,
+          tokenOut: SEPOLIA_USDC,
+          amount: ONE_ETH,
+          fee: FEE_TIER_030,
+          sqrtPriceLimitX96: "0",
+        },
+        chainId: CHAIN_ID,
+      });
 
-    const provider = await makeProvider();
-    try {
-      await provider.executeWithFailover(
-        async (p) => await p.call({ to, data })
-      );
-    } catch (error) {
-      const msg = String(error);
-      expect(msg).not.toContain("INVALID_ARGUMENT");
-      expect(msg).not.toContain("could not decode");
-      expect(msg).not.toContain("invalid function");
-    }
-  }, 30_000);
+      const provider = await makeProvider();
+      try {
+        await provider.executeWithFailover(
+          async (p) => await p.call({ to, data })
+        );
+      } catch (error) {
+        const msg = String(error);
+        expect(msg).not.toContain("INVALID_ARGUMENT");
+        expect(msg).not.toContain("could not decode");
+        expect(msg).not.toContain("invalid function");
+      }
+    },
+    30_000
+  );
 
   // -- swapRouter (tuple-flattened inputs) -----------------------------------
 
-  it("swap-exact-input: estimateGas calldata is valid (business revert expected - no approval)", async () => {
-    const { to, data } = buildCalldata({
-      protocol: uniswapDef,
-      actionSlug: "swap-exact-input",
-      sampleInputs: {
-        tokenIn: SEPOLIA_WETH,
-        tokenOut: SEPOLIA_USDC,
-        fee: FEE_TIER_030,
-        recipient: TEST_ADDRESS,
-        amountIn: ONE_ETH,
-        amountOutMinimum: "0",
-        sqrtPriceLimitX96: "0",
-      },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "swap-exact-input: estimateGas calldata is valid (business revert expected - no approval)",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: uniswapDef,
+        actionSlug: "swap-exact-input",
+        sampleInputs: {
+          tokenIn: SEPOLIA_WETH,
+          tokenOut: SEPOLIA_USDC,
+          fee: FEE_TIER_030,
+          recipient: TEST_ADDRESS,
+          amountIn: ONE_ETH,
+          amountOutMinimum: "0",
+          sqrtPriceLimitX96: "0",
+        },
+        chainId: CHAIN_ID,
+      });
 
-    const provider = await makeProvider();
-    try {
-      await provider.executeWithFailover(
-        async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
-      );
-    } catch (error) {
-      const msg = String(error);
-      expect(msg).not.toContain("INVALID_ARGUMENT");
-      expect(msg).not.toContain("could not decode");
-      expect(msg).not.toContain("invalid function");
-    }
-  }, 30_000);
+      const provider = await makeProvider();
+      try {
+        await provider.executeWithFailover(
+          async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
+        );
+      } catch (error) {
+        const msg = String(error);
+        expect(msg).not.toContain("INVALID_ARGUMENT");
+        expect(msg).not.toContain("could not decode");
+        expect(msg).not.toContain("invalid function");
+      }
+    },
+    30_000
+  );
 
-  it("swap-exact-output: estimateGas calldata is valid (business revert expected - no approval)", async () => {
-    const { to, data } = buildCalldata({
-      protocol: uniswapDef,
-      actionSlug: "swap-exact-output",
-      sampleInputs: {
-        tokenIn: SEPOLIA_WETH,
-        tokenOut: SEPOLIA_USDC,
-        fee: FEE_TIER_030,
-        recipient: TEST_ADDRESS,
-        amountOut: ONE_ETH,
-        amountInMaximum: ONE_ETH,
-        sqrtPriceLimitX96: "0",
-      },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "swap-exact-output: estimateGas calldata is valid (business revert expected - no approval)",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: uniswapDef,
+        actionSlug: "swap-exact-output",
+        sampleInputs: {
+          tokenIn: SEPOLIA_WETH,
+          tokenOut: SEPOLIA_USDC,
+          fee: FEE_TIER_030,
+          recipient: TEST_ADDRESS,
+          amountOut: ONE_ETH,
+          amountInMaximum: ONE_ETH,
+          sqrtPriceLimitX96: "0",
+        },
+        chainId: CHAIN_ID,
+      });
 
-    const provider = await makeProvider();
-    try {
-      await provider.executeWithFailover(
-        async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
-      );
-    } catch (error) {
-      const msg = String(error);
-      expect(msg).not.toContain("INVALID_ARGUMENT");
-      expect(msg).not.toContain("could not decode");
-      expect(msg).not.toContain("invalid function");
-    }
-  }, 30_000);
+      const provider = await makeProvider();
+      try {
+        await provider.executeWithFailover(
+          async (p) => await p.estimateGas({ to, data, from: TEST_ADDRESS })
+        );
+      } catch (error) {
+        const msg = String(error);
+        expect(msg).not.toContain("INVALID_ARGUMENT");
+        expect(msg).not.toContain("could not decode");
+        expect(msg).not.toContain("invalid function");
+      }
+    },
+    30_000
+  );
 });

--- a/tests/integration/protocol-wrapped-onchain.test.ts
+++ b/tests/integration/protocol-wrapped-onchain.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { ethers } from "ethers";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, vi } from "vitest";
 
 // `lib/rpc/providers` transitively imports `lib/safe-fetch` (via the
 // safe-ethers adapter), which declares `import "server-only"` and would
@@ -32,6 +32,7 @@ import {
 } from "@/lib/rpc/rpc-config";
 import wrappedDef from "@/protocols/wrapped";
 import { buildCalldata } from "./_shared/build-calldata";
+import { itOnchain } from "./_shared/onchain-rpc";
 
 const CHAIN_ID = "11155111";
 const SEPOLIA_CHAIN_ID = 11_155_111;
@@ -69,66 +70,78 @@ describe("Wrapped on-chain integration", () => {
     );
   });
 
-  it("balanceOf: eth_call returns a decodable uint256", async () => {
-    const { to, data, contract } = buildCalldata({
-      protocol: wrappedDef,
-      actionSlug: "balance-of",
-      sampleInputs: { account: TEST_ADDRESS },
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "balanceOf: eth_call returns a decodable uint256",
+    async () => {
+      const { to, data, contract } = buildCalldata({
+        protocol: wrappedDef,
+        actionSlug: "balance-of",
+        sampleInputs: { account: TEST_ADDRESS },
+        chainId: CHAIN_ID,
+      });
 
-    const result = await manager.executeWithFailover((p) =>
-      p.call({ to, data })
-    );
+      const result = await manager.executeWithFailover((p) =>
+        p.call({ to, data })
+      );
 
-    const abi = JSON.parse(contract.abi as string);
-    const iface = new ethers.Interface(abi);
-    const decoded = iface.decodeFunctionResult("balanceOf", result);
-    expect(decoded).toBeDefined();
-    expect(typeof decoded[0]).toBe("bigint");
-  }, 15_000);
+      const abi = JSON.parse(contract.abi as string);
+      const iface = new ethers.Interface(abi);
+      const decoded = iface.decodeFunctionResult("balanceOf", result);
+      expect(decoded).toBeDefined();
+      expect(typeof decoded[0]).toBe("bigint");
+    },
+    15_000
+  );
 
-  it("deposit: estimateGas succeeds with ETH value", async () => {
-    const { to, data } = buildCalldata({
-      protocol: wrappedDef,
-      actionSlug: "wrap",
-      sampleInputs: {},
-      chainId: CHAIN_ID,
-    });
+  itOnchain(
+    "deposit: estimateGas succeeds with ETH value",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: wrappedDef,
+        actionSlug: "wrap",
+        sampleInputs: {},
+        chainId: CHAIN_ID,
+      });
 
-    const gas = await manager.executeWithFailover((p) =>
-      p.estimateGas({
-        to,
-        data,
-        value: ethers.parseEther("0.001"),
-        from: TEST_ADDRESS,
-      })
-    );
-
-    expect(gas).toBeGreaterThan(BigInt(0));
-  }, 15_000);
-
-  it("withdraw: calldata encodes correctly (business revert expected)", async () => {
-    const { to, data } = buildCalldata({
-      protocol: wrappedDef,
-      actionSlug: "unwrap",
-      sampleInputs: { wad: "1000000000000000000" },
-      chainId: CHAIN_ID,
-    });
-
-    try {
-      await manager.executeWithFailover((p) =>
+      const gas = await manager.executeWithFailover((p) =>
         p.estimateGas({
           to,
           data,
+          value: ethers.parseEther("0.001"),
           from: TEST_ADDRESS,
         })
       );
-    } catch (error) {
-      const msg = String(error);
-      expect(msg).not.toContain("INVALID_ARGUMENT");
-      expect(msg).not.toContain("could not decode");
-      expect(msg).not.toContain("invalid function");
-    }
-  }, 15_000);
+
+      expect(gas).toBeGreaterThan(BigInt(0));
+    },
+    15_000
+  );
+
+  itOnchain(
+    "withdraw: calldata encodes correctly (business revert expected)",
+    async () => {
+      const { to, data } = buildCalldata({
+        protocol: wrappedDef,
+        actionSlug: "unwrap",
+        sampleInputs: { wad: "1000000000000000000" },
+        chainId: CHAIN_ID,
+      });
+
+      try {
+        await manager.executeWithFailover((p) =>
+          p.estimateGas({
+            to,
+            data,
+            from: TEST_ADDRESS,
+          })
+        );
+      } catch (error) {
+        const msg = String(error);
+        expect(msg).not.toContain("INVALID_ARGUMENT");
+        expect(msg).not.toContain("could not decode");
+        expect(msg).not.toContain("invalid function");
+      }
+    },
+    15_000
+  );
 });

--- a/tests/integration/web3-write-onchain.test.ts
+++ b/tests/integration/web3-write-onchain.test.ts
@@ -20,7 +20,8 @@
  */
 
 import { ethers } from "ethers";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, vi } from "vitest";
+import { itOnchain } from "./_shared/onchain-rpc";
 
 // `lib/rpc/providers` transitively imports `lib/safe-fetch` (via the
 // safe-ethers adapter), which declares `import "server-only"` and would
@@ -170,110 +171,137 @@ describe("Web3 write-contract on-chain integration", () => {
     );
   });
 
-  it("deposit (payable, no args): estimateGas with ETH value", async () => {
-    const { data, value } = buildWeb3Calldata("deposit", undefined, "0.001");
+  itOnchain(
+    "deposit (payable, no args): estimateGas with ETH value",
+    async () => {
+      const { data, value } = buildWeb3Calldata("deposit", undefined, "0.001");
 
-    const gas = await manager.executeWithFailover((p) =>
-      p.estimateGas({
-        to: WETH_SEPOLIA,
-        data,
-        value,
-        from: TEST_ADDRESS,
-      })
-    );
+      const gas = await manager.executeWithFailover((p) =>
+        p.estimateGas({
+          to: WETH_SEPOLIA,
+          data,
+          value,
+          from: TEST_ADDRESS,
+        })
+      );
 
-    expect(gas).toBeGreaterThan(BigInt(0));
-  }, 15_000);
+      expect(gas).toBeGreaterThan(BigInt(0));
+    },
+    15_000
+  );
 
-  it("withdraw (uint256 arg): calldata encodes correctly", async () => {
-    const { data } = buildWeb3Calldata("withdraw", '["1000000000000000000"]');
+  itOnchain(
+    "withdraw (uint256 arg): calldata encodes correctly",
+    async () => {
+      const { data } = buildWeb3Calldata("withdraw", '["1000000000000000000"]');
 
-    try {
-      await manager.executeWithFailover((p) =>
+      try {
+        await manager.executeWithFailover((p) =>
+          p.estimateGas({
+            to: WETH_SEPOLIA,
+            data,
+            from: TEST_ADDRESS,
+          })
+        );
+      } catch (error) {
+        const msg = String(error);
+        expect(msg).not.toContain("INVALID_ARGUMENT");
+        expect(msg).not.toContain("could not decode");
+      }
+    },
+    15_000
+  );
+
+  itOnchain(
+    "approve (address + uint256 args): calldata encodes correctly",
+    async () => {
+      const { data } = buildWeb3Calldata(
+        "approve",
+        `["${TEST_ADDRESS}", "1000000000000000000"]`
+      );
+
+      const gas = await manager.executeWithFailover((p) =>
         p.estimateGas({
           to: WETH_SEPOLIA,
           data,
           from: TEST_ADDRESS,
         })
       );
-    } catch (error) {
-      const msg = String(error);
-      expect(msg).not.toContain("INVALID_ARGUMENT");
-      expect(msg).not.toContain("could not decode");
-    }
-  }, 15_000);
 
-  it("approve (address + uint256 args): calldata encodes correctly", async () => {
-    const { data } = buildWeb3Calldata(
-      "approve",
-      `["${TEST_ADDRESS}", "1000000000000000000"]`
-    );
+      expect(gas).toBeGreaterThan(BigInt(0));
+    },
+    15_000
+  );
 
-    const gas = await manager.executeWithFailover((p) =>
-      p.estimateGas({
-        to: WETH_SEPOLIA,
-        data,
-        from: TEST_ADDRESS,
-      })
-    );
+  itOnchain(
+    "transfer (address + uint256 args): calldata encodes correctly",
+    async () => {
+      const { data } = buildWeb3Calldata(
+        "transfer",
+        `["${TEST_ADDRESS}", "0"]`
+      );
 
-    expect(gas).toBeGreaterThan(BigInt(0));
-  }, 15_000);
+      const gas = await manager.executeWithFailover((p) =>
+        p.estimateGas({
+          to: WETH_SEPOLIA,
+          data,
+          from: TEST_ADDRESS,
+        })
+      );
 
-  it("transfer (address + uint256 args): calldata encodes correctly", async () => {
-    const { data } = buildWeb3Calldata("transfer", `["${TEST_ADDRESS}", "0"]`);
+      expect(gas).toBeGreaterThan(BigInt(0));
+    },
+    15_000
+  );
 
-    const gas = await manager.executeWithFailover((p) =>
-      p.estimateGas({
-        to: WETH_SEPOLIA,
-        data,
-        from: TEST_ADDRESS,
-      })
-    );
+  itOnchain(
+    "balanceOf (read via eth_call): returns decodable uint256",
+    async () => {
+      const { data } = buildWeb3Calldata("balanceOf", `["${TEST_ADDRESS}"]`);
 
-    expect(gas).toBeGreaterThan(BigInt(0));
-  }, 15_000);
+      const result = await manager.executeWithFailover((p) =>
+        p.call({
+          to: WETH_SEPOLIA,
+          data,
+        })
+      );
 
-  it("balanceOf (read via eth_call): returns decodable uint256", async () => {
-    const { data } = buildWeb3Calldata("balanceOf", `["${TEST_ADDRESS}"]`);
+      const iface = new ethers.Interface(WETH_ABI);
+      const decoded = iface.decodeFunctionResult("balanceOf", result);
+      expect(decoded).toBeDefined();
+      expect(typeof decoded[0]).toBe("bigint");
+    },
+    15_000
+  );
 
-    const result = await manager.executeWithFailover((p) =>
-      p.call({
-        to: WETH_SEPOLIA,
-        data,
-      })
-    );
+  itOnchain(
+    "allowance (two address args via eth_call): returns decodable uint256",
+    async () => {
+      const { data } = buildWeb3Calldata(
+        "allowance",
+        `["${TEST_ADDRESS}", "${TEST_ADDRESS}"]`
+      );
 
-    const iface = new ethers.Interface(WETH_ABI);
-    const decoded = iface.decodeFunctionResult("balanceOf", result);
-    expect(decoded).toBeDefined();
-    expect(typeof decoded[0]).toBe("bigint");
-  }, 15_000);
+      const result = await manager.executeWithFailover((p) =>
+        p.call({
+          to: WETH_SEPOLIA,
+          data,
+        })
+      );
 
-  it("allowance (two address args via eth_call): returns decodable uint256", async () => {
-    const { data } = buildWeb3Calldata(
-      "allowance",
-      `["${TEST_ADDRESS}", "${TEST_ADDRESS}"]`
-    );
+      const iface = new ethers.Interface(WETH_ABI);
+      const decoded = iface.decodeFunctionResult("allowance", result);
+      expect(decoded).toBeDefined();
+      expect(typeof decoded[0]).toBe("bigint");
+    },
+    15_000
+  );
 
-    const result = await manager.executeWithFailover((p) =>
-      p.call({
-        to: WETH_SEPOLIA,
-        data,
-      })
-    );
-
-    const iface = new ethers.Interface(WETH_ABI);
-    const decoded = iface.decodeFunctionResult("allowance", result);
-    expect(decoded).toBeDefined();
-    expect(typeof decoded[0]).toBe("bigint");
-  }, 15_000);
-
-  it("rejects invalid ethValue at parseEther", () => {
+  itOnchain("rejects invalid ethValue at parseEther", () => {
     expect(() => buildWeb3Calldata("deposit", undefined, "abc")).toThrow();
   });
 
-  it("rejects invalid JSON functionArgs", () => {
+  itOnchain("rejects invalid JSON functionArgs", () => {
     expect(() => buildWeb3Calldata("withdraw", "{bad json")).toThrow();
   });
 });


### PR DESCRIPTION
## Problem

A chain's WebSocket connection can stay alive at the RPC layer while its `newHeads` block subscription silently stops delivering blocks. When that happens the event-tracker processes no blocks, calls no `eth_getLogs`, dispatches no events, and never reconnects. Every event-triggered workflow on that chain stops firing with no error and no auto-recovery until the pod is restarted.

This surfaced in production: the Ethereum mainnet block stream froze while the connection kept answering the heartbeat. Mainnet is ~99% of event execution volume, so event executions dropped to zero for ~50 minutes and the "Zero Executions - Event Trigger" alert fired. A pod restart re-established the subscription.

## Why detection failed

`ChainProviderManager` drop detection has two signals: `provider.on("error")` and a heartbeat that pings `eth_blockNumber` every 30s. The heartbeat is a request/response RPC call that succeeds independently of the `newHeads` push subscription, so a connection whose subscription has died keeps passing it forever. `lastBlockAt` was tracked and surfaced on `/healthz` but never wired into a reconnect trigger.

## Fix

Add a block-staleness watchdog:

- On each heartbeat tick, after a successful `eth_blockNumber` ping, check block staleness. If `now - lastBlockAt` exceeds `BLOCK_STALENESS_TIMEOUT_MS`, treat the subscription as dead and call the existing `triggerReconnect(...)` with a new `block_staleness` reason.
- Default ceiling is 120s (well above any supported chain's block time to avoid false reconnects on a normal inter-block gap); overridable per-manager via `blockStalenessTimeoutMs`.
- A `blockListenerAttachedAt` baseline catches a subscription that never delivers even a first block, and is folded into the staleness reference (`max(lastBlockAt, attachedAt)`) so a freshly reconnected provider gets a full window instead of tripping again immediately.
- Inherits the heartbeat's subscriber-scoped lifecycle: starts/stops with subscribers, re-armed on reconnect, torn down on `destroy()`.

## Testing

- New unit tests: trips on a silent block-stall while the heartbeat passes; does not trip while blocks keep arriving; does not run without subscribers; gives a reconnected provider a fresh window.
- Full event-tracker unit suite (143 tests), `tsc --noEmit`, and Biome all pass.