### PR TITLE
fix: exclude pending/running/cancelled runs from success rate

### DIFF
--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -272,7 +272,6 @@ async function getWorkflowCounts(
 }> {
   const result = await db
     .select({
-      total: count(),
       success: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'success' THEN 1 ELSE 0 END)`,
       error: sql<number>`SUM(CASE WHEN ${inArray(workflowExecutions.status, [...ERROR_STATUSES])} THEN 1 ELSE 0 END)`,
       cancelled: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'cancelled' THEN 1 ELSE 0 END)`,
@@ -291,10 +290,15 @@ async function getWorkflowCounts(
     );
 
   const row = result[0];
+  const success = Number(row?.success) || 0;
+  const error = Number(row?.error) || 0;
+  // Total counts only completed runs (success + error). Pending, running and
+  // cancelled runs are excluded so the success rate and Total Runs KPI ignore
+  // in-flight and cancelled executions.
   return {
-    total: Number(row?.total) || 0,
-    success: Number(row?.success) || 0,
-    error: Number(row?.error) || 0,
+    total: success + error,
+    success,
+    error,
     cancelled: Number(row?.cancelled) || 0,
     durationSum: Number(row?.durationSum) || 0,
     durationCount: Number(row?.durationCount) || 0,
@@ -315,7 +319,6 @@ async function getDirectCounts(
 }> {
   const result = await db
     .select({
-      total: count(),
       success: sql<number>`SUM(CASE WHEN ${directExecutions.status} = 'completed' THEN 1 ELSE 0 END)`,
       error: sql<number>`SUM(CASE WHEN ${directExecutions.status} = 'failed' THEN 1 ELSE 0 END)`,
       durationSum: sql<number>`COALESCE(SUM(EXTRACT(EPOCH FROM (${directExecutions.completedAt} - ${directExecutions.createdAt})) * 1000), 0)`,
@@ -332,10 +335,14 @@ async function getDirectCounts(
     );
 
   const row = result[0];
+  const success = Number(row?.success) || 0;
+  const error = Number(row?.error) || 0;
+  // Completed runs only (see getWorkflowCounts): pending and running direct
+  // executions are excluded from the total and the success rate.
   return {
-    total: Number(row?.total) || 0,
-    success: Number(row?.success) || 0,
-    error: Number(row?.error) || 0,
+    total: success + error,
+    success,
+    error,
     durationSum: Number(row?.durationSum) || 0,
     durationCount: Number(row?.durationCount) || 0,
     totalGasWei: row?.totalGasWei ?? "0",
@@ -685,7 +692,9 @@ async function computeNetworkBreakdown(
           .select({
             network: directExecutions.network,
             totalGasWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.gasUsedWei} AS NUMERIC)), 0)::text`,
-            executionCount: count(),
+            // Completed runs only, so pending/running direct executions do not
+            // inflate the per-network execution count.
+            executionCount: sql<number>`SUM(CASE WHEN ${directExecutions.status} IN ('completed', 'failed') THEN 1 ELSE 0 END)`,
             successCount: sql<number>`SUM(CASE WHEN ${directExecutions.status} = 'completed' THEN 1 ELSE 0 END)`,
             errorCount: sql<number>`SUM(CASE WHEN ${directExecutions.status} = 'failed' THEN 1 ELSE 0 END)`,
           })

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -723,10 +723,14 @@ export async function sendWorkflowExecutionDigestEmail(
   const period = DIGEST_PERIOD_LABEL[cadence];
   const summaryLabel = DIGEST_SUMMARY_LABEL[cadence];
   const periodRange = `${formatUtcStamp(since)} to ${formatUtcStamp(until)}`;
+  // Rate the run against completed runs only (success + error); pending,
+  // running and cancelled runs are excluded so an org with many in-flight runs
+  // is not reported as low success rate.
+  const completed = stats.success + stats.error;
   const successRate =
-    stats.total > 0 ? Math.round((stats.success / stats.total) * 100) : 0;
+    completed > 0 ? Math.round((stats.success / completed) * 100) : 0;
   const failRate =
-    stats.total > 0 ? Math.round((stats.error / stats.total) * 100) : 0;
+    completed > 0 ? Math.round((stats.error / completed) * 100) : 0;
   const gasEth = formatWeiToEth(stats.gasUsedWei);
   const subject = `${orgName} workflow digest: ${stats.total} run${
     stats.total === 1 ? "" : "s"

--- a/tests/unit/execution-digest-email.test.ts
+++ b/tests/unit/execution-digest-email.test.ts
@@ -100,6 +100,19 @@ describe("sendWorkflowExecutionDigestEmail", () => {
     expect(content).toContain("Failed: 2 (40%)");
   });
 
+  it("rates success against completed runs, excluding pending/running/cancelled", async () => {
+    const data = baseData();
+    // 3 success + 2 error = 5 completed, but 10 total runs (5 in-flight or
+    // cancelled). The rate must be over completed (3/5 = 60%), not total.
+    await sendWorkflowExecutionDigestEmail({
+      ...data,
+      stats: { ...data.stats, total: 10, success: 3, error: 2 },
+    });
+    const content = sentContent();
+    expect(content).toContain("Succeeded: 3 (60%)");
+    expect(content).toContain("Failed: 2 (40%)");
+  });
+
   it("reports the number of distinct workflows run", async () => {
     await sendWorkflowExecutionDigestEmail(baseData());
     const content = sentContent();


### PR DESCRIPTION
## Problem

On the Analytics page, success rate treated every execution not in `success` status as a failure. Any run that was still `pending` or `running` (and any `cancelled` run) counted against the rate, so an org with a steady backlog of in-flight runs saw an artificially low hourly success rate that jumped as soon as those runs settled. The same denominator flowed into the Total Runs KPI, the period-over-period delta, the per-network breakdown, and the workflow digest email.

## Fix

Define the analytics total as **completed runs only** (`success + error`) and exclude `pending`, `running`, and `cancelled` everywhere the rate or total is derived:

- `getWorkflowCounts` / `getDirectCounts` now return `total = success + error`, so the Total Runs KPI and `successRate = success / total` both ignore in-flight and cancelled runs. The previous-period comparison inherits the same total.
- The per-network breakdown's direct-side execution count is now completed-only (the workflow side already aggregates gas-bearing success/error step logs).
- The digest email rates success/failure against completed runs, leaving its activity "Total runs" headline and most-executed list as full activity counts.

`activeRuns` (pending+running), `cancelledCount`, the runs-list pagination total, and the time-series buckets are unchanged, so in-flight and cancelled runs still appear in the runs table and the status chart.

## Tests

Added a digest-email case asserting the rate is computed over completed runs (`total=10, success=3, error=2` -> 60%, not 30%). Existing analytics and digest unit suites pass; lint and type-check clean.