### PR TITLE
feat(metrics): add workflow_executions_finished counter for windowed SLIs

### DIFF
--- a/app/api/internal/executions/[executionId]/route.ts
+++ b/app/api/internal/executions/[executionId]/route.ts
@@ -152,7 +152,8 @@ export async function PATCH(
       await recordExecutionErrorFinalized({
         workflowId,
         errorMessage: updateData.error,
-        persistedStatus: typedStatus === "system_error" ? "system_error" : "error",
+        persistedStatus:
+          typedStatus === "system_error" ? "system_error" : "error",
         errorCategory: updateData.errorCategory,
       });
     } else {

--- a/app/api/internal/executions/[executionId]/route.ts
+++ b/app/api/internal/executions/[executionId]/route.ts
@@ -1,11 +1,15 @@
 import { and, eq, ne } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { workflowExecutions } from "@/lib/db/schema";
 import { type ErrorCode, getErrorCodeEntry } from "@/lib/errors/error-codes";
 import { isErrorStatus } from "@/lib/errors/execution-status";
+import { recordExecutionErrorFinalized } from "@/lib/errors/finalize-error";
 import { authenticateInternalService } from "@/lib/internal-service-auth";
 import { ErrorCategory } from "@/lib/logging";
+import { recordWorkflowExecutionFinished } from "@/lib/metrics/collectors/prometheus";
+import { resolveOrgSlugForCounter } from "@/lib/metrics/org-slug.server";
 
 export async function PATCH(
   request: Request,
@@ -112,15 +116,56 @@ export async function PATCH(
     }
   }
 
-  await db
+  // Self-join alias exposing the pre-update status (the FROM clause reads the
+  // statement snapshot) so the terminal counters below emit only on the first
+  // non-terminal -> terminal transition. This route is a real terminal writer
+  // (scheduler/event-tracker phantom resolution marks enqueue failures as
+  // system_error here) that bypasses every other counted finalize path.
+  const prevExecution = alias(workflowExecutions, "prev_execution");
+
+  const updated = await db
     .update(workflowExecutions)
     .set(updateData)
+    .from(prevExecution)
     .where(
       and(
         eq(workflowExecutions.id, executionId),
+        eq(prevExecution.id, workflowExecutions.id),
         ne(workflowExecutions.status, "cancelled")
       )
-    );
+    )
+    .returning({
+      workflowId: workflowExecutions.workflowId,
+      previousStatus: prevExecution.status,
+    });
+
+  const previousStatus = updated[0]?.previousStatus;
+  const wasNonTerminal =
+    previousStatus !== undefined &&
+    previousStatus !== "success" &&
+    !isErrorStatus(previousStatus);
+
+  if (updated.length > 0 && isTerminal && wasNonTerminal) {
+    const workflowId = updated[0].workflowId;
+    if (isError) {
+      await recordExecutionErrorFinalized({
+        workflowId,
+        errorMessage: updateData.error,
+        persistedStatus: typedStatus === "system_error" ? "system_error" : "error",
+        errorCategory: updateData.errorCategory,
+      });
+    } else {
+      try {
+        recordWorkflowExecutionFinished({
+          status: "success",
+          orgSlug: await resolveOrgSlugForCounter(workflowId),
+          errorType: "na",
+        });
+      } catch {
+        // Counter emission must never fail the status write.
+      }
+    }
+  }
 
   return NextResponse.json({ success: true });
 }

--- a/app/api/internal/executions/[executionId]/route.ts
+++ b/app/api/internal/executions/[executionId]/route.ts
@@ -9,6 +9,7 @@ import { recordExecutionErrorFinalized } from "@/lib/errors/finalize-error";
 import { authenticateInternalService } from "@/lib/internal-service-auth";
 import { ErrorCategory } from "@/lib/logging";
 import { recordWorkflowExecutionFinished } from "@/lib/metrics/collectors/prometheus";
+import { NA_ERROR_TYPE } from "@/lib/metrics/metric-constants";
 import { resolveOrgSlugForCounter } from "@/lib/metrics/org-slug.server";
 
 export async function PATCH(
@@ -159,7 +160,7 @@ export async function PATCH(
         recordWorkflowExecutionFinished({
           status: "success",
           orgSlug: await resolveOrgSlugForCounter(workflowId),
-          errorType: "na",
+          errorType: NA_ERROR_TYPE,
         });
       } catch {
         // Counter emission must never fail the status write.

--- a/app/api/internal/reaper/route.ts
+++ b/app/api/internal/reaper/route.ts
@@ -147,6 +147,7 @@ export async function GET(request: Request): Promise<NextResponse> {
       await recordExecutionErrorFinalized({
         workflowId: row.workflowId,
         errorMessage: reaperErrorMessage,
+        persistedStatus: "system_error",
         errorCategory: row.errorCategory ?? undefined,
       });
     }

--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -440,6 +440,7 @@ async function handlePaidWorkflow(
             await recordExecutionErrorFinalized({
               workflowId: updated[0].workflowId,
               errorMessage,
+              persistedStatus: "error",
             });
           }
           throw err;

--- a/keeperhub-executor/lib/db-helpers.ts
+++ b/keeperhub-executor/lib/db-helpers.ts
@@ -11,6 +11,7 @@ import { calculateTotalSteps } from "../../lib/workflow/executor/progress";
 import type { WorkflowEdge, WorkflowNode } from "../../lib/workflow/store";
 import type { executeWorkflow } from "../../lib/workflow/executor/executor.workflow";
 import { toJsonSafe } from "./serialize";
+import { recordTerminalSample } from "./terminal-counters";
 
 export type DbSchema = {
   workflows: typeof workflows;
@@ -49,7 +50,7 @@ export async function updateExecutionStatus(
   // (it can throw and only be logged), this closes the row instead of leaving
   // it stuck "running". Excluding all three terminal states keeps the backstop
   // from clobbering the engine's richer fields (KEEP-431).
-  await db
+  const updated = await db
     .update(workflowExecutions)
     .set(updateData)
     .where(
@@ -60,7 +61,24 @@ export async function updateExecutionStatus(
         ne(workflowExecutions.status, "system_error"),
         ne(workflowExecutions.status, "cancelled")
       )
-    );
+    )
+    .returning({ workflowId: workflowExecutions.workflowId });
+
+  // A matched row means the engine's own terminal write was lost (the CAS
+  // above excludes every terminal state), so this backstop is the execution's
+  // first and only terminal transition and must emit the terminal counters
+  // the engine would have emitted. Cancellation is intentionally not counted
+  // (the finished counter tracks success/error outcomes only).
+  if (
+    updated.length > 0 &&
+    (status === "success" || status === "error")
+  ) {
+    await recordTerminalSample(db, {
+      workflowId: updated[0].workflowId,
+      status,
+      errorMessage: result?.error,
+    });
+  }
 }
 
 /**
@@ -99,7 +117,23 @@ export async function failExecutionAsSystemError(
         inArray(workflowExecutions.status, ["phantom", "pending"])
       )
     )
-    .returning({ id: workflowExecutions.id });
+    .returning({
+      id: workflowExecutions.id,
+      workflowId: workflowExecutions.workflowId,
+    });
+
+  // The phantom/pending CAS means a match is the row's first terminal
+  // transition; these rows never reach logWorkflowCompleteDb or the reaper,
+  // so this is their only chance to be counted.
+  if (marked.length > 0) {
+    await recordTerminalSample(db, {
+      workflowId: marked[0].workflowId,
+      status: "system_error",
+      errorMessage: fields.error,
+      errorType: "system",
+      errorCategory: "infrastructure",
+    });
+  }
   return marked.length > 0;
 }
 
@@ -182,7 +216,7 @@ export async function resolvePhantomToError(
   if (!executionId) {
     return;
   }
-  await db
+  const resolved = await db
     .update(workflowExecutions)
     .set({
       status: "error",
@@ -196,7 +230,21 @@ export async function resolvePhantomToError(
         eq(workflowExecutions.id, executionId),
         inArray(workflowExecutions.status, ["phantom", "pending"])
       )
-    );
+    )
+    .returning({ workflowId: workflowExecutions.workflowId });
+
+  // Same reasoning as failExecutionAsSystemError: the phantom/pending CAS
+  // makes a match the first terminal transition, and billing-blocked rows
+  // never reach any other counted finalize path.
+  if (resolved.length > 0) {
+    await recordTerminalSample(db, {
+      workflowId: resolved[0].workflowId,
+      status: "error",
+      errorMessage: fields.error,
+      errorType: fields.errorType,
+      errorCategory: fields.errorCategory,
+    });
+  }
 }
 
 export async function initializeExecutionProgress(

--- a/keeperhub-executor/lib/metrics-shipping.test.ts
+++ b/keeperhub-executor/lib/metrics-shipping.test.ts
@@ -35,8 +35,14 @@ const counters = {
   errorsByType: makeCounter(),
 };
 
+const workflowCounters = {
+  executionErrorsCreated: makeCounter(),
+  executionsFinished: makeCounter(),
+};
+
 vi.mock("../../lib/metrics/collectors/prometheus", () => ({
   rpcMetrics: counters,
+  workflowCounterMetrics: workflowCounters,
 }));
 
 const {
@@ -49,7 +55,10 @@ const {
 
 describe("collectCounterDeltas", () => {
   beforeEach(() => {
-    for (const c of Object.values(counters)) {
+    for (const c of [
+      ...Object.values(counters),
+      ...Object.values(workflowCounters),
+    ]) {
       c.incCalls.length = 0;
     }
   });
@@ -105,7 +114,10 @@ describe("collectCounterDeltas", () => {
 
 describe("applyCounterDeltas", () => {
   beforeEach(() => {
-    for (const c of Object.values(counters)) {
+    for (const c of [
+      ...Object.values(counters),
+      ...Object.values(workflowCounters),
+    ]) {
       c.incCalls.length = 0;
     }
   });
@@ -128,6 +140,44 @@ describe("applyCounterDeltas", () => {
     expect(skipped).toBe(1);
     expect(counters.primaryAttempts.incCalls).toEqual([
       { labels: { chain: "ethereum", operation: "read" }, value: 5 },
+    ]);
+  });
+
+  it("applies workflow terminal counter deltas with labels preserved", async () => {
+    const { applied, skipped } = await applyCounterDeltas([
+      {
+        name: "keeperhub_workflow_executions_finished_total",
+        labels: { status: "success", org_slug: "acme", error_type: "na" },
+        value: 2,
+      },
+      {
+        name: "keeperhub_workflow_execution_errors_created_total",
+        labels: {
+          org_slug: "acme",
+          error_category: "infrastructure",
+          error_type: "system",
+        },
+        value: 1,
+      },
+    ]);
+
+    expect(applied).toBe(2);
+    expect(skipped).toBe(0);
+    expect(workflowCounters.executionsFinished.incCalls).toEqual([
+      {
+        labels: { status: "success", org_slug: "acme", error_type: "na" },
+        value: 2,
+      },
+    ]);
+    expect(workflowCounters.executionErrorsCreated.incCalls).toEqual([
+      {
+        labels: {
+          org_slug: "acme",
+          error_category: "infrastructure",
+          error_type: "system",
+        },
+        value: 1,
+      },
     ]);
   });
 
@@ -195,6 +245,15 @@ describe("SHIPPABLE_COUNTER_NAMES", () => {
     );
     expect(SHIPPABLE_COUNTER_NAMES).toContain(
       "keeperhub_rpc_errors_by_type_total"
+    );
+  });
+
+  it("includes the workflow terminal counters emitted inside runner pods", () => {
+    expect(SHIPPABLE_COUNTER_NAMES).toContain(
+      "keeperhub_workflow_executions_finished_total"
+    );
+    expect(SHIPPABLE_COUNTER_NAMES).toContain(
+      "keeperhub_workflow_execution_errors_created_total"
     );
   });
 });

--- a/keeperhub-executor/lib/metrics-shipping.ts
+++ b/keeperhub-executor/lib/metrics-shipping.ts
@@ -24,8 +24,10 @@ export type IngestPayload = {
   deltas: MetricDelta[];
 };
 
-async function loadRpcMetrics(): Promise<Record<string, Counter<string>>> {
-  const { rpcMetrics } = await import(
+async function loadShippableCounters(): Promise<
+  Record<string, Counter<string>>
+> {
+  const { rpcMetrics, workflowCounterMetrics } = await import(
     "../../lib/metrics/collectors/prometheus"
   );
   return {
@@ -37,6 +39,10 @@ async function loadRpcMetrics(): Promise<Record<string, Counter<string>>> {
     keeperhub_rpc_recovery_events_total: rpcMetrics.recoveryEvents,
     keeperhub_rpc_both_failed_total: rpcMetrics.bothFailedEvents,
     keeperhub_rpc_errors_by_type_total: rpcMetrics.errorsByType,
+    keeperhub_workflow_execution_errors_created_total:
+      workflowCounterMetrics.executionErrorsCreated,
+    keeperhub_workflow_executions_finished_total:
+      workflowCounterMetrics.executionsFinished,
   };
 }
 
@@ -49,10 +55,12 @@ export const SHIPPABLE_COUNTER_NAMES = [
   "keeperhub_rpc_recovery_events_total",
   "keeperhub_rpc_both_failed_total",
   "keeperhub_rpc_errors_by_type_total",
+  "keeperhub_workflow_execution_errors_created_total",
+  "keeperhub_workflow_executions_finished_total",
 ] as const;
 
 export async function collectCounterDeltas(): Promise<MetricDelta[]> {
-  const counters = await loadRpcMetrics();
+  const counters = await loadShippableCounters();
   const deltas: MetricDelta[] = [];
 
   for (const name of SHIPPABLE_COUNTER_NAMES) {
@@ -78,7 +86,7 @@ export async function collectCounterDeltas(): Promise<MetricDelta[]> {
 export async function applyCounterDeltas(
   deltas: readonly MetricDelta[]
 ): Promise<{ applied: number; skipped: number }> {
-  const counters = await loadRpcMetrics();
+  const counters = await loadShippableCounters();
   let applied = 0;
   let skipped = 0;
 

--- a/keeperhub-executor/lib/terminal-counters.ts
+++ b/keeperhub-executor/lib/terminal-counters.ts
@@ -3,11 +3,6 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { organization, workflows } from "../../lib/db/schema";
 import { classifyExecutionError } from "../../lib/errors/classify";
 import type { ErrorStatus } from "../../lib/errors/execution-status";
-import {
-  recordWorkflowExecutionError,
-  recordWorkflowExecutionErrorByWorkflow,
-  recordWorkflowExecutionFinished,
-} from "../../lib/metrics/collectors/prometheus";
 import { NA_ERROR_TYPE } from "../../lib/metrics/metric-constants";
 import { resolveOrgSlugCached } from "../../lib/metrics/org-slug-cache";
 import type { DbSchema } from "./db-helpers";
@@ -32,6 +27,16 @@ export async function recordTerminalSample(
   }
 ): Promise<void> {
   try {
+    // Deferred so importing this module (and db-helpers) never pulls in the
+    // prometheus collector's "server-only" guard at load time - same pattern
+    // as metrics-shipping.ts. The Docker images shim server-only, but vitest
+    // and any non-shimmed context would throw on a static import.
+    const {
+      recordWorkflowExecutionError,
+      recordWorkflowExecutionErrorByWorkflow,
+      recordWorkflowExecutionFinished,
+    } = await import("../../lib/metrics/collectors/prometheus");
+
     const orgSlug = await resolveOrgSlugCached(args.workflowId, (id) =>
       db
         .select({ slug: organization.slug })

--- a/keeperhub-executor/lib/terminal-counters.ts
+++ b/keeperhub-executor/lib/terminal-counters.ts
@@ -8,6 +8,7 @@ import {
   recordWorkflowExecutionErrorByWorkflow,
   recordWorkflowExecutionFinished,
 } from "../../lib/metrics/collectors/prometheus";
+import { NA_ERROR_TYPE } from "../../lib/metrics/metric-constants";
 import { resolveOrgSlugCached } from "../../lib/metrics/org-slug-cache";
 import type { DbSchema } from "./db-helpers";
 
@@ -44,7 +45,7 @@ export async function recordTerminalSample(
       recordWorkflowExecutionFinished({
         status: "success",
         orgSlug,
-        errorType: "na",
+        errorType: NA_ERROR_TYPE,
       });
       return;
     }

--- a/keeperhub-executor/lib/terminal-counters.ts
+++ b/keeperhub-executor/lib/terminal-counters.ts
@@ -1,0 +1,70 @@
+import { eq } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { organization, workflows } from "../../lib/db/schema";
+import { classifyExecutionError } from "../../lib/errors/classify";
+import type { ErrorStatus } from "../../lib/errors/execution-status";
+import {
+  recordWorkflowExecutionError,
+  recordWorkflowExecutionErrorByWorkflow,
+  recordWorkflowExecutionFinished,
+} from "../../lib/metrics/collectors/prometheus";
+import { resolveOrgSlugCached } from "../../lib/metrics/org-slug-cache";
+import type { DbSchema } from "./db-helpers";
+
+/**
+ * Emit the terminal workflow counters for an executor-side terminal write
+ * (consumer-crash backstop, billing block, engine-write-lost backstop).
+ * These writes happen outside logWorkflowCompleteDb/recordExecutionErrorFinalized,
+ * so without this the executions they finalize are invisible to the
+ * success-rate SLI. Callers must only invoke it when their compare-and-set
+ * actually flipped a non-terminal row, which preserves the emit-once
+ * contract. Never throws: metric emission must not break executor DB writes.
+ */
+export async function recordTerminalSample(
+  db: PostgresJsDatabase<DbSchema>,
+  args: {
+    workflowId: string;
+    status: "success" | ErrorStatus;
+    errorMessage?: string | null;
+    errorType?: "user" | "system";
+    errorCategory?: string;
+  }
+): Promise<void> {
+  try {
+    const orgSlug = await resolveOrgSlugCached(args.workflowId, (id) =>
+      db
+        .select({ slug: organization.slug })
+        .from(workflows)
+        .leftJoin(organization, eq(workflows.organizationId, organization.id))
+        .where(eq(workflows.id, id))
+        .limit(1)
+    );
+
+    if (args.status === "success") {
+      recordWorkflowExecutionFinished({
+        status: "success",
+        orgSlug,
+        errorType: "na",
+      });
+      return;
+    }
+
+    const classification = classifyExecutionError(args.errorMessage);
+    const errorType = args.errorType ?? classification.errorType;
+    const errorCategory = args.errorCategory ?? classification.errorCategory;
+
+    recordWorkflowExecutionError({ orgSlug, errorCategory, errorType });
+    recordWorkflowExecutionErrorByWorkflow({
+      workflowId: args.workflowId,
+      orgSlug,
+      errorType,
+    });
+    recordWorkflowExecutionFinished({
+      status: args.status,
+      orgSlug,
+      errorType,
+    });
+  } catch {
+    // Counter emission must never break the executor's terminal writes.
+  }
+}

--- a/lib/errors/finalize-error.ts
+++ b/lib/errors/finalize-error.ts
@@ -1,8 +1,5 @@
 import "server-only";
 
-import { eq } from "drizzle-orm";
-import { db } from "@/lib/db";
-import { organization, workflows } from "@/lib/db/schema";
 import { classifyExecutionError } from "@/lib/errors/classify";
 import type { ErrorStatus } from "@/lib/errors/execution-status";
 import {
@@ -10,7 +7,7 @@ import {
   recordWorkflowExecutionErrorByWorkflow,
   recordWorkflowExecutionFinished,
 } from "@/lib/metrics/collectors/prometheus";
-import { ANONYMOUS_ORG_SLUG } from "@/lib/metrics/db-metrics";
+import { resolveOrgSlugForCounter } from "@/lib/metrics/org-slug.server";
 
 /**
  * Increment `keeperhub_workflow_execution_errors_created_total` after a
@@ -39,14 +36,7 @@ export async function recordExecutionErrorFinalized(args: {
     const errorCategory = args.errorCategory ?? classification.errorCategory;
     const { errorType } = classification;
 
-    const row = await db
-      .select({ slug: organization.slug })
-      .from(workflows)
-      .leftJoin(organization, eq(workflows.organizationId, organization.id))
-      .where(eq(workflows.id, args.workflowId))
-      .limit(1);
-
-    const orgSlug = row[0]?.slug ?? ANONYMOUS_ORG_SLUG;
+    const orgSlug = await resolveOrgSlugForCounter(args.workflowId);
 
     recordWorkflowExecutionError({
       orgSlug,

--- a/lib/errors/finalize-error.ts
+++ b/lib/errors/finalize-error.ts
@@ -4,9 +4,11 @@ import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { organization, workflows } from "@/lib/db/schema";
 import { classifyExecutionError } from "@/lib/errors/classify";
+import { statusForErrorType } from "@/lib/errors/execution-status";
 import {
   recordWorkflowExecutionError,
   recordWorkflowExecutionErrorByWorkflow,
+  recordWorkflowExecutionFinished,
 } from "@/lib/metrics/collectors/prometheus";
 import { ANONYMOUS_ORG_SLUG } from "@/lib/metrics/db-metrics";
 
@@ -48,6 +50,12 @@ export async function recordExecutionErrorFinalized(args: {
 
     recordWorkflowExecutionErrorByWorkflow({
       workflowId: args.workflowId,
+      orgSlug,
+      errorType,
+    });
+
+    recordWorkflowExecutionFinished({
+      status: statusForErrorType(errorType),
       orgSlug,
       errorType,
     });

--- a/lib/errors/finalize-error.ts
+++ b/lib/errors/finalize-error.ts
@@ -4,7 +4,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { organization, workflows } from "@/lib/db/schema";
 import { classifyExecutionError } from "@/lib/errors/classify";
-import { statusForErrorType } from "@/lib/errors/execution-status";
+import type { ErrorStatus } from "@/lib/errors/execution-status";
 import {
   recordWorkflowExecutionError,
   recordWorkflowExecutionErrorByWorkflow,
@@ -14,11 +14,16 @@ import { ANONYMOUS_ORG_SLUG } from "@/lib/metrics/db-metrics";
 
 /**
  * Increment `keeperhub_workflow_execution_errors_created_total` after a
- * `workflow_executions` row has been written with status='error'.
+ * `workflow_executions` row has been written with a terminal error status.
  *
  * Resolves the org slug for the workflow so the counter series is scoped
  * for the SLA alert (Sky/Ajna). Falls back to ANONYMOUS_ORG_SLUG for
  * personal workflows so personal failures still emit a series.
+ *
+ * `persistedStatus` must be the status the caller actually wrote to the row.
+ * The finished counter's status label has to match the DB (and the engine
+ * path, which applies the isDefaultClassification carve-out before writing),
+ * so it cannot be re-derived here from the classified error type alone.
  *
  * Safe to call after the DB write succeeded. Errors are caught and dropped
  * because metric emission must never break an already-finalized execution.
@@ -26,6 +31,7 @@ import { ANONYMOUS_ORG_SLUG } from "@/lib/metrics/db-metrics";
 export async function recordExecutionErrorFinalized(args: {
   workflowId: string;
   errorMessage: string | null | undefined;
+  persistedStatus: ErrorStatus;
   errorCategory?: string;
 }): Promise<void> {
   try {
@@ -55,7 +61,7 @@ export async function recordExecutionErrorFinalized(args: {
     });
 
     recordWorkflowExecutionFinished({
-      status: statusForErrorType(errorType),
+      status: args.persistedStatus,
       orgSlug,
       errorType,
     });

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -961,6 +961,31 @@ export function recordWorkflowExecutionError(labels: {
   });
 }
 
+// Per-execution terminal counter: incremented once per execution finalization
+// (success | error | system_error), gated on the CAS-guarded terminal write so
+// lost finalize races are not counted. Unlike errors_created it also counts
+// successes, so windowed success-rate SLIs can be computed per org from
+// increase() without reading the 30-day executions gauge. Non-error rows carry
+// error_type="na". Cardinality is the same order as errors_created.
+const workflowExecutionsFinished = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_workflow_executions_finished_total",
+  "Workflow executions finished since pod start, by terminal status, org_slug and error_type",
+  ["status", "org_slug", "error_type"]
+);
+
+export function recordWorkflowExecutionFinished(labels: {
+  status: string;
+  orgSlug: string;
+  errorType: string;
+}): void {
+  workflowExecutionsFinished.inc({
+    status: labels.status,
+    org_slug: labels.orgSlug,
+    error_type: labels.errorType,
+  });
+}
+
 // Per-workflow error counter used exclusively for managed-client alert dedup.
 // Labels are kept to (workflow_id, org_slug, error_type) — no error_category —
 // so cardinality stays bounded: only workflows that actually fail contribute
@@ -1550,7 +1575,7 @@ async function refreshDbMetricsNow(): Promise<void> {
     workflowDurationBucket.set(
       { le: "+Inf" },
       workflowStats.durationBuckets[WORKFLOW_DURATION_BUCKETS.length] ??
-      workflowStats.durationCount
+        workflowStats.durationCount
     );
 
     // Update workflow duration sum and count
@@ -1585,7 +1610,7 @@ async function refreshDbMetricsNow(): Promise<void> {
     stepDurationBucket.set(
       { le: "+Inf" },
       stepStats.durationBuckets[STEP_DURATION_BUCKETS.length] ??
-      stepStats.durationCount
+        stepStats.durationCount
     );
 
     // Update step duration sum and count

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -1841,3 +1841,16 @@ export const rpcProbeMetrics = {
   errorsTotal: rpcProbeErrorsTotal,
   lastSuccess: rpcProbeLastSuccess,
 };
+
+/**
+ * Workflow terminal counter accessors for the runner-pod metric shipping
+ * bridge (keeperhub-executor/lib/metrics-shipping.ts). In isolated (k8s-job)
+ * execution mode the workflow engine finalizes executions inside ephemeral
+ * runner pods whose registry is never scraped, so increments to these
+ * counters must be shipped to the long-lived executor to be visible to
+ * Prometheus.
+ */
+export const workflowCounterMetrics = {
+  executionErrorsCreated: workflowExecutionErrorsCreated,
+  executionsFinished: workflowExecutionsFinished,
+};

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -970,7 +970,7 @@ export function recordWorkflowExecutionError(labels: {
 const workflowExecutionsFinished = getOrCreateCounter(
   apiRegistry,
   "keeperhub_workflow_executions_finished_total",
-  "Workflow executions finished since pod start, by terminal status, org_slug and error_type",
+  "Workflow executions finished since pod start, by terminal status (success, error, system_error; cancellations are not counted), org_slug and error_type",
   ["status", "org_slug", "error_type"]
 );
 

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -986,6 +986,24 @@ export function recordWorkflowExecutionFinished(labels: {
   });
 }
 
+// Compensation series for the finished counter. selfHealWorkflowAfterLateStepCommit
+// flips error -> success after finalization has already emitted
+// finished{status="error"|"system_error"}, and a counter cannot be
+// decremented, so dashboards correct the per-org SLI with this series
+// (successes += healed, failures -= healed).
+const workflowExecutionsHealed = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_workflow_executions_healed_total",
+  "Workflow executions self-healed from error to success after finalization, by org_slug",
+  ["org_slug"]
+);
+
+export function recordWorkflowExecutionHealed(labels: {
+  orgSlug: string;
+}): void {
+  workflowExecutionsHealed.inc({ org_slug: labels.orgSlug });
+}
+
 // Per-workflow error counter used exclusively for managed-client alert dedup.
 // Labels are kept to (workflow_id, org_slug, error_type) — no error_category —
 // so cardinality stays bounded: only workflows that actually fail contribute

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -8,7 +8,9 @@
 import "server-only";
 
 import { Counter, Gauge, Histogram, Registry } from "prom-client";
+import type { ErrorStatus } from "@/lib/errors/execution-status";
 import { ErrorCategory, logSystemWarn, logWarn } from "@/lib/logging";
+import type { NA_ERROR_TYPE } from "@/lib/metrics/metric-constants";
 import type { ErrorContext, MetricLabels, MetricsCollector } from "../types";
 
 // Use global singletons to prevent duplicate registration during hot reload
@@ -975,9 +977,9 @@ const workflowExecutionsFinished = getOrCreateCounter(
 );
 
 export function recordWorkflowExecutionFinished(labels: {
-  status: string;
+  status: "success" | ErrorStatus;
   orgSlug: string;
-  errorType: string;
+  errorType: "user" | "system" | typeof NA_ERROR_TYPE;
 }): void {
   workflowExecutionsFinished.inc({
     status: labels.status,

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -50,14 +50,15 @@ import {
 } from "@/lib/db/schema";
 import { ERROR_STATUSES } from "@/lib/errors/execution-status";
 import { ErrorCategory, logSystemWarn } from "@/lib/logging";
+import { ANONYMOUS_ORG_SLUG } from "@/lib/metrics/metric-constants";
 import type { BillingStatus } from "./types";
 
 // Label value used for workflow executions whose workflow has no organization
 // (personal/anonymous workflows). Keeps the per-(status, org_slug) execution
 // gauge total equal to the global total instead of silently dropping these
-// rows. Also re-exported for the runtime finalization counter so personal
-// workflows still produce a series rather than silently dropping increments.
-export const ANONYMOUS_ORG_SLUG = "_anonymous";
+// rows. Lives in metric-constants.ts (dependency-free) so the standalone
+// executor can share it; re-exported here for existing import sites.
+export { ANONYMOUS_ORG_SLUG };
 
 // Org slugs for the managed clients (Sky, Ajna) whose per-workflow error series
 // power the managed-client user-error alerts. The per-workflow gauge is scoped

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -50,7 +50,10 @@ import {
 } from "@/lib/db/schema";
 import { ERROR_STATUSES } from "@/lib/errors/execution-status";
 import { ErrorCategory, logSystemWarn } from "@/lib/logging";
-import { ANONYMOUS_ORG_SLUG } from "@/lib/metrics/metric-constants";
+import {
+  ANONYMOUS_ORG_SLUG,
+  NA_ERROR_TYPE,
+} from "@/lib/metrics/metric-constants";
 import type { BillingStatus } from "./types";
 
 // Label value used for workflow executions whose workflow has no organization
@@ -152,7 +155,7 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
         status: workflowExecutions.status,
         orgSlug: sql<string>`COALESCE(${organization.slug}, ${ANONYMOUS_ORG_SLUG})`,
         errorType: sql<string>`CASE
-          WHEN ${notInArray(workflowExecutions.status, [...ERROR_STATUSES])} THEN 'na'
+          WHEN ${notInArray(workflowExecutions.status, [...ERROR_STATUSES])} THEN ${NA_ERROR_TYPE}
           WHEN ${workflowExecutions.errorType} IS NULL THEN 'unknown'
           ELSE ${workflowExecutions.errorType}
         END`,

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -61,7 +61,7 @@ import type { BillingStatus } from "./types";
 // gauge total equal to the global total instead of silently dropping these
 // rows. Lives in metric-constants.ts (dependency-free) so the standalone
 // executor can share it; re-exported here for existing import sites.
-export { ANONYMOUS_ORG_SLUG };
+export { ANONYMOUS_ORG_SLUG } from "@/lib/metrics/metric-constants";
 
 // Org slugs for the managed clients (Sky, Ajna) whose per-workflow error series
 // power the managed-client user-error alerts. The per-workflow gauge is scoped
@@ -164,9 +164,7 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
       .from(workflowExecutions)
       .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
       .leftJoin(organization, eq(workflows.organizationId, organization.id))
-      .where(
-        gte(workflowExecutions.startedAt, sql`now() - interval '30 days'`)
-      )
+      .where(gte(workflowExecutions.startedAt, sql`now() - interval '30 days'`))
       .groupBy(
         workflowExecutions.status,
         organization.slug,

--- a/lib/metrics/metric-constants.ts
+++ b/lib/metrics/metric-constants.ts
@@ -1,0 +1,9 @@
+// Label constants shared by the app (server-only modules) and the standalone
+// executor service. This module must stay dependency-free: the executor
+// imports it directly, so pulling in @/lib/db or "server-only" here would
+// open a second connection pool or break the runner bootstrap shim.
+
+// Label value used for workflow executions whose workflow has no organization
+// (personal/anonymous workflows). Keeps per-(status, org_slug) series totals
+// equal to the global total instead of silently dropping these rows.
+export const ANONYMOUS_ORG_SLUG = "_anonymous";

--- a/lib/metrics/metric-constants.ts
+++ b/lib/metrics/metric-constants.ts
@@ -7,3 +7,9 @@
 // (personal/anonymous workflows). Keeps per-(status, org_slug) series totals
 // equal to the global total instead of silently dropping these rows.
 export const ANONYMOUS_ORG_SLUG = "_anonymous";
+
+// error_type label value for rows that carry no error (success and other
+// non-error statuses). Shared by the finished counter emitters and the
+// db-sourced executions gauge so PromQL joins on error_type="na" cannot
+// drift between the two.
+export const NA_ERROR_TYPE = "na";

--- a/lib/metrics/org-slug-cache.ts
+++ b/lib/metrics/org-slug-cache.ts
@@ -1,0 +1,41 @@
+import { ANONYMOUS_ORG_SLUG } from "@/lib/metrics/metric-constants";
+
+// Dependency-free so the standalone executor can share the cache without
+// importing the app's eagerly-created db client; each context supplies its
+// own lookup bound to its own db instance (see org-slug.server.ts and
+// keeperhub-executor/lib/terminal-counters.ts).
+
+export type OrgSlugLookup = (
+  workflowId: string
+) => Promise<Array<{ slug: string | null }>>;
+
+// A workflow's organization never changes after creation, so the mapping is
+// safe to memoize for the pod lifetime. An org slug rename can leave stale
+// label values until pods restart; counters tolerate that (the series simply
+// splits at the rename) and it avoids one JOIN per finalized execution on
+// the hot finalize path. Bounded FIFO eviction caps memory on long-lived
+// pods that see many distinct workflows.
+const cache = new Map<string, string>();
+export const ORG_SLUG_CACHE_MAX = 10_000;
+
+export async function resolveOrgSlugCached(
+  workflowId: string,
+  lookup: OrgSlugLookup
+): Promise<string> {
+  const hit = cache.get(workflowId);
+  if (hit !== undefined) {
+    return hit;
+  }
+
+  const rows = await lookup(workflowId);
+  const slug = rows[0]?.slug ?? ANONYMOUS_ORG_SLUG;
+
+  if (cache.size >= ORG_SLUG_CACHE_MAX) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) {
+      cache.delete(oldest);
+    }
+  }
+  cache.set(workflowId, slug);
+  return slug;
+}

--- a/lib/metrics/org-slug.server.ts
+++ b/lib/metrics/org-slug.server.ts
@@ -1,0 +1,23 @@
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { organization, workflows } from "@/lib/db/schema";
+import { resolveOrgSlugCached } from "@/lib/metrics/org-slug-cache";
+
+/**
+ * Resolve the org slug that owns the workflow behind an execution, falling
+ * back to ANONYMOUS_ORG_SLUG for personal/anonymous workflows so counters
+ * always emit a series (the SLA alert filters by `org_slug=~`). Memoized per
+ * workflowId for the pod lifetime; see org-slug-cache.ts for the trade-offs.
+ */
+export function resolveOrgSlugForCounter(workflowId: string): Promise<string> {
+  return resolveOrgSlugCached(workflowId, (id) =>
+    db
+      .select({ slug: organization.slug })
+      .from(workflows)
+      .leftJoin(organization, eq(workflows.organizationId, organization.id))
+      .where(eq(workflows.id, id))
+      .limit(1)
+  );
+}

--- a/lib/workflow/execute-in-background.ts
+++ b/lib/workflow/execute-in-background.ts
@@ -1,5 +1,6 @@
 import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
-import { and, eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import { start } from "workflow/api";
 import { db } from "@/lib/db";
 import { workflowExecutions } from "@/lib/db/schema";
@@ -7,7 +8,10 @@ import {
   classifyExecutionError,
   isDefaultClassification,
 } from "@/lib/errors/classify";
-import { statusForErrorType } from "@/lib/errors/execution-status";
+import {
+  isErrorStatus,
+  statusForErrorType,
+} from "@/lib/errors/execution-status";
 import { recordExecutionErrorFinalized } from "@/lib/errors/finalize-error";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { executeWorkflow } from "@/lib/workflow/executor/executor.workflow";
@@ -143,6 +147,15 @@ export async function executeWorkflowInBackground(
       isDefaultClassification(classification) ? null : classification.errorType
     );
 
+    // This catch is also reachable after start() has durably enqueued the run
+    // (the runId UPDATE above sits in the same try). The workflow may already
+    // have finished, or may still finish, through logWorkflowCompleteDb, so
+    // this write must not clobber a terminal row and must not emit a second
+    // finished sample: exclude success/cancelled rows via the WHERE, and gate
+    // the counter on the pre-update status (exposed via the self-join alias,
+    // which reads the statement snapshot) not already being terminal.
+    const prevExecution = alias(workflowExecutions, "prev_execution");
+
     const updated = await db
       .update(workflowExecutions)
       .set({
@@ -153,10 +166,21 @@ export async function executeWorkflowInBackground(
         errorCode: classification.code,
         completedAt: new Date(),
       })
-      .where(eq(workflowExecutions.id, executionId))
-      .returning({ workflowId: workflowExecutions.workflowId });
+      .from(prevExecution)
+      .where(
+        and(
+          eq(workflowExecutions.id, executionId),
+          eq(prevExecution.id, workflowExecutions.id),
+          ne(workflowExecutions.status, "cancelled"),
+          ne(workflowExecutions.status, "success")
+        )
+      )
+      .returning({
+        workflowId: workflowExecutions.workflowId,
+        previousStatus: prevExecution.status,
+      });
 
-    if (updated.length > 0) {
+    if (updated.length > 0 && !isErrorStatus(updated[0].previousStatus)) {
       await recordExecutionErrorFinalized({
         workflowId: updated[0].workflowId,
         errorMessage,

--- a/lib/workflow/execute-in-background.ts
+++ b/lib/workflow/execute-in-background.ts
@@ -139,15 +139,14 @@ export async function executeWorkflowInBackground(
     const errorMessage =
       error instanceof Error ? error.message : "Unknown error";
     const classification = classifyExecutionError(errorMessage);
+    const persistedStatus = statusForErrorType(
+      isDefaultClassification(classification) ? null : classification.errorType
+    );
 
     const updated = await db
       .update(workflowExecutions)
       .set({
-        status: statusForErrorType(
-          isDefaultClassification(classification)
-            ? null
-            : classification.errorType
-        ),
+        status: persistedStatus,
         error: errorMessage,
         errorCategory: classification.errorCategory,
         errorType: classification.errorType,
@@ -161,6 +160,7 @@ export async function executeWorkflowInBackground(
       await recordExecutionErrorFinalized({
         workflowId: updated[0].workflowId,
         errorMessage,
+        persistedStatus,
       });
     }
   }

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -29,7 +29,10 @@ import {
 } from "@/lib/errors/execution-status";
 import { ErrorCategory, logSystemError, logSystemWarn } from "@/lib/logging";
 import { getMetricsCollector } from "@/lib/metrics";
-import { recordWorkflowExecutionError } from "@/lib/metrics/collectors/prometheus";
+import {
+  recordWorkflowExecutionError,
+  recordWorkflowExecutionFinished,
+} from "@/lib/metrics/collectors/prometheus";
 import { ANONYMOUS_ORG_SLUG } from "@/lib/metrics/db-metrics";
 import { toJsonSafe } from "@/lib/utils/json-safe";
 import {
@@ -779,15 +782,32 @@ export async function logWorkflowCompleteDb(
   // UPDATE actually flipped a row to 'error'. The WHERE clause excludes
   // already-cancelled/healed rows, so `updated` is empty in those races
   // and we correctly skip the counter increment for the lost write.
-  if (resolvedStatus === "error" && updated.length > 0 && classification) {
+  // The finished counter mirrors this: emit exactly once, for both success and
+  // error, so windowed success-rate SLIs can be derived per org. resolvedStatus
+  // is post-reconciliation, so spurious errors already flipped to success are
+  // counted as success here.
+  if (updated.length > 0) {
     const workflowId = updated[0].workflowId;
     try {
       const orgSlug = await resolveOrgSlugForCounter(workflowId);
-      recordWorkflowExecutionError({
-        orgSlug,
-        errorCategory: classification.errorCategory,
-        errorType: classification.errorType,
-      });
+      if (resolvedStatus === "error" && classification) {
+        recordWorkflowExecutionError({
+          orgSlug,
+          errorCategory: classification.errorCategory,
+          errorType: classification.errorType,
+        });
+        recordWorkflowExecutionFinished({
+          status: executionStatus,
+          orgSlug,
+          errorType: classification.errorType,
+        });
+      } else if (resolvedStatus === "success") {
+        recordWorkflowExecutionFinished({
+          status: "success",
+          orgSlug,
+          errorType: "na",
+        });
+      }
     } catch {
       // Counter emission must never break finalization.
     }

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -33,6 +33,7 @@ import {
   recordWorkflowExecutionFinished,
   recordWorkflowExecutionHealed,
 } from "@/lib/metrics/collectors/prometheus";
+import { NA_ERROR_TYPE } from "@/lib/metrics/metric-constants";
 import { resolveOrgSlugForCounter } from "@/lib/metrics/org-slug.server";
 import { toJsonSafe } from "@/lib/utils/json-safe";
 import {
@@ -815,24 +816,18 @@ export async function logWorkflowCompleteDb(
     const workflowId = updated[0].workflowId;
     try {
       const orgSlug = await resolveOrgSlugForCounter(workflowId);
-      if (resolvedStatus === "error" && classification) {
+      if (classification) {
         recordWorkflowExecutionError({
           orgSlug,
           errorCategory: classification.errorCategory,
           errorType: classification.errorType,
         });
-        recordWorkflowExecutionFinished({
-          status: executionStatus,
-          orgSlug,
-          errorType: classification.errorType,
-        });
-      } else if (resolvedStatus === "success") {
-        recordWorkflowExecutionFinished({
-          status: "success",
-          orgSlug,
-          errorType: "na",
-        });
       }
+      recordWorkflowExecutionFinished({
+        status: executionStatus,
+        orgSlug,
+        errorType: classification?.errorType ?? NA_ERROR_TYPE,
+      });
     } catch {
       // Counter emission must never break finalization.
     }

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -31,6 +31,7 @@ import { getMetricsCollector } from "@/lib/metrics";
 import {
   recordWorkflowExecutionError,
   recordWorkflowExecutionFinished,
+  recordWorkflowExecutionHealed,
 } from "@/lib/metrics/collectors/prometheus";
 import { resolveOrgSlugForCounter } from "@/lib/metrics/org-slug.server";
 import { toJsonSafe } from "@/lib/utils/json-safe";
@@ -274,6 +275,7 @@ async function selfHealWorkflowAfterLateStepCommit(
       error: true,
       completedAt: true,
       startedAt: true,
+      workflowId: true,
     },
   });
 
@@ -385,6 +387,17 @@ async function selfHealWorkflowAfterLateStepCommit(
       "workflow.executor.self_heal_late_commit.total",
       { outcome: "flipped" }
     );
+
+    // The finished counter already recorded this execution as error/system_error
+    // at finalize time and cannot be decremented; emit the org-labelled healed
+    // series so per-org success-rate dashboards can compensate.
+    try {
+      recordWorkflowExecutionHealed({
+        orgSlug: await resolveOrgSlugForCounter(execution.workflowId),
+      });
+    } catch {
+      // Counter emission must never break the self-heal path.
+    }
 
     logSystemWarn(
       ErrorCategory.WORKFLOW_ENGINE,

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -13,11 +13,9 @@ import {
   logOutputField,
 } from "@/lib/db/execution-log-fields";
 import {
-  organization,
   type TransactionHashEntry,
   workflowExecutionLogs,
   workflowExecutions,
-  workflows,
 } from "@/lib/db/schema";
 import {
   classifyExecutionError,
@@ -34,7 +32,7 @@ import {
   recordWorkflowExecutionError,
   recordWorkflowExecutionFinished,
 } from "@/lib/metrics/collectors/prometheus";
-import { ANONYMOUS_ORG_SLUG } from "@/lib/metrics/db-metrics";
+import { resolveOrgSlugForCounter } from "@/lib/metrics/org-slug.server";
 import { toJsonSafe } from "@/lib/utils/json-safe";
 import {
   EXCEEDED_MAX_RETRIES_REGEX,
@@ -826,21 +824,6 @@ export async function logWorkflowCompleteDb(
       // Counter emission must never break finalization.
     }
   }
-}
-
-/**
- * Resolve the org slug that owns the workflow behind an execution, falling
- * back to ANONYMOUS_ORG_SLUG for personal/anonymous workflows so the
- * counter always emits a series (the SLA alert filters by `org_slug=~`).
- */
-async function resolveOrgSlugForCounter(workflowId: string): Promise<string> {
-  const row = await db
-    .select({ slug: organization.slug })
-    .from(workflows)
-    .leftJoin(organization, eq(workflows.organizationId, organization.id))
-    .where(eq(workflows.id, workflowId))
-    .limit(1);
-  return row[0]?.slug ?? ANONYMOUS_ORG_SLUG;
 }
 
 // ============================================================================

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -5,6 +5,7 @@
 import "server-only";
 
 import { and, asc, eq, inArray, isNotNull, isNull, ne, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import { db } from "@/lib/db";
 import {
   extractLogGasUsedWei,
@@ -746,6 +747,13 @@ export async function logWorkflowCompleteDb(
         )
       : resolvedStatus;
 
+  // Self-join alias so RETURNING can expose the pre-update status (the FROM
+  // clause reads the statement snapshot, i.e. the row as it was before this
+  // UPDATE). The counters below must know whether this finalize was the
+  // first terminal transition or a re-finalization of an already-terminal
+  // row (reaped by the reaper, or a duplicate _workflowComplete).
+  const prevExecution = alias(workflowExecutions, "prev_execution");
+
   const updated = await db
     .update(workflowExecutions)
     .set({
@@ -763,9 +771,11 @@ export async function logWorkflowCompleteDb(
       transactionHashes,
       gasUsedWei,
     })
+    .from(prevExecution)
     .where(
       and(
         eq(workflowExecutions.id, params.executionId),
+        eq(prevExecution.id, workflowExecutions.id),
         ne(workflowExecutions.status, "cancelled"),
         // KEEP-431 follow-up: defense in depth. If selfHealWorkflowAfterLateStepCommit
         // already CAS-flipped status to 'success', a stray late call to
@@ -776,17 +786,21 @@ export async function logWorkflowCompleteDb(
         ne(workflowExecutions.status, "success")
       )
     )
-    .returning({ workflowId: workflowExecutions.workflowId });
+    .returning({
+      workflowId: workflowExecutions.workflowId,
+      previousStatus: prevExecution.status,
+    });
 
-  // KEEP-545: increment the per-execution-error counter only when this
-  // UPDATE actually flipped a row to 'error'. The WHERE clause excludes
-  // already-cancelled/healed rows, so `updated` is empty in those races
-  // and we correctly skip the counter increment for the lost write.
-  // The finished counter mirrors this: emit exactly once, for both success and
-  // error, so windowed success-rate SLIs can be derived per org. resolvedStatus
-  // is post-reconciliation, so spurious errors already flipped to success are
-  // counted as success here.
-  if (updated.length > 0) {
+  // KEEP-545: increment the counters only when this UPDATE performed the
+  // first non-terminal -> terminal transition. The WHERE clause excludes
+  // already-cancelled/healed rows (updated is empty in those races), and the
+  // previousStatus gate excludes rows that were already error/system_error:
+  // a reaped execution whose pod later finishes, or a duplicate
+  // _workflowComplete, still overwrites the row with the fresher result but
+  // must not emit a second sample - counters are append-only, so the first
+  // terminal sample stands. resolvedStatus is post-reconciliation, so
+  // spurious errors already flipped to success are counted as success here.
+  if (updated.length > 0 && !isErrorStatus(updated[0].previousStatus)) {
     const workflowId = updated[0].workflowId;
     try {
       const orgSlug = await resolveOrgSlugForCounter(workflowId);

--- a/tests/integration/internal-executions-route.test.ts
+++ b/tests/integration/internal-executions-route.test.ts
@@ -60,6 +60,12 @@ let mockWorkflow: {
 let mockExistingExecution: { id: string; status: string } | null;
 let insertedValues: Record<string, unknown> | null;
 let updatedSet: Record<string, unknown> | null;
+// Rows the PATCH terminal UPDATE's .returning() resolves to; seed with
+// workflowId + previousStatus to exercise the counter-emission gate.
+let mockUpdateReturning: Array<{
+  workflowId: string;
+  previousStatus: string;
+}> = [];
 
 vi.mock("@/lib/db", () => ({
   db: {
@@ -79,10 +85,18 @@ vi.mock("@/lib/db", () => ({
         };
       },
     })),
+    // PATCH chains .set().from(prevExecution).where().returning() for the
+    // pre-update-status self-join.
     update: vi.fn(() => ({
       set: (values: Record<string, unknown>) => {
         updatedSet = values;
-        return { where: () => Promise.resolve(undefined) };
+        return {
+          from: () => ({
+            where: () => ({
+              returning: () => Promise.resolve(mockUpdateReturning),
+            }),
+          }),
+        };
       },
     })),
   },
@@ -91,6 +105,28 @@ vi.mock("@/lib/db", () => ({
 vi.mock("@/lib/db/schema", () => ({
   workflowExecutions: { id: "id", status: "status" },
   workflows: { id: "id" },
+}));
+
+// The alias() self-join needs drizzle table internals the schema stub lacks.
+vi.mock("drizzle-orm/pg-core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("drizzle-orm/pg-core")>();
+  return {
+    ...actual,
+    alias: (_table: unknown, name: string) => ({
+      id: `${name}.id`,
+      status: `${name}.status`,
+    }),
+  };
+});
+
+vi.mock("@/lib/errors/finalize-error", () => ({
+  recordExecutionErrorFinalized: vi.fn(),
+}));
+vi.mock("@/lib/metrics/collectors/prometheus", () => ({
+  recordWorkflowExecutionFinished: vi.fn(),
+}));
+vi.mock("@/lib/metrics/org-slug.server", () => ({
+  resolveOrgSlugForCounter: vi.fn(async () => "acme"),
 }));
 
 import { PATCH } from "@/app/api/internal/executions/[executionId]/route";
@@ -230,6 +266,7 @@ describe("PATCH /api/internal/executions/[executionId]", () => {
     mockAuthResult.authenticated = true;
     mockExistingExecution = { id: "exec_1", status: "phantom" };
     updatedSet = null;
+    mockUpdateReturning = [];
   });
 
   it("writes a valid error code and derives type/category from the registry", async () => {
@@ -281,5 +318,63 @@ describe("PATCH /api/internal/executions/[executionId]", () => {
       patchContext
     );
     expect(response.status).toBe(400);
+  });
+
+  it("emits the error counters when a phantom row is first finalized as system_error", async () => {
+    mockUpdateReturning = [{ workflowId: "wf_1", previousStatus: "phantom" }];
+    const { recordExecutionErrorFinalized } = await import(
+      "@/lib/errors/finalize-error"
+    );
+
+    const response = await PATCH(
+      patchRequest({ status: "system_error", error: "enqueue failed" }),
+      patchContext
+    );
+
+    expect(response.status).toBe(200);
+    expect(recordExecutionErrorFinalized).toHaveBeenCalledWith({
+      workflowId: "wf_1",
+      errorMessage: "enqueue failed",
+      persistedStatus: "system_error",
+      errorCategory: "infrastructure",
+    });
+  });
+
+  it("emits the finished counter on a first success transition", async () => {
+    mockUpdateReturning = [{ workflowId: "wf_1", previousStatus: "running" }];
+    const prometheusMod = await import("@/lib/metrics/collectors/prometheus");
+
+    const response = await PATCH(
+      patchRequest({ status: "success" }),
+      patchContext
+    );
+
+    expect(response.status).toBe(200);
+    expect(prometheusMod.recordWorkflowExecutionFinished).toHaveBeenCalledWith({
+      status: "success",
+      orgSlug: "acme",
+      errorType: "na",
+    });
+  });
+
+  it("emits nothing when re-finalizing an already-terminal row", async () => {
+    mockUpdateReturning = [
+      { workflowId: "wf_1", previousStatus: "system_error" },
+    ];
+    const { recordExecutionErrorFinalized } = await import(
+      "@/lib/errors/finalize-error"
+    );
+    const prometheusMod = await import("@/lib/metrics/collectors/prometheus");
+
+    const response = await PATCH(
+      patchRequest({ status: "success" }),
+      patchContext
+    );
+
+    expect(response.status).toBe(200);
+    expect(recordExecutionErrorFinalized).not.toHaveBeenCalled();
+    expect(
+      prometheusMod.recordWorkflowExecutionFinished
+    ).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/workflow-logging.test.ts
+++ b/tests/integration/workflow-logging.test.ts
@@ -99,6 +99,7 @@ vi.mock("@/lib/errors/classify", () => ({
 vi.mock("@/lib/metrics/collectors/prometheus", () => ({
   recordWorkflowExecutionError: vi.fn(),
   recordWorkflowExecutionFinished: vi.fn(),
+  recordWorkflowExecutionHealed: vi.fn(),
 }));
 vi.mock("@/lib/metrics/db-metrics", () => ({
   ANONYMOUS_ORG_SLUG: "_anonymous",

--- a/tests/integration/workflow-logging.test.ts
+++ b/tests/integration/workflow-logging.test.ts
@@ -71,6 +71,20 @@ vi.mock("@/lib/db/schema", () => ({
   organization: organizationMock,
 }));
 
+// The terminal UPDATE self-joins workflow_executions via alias() so RETURNING
+// can expose the pre-update status. Real alias() needs drizzle table internals
+// the schema stubs don't have, so substitute a plain aliased-column object.
+vi.mock("drizzle-orm/pg-core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("drizzle-orm/pg-core")>();
+  return {
+    ...actual,
+    alias: (_table: unknown, name: string) => ({
+      id: `${name}.id`,
+      status: `${name}.status`,
+    }),
+  };
+});
+
 // KEEP-545: stub classifier + counter so the test doesn't load the
 // server-only metric collector module.
 vi.mock("@/lib/errors/classify", () => ({
@@ -84,6 +98,7 @@ vi.mock("@/lib/errors/classify", () => ({
 }));
 vi.mock("@/lib/metrics/collectors/prometheus", () => ({
   recordWorkflowExecutionError: vi.fn(),
+  recordWorkflowExecutionFinished: vi.fn(),
 }));
 vi.mock("@/lib/metrics/db-metrics", () => ({
   ANONYMOUS_ORG_SLUG: "_anonymous",
@@ -113,6 +128,16 @@ let siblingErrorRows: Array<{ id: string }> = [];
 // rows[0].gasUsedWei. Default to a no-gas run; tests that exercise the gas
 // denormalisation set this to a summed value.
 let mockGasRows: Array<{ gasUsedWei: string | null }> = [{ gasUsedWei: null }];
+// Rows returned by the terminal UPDATE's .returning(). Tests exercising the
+// counter-emission gate seed workflowId + previousStatus here; the default
+// empty array means "no row flipped" so the counter path is skipped.
+let mockReturningRows: Array<{
+  workflowId?: string;
+  previousStatus?: string;
+}> = [];
+// resolveOrgSlugForCounter issues
+// `db.select(...).from(workflows).leftJoin(...).where(...).limit(1)`.
+let mockOrgRows: Array<{ slug: string | null }> = [{ slug: "acme" }];
 
 // KEEP-545: the workflow_executions UPDATE in logWorkflowCompleteDb now chains
 // `.returning({workflowId})` on the where() result so the per-execution error
@@ -132,9 +157,14 @@ type WhereChain = {
   catch: <T>(
     onRejected: (reason: unknown) => T | PromiseLike<T>
   ) => Promise<T | void>;
-  returning: (..._args: unknown[]) => Promise<Array<{ workflowId?: string }>>;
+  returning: (
+    ..._args: unknown[]
+  ) => Promise<Array<{ workflowId?: string; previousStatus?: string }>>;
 };
-type SetChain = { where: () => WhereChain };
+type SetChain = {
+  where: () => WhereChain;
+  from: (aliasTable: unknown) => { where: () => WhereChain };
+};
 type UpdateChain = { set: (values: Record<string, unknown>) => SetChain };
 
 function makeWhereChain(failure: Error | null): WhereChain {
@@ -144,7 +174,7 @@ function makeWhereChain(failure: Error | null): WhereChain {
   return {
     then: (onFulfilled, onRejected) => promise.then(onFulfilled, onRejected),
     catch: (onRejected) => promise.catch(onRejected),
-    returning: () => Promise.resolve([]),
+    returning: () => Promise.resolve(mockReturningRows),
   };
 }
 
@@ -155,6 +185,11 @@ function buildUpdate(target: unknown): UpdateChain {
       const failure = updateShouldThrow ? new Error("db down") : null;
       return {
         where: (): WhereChain => makeWhereChain(failure),
+        // The workflow_executions terminal UPDATE chains
+        // .from(prevExecution).where(...) for the pre-update status self-join.
+        from: (): { where: () => WhereChain } => ({
+          where: (): WhereChain => makeWhereChain(failure),
+        }),
       };
     },
   };
@@ -188,9 +223,16 @@ vi.mock("@/lib/db", () => ({
     },
     update: vi.fn((target: unknown) => buildUpdate(target)),
     // resolveGasTotal: db.select({...}).from(logs).where(...) -> rows[]
+    // resolveOrgSlugForCounter: db.select({...}).from(workflows)
+    //   .leftJoin(organization).where(...).limit(1) -> rows[]
     select: vi.fn(() => ({
       from: () => ({
         where: () => Promise.resolve(mockGasRows),
+        leftJoin: () => ({
+          where: () => ({
+            limit: () => Promise.resolve(mockOrgRows),
+          }),
+        }),
       }),
     })),
   },
@@ -223,6 +265,8 @@ describe("logWorkflowCompleteDb", () => {
     updateShouldThrow = false;
     siblingErrorRows = [];
     mockGasRows = [{ gasUsedWei: null }];
+    mockReturningRows = [];
+    mockOrgRows = [{ slug: "acme" }];
     vi.clearAllMocks();
   });
 
@@ -567,11 +611,11 @@ describe("logWorkflowCompleteDb", () => {
         const shouldThrow =
           callIndex === 0 && target === workflowExecutionLogsMock;
         callIndex += 1;
+        const whereChain = (): WhereChain =>
+          makeWhereChain(shouldThrow ? new Error("transient db failure") : null);
         return {
-          where: (): WhereChain =>
-            makeWhereChain(
-              shouldThrow ? new Error("transient db failure") : null
-            ),
+          where: whereChain,
+          from: (): { where: () => WhereChain } => ({ where: whereChain }),
         };
       },
     }));
@@ -597,6 +641,46 @@ describe("logWorkflowCompleteDb", () => {
     // Execution update still ran despite the log cleanup throwing.
     expect(getExecUpdate()).toBeDefined();
   });
+
+  it("emits the finished counter when the row transitions from a non-terminal status", async () => {
+    mockReturningRows = [{ workflowId: "wf_1", previousStatus: "running" }];
+    const prometheusMod = await import("@/lib/metrics/collectors/prometheus");
+
+    await logWorkflowCompleteDb({
+      executionId: "exec_1",
+      status: "success",
+      startTime: Date.now() - 1000,
+    });
+
+    expect(prometheusMod.recordWorkflowExecutionFinished).toHaveBeenCalledWith({
+      status: "success",
+      orgSlug: "acme",
+      errorType: "na",
+    });
+  });
+
+  it("skips counter emission when re-finalizing an already-terminal row", async () => {
+    // Reaper race: the row was already flipped to system_error (and counted)
+    // before the slow pod finished. The UPDATE still overwrites the row with
+    // the fresher result, but no second finished/error sample may be emitted.
+    mockReturningRows = [
+      { workflowId: "wf_1", previousStatus: "system_error" },
+    ];
+    const prometheusMod = await import("@/lib/metrics/collectors/prometheus");
+
+    await logWorkflowCompleteDb({
+      executionId: "exec_1",
+      status: "success",
+      startTime: Date.now() - 1000,
+    });
+
+    // The row overwrite itself still happened.
+    expect(getExecUpdate()).toBeDefined();
+    expect(
+      prometheusMod.recordWorkflowExecutionFinished
+    ).not.toHaveBeenCalled();
+    expect(prometheusMod.recordWorkflowExecutionError).not.toHaveBeenCalled();
+  });
 });
 
 // KEEP-470: top-level transactionHashes persistence at workflow completion.
@@ -617,6 +701,8 @@ describe("logWorkflowCompleteDb transactionHashes (KEEP-470)", () => {
     updateShouldThrow = false;
     siblingErrorRows = [];
     mockGasRows = [{ gasUsedWei: null }];
+    mockReturningRows = [];
+    mockOrgRows = [{ slug: "acme" }];
     vi.clearAllMocks();
   });
 

--- a/tests/integration/workflow-logging.test.ts
+++ b/tests/integration/workflow-logging.test.ts
@@ -613,7 +613,9 @@ describe("logWorkflowCompleteDb", () => {
           callIndex === 0 && target === workflowExecutionLogsMock;
         callIndex += 1;
         const whereChain = (): WhereChain =>
-          makeWhereChain(shouldThrow ? new Error("transient db failure") : null);
+          makeWhereChain(
+            shouldThrow ? new Error("transient db failure") : null
+          );
         return {
           where: whereChain,
           from: (): { where: () => WhereChain } => ({ where: whereChain }),

--- a/tests/unit/apply-execution-result.test.ts
+++ b/tests/unit/apply-execution-result.test.ts
@@ -52,7 +52,22 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 function makeMockDb(
   scheduleRow?: object | null
 ): PostgresJsDatabase<DbSchema> {
-  const mockWhere = vi.fn().mockResolvedValue([]);
+  // where() must be awaitable (updateScheduleStatus awaits it directly) AND
+  // expose .returning() (updateExecutionStatus chains it for the terminal
+  // counter gate). Modeled as a custom thenable; returning [] means "no row
+  // flipped" so no counter emission is attempted.
+  const mockWhere = vi.fn().mockImplementation(() => {
+    const promise = Promise.resolve([]);
+    return {
+      then: (
+        onFulfilled?: (value: unknown[]) => unknown,
+        onRejected?: (reason: unknown) => unknown
+      ) => promise.then(onFulfilled, onRejected),
+      catch: (onRejected: (reason: unknown) => unknown) =>
+        promise.catch(onRejected),
+      returning: vi.fn().mockResolvedValue([]),
+    };
+  });
   const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
   const mockUpdate = vi.fn().mockReturnValue({ set: mockSet });
   const mockFindFirst = vi.fn().mockResolvedValue(

--- a/tests/unit/execution-error-finalize.test.ts
+++ b/tests/unit/execution-error-finalize.test.ts
@@ -100,7 +100,33 @@ describe("recordExecutionErrorFinalized", () => {
     vi.restoreAllMocks();
   });
 
-  it("also records the finished counter with the terminal status derived from error_type", async () => {
+  it("records the finished counter with the status the caller persisted", async () => {
+    mockLimit.mockResolvedValue([{ slug: "acme" }]);
+
+    const prometheusMod = await import("@/lib/metrics/collectors/prometheus");
+    const recordFinishedSpy = vi.spyOn(
+      prometheusMod,
+      "recordWorkflowExecutionFinished"
+    );
+
+    // "step execution failed" gets the default (system) classification, but
+    // writers apply the isDefaultClassification carve-out and persist plain
+    // 'error'. The finished counter must mirror the persisted status, not
+    // re-derive system_error from the classified error_type.
+    await recordExecutionErrorFinalized({
+      workflowId: "wf_abc123",
+      errorMessage: "step execution failed",
+      persistedStatus: "error",
+    });
+
+    expect(recordFinishedSpy).toHaveBeenCalledWith({
+      status: "error",
+      orgSlug: "acme",
+      errorType: "system",
+    });
+  });
+
+  it("emits status system_error when the caller persisted system_error", async () => {
     mockLimit.mockResolvedValue([{ slug: "acme" }]);
 
     const prometheusMod = await import("@/lib/metrics/collectors/prometheus");
@@ -110,8 +136,9 @@ describe("recordExecutionErrorFinalized", () => {
     );
 
     await recordExecutionErrorFinalized({
-      workflowId: "wf_abc123",
-      errorMessage: "step execution failed",
+      workflowId: "wf_reaped",
+      errorMessage: "Execution timed out: no progress for 30 minutes",
+      persistedStatus: "system_error",
     });
 
     expect(recordFinishedSpy).toHaveBeenCalledWith({
@@ -137,6 +164,7 @@ describe("recordExecutionErrorFinalized", () => {
     await recordExecutionErrorFinalized({
       workflowId: "wf_abc123",
       errorMessage: "step execution failed",
+      persistedStatus: "error",
     });
 
     expect(recordErrorSpy).toHaveBeenCalledWith({
@@ -167,6 +195,7 @@ describe("recordExecutionErrorFinalized", () => {
     await recordExecutionErrorFinalized({
       workflowId: "wf_personal",
       errorMessage: null,
+      persistedStatus: "error",
     });
 
     expect(recordErrorSpy).toHaveBeenCalledWith(
@@ -187,6 +216,7 @@ describe("recordExecutionErrorFinalized", () => {
       recordExecutionErrorFinalized({
         workflowId: "wf_db_fail",
         errorMessage: "some error",
+        persistedStatus: "error",
       })
     ).resolves.toBeUndefined();
   });

--- a/tests/unit/execution-error-finalize.test.ts
+++ b/tests/unit/execution-error-finalize.test.ts
@@ -39,12 +39,12 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
+import { recordExecutionErrorFinalized } from "@/lib/errors/finalize-error";
 import {
   getPrometheusMetrics,
   recordWorkflowExecutionErrorByWorkflow,
+  recordWorkflowExecutionFinished,
 } from "@/lib/metrics/collectors/prometheus";
-
-import { recordExecutionErrorFinalized } from "@/lib/errors/finalize-error";
 
 describe("recordWorkflowExecutionErrorByWorkflow", () => {
   it("increments keeperhub_workflow_execution_errors_by_workflow_total with correct labels", async () => {
@@ -59,9 +59,9 @@ describe("recordWorkflowExecutionErrorByWorkflow", () => {
     expect(output).toContain(
       "keeperhub_workflow_execution_errors_by_workflow_total"
     );
-    expect(output).toMatch(/workflow_id="wf_test_abc"/);
-    expect(output).toMatch(/org_slug="acme"/);
-    expect(output).toMatch(/error_type="system"/);
+    expect(output).toContain('workflow_id="wf_test_abc"');
+    expect(output).toContain('org_slug="acme"');
+    expect(output).toContain('error_type="system"');
   });
 
   it("accepts error_type user as well as system", async () => {
@@ -73,8 +73,25 @@ describe("recordWorkflowExecutionErrorByWorkflow", () => {
 
     const output = await getPrometheusMetrics();
 
-    expect(output).toMatch(/workflow_id="wf_user_err"/);
-    expect(output).toMatch(/error_type="user"/);
+    expect(output).toContain('workflow_id="wf_user_err"');
+    expect(output).toContain('error_type="user"');
+  });
+});
+
+describe("recordWorkflowExecutionFinished", () => {
+  it("increments keeperhub_workflow_executions_finished_total with status/org/error_type labels", async () => {
+    recordWorkflowExecutionFinished({
+      status: "success",
+      orgSlug: "acme-finished",
+      errorType: "na",
+    });
+
+    const output = await getPrometheusMetrics();
+
+    expect(output).toContain("keeperhub_workflow_executions_finished_total");
+    expect(output).toContain('status="success"');
+    expect(output).toContain('org_slug="acme-finished"');
+    expect(output).toContain('error_type="na"');
   });
 });
 
@@ -83,11 +100,35 @@ describe("recordExecutionErrorFinalized", () => {
     vi.restoreAllMocks();
   });
 
+  it("also records the finished counter with the terminal status derived from error_type", async () => {
+    mockLimit.mockResolvedValue([{ slug: "acme" }]);
+
+    const prometheusMod = await import("@/lib/metrics/collectors/prometheus");
+    const recordFinishedSpy = vi.spyOn(
+      prometheusMod,
+      "recordWorkflowExecutionFinished"
+    );
+
+    await recordExecutionErrorFinalized({
+      workflowId: "wf_abc123",
+      errorMessage: "step execution failed",
+    });
+
+    expect(recordFinishedSpy).toHaveBeenCalledWith({
+      status: "system_error",
+      orgSlug: "acme",
+      errorType: "system",
+    });
+  });
+
   it("calls both counters with the org slug resolved from the DB", async () => {
     mockLimit.mockResolvedValue([{ slug: "acme" }]);
 
     const prometheusMod = await import("@/lib/metrics/collectors/prometheus");
-    const recordErrorSpy = vi.spyOn(prometheusMod, "recordWorkflowExecutionError");
+    const recordErrorSpy = vi.spyOn(
+      prometheusMod,
+      "recordWorkflowExecutionError"
+    );
     const recordByWorkflowSpy = vi.spyOn(
       prometheusMod,
       "recordWorkflowExecutionErrorByWorkflow"
@@ -114,7 +155,10 @@ describe("recordExecutionErrorFinalized", () => {
     mockLimit.mockResolvedValue([]);
 
     const prometheusMod = await import("@/lib/metrics/collectors/prometheus");
-    const recordErrorSpy = vi.spyOn(prometheusMod, "recordWorkflowExecutionError");
+    const recordErrorSpy = vi.spyOn(
+      prometheusMod,
+      "recordWorkflowExecutionError"
+    );
     const recordByWorkflowSpy = vi.spyOn(
       prometheusMod,
       "recordWorkflowExecutionErrorByWorkflow"
@@ -129,7 +173,10 @@ describe("recordExecutionErrorFinalized", () => {
       expect.objectContaining({ orgSlug: "_anonymous" })
     );
     expect(recordByWorkflowSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ orgSlug: "_anonymous", workflowId: "wf_personal" })
+      expect.objectContaining({
+        orgSlug: "_anonymous",
+        workflowId: "wf_personal",
+      })
     );
   });
 


### PR DESCRIPTION
## What
Adds `keeperhub_workflow_executions_finished_total{status, org_slug, error_type}` — a monotonic counter incremented once per execution finalization (success, error, system_error).

## Why
The Grafana success-rate SLIs and Traffic-by-status panels were built on the DB-sourced 30-day `keeperhub_workflow_executions_total` **gauge**, which can't be windowed by the dashboard time picker. During an incident an operator needs to watch the current window (5m/1h) to confirm a fix, not a 30-day figure. No success/finished counter with `org_slug` existed (only `..._started_total`, no org/status labels, and `..._errors_created`, errors only). This counter lets Grafana derive windowed per-org success rates via `increase(...[range])`.

## Where it's emitted
Once per finalization, at the CAS-guarded terminal write so lost finalize races aren't counted:
- `logWorkflowCompleteDb` — success and error branches (post-reconciliation `resolvedStatus`).
- `recordExecutionErrorFinalized` — covers execute-in-background, reaper, and the mcp call route.

It mirrors the existing `errors_created` emission exactly (same call sites, same CAS gate), so no new double-count path is introduced. Non-error rows carry `error_type="na"`. Cardinality is the same order as `errors_created`.

## Tests
Extended `tests/unit/execution-error-finalize.test.ts`: asserts the counter emits with the right labels and that `recordExecutionErrorFinalized` also records the finished counter with the terminal status derived from `error_type`. `pnpm type-check` and `pnpm check` are clean.

## Rollout
The paired Grafana dashboard change consumes this metric; deploy this first so the counter exists before the panels reference it (windowed data is forward-only from deploy).