### PR TITLE
fix(deploy): scrape schedule-dispatcher metrics via ServiceMonitor

### DIFF
--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -820,6 +820,20 @@ schedule:
   podAnnotations:
     reloader.stakater.com/auto: "true"
 
+  # Prod Alloy scrapes via ServiceMonitor CRDs, not prometheus.io/* annotations.
+  # Same pattern the block component uses below (block.serviceMonitors). Without
+  # this block, the schedule-dispatcher /metrics endpoint (served on the health
+  # port) is never scraped, so the keeperhub_schedule_dispatcher_* series do not
+  # exist and the Grafana dispatcher alerts stay blind.
+  serviceMonitors:
+    enabled: true
+    monitors:
+      - name: schedule-dispatcher-metrics
+        port: http
+        path: /metrics
+        interval: 30s
+        scrapeTimeout: 10s
+
   resources:
     limits:
       memory: 256Mi

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -822,6 +822,20 @@ schedule:
   podAnnotations:
     reloader.stakater.com/auto: "true"
 
+  # Staging Alloy scrapes via ServiceMonitor CRDs, not prometheus.io/* annotations.
+  # Same pattern the block component uses below (block.serviceMonitors). Without
+  # this block, the schedule-dispatcher /metrics endpoint (served on the health
+  # port) is never scraped, so the keeperhub_schedule_dispatcher_* series do not
+  # exist and the Grafana dispatcher alerts stay blind.
+  serviceMonitors:
+    enabled: true
+    monitors:
+      - name: schedule-dispatcher-metrics
+        port: http
+        path: /metrics
+        interval: 30s
+        scrapeTimeout: 10s
+
   resources:
     limits:
       memory: 256Mi

--- a/lib/metrics/METRICS_REFERENCE.md
+++ b/lib/metrics/METRICS_REFERENCE.md
@@ -251,6 +251,28 @@ The dashboard and alert rules for these metrics are defined in `techops-infrastr
 
 ---
 
+## 7. SCHEDULE DISPATCHER
+
+Dispatch-pass latency and enqueue signals from the schedule-dispatcher pod (`keeperhub-scheduler/schedule-dispatcher`). The dispatcher evaluates cron schedules once per minute and enqueues matching workflows to SQS. All metrics live in the dispatcher's own in-process Prometheus registry exposed at `:3000/metrics` on the health server (separate from the main app's `/api/metrics`), scraped via the `schedule.serviceMonitors` block in `deploy/keeperhub-stack/<env>/values.yaml`. Source code: `keeperhub-scheduler/schedule-dispatcher/metrics.ts`.
+
+The alert rules for these metrics are defined in `techops-infrastructure/grafana/keeperhub-dashboards/` (see its `ALERTS_REFERENCE.md`, Schedule Dispatcher section).
+
+### Counters
+
+| Metric Name | Description | Labels |
+|-------------|-------------|--------|
+| `keeperhub_schedule_dispatcher_runs_total` | Dispatch passes completed (fetch succeeded and loop ran). `rate()` gives passes/min - should hold at ~1/min. | - |
+| `keeperhub_schedule_dispatcher_triggered_total` | Workflow trigger messages successfully enqueued to SQS. A sustained zero over 90 minutes while schedules exist is the missed-hourly-trigger signal. | - |
+| `keeperhub_schedule_dispatcher_errors_total` | Per-schedule errors during a dispatch pass (SQS failure, bad cron caught late). Distinct from fetch errors, which abort the whole pass and are not counted here. | - |
+
+### Histograms
+
+| Metric Name | Description | Labels | Buckets (s) |
+|-------------|-------------|--------|-------------|
+| `keeperhub_schedule_dispatcher_run_duration_seconds` | Wall-clock seconds per dispatch pass (fetch + evaluate + enqueue). The primary latency signal - p95 > 10s indicates DB or SQS slowness severe enough to threaten the trigger window. | - | 0.1, 0.5, 1, 2, 5, 10, 20, 30, 60 |
+
+---
+
 ## Label Keys Reference
 
 | Label Key | Description | Example Values |


### PR DESCRIPTION
## Summary

- The schedule-dispatcher exposes a prom-client registry at `:3000/metrics` on its health server, but the metrics were never scraped: prod and staging Alloy discover targets via ServiceMonitor CRDs (not `prometheus.io/*` annotations), and the `schedule` component in `deploy/keeperhub-stack/<env>/values.yaml` had no `serviceMonitors` block, unlike its `block` sibling. As a result the `keeperhub_schedule_dispatcher_*` series do not exist in Grafana Cloud (the dispatcher is not a scrape target at all).
- Mirrors the `block.serviceMonitors` pattern for the `schedule` component in both prod and staging values (`port: http`, `path: /metrics`, 30s interval).
- Adds a Schedule Dispatcher section to `lib/metrics/METRICS_REFERENCE.md` documenting the four dispatcher metrics; the infrastructure alert descriptions link to this anchor.

## Context

The Grafana alerts for these metrics are in techops-services/infrastructure#287, which is blocked on this change: its zero-triggers alert uses `no_data_state = Alerting` and would fire immediately while the series is absent.

## Test plan

- Both values files parse as valid YAML; the new block is byte-for-byte the block-dispatcher monitor pattern with the name changed
- After deploy, verify on staging then prod: `up{service=~"keeperhub-scheduler-.*"}` appears and `keeperhub_schedule_dispatcher_runs_total` increments ~1/min
- Only after prod series are confirmed should the infrastructure alert plan be applied