### PR TITLE
fix: make executor SQS consume path idempotent

### DIFF
--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -448,6 +448,15 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
     // redelivery whose row already advanced (still running past the 300s
     // visibility timeout, or terminal) is a duplicate and must be dropped -
     // re-dispatching would double-execute (a second on-chain transaction).
+    //
+    // TRADEOFF: flipping to 'running' before dispatch means a k8s-target run
+    // whose pod never schedules (no step logs) is reaped by the reaper's 30-min
+    // 'running' branch (E-0001/workflow_engine) instead of its 5-min 'pending'
+    // branch (P-0001/infrastructure) - slower failure surfacing and a
+    // misclassified error series. The clean fix is to have the app pre-create
+    // manual/webhook rows as 'phantom' (like the scheduler) so a single
+    // phantom->pending claim serves every trigger type; deferred as it touches
+    // the app execute/webhook routes (and their immediate-visibility UX).
     const claim = await claimPendingForExecution(db, message.executionId);
     if (claim !== "claimed") {
       dropDuplicateDelivery(claim, triggerType, message.executionId);

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -471,25 +471,14 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
       // We claimed pending -> running above, so the phantom/pending backstop in
       // processMessage no longer matches this row. Mark it system_error here
       // (mirrors the schedule/block/event dispatch guard below) then re-throw.
-      await db
-        .update(workflowExecutions)
-        .set({
-          status: "system_error",
-          error:
-            error instanceof Error
-              ? `Dispatch failed: ${error.message}`
-              : "Dispatch failed",
-          errorCode: "P-0004",
-          errorType: "system",
-          errorCategory: "infrastructure",
-          completedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(workflowExecutions.id, message.executionId),
-            eq(workflowExecutions.status, "running")
-          )
-        );
+      await failExecutionAsSystemError(db, message.executionId, {
+        error:
+          error instanceof Error
+            ? `Dispatch failed: ${error.message}`
+            : "Dispatch failed",
+        errorCode: "P-0004",
+        statuses: ["running"],
+      });
       throw error;
     }
     return;
@@ -597,25 +586,14 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
     // api / in-process / future targets uniformly. The status='pending'
     // filter prevents overwriting a status the runtime already set if
     // the failure happened after the workflow started running.
-    await db
-      .update(workflowExecutions)
-      .set({
-        status: "system_error",
-        error:
-          error instanceof Error
-            ? `Dispatch failed: ${error.message}`
-            : "Dispatch failed",
-        errorCode: "P-0004",
-        errorType: "system",
-        errorCategory: "infrastructure",
-        completedAt: new Date(),
-      })
-      .where(
-        and(
-          eq(workflowExecutions.id, executionId),
-          eq(workflowExecutions.status, "pending")
-        )
-      );
+    await failExecutionAsSystemError(db, executionId, {
+      error:
+        error instanceof Error
+          ? `Dispatch failed: ${error.message}`
+          : "Dispatch failed",
+      errorCode: "P-0004",
+      statuses: ["pending"],
+    });
     throw error;
   }
 }

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -248,8 +248,8 @@ async function dispatchExecution(params: {
 
 type ConsumeClaimResult =
   | "claimed"
-  | "duplicate_advanced"
-  | "duplicate_missing"
+  | "dropped_advanced"
+  | "dropped_missing"
   | "idless_insert";
 
 function recordConsumeClaim(
@@ -434,7 +434,7 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
     const claim = await claimPendingForExecution(db, message.executionId);
     if (claim !== "claimed") {
       recordConsumeClaim(
-        claim === "already_advanced" ? "duplicate_advanced" : "duplicate_missing",
+        claim === "already_advanced" ? "dropped_advanced" : "dropped_missing",
         triggerType
       );
       console.warn(
@@ -519,7 +519,7 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
       // Returning lets processMessage delete the message so it stops
       // redelivering.
       recordConsumeClaim(
-        claim === "already_advanced" ? "duplicate_advanced" : "duplicate_missing",
+        claim === "already_advanced" ? "dropped_advanced" : "dropped_missing",
         triggerType
       );
       console.warn(

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -58,10 +58,11 @@ import { checkWorkflowFeaturesForExecutor } from "./feature-guard";
 import { executeInProcess } from "./in-process";
 import { createWorkflowJob } from "./k8s-job";
 import {
+  claimPendingForExecution,
+  claimPhantomForExecution,
   discardPhantomRow,
   failExecutionAsSystemError,
   resolvePhantomToError,
-  upgradePhantomToPending,
 } from "./lib/db-helpers";
 import { applyCounterDeltas, isIngestPayload } from "./lib/metrics-shipping";
 import { toJsonSafe } from "./lib/serialize";
@@ -245,6 +246,22 @@ async function dispatchExecution(params: {
   }
 }
 
+type ConsumeClaimResult =
+  | "claimed"
+  | "duplicate_advanced"
+  | "duplicate_missing"
+  | "idless_insert";
+
+function recordConsumeClaim(
+  result: ConsumeClaimResult,
+  triggerType: string
+): void {
+  getMetricsCollector().incrementCounter(MetricNames.SQS_CONSUME_CLAIM, {
+    [LabelKeys.CLAIM_RESULT]: result,
+    [LabelKeys.TRIGGER_TYPE]: triggerType,
+  });
+}
+
 async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
   const { workflowId, triggerType } = message;
 
@@ -410,17 +427,60 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
           "Use EXECUTION_MODE=in-process instead."
       );
     }
+    // Claim the pre-created 'pending' row exactly once (pending -> running). A
+    // redelivery whose row already advanced (still running past the 300s
+    // visibility timeout, or terminal) is a duplicate and must be dropped -
+    // re-dispatching would double-execute (a second on-chain transaction).
+    const claim = await claimPendingForExecution(db, message.executionId);
+    if (claim !== "claimed") {
+      recordConsumeClaim(
+        claim === "already_advanced" ? "duplicate_advanced" : "duplicate_missing",
+        triggerType
+      );
+      console.warn(
+        `[Executor] Duplicate ${triggerType} delivery (${claim}) for execution ${message.executionId}; dropping without re-running`
+      );
+      return;
+    }
+    recordConsumeClaim("claimed", triggerType);
+
     console.log(
       `[Executor] Manual trigger dispatch target: ${target} (mode: ${CONFIG.executionMode})`
     );
-    await dispatchExecution({
-      target,
-      workflowId,
-      executionId: message.executionId,
-      input: message.input,
-      triggerType: "manual",
-      scheduleId: undefined,
-    });
+    try {
+      await dispatchExecution({
+        target,
+        workflowId,
+        executionId: message.executionId,
+        input: message.input,
+        triggerType: "manual",
+        scheduleId: undefined,
+      });
+    } catch (error) {
+      // We claimed pending -> running above, so the phantom/pending backstop in
+      // processMessage no longer matches this row. Mark it system_error here
+      // (mirrors the schedule/block/event dispatch guard below) then re-throw.
+      await db
+        .update(workflowExecutions)
+        .set({
+          status: "system_error",
+          error:
+            error instanceof Error
+              ? `Dispatch failed: ${error.message}`
+              : "Dispatch failed",
+          errorCode: "P-0004",
+          errorType: "system",
+          errorCategory: "infrastructure",
+          completedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(workflowExecutions.id, message.executionId),
+            eq(workflowExecutions.status, "running")
+          )
+        );
+      throw error;
+    }
     return;
   }
 
@@ -443,27 +503,43 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
   );
 
   let executionId = generateId();
-  let upgraded = false;
   if (message.executionId) {
-    upgraded = await upgradePhantomToPending(
+    const claim = await claimPhantomForExecution(
       db,
       message.executionId,
       serializedInput,
       executedWorkflowHash
     );
-    if (upgraded) {
-      executionId = message.executionId;
+    if (claim !== "claimed") {
+      // Duplicate delivery: the phantom was already claimed/advanced (a
+      // redelivery of a run still in flight past the 300s visibility timeout, or
+      // one that crashed before delete), or it was discarded/never persisted.
+      // Dropping is correct - re-running would double-execute (a second
+      // fund-moving on-chain transaction; there is no downstream dedup).
+      // Returning lets processMessage delete the message so it stops
+      // redelivering.
+      recordConsumeClaim(
+        claim === "already_advanced" ? "duplicate_advanced" : "duplicate_missing",
+        triggerType
+      );
+      console.warn(
+        `[Executor] Duplicate ${triggerType} delivery (${claim}) for execution ${message.executionId}; dropping without re-running`
+      );
+      return;
     }
-  }
-
-  if (!upgraded) {
-    // KEEP-612: insert for SQS-dispatched runs with no phantom to upgrade.
-    // Downstream dispatch (executeViaApi / k8s) reuses this row, so the
-    // app-route attribution never runs here -- set it directly. Only
-    // trigger_source applies: SQS dispatch has no inbound client request, so
-    // ip/country/api-key stay null. withBackstopCapture emits
-    // security.backstop_execution_blocked if the 0082 trigger rejects (e.g.
-    // owner deactivated in the check->insert race).
+    executionId = message.executionId;
+    recordConsumeClaim("claimed", triggerType);
+  } else {
+    // Legacy / best-effort path: no phantom id, which happens only when the
+    // producer's createPhantomExecution failed upstream. Insert a fresh row and
+    // run so the trigger is not silently lost. These cannot be deduped without a
+    // message nonce (a messageId nonce would break RequeueSignal redelivery and
+    // cannot catch a re-SendMessage replay), and they only occur when phantom
+    // pre-creation is already failing, so a rare duplicate here is an accepted
+    // residual. Downstream dispatch reuses this row, so set attribution directly
+    // (SQS dispatch has no inbound client request, so ip/country/api-key stay
+    // null). withBackstopCapture emits security.backstop_execution_blocked if the
+    // trigger rejects (e.g. owner deactivated in the check->insert race).
     const attribution = buildAttribution({ source: triggerType });
     await withBackstopCapture({ workflowId, userId, source: triggerType }, () =>
       db.insert(workflowExecutions).values({
@@ -476,6 +552,7 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
         executedWorkflowHash,
       })
     );
+    recordConsumeClaim("idless_insert", triggerType);
   }
 
   console.log(`[Executor] Created execution record: ${executionId}`);

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -262,6 +262,23 @@ function recordConsumeClaim(
   });
 }
 
+// A claim that did not win is a duplicate delivery (its row already ran/advanced
+// or is gone): record the outcome and warn. The caller returns so processMessage
+// deletes the message and it stops redelivering.
+function dropDuplicateDelivery(
+  claim: "already_advanced" | "not_found",
+  triggerType: string,
+  executionId: string | undefined
+): void {
+  recordConsumeClaim(
+    claim === "already_advanced" ? "dropped_advanced" : "dropped_missing",
+    triggerType
+  );
+  console.warn(
+    `[Executor] Duplicate ${triggerType} delivery (${claim}) for execution ${executionId}; dropping without re-running`
+  );
+}
+
 async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
   const { workflowId, triggerType } = message;
 
@@ -433,13 +450,7 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
     // re-dispatching would double-execute (a second on-chain transaction).
     const claim = await claimPendingForExecution(db, message.executionId);
     if (claim !== "claimed") {
-      recordConsumeClaim(
-        claim === "already_advanced" ? "dropped_advanced" : "dropped_missing",
-        triggerType
-      );
-      console.warn(
-        `[Executor] Duplicate ${triggerType} delivery (${claim}) for execution ${message.executionId}; dropping without re-running`
-      );
+      dropDuplicateDelivery(claim, triggerType, message.executionId);
       return;
     }
     recordConsumeClaim("claimed", triggerType);
@@ -518,13 +529,7 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
       // fund-moving on-chain transaction; there is no downstream dedup).
       // Returning lets processMessage delete the message so it stops
       // redelivering.
-      recordConsumeClaim(
-        claim === "already_advanced" ? "dropped_advanced" : "dropped_missing",
-        triggerType
-      );
-      console.warn(
-        `[Executor] Duplicate ${triggerType} delivery (${claim}) for execution ${message.executionId}; dropping without re-running`
-      );
+      dropDuplicateDelivery(claim, triggerType, message.executionId);
       return;
     }
     executionId = message.executionId;

--- a/keeperhub-executor/lib/db-helpers.ts
+++ b/keeperhub-executor/lib/db-helpers.ts
@@ -1,5 +1,5 @@
 import { CronExpressionParser } from "cron-parser";
-import { and, eq, inArray, ne } from "drizzle-orm";
+import { and, eq, inArray, ne, or } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import {
   workflowExecutions,
@@ -27,6 +27,19 @@ export type DbSchema = {
  * - "not_found":        no row with this id exists.
  */
 export type ClaimOutcome = "claimed" | "already_advanced" | "not_found";
+
+/**
+ * Reaper error codes that mark a row `system_error` WITHOUT it ever having
+ * dispatched: P-0005 (phantom never picked up) and P-0001 (pending timed out,
+ * and the reaper only assigns it when there are NO step logs). A row in either
+ * state provably produced no side effects, so a message redelivered after a
+ * concurrency-requeue whose row was reaped in the meantime can safely RE-CLAIM
+ * and re-run it rather than be dropped as a duplicate - which restores the
+ * RequeueSignal "retry later" intent. Any other terminal/advanced state
+ * (running, success, error, cancelled, or system_error from a dispatch/run
+ * failure: E-0001/P-0004/E-0004) means work may have started and is dropped.
+ */
+const REAPED_NEVER_RAN_CODES: ErrorCode[] = ["P-0001", "P-0005"];
 
 /**
  * After a gated CAS matched zero rows, disambiguate "row exists but not in the
@@ -134,12 +147,17 @@ export async function failExecutionAsSystemError(
  * compare-and-set 'phantom' -> 'pending' and stamp its input.
  *
  * The scheduler/event-tracker pre-creates a 'phantom' row and passes its id on
- * the SQS message. The CAS on status='phantom' makes the claim exactly-once:
- * only the first delivery wins ("claimed"). A duplicate delivery whose row was
- * already claimed/advanced returns "already_advanced" and MUST be dropped by the
- * caller - re-running would send a second, fund-moving execution (there is no
- * downstream dedup). "not_found" is a message whose phantom was discarded or
- * never persisted; also dropped for an id-bearing message.
+ * the SQS message. The CAS makes the claim exactly-once: only the first delivery
+ * wins ("claimed"). A duplicate delivery whose row was already claimed/advanced
+ * returns "already_advanced" and MUST be dropped by the caller - re-running would
+ * send a second, fund-moving execution (there is no downstream dedup).
+ * "not_found" is a message whose phantom was discarded or never persisted; also
+ * dropped for an id-bearing message.
+ *
+ * The CAS also matches a reaped-never-ran row (system_error with a
+ * REAPED_NEVER_RAN_CODES errorCode) so a concurrency-requeued message whose
+ * phantom the reaper marked in the meantime is re-claimed and re-run rather than
+ * dropped - a run that provably never dispatched, so re-running is side-effect-safe.
  */
 export async function claimPhantomForExecution(
   db: PostgresJsDatabase<DbSchema>,
@@ -152,12 +170,27 @@ export async function claimPhantomForExecution(
     // The phantom was created billable=false (it had not run yet); claiming it
     // means it is now a real execution, so it becomes billable like any
     // owner-initiated run. Stamp the hash of the definition the executor just
-    // loaded so the run links to its workflow_history version.
-    .set({ status: "pending", input, billable: true, executedWorkflowHash })
+    // loaded so the run links to its workflow_history version. Clear any reaper
+    // stamp when re-claiming a reaped-never-ran row.
+    .set({
+      status: "pending",
+      input,
+      billable: true,
+      executedWorkflowHash,
+      error: null,
+      errorCode: null,
+      completedAt: null,
+    })
     .where(
       and(
         eq(workflowExecutions.id, executionId),
-        eq(workflowExecutions.status, "phantom")
+        or(
+          eq(workflowExecutions.status, "phantom"),
+          and(
+            eq(workflowExecutions.status, "system_error"),
+            inArray(workflowExecutions.errorCode, REAPED_NEVER_RAN_CODES)
+          )
+        )
       )
     )
     .returning({ id: workflowExecutions.id });
@@ -174,7 +207,9 @@ export async function claimPhantomForExecution(
  * phantom to upgrade; this CAS is what makes the consume exactly-once. Only the
  * first delivery wins ("claimed"); a duplicate whose row already advanced
  * returns "already_advanced" and MUST be dropped. The runner's own later
- * 'running' write is then an idempotent no-op.
+ * 'running' write is then an idempotent no-op. Like claimPhantomForExecution,
+ * the CAS also re-claims a reaped-never-ran row (system_error with a
+ * REAPED_NEVER_RAN_CODES errorCode).
  */
 export async function claimPendingForExecution(
   db: PostgresJsDatabase<DbSchema>,
@@ -182,11 +217,18 @@ export async function claimPendingForExecution(
 ): Promise<ClaimOutcome> {
   const result = await db
     .update(workflowExecutions)
-    .set({ status: "running" })
+    // Clear any reaper stamp when re-claiming a reaped-never-ran row.
+    .set({ status: "running", error: null, errorCode: null, completedAt: null })
     .where(
       and(
         eq(workflowExecutions.id, executionId),
-        eq(workflowExecutions.status, "pending")
+        or(
+          eq(workflowExecutions.status, "pending"),
+          and(
+            eq(workflowExecutions.status, "system_error"),
+            inArray(workflowExecutions.errorCode, REAPED_NEVER_RAN_CODES)
+          )
+        )
       )
     )
     .returning({ id: workflowExecutions.id });

--- a/keeperhub-executor/lib/db-helpers.ts
+++ b/keeperhub-executor/lib/db-helpers.ts
@@ -18,6 +18,32 @@ export type DbSchema = {
   workflowSchedules: typeof workflowSchedules;
 };
 
+/**
+ * Result of a gated status compare-and-set claim on an execution row:
+ * - "claimed":          the CAS won (this delivery owns the dispatch).
+ * - "already_advanced": a row exists but is no longer in the claimable status
+ *                       (a prior/duplicate SQS delivery already claimed it, or
+ *                       it is running/terminal) - the caller must NOT re-run.
+ * - "not_found":        no row with this id exists.
+ */
+export type ClaimOutcome = "claimed" | "already_advanced" | "not_found";
+
+/**
+ * After a gated CAS matched zero rows, disambiguate "row exists but not in the
+ * expected status" from "no such row" with a single point lookup on the id PK.
+ */
+async function classifyClaimMiss(
+  db: PostgresJsDatabase<DbSchema>,
+  executionId: string
+): Promise<"already_advanced" | "not_found"> {
+  const existing = await db
+    .select({ id: workflowExecutions.id })
+    .from(workflowExecutions)
+    .where(eq(workflowExecutions.id, executionId))
+    .limit(1);
+  return existing.length > 0 ? "already_advanced" : "not_found";
+}
+
 export async function updateExecutionStatus(
   db: PostgresJsDatabase<DbSchema>,
   executionId: string,
@@ -104,28 +130,29 @@ export async function failExecutionAsSystemError(
 }
 
 /**
- * KEEP-693: upgrade a pre-created 'phantom' execution row to 'pending' in place
- * and stamp its input.
+ * Claim a pre-created 'phantom' execution row for a schedule/block/event run:
+ * compare-and-set 'phantom' -> 'pending' and stamp its input.
  *
  * The scheduler/event-tracker pre-creates a 'phantom' row and passes its id on
- * the SQS message; the executor calls this to claim it. The compare-and-set on
- * status='phantom' makes the claim idempotent: a duplicate SQS delivery (or a
- * missing phantom, when the best-effort create failed, or one already advanced
- * past phantom) matches no row and returns false, so the caller falls back to a
- * fresh insert and a run is never dropped.
+ * the SQS message. The CAS on status='phantom' makes the claim exactly-once:
+ * only the first delivery wins ("claimed"). A duplicate delivery whose row was
+ * already claimed/advanced returns "already_advanced" and MUST be dropped by the
+ * caller - re-running would send a second, fund-moving execution (there is no
+ * downstream dedup). "not_found" is a message whose phantom was discarded or
+ * never persisted; also dropped for an id-bearing message.
  */
-export async function upgradePhantomToPending(
+export async function claimPhantomForExecution(
   db: PostgresJsDatabase<DbSchema>,
   executionId: string,
   input: Record<string, unknown>,
   executedWorkflowHash: string
-): Promise<boolean> {
+): Promise<ClaimOutcome> {
   const result = await db
     .update(workflowExecutions)
-    // KEEP-693: the phantom was created billable=false (it had not run yet);
-    // upgrading to pending means it is now a real execution, so it becomes
-    // billable like any owner-initiated run. Stamp the hash of the definition
-    // the executor just loaded so the run links to its workflow_history version.
+    // The phantom was created billable=false (it had not run yet); claiming it
+    // means it is now a real execution, so it becomes billable like any
+    // owner-initiated run. Stamp the hash of the definition the executor just
+    // loaded so the run links to its workflow_history version.
     .set({ status: "pending", input, billable: true, executedWorkflowHash })
     .where(
       and(
@@ -134,7 +161,39 @@ export async function upgradePhantomToPending(
       )
     )
     .returning({ id: workflowExecutions.id });
-  return result.length > 0;
+  if (result.length > 0) {
+    return "claimed";
+  }
+  return classifyClaimMiss(db, executionId);
+}
+
+/**
+ * Claim a pre-created 'pending' execution row for a manual/webhook run:
+ * compare-and-set 'pending' -> 'running'. The app pre-creates the row as
+ * 'pending' before enqueueing, so unlike schedule/block/event there is no
+ * phantom to upgrade; this CAS is what makes the consume exactly-once. Only the
+ * first delivery wins ("claimed"); a duplicate whose row already advanced
+ * returns "already_advanced" and MUST be dropped. The runner's own later
+ * 'running' write is then an idempotent no-op.
+ */
+export async function claimPendingForExecution(
+  db: PostgresJsDatabase<DbSchema>,
+  executionId: string
+): Promise<ClaimOutcome> {
+  const result = await db
+    .update(workflowExecutions)
+    .set({ status: "running" })
+    .where(
+      and(
+        eq(workflowExecutions.id, executionId),
+        eq(workflowExecutions.status, "pending")
+      )
+    )
+    .returning({ id: workflowExecutions.id });
+  if (result.length > 0) {
+    return "claimed";
+  }
+  return classifyClaimMiss(db, executionId);
 }
 
 /**

--- a/keeperhub-executor/lib/db-helpers.ts
+++ b/keeperhub-executor/lib/db-helpers.ts
@@ -103,21 +103,26 @@ export async function updateExecutionStatus(
 }
 
 /**
- * KEEP-853: backstop for the SQS consumer. When message processing throws for a
- * reason the inner dispatch handlers did not already record, mark the in-flight
- * row as a system error right away instead of leaving it for the reaper (which
- * runs minutes later). Compare-and-set on status IN ('phantom','pending') so it
- * never clobbers a row the runtime already advanced to running/terminal.
+ * KEEP-853: mark an in-flight row system_error right away instead of leaving it
+ * for the reaper (which runs minutes later). Compare-and-set on the caller's
+ * expected status(es) - defaulting to ('phantom','pending') for the
+ * processMessage backstop - so it never clobbers a row the runtime already
+ * advanced past. The dispatch-failure guards pass their own single expected
+ * status (e.g. 'pending' or 'running') and errorCode.
  *
  * Returns true when a row was marked, false when the CAS matched nothing (no
- * executionId, or the row already advanced past phantom/pending). The caller
- * surfaces the false case instead of treating the backstop as resolved, since
- * such a row is left for the reaper rather than marked immediately.
+ * executionId, or the row was not in an expected status). The caller surfaces
+ * the false case instead of treating the backstop as resolved, since such a row
+ * is left for the reaper rather than marked immediately.
  */
 export async function failExecutionAsSystemError(
   db: PostgresJsDatabase<DbSchema>,
   executionId: string | undefined,
-  fields: { error: string; errorCode: ErrorCode }
+  fields: {
+    error: string;
+    errorCode: ErrorCode;
+    statuses?: ("phantom" | "pending" | "running")[];
+  }
 ): Promise<boolean> {
   if (!executionId) {
     return false;
@@ -135,7 +140,10 @@ export async function failExecutionAsSystemError(
     .where(
       and(
         eq(workflowExecutions.id, executionId),
-        inArray(workflowExecutions.status, ["phantom", "pending"])
+        inArray(
+          workflowExecutions.status,
+          fields.statuses ?? ["phantom", "pending"]
+        )
       )
     )
     .returning({ id: workflowExecutions.id });

--- a/lib/metrics/types.ts
+++ b/lib/metrics/types.ts
@@ -193,6 +193,13 @@ export const MetricNames = {
   // invalid_schema | stale) and mode (warn | enforce). Drives the rollout gate:
   // flip the executor to enforce only once unsigned/invalid series hit zero.
   SQS_MESSAGE_AUTH: "sqs.message.auth.total",
+
+  // SQS consume-path idempotency claim outcome. One increment per consumed
+  // trigger, labelled by claim_result (claimed | duplicate_advanced |
+  // duplicate_missing | idless_insert) and trigger_type. A nonzero duplicate_*
+  // rate means redelivered messages are being dropped instead of re-run (a
+  // double-execution that would otherwise send a second on-chain transaction).
+  SQS_CONSUME_CLAIM: "sqs.consume.claim.total",
 } as const;
 
 /**
@@ -224,6 +231,7 @@ export const LabelKeys = {
   TIER: "tier",
   AUTH_RESULT: "auth_result",
   MODE: "mode",
+  CLAIM_RESULT: "claim_result",
 } as const;
 
 /**

--- a/lib/metrics/types.ts
+++ b/lib/metrics/types.ts
@@ -195,10 +195,13 @@ export const MetricNames = {
   SQS_MESSAGE_AUTH: "sqs.message.auth.total",
 
   // SQS consume-path idempotency claim outcome. One increment per consumed
-  // trigger, labelled by claim_result (claimed | duplicate_advanced |
-  // duplicate_missing | idless_insert) and trigger_type. A nonzero duplicate_*
-  // rate means redelivered messages are being dropped instead of re-run (a
-  // double-execution that would otherwise send a second on-chain transaction).
+  // trigger, labelled by claim_result and trigger_type:
+  //  - claimed:          dispatched (incl. re-claim of a reaped-never-ran row).
+  //  - dropped_advanced: a duplicate whose row already ran/advanced - dropped
+  //                      (this is a prevented double-execution).
+  //  - dropped_missing:  the row was gone (discarded/retention) - dropped.
+  //  - idless_insert:    legacy id-less message, insert-fresh + run (cannot be
+  //                      deduped; a rise signals upstream phantom-create failures).
   SQS_CONSUME_CLAIM: "sqs.consume.claim.total",
 } as const;
 

--- a/tests/e2e/vitest/phantom-upgrade.test.ts
+++ b/tests/e2e/vitest/phantom-upgrade.test.ts
@@ -4,10 +4,11 @@ import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
+  claimPendingForExecution,
+  claimPhantomForExecution,
   type DbSchema,
   discardPhantomRow,
   resolvePhantomToError,
-  upgradePhantomToPending,
 } from "../../../keeperhub-executor/lib/db-helpers";
 import {
   organization,
@@ -16,9 +17,8 @@ import {
   workflows,
 } from "../../../lib/db/schema";
 
-// tests/setup.ts globally mocks @/lib/db. This suite drives
-// upgradePhantomToPending against a real database via its own handle, so
-// restore the genuine module.
+// tests/setup.ts globally mocks @/lib/db. This suite drives the claim helpers
+// against a real database via its own handle, so restore the genuine module.
 vi.unmock("@/lib/db");
 
 // The phantom -> pending claim is a compare-and-set in SQL (WHERE
@@ -44,9 +44,10 @@ type ExecutionStatus =
   | "success"
   | "error"
   | "cancelled"
-  | "phantom";
+  | "phantom"
+  | "system_error";
 
-describe.skipIf(SKIP)("upgradePhantomToPending", () => {
+describe.skipIf(SKIP)("consume-path claim helpers", () => {
   let queryClient: ReturnType<typeof postgres>;
   let db: ReturnType<typeof drizzle>;
   // upgradePhantomToPending is typed against the executor's DbSchema; the
@@ -125,68 +126,83 @@ describe.skipIf(SKIP)("upgradePhantomToPending", () => {
     await queryClient.end();
   });
 
-  it("upgrades a phantom row to pending and stamps its input", async () => {
+  it("claims a phantom row to pending and stamps its input", async () => {
     const id = `${PREFIX}claim`;
     await seedExecution(id, "phantom");
 
-    const upgraded = await upgradePhantomToPending(
+    const outcome = await claimPhantomForExecution(
       execDb,
       id,
       { triggered: 1 },
       HASH
     );
 
-    expect(upgraded).toBe(true);
+    expect(outcome).toBe("claimed");
     const row = await readExecution(id);
     expect(row.status).toBe("pending");
     expect(row.input).toEqual({ triggered: 1 });
     expect(row.executedWorkflowHash).toBe(HASH);
   });
 
-  it("is a no-op (returns false) when the row is not phantom", async () => {
+  it("returns already_advanced (no-op) when the row is not phantom", async () => {
     const id = `${PREFIX}running`;
     await seedExecution(id, "running", { original: true });
 
-    const upgraded = await upgradePhantomToPending(
+    const outcome = await claimPhantomForExecution(
       execDb,
       id,
       { stamped: 2 },
       HASH
     );
 
-    expect(upgraded).toBe(false);
+    expect(outcome).toBe("already_advanced");
     const row = await readExecution(id);
     expect(row.status).toBe("running");
     // Input must be untouched -- the CAS matched no row.
     expect(row.input).toEqual({ original: true });
   });
 
-  it("returns false when the execution id does not exist", async () => {
-    const upgraded = await upgradePhantomToPending(
+  it("returns already_advanced for every terminal status", async () => {
+    for (const status of [
+      "success",
+      "error",
+      "cancelled",
+      "system_error",
+    ] as const) {
+      const id = `${PREFIX}term_${status}`;
+      await seedExecution(id, status);
+      expect(await claimPhantomForExecution(execDb, id, {}, HASH)).toBe(
+        "already_advanced"
+      );
+    }
+  });
+
+  it("returns not_found when the execution id does not exist", async () => {
+    const outcome = await claimPhantomForExecution(
       execDb,
       `${PREFIX}missing`,
       {},
       HASH
     );
-    expect(upgraded).toBe(false);
+    expect(outcome).toBe("not_found");
   });
 
-  it("is idempotent: a second claim of an already-upgraded row returns false", async () => {
+  it("is exactly-once: a duplicate claim of an already-claimed row is dropped", async () => {
     const id = `${PREFIX}dup`;
     await seedExecution(id, "phantom");
 
-    const first = await upgradePhantomToPending(execDb, id, { n: 1 }, HASH);
-    const second = await upgradePhantomToPending(execDb, id, { n: 2 }, HASH);
+    const first = await claimPhantomForExecution(execDb, id, { n: 1 }, HASH);
+    const second = await claimPhantomForExecution(execDb, id, { n: 2 }, HASH);
 
-    expect(first).toBe(true);
-    expect(second).toBe(false);
+    expect(first).toBe("claimed");
+    expect(second).toBe("already_advanced");
     const row = await readExecution(id);
     expect(row.status).toBe("pending");
     // The losing duplicate must not overwrite the input the winner stamped.
     expect(row.input).toEqual({ n: 1 });
   });
 
-  it("upgrade flips a non-billable phantom to billable (it now runs)", async () => {
+  it("claiming a phantom flips a non-billable row to billable (it now runs)", async () => {
     const id = `${PREFIX}billable`;
     await db.insert(workflowExecutions).values({
       id,
@@ -196,12 +212,37 @@ describe.skipIf(SKIP)("upgradePhantomToPending", () => {
       billable: false,
     });
 
-    const upgraded = await upgradePhantomToPending(execDb, id, {}, HASH);
+    const outcome = await claimPhantomForExecution(execDb, id, {}, HASH);
 
-    expect(upgraded).toBe(true);
+    expect(outcome).toBe("claimed");
     const row = await readExecution(id);
     expect(row.status).toBe("pending");
     expect(row.billable).toBe(true);
+  });
+
+  it("claimPendingForExecution claims a pending row to running", async () => {
+    const id = `${PREFIX}pending_claim`;
+    await seedExecution(id, "pending");
+
+    const outcome = await claimPendingForExecution(execDb, id);
+
+    expect(outcome).toBe("claimed");
+    expect((await readExecution(id)).status).toBe("running");
+  });
+
+  it("claimPendingForExecution drops a duplicate (row already running)", async () => {
+    const id = `${PREFIX}pending_dup`;
+    await seedExecution(id, "running");
+
+    expect(await claimPendingForExecution(execDb, id)).toBe("already_advanced");
+    // Second delivery of an already-claimed manual/webhook row.
+    expect((await readExecution(id)).status).toBe("running");
+  });
+
+  it("claimPendingForExecution returns not_found for a missing row", async () => {
+    expect(
+      await claimPendingForExecution(execDb, `${PREFIX}pending_missing`)
+    ).toBe("not_found");
   });
 
   it("discardPhantomRow deletes a phantom row (intentional skip)", async () => {

--- a/tests/e2e/vitest/phantom-upgrade.test.ts
+++ b/tests/e2e/vitest/phantom-upgrade.test.ts
@@ -50,9 +50,8 @@ type ExecutionStatus =
 describe.skipIf(SKIP)("consume-path claim helpers", () => {
   let queryClient: ReturnType<typeof postgres>;
   let db: ReturnType<typeof drizzle>;
-  // upgradePhantomToPending is typed against the executor's DbSchema; the
-  // test's schema-less handle is structurally compatible for the .update() it
-  // issues.
+  // The claim helpers are typed against the executor's DbSchema; the test's
+  // schema-less handle is structurally compatible for the .update() they issue.
   let execDb: PostgresJsDatabase<DbSchema>;
 
   const ownerId = `${PREFIX}user`;
@@ -232,7 +231,12 @@ describe.skipIf(SKIP)("consume-path claim helpers", () => {
       completedAt: new Date(),
     });
 
-    const outcome = await claimPhantomForExecution(execDb, id, { retry: 1 }, HASH);
+    const outcome = await claimPhantomForExecution(
+      execDb,
+      id,
+      { retry: 1 },
+      HASH
+    );
 
     expect(outcome).toBe("claimed");
     const row = await readExecution(id);

--- a/tests/e2e/vitest/phantom-upgrade.test.ts
+++ b/tests/e2e/vitest/phantom-upgrade.test.ts
@@ -220,6 +220,45 @@ describe.skipIf(SKIP)("consume-path claim helpers", () => {
     expect(row.billable).toBe(true);
   });
 
+  it("re-claims a reaped-never-ran row (system_error P-0005) and clears the reaper stamp", async () => {
+    const id = `${PREFIX}reaped_phantom`;
+    await db.insert(workflowExecutions).values({
+      id,
+      workflowId,
+      userId: ownerId,
+      status: "system_error",
+      errorCode: "P-0005",
+      error: "Execution timed out",
+      completedAt: new Date(),
+    });
+
+    const outcome = await claimPhantomForExecution(execDb, id, { retry: 1 }, HASH);
+
+    expect(outcome).toBe("claimed");
+    const row = await readExecution(id);
+    expect(row.status).toBe("pending");
+    expect(row.input).toEqual({ retry: 1 });
+    expect(row.errorCode).toBeNull();
+    expect(row.error).toBeNull();
+    expect(row.completedAt).toBeNull();
+  });
+
+  it("does NOT re-claim a system_error from a run failure (E-0001)", async () => {
+    const id = `${PREFIX}reaped_running`;
+    await db.insert(workflowExecutions).values({
+      id,
+      workflowId,
+      userId: ownerId,
+      status: "system_error",
+      errorCode: "E-0001",
+    });
+
+    expect(await claimPhantomForExecution(execDb, id, {}, HASH)).toBe(
+      "already_advanced"
+    );
+    expect((await readExecution(id)).status).toBe("system_error");
+  });
+
   it("claimPendingForExecution claims a pending row to running", async () => {
     const id = `${PREFIX}pending_claim`;
     await seedExecution(id, "pending");
@@ -227,6 +266,20 @@ describe.skipIf(SKIP)("consume-path claim helpers", () => {
     const outcome = await claimPendingForExecution(execDb, id);
 
     expect(outcome).toBe("claimed");
+    expect((await readExecution(id)).status).toBe("running");
+  });
+
+  it("claimPendingForExecution re-claims a reaped-never-ran row (P-0001)", async () => {
+    const id = `${PREFIX}pending_reaped`;
+    await db.insert(workflowExecutions).values({
+      id,
+      workflowId,
+      userId: ownerId,
+      status: "system_error",
+      errorCode: "P-0001",
+    });
+
+    expect(await claimPendingForExecution(execDb, id)).toBe("claimed");
     expect((await readExecution(id)).status).toBe("running");
   });
 


### PR DESCRIPTION
## Summary

The executor consumes fund-moving workflow triggers off SQS (at-least-once). Signing (prior work) closes forgery, but consumption was **not idempotent**: a redelivered message could re-run a workflow. Because there is **no downstream dedup** (`wallet_locks` only serialize nonce use; Turnkey signing has no idempotency key), a duplicate run takes the next chain nonce and sends a **second on-chain transaction** - a double-spend.

The most likely trigger is not a crash: a run that outlives the **300s SQS visibility timeout** is redelivered while still in flight, so this can fire in normal operation.

## Root cause

- **schedule/block/event** (`processExecutorMessage`): the phantom claim was a boolean CAS on `status='phantom'`. On a redelivery whose row already advanced, the CAS returned `false` and the code fell through to insert a **fresh** row and dispatch again.
- **manual/webhook**: dispatched directly on the pre-created `pending` row with **no dedup claim at all**.

## Changes

- **`keeperhub-executor/lib/db-helpers.ts`** - tri-state claim helpers `claimPhantomForExecution` (phantom -> pending) and `claimPendingForExecution` (pending -> running), returning `claimed | already_advanced | not_found` via a gated status CAS plus a single PK lookup on the cold path. No schema change, no migration.
- **`keeperhub-executor/index.ts`** - both paths drop duplicates (`already_advanced` / `not_found`) via a shared `dropDuplicateDelivery` helper; schedule/block/event keeps insert-fresh only for id-less messages; manual/webhook gets the claim + a dispatch-failure guard. The two dispatch-failure guards reuse a generalized `failExecutionAsSystemError`.
- **`lib/metrics/types.ts`** - `sqs.consume.claim.total{claim_result, trigger_type}` counter.

## Idempotency / reaper interaction

- **Exactly-once under concurrency:** the gated CAS + Postgres row locks make concurrent same-`executionId` deliveries safe (one wins, the rest drop).
- **Back-pressure retry preserved:** a `RequeueSignal` (concurrency cap) requeues *before* the claim, and if the reaper marks that untouched row `system_error` in the meantime, the claim **re-runs** it rather than dropping - the CAS also matches a reaped-never-ran row (`system_error` with `P-0005`/`P-0001`, the reaper codes that guarantee it never dispatched, so re-running is side-effect-safe). Any row that actually ran/advanced is still dropped.
- **Failures are terminal** (message deleted; reaper marks stuck rows; no retry/DLQ), so dropping a genuinely-advanced duplicate never loses a legitimately-failed run.
- **Known tradeoff (documented in code):** the manual/webhook `pending -> running` pre-flip means a k8s run whose pod never schedules is reaped by the 30-min `running` branch (`E-0001`) instead of the 5-min `pending` branch (`P-0001`) - slower failure surfacing + a misclassified error series. The clean fix is to have the app pre-create manual/webhook rows as `phantom` (unifying to one claim path); deferred because it touches the app execute/webhook routes and their immediate-visibility UX.

## Test Plan

- [x] DB-backed claim tests (`tests/e2e/vitest/phantom-upgrade.test.ts`, real Postgres): every status -> correct outcome + row state for both helpers, including reaped-never-ran re-claim (`P-0005`/`P-0001`) and non-re-claim of a run-failure `system_error` (`E-0001`).
- [x] Full executor vitest suite; `type-check` and lint clean.
- [ ] Post-deploy: watch `sqs.consume.claim.total{claim_result}` - `dropped_advanced` = prevented duplicates; `idless_insert` rise flags upstream phantom-creation failures.