### PR TITLE
fix: enforce daily value cap on workflow and protocol executions

### DIFF
--- a/app/api/execute/_lib/reserved-value.ts
+++ b/app/api/execute/_lib/reserved-value.ts
@@ -1,10 +1,14 @@
 import "server-only";
 
-import { parseNativeValueWei } from "@/lib/execute/native-value";
+import {
+  parseNativeValueWei,
+  type ReservedValue,
+} from "@/lib/execute/native-value";
 
 // parseNativeValueWei lives in lib/execute so both the direct-execution routes
 // (here) and the workflow step wrappers can charge native value against the
-// same cap. Re-exported for the routes/tests that import it from this path.
+// same cap. Imported above for local use (parseNodeNativeValueWei), and
+// re-exported for the routes/tests that import it from this path.
 export {
   parseNativeValueWei,
   type ReservedValue,

--- a/app/api/execute/_lib/reserved-value.ts
+++ b/app/api/execute/_lib/reserved-value.ts
@@ -1,49 +1,14 @@
 import "server-only";
 
-import { ethers } from "ethers";
+import { parseNativeValueWei } from "@/lib/execute/native-value";
 
-export type ReservedValue =
-  | { ok: true; valueWei: string }
-  | { ok: false; error: string };
-
-/**
- * Native notional value (in wei) a direct execution will move, used by the
- * per-org daily spending cap. Parses a human-decimal ETH amount (e.g. "1.5")
- * the same way the web3 cores do (`ethers.parseEther`).
- *
- * An absent/empty amount reserves "0". Only native value is counted today;
- * ERC-20 token amounts are not yet priced into the cap, so token-only transfers
- * pass "0" directly rather than calling this.
- *
- * Malformed amounts return `{ ok: false }` so the caller can reject with 400
- * instead of silently under-reserving (which would weaken the cap). Negative
- * amounts are rejected too: `ethers.parseEther("-5")` yields a negative BigInt
- * (it does not throw), and a negative reservation would lower the day's SUM and
- * bank credit against the cap.
- */
-export function parseNativeValueWei(
-  rawAmount: string | undefined | null
-): ReservedValue {
-  if (rawAmount === undefined || rawAmount === null || rawAmount === "") {
-    return { ok: true, valueWei: "0" };
-  }
-
-  let parsed: bigint;
-  try {
-    parsed = ethers.parseEther(rawAmount);
-  } catch {
-    return { ok: false, error: `Invalid value amount: ${rawAmount}` };
-  }
-
-  if (parsed < BigInt(0)) {
-    return {
-      ok: false,
-      error: `Value amount must not be negative: ${rawAmount}`,
-    };
-  }
-
-  return { ok: true, valueWei: parsed.toString() };
-}
+// parseNativeValueWei lives in lib/execute so both the direct-execution routes
+// (here) and the workflow step wrappers can charge native value against the
+// same cap. Re-exported for the routes/tests that import it from this path.
+export {
+  parseNativeValueWei,
+  type ReservedValue,
+} from "@/lib/execute/native-value";
 
 /**
  * Native value (wei) reserved for a generic node execution.

--- a/app/api/execute/_lib/spending-cap.ts
+++ b/app/api/execute/_lib/spending-cap.ts
@@ -1,8 +1,9 @@
 import "server-only";
 
-import { and, eq, gte, ne, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { directExecutions, organizationSpendCaps } from "@/lib/db/schema";
+import { sumOrgValueTodayWei } from "@/lib/execute/value-ledger";
 import { generateId } from "@/lib/utils/id";
 
 export type SpendCapResult =
@@ -72,31 +73,11 @@ export async function checkAndReserveExecution(
       return { allowed: true, executionId: id } as const;
     }
 
-    const todayStart = new Date();
-    todayStart.setUTCHours(0, 0, 0, 0);
-
-    const result = await tx
-      .select({
-        totalWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.valueWei} AS NUMERIC)), 0)::text`,
-      })
-      .from(directExecutions)
-      .where(
-        and(
-          eq(directExecutions.organizationId, params.organizationId),
-          ne(directExecutions.status, "failed"),
-          gte(directExecutions.createdAt, todayStart),
-          // Exclude stale in-flight reservations: a pending/running row from a
-          // crashed pod or a throwing core would otherwise hold its reserved
-          // value against the cap for the rest of the UTC day. Completed rows
-          // always count; pending/running only within a 15m window (matches the
-          // concurrency limiter's stale window). Legitimate in-flight requests
-          // settle in seconds, so this never drops a real concurrent reservation.
-          sql`(${directExecutions.status} = 'completed' OR ${directExecutions.createdAt} > now() - interval '15 minutes')`
-        )
-      )
-      .then((rows) => rows[0]);
-
-    const totalWei = BigInt(result?.totalWei ?? "0");
+    // Sum today's value across BOTH stores (direct executions AND the workflow/
+    // protocol value ledger) so a direct-API request is charged against value
+    // moved by workflow runs too, and cannot exceed the cap by racing them.
+    // Runs inside this FOR UPDATE tx, so it is consistent under concurrency.
+    const totalWei = await sumOrgValueTodayWei(tx, params.organizationId);
     const reservedWei = BigInt(params.reservedValueWei);
     const dailyCap = BigInt(cap.dailyValueCapWei);
 

--- a/drizzle/0122_keep_933_org_value_reservations.sql
+++ b/drizzle/0122_keep_933_org_value_reservations.sql
@@ -1,0 +1,28 @@
+-- KEEP-933: close the workflow/protocol value-cap bypass.
+--
+-- The KEEP-911 daily value cap is only charged by the direct-execution API
+-- routes (direct_executions.value_wei). Value moved by a workflow run or a
+-- protocol write goes through the same value-moving cores but never touches
+-- direct_executions, so an authenticated key could create+trigger a workflow to
+-- exceed the cap. This ledger records reservations from those other entrances;
+-- the cap SUM now unions both stores, so every value-moving path is bounded by
+-- the same per-org daily cap.
+--
+-- status: reserved (in-flight) | settled (broadcast succeeded, counts all day) |
+-- released (denied/failed, drops out of the SUM). Native value only, in wei.
+--
+-- Plain CREATE TABLE + CREATE INDEX on a brand-new (empty) table takes no
+-- meaningful lock, so no lock-free prep is required.
+
+CREATE TABLE IF NOT EXISTS "org_value_reservations" (
+    "id" text PRIMARY KEY NOT NULL,
+    "organization_id" text NOT NULL,
+    "value_wei" text NOT NULL,
+    "status" text DEFAULT 'reserved' NOT NULL,
+    "source" text,
+    "ref" text,
+    "created_at" timestamp DEFAULT now() NOT NULL,
+    "updated_at" timestamp DEFAULT now() NOT NULL,
+    CONSTRAINT "org_value_reservations_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE no action ON UPDATE no action
+);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_org_value_reservations_org_created" ON "org_value_reservations" ("organization_id","created_at");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -855,6 +855,13 @@
       "when": 1782765380001,
       "tag": "0121_keep_911_daily_value_cap",
       "breakpoints": true
+    },
+    {
+      "idx": 122,
+      "version": "7",
+      "when": 1782765380002,
+      "tag": "0122_keep_933_org_value_reservations",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -9,7 +9,6 @@ import {
   inArray,
   isNotNull,
   lt,
-  ne,
   sql,
 } from "drizzle-orm";
 import { db } from "@/lib/db";
@@ -25,6 +24,7 @@ import {
   organizationSpendCaps,
 } from "@/lib/db/schema-extensions";
 import { ERROR_STATUSES } from "@/lib/errors/execution-status";
+import { sumOrgValueTodayWei } from "@/lib/execute/value-ledger";
 import { analyticsCacheKey, cachedAnalytics } from "./cache";
 import {
   getBucketInterval,
@@ -1293,35 +1293,23 @@ export async function getSpendCapData(organizationId: string): Promise<{
   dailyCapWei: string | null;
   dailyUsedWei: string;
 }> {
-  const todayStart = new Date();
-  todayStart.setUTCHours(0, 0, 0, 0);
-
   // Mirror spending-cap enforcement exactly: the notional VALUE moved per org
-  // per day (SUM value_wei over non-failed direct executions -- pending/running
-  // reservations included) against the org's daily value cap.
-  const [capResult, usageResult] = await Promise.all([
+  // per day, summed across BOTH stores (direct executions AND the workflow/
+  // protocol value ledger, with the same stale-window aging), against the org's
+  // daily value cap. Using the shared SUM keeps the gauge honest -- it shows the
+  // same number enforcement checks, so workflow spend counts too.
+  const [capResult, dailyUsedWei] = await Promise.all([
     db
       .select({ dailyValueCapWei: organizationSpendCaps.dailyValueCapWei })
       .from(organizationSpendCaps)
       .where(eq(organizationSpendCaps.organizationId, organizationId))
       .limit(1),
-    db
-      .select({
-        totalWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.valueWei} AS NUMERIC)), 0)::text`,
-      })
-      .from(directExecutions)
-      .where(
-        and(
-          eq(directExecutions.organizationId, organizationId),
-          ne(directExecutions.status, "failed"),
-          gte(directExecutions.createdAt, todayStart)
-        )
-      ),
+    sumOrgValueTodayWei(db, organizationId),
   ]);
 
   return {
     dailyCapWei: capResult[0]?.dailyValueCapWei ?? null,
-    dailyUsedWei: usageResult[0]?.totalWei ?? "0",
+    dailyUsedWei: dailyUsedWei.toString(),
   };
 }
 

--- a/lib/db/schema-extensions.ts
+++ b/lib/db/schema-extensions.ts
@@ -731,6 +731,46 @@ export type OrganizationSpendCap = typeof organizationSpendCaps.$inferSelect;
 export type NewOrganizationSpendCap = typeof organizationSpendCaps.$inferInsert;
 
 /**
+ * Organization Value Reservations ledger
+ *
+ * Unified per-org record of native value moved by execution so the daily value
+ * cap covers every path -- direct API, workflow steps, and protocol writes --
+ * rather than only the direct-execution routes. Every value-moving core reserves
+ * a row before broadcast and settles or releases it afterward.
+ *
+ * status: `reserved` (in-flight) -> `settled` (broadcast succeeded) | `released`
+ * (denied or failed; excluded from the cap SUM). Wei stored as text for BigInt.
+ */
+export const orgValueReservations = pgTable(
+  "org_value_reservations",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => generateId()),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id),
+    valueWei: text("value_wei").notNull(),
+    status: text("status").notNull().default("reserved"), // reserved | settled | released
+    // Origin of the value-moving execution, for audit only.
+    source: text("source"), // direct | workflow | protocol
+    // Correlation id (executionId when available), for audit only.
+    ref: text("ref"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_org_value_reservations_org_created").on(
+      table.organizationId,
+      table.createdAt
+    ),
+  ]
+);
+
+export type OrgValueReservation = typeof orgValueReservations.$inferSelect;
+export type NewOrgValueReservation = typeof orgValueReservations.$inferInsert;
+
+/**
  * Overage Billing Records table
  *
  * Tracks overage charges applied at the end of each billing period.

--- a/lib/execute/native-value.ts
+++ b/lib/execute/native-value.ts
@@ -1,0 +1,47 @@
+import "server-only";
+
+import { ethers } from "ethers";
+
+export type ReservedValue =
+  | { ok: true; valueWei: string }
+  | { ok: false; error: string };
+
+/**
+ * Native notional value (in wei) an execution will move, used by the per-org
+ * daily spending cap. Parses a human-decimal ETH amount (e.g. "1.5") the same
+ * way the web3 cores do (`ethers.parseEther`).
+ *
+ * An absent/empty amount reserves "0". Only native value is counted today;
+ * ERC-20 token amounts are not yet priced into the cap, so token-only transfers
+ * pass "0" directly rather than calling this.
+ *
+ * Malformed amounts return `{ ok: false }` so the caller can decide (the direct
+ * routes reject with 400; the workflow wrapper reserves 0 and lets the core's
+ * own validation surface the canonical error). Negative amounts are rejected
+ * too: `ethers.parseEther("-5")` yields a negative BigInt (it does not throw),
+ * and a negative reservation would lower the day's SUM and bank credit against
+ * the cap.
+ */
+export function parseNativeValueWei(
+  rawAmount: string | undefined | null
+): ReservedValue {
+  if (rawAmount === undefined || rawAmount === null || rawAmount === "") {
+    return { ok: true, valueWei: "0" };
+  }
+
+  let parsed: bigint;
+  try {
+    parsed = ethers.parseEther(rawAmount);
+  } catch {
+    return { ok: false, error: `Invalid value amount: ${rawAmount}` };
+  }
+
+  if (parsed < BigInt(0)) {
+    return {
+      ok: false,
+      error: `Value amount must not be negative: ${rawAmount}`,
+    };
+  }
+
+  return { ok: true, valueWei: parsed.toString() };
+}

--- a/lib/execute/value-ledger.ts
+++ b/lib/execute/value-ledger.ts
@@ -1,0 +1,246 @@
+import "server-only";
+
+import { and, eq, gte, ne, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  directExecutions,
+  organizationSpendCaps,
+  orgValueReservations,
+} from "@/lib/db/schema-extensions";
+import { parseNativeValueWei } from "@/lib/execute/native-value";
+
+// In-flight rows older than this are treated as stale (crashed pod / lost
+// process) and drop out of the cap SUM, matching the direct-execution
+// concurrency limiter, so a stuck reservation cannot hold the cap all day.
+const STALE_INFLIGHT_MINUTES = 15;
+
+// biome-ignore lint/suspicious/noExplicitAny: accept either the app db or a tx
+type Executor = any;
+
+/**
+ * Total native value (wei) an org has moved / has in-flight today, summed across
+ * BOTH stores so every path counts against the same cap: direct-execution rows
+ * (`direct_executions.value_wei`, set by the direct API routes) and the value
+ * ledger (`org_value_reservations`, set by workflow + protocol executions).
+ *
+ * Settled/completed rows count for the whole UTC day; in-flight (pending/running
+ * or reserved) rows only within the stale window, so a stuck row ages out.
+ * Runs inside the caller's transaction so it is consistent with the FOR UPDATE.
+ */
+export async function sumOrgValueTodayWei(
+  executor: Executor,
+  organizationId: string
+): Promise<bigint> {
+  const todayStart = new Date();
+  todayStart.setUTCHours(0, 0, 0, 0);
+
+  const directRows = await executor
+    .select({
+      totalWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.valueWei} AS NUMERIC)), 0)::text`,
+    })
+    .from(directExecutions)
+    .where(
+      and(
+        eq(directExecutions.organizationId, organizationId),
+        ne(directExecutions.status, "failed"),
+        gte(directExecutions.createdAt, todayStart),
+        sql`(${directExecutions.status} = 'completed' OR ${directExecutions.createdAt} > now() - interval '${sql.raw(String(STALE_INFLIGHT_MINUTES))} minutes')`
+      )
+    );
+
+  const ledgerRows = await executor
+    .select({
+      totalWei: sql<string>`COALESCE(SUM(CAST(${orgValueReservations.valueWei} AS NUMERIC)), 0)::text`,
+    })
+    .from(orgValueReservations)
+    .where(
+      and(
+        eq(orgValueReservations.organizationId, organizationId),
+        ne(orgValueReservations.status, "released"),
+        gte(orgValueReservations.createdAt, todayStart),
+        sql`(${orgValueReservations.status} = 'settled' OR ${orgValueReservations.createdAt} > now() - interval '${sql.raw(String(STALE_INFLIGHT_MINUTES))} minutes')`
+      )
+    );
+
+  const direct = BigInt(directRows[0]?.totalWei ?? "0");
+  const ledger = BigInt(ledgerRows[0]?.totalWei ?? "0");
+  return direct + ledger;
+}
+
+/**
+ * The org's total value moved today (wei) across both stores, for read-only
+ * surfaces (the dashboard gauge). Uses the app db, not a transaction.
+ */
+export function getOrgValueUsedTodayWei(
+  organizationId: string
+): Promise<bigint> {
+  return sumOrgValueTodayWei(db, organizationId);
+}
+
+export type ReserveResult =
+  | { allowed: true; reservationId: string }
+  | { allowed: false; reason: string };
+
+type ReserveParams = {
+  organizationId: string;
+  // Native value being moved, in wei.
+  valueWei: string;
+  // Origin of the execution and a correlation id, for audit only.
+  source?: string;
+  ref?: string;
+};
+
+/**
+ * Atomically check the org's daily value cap and reserve `valueWei` against it,
+ * recording into the value ledger. Shared by the value-moving paths that are not
+ * the direct-execution API (workflow steps, protocol writes) so the cap cannot
+ * be bypassed by using a different entrance.
+ *
+ * A `SELECT ... FOR UPDATE` on the cap row serializes per org (the same row the
+ * direct routes lock, so direct + workflow reservations serialize together); the
+ * day's value across BOTH stores is summed; the request is denied if it would
+ * push the total over the cap; otherwise a `reserved` ledger row is inserted so
+ * concurrent callers see it (closing the TOCTOU). When the org has no cap,
+ * nothing is recorded (unlimited) and the empty reservationId makes settle/
+ * release a no-op.
+ */
+export async function reserveOrgValue(
+  params: ReserveParams
+): Promise<ReserveResult> {
+  return await db.transaction(async (tx) => {
+    const caps = await tx
+      .select({ dailyValueCapWei: organizationSpendCaps.dailyValueCapWei })
+      .from(organizationSpendCaps)
+      .where(eq(organizationSpendCaps.organizationId, params.organizationId))
+      .for("update")
+      .limit(1);
+
+    const cap = caps[0];
+
+    // No cap configured -> unlimited; record nothing.
+    if (!cap || cap.dailyValueCapWei === null) {
+      return { allowed: true, reservationId: "" } as const;
+    }
+
+    const totalWei = await sumOrgValueTodayWei(tx, params.organizationId);
+    const reservedWei = BigInt(params.valueWei);
+    const dailyCap = BigInt(cap.dailyValueCapWei);
+
+    if (totalWei + reservedWei > dailyCap) {
+      return { allowed: false, reason: "Daily spending cap exceeded" } as const;
+    }
+
+    const [row] = await tx
+      .insert(orgValueReservations)
+      .values({
+        organizationId: params.organizationId,
+        valueWei: params.valueWei,
+        status: "reserved",
+        source: params.source ?? null,
+        ref: params.ref ?? null,
+      })
+      .returning({ id: orgValueReservations.id });
+
+    return { allowed: true, reservationId: row.id } as const;
+  });
+}
+
+/** Mark a reservation as settled (broadcast succeeded); it counts all day. */
+export async function settleReservation(reservationId: string): Promise<void> {
+  if (!reservationId) {
+    return;
+  }
+  await db
+    .update(orgValueReservations)
+    .set({ status: "settled", updatedAt: new Date() })
+    .where(eq(orgValueReservations.id, reservationId));
+}
+
+/** Release a reservation (denied or failed); it drops out of the cap SUM. */
+export async function releaseReservation(reservationId: string): Promise<void> {
+  if (!reservationId) {
+    return;
+  }
+  await db
+    .update(orgValueReservations)
+    .set({ status: "released", updatedAt: new Date() })
+    .where(eq(orgValueReservations.id, reservationId));
+}
+
+/**
+ * Wrap a value-moving execution so it is charged against the org's daily cap.
+ * Reserves `valueWei` before running `run`, then settles on a successful result
+ * or releases on a failed result or a thrown error. A zero value skips the cap.
+ * Returns the run result, or a cap-exceeded failure without running.
+ */
+export async function withValueCap<T extends { success: boolean }>(
+  params: ReserveParams,
+  run: () => Promise<T>
+): Promise<T | { success: false; error: string }> {
+  if (params.valueWei === "0" || BigInt(params.valueWei) <= BigInt(0)) {
+    return await run();
+  }
+
+  const reservation = await reserveOrgValue(params);
+  if (!reservation.allowed) {
+    return { success: false, error: reservation.reason };
+  }
+
+  let result: T;
+  try {
+    result = await run();
+  } catch (error) {
+    await releaseReservation(reservation.reservationId);
+    throw error;
+  }
+
+  if (result.success) {
+    await settleReservation(reservation.reservationId);
+  } else {
+    await releaseReservation(reservation.reservationId);
+  }
+  return result;
+}
+
+type StepValueCapArgs = {
+  // The workflow's owning org (the credential authority). Absent for
+  // org-less workflows -> no org cap applies, so the run is not charged.
+  organizationId?: string;
+  // Human-decimal native amount the step moves (e.g. "1.5"); undefined/"0"
+  // for token-only or off-chain steps.
+  amountEth?: string | null;
+  // Correlation id for audit; the workflow execution id when available.
+  executionId?: string;
+  source?: string;
+};
+
+/**
+ * Charge a workflow/protocol step's native value against the org's daily cap.
+ * Thin front door over `withValueCap` for the step wrappers: parses the human
+ * ETH amount, skips the cap when there is no org or no native value, and treats
+ * an unparseable amount as 0 (the core's own validation surfaces the real
+ * error; a parse quirk here must never block a valid call or bank negative
+ * credit). Direct-execution API routes do NOT use this -- they reserve via
+ * `checkAndReserveExecution`, and the cap SUM unions both stores.
+ */
+export function withStepValueCap<T extends { success: boolean }>(
+  args: StepValueCapArgs,
+  run: () => Promise<T>
+): Promise<T | { success: false; error: string }> {
+  const parsed = parseNativeValueWei(args.amountEth);
+  const valueWei = parsed.ok ? parsed.valueWei : "0";
+
+  if (!args.organizationId || valueWei === "0") {
+    return run();
+  }
+
+  return withValueCap(
+    {
+      organizationId: args.organizationId,
+      valueWei,
+      source: args.source ?? "workflow",
+      ref: args.executionId,
+    },
+    run
+  );
+}

--- a/plugins/protocol/steps/protocol-write.ts
+++ b/plugins/protocol/steps/protocol-write.ts
@@ -9,6 +9,7 @@ import {
 } from "@/plugins/web3/steps/write-contract-core";
 import { resolveAbi } from "@/lib/abi/cache";
 import { type AbiItem, findAbiFunction } from "@/lib/abi/utils";
+import { withStepValueCap } from "@/lib/execute/value-ledger";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getProtocol, resolveContractAddress } from "@/lib/protocol-registry";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
@@ -295,7 +296,18 @@ export async function protocolWriteStep(
         : undefined,
     };
 
-    return await writeContractCore(coreInput);
+    // Charge the payable value against the org's daily cap. `ethValue` is the
+    // resolved native value forwarded to writeContractCore; a non-payable /
+    // absent value reserves nothing.
+    return await withStepValueCap(
+      {
+        organizationId: input._context?.organizationId,
+        amountEth: ethValue,
+        executionId: input._context?.executionId,
+        source: "protocol",
+      },
+      () => writeContractCore(coreInput)
+    );
   });
 }
 

--- a/plugins/web3/steps/transfer-funds.ts
+++ b/plugins/web3/steps/transfer-funds.ts
@@ -5,6 +5,7 @@ import { db } from "@/lib/db";
 import { explorerConfigs } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import { withStepValueCap } from "@/lib/execute/value-ledger";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import type {
@@ -56,7 +57,17 @@ export async function transferFundsStep(
       actionName: "transfer-funds",
       executionId: input._context?.executionId,
     },
-    () => withStepLogging(enrichedInput, () => transferFundsCore(input))
+    () =>
+      withStepLogging(enrichedInput, () =>
+        withStepValueCap(
+          {
+            organizationId: input._context?.organizationId,
+            amountEth: input.amount,
+            executionId: input._context?.executionId,
+          },
+          () => transferFundsCore(input)
+        )
+      )
   );
 }
 

--- a/plugins/web3/steps/write-contract.ts
+++ b/plugins/web3/steps/write-contract.ts
@@ -5,6 +5,7 @@ import { db } from "@/lib/db";
 import { explorerConfigs } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import { withStepValueCap } from "@/lib/execute/value-ledger";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import {
@@ -51,7 +52,17 @@ export async function writeContractStep(
       actionName: "write-contract",
       executionId: input._context?.executionId,
     },
-    () => withStepLogging(enrichedInput, () => writeContractCore(input))
+    () =>
+      withStepLogging(enrichedInput, () =>
+        withStepValueCap(
+          {
+            organizationId: input._context?.organizationId,
+            amountEth: input.ethValue,
+            executionId: input._context?.executionId,
+          },
+          () => writeContractCore(input)
+        )
+      )
   );
 }
 

--- a/tests/unit/spending-cap.test.ts
+++ b/tests/unit/spending-cap.test.ts
@@ -7,12 +7,14 @@ vi.mock("@/lib/utils/id", () => ({ generateId: () => "exec_test" }));
 const state = vi.hoisted(() => ({
   caps: [] as Array<{ dailyValueCapWei: string | null }>,
   sumRows: [] as Array<{ totalWei: string }>,
+  ledgerRows: [] as Array<{ totalWei: string }>,
   inserted: [] as Record<string, unknown>[],
 }));
 
 // Fake db.transaction whose tx supports what the reservation uses: the cap
-// FOR UPDATE lookup (.for().limit()), the value SUM (a thenable .where()), and
-// the reservation insert.
+// FOR UPDATE lookup (.for().limit()), the value SUM -- now two thenable
+// .where() selects (direct executions, then the value ledger) via
+// sumOrgValueTodayWei -- and the reservation insert.
 vi.mock("@/lib/db", () => ({
   db: {
     transaction: (cb: (tx: unknown) => unknown) => {
@@ -31,9 +33,11 @@ vi.mock("@/lib/db", () => ({
               }),
             };
           }
+          // select #2 = direct-executions SUM, select #3 = ledger SUM.
+          const rows = selectCall === 2 ? state.sumRows : state.ledgerRows;
           return {
             from: () => ({
-              where: () => Promise.resolve(state.sumRows),
+              where: () => Promise.resolve(rows),
             }),
           };
         },
@@ -62,6 +66,7 @@ const baseParams = {
 beforeEach(() => {
   state.caps = [];
   state.sumRows = [{ totalWei: "0" }];
+  state.ledgerRows = [{ totalWei: "0" }];
   state.inserted = [];
 });
 
@@ -120,6 +125,23 @@ describe("checkAndReserveExecution value cap", () => {
       allowed: false,
       reason: "Daily spending cap exceeded",
     });
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("counts workflow/protocol value (the ledger) against a direct reservation", async () => {
+    // Direct spend 600 + ledger (workflow) spend 300 = 900; a further 200
+    // direct reservation would reach 1100 > 1000 -> denied. Without the ledger
+    // in the SUM this would wrongly pass (600 + 200 = 800).
+    state.caps = [{ dailyValueCapWei: "1000" }];
+    state.sumRows = [{ totalWei: "600" }];
+    state.ledgerRows = [{ totalWei: "300" }];
+
+    const result = await checkAndReserveExecution({
+      ...baseParams,
+      reservedValueWei: "200",
+    });
+
+    expect(result.allowed).toBe(false);
     expect(state.inserted).toHaveLength(0);
   });
 

--- a/tests/unit/value-ledger.test.ts
+++ b/tests/unit/value-ledger.test.ts
@@ -1,0 +1,303 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/utils/id", () => ({ generateId: () => "res_gen" }));
+
+// Hoisted state the fake db reads from / writes to, set per test.
+const state = vi.hoisted(() => ({
+  caps: [] as Array<{ dailyValueCapWei: string | null }>,
+  directSum: [{ totalWei: "0" }] as Array<{ totalWei: string }>,
+  ledgerSum: [{ totalWei: "0" }] as Array<{ totalWei: string }>,
+  inserted: [] as Record<string, unknown>[],
+  updates: [] as Record<string, unknown>[],
+  returningId: "res_1",
+}));
+
+// Fake db: transaction whose tx serves the cap FOR UPDATE lookup, then the two
+// SUM selects (direct executions, then the value ledger) that
+// sumOrgValueTodayWei runs, then the reservation insert (.returning). update()
+// records the settle/release status.
+vi.mock("@/lib/db", () => ({
+  db: {
+    transaction: (cb: (tx: unknown) => unknown) => {
+      let selectCall = 0;
+      const tx = {
+        select: () => {
+          selectCall += 1;
+          if (selectCall === 1) {
+            return {
+              from: () => ({
+                where: () => ({
+                  for: () => ({
+                    limit: () => Promise.resolve(state.caps),
+                  }),
+                }),
+              }),
+            };
+          }
+          const rows = selectCall === 2 ? state.directSum : state.ledgerSum;
+          return {
+            from: () => ({ where: () => Promise.resolve(rows) }),
+          };
+        },
+        insert: () => ({
+          values: (v: Record<string, unknown>) => {
+            state.inserted.push(v);
+            return {
+              returning: () => Promise.resolve([{ id: state.returningId }]),
+            };
+          },
+        }),
+      };
+      return cb(tx);
+    },
+    update: () => ({
+      set: (s: Record<string, unknown>) => ({
+        where: () => {
+          state.updates.push(s);
+          return Promise.resolve(undefined);
+        },
+      }),
+    }),
+  },
+}));
+
+import {
+  reserveOrgValue,
+  withStepValueCap,
+  withValueCap,
+} from "@/lib/execute/value-ledger";
+
+const ONE_ETH_WEI = "1000000000000000000";
+
+beforeEach(() => {
+  state.caps = [];
+  state.directSum = [{ totalWei: "0" }];
+  state.ledgerSum = [{ totalWei: "0" }];
+  state.inserted = [];
+  state.updates = [];
+  state.returningId = "res_1";
+});
+
+describe("reserveOrgValue", () => {
+  it("is unlimited (records nothing) when no cap row exists", async () => {
+    state.caps = [];
+
+    const result = await reserveOrgValue({
+      organizationId: "org_1",
+      valueWei: "500",
+    });
+
+    expect(result).toEqual({ allowed: true, reservationId: "" });
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("treats a null daily value cap as unlimited", async () => {
+    state.caps = [{ dailyValueCapWei: null }];
+
+    const result = await reserveOrgValue({
+      organizationId: "org_1",
+      valueWei: ONE_ETH_WEI,
+    });
+
+    expect(result).toEqual({ allowed: true, reservationId: "" });
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("allows and inserts a reserved row within the cap", async () => {
+    state.caps = [{ dailyValueCapWei: "1000" }];
+    state.directSum = [{ totalWei: "600" }];
+
+    const result = await reserveOrgValue({
+      organizationId: "org_1",
+      valueWei: "300",
+      source: "workflow",
+      ref: "exec_1",
+    });
+
+    expect(result).toEqual({ allowed: true, reservationId: "res_1" });
+    expect(state.inserted).toHaveLength(1);
+    expect(state.inserted[0]).toMatchObject({
+      valueWei: "300",
+      status: "reserved",
+      source: "workflow",
+      ref: "exec_1",
+    });
+  });
+
+  it("denies (no insert) when the reservation would exceed the cap", async () => {
+    state.caps = [{ dailyValueCapWei: "1000" }];
+    state.directSum = [{ totalWei: "600" }];
+
+    const result = await reserveOrgValue({
+      organizationId: "org_1",
+      valueWei: "500",
+    });
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: "Daily spending cap exceeded",
+    });
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("counts prior direct-execution spend in its own SUM", async () => {
+    // 900 already spent via the direct API (directSum) leaves only 100 room;
+    // a 200 workflow reservation is denied. Proves the ledger path sees direct
+    // spend, the mirror of the direct path seeing ledger spend.
+    state.caps = [{ dailyValueCapWei: "1000" }];
+    state.directSum = [{ totalWei: "900" }];
+
+    const result = await reserveOrgValue({
+      organizationId: "org_1",
+      valueWei: "200",
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(state.inserted).toHaveLength(0);
+  });
+});
+
+describe("withValueCap", () => {
+  it("skips the cap and runs when the value is zero", async () => {
+    const run = vi.fn().mockResolvedValue({ success: true, id: "ran" });
+
+    const result = await withValueCap(
+      { organizationId: "org_1", valueWei: "0" },
+      run
+    );
+
+    expect(run).toHaveBeenCalledOnce();
+    expect(result).toEqual({ success: true, id: "ran" });
+    expect(state.inserted).toHaveLength(0);
+    expect(state.updates).toHaveLength(0);
+  });
+
+  it("reserves then settles on a successful result", async () => {
+    state.caps = [{ dailyValueCapWei: "1000" }];
+    const run = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await withValueCap(
+      { organizationId: "org_1", valueWei: "100" },
+      run
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(state.inserted).toHaveLength(1);
+    expect(state.updates).toEqual([
+      expect.objectContaining({ status: "settled" }),
+    ]);
+  });
+
+  it("reserves then releases on a failed result", async () => {
+    state.caps = [{ dailyValueCapWei: "1000" }];
+    const run = vi.fn().mockResolvedValue({ success: false, error: "boom" });
+
+    const result = await withValueCap(
+      { organizationId: "org_1", valueWei: "100" },
+      run
+    );
+
+    expect(result).toEqual({ success: false, error: "boom" });
+    expect(state.inserted).toHaveLength(1);
+    expect(state.updates).toEqual([
+      expect.objectContaining({ status: "released" }),
+    ]);
+  });
+
+  it("releases and rethrows when the run throws", async () => {
+    state.caps = [{ dailyValueCapWei: "1000" }];
+    const run = vi.fn().mockRejectedValue(new Error("kaboom"));
+
+    await expect(
+      withValueCap({ organizationId: "org_1", valueWei: "100" }, run)
+    ).rejects.toThrow("kaboom");
+
+    expect(state.inserted).toHaveLength(1);
+    expect(state.updates).toEqual([
+      expect.objectContaining({ status: "released" }),
+    ]);
+  });
+
+  it("denies without running when over the cap", async () => {
+    state.caps = [{ dailyValueCapWei: "100" }];
+    const run = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await withValueCap(
+      { organizationId: "org_1", valueWei: "500" },
+      run
+    );
+
+    expect(run).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      success: false,
+      error: "Daily spending cap exceeded",
+    });
+    expect(state.updates).toHaveLength(0);
+  });
+});
+
+describe("withStepValueCap", () => {
+  it("runs without a cap check when the workflow has no organization", async () => {
+    const run = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await withStepValueCap({ amountEth: "1" }, run);
+
+    expect(run).toHaveBeenCalledOnce();
+    expect(result).toEqual({ success: true });
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("runs without a cap check when the step moves no native value", async () => {
+    state.caps = [{ dailyValueCapWei: "1" }];
+    const run = vi.fn().mockResolvedValue({ success: true });
+
+    await withStepValueCap({ organizationId: "org_1", amountEth: "0" }, run);
+    await withStepValueCap(
+      { organizationId: "org_1", amountEth: undefined },
+      run
+    );
+
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("blocks the value-moving core when a workflow step exceeds the cap", async () => {
+    // The KEEP-933 fix: a 5 ETH transfer triggered from a workflow (not the
+    // direct API) is now bounded by the same 1 ETH org cap. The core never runs.
+    state.caps = [{ dailyValueCapWei: ONE_ETH_WEI }];
+    const run = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await withStepValueCap(
+      { organizationId: "org_1", amountEth: "5", executionId: "exec_1" },
+      run
+    );
+
+    expect(run).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      success: false,
+      error: "Daily spending cap exceeded",
+    });
+  });
+
+  it("runs and settles a workflow step within the cap", async () => {
+    state.caps = [{ dailyValueCapWei: ONE_ETH_WEI }];
+    const run = vi.fn().mockResolvedValue({ success: true, hash: "0xabc" });
+
+    const result = await withStepValueCap(
+      { organizationId: "org_1", amountEth: "0.5", executionId: "exec_1" },
+      run
+    );
+
+    expect(run).toHaveBeenCalledOnce();
+    expect(result).toEqual({ success: true, hash: "0xabc" });
+    expect(state.inserted[0]).toMatchObject({
+      valueWei: "500000000000000000",
+      source: "workflow",
+      ref: "exec_1",
+    });
+    expect(state.updates).toEqual([
+      expect.objectContaining({ status: "settled" }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem

The daily value cap (native notional value moved per org per day) is only charged by the direct-execution API routes (`direct_executions.value_wei`). Workflow-triggered and protocol transfers move value through the same value-moving cores but never touch `direct_executions`, so an authenticated key could create-and-trigger a workflow to move value past the cap - the exact bypass this branch's cap was meant to prevent.

## Fix

Charge the cap at the shared value-moving entrances via a call-site wrapper, unified at the SUM so there is a single source of truth:

- New `org_value_reservations` ledger + `lib/execute/value-ledger.ts` (`reserveOrgValue` / `settleReservation` / `releaseReservation` / `withValueCap` / `withStepValueCap`).
- The three workflow/protocol step wrappers (`transferFundsStep`, `writeContractStep`, `protocolWriteStep`) reserve before the core runs, settle on success, release on failure or throw.
- `sumOrgValueTodayWei` unions **both** stores (direct executions + ledger, same 15-minute stale window). Both reservation checks lock the org's cap row `FOR UPDATE`, so direct and workflow spend serialize and count against one cap.
- No double-charge: direct routes call the cores directly and keep their `direct_executions` reservation; only the workflow step wrappers get `withValueCap`.
- Dashboard gauge (`getSpendCapData`) reads the same union SUM.
- Pure native-value parser moved to `lib/execute/native-value.ts` (correct app -> lib dependency direction); the direct-route helper re-exports it.

## Scope

Native value only. ERC-20 / USD-normalized value remains uncapped and is a tracked follow-up. `transferTokenStep` is intentionally unwrapped (ERC-20 transfers move no native value). Simulate never calls the cores, so it reserves nothing.

## Verification

- `tsc --noEmit`: clean
- `ultracite check` (changed files): clean
- vitest: 40 passing - new `value-ledger` (14), updated `spending-cap` (6), `reserved-value` (11), `execute-node-reserved-fields` (9). The key test proves a 5 ETH workflow transfer against a 1 ETH cap never calls the value-moving core.
- Migration `0122` applied to a local DB.

Targets the KEEP-911 branch so it merges into that PR and rides its PR-environment build (which exercises the `"use step"` workflow bundler for the wrapped steps).