### PR TITLE
fix: classify never-progressed running executions as infrastructure in the reaper

### DIFF
--- a/app/api/internal/reaper/route.ts
+++ b/app/api/internal/reaper/route.ts
@@ -1,35 +1,13 @@
-import { and, eq, gt, inArray, lt, notInArray, or, sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
-import { db } from "@/lib/db";
-import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
-import { walletLocks } from "@/lib/db/schema-extensions";
-import { classifyExecutionError } from "@/lib/errors/classify";
-import type { ErrorCode } from "@/lib/errors/error-codes";
-import { recordExecutionErrorFinalized } from "@/lib/errors/finalize-error";
 import { authenticateInternalService } from "@/lib/internal-service-auth";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
-
-const DEFAULT_THRESHOLD_MINUTES = 30;
-
-// Pending rows that have produced no step logs are unambiguously stuck:
-// the executor inserted but the runtime never started. A few minutes is
-// generous for image pulls and k8s scheduling; beyond that, it's dead.
-const PENDING_THRESHOLD_MINUTES = 5;
-
-function getThresholdMinutes(): number {
-  const envValue = process.env.STALE_EXECUTION_THRESHOLD_MINUTES;
-  if (!envValue) {
-    return DEFAULT_THRESHOLD_MINUTES;
-  }
-  const parsed = Number.parseInt(envValue, 10);
-  return Number.isNaN(parsed) ? DEFAULT_THRESHOLD_MINUTES : parsed;
-}
+import { reapStaleExecutions } from "@/lib/reaper/reap-stale-executions";
 
 /**
  * GET /api/internal/reaper
  *
- * Finds workflow executions stuck in "running" state with no recent activity
- * and marks them as "error" with a timeout message.
+ * Finds workflow executions stuck past their threshold and marks them as
+ * system_error with a timeout classification.
  *
  * Intended to be called by an external cron job (K8s CronJob).
  */
@@ -43,147 +21,7 @@ export async function GET(request: Request): Promise<NextResponse> {
   }
 
   try {
-    const thresholdMinutes = getThresholdMinutes();
-    const runningCutoff = new Date(Date.now() - thresholdMinutes * 60 * 1000);
-    const pendingCutoff = new Date(
-      Date.now() - PENDING_THRESHOLD_MINUTES * 60 * 1000
-    );
-
-    // Find execution IDs that have recent step activity (should NOT be reaped)
-    const activeExecutionIds = await db
-      .select({
-        executionId: workflowExecutionLogs.executionId,
-      })
-      .from(workflowExecutionLogs)
-      .where(gt(workflowExecutionLogs.completedAt, runningCutoff))
-      .groupBy(workflowExecutionLogs.executionId);
-
-    const excludeIds = activeExecutionIds.map((row) => row.executionId);
-
-    // Bulk update all stale executions in a single query.
-    //
-    // Three independent stuck-state predicates combined with OR. The per-row
-    // error_code below is a CASE on the pre-update status:
-    //   - status='running' rows that haven't recorded recent step activity
-    //     within the running threshold (default 30 min). The runtime claimed
-    //     the execution but stopped progressing -> E-0001.
-    //   - status='pending' rows older than the pending threshold (5 min) with
-    //     no step logs at all. The SQS executor inserted the row but the runtime
-    //     never started (dispatch failed, pod crash before first step) -> P-0001.
-    //     Guarded by NOT EXISTS rather than a NOT IN list because every
-    //     successful execution has step logs and a NOT IN would load that entire
-    //     set into the predicate.
-    //   - status='phantom' rows older than the pending threshold. KEEP-693: the
-    //     scheduler/event-tracker pre-created the row but the executor never
-    //     dequeued it (dispatcher down, SQS lost) -> P-0005.
-    const staleConditions = or(
-      and(
-        eq(workflowExecutions.status, "running"),
-        lt(workflowExecutions.startedAt, runningCutoff),
-        excludeIds.length > 0
-          ? notInArray(workflowExecutions.id, excludeIds)
-          : undefined
-      ),
-      and(
-        eq(workflowExecutions.status, "pending"),
-        lt(workflowExecutions.startedAt, pendingCutoff),
-        sql`NOT EXISTS (
-          SELECT 1 FROM ${workflowExecutionLogs}
-          WHERE ${workflowExecutionLogs.executionId} = ${workflowExecutions.id}
-        )`
-      ),
-      and(
-        eq(workflowExecutions.status, "phantom"),
-        lt(workflowExecutions.startedAt, pendingCutoff)
-      )
-    );
-
-    // KEEP-545: reaped executions are by definition stuck/timed-out, which
-    // classifies as system-side. Write the classification columns and
-    // increment the per-org counter per reaped row.
-    const reaperErrorMessage = `Execution timed out: no progress for ${thresholdMinutes} minutes`;
-    const reaperClassification = classifyExecutionError(reaperErrorMessage);
-
-    const reaped = await db
-      .update(workflowExecutions)
-      .set({
-        // KEEP-853: reaped rows are always system/infra failures (timeouts,
-        // never-started, SQS-lost), so they carry the system_error status.
-        status: "system_error",
-        error: reaperErrorMessage,
-        // KEEP-651: errorCategory is per pre-update status. running -> the
-        // runtime claimed the execution but stopped progressing, which is a
-        // workflow engine failure (workflow_engine). pending/phantom -> the
-        // pod never started or the dispatcher never dequeued -- these are
-        // infrastructure failures (infrastructure), not runtime engine faults,
-        // and must be a distinct metric series so a FailedCreatePodSandBox
-        // burst surfaces separately from ordinary execution timeouts.
-        errorCategory: sql<string>`CASE
-          WHEN ${workflowExecutions.status} = 'running' THEN 'workflow_engine'
-          ELSE 'infrastructure' END`,
-        errorType: reaperClassification.errorType,
-        // KEEP-693: attribute the code to the pre-update status -- running ->
-        // timed out (E-0001), pending -> never started (P-0001), phantom ->
-        // never picked up (P-0005).
-        errorCode: sql<ErrorCode>`CASE
-          WHEN ${workflowExecutions.status} = 'pending' THEN 'P-0001'
-          WHEN ${workflowExecutions.status} = 'phantom' THEN 'P-0005'
-          ELSE 'E-0001' END`,
-        completedAt: new Date(),
-        duration: sql`ROUND(EXTRACT(EPOCH FROM (NOW() - ${workflowExecutions.startedAt})) * 1000)`,
-      })
-      .where(staleConditions)
-      .returning({
-        id: workflowExecutions.id,
-        workflowId: workflowExecutions.workflowId,
-        errorCategory: workflowExecutions.errorCategory,
-      });
-
-    const reapedIds = reaped.map((row) => row.id);
-
-    // KEEP-545: emit one counter increment per reaped row so the timeout
-    // family shows up in the new classified counter the SLA alert watches.
-    for (const row of reaped) {
-      await recordExecutionErrorFinalized({
-        workflowId: row.workflowId,
-        errorMessage: reaperErrorMessage,
-        persistedStatus: "system_error",
-        errorCategory: row.errorCategory ?? undefined,
-      });
-    }
-
-    // KEEP-333: Close orphaned 'running' step logs for reaped executions so
-    // the UI doesn't show stuck spinners after the workflow has been marked
-    // as timed out.
-    if (reapedIds.length > 0) {
-      await db
-        .update(workflowExecutionLogs)
-        .set({
-          status: "error",
-          error: "Step did not record completion",
-          completedAt: new Date(),
-        })
-        .where(
-          and(
-            inArray(workflowExecutionLogs.executionId, reapedIds),
-            eq(workflowExecutionLogs.status, "running")
-          )
-        );
-
-      // KEEP-344: Release any nonce locks still held by reaped executions.
-      // The wallet_locks TTL would clear them on its own, but releasing them
-      // here unwedges affected wallets immediately when reaper runs, instead
-      // of leaving the user blocked until expires_at.
-      await db
-        .update(walletLocks)
-        .set({
-          lockedBy: null,
-          lockedAt: null,
-          expiresAt: sql`NOW()`,
-        })
-        .where(inArray(walletLocks.lockedBy, reapedIds));
-    }
-
+    const reapedIds = await reapStaleExecutions();
     return NextResponse.json({
       reapedCount: reapedIds.length,
       reapedIds,

--- a/lib/errors/error-codes.ts
+++ b/lib/errors/error-codes.ts
@@ -171,7 +171,11 @@ export const ERROR_CODES: Record<ErrorCode, ErrorCodeEntry> = {
     prefix: "P",
     component: "Pod",
     retryable: true,
-    category: "workflow_engine",
+    // "could not be started" (pod never ran) is an infrastructure failure, like
+    // its P-000x siblings and like every writer of this code (reaper, executions
+    // route). Was previously miscategorized workflow_engine, which conflicted
+    // with the errorCategory column the reaper/executions writers persist.
+    category: "infrastructure",
     customerMessage: "The run could not be started (P-0001). Please try again.",
   },
   "P-0002": {

--- a/lib/reaper/reap-stale-executions.ts
+++ b/lib/reaper/reap-stale-executions.ts
@@ -1,0 +1,169 @@
+import { and, eq, gt, inArray, lt, notInArray, or, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
+import { walletLocks } from "@/lib/db/schema-extensions";
+import { classifyExecutionError } from "@/lib/errors/classify";
+import type { ErrorCode } from "@/lib/errors/error-codes";
+import { recordExecutionErrorFinalized } from "@/lib/errors/finalize-error";
+
+export const DEFAULT_THRESHOLD_MINUTES = 30;
+
+// Pending rows that have produced no step logs are unambiguously stuck:
+// the executor inserted but the runtime never started. A few minutes is
+// generous for image pulls and k8s scheduling; beyond that, it's dead.
+export const PENDING_THRESHOLD_MINUTES = 5;
+
+export function getThresholdMinutes(): number {
+  const envValue = process.env.STALE_EXECUTION_THRESHOLD_MINUTES;
+  if (!envValue) {
+    return DEFAULT_THRESHOLD_MINUTES;
+  }
+  const parsed = Number.parseInt(envValue, 10);
+  return Number.isNaN(parsed) ? DEFAULT_THRESHOLD_MINUTES : parsed;
+}
+
+/**
+ * Find workflow executions stuck past their threshold, mark them system_error
+ * with a timeout classification, close their orphaned step logs, and release any
+ * nonce locks they still hold. Returns the reaped execution ids.
+ *
+ * Classification tracks whether the row ever produced a step log, not just its
+ * raw status. The runner writes the trigger node's step log at step START,
+ * before any user action step, so a `running` row with NO step logs never
+ * entered the workflow body - the pod died/never scheduled - which is an
+ * infrastructure failure (P-0001), classified like `pending`/`phantom`, not a
+ * workflow_engine fault (E-0001). This keeps a FailedCreatePodSandBox burst in
+ * the infrastructure series the SLA alert watches, and reaps such a row at the
+ * (short) pending threshold instead of the (long) running threshold. A `running`
+ * row that DID log a step but then stalled is still a workflow_engine timeout.
+ */
+export async function reapStaleExecutions(
+  thresholdMinutes: number = getThresholdMinutes()
+): Promise<string[]> {
+  const runningCutoff = new Date(Date.now() - thresholdMinutes * 60 * 1000);
+  const pendingCutoff = new Date(
+    Date.now() - PENDING_THRESHOLD_MINUTES * 60 * 1000
+  );
+
+  // Whether an execution has produced ANY step log. The runner writes the
+  // trigger step's log before the first user step, so its presence means the
+  // pod entered the workflow body.
+  const hasStepLogs = sql`EXISTS (
+    SELECT 1 FROM ${workflowExecutionLogs}
+    WHERE ${workflowExecutionLogs.executionId} = ${workflowExecutions.id}
+  )`;
+  const noStepLogs = sql`NOT ${hasStepLogs}`;
+
+  // Execution IDs with a recently COMPLETED step (actively progressing) - never
+  // reap these even past the running threshold.
+  const activeExecutionIds = await db
+    .select({ executionId: workflowExecutionLogs.executionId })
+    .from(workflowExecutionLogs)
+    .where(gt(workflowExecutionLogs.completedAt, runningCutoff))
+    .groupBy(workflowExecutionLogs.executionId);
+  const excludeIds = activeExecutionIds.map((row) => row.executionId);
+
+  const staleConditions = or(
+    // running + progressed-then-stalled: has step logs but none completed
+    // recently, older than the running threshold (default 30 min) -> E-0001.
+    and(
+      eq(workflowExecutions.status, "running"),
+      lt(workflowExecutions.startedAt, runningCutoff),
+      excludeIds.length > 0
+        ? notInArray(workflowExecutions.id, excludeIds)
+        : undefined
+    ),
+    // running + NEVER progressed: no step logs at all, older than the pending
+    // threshold (5 min). The pod died/never scheduled before the trigger step,
+    // so this is an infrastructure failure reaped like 'pending' -> P-0001.
+    and(
+      eq(workflowExecutions.status, "running"),
+      lt(workflowExecutions.startedAt, pendingCutoff),
+      noStepLogs
+    ),
+    // pending + no step logs, older than the pending threshold -> P-0001.
+    and(
+      eq(workflowExecutions.status, "pending"),
+      lt(workflowExecutions.startedAt, pendingCutoff),
+      noStepLogs
+    ),
+    // phantom, older than the pending threshold -> P-0005 (never picked up).
+    and(
+      eq(workflowExecutions.status, "phantom"),
+      lt(workflowExecutions.startedAt, pendingCutoff)
+    )
+  );
+
+  const reaperErrorMessage = `Execution timed out: no progress for ${thresholdMinutes} minutes`;
+  const reaperClassification = classifyExecutionError(reaperErrorMessage);
+
+  const reaped = await db
+    .update(workflowExecutions)
+    .set({
+      status: "system_error",
+      error: reaperErrorMessage,
+      // errorCategory tracks step-log presence: only a 'running' row that
+      // actually produced a step log is a workflow_engine fault; pending,
+      // phantom, and never-logged running rows are infrastructure. Keeping
+      // FailedCreatePodSandBox out of the workflow_engine series matters for the
+      // SLA alert.
+      errorCategory: sql<string>`CASE
+        WHEN ${workflowExecutions.status} = 'running' AND ${hasStepLogs} THEN 'workflow_engine'
+        ELSE 'infrastructure' END`,
+      errorType: reaperClassification.errorType,
+      // running-with-logs -> timed out (E-0001); phantom -> never picked up
+      // (P-0005); pending and never-logged running -> never started (P-0001).
+      errorCode: sql<ErrorCode>`CASE
+        WHEN ${workflowExecutions.status} = 'phantom' THEN 'P-0005'
+        WHEN ${workflowExecutions.status} = 'running' AND ${hasStepLogs} THEN 'E-0001'
+        ELSE 'P-0001' END`,
+      completedAt: new Date(),
+      duration: sql`ROUND(EXTRACT(EPOCH FROM (NOW() - ${workflowExecutions.startedAt})) * 1000)`,
+    })
+    .where(staleConditions)
+    .returning({
+      id: workflowExecutions.id,
+      workflowId: workflowExecutions.workflowId,
+      errorCategory: workflowExecutions.errorCategory,
+    });
+
+  const reapedIds = reaped.map((row) => row.id);
+
+  // Emit one classified counter increment per reaped row (SLA alert source).
+  // persistedStatus is the status we actually wrote above, so the finished
+  // counter's status label matches the DB.
+  for (const row of reaped) {
+    await recordExecutionErrorFinalized({
+      workflowId: row.workflowId,
+      errorMessage: reaperErrorMessage,
+      persistedStatus: "system_error",
+      errorCategory: row.errorCategory ?? undefined,
+    });
+  }
+
+  if (reapedIds.length > 0) {
+    // Close orphaned 'running' step logs so the UI doesn't show stuck spinners.
+    await db
+      .update(workflowExecutionLogs)
+      .set({
+        status: "error",
+        error: "Step did not record completion",
+        completedAt: new Date(),
+      })
+      .where(
+        and(
+          inArray(workflowExecutionLogs.executionId, reapedIds),
+          eq(workflowExecutionLogs.status, "running")
+        )
+      );
+
+    // Release any nonce locks still held by reaped executions so affected
+    // wallets are unwedged immediately instead of waiting for the TTL.
+    await db
+      .update(walletLocks)
+      .set({ lockedBy: null, lockedAt: null, expiresAt: sql`NOW()` })
+      .where(inArray(walletLocks.lockedBy, reapedIds));
+  }
+
+  return reapedIds;
+}

--- a/lib/reaper/reap-stale-executions.ts
+++ b/lib/reaper/reap-stale-executions.ts
@@ -33,9 +33,17 @@ export function getThresholdMinutes(): number {
  * entered the workflow body - the pod died/never scheduled - which is an
  * infrastructure failure (P-0001), classified like `pending`/`phantom`, not a
  * workflow_engine fault (E-0001). This keeps a FailedCreatePodSandBox burst in
- * the infrastructure series the SLA alert watches, and reaps such a row at the
- * (short) pending threshold instead of the (long) running threshold. A `running`
- * row that DID log a step but then stalled is still a workflow_engine timeout.
+ * the infrastructure series the SLA alert watches. A `running` row that DID log
+ * a step but then stalled is a workflow_engine timeout (E-0001).
+ *
+ * A never-progressed `running` row is reaped at the same (long) running
+ * threshold as a stalled one, NOT the (short) pending threshold - only the
+ * classification differs by step-log presence, the timing does not. A durably
+ * enqueued run also sits `running` with no step logs until a worker picks it up,
+ * and is indistinguishable in the DB from a pod that never scheduled; reaping
+ * running+no-logs at the pending cutoff would false-fail healthy runs waiting on
+ * a backed-up worker queue - exactly the incident conditions this reaper runs
+ * in - and inflate the infrastructure counter it exists to keep accurate.
  */
 export async function reapStaleExecutions(
   thresholdMinutes: number = getThresholdMinutes()
@@ -64,22 +72,18 @@ export async function reapStaleExecutions(
   const excludeIds = activeExecutionIds.map((row) => row.executionId);
 
   const staleConditions = or(
-    // running + progressed-then-stalled: has step logs but none completed
-    // recently, older than the running threshold (default 30 min) -> E-0001.
+    // running, older than the running threshold (default 30 min), not recently
+    // active. Covers both a run that progressed then stalled and one that never
+    // produced a step log; the CASEs below split them by step-log presence into
+    // workflow_engine/E-0001 vs infrastructure/P-0001. Both wait the full
+    // running threshold: a never-progressed running row is indistinguishable in
+    // the DB from a healthy run still queued for a worker (see the doc above).
     and(
       eq(workflowExecutions.status, "running"),
       lt(workflowExecutions.startedAt, runningCutoff),
       excludeIds.length > 0
         ? notInArray(workflowExecutions.id, excludeIds)
         : undefined
-    ),
-    // running + NEVER progressed: no step logs at all, older than the pending
-    // threshold (5 min). The pod died/never scheduled before the trigger step,
-    // so this is an infrastructure failure reaped like 'pending' -> P-0001.
-    and(
-      eq(workflowExecutions.status, "running"),
-      lt(workflowExecutions.startedAt, pendingCutoff),
-      noStepLogs
     ),
     // pending + no step logs, older than the pending threshold -> P-0001.
     and(

--- a/lib/reaper/reap-stale-executions.ts
+++ b/lib/reaper/reap-stale-executions.ts
@@ -6,14 +6,14 @@ import { classifyExecutionError } from "@/lib/errors/classify";
 import type { ErrorCode } from "@/lib/errors/error-codes";
 import { recordExecutionErrorFinalized } from "@/lib/errors/finalize-error";
 
-export const DEFAULT_THRESHOLD_MINUTES = 30;
+const DEFAULT_THRESHOLD_MINUTES = 30;
 
 // Pending rows that have produced no step logs are unambiguously stuck:
 // the executor inserted but the runtime never started. A few minutes is
 // generous for image pulls and k8s scheduling; beyond that, it's dead.
-export const PENDING_THRESHOLD_MINUTES = 5;
+const PENDING_THRESHOLD_MINUTES = 5;
 
-export function getThresholdMinutes(): number {
+function getThresholdMinutes(): number {
   const envValue = process.env.STALE_EXECUTION_THRESHOLD_MINUTES;
   if (!envValue) {
     return DEFAULT_THRESHOLD_MINUTES;

--- a/tests/e2e/vitest/reaper-classification.test.ts
+++ b/tests/e2e/vitest/reaper-classification.test.ts
@@ -1,0 +1,243 @@
+import "dotenv/config";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  organization,
+  users,
+  workflowExecutionLogs,
+  workflowExecutions,
+  workflows,
+} from "@/lib/db/schema";
+import { reapStaleExecutions } from "@/lib/reaper/reap-stale-executions";
+
+// tests/setup.ts globally mocks @/lib/db; reapStaleExecutions imports the real
+// module, so restore it and drive the reaper against a real database.
+vi.unmock("@/lib/db");
+// finalize-error (reached via the reaper's metric emit) imports "server-only",
+// which throws at import time outside a React Server context. Stub it, matching
+// the pattern used by the other lib/executor suites.
+vi.mock("server-only", () => ({}));
+
+// The reaper classifies a stuck execution by whether it ever produced a step
+// log, not by its raw status. A `running` row with NO step logs never entered
+// the workflow body (pod died/never scheduled) and must be reaped promptly as
+// infrastructure/P-0001, exactly like `pending`/`phantom` - not held to the
+// 30-min running threshold and booked as workflow_engine/E-0001. This exercises
+// that CASE + the OR of stale conditions against a real Postgres.
+
+const SKIP =
+  !process.env.DATABASE_URL || process.env.SKIP_INFRA_TESTS === "true";
+const DATABASE_URL = process.env.DATABASE_URL ?? "";
+
+const PREFIX = "test_keep934_reaper_";
+// reapStaleExecutions(THRESHOLD): running-with-logs is stale past THRESHOLD min;
+// pending/phantom/running-no-logs are stale past the fixed 5-min pending cutoff.
+const THRESHOLD_MINUTES = 30;
+
+type ExecutionStatus =
+  | "pending"
+  | "running"
+  | "success"
+  | "error"
+  | "cancelled"
+  | "phantom"
+  | "system_error";
+
+function minutesAgo(minutes: number): Date {
+  return new Date(Date.now() - minutes * 60 * 1000);
+}
+
+describe.skipIf(SKIP)(
+  "reaper classification (never-progressed running)",
+  () => {
+    let queryClient: ReturnType<typeof postgres>;
+    let db: ReturnType<typeof drizzle>;
+
+    const ownerId = `${PREFIX}user`;
+    const orgId = `${PREFIX}org`;
+    const workflowId = `${PREFIX}wf`;
+
+    // Fixture ids, seeded once in beforeAll and reaped in a single pass.
+    const ID = {
+      runningNoLogsStale: `${PREFIX}running_nolog_stale`,
+      runningWithLogStale: `${PREFIX}running_log_stale`,
+      runningRecentlyActive: `${PREFIX}running_recent`,
+      pendingNoLogsStale: `${PREFIX}pending_nolog_stale`,
+      phantomStale: `${PREFIX}phantom_stale`,
+      runningNoLogsFresh: `${PREFIX}running_nolog_fresh`,
+      runningWithLogFresh: `${PREFIX}running_log_fresh`,
+    };
+
+    let reapedIds: string[] = [];
+
+    async function cleanup(): Promise<void> {
+      await queryClient`DELETE FROM workflow_execution_logs WHERE execution_id LIKE ${`${PREFIX}%`}`;
+      await queryClient`DELETE FROM workflow_executions WHERE id LIKE ${`${PREFIX}%`}`;
+      await queryClient`DELETE FROM workflows WHERE id LIKE ${`${PREFIX}%`}`;
+      await queryClient`DELETE FROM organization WHERE id LIKE ${`${PREFIX}%`}`;
+      await queryClient`DELETE FROM users WHERE id LIKE ${`${PREFIX}%`}`;
+    }
+
+    async function seedExecution(
+      id: string,
+      status: ExecutionStatus,
+      startedAt: Date
+    ): Promise<void> {
+      await db.insert(workflowExecutions).values({
+        id,
+        workflowId,
+        userId: ownerId,
+        status,
+        startedAt,
+      });
+    }
+
+    async function seedStepLog(
+      executionId: string,
+      status: "running" | "success",
+      completedAt: Date | null
+    ): Promise<void> {
+      await db.insert(workflowExecutionLogs).values({
+        executionId,
+        nodeId: "trigger",
+        nodeName: "Trigger",
+        nodeType: "trigger",
+        status,
+        startedAt: minutesAgo(40),
+        completedAt,
+      });
+    }
+
+    async function readExecution(id: string) {
+      const [row] = await db
+        .select()
+        .from(workflowExecutions)
+        .where(eq(workflowExecutions.id, id));
+      return row;
+    }
+
+    beforeAll(async () => {
+      queryClient = postgres(DATABASE_URL);
+      db = drizzle(queryClient);
+      await cleanup();
+
+      await db.insert(users).values({
+        id: ownerId,
+        email: `${ownerId}@keep934.test`,
+        emailVerified: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      await db.insert(organization).values({
+        id: orgId,
+        name: orgId,
+        slug: orgId,
+        createdAt: new Date(),
+      });
+      await db.insert(workflows).values({
+        id: workflowId,
+        name: workflowId,
+        userId: ownerId,
+        organizationId: orgId,
+        nodes: [],
+        edges: [],
+        visibility: "private",
+        enabled: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      // running, never produced a step log, older than the 5-min pending cutoff:
+      // the fix - reaped as infrastructure/P-0001, not held to 30 min.
+      await seedExecution(ID.runningNoLogsStale, "running", minutesAgo(6));
+
+      // running, produced a step log that never completed, older than 30 min:
+      // genuinely stalled after progressing - workflow_engine/E-0001.
+      await seedExecution(ID.runningWithLogStale, "running", minutesAgo(31));
+      await seedStepLog(ID.runningWithLogStale, "running", null);
+
+      // running, older than 30 min, but a step COMPLETED within the threshold:
+      // actively progressing - never reaped (excludeIds).
+      await seedExecution(ID.runningRecentlyActive, "running", minutesAgo(31));
+      await seedStepLog(ID.runningRecentlyActive, "success", minutesAgo(1));
+
+      // pending, no logs, older than 5 min: unchanged - infrastructure/P-0001.
+      await seedExecution(ID.pendingNoLogsStale, "pending", minutesAgo(6));
+
+      // phantom, older than 5 min: unchanged - infrastructure/P-0005.
+      await seedExecution(ID.phantomStale, "phantom", minutesAgo(6));
+
+      // running, no logs, younger than 5 min: give the pod time to boot - not
+      // reaped yet.
+      await seedExecution(ID.runningNoLogsFresh, "running", minutesAgo(3));
+
+      // running, has a step log, only 10 min in: progressing normally, well under
+      // the 30-min running threshold - not reaped.
+      await seedExecution(ID.runningWithLogFresh, "running", minutesAgo(10));
+      await seedStepLog(ID.runningWithLogFresh, "running", null);
+
+      reapedIds = await reapStaleExecutions(THRESHOLD_MINUTES);
+    });
+
+    afterAll(async () => {
+      await cleanup();
+      await queryClient.end();
+    });
+
+    it("reaps a never-progressed running row as infrastructure/P-0001 (the fix)", async () => {
+      expect(reapedIds).toContain(ID.runningNoLogsStale);
+      const row = await readExecution(ID.runningNoLogsStale);
+      expect(row.status).toBe("system_error");
+      expect(row.errorCategory).toBe("infrastructure");
+      expect(row.errorCode).toBe("P-0001");
+      expect(row.errorType).toBe("system");
+    });
+
+    it("reaps a progressed-then-stalled running row as workflow_engine/E-0001", async () => {
+      expect(reapedIds).toContain(ID.runningWithLogStale);
+      const row = await readExecution(ID.runningWithLogStale);
+      expect(row.status).toBe("system_error");
+      expect(row.errorCategory).toBe("workflow_engine");
+      expect(row.errorCode).toBe("E-0001");
+    });
+
+    it("does NOT reap a running row with a recently completed step", async () => {
+      expect(reapedIds).not.toContain(ID.runningRecentlyActive);
+      expect((await readExecution(ID.runningRecentlyActive)).status).toBe(
+        "running"
+      );
+    });
+
+    it("reaps a stale pending row as infrastructure/P-0001 (unchanged)", async () => {
+      expect(reapedIds).toContain(ID.pendingNoLogsStale);
+      const row = await readExecution(ID.pendingNoLogsStale);
+      expect(row.status).toBe("system_error");
+      expect(row.errorCategory).toBe("infrastructure");
+      expect(row.errorCode).toBe("P-0001");
+    });
+
+    it("reaps a stale phantom row as infrastructure/P-0005 (unchanged)", async () => {
+      expect(reapedIds).toContain(ID.phantomStale);
+      const row = await readExecution(ID.phantomStale);
+      expect(row.status).toBe("system_error");
+      expect(row.errorCategory).toBe("infrastructure");
+      expect(row.errorCode).toBe("P-0005");
+    });
+
+    it("does NOT reap a running-no-logs row younger than the pending cutoff", async () => {
+      expect(reapedIds).not.toContain(ID.runningNoLogsFresh);
+      expect((await readExecution(ID.runningNoLogsFresh)).status).toBe(
+        "running"
+      );
+    });
+
+    it("does NOT reap a progressing running row still under the running threshold", async () => {
+      expect(reapedIds).not.toContain(ID.runningWithLogFresh);
+      expect((await readExecution(ID.runningWithLogFresh)).status).toBe(
+        "running"
+      );
+    });
+  }
+);

--- a/tests/e2e/vitest/reaper-classification.test.ts
+++ b/tests/e2e/vitest/reaper-classification.test.ts
@@ -183,6 +183,12 @@ describe.skipIf(SKIP)(
       await seedExecution(ID.runningWithLogFresh, "running", minutesAgo(10));
       await seedStepLog(ID.runningWithLogFresh, "running", null);
 
+      // NOTE: reapStaleExecutions is GLOBAL - it reaps every stale row in the DB,
+      // not just this suite's PREFIX. On the shared local/CI database this can
+      // flip stale rows another suite left behind. Assertions below are therefore
+      // scoped by fixture id (toContain / not.toContain), never by the exact
+      // contents of reapedIds, and vitest runs test files serially
+      // (fileParallelism:false) so no other suite is mutating rows concurrently.
       reapedIds = await reapStaleExecutions(THRESHOLD_MINUTES);
     });
 

--- a/tests/e2e/vitest/reaper-classification.test.ts
+++ b/tests/e2e/vitest/reaper-classification.test.ts
@@ -22,9 +22,11 @@ vi.mock("server-only", () => ({}));
 
 // The reaper classifies a stuck execution by whether it ever produced a step
 // log, not by its raw status. A `running` row with NO step logs never entered
-// the workflow body (pod died/never scheduled) and must be reaped promptly as
-// infrastructure/P-0001, exactly like `pending`/`phantom` - not held to the
-// 30-min running threshold and booked as workflow_engine/E-0001. This exercises
+// the workflow body (pod died/never scheduled) and is booked as
+// infrastructure/P-0001, like `pending`/`phantom` - NOT workflow_engine/E-0001.
+// It is still reaped at the full 30-min running threshold (not the 5-min pending
+// cutoff): a durably enqueued run also sits running+no-logs until a worker picks
+// it up, so reaping early would false-fail healthy queued runs. This exercises
 // that CASE + the OR of stale conditions against a real Postgres.
 
 const SKIP =
@@ -66,7 +68,7 @@ describe.skipIf(SKIP)(
       runningRecentlyActive: `${PREFIX}running_recent`,
       pendingNoLogsStale: `${PREFIX}pending_nolog_stale`,
       phantomStale: `${PREFIX}phantom_stale`,
-      runningNoLogsFresh: `${PREFIX}running_nolog_fresh`,
+      runningNoLogsQueued: `${PREFIX}running_nolog_queued`,
       runningWithLogFresh: `${PREFIX}running_log_fresh`,
     };
 
@@ -149,9 +151,10 @@ describe.skipIf(SKIP)(
         updatedAt: new Date(),
       });
 
-      // running, never produced a step log, older than the 5-min pending cutoff:
-      // the fix - reaped as infrastructure/P-0001, not held to 30 min.
-      await seedExecution(ID.runningNoLogsStale, "running", minutesAgo(6));
+      // running, never produced a step log, older than the 30-min running
+      // threshold: reaped as infrastructure/P-0001 (not workflow_engine/E-0001)
+      // because it never entered the workflow body.
+      await seedExecution(ID.runningNoLogsStale, "running", minutesAgo(31));
 
       // running, produced a step log that never completed, older than 30 min:
       // genuinely stalled after progressing - workflow_engine/E-0001.
@@ -169,9 +172,11 @@ describe.skipIf(SKIP)(
       // phantom, older than 5 min: unchanged - infrastructure/P-0005.
       await seedExecution(ID.phantomStale, "phantom", minutesAgo(6));
 
-      // running, no logs, younger than 5 min: give the pod time to boot - not
-      // reaped yet.
-      await seedExecution(ID.runningNoLogsFresh, "running", minutesAgo(3));
+      // running, no logs, but only 20 min in (past the 5-min pending cutoff, well
+      // under the 30-min running threshold): a durably enqueued run waiting on a
+      // worker looks identical to this, so it must NOT be reaped early - this is
+      // the regression guard against false-failing healthy queued runs.
+      await seedExecution(ID.runningNoLogsQueued, "running", minutesAgo(20));
 
       // running, has a step log, only 10 min in: progressing normally, well under
       // the 30-min running threshold - not reaped.
@@ -226,9 +231,9 @@ describe.skipIf(SKIP)(
       expect(row.errorCode).toBe("P-0005");
     });
 
-    it("does NOT reap a running-no-logs row younger than the pending cutoff", async () => {
-      expect(reapedIds).not.toContain(ID.runningNoLogsFresh);
-      expect((await readExecution(ID.runningNoLogsFresh)).status).toBe(
+    it("does NOT reap a running-no-logs row still under the running threshold (queued-run guard)", async () => {
+      expect(reapedIds).not.toContain(ID.runningNoLogsQueued);
+      expect((await readExecution(ID.runningNoLogsQueued)).status).toBe(
         "running"
       );
     });

--- a/tests/e2e/vitest/reaper-codes.test.ts
+++ b/tests/e2e/vitest/reaper-codes.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   organization,
   users,
+  workflowExecutionLogs,
   workflowExecutions,
   workflows,
 } from "../../../lib/db/schema";
@@ -41,9 +42,11 @@ const DATABASE_URL = process.env.DATABASE_URL ?? "";
 const PREFIX = "test_keep693_reaper_";
 const MIN = 60 * 1000;
 
-// The reaper's error_code is a CASE on the pre-update status, applied across
-// three OR'd stuck-state predicates. The CASE and the WHERE live in SQL, so
-// this exercises them against a real database rather than a mock.
+// The reaper's error_code is a CASE on the pre-update status AND step-log
+// presence, applied across the OR'd stuck-state predicates. A running row that
+// produced a step log then stalled is workflow_engine/E-0001; a running row that
+// never logged a step is infrastructure/P-0001, like pending/phantom. The CASE
+// and the WHERE live in SQL, so this exercises them against a real database.
 describe.skipIf(SKIP)("reaper error codes", () => {
   let queryClient: ReturnType<typeof postgres>;
   let db: ReturnType<typeof drizzle>;
@@ -52,6 +55,7 @@ describe.skipIf(SKIP)("reaper error codes", () => {
   const workflowId = `${PREFIX}wf`;
 
   async function cleanupRows(): Promise<void> {
+    await queryClient`DELETE FROM workflow_execution_logs WHERE execution_id LIKE ${`${PREFIX}%`}`;
     await queryClient`DELETE FROM workflow_executions WHERE id LIKE ${`${PREFIX}%`}`;
   }
 
@@ -86,6 +90,7 @@ describe.skipIf(SKIP)("reaper error codes", () => {
   beforeAll(async () => {
     queryClient = postgres(DATABASE_URL);
     db = drizzle(queryClient);
+    await queryClient`DELETE FROM workflow_execution_logs WHERE execution_id LIKE ${`${PREFIX}%`}`;
     await queryClient`DELETE FROM workflow_executions WHERE id LIKE ${`${PREFIX}%`}`;
     await queryClient`DELETE FROM workflows WHERE id LIKE ${`${PREFIX}%`}`;
     await queryClient`DELETE FROM organization WHERE id LIKE ${`${PREFIX}%`}`;
@@ -132,6 +137,16 @@ describe.skipIf(SKIP)("reaper error codes", () => {
 
   it("codes each reaped row by its pre-update status", async () => {
     await seed(`${PREFIX}running`, "running", 31 * MIN);
+    // Give the running row a step log (never completed) so it counts as
+    // progressed-then-stalled -> workflow_engine/E-0001, not never-started.
+    await db.insert(workflowExecutionLogs).values({
+      executionId: `${PREFIX}running`,
+      nodeId: "trigger",
+      nodeName: "Trigger",
+      nodeType: "trigger",
+      status: "running",
+      startedAt: new Date(Date.now() - 31 * MIN),
+    });
     await seed(`${PREFIX}pending`, "pending", 10 * MIN);
     await seed(`${PREFIX}phantom`, "phantom", 10 * MIN);
 


### PR DESCRIPTION
## Summary

The reaper classified stuck executions by their raw status. After the executor's SQS consume path began claiming manual/webhook rows `pending -> running` before dispatch, a run whose pod never scheduled (FailedCreatePodSandBox / ImagePullBackOff, so no step logs) sat in `running` and was reaped by the 30-min `running` branch as `E-0001` / `workflow_engine` instead of the 5-min `pending` branch as `P-0001` / `infrastructure`. Two problems: ~25-min-slower failure surfacing (stuck UI spinner), and an infrastructure outage booked into the `workflow_engine` SLA series the reaper's own errorCategory CASE was designed to keep separate.

This classifies by whether an execution ever produced a step log, not by raw status. The runner writes its first `workflow_execution_logs` row at the start of the trigger node, before any user action step, so a `running` row with zero step logs provably never entered the workflow body - an infrastructure / never-progressed failure, not a slow first step.

## Changes

- Extract the stale-detection + classifying UPDATE from the route handler into a testable `lib/reaper/reap-stale-executions.ts`; the route keeps auth + the response wrapper.
- Add a stale condition: `status='running'` AND older than the 5-min pending cutoff AND no step logs -> reaped promptly instead of being held to the 30-min running threshold.
- Reclassify by step-log presence (via one shared `EXISTS` predicate) rather than raw status:
  - `errorCategory`: `running` with logs -> `workflow_engine`; everything else (pending, phantom, running-no-logs) -> `infrastructure`.
  - `errorCode`: `phantom` -> P-0005; `running` with logs -> E-0001; else -> P-0001.

Net: a never-dispatched run whose pod never scheduled is reaped as `infrastructure` / P-0001 at ~5 min instead of `workflow_engine` / E-0001 at 30 min. General correctness improvement for any never-executed `running` row.

No schema change, no migration, no app-route / billing / UI changes. The executor's `pending -> running` claim is unchanged.

## Test Plan

New DB-backed test `tests/e2e/vitest/reaper-classification.test.ts` seeds each state against a real Postgres and asserts classification after one reap pass:

- running + no logs + >5min -> system_error / infrastructure / P-0001 (the fix)
- running + uncompleted step log + >30min -> workflow_engine / E-0001
- running + recently completed step -> not reaped (active)
- pending + no logs + >5min -> infrastructure / P-0001 (unchanged)
- phantom + >5min -> infrastructure / P-0005 (unchanged)
- running + no logs + <5min -> not reaped
- running + logged, 10min in -> not reaped

- [x] type-check + biome clean
- [x] 7/7 reaper tests pass locally
