### PR TITLE
fix(web3): don't double-send sponsored transactions on slow Turnkey confirmations

### DIFF
--- a/lib/web3/sponsored-send-error.ts
+++ b/lib/web3/sponsored-send-error.ts
@@ -1,0 +1,84 @@
+import "server-only";
+
+import { ErrorCategory, logSystemWarn, logUserError } from "@/lib/logging";
+import {
+  isSponsoredTxPendingError,
+  isSponsoredTxRevertError,
+} from "@/lib/web3/turnkey-revert";
+
+export type SponsoredSendDecision =
+  | { fallback: false; error: string }
+  | { fallback: true };
+
+/**
+ * Classify a throw from the Turnkey-sponsored send path and decide whether the
+ * caller may retry the transaction via direct signing.
+ *
+ * Returns `fallback: false` (a terminal error result) whenever the sponsored
+ * transaction is already committed on Turnkey's side -- it either reverted
+ * on-chain, or was accepted but not yet confirmed. Re-sending in those cases
+ * would broadcast a second transaction from the same wallet and race the
+ * sponsored one. Returns `fallback: true` only for genuine pre-broadcast
+ * failures, where direct signing is safe.
+ *
+ * Shared by every web3 write step so the "never double-send" rule stays
+ * identical across write-contract, transfer-token, approve-token, and
+ * transfer-funds.
+ */
+export function resolveSponsoredSendError(
+  error: unknown,
+  ctx: { logPrefix: string; actionName: string; chainId: number }
+): SponsoredSendDecision {
+  const { logPrefix, actionName, chainId } = ctx;
+
+  if (isSponsoredTxRevertError(error)) {
+    logUserError(
+      ErrorCategory.TRANSACTION,
+      `${logPrefix} Sponsored transaction reverted on-chain`,
+      error,
+      {
+        plugin_name: "web3",
+        action_name: actionName,
+        chain_id: String(chainId),
+        tx_hash: error.txHash,
+        send_transaction_status_id: error.sendTransactionStatusId,
+        revert_chain_depth: String(error.revertChain.length),
+      }
+    );
+    return {
+      fallback: false,
+      error: `Transaction reverted: ${error.message} (tx ${error.txHash})`,
+    };
+  }
+
+  if (isSponsoredTxPendingError(error)) {
+    logSystemWarn(
+      ErrorCategory.TRANSACTION,
+      `${logPrefix} Sponsored transaction unconfirmed; not falling back to direct signing`,
+      error,
+      {
+        plugin_name: "web3",
+        action_name: actionName,
+        chain_id: String(chainId),
+        send_transaction_status_id: error.sendTransactionStatusId,
+      }
+    );
+    return {
+      fallback: false,
+      error:
+        "Sponsored transaction was submitted but not confirmed in time. It may still complete; not retrying to avoid a duplicate transaction.",
+    };
+  }
+
+  logUserError(
+    ErrorCategory.TRANSACTION,
+    `${logPrefix} Sponsorship attempted but failed, falling back to direct signing`,
+    error,
+    {
+      plugin_name: "web3",
+      action_name: actionName,
+      chain_id: String(chainId),
+    }
+  );
+  return { fallback: true };
+}

--- a/lib/web3/sponsored-transaction-manager.ts
+++ b/lib/web3/sponsored-transaction-manager.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import type { Hex } from "viem";
-import { createPublicClient, encodeFunctionData, http } from "viem";
+import { BaseError, createPublicClient, encodeFunctionData, http } from "viem";
 import {
   checkGasCredits,
   getGasTokenPriceUsd,
@@ -12,6 +12,7 @@ import { MetricNames } from "@/lib/metrics/types";
 import { isTestnetChain } from "@/lib/web3/chainlink-feeds";
 import { createSponsoredClient } from "@/lib/web3/sponsored-client";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
+import { SponsoredTxRevertError } from "@/lib/web3/turnkey-revert";
 import { submitTurnkeySponsoredTransaction } from "@/lib/web3/turnkey-sponsored-tx";
 import { isSponsorshipSupported } from "@/lib/web3/turnkey-sponsorship-config";
 
@@ -97,6 +98,7 @@ export async function executeSponsoredTransaction(
 
   return await finalizeSponsoredTx(
     submitResult.txHash,
+    submitResult.sendTransactionStatusId,
     params.rpcUrl,
     params.organizationId,
     params.chainId,
@@ -156,11 +158,56 @@ export async function executeSponsoredContractTransaction(
 
   return await finalizeSponsoredTx(
     submitResult.txHash,
+    submitResult.sendTransactionStatusId,
     params.rpcUrl,
     params.organizationId,
     params.chainId,
     params.executionId
   );
+}
+
+// viem renders an Error(string) revert as
+// "Execution reverted with reason: <reason>." -- pull <reason> back out.
+const VIEM_REVERT_REASON_RE = /reverted with reason:\s*(.+?)\.?\s*$/i;
+
+/**
+ * Recover the revert reason of an already-mined, reverted sponsored tx.
+ *
+ * This is a read-only `eth_call` replay against the block the tx landed in --
+ * it never broadcasts a second transaction, so it does NOT double-send. Returns
+ * undefined when the reason cannot be decoded (custom error without an ABI, or
+ * state drift so the replay no longer reverts); callers fall back to a generic
+ * message.
+ */
+async function decodeSponsoredRevertReason(
+  publicClient: ReturnType<typeof createPublicClient>,
+  txHash: Hex,
+  blockNumber: bigint
+): Promise<string | undefined> {
+  let tx: Awaited<ReturnType<typeof publicClient.getTransaction>>;
+  try {
+    tx = await publicClient.getTransaction({ hash: txHash });
+  } catch {
+    return;
+  }
+  if (!tx.to) {
+    return;
+  }
+  try {
+    await publicClient.call({
+      account: tx.from,
+      to: tx.to,
+      data: tx.input,
+      value: tx.value,
+      blockNumber,
+    });
+    return;
+  } catch (replayError) {
+    if (replayError instanceof BaseError) {
+      return VIEM_REVERT_REASON_RE.exec(replayError.shortMessage)?.[1]?.trim();
+    }
+    return;
+  }
 }
 
 /**
@@ -173,6 +220,7 @@ export async function executeSponsoredContractTransaction(
  */
 async function finalizeSponsoredTx(
   txHash: Hex,
+  sendTransactionStatusId: string,
   rpcUrl: string,
   organizationId: string,
   chainId: number,
@@ -187,7 +235,21 @@ async function finalizeSponsoredTx(
   });
 
   if (receipt.status !== "success") {
-    throw new Error(`Sponsored transaction reverted: ${txHash}`);
+    // The sponsored tx is on-chain and reverted. Read-only replay to recover
+    // the reason (Turnkey's early hash meant we never saw its FAILED status),
+    // then raise the typed revert error -- not a generic Error -- so the caller
+    // reports it as the node result instead of falling back and duplicating.
+    const reason = await decodeSponsoredRevertReason(
+      publicClient,
+      txHash,
+      receipt.blockNumber
+    );
+    throw new SponsoredTxRevertError({
+      message: reason ?? "reason unavailable",
+      txHash,
+      sendTransactionStatusId,
+      revertChain: [],
+    });
   }
 
   const gasUsed = receipt.gasUsed;

--- a/lib/web3/turnkey-revert.ts
+++ b/lib/web3/turnkey-revert.ts
@@ -66,6 +66,34 @@ export function isSponsoredTxRevertError(
 }
 
 /**
+ * Thrown when a sponsored transaction was accepted by Turnkey (we hold a
+ * `sendTransactionStatusId`) but we could not confirm its terminal outcome
+ * within the wait window, or Turnkey's status API kept failing. The send may
+ * still broadcast and mine, so callers MUST NOT fall back to direct signing --
+ * re-sending would put a second transaction from the same wallet on-chain and
+ * race the sponsored one.
+ */
+export class SponsoredTxPendingError extends Error {
+  readonly kind = "sponsored-tx-pending" as const;
+  readonly sendTransactionStatusId: string;
+
+  constructor(opts: { message: string; sendTransactionStatusId: string }) {
+    super(opts.message);
+    this.name = "SponsoredTxPendingError";
+    this.sendTransactionStatusId = opts.sendTransactionStatusId;
+  }
+}
+
+export function isSponsoredTxPendingError(
+  err: unknown
+): err is SponsoredTxPendingError {
+  return (
+    err instanceof Error &&
+    (err as { kind?: string }).kind === "sponsored-tx-pending"
+  );
+}
+
+/**
  * Render a Turnkey revert chain into a single human-readable string.
  *
  * Walks the chain outermost-to-innermost (the order Turnkey returns).

--- a/lib/web3/turnkey-sponsored-tx.ts
+++ b/lib/web3/turnkey-sponsored-tx.ts
@@ -5,6 +5,7 @@ import { getTurnkeyClientForOrg } from "@/lib/turnkey/agentic-wallet";
 import {
   formatRevertChain,
   type RevertChainEntry,
+  SponsoredTxPendingError,
   SponsoredTxRevertError,
 } from "@/lib/web3/turnkey-revert";
 import { toCaip2 } from "@/lib/web3/turnkey-sponsorship-config";
@@ -18,33 +19,43 @@ import { toCaip2 } from "@/lib/web3/turnkey-sponsorship-config";
  * Station, and broadcasts. The activity returns a `sendTransactionStatusId`
  * which we poll until the transaction is broadcast and a hash is available.
  *
- * If the chain is not supported, or the polling deadline expires, callers
- * receive null and should fall back to direct signing.
+ * Return contract:
+ *   - `null` only for failures that happened BEFORE anything was broadcast
+ *     (unsupported chain, `ethSendTransaction` rejected, or a terminal-failure
+ *     status with no tx hash). Callers may safely fall back to direct signing.
+ *   - `SponsoredTxRevertError` when the tx broadcast and reverted on-chain.
+ *   - `SponsoredTxPendingError` when the send was accepted but we could not
+ *     confirm its outcome within the wait window (Turnkey slow to broadcast,
+ *     or its status API kept erroring). The tx may still land, so callers MUST
+ *     NOT fall back -- doing so double-sends from the same wallet.
  */
 
 const STATUS_POLL_INTERVAL_MS = 1000;
-const STATUS_POLL_TIMEOUT_MS = 30_000;
+// Turnkey's Gas Station queues, gas-funds, and broadcasts, then inclusion waits
+// on the mempool -- routinely longer than 30s under load. A short deadline made
+// the poll return null and the caller re-send via direct signing, so a slow
+// sponsored tx and its direct-signed retry both landed a block apart and the
+// second reverted. Wait longer so a normal-but-slow send resolves to a real
+// hash (or a real revert) instead of an ambiguous timeout.
+const STATUS_POLL_TIMEOUT_MS = 120_000;
+// Tolerate transient Turnkey status-API blips before giving up on confirmation.
+const MAX_CONSECUTIVE_STATUS_ERRORS = 3;
+
+type PollOptions = {
+  timeoutMs?: number;
+  intervalMs?: number;
+};
 
 // Turnkey's getSendTransactionStatus returns short status strings
 // (INITIALIZED, BROADCASTING, BROADCASTED, INCLUDED, CONFIRMED, FINALIZED,
-// FAILED, DROPPED, REJECTED), NOT the `TRANSACTION_STATUS_*` enum the API uses
-// elsewhere -- the original constants never matched, so the poll always timed
-// out and callers fell back to direct signing. Turnkey reports INCLUDED only
-// once the tx succeeded on-chain and FAILED for reverts, so matching the real
-// terminal states keeps revert detection (SponsoredTxRevertError) intact.
+// FAILED, DROPPED, REJECTED). We treat these as failures; any other status
+// that carries a tx hash means the send is broadcast and we wait on that hash.
 const TERMINAL_FAILURE_STATUSES = new Set([
   "FAILED",
   "DROPPED",
   "REJECTED",
   "TIMEOUT",
   "REVERTED",
-]);
-
-const TERMINAL_SUCCESS_STATUSES = new Set([
-  "BROADCASTED",
-  "INCLUDED",
-  "CONFIRMED",
-  "FINALIZED",
 ]);
 
 export type TurnkeySponsoredTxParams = {
@@ -73,7 +84,8 @@ function sleep(ms: number): Promise<void> {
  * fall back to direct signing.
  */
 export async function submitTurnkeySponsoredTransaction(
-  params: TurnkeySponsoredTxParams
+  params: TurnkeySponsoredTxParams,
+  pollOptions?: PollOptions
 ): Promise<TurnkeySponsoredTxResult | null> {
   const caip2 = toCaip2(params.chainId);
   if (caip2 === null) {
@@ -118,7 +130,7 @@ export async function submitTurnkeySponsoredTransaction(
     return null;
   }
 
-  const txHash = await pollForTxHash(params.subOrgId, statusId);
+  const txHash = await pollForTxHash(params.subOrgId, statusId, pollOptions);
   if (txHash === null) {
     return null;
   }
@@ -128,11 +140,16 @@ export async function submitTurnkeySponsoredTransaction(
 
 async function pollForTxHash(
   subOrgId: string,
-  sendTransactionStatusId: string
+  sendTransactionStatusId: string,
+  pollOptions?: PollOptions
 ): Promise<Hex | null> {
   const turnkey = getTurnkeyClientForOrg(subOrgId);
   const client = turnkey.apiClient();
-  const deadline = Date.now() + STATUS_POLL_TIMEOUT_MS;
+  const timeoutMs = pollOptions?.timeoutMs ?? STATUS_POLL_TIMEOUT_MS;
+  const intervalMs = pollOptions?.intervalMs ?? STATUS_POLL_INTERVAL_MS;
+  const deadline = Date.now() + timeoutMs;
+
+  let consecutiveStatusErrors = 0;
 
   while (Date.now() < deadline) {
     let response: Awaited<ReturnType<typeof client.getSendTransactionStatus>>;
@@ -141,6 +158,7 @@ async function pollForTxHash(
         organizationId: subOrgId,
         sendTransactionStatusId,
       });
+      consecutiveStatusErrors = 0;
     } catch (error) {
       logSystemError(
         ErrorCategory.EXTERNAL_SERVICE,
@@ -151,7 +169,19 @@ async function pollForTxHash(
           send_transaction_status_id: sendTransactionStatusId,
         }
       );
-      return null;
+      // The send was already accepted; a status blip does not mean it failed.
+      // Retry a few times, then surface a pending error rather than returning
+      // null (which would let the caller re-send and double-broadcast).
+      consecutiveStatusErrors++;
+      if (consecutiveStatusErrors >= MAX_CONSECUTIVE_STATUS_ERRORS) {
+        throw new SponsoredTxPendingError({
+          message:
+            "Turnkey status API unavailable; sponsored transaction outcome unknown",
+          sendTransactionStatusId,
+        });
+      }
+      await sleep(intervalMs);
+      continue;
     }
 
     const hash = response.eth?.txHash;
@@ -193,25 +223,30 @@ async function pollForTxHash(
       return null;
     }
 
-    if (
-      TERMINAL_SUCCESS_STATUSES.has(response.txStatus) &&
-      hash !== undefined &&
-      hash !== ""
-    ) {
+    // Turnkey assigned a hash -> the tx is broadcast and we own it. Return it
+    // so the caller waits for the receipt and reports the real on-chain outcome
+    // (included or reverted) as the node result, and never re-sends.
+    if (hash !== undefined && hash !== "") {
       return hash as Hex;
     }
 
-    await sleep(STATUS_POLL_INTERVAL_MS);
+    await sleep(intervalMs);
   }
 
+  // Deadline hit without a terminal status. The send was accepted and may
+  // still broadcast, so surface a pending error instead of null: the caller
+  // must fail the step rather than re-send via direct signing.
   logSystemError(
     ErrorCategory.EXTERNAL_SERVICE,
     "[Turnkey Sponsorship] Timed out waiting for tx hash",
-    new Error(`No txHash within ${STATUS_POLL_TIMEOUT_MS}ms`),
+    new Error(`No terminal status within ${timeoutMs}ms`),
     {
       service: "turnkey",
       send_transaction_status_id: sendTransactionStatusId,
     }
   );
-  return null;
+  throw new SponsoredTxPendingError({
+    message: `Sponsored transaction not confirmed within ${timeoutMs}ms; outcome unknown`,
+    sendTransactionStatusId,
+  });
 }

--- a/plugins/web3/steps/approve-token-core.ts
+++ b/plugins/web3/steps/approve-token-core.ts
@@ -36,11 +36,11 @@ import {
 import { resolveGasLimitOverrides } from "@/lib/web3/gas-defaults";
 import { isSponsorshipSupported } from "@/lib/web3/turnkey-sponsorship-config";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
+import { resolveSponsoredSendError } from "@/lib/web3/sponsored-send-error";
 import { executeSponsoredContractTransaction } from "@/lib/web3/sponsored-transaction-manager";
 import type { ExecutedCall } from "@/lib/web3/trace-decode";
 import { traceExecutedCallWithFailover } from "@/lib/web3/trace-executed-call";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
-import { isSponsoredTxRevertError } from "@/lib/web3/turnkey-revert";
 import {
   type TransactionContext,
   withNonceSession,
@@ -341,35 +341,14 @@ export async function approveTokenCore(
         }
       );
     } catch (error) {
-      if (isSponsoredTxRevertError(error)) {
-        logUserError(
-          ErrorCategory.TRANSACTION,
-          "[Approve Token] Sponsored transaction reverted on-chain",
-          error,
-          {
-            plugin_name: "web3",
-            action_name: "approve-token",
-            chain_id: String(chainId),
-            tx_hash: error.txHash,
-            send_transaction_status_id: error.sendTransactionStatusId,
-            revert_chain_depth: String(error.revertChain.length),
-          }
-        );
-        return {
-          success: false,
-          error: `Transaction reverted: ${error.message}`,
-        };
+      const decision = resolveSponsoredSendError(error, {
+        logPrefix: "[Approve Token]",
+        actionName: "approve-token",
+        chainId,
+      });
+      if (!decision.fallback) {
+        return { success: false, error: decision.error };
       }
-      logUserError(
-        ErrorCategory.TRANSACTION,
-        "[Approve Token] Sponsorship attempted but failed, falling back to direct signing",
-        error,
-        {
-          plugin_name: "web3",
-          action_name: "approve-token",
-          chain_id: String(chainId),
-        }
-      );
     }
   }
 

--- a/plugins/web3/steps/transfer-funds-core.ts
+++ b/plugins/web3/steps/transfer-funds-core.ts
@@ -34,9 +34,9 @@ import {
 } from "@/lib/web3/decode-revert-error";
 import { resolveGasLimitOverrides } from "@/lib/web3/gas-defaults";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
+import { resolveSponsoredSendError } from "@/lib/web3/sponsored-send-error";
 import { executeSponsoredTransaction } from "@/lib/web3/sponsored-transaction-manager";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
-import { isSponsoredTxRevertError } from "@/lib/web3/turnkey-revert";
 import {
   type TransactionContext,
   withNonceSession,
@@ -266,38 +266,14 @@ export async function transferFundsCore(
         }
       );
     } catch (error) {
-      if (isSponsoredTxRevertError(error)) {
-        // Sponsored tx was broadcast and reverted on-chain. Do NOT fall back
-        // to direct signing -- the underlying call would just revert again
-        // and the user would pay gas twice.
-        logUserError(
-          ErrorCategory.TRANSACTION,
-          "[Transfer Funds] Sponsored transaction reverted on-chain",
-          error,
-          {
-            plugin_name: "web3",
-            action_name: "transfer-funds",
-            chain_id: String(chainId),
-            tx_hash: error.txHash,
-            send_transaction_status_id: error.sendTransactionStatusId,
-            revert_chain_depth: String(error.revertChain.length),
-          }
-        );
-        return {
-          success: false,
-          error: `Transaction reverted: ${error.message}`,
-        };
+      const decision = resolveSponsoredSendError(error, {
+        logPrefix: "[Transfer Funds]",
+        actionName: "transfer-funds",
+        chainId,
+      });
+      if (!decision.fallback) {
+        return { success: false, error: decision.error };
       }
-      logUserError(
-        ErrorCategory.TRANSACTION,
-        "[Transfer Funds] Sponsorship attempted but failed, falling back to direct signing",
-        error,
-        {
-          plugin_name: "web3",
-          action_name: "transfer-funds",
-          chain_id: String(chainId),
-        }
-      );
     }
   }
 

--- a/plugins/web3/steps/transfer-token-core.ts
+++ b/plugins/web3/steps/transfer-token-core.ts
@@ -40,11 +40,11 @@ import {
 import { resolveGasLimitOverrides } from "@/lib/web3/gas-defaults";
 import { isSponsorshipSupported } from "@/lib/web3/turnkey-sponsorship-config";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
+import { resolveSponsoredSendError } from "@/lib/web3/sponsored-send-error";
 import { executeSponsoredContractTransaction } from "@/lib/web3/sponsored-transaction-manager";
 import type { ExecutedCall } from "@/lib/web3/trace-decode";
 import { traceExecutedCallWithFailover } from "@/lib/web3/trace-executed-call";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
-import { isSponsoredTxRevertError } from "@/lib/web3/turnkey-revert";
 import {
   type TransactionContext,
   withNonceSession,
@@ -431,35 +431,14 @@ export async function transferTokenCore(
         }
       );
     } catch (error) {
-      if (isSponsoredTxRevertError(error)) {
-        logUserError(
-          ErrorCategory.TRANSACTION,
-          "[Transfer Token] Sponsored transaction reverted on-chain",
-          error,
-          {
-            plugin_name: "web3",
-            action_name: "transfer-token",
-            chain_id: String(chainId),
-            tx_hash: error.txHash,
-            send_transaction_status_id: error.sendTransactionStatusId,
-            revert_chain_depth: String(error.revertChain.length),
-          }
-        );
-        return {
-          success: false,
-          error: `Transaction reverted: ${error.message}`,
-        };
+      const decision = resolveSponsoredSendError(error, {
+        logPrefix: "[Transfer Token]",
+        actionName: "transfer-token",
+        chainId,
+      });
+      if (!decision.fallback) {
+        return { success: false, error: decision.error };
       }
-      logUserError(
-        ErrorCategory.TRANSACTION,
-        "[Transfer Token] Sponsorship attempted but failed, falling back to direct signing",
-        error,
-        {
-          plugin_name: "web3",
-          action_name: "transfer-token",
-          chain_id: String(chainId),
-        }
-      );
     }
   }
 

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -44,8 +44,8 @@ import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
 import { executeSponsoredContractTransaction } from "@/lib/web3/sponsored-transaction-manager";
 import type { ExecutedCall } from "@/lib/web3/trace-decode";
 import { traceExecutedCallWithFailover } from "@/lib/web3/trace-executed-call";
+import { resolveSponsoredSendError } from "@/lib/web3/sponsored-send-error";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
-import { isSponsoredTxRevertError } from "@/lib/web3/turnkey-revert";
 import {
   type TransactionContext,
   withNonceSession,
@@ -400,35 +400,14 @@ export async function writeContractCore(
         }
       );
     } catch (error) {
-      if (isSponsoredTxRevertError(error)) {
-        logUserError(
-          ErrorCategory.TRANSACTION,
-          "[Write Contract] Sponsored transaction reverted on-chain",
-          error,
-          {
-            plugin_name: "web3",
-            action_name: "write-contract",
-            chain_id: String(chainId),
-            tx_hash: error.txHash,
-            send_transaction_status_id: error.sendTransactionStatusId,
-            revert_chain_depth: String(error.revertChain.length),
-          }
-        );
-        return {
-          success: false,
-          error: `Transaction reverted: ${error.message}`,
-        };
+      const decision = resolveSponsoredSendError(error, {
+        logPrefix: "[Write Contract]",
+        actionName: "write-contract",
+        chainId,
+      });
+      if (!decision.fallback) {
+        return { success: false, error: decision.error };
       }
-      logUserError(
-        ErrorCategory.TRANSACTION,
-        "[Write Contract] Sponsorship attempted but failed, falling back to direct signing",
-        error,
-        {
-          plugin_name: "web3",
-          action_name: "write-contract",
-          chain_id: String(chainId),
-        }
-      );
     }
   }
 

--- a/tests/unit/sponsored-send-error.test.ts
+++ b/tests/unit/sponsored-send-error.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { TRANSACTION: "transaction" },
+  logSystemWarn: vi.fn(),
+  logUserError: vi.fn(),
+}));
+
+// Real error classes so the type guards inside the helper work.
+import { resolveSponsoredSendError } from "@/lib/web3/sponsored-send-error";
+import {
+  SponsoredTxPendingError,
+  SponsoredTxRevertError,
+} from "@/lib/web3/turnkey-revert";
+
+const CTX = { logPrefix: "[Test]", actionName: "write-contract", chainId: 1 };
+
+describe("resolveSponsoredSendError", () => {
+  it("does not fall back on an on-chain revert", () => {
+    const error = new SponsoredTxRevertError({
+      message: "Guard/not-allowed",
+      txHash: "0xabc",
+      sendTransactionStatusId: "sid",
+      revertChain: [],
+    });
+
+    const decision = resolveSponsoredSendError(error, CTX);
+
+    expect(decision.fallback).toBe(false);
+    expect(decision).toMatchObject({
+      error: "Transaction reverted: Guard/not-allowed (tx 0xabc)",
+    });
+  });
+
+  it("does not fall back when the sponsored send is submitted but unconfirmed", () => {
+    const error = new SponsoredTxPendingError({
+      message: "outcome unknown",
+      sendTransactionStatusId: "sid",
+    });
+
+    const decision = resolveSponsoredSendError(error, CTX);
+
+    expect(decision.fallback).toBe(false);
+    expect(decision).toMatchObject({
+      error: expect.stringContaining("not confirmed"),
+    });
+  });
+
+  it("falls back to direct signing on a generic pre-broadcast error", () => {
+    const decision = resolveSponsoredSendError(new Error("boom"), CTX);
+
+    expect(decision.fallback).toBe(true);
+  });
+});

--- a/tests/unit/turnkey-sponsored-tx.test.ts
+++ b/tests/unit/turnkey-sponsored-tx.test.ts
@@ -27,10 +27,16 @@ vi.mock("@/lib/web3/turnkey-sponsorship-config", () => ({
   toCaip2: (chainId: number) => `eip155:${chainId}`,
 }));
 
-// turnkey-revert is intentionally NOT mocked so `instanceof SponsoredTxRevertError`
-// works against the real class.
-import { SponsoredTxRevertError } from "@/lib/web3/turnkey-revert";
+// turnkey-revert is intentionally NOT mocked so `instanceof` works against the
+// real error classes.
+import {
+  SponsoredTxPendingError,
+  SponsoredTxRevertError,
+} from "@/lib/web3/turnkey-revert";
 import { submitTurnkeySponsoredTransaction } from "@/lib/web3/turnkey-sponsored-tx";
+
+// Tight poll options so the timeout / retry paths resolve in milliseconds.
+const FAST_POLL = { timeoutMs: 40, intervalMs: 5 };
 
 const SEPOLIA = 11_155_111;
 // Generic, lowercased test address (not a real wallet); getAddress() yields its
@@ -113,5 +119,44 @@ describe("submitTurnkeySponsoredTransaction", () => {
     const result = await submitTurnkeySponsoredTransaction(baseParams());
 
     expect(result).toBeNull();
+  });
+
+  it("returns the hash as soon as Turnkey assigns one, before a terminal-success status", async () => {
+    mockEthSend.mockResolvedValue({ sendTransactionStatusId: "sid-5" });
+    // Non-terminal status, but Turnkey already has a tx hash -> the send is
+    // broadcast and we own it, so we must return it (not keep polling / re-send).
+    mockGetStatus.mockResolvedValue({
+      txStatus: "BROADCASTING",
+      eth: { txHash: "0xbroadcasting" },
+    });
+
+    const result = await submitTurnkeySponsoredTransaction(
+      baseParams(),
+      FAST_POLL
+    );
+
+    expect(result).toEqual({
+      txHash: "0xbroadcasting",
+      sendTransactionStatusId: "sid-5",
+    });
+  });
+
+  it("throws SponsoredTxPendingError when the wait elapses without a terminal status", async () => {
+    mockEthSend.mockResolvedValue({ sendTransactionStatusId: "sid-6" });
+    // Stuck before broadcast: accepted, but never a hash or terminal status.
+    mockGetStatus.mockResolvedValue({ txStatus: "INITIALIZED", eth: {} });
+
+    await expect(
+      submitTurnkeySponsoredTransaction(baseParams(), FAST_POLL)
+    ).rejects.toBeInstanceOf(SponsoredTxPendingError);
+  });
+
+  it("throws SponsoredTxPendingError after repeated status-API failures instead of returning null", async () => {
+    mockEthSend.mockResolvedValue({ sendTransactionStatusId: "sid-7" });
+    mockGetStatus.mockRejectedValue(new Error("Turnkey status API 503"));
+
+    await expect(
+      submitTurnkeySponsoredTransaction(baseParams(), FAST_POLL)
+    ).rejects.toBeInstanceOf(SponsoredTxPendingError);
   });
 });


### PR DESCRIPTION
## Summary

A gas-sponsored (Turnkey) web3 write could be broadcast twice from the same wallet, one block apart, with the second transaction reverting. The sponsorship poll waited only 30s for Turnkey to confirm; on timeout it returned `null`, the caller read that as "sponsorship failed" and re-sent the transaction via direct signing. The sponsored send and its direct-signed retry then raced each other on-chain.

## Root cause

`pollForTxHash` returned `null` on a 30s timeout without distinguishing "still pending" from "failed before broadcast". `writeContractCore` (and the other write steps) treated `null` as a reason to fall back to direct signing, producing a second transaction while the first was still in flight. Separately, a reverted sponsored receipt threw a generic `Error` that also fell through to the direct-signing fallback.

## Fix

- Raise the confirm wait to 120s and return the tx hash as soon as Turnkey assigns one. The poll stops the instant a hash appears (or a terminal revert), so fast confirmations are unaffected; the timeout is only the maximum.
- Once a send is accepted by Turnkey, never fall back to direct signing. A submitted-but-unconfirmed outcome (timeout or repeated status-API failures) raises the new `SponsoredTxPendingError`; the step fails cleanly instead of re-broadcasting.
- A reverted sponsored receipt now raises the typed `SponsoredTxRevertError`, which callers already report as a terminal node result rather than retrying.
- Extract `resolveSponsoredSendError` and route all four web3 write steps (`write-contract`, `transfer-token`, `approve-token`, `transfer-funds`) through it, so the "never double-send" rule is identical everywhere and cannot drift.

Direct signing is now used only for genuine pre-broadcast failures (unsupported chain, credits exhausted, Turnkey rejected before broadcast).

## Tests

`pnpm type-check` and lint clean; full unit suite passes. Added coverage for returning the hash as soon as Turnkey broadcasts, raising the pending error on timeout and on repeated status-API failures, and the shared fall-back decision.