### PR TITLE
fix: refresh analytics projects list on org switch

### DIFF
--- a/components/analytics/project-drawer.tsx
+++ b/components/analytics/project-drawer.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, ChevronRight, Layers } from "lucide-react";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useState } from "react";
 import { analyticsProjectIdAtom } from "@/lib/atoms/analytics";
+import { authClient } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 
 const STORAGE_KEY = "keeperhub-analytics-drawer";
@@ -40,9 +41,13 @@ function useDrawerState(): [DrawerState, (s: DrawerState) => void] {
 function useProjects(): { projects: Project[]; loading: boolean } {
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
+  const { data: activeOrg } = authClient.useActiveOrganization();
+  const activeOrgId = activeOrg?.id ?? null;
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: activeOrgId is the refetch trigger on org switch; the endpoint scopes by the active org server-side, so it is not read in the body
   useEffect(() => {
     let cancelled = false;
+    setLoading(true);
 
     async function load(): Promise<void> {
       try {
@@ -70,7 +75,7 @@ function useProjects(): { projects: Project[]; loading: boolean } {
     return (): void => {
       cancelled = true;
     };
-  }, []);
+  }, [activeOrgId]);
 
   return { projects, loading };
 }

--- a/lib/hooks/use-organization.ts
+++ b/lib/hooks/use-organization.ts
@@ -1,10 +1,11 @@
 "use client";
 
-import { getDefaultStore } from "jotai";
+import { getDefaultStore, useSetAtom } from "jotai";
 import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { invalidateFeatureSnapshot } from "@/hooks/use-features";
 import { api } from "@/lib/api-client";
+import { analyticsProjectIdAtom } from "@/lib/atoms/analytics";
 import { authClient } from "@/lib/auth-client";
 import { registerOrganizationRefetch } from "@/lib/refetch-organizations";
 import { refetchSidebar } from "@/lib/refetch-sidebar";
@@ -19,6 +20,7 @@ export function useOrganization() {
   } = authClient.useActiveOrganization();
   const router = useRouter();
   const pathname = usePathname();
+  const setAnalyticsProjectId = useSetAtom(analyticsProjectIdAtom);
 
   // Register this hook's refetch callback so it can be triggered externally
   useEffect(
@@ -34,6 +36,7 @@ export function useOrganization() {
     await authClient.organization.setActive({ organizationId: orgId });
     // Reset workflow state only after org switch succeeds (safe in hook context)
     getDefaultStore().set(resetWorkflowStateForOrgSwitchAtom);
+    setAnalyticsProjectId(null);
     invalidateFeatureSnapshot();
     refetchSidebar();
 


### PR DESCRIPTION
## Problem

Switching organizations on the Analytics page left the Projects drawer showing the previous org's projects, and a project selected before the switch kept filtering the KPIs and runs to a project that does not exist in the new org (empty results with no visible cause).

## Root cause

- The drawer's local useProjects hook fetched /api/projects once on mount with an empty dependency array. Nothing re-triggered it on org switch: switchOrganization only calls setActive plus router.refresh(), which re-runs server components, and the whole analytics tree is client-side. The endpoint itself is correctly org-scoped server-side.
- The selected-project atom was never cleared on org switch, so every analytics query kept the old org's project id as a filter.

## Changes

- project-drawer.tsx: useProjects now subscribes to the active organization and re-fetches when the org id changes, showing the loading state during the refetch. Same pattern as the audit-activity projects picker.
- use-organization.ts: switchOrganization clears the analytics project selection via a useSetAtom setter. Note this deliberately does not use getDefaultStore(): the app tree is wrapped in a jotai Provider with its own store, so getDefaultStore() writes are invisible to components (verified empirically; the adjacent workflow-state reset uses getDefaultStore() and is likely a silent no-op today, left untouched here and worth a follow-up).

## Testing

- Biome clean on both files; full tsc --noEmit passes.
- Verified end to end in a browser against local dev with two orgs holding distinct project sets: the drawer showed org A's projects, a project was selected, and after switching orgs the drawer refetched to org B's projects with the selection reset to All Runs and org B's runs displayed. Before the fix the list stayed frozen on org A.