### PR TITLE
fix: scrub RPC provider URLs from workflow error surfaces

### DIFF
--- a/app/api/workflows/executions/[executionId]/logs/route.ts
+++ b/app/api/workflows/executions/[executionId]/logs/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { workflowExecutionLogs } from "@/lib/db/schema";
+import { scrubRpcUrls } from "@/lib/rpc/scrub-rpc-urls";
 import { redactSensitiveData } from "@/lib/utils/redact";
 import { resolveAuthorizedExecution } from "@/lib/workflow/execution-access";
 
@@ -64,6 +65,12 @@ export async function GET(
       );
     }
     const { execution } = resolved;
+    // Scrub on read so rows persisted before URL masking existed do not
+    // re-display keyed RPC URLs.
+    const scrubbedExecution = {
+      ...execution,
+      error: execution.error === null ? null : scrubRpcUrls(execution.error),
+    };
 
     const logs = await db.query.workflowExecutionLogs.findMany({
       where: eq(workflowExecutionLogs.executionId, executionId),
@@ -74,11 +81,12 @@ export async function GET(
       ...log,
       input: redactSensitiveData(log.input),
       output: redactSensitiveData(log.output),
+      error: log.error === null ? null : scrubRpcUrls(log.error),
     }));
 
     if (!hasAnyPartialParam) {
       return NextResponse.json({
-        execution,
+        execution: scrubbedExecution,
         logs: redactedLogs,
       });
     }
@@ -105,7 +113,7 @@ export async function GET(
     });
 
     return NextResponse.json({
-      execution,
+      execution: scrubbedExecution,
       logs: transformedLogs,
     });
   } catch (error) {

--- a/app/api/workflows/executions/[executionId]/logs/route.ts
+++ b/app/api/workflows/executions/[executionId]/logs/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { workflowExecutionLogs } from "@/lib/db/schema";
-import { scrubRpcUrls } from "@/lib/rpc/scrub-rpc-urls";
+import { redactAllUrls, redactSecretUrls } from "@/lib/rpc/scrub-rpc-urls";
 import { redactSensitiveData } from "@/lib/utils/redact";
 import { resolveAuthorizedExecution } from "@/lib/workflow/execution-access";
 
@@ -65,11 +65,14 @@ export async function GET(
       );
     }
     const { execution } = resolved;
-    // Scrub on read so rows persisted before URL masking existed do not
-    // re-display keyed RPC URLs.
+    // Redact on read so rows persisted before URL redaction existed do not
+    // re-display provider RPC URLs. web3 step errors only ever contain
+    // provider URLs, so drop every URL there; other steps may legitimately
+    // reference user-owned URLs.
     const scrubbedExecution = {
       ...execution,
-      error: execution.error === null ? null : scrubRpcUrls(execution.error),
+      error:
+        execution.error === null ? null : redactSecretUrls(execution.error),
     };
 
     const logs = await db.query.workflowExecutionLogs.findMany({
@@ -81,7 +84,12 @@ export async function GET(
       ...log,
       input: redactSensitiveData(log.input),
       output: redactSensitiveData(log.output),
-      error: log.error === null ? null : scrubRpcUrls(log.error),
+      error:
+        log.error === null
+          ? null
+          : log.nodeType.startsWith("web3/")
+            ? redactAllUrls(log.error)
+            : redactSecretUrls(log.error),
     }));
 
     if (!hasAnyPartialParam) {

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -25,7 +25,7 @@ import {
 } from "@/lib/db/schema-extensions";
 import { ERROR_STATUSES } from "@/lib/errors/execution-status";
 import { sumOrgValueTodayWei } from "@/lib/execute/value-ledger";
-import { scrubRpcUrls } from "@/lib/rpc/scrub-rpc-urls";
+import { redactAllUrls, redactSecretUrls } from "@/lib/rpc/scrub-rpc-urls";
 import { analyticsCacheKey, cachedAnalytics } from "./cache";
 import {
   getBucketInterval,
@@ -1050,9 +1050,9 @@ async function fetchWorkflowRuns(
       row.gasUsedWei && row.gasUsedWei !== "0" ? row.gasUsedWei : null,
     totalSteps: row.totalSteps ? Number(row.totalSteps) : null,
     completedSteps: row.completedSteps ? Number(row.completedSteps) : null,
-    // Scrub on read so rows persisted before URL masking existed do not
-    // re-display keyed RPC URLs.
-    error: row.error === null ? null : scrubRpcUrls(row.error),
+    // Redact on read so rows persisted before URL redaction existed do not
+    // re-display provider RPC URLs.
+    error: row.error === null ? null : redactSecretUrls(row.error),
     errorCode: row.errorCode ?? null,
     errorType: row.errorType ?? null,
     errorCategory: row.errorCategory ?? null,
@@ -1289,9 +1289,16 @@ export async function getStepLogs(
     startedAt: row.startedAt.toISOString(),
     completedAt: row.completedAt?.toISOString() ?? null,
     durationMs: row.duration ? Number(row.duration) : null,
-    // Scrub on read so rows persisted before URL masking existed do not
-    // re-display keyed RPC URLs.
-    error: row.error === null ? null : scrubRpcUrls(row.error),
+    // Redact on read so rows persisted before URL redaction existed do not
+    // re-display provider RPC URLs. web3 step errors only ever contain
+    // provider URLs, so drop every URL there; other steps may legitimately
+    // reference user-owned URLs.
+    error:
+      row.error === null
+        ? null
+        : row.nodeType.startsWith("web3/")
+          ? redactAllUrls(row.error)
+          : redactSecretUrls(row.error),
     iterationIndex: row.iterationIndex,
     forEachNodeId: row.forEachNodeId,
     network: row.network,

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -25,6 +25,7 @@ import {
 } from "@/lib/db/schema-extensions";
 import { ERROR_STATUSES } from "@/lib/errors/execution-status";
 import { sumOrgValueTodayWei } from "@/lib/execute/value-ledger";
+import { scrubRpcUrls } from "@/lib/rpc/scrub-rpc-urls";
 import { analyticsCacheKey, cachedAnalytics } from "./cache";
 import {
   getBucketInterval,
@@ -1049,7 +1050,9 @@ async function fetchWorkflowRuns(
       row.gasUsedWei && row.gasUsedWei !== "0" ? row.gasUsedWei : null,
     totalSteps: row.totalSteps ? Number(row.totalSteps) : null,
     completedSteps: row.completedSteps ? Number(row.completedSteps) : null,
-    error: row.error ?? null,
+    // Scrub on read so rows persisted before URL masking existed do not
+    // re-display keyed RPC URLs.
+    error: row.error === null ? null : scrubRpcUrls(row.error),
     errorCode: row.errorCode ?? null,
     errorType: row.errorType ?? null,
     errorCategory: row.errorCategory ?? null,
@@ -1286,7 +1289,9 @@ export async function getStepLogs(
     startedAt: row.startedAt.toISOString(),
     completedAt: row.completedAt?.toISOString() ?? null,
     durationMs: row.duration ? Number(row.duration) : null,
-    error: row.error,
+    // Scrub on read so rows persisted before URL masking existed do not
+    // re-display keyed RPC URLs.
+    error: row.error === null ? null : scrubRpcUrls(row.error),
     iterationIndex: row.iterationIndex,
     forEachNodeId: row.forEachNodeId,
     network: row.network,

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -25,6 +25,7 @@ import { captureException, captureMessage } from "@sentry/nextjs";
 import { emitLogLine, type LogLevel, type LogPayload } from "@/lib/log/core";
 import { getMetricsCollector } from "@/lib/metrics";
 import { LabelKeys, MetricNames } from "@/lib/metrics/types";
+import { scrubRpcUrls } from "@/lib/rpc/scrub-rpc-urls";
 import { getWorkflowErrorContext } from "@/lib/workflow/executor/error-context";
 
 /**
@@ -115,15 +116,15 @@ function buildErrPayload(
 ): { message: string; name?: string; stack?: string } | undefined {
   if (error instanceof Error) {
     return {
-      message: error.message,
+      message: scrubRpcUrls(error.message),
       name: error.name,
-      stack: error.stack,
+      stack: error.stack === undefined ? undefined : scrubRpcUrls(error.stack),
     };
   }
   if (error === undefined || error === null || error === "") {
     return;
   }
-  return { message: String(error) };
+  return { message: scrubRpcUrls(String(error)) };
 }
 
 /**

--- a/lib/rpc/providers/index.ts
+++ b/lib/rpc/providers/index.ts
@@ -1,6 +1,7 @@
 import { ethers, isError } from "ethers";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { safeEthersGetUrl } from "../safe-ethers-fetch";
+import { scrubRpcUrls } from "../scrub-rpc-urls";
 import { isNonRetryableError } from "./error-classification";
 
 export {
@@ -596,7 +597,9 @@ export class RpcProviderManager {
 
     return {
       success: false,
-      error: lastError?.message || "Unknown error",
+      // Ethers v6 inlines info.requestUrl (keyed RPC URL) into Error.message;
+      // mask the key before the message reaches thrown errors and logs.
+      error: scrubRpcUrls(lastError?.message ?? "") || "Unknown error",
     };
   }
 

--- a/lib/rpc/providers/index.ts
+++ b/lib/rpc/providers/index.ts
@@ -1,7 +1,7 @@
 import { ethers, isError } from "ethers";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { safeEthersGetUrl } from "../safe-ethers-fetch";
-import { scrubRpcUrls } from "../scrub-rpc-urls";
+import { redactAllUrls, scrubRpcUrls } from "../scrub-rpc-urls";
 import { isNonRetryableError } from "./error-classification";
 
 export {
@@ -373,8 +373,13 @@ export class RpcProviderManager {
             chain: this.config.chainName,
           }
         );
+        // Thrown messages reach end users via step errors; drop provider
+        // URLs entirely (host included). Internal logs above keep the
+        // host-visible masked form.
         throw new Error(
-          `RPC failed on both endpoints. Fallback: ${fallbackResult.error}. Primary: ${primaryResult.error}`
+          redactAllUrls(
+            `RPC failed on both endpoints. Fallback: ${fallbackResult.error}. Primary: ${primaryResult.error}`
+          )
         );
       }
     }
@@ -439,11 +444,15 @@ export class RpcProviderManager {
         }
       );
       throw new Error(
-        `RPC failed on both endpoints. Primary: ${primaryResult.error}. Fallback: ${fallbackResult.error}`
+        redactAllUrls(
+          `RPC failed on both endpoints. Primary: ${primaryResult.error}. Fallback: ${fallbackResult.error}`
+        )
       );
     }
 
-    throw new Error(`RPC failed on primary endpoint: ${primaryResult.error}`);
+    throw new Error(
+      redactAllUrls(`RPC failed on primary endpoint: ${primaryResult.error}`)
+    );
   }
 
   private recordAttempt(

--- a/lib/rpc/providers/solana.ts
+++ b/lib/rpc/providers/solana.ts
@@ -1,7 +1,7 @@
 import { type Commitment, Connection } from "@solana/web3.js";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { safeFetch } from "@/lib/safe-fetch";
-import { scrubRpcUrls } from "../scrub-rpc-urls";
+import { redactAllUrls, scrubRpcUrls } from "../scrub-rpc-urls";
 import {
   RPC_CONNECTION_ERROR_PATTERNS,
   type RpcErrorType,
@@ -369,13 +369,20 @@ export class SolanaProviderManager {
           chain: this.config.chainName,
         }
       );
+      // Thrown messages reach end users via step errors; drop provider URLs
+      // entirely (host included). Internal logs above keep the host-visible
+      // masked form.
       throw new Error(
-        `Solana RPC failed on both endpoints. Primary: ${primaryResult.error}. Fallback: ${fallbackResult.error}`
+        redactAllUrls(
+          `Solana RPC failed on both endpoints. Primary: ${primaryResult.error}. Fallback: ${fallbackResult.error}`
+        )
       );
     }
 
     throw new Error(
-      `Solana RPC failed on primary endpoint: ${primaryResult.error}`
+      redactAllUrls(
+        `Solana RPC failed on primary endpoint: ${primaryResult.error}`
+      )
     );
   }
 

--- a/lib/rpc/providers/solana.ts
+++ b/lib/rpc/providers/solana.ts
@@ -1,6 +1,7 @@
 import { type Commitment, Connection } from "@solana/web3.js";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { safeFetch } from "@/lib/safe-fetch";
+import { scrubRpcUrls } from "../scrub-rpc-urls";
 import {
   RPC_CONNECTION_ERROR_PATTERNS,
   type RpcErrorType,
@@ -482,7 +483,9 @@ export class SolanaProviderManager {
 
     return {
       success: false,
-      error: lastError?.message || "Unknown error",
+      // Mask keyed RPC URLs that providers inline into error messages
+      // before the message reaches thrown errors and logs.
+      error: scrubRpcUrls(lastError?.message ?? "") || "Unknown error",
     };
   }
 

--- a/lib/rpc/scrub-rpc-urls.ts
+++ b/lib/rpc/scrub-rpc-urls.ts
@@ -69,3 +69,56 @@ export function scrubRpcUrls(text: string): string {
   }
   return text.replace(URL_RE, maskUrl);
 }
+
+const URL_PLACEHOLDER = "[REDACTED-URL]";
+
+/**
+ * Hosts we operate or configure as RPC providers (CHAIN_RPC_CONFIG and the
+ * public fallbacks). Used by `redactSecretUrls` to drop provider URLs whose
+ * path carries no detectable secret - the host itself is what must not reach
+ * users.
+ */
+const KNOWN_PROVIDER_HOSTS =
+  /\/\/[^/\s]*(g\.alchemy\.com|infura\.io|quiknode\.pro|rpc\.ankr\.com|drpc\.(live|org)|chain\.techops\.services|publicnode\.com|flashbots\.net|arbitrum\.io|binance\.org|polygon\.technology|solana\.com|tempo\.xyz)/i;
+
+/**
+ * Replace EVERY URL with a placeholder. For contexts where any URL is a
+ * provider endpoint by construction (RPC failover errors, web3 step errors)
+ * and provider identity - including the host - must not reach users.
+ * Idempotent: the placeholder contains no URL.
+ */
+export function redactAllUrls(text: string): string {
+  if (!text) {
+    return text;
+  }
+  return text.replace(URL_RE, URL_PLACEHOLDER);
+}
+
+/**
+ * Replace a URL with a placeholder only when it looks provider- or
+ * secret-related: known provider host, a key-shaped path segment, a query
+ * string, or a previously masked `[REDACTED]` segment. Plain URLs (e.g. a
+ * user's own webhook endpoint in a webhook step error) pass through, so this
+ * is safe on error text from arbitrary steps.
+ */
+export function redactSecretUrls(text: string): string {
+  if (!text) {
+    return text;
+  }
+  return text.replace(URL_RE, (url) => {
+    if (url.includes("?") || url.includes("[REDACTED]")) {
+      return URL_PLACEHOLDER;
+    }
+    if (KNOWN_PROVIDER_HOSTS.test(url)) {
+      return URL_PLACEHOLDER;
+    }
+    for (const pattern of PROVIDER_KEY_PATTERNS) {
+      // Reset lastIndex: these are /g/ regexes shared with maskUrl.
+      pattern.lastIndex = 0;
+      if (pattern.test(url)) {
+        return URL_PLACEHOLDER;
+      }
+    }
+    return url;
+  });
+}

--- a/lib/workflow/executor/step-handler.ts
+++ b/lib/workflow/executor/step-handler.ts
@@ -7,7 +7,7 @@ import "server-only";
 
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { recordStepMetrics } from "@/lib/metrics/instrumentation/workflow";
-import { scrubRpcUrls } from "@/lib/rpc/scrub-rpc-urls";
+import { redactAllUrls, redactSecretUrls } from "@/lib/rpc/scrub-rpc-urls";
 import { redactSensitiveData } from "@/lib/utils/redact";
 import {
   runWithWorkflowErrorContext,
@@ -82,6 +82,21 @@ type LogInfo = {
   logId: string;
   startTime: number;
 };
+
+/**
+ * User-facing error redaction for a step's error string. In web3 steps every
+ * URL is an RPC provider endpoint, and provider identity (host included)
+ * must not reach users. In other steps a URL may be user-owned (webhook
+ * endpoints), so only provider/secret-looking URLs are dropped.
+ */
+function redactStepError(
+  message: string,
+  context: StepContext | undefined
+): string {
+  return context?.nodeType?.startsWith("web3/")
+    ? redactAllUrls(message)
+    : redactSecretUrls(message);
+}
 
 /**
  * Log the start of a step execution
@@ -288,11 +303,11 @@ async function withStepLoggingInner<TInput extends StepInput, TOutput>(
         error?: string;
         code?: string;
       };
-      // Mutate in place: errorResult aliases result, so the scrubbed string
+      // Mutate in place: errorResult aliases result, so the redacted string
       // is what gets persisted (output/outputRaw), returned to the executor,
       // and threaded into the run-level error.
       if (errorResult.error) {
-        errorResult.error = scrubRpcUrls(errorResult.error);
+        errorResult.error = redactStepError(errorResult.error, context);
       }
       await logStepComplete(
         logInfo,
@@ -378,11 +393,11 @@ async function withStepLoggingInner<TInput extends StepInput, TOutput>(
   } catch (error) {
     if (error instanceof Error) {
       try {
-        // Scrub before rethrow so the executor's fatal catch and every
-        // downstream consumer of the thrown error see the masked message.
-        error.message = scrubRpcUrls(error.message);
+        // Redact before rethrow so the executor's fatal catch and every
+        // downstream consumer of the thrown error see the clean message.
+        error.message = redactStepError(error.message, context);
       } catch {
-        // Frozen/proxied error object; read-path scrubbing still applies.
+        // Frozen/proxied error object; read-path redaction still applies.
       }
     }
     const errorMessage =

--- a/lib/workflow/executor/step-handler.ts
+++ b/lib/workflow/executor/step-handler.ts
@@ -7,6 +7,7 @@ import "server-only";
 
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { recordStepMetrics } from "@/lib/metrics/instrumentation/workflow";
+import { scrubRpcUrls } from "@/lib/rpc/scrub-rpc-urls";
 import { redactSensitiveData } from "@/lib/utils/redact";
 import {
   runWithWorkflowErrorContext,
@@ -287,6 +288,12 @@ async function withStepLoggingInner<TInput extends StepInput, TOutput>(
         error?: string;
         code?: string;
       };
+      // Mutate in place: errorResult aliases result, so the scrubbed string
+      // is what gets persisted (output/outputRaw), returned to the executor,
+      // and threaded into the run-level error.
+      if (errorResult.error) {
+        errorResult.error = scrubRpcUrls(errorResult.error);
+      }
       await logStepComplete(
         logInfo,
         "error",
@@ -369,6 +376,15 @@ async function withStepLoggingInner<TInput extends StepInput, TOutput>(
 
     return result;
   } catch (error) {
+    if (error instanceof Error) {
+      try {
+        // Scrub before rethrow so the executor's fatal catch and every
+        // downstream consumer of the thrown error see the masked message.
+        error.message = scrubRpcUrls(error.message);
+      } catch {
+        // Frozen/proxied error object; read-path scrubbing still applies.
+      }
+    }
     const errorMessage =
       error instanceof Error ? error.message : "Unknown error";
     await logStepComplete(

--- a/tests/unit/classify-execution-error.test.ts
+++ b/tests/unit/classify-execution-error.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { classifyExecutionError } from "@/lib/errors/classify";
 import { ErrorCategory } from "@/lib/logging";
-import { scrubRpcUrls } from "@/lib/rpc/scrub-rpc-urls";
+import { redactAllUrls } from "@/lib/rpc/scrub-rpc-urls";
 
 describe("classifyExecutionError", () => {
   it("classifies a missing integration credential as a user config error", () => {
@@ -28,14 +28,15 @@ describe("classifyExecutionError", () => {
     expect(classifyExecutionError("   ").errorType).toBe("system");
   });
 
-  it("still classifies RPC failover errors after URL scrubbing", () => {
-    // Error messages are scrubbed of keyed RPC URLs before classification;
-    // the scrubber must not disturb the prose the patterns match on.
+  it("still classifies RPC failover errors after URL redaction", () => {
+    // Error messages have provider URLs fully redacted before
+    // classification; the redaction must not disturb the prose the patterns
+    // match on.
     const fakeDrpcKey = "FAKE_TEST_KEY_DO_NOT_USE_AAAAAAAAAAAAAAAAAAAA";
     const raw =
       "Event query failed: RPC failed on both endpoints. Primary: could not coalesce error. " +
       `Fallback: server response 400 Bad Request (info={ "requestUrl": "https://lb.drpc.live/ethereum/${fakeDrpcKey}" })`;
-    const result = classifyExecutionError(scrubRpcUrls(raw));
+    const result = classifyExecutionError(redactAllUrls(raw));
     expect(result).toEqual({
       errorCategory: ErrorCategory.NETWORK_RPC,
       errorType: "system",

--- a/tests/unit/classify-execution-error.test.ts
+++ b/tests/unit/classify-execution-error.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { classifyExecutionError } from "@/lib/errors/classify";
 import { ErrorCategory } from "@/lib/logging";
+import { scrubRpcUrls } from "@/lib/rpc/scrub-rpc-urls";
 
 describe("classifyExecutionError", () => {
   it("classifies a missing integration credential as a user config error", () => {
@@ -25,5 +26,20 @@ describe("classifyExecutionError", () => {
   it("classifies null/empty messages as system", () => {
     expect(classifyExecutionError(null).errorType).toBe("system");
     expect(classifyExecutionError("   ").errorType).toBe("system");
+  });
+
+  it("still classifies RPC failover errors after URL scrubbing", () => {
+    // Error messages are scrubbed of keyed RPC URLs before classification;
+    // the scrubber must not disturb the prose the patterns match on.
+    const fakeDrpcKey = "FAKE_TEST_KEY_DO_NOT_USE_AAAAAAAAAAAAAAAAAAAA";
+    const raw =
+      "Event query failed: RPC failed on both endpoints. Primary: could not coalesce error. " +
+      `Fallback: server response 400 Bad Request (info={ "requestUrl": "https://lb.drpc.live/ethereum/${fakeDrpcKey}" })`;
+    const result = classifyExecutionError(scrubRpcUrls(raw));
+    expect(result).toEqual({
+      errorCategory: ErrorCategory.NETWORK_RPC,
+      errorType: "system",
+      code: "N-0001",
+    });
   });
 });

--- a/tests/unit/rpc-provider.test.ts
+++ b/tests/unit/rpc-provider.test.ts
@@ -266,6 +266,41 @@ describe("RpcProviderManager", () => {
       );
     });
 
+    it("masks keyed RPC URLs that provider errors inline into the thrown message", async () => {
+      const manager = new RpcProviderManager({
+        config: {
+          primaryRpcUrl: "https://primary.example.com",
+          fallbackRpcUrl: "https://fallback.example.com",
+          maxRetries: 1,
+          timeoutMs: 100,
+          chainName: "Ethereum",
+        },
+        metricsCollector,
+      });
+
+      // Ethers v6 SERVER_ERROR shape: info.requestUrl (keyed URL) is inlined
+      // into Error.message.
+      const fakeDrpcKey = "FAKE_TEST_KEY_DO_NOT_USE_AAAAAAAAAAAAAAAAAAAA";
+      const mockOperation = vi
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            `server response 400 Bad Request (request={ }, response={ }, error=null, info={ "requestUrl": "https://lb.drpc.live/ethereum/${fakeDrpcKey}" }, code=SERVER_ERROR, version=6.16.0)`
+          )
+        );
+
+      await expect(
+        manager.executeWithFailover(mockOperation)
+      ).rejects.toSatisfy((error: unknown) => {
+        const message = (error as Error).message;
+        expect(message).toContain("RPC failed on both endpoints");
+        expect(message).not.toContain(fakeDrpcKey);
+        expect(message).toContain("lb.drpc.live");
+        expect(message).toContain("[REDACTED]");
+        return true;
+      });
+    });
+
     it("should throw error when primary fails and no fallback configured", async () => {
       const manager = new RpcProviderManager({
         config: {

--- a/tests/unit/rpc-provider.test.ts
+++ b/tests/unit/rpc-provider.test.ts
@@ -295,8 +295,10 @@ describe("RpcProviderManager", () => {
         const message = (error as Error).message;
         expect(message).toContain("RPC failed on both endpoints");
         expect(message).not.toContain(fakeDrpcKey);
-        expect(message).toContain("lb.drpc.live");
-        expect(message).toContain("[REDACTED]");
+        // Provider identity must not reach users: the whole URL goes,
+        // host included.
+        expect(message).not.toContain("lb.drpc.live");
+        expect(message).toContain("[REDACTED-URL]");
         return true;
       });
     });

--- a/tests/unit/scrub-rpc-urls.test.ts
+++ b/tests/unit/scrub-rpc-urls.test.ts
@@ -99,6 +99,21 @@ describe("scrubRpcUrls", () => {
     expect(out).not.toContain(fakeDrpcKey);
     expect(out).toContain("/0g-galileo-testnet/");
   });
+
+  it("is idempotent - scrubbing already-scrubbed output is a no-op", () => {
+    // The runtime applies the scrubber at multiple layers (provider source,
+    // step-handler backstop, read path), so masked output must be a fixed
+    // point - including the query-string replacement shape.
+    const inputs = [
+      `Primary: https://lb.drpc.live/ethereum/${FAKE_ALCHEMY_KEY}. Fallback: https://mainnet.infura.io/v3/${FAKE_INFURA_KEY}`,
+      `https://rpc.example.com/foo?apikey=${FAKE_ALCHEMY_KEY}&debug=1`,
+      "connection refused",
+    ];
+    for (const input of inputs) {
+      const once = scrubRpcUrls(input);
+      expect(scrubRpcUrls(once)).toBe(once);
+    }
+  });
 });
 
 // Regression-style coverage: every distinct URL shape currently present in

--- a/tests/unit/scrub-rpc-urls.test.ts
+++ b/tests/unit/scrub-rpc-urls.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { scrubRpcUrls } from "@/lib/rpc/scrub-rpc-urls";
+import {
+  redactAllUrls,
+  redactSecretUrls,
+  scrubRpcUrls,
+} from "@/lib/rpc/scrub-rpc-urls";
 
 // Fake key markers. Long enough to trip the generic 32+ char path mask;
 // recognizable in greps so any regression that lets them through is loud.
@@ -113,6 +117,60 @@ describe("scrubRpcUrls", () => {
       const once = scrubRpcUrls(input);
       expect(scrubRpcUrls(once)).toBe(once);
     }
+  });
+});
+
+describe("redactAllUrls", () => {
+  it("replaces every URL with the placeholder, host included", () => {
+    const input =
+      `RPC failed on both endpoints. Primary: fetch https://lb.drpc.live/ethereum/${FAKE_ALCHEMY_KEY} failed. ` +
+      "Fallback: fetch wss://chain.techops.services/eth-mainnet failed";
+    const out = redactAllUrls(input);
+    expect(out).not.toContain("lb.drpc.live");
+    expect(out).not.toContain("chain.techops.services");
+    expect(out).not.toContain(FAKE_ALCHEMY_KEY);
+    expect(out).toContain("[REDACTED-URL]");
+    expect(out).toContain("RPC failed on both endpoints");
+  });
+
+  it("is idempotent and a no-op on URL-free prose", () => {
+    const once = redactAllUrls("fetch https://example.com/a failed");
+    expect(redactAllUrls(once)).toBe(once);
+    expect(redactAllUrls("connection refused")).toBe("connection refused");
+  });
+});
+
+describe("redactSecretUrls", () => {
+  it("drops known provider hosts even without a key in the path", () => {
+    const out = redactSecretUrls(
+      "fetch https://chain.techops.services/eth-mainnet failed"
+    );
+    expect(out).not.toContain("chain.techops.services");
+    expect(out).toContain("[REDACTED-URL]");
+  });
+
+  it("drops key-bearing, query-bearing, and already-masked URLs entirely", () => {
+    const inputs = [
+      `https://lb.drpc.live/ethereum/${FAKE_ALCHEMY_KEY}`,
+      `https://my-custom-node.example.com/rpc?apikey=${FAKE_INFURA_KEY}`,
+      "https://my-custom-node.example.com/[REDACTED]",
+      `https://my-custom-node.example.com/${FAKE_QUICKNODE_KEY}`,
+    ];
+    for (const input of inputs) {
+      const out = redactSecretUrls(`request to ${input} failed`);
+      expect(out).toBe("request to [REDACTED-URL] failed");
+    }
+  });
+
+  it("keeps plain user-owned URLs readable", () => {
+    const input = "Failed to send webhook: https://users-own-site.com/hook returned 404";
+    expect(redactSecretUrls(input)).toBe(input);
+  });
+
+  it("is idempotent", () => {
+    const input = `mixed: https://users-own-site.com/hook and https://lb.drpc.live/base/${FAKE_ALCHEMY_KEY}`;
+    const once = redactSecretUrls(input);
+    expect(redactSecretUrls(once)).toBe(once);
   });
 });
 

--- a/tests/unit/solana-provider.test.ts
+++ b/tests/unit/solana-provider.test.ts
@@ -208,6 +208,39 @@ describe("SolanaProviderManager", () => {
       );
     });
 
+    it("masks keyed RPC URLs that provider errors inline into the thrown message", async () => {
+      const manager = new SolanaProviderManager({
+        config: {
+          primaryRpcUrl: "https://primary.example.com",
+          fallbackRpcUrl: "https://fallback.example.com",
+          maxRetries: 1,
+          timeoutMs: 100,
+          chainName: "Solana",
+        },
+        metricsCollector,
+      });
+
+      const fakeAlchemyKey = "FAKE_TEST_KEY_DO_NOT_USE_AAAAAAAAAA";
+      const mockOperation = vi
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            `failed to get balance: fetch https://solana-mainnet.g.alchemy.com/v2/${fakeAlchemyKey} returned 401`
+          )
+        );
+
+      await expect(
+        manager.executeWithFailover(mockOperation)
+      ).rejects.toSatisfy((error: unknown) => {
+        const message = (error as Error).message;
+        expect(message).toContain("Solana RPC failed on both endpoints");
+        expect(message).not.toContain(fakeAlchemyKey);
+        expect(message).toContain("solana-mainnet.g.alchemy.com");
+        expect(message).toContain("[REDACTED]");
+        return true;
+      });
+    });
+
     it("should throw error when primary fails and no fallback configured", async () => {
       const manager = new SolanaProviderManager({
         config: {

--- a/tests/unit/solana-provider.test.ts
+++ b/tests/unit/solana-provider.test.ts
@@ -235,8 +235,10 @@ describe("SolanaProviderManager", () => {
         const message = (error as Error).message;
         expect(message).toContain("Solana RPC failed on both endpoints");
         expect(message).not.toContain(fakeAlchemyKey);
-        expect(message).toContain("solana-mainnet.g.alchemy.com");
-        expect(message).toContain("[REDACTED]");
+        // Provider identity must not reach users: the whole URL goes,
+        // host included.
+        expect(message).not.toContain("solana-mainnet.g.alchemy.com");
+        expect(message).toContain("[REDACTED-URL]");
         return true;
       });
     });

--- a/tests/unit/step-handler-error-scrub.test.ts
+++ b/tests/unit/step-handler-error-scrub.test.ts
@@ -29,14 +29,21 @@ import {
 const FAKE_DRPC_KEY = "FAKE_TEST_KEY_DO_NOT_USE_AAAAAAAAAAAAAAAAAAAA";
 const KEYED_URL = `https://lb.drpc.live/ethereum/${FAKE_DRPC_KEY}`;
 
-const context: StepContext = {
+const web3Context: StepContext = {
   executionId: "exec-1",
   nodeId: "node-1",
   nodeName: "Query Poke Events",
   nodeType: "web3/query-events",
 };
 
-describe("withStepLogging error scrubbing", () => {
+const webhookContext: StepContext = {
+  executionId: "exec-1",
+  nodeId: "node-2",
+  nodeName: "Notify",
+  nodeType: "webhook/send-webhook",
+};
+
+describe("withStepLogging error redaction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(logStepStartDb).mockResolvedValue({
@@ -45,52 +52,65 @@ describe("withStepLogging error scrubbing", () => {
     });
   });
 
-  it("scrubs keyed RPC URLs from returned error results before persisting and returning", async () => {
+  it("drops entire provider URLs (host included) from web3 step error results", async () => {
     const rawError = `Event query failed: RPC failed on both endpoints. Fallback: server response 400 Bad Request (info={ "requestUrl": "${KEYED_URL}" })`;
 
-    const result = await withStepLogging({ _context: context }, () =>
+    const result = await withStepLogging({ _context: web3Context }, () =>
       Promise.resolve({ success: false, error: rawError })
     );
 
     expect(result.error).not.toContain(FAKE_DRPC_KEY);
-    expect(result.error).toContain("lb.drpc.live");
-    expect(result.error).toContain("[REDACTED]");
+    expect(result.error).not.toContain("lb.drpc.live");
+    expect(result.error).toContain("[REDACTED-URL]");
     expect(result.error).toContain("RPC failed on both endpoints");
 
     expect(logStepCompleteDb).toHaveBeenCalledTimes(1);
     const persisted = vi.mocked(logStepCompleteDb).mock.calls[0][0];
-    expect(persisted.error).not.toContain(FAKE_DRPC_KEY);
+    expect(persisted.error).not.toContain("lb.drpc.live");
     // The result object is persisted whole as output/outputRaw; its error
-    // field must carry the scrubbed string too.
+    // field must carry the redacted string too.
     expect((persisted.outputRaw as { error: string }).error).not.toContain(
-      FAKE_DRPC_KEY
+      "lb.drpc.live"
     );
     expect((persisted.output as { error: string }).error).not.toContain(
-      FAKE_DRPC_KEY
+      "lb.drpc.live"
     );
 
     const metrics = vi.mocked(recordStepMetrics).mock.calls[0][0];
-    expect(metrics.error).not.toContain(FAKE_DRPC_KEY);
+    expect(metrics.error).not.toContain("lb.drpc.live");
   });
 
-  it("scrubs keyed RPC URLs from thrown errors and rethrows with the masked message", async () => {
+  it("keeps user-owned URLs in non-web3 step errors while dropping keyed ones", async () => {
+    const rawError = `Failed to send webhook: https://users-own-site.com/hook returned 502 (upstream ${KEYED_URL})`;
+
+    const result = await withStepLogging({ _context: webhookContext }, () =>
+      Promise.resolve({ success: false, error: rawError })
+    );
+
+    expect(result.error).toContain("https://users-own-site.com/hook");
+    expect(result.error).not.toContain(FAKE_DRPC_KEY);
+    expect(result.error).not.toContain("lb.drpc.live");
+    expect(result.error).toContain("[REDACTED-URL]");
+  });
+
+  it("redacts thrown web3 step errors and rethrows with the clean message", async () => {
     const thrown = new Error(
       `could not coalesce error (info={ "requestUrl": "${KEYED_URL}" }, code=UNKNOWN_ERROR, version=6.16.0)`
     );
 
     await expect(
-      withStepLogging({ _context: context }, () => Promise.reject(thrown))
+      withStepLogging({ _context: web3Context }, () => Promise.reject(thrown))
     ).rejects.toSatisfy((error: unknown) => {
       const message = (error as Error).message;
       expect(message).not.toContain(FAKE_DRPC_KEY);
-      expect(message).toContain("lb.drpc.live");
-      expect(message).toContain("[REDACTED]");
+      expect(message).not.toContain("lb.drpc.live");
+      expect(message).toContain("[REDACTED-URL]");
       return true;
     });
 
     expect(logStepCompleteDb).toHaveBeenCalledTimes(1);
     const persisted = vi.mocked(logStepCompleteDb).mock.calls[0][0];
-    expect(persisted.error).not.toContain(FAKE_DRPC_KEY);
+    expect(persisted.error).not.toContain("lb.drpc.live");
   });
 
   it("survives frozen thrown errors without masking the failure", async () => {
@@ -99,7 +119,7 @@ describe("withStepLogging error scrubbing", () => {
     );
 
     await expect(
-      withStepLogging({ _context: context }, () => Promise.reject(frozen))
+      withStepLogging({ _context: web3Context }, () => Promise.reject(frozen))
     ).rejects.toBe(frozen);
   });
 });

--- a/tests/unit/step-handler-error-scrub.test.ts
+++ b/tests/unit/step-handler-error-scrub.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { WORKFLOW_ENGINE: "workflow_engine" },
+  logSystemError: vi.fn(),
+}));
+vi.mock("@/lib/metrics/instrumentation/workflow", () => ({
+  recordStepMetrics: vi.fn(),
+}));
+vi.mock("@/lib/workflow/executor/logging", () => ({
+  incrementCompletedSteps: vi.fn(),
+  logStepCompleteDb: vi.fn(),
+  logStepStartDb: vi.fn(),
+  logWorkflowCompleteDb: vi.fn(),
+  updateCurrentStep: vi.fn(),
+}));
+
+import { recordStepMetrics } from "@/lib/metrics/instrumentation/workflow";
+import {
+  logStepCompleteDb,
+  logStepStartDb,
+} from "@/lib/workflow/executor/logging";
+import {
+  type StepContext,
+  withStepLogging,
+} from "@/lib/workflow/executor/step-handler";
+
+const FAKE_DRPC_KEY = "FAKE_TEST_KEY_DO_NOT_USE_AAAAAAAAAAAAAAAAAAAA";
+const KEYED_URL = `https://lb.drpc.live/ethereum/${FAKE_DRPC_KEY}`;
+
+const context: StepContext = {
+  executionId: "exec-1",
+  nodeId: "node-1",
+  nodeName: "Query Poke Events",
+  nodeType: "web3/query-events",
+};
+
+describe("withStepLogging error scrubbing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(logStepStartDb).mockResolvedValue({
+      logId: "log-1",
+      startTime: Date.now(),
+    });
+  });
+
+  it("scrubs keyed RPC URLs from returned error results before persisting and returning", async () => {
+    const rawError = `Event query failed: RPC failed on both endpoints. Fallback: server response 400 Bad Request (info={ "requestUrl": "${KEYED_URL}" })`;
+
+    const result = await withStepLogging({ _context: context }, () =>
+      Promise.resolve({ success: false, error: rawError })
+    );
+
+    expect(result.error).not.toContain(FAKE_DRPC_KEY);
+    expect(result.error).toContain("lb.drpc.live");
+    expect(result.error).toContain("[REDACTED]");
+    expect(result.error).toContain("RPC failed on both endpoints");
+
+    expect(logStepCompleteDb).toHaveBeenCalledTimes(1);
+    const persisted = vi.mocked(logStepCompleteDb).mock.calls[0][0];
+    expect(persisted.error).not.toContain(FAKE_DRPC_KEY);
+    // The result object is persisted whole as output/outputRaw; its error
+    // field must carry the scrubbed string too.
+    expect((persisted.outputRaw as { error: string }).error).not.toContain(
+      FAKE_DRPC_KEY
+    );
+    expect((persisted.output as { error: string }).error).not.toContain(
+      FAKE_DRPC_KEY
+    );
+
+    const metrics = vi.mocked(recordStepMetrics).mock.calls[0][0];
+    expect(metrics.error).not.toContain(FAKE_DRPC_KEY);
+  });
+
+  it("scrubs keyed RPC URLs from thrown errors and rethrows with the masked message", async () => {
+    const thrown = new Error(
+      `could not coalesce error (info={ "requestUrl": "${KEYED_URL}" }, code=UNKNOWN_ERROR, version=6.16.0)`
+    );
+
+    await expect(
+      withStepLogging({ _context: context }, () => Promise.reject(thrown))
+    ).rejects.toSatisfy((error: unknown) => {
+      const message = (error as Error).message;
+      expect(message).not.toContain(FAKE_DRPC_KEY);
+      expect(message).toContain("lb.drpc.live");
+      expect(message).toContain("[REDACTED]");
+      return true;
+    });
+
+    expect(logStepCompleteDb).toHaveBeenCalledTimes(1);
+    const persisted = vi.mocked(logStepCompleteDb).mock.calls[0][0];
+    expect(persisted.error).not.toContain(FAKE_DRPC_KEY);
+  });
+
+  it("survives frozen thrown errors without masking the failure", async () => {
+    const frozen = Object.freeze(
+      new Error(`fetch ${KEYED_URL} failed with 401`)
+    );
+
+    await expect(
+      withStepLogging({ _context: context }, () => Promise.reject(frozen))
+    ).rejects.toBe(frozen);
+  });
+});


### PR DESCRIPTION
## Summary

When RPC providers fail, ethers v6 inlines the full request URL - including the embedded API key - into the error message (the info.requestUrl field). That message was persisted verbatim to workflow_executions.error / workflow_execution_logs.error, rendered verbatim in the Analytics and workflow runs UIs (with a copy button), returned raw by the step/log APIs, and shipped raw to Loki and Sentry.

This removes provider URLs from every user-facing error surface. In user-facing contexts the entire URL is dropped - host included - so neither credentials nor provider identity reach users. Internal logs (Loki/Sentry) keep a key-masked but host-visible form so operators can still tell which endpoint failed.

## Redaction semantics

Three primitives in lib/rpc/scrub-rpc-urls.ts:

- redactAllUrls: replaces every URL with [REDACTED-URL]. Used where every URL is a provider endpoint by construction: RPC failover throw messages and web3 step errors.
- redactSecretUrls: replaces a URL only when it is provider- or secret-related (known provider host, key-shaped path segment, query string, or previously masked segment). Plain URLs pass through, so a webhook step error still shows the user their own endpoint. Used for non-web3 step errors and run-level errors.
- scrubRpcUrls (pre-existing): masks the key but keeps the host. Used only for internal logs (buildErrPayload -> Loki/Sentry).

## Changes

- Failover managers (EVM + Solana): thrown failover messages pass through redactAllUrls; the captured per-provider error strings remain key-masked for the internal failover logs.
- Step wrapper (withStepLogging): redacts returned error results in place - the same object is persisted as output/output_raw and threaded into the run-level error - and redacts thrown error messages before rethrow (guarded for frozen error objects). web3/* steps drop all URLs; other steps drop only provider/secret URLs.
- Structured logger (buildErrPayload): scrubs message, stack, and the string fallback (key-masked, host visible) before Loki/Sentry emission.
- Read path: the analytics run/step query mappers and the execution logs route redact on read with the same node-type-aware rule, so rows persisted before this fix stop displaying provider URLs immediately.

## Notes for reviewers

- output_raw for failed steps now carries a redacted error field - a narrow, deliberate exception to its unredacted-payload contract. Failed step results are not consumed as template inputs by downstream steps the way success outputs are.
- Redaction rewrites only URL substrings, so the error-classification regexes that drive system_error status keep matching; locked in by a test.
- Keys already persisted to the DB, Loki, and Sentry should be treated as compromised. Rotating the affected RPC API keys is the actual remediation for historical exposure; the read-path redaction only stops re-display.
- Residual gap: in non-web3 contexts, a custom provider URL with no key-shaped segment and an unknown host passes through redactSecretUrls unchanged (documented in scrub-rpc-urls.ts, with a Sentry beforeSend follow-up noted there).

## Testing

- Unit: scrub-rpc-urls (masking, idempotency, redactAllUrls/redactSecretUrls behavior), rpc-provider and solana-provider (thrown failover messages contain no key and no host), classify-execution-error (redacted message still classifies as NETWORK_RPC system error), plus a step-handler suite covering web3 full-removal, non-web3 user-URL preservation, thrown, and frozen-error paths. 107 tests pass across the five suites.
- tsc --noEmit clean.
- Manually verified in a local browser against a seeded pre-fix raw error row: the logs API returns "requestUrl": "[REDACTED-URL]" with no key and no provider host.