### PR TITLE
fix: retry reverted simulation sends once to absorb transient fork state

### DIFF
--- a/tests/e2e/vitest/protocol-simulation/_shared/simulate.ts
+++ b/tests/e2e/vitest/protocol-simulation/_shared/simulate.ts
@@ -46,7 +46,7 @@ export const SIM_WALLET = "0x5115000000000000000000000000000000000051";
 const WRITE_TIMEOUT_MS = 120_000;
 const READ_TIMEOUT_MS = 30_000;
 
-async function impersonatedSend(
+async function sendImpersonatedOnce(
   provider: JsonRpcProvider,
   from: string,
   tx: { to: string; data?: string; value?: bigint }
@@ -61,6 +61,24 @@ async function impersonatedSend(
     }
   } finally {
     await provider.send("anvil_stopImpersonatingAccount", [from]);
+  }
+}
+
+async function impersonatedSend(
+  provider: JsonRpcProvider,
+  from: string,
+  tx: { to: string; data?: string; value?: bigint }
+): Promise<void> {
+  try {
+    await sendImpersonatedOnce(provider, from, tx);
+  } catch {
+    // A reverted send left no state behind, so one retry is safe. Public
+    // fork upstreams intermittently serve stale slots to mid-execution
+    // state fetches, producing reason-less reverts that replay green on
+    // the same fork moments later; the retry absorbs exactly that class,
+    // while a genuine revert fails again deterministically.
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await sendImpersonatedOnce(provider, from, tx);
   }
 }
 


### PR DESCRIPTION
## Summary

The tier1-simulations job flakes on public fork upstreams: one write per run intermittently reverts with no reason, on a different test each time, and the identical transaction replays green on the same fork one block earlier. The upstream's load balancer serves stale state slots to mid-execution fetches; today this blocked the prod release pipeline twice in a row (aave-v3 repay on attempt 1, morpho withdraw-collateral on attempt 2).

## Changes

impersonatedSend now retries a reverted send once, after a 2 second pause. A reverted transaction changed no chain state, so the retry is safe by construction: the transient-slot flake passes on retry, while a genuine revert fails again deterministically and still fails the test. This covers setup provisioning and all simulation write tests without weakening any assertion.

The durable root-cause fix remains provisioning an archive-grade ANVIL_FORK_MAINNET_URL secret so forks stop depending on the public balanced endpoint; this change absorbs the flake class until that lands.

## Test Plan

- [x] Lint and type-check clean
- [x] Failure class empirically characterized: reverted transactions replay green on the same fork (verified via eth_call at parent block for both morpho and aave failures)
- [ ] tier1-simulations green in CI on this PR