### PR TITLE
fix(security): flag logins that lose country attestation

### DIFF
--- a/components/organization/member-sessions-dialog.tsx
+++ b/components/organization/member-sessions-dialog.tsx
@@ -58,6 +58,7 @@ type LoadState =
 // risk_flags_json onto labels an org admin can read at a glance.
 const REASON_LABELS: Record<string, string> = {
   new_country: "New country",
+  unknown_country: "Unknown location",
   impossible_travel: "Impossible travel",
   first_geo_attestation: "First sign-in location",
 };

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -846,6 +846,12 @@ export const auth = betterAuth({
           // cookie expires before a legitimate user finishes the
           // /verify-mfa flow.
           const PRE_STEPUP_TTL_MS = 10 * 60 * 1000;
+          // Persist the risk blob whenever there is signal: a resolved
+          // country, or an anomaly with no country (unknown_country — a
+          // login we could no longer place). A null country with no anomaly
+          // is inconclusive (local dev / self-hosted) and stored as null.
+          const riskFlagsJson =
+            risk.country || risk.anomaly ? serializeRiskFlags(risk) : null;
           // IP-verification does not write to the session row. The
           // atomic flow in strict-signin / oauth-mfa-finalize / the
           // /verify-ip endpoint resolves IP trust BEFORE any session
@@ -857,11 +863,11 @@ export const auth = betterAuth({
               ? {
                   requiresMfa: true,
                   expiresAt: new Date(Date.now() + PRE_STEPUP_TTL_MS),
-                  riskFlagsJson: risk.country ? serializeRiskFlags(risk) : null,
+                  riskFlagsJson,
                 }
               : {
                   requiresMfa: false,
-                  riskFlagsJson: risk.country ? serializeRiskFlags(risk) : null,
+                  riskFlagsJson,
                 },
           };
         },

--- a/lib/security/login-risk.ts
+++ b/lib/security/login-risk.ts
@@ -23,9 +23,12 @@ import {
  *
  * `country` is the resolved Cloudflare-attested country for the login.
  * Null when the request did not arrive via Cloudflare (local dev, direct
- * origin access). When null, the geo check is treated as inconclusive
- * (anomaly = false) — we do not flag based on missing signal, because
- * doing so would trip every local-dev login and self-hosted setup.
+ * origin access). A null country with no prior country history is treated
+ * as inconclusive (anomaly = false) — we do not flag on a missing signal
+ * for users who have never been placed, because doing so would trip every
+ * local-dev login and self-hosted setup. But a null country for a user who
+ * DOES have a country history is itself the anomaly (unknown_country): a
+ * session we can no longer place is as suspicious as one from a new country.
  */
 export type LoginRiskSignal = {
   anomaly: boolean;
@@ -52,16 +55,6 @@ const MAX_PLAUSIBLE_VELOCITY_KMH = 800;
 // instead of dividing by zero.
 const MIN_ELAPSED_HOURS = 1 / 3600;
 const EARTH_RADIUS_KM = 6371;
-const NULL_RISK: LoginRiskSignal = {
-  anomaly: false,
-  reasons: [],
-  country: null,
-  region: null,
-  city: null,
-  latitude: null,
-  longitude: null,
-  recentCountries: [],
-};
 
 /**
  * Resolves the geographic location of the current request. CF-IPCountry
@@ -251,7 +244,9 @@ function isImpossibleTravel(
  *
  * Two independent signals are merged into one `anomaly`:
  *  - Country: empty history -> first_geo_attestation; known country ->
- *    clean; unseen country -> new_country anomaly.
+ *    clean; unseen country -> new_country anomaly; no country attested but
+ *    a country history exists -> unknown_country anomaly (a login we can no
+ *    longer place, treated the same as a change to a new country).
  *  - Impossible travel: when the current login carries coordinates and a
  *    prior located session exists, an implausible velocity between them
  *    flags impossible_travel — even when the country is familiar, which
@@ -262,21 +257,28 @@ export async function assessLoginRisk(
 ): Promise<LoginRiskSignal> {
   const location = await resolveLoginLocation();
   const { country, region, city, latitude, longitude } = location;
-  if (!country) {
-    return NULL_RISK;
-  }
   const priorCountries = await loadRecentCountries(userId);
   const reasons: string[] = [];
   let anomaly = false;
   let recentCountries: string[] = [];
 
-  if (priorCountries.length === 0) {
-    reasons.push("first_geo_attestation");
-  } else if (priorCountries.includes(country)) {
-    recentCountries = priorCountries.filter((c) => c !== country);
-  } else {
+  if (country) {
+    if (priorCountries.length === 0) {
+      reasons.push("first_geo_attestation");
+    } else if (priorCountries.includes(country)) {
+      recentCountries = priorCountries.filter((c) => c !== country);
+    } else {
+      anomaly = true;
+      reasons.push("new_country");
+      recentCountries = priorCountries;
+    }
+  } else if (priorCountries.length > 0) {
+    // No country attested for this login, but the user has an established
+    // country history. Falling off the map is as suspicious as moving to a
+    // new one, so flag it. With no prior history (local dev, self-hosted,
+    // first login) a missing country stays inconclusive and never flags.
     anomaly = true;
-    reasons.push("new_country");
+    reasons.push("unknown_country");
     recentCountries = priorCountries;
   }
 

--- a/tests/unit/login-risk.test.ts
+++ b/tests/unit/login-risk.test.ts
@@ -98,8 +98,9 @@ beforeEach(() => {
 });
 
 describe("assessLoginRisk", () => {
-  it("returns NULL_RISK when CF-Connecting-IP is absent (local dev / direct origin)", async () => {
+  it("stays inconclusive when CF-Connecting-IP is absent and there is no country history (local dev / direct origin)", async () => {
     setHeaders({ "cf-ipcountry": "AU" });
+    setRecentSessionCountries([]);
     const result = await assessLoginRisk("user_1");
     expect(result).toEqual({
       anomaly: false,
@@ -111,23 +112,48 @@ describe("assessLoginRisk", () => {
       longitude: null,
       recentCountries: [],
     });
-    expect(mockSelect).not.toHaveBeenCalled();
   });
 
-  it("returns NULL_RISK when CF-IPCountry is missing despite CF-Connecting-IP", async () => {
+  it("stays inconclusive when CF-IPCountry is missing and there is no country history", async () => {
     setHeaders({ "cf-connecting-ip": "203.0.113.1" });
+    setRecentSessionCountries([null, null]);
     const result = await assessLoginRisk("user_1");
     expect(result.country).toBeNull();
     expect(result.anomaly).toBe(false);
   });
 
-  it("returns NULL_RISK when CF-IPCountry is the unknown sentinel XX", async () => {
+  it("stays inconclusive when CF-IPCountry is the unknown sentinel XX and there is no country history", async () => {
     setHeaders({
       "cf-connecting-ip": "203.0.113.1",
       "cf-ipcountry": "XX",
     });
+    setRecentSessionCountries([]);
     const result = await assessLoginRisk("user_1");
     expect(result.country).toBeNull();
+    expect(result.anomaly).toBe(false);
+  });
+
+  it("flags unknown_country when a login with no attested country follows a known-country history", async () => {
+    setHeaders({
+      "cf-connecting-ip": "203.0.113.1",
+      "cf-ipcountry": "XX",
+    });
+    setRecentSessionCountries(["AU", "AU"]);
+    const result = await assessLoginRisk("user_1");
+    expect(result.country).toBeNull();
+    expect(result.anomaly).toBe(true);
+    expect(result.reasons).toEqual(["unknown_country"]);
+    expect(result.recentCountries).toEqual(["AU"]);
+  });
+
+  it("flags unknown_country when CF is bypassed entirely for a user with country history", async () => {
+    setHeaders({ "cf-ipcountry": "AU" });
+    setRecentSessionCountries(["KR"]);
+    const result = await assessLoginRisk("user_1");
+    expect(result.country).toBeNull();
+    expect(result.anomaly).toBe(true);
+    expect(result.reasons).toEqual(["unknown_country"]);
+    expect(result.recentCountries).toEqual(["KR"]);
   });
 
   it("flags first_geo_attestation (not anomaly) for a user's first geo-attested session", async () => {


### PR DESCRIPTION
## Problem

An org owner reviewing a member's recent sessions sees a red flag when the member's country changes from one known country to another (`AU -> KR`), but a change from a known country to an unplaceable location (no country attested) raised no flag at all. Both should be treated the same way.

## Root cause

The red flag is computed at login in `assessLoginRisk` and stored in `sessions.risk_flags_json`; the member-sessions panel only renders what was stored. That function returned early with a no-anomaly signal whenever the login carried no country attestation, before comparing against the user's prior countries. A second guard in the session-create hook only persisted the risk blob when a country was present, so even a computed anomaly with a null country would have been dropped.

## Fix

- Remove the early return. A null country now raises an `unknown_country` anomaly when the user has an established country history, mirroring the existing `new_country` path. A null country with no prior history stays inconclusive, so local-dev and self-hosted logins are not tripped.
- Persist the risk blob whenever there is a resolved country or an anomaly, so the `unknown_country` verdict reaches the panel.
- Add the `unknown_country -> "Unknown location"` badge label.

Impossible-travel detection now also runs on the null-country path (previously skipped by the early return), a strict improvement since IP-fallback coordinates can still be present.

## Tests

- `pnpm vitest run tests/unit/login-risk.test.ts` -- 17 passed. Updated the "no country" cases to assert they stay inconclusive only without history, and added coverage for `unknown_country` firing with prior history (CF `XX` sentinel and full CF bypass).
- `pnpm type-check` -- clean.
