### PR TITLE
refactor: consolidate protocol test harness internals on shared kernels

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -45,10 +45,6 @@ scripts/dev-mint-session.ts
 scripts/dev-login.ts
 scripts/dev-login-browser.ts
 
-# Coverage yardstick (pnpm coverage:report). CI/local-only and imports the
-# fixture planner from tests/, which is excluded above.
-scripts/protocol-coverage-report.ts
-
 # Dev-only config files
 playwright.config.ts
 vitest.config.mts

--- a/lib/test-data/encode-action.ts
+++ b/lib/test-data/encode-action.ts
@@ -20,6 +20,7 @@ import { applyEncodeTransformsNamed } from "@/lib/protocol-encode-transforms";
 import {
   getProtocol,
   type ProtocolAction,
+  type ProtocolContract,
   type ProtocolDefinition,
   resolveContractAddress,
 } from "@/lib/protocol-registry";
@@ -52,27 +53,29 @@ export type EncodedAction = {
 };
 
 /** Interfaces are immutable and ABI parsing is the hot cost of a sweep
- *  (every action of a contract re-parsed its full ABI); cache per
- *  registry contract. */
-const ifaceCache = new Map<string, Interface>();
+ *  (every action of a contract re-parsed its full ABI); cache keyed on
+ *  the contract object itself, not a slug/contract-name string, so a
+ *  synthetic definition reusing the same slug and contract key with a
+ *  different ABI can never be served a stale Interface. Registry
+ *  contract objects are stable, so memoization still holds. */
+const ifaceCache = new WeakMap<ProtocolContract, Interface>();
 
 export function ifaceFor(
   protocol: ProtocolDefinition,
   action: ProtocolAction
 ): Interface {
-  const key = `${protocol.slug}/${action.contract}`;
-  const cached = ifaceCache.get(key);
-  if (cached) {
-    return cached;
-  }
   const contract = protocol.contracts[action.contract];
   if (!contract?.abi) {
     throw new Error(
       `${protocol.slug}: action ${action.slug} references missing contract or ABI "${action.contract}"`
     );
   }
+  const cached = ifaceCache.get(contract);
+  if (cached) {
+    return cached;
+  }
   const iface = new Interface(JSON.parse(contract.abi));
-  ifaceCache.set(key, iface);
+  ifaceCache.set(contract, iface);
   return iface;
 }
 

--- a/lib/test-data/encode-action.ts
+++ b/lib/test-data/encode-action.ts
@@ -6,8 +6,10 @@
  * transforms, then runs the identical reshapeArgsForAbi and
  * coerceArgsForAbi pipeline the runtime protocol steps use, producing
  * the exact transaction the platform would send. Consumed by the Tier 0
- * golden-calldata tests and the Tier 1 fork simulation harness so both
- * layers share one encoding source of truth.
+ * golden-calldata tests, the Tier 1 fork simulation harness, and the
+ * integration-test calldata builder
+ * (tests/integration/_shared/build-calldata.ts) so all layers share one
+ * encoding source of truth.
  */
 
 import { Interface, parseEther } from "ethers";

--- a/lib/test-data/encode-action.ts
+++ b/lib/test-data/encode-action.ts
@@ -27,6 +27,7 @@ import {
   buildActionWorkflow,
   buildSetupWorkflow,
 } from "@/lib/test-data/build-workflow";
+import type { AbiOutputParam } from "@/plugins/web3/steps/structure-abi-result";
 
 function requireProtocol(slug: string): ProtocolDefinition {
   const def = getProtocol(slug);
@@ -41,9 +42,10 @@ export type EncodedAction = {
   data: string;
   /** msg.value in wei when the testData binds the virtual ethValue key. */
   value: bigint;
-  skipped: boolean;
   iface: Interface;
-  fragment: FunctionAbiEntry;
+  /** ABI output params from the resolved fragment JSON, retained so read
+   *  simulations can structure decoded results without re-deriving them. */
+  abiOutputs: AbiOutputParam[];
   /** The live ethers fragment; use for decodeFunctionResult (string
    *  re-resolution mangles tuple signatures). */
   ethersFragment: unknown;
@@ -74,6 +76,11 @@ export function ifaceFor(
   return iface;
 }
 
+/** The fragment JSON carries the outputs alongside the inputs
+ *  FunctionAbiEntry declares; retaining them here saves consumers from
+ *  re-parsing the fragment to structure decoded read results. */
+type ParsedFragment = FunctionAbiEntry & { outputs?: AbiOutputParam[] };
+
 /** Resolve the exact fragment for an action. Bare-name lookup throws on
  *  overload ambiguity, and registry actions flatten single-tuple params
  *  (deriveTupleInputs), so fragment arity can differ from the action's
@@ -82,13 +89,13 @@ export function ifaceFor(
 export function fragmentFor(
   iface: Interface,
   action: ProtocolAction
-): { ethersFragment: unknown; abi: FunctionAbiEntry } {
+): { ethersFragment: unknown; abi: ParsedFragment } {
   const byName = iface.fragments.filter(
     (f) =>
       f.type === "function" && (f as { name?: string }).name === action.function
   );
   const parsed = byName.map(
-    (f) => JSON.parse(f.format("json")) as FunctionAbiEntry
+    (f) => JSON.parse(f.format("json")) as ParsedFragment
   );
   const flatArity = (f: FunctionAbiEntry): number =>
     (f.inputs ?? []).reduce(
@@ -212,15 +219,12 @@ export function encodeFromConfig(
       (config.contractAddress as string | undefined) ?? undefined
     ) ?? "";
   const ethValue = config.ethValue as string | undefined;
-  const skipped =
-    protocol.testData?.[chainId]?.skipped?.[action.slug] !== undefined;
   return {
     to,
     data,
     value: ethValue ? parseEther(ethValue) : BigInt(0),
-    skipped,
     iface,
-    fragment: abi,
+    abiOutputs: abi.outputs ?? [],
     ethersFragment,
   };
 }

--- a/lib/test-data/plan.ts
+++ b/lib/test-data/plan.ts
@@ -5,7 +5,9 @@
  * which throws when loaded outside a test run - and this logic is also
  * consumed by scripts/protocol-coverage-report.ts (a tsx CLI). The
  * coverage report must agree exactly with what the runner registers, so
- * both import this single implementation.
+ * both import this single implementation. Placed under lib/test-data
+ * (its only import is type-only) so non-test consumers do not have to
+ * reach into tests/.
  */
 
 import type {

--- a/lib/test-data/plan.ts
+++ b/lib/test-data/plan.ts
@@ -1,7 +1,9 @@
 /**
  * Pure fixture-planning layer for protocol-coverage.
  *
- * Lives apart from run-fixture.ts because that module imports vitest,
+ * Lives apart from the coverage runner
+ * (tests/e2e/vitest/protocol-coverage/_shared/run-fixture.ts) because
+ * that module imports vitest,
  * which throws when loaded outside a test run - and this logic is also
  * consumed by scripts/protocol-coverage-report.ts (a tsx CLI). The
  * coverage report must agree exactly with what the runner registers, so

--- a/scripts/protocol-coverage-report.ts
+++ b/scripts/protocol-coverage-report.ts
@@ -16,7 +16,8 @@
  *
  * The runnable/skipped numbers come from the same planPhaseFixtures the
  * suite runner uses, so this report cannot drift from what the runner
- * registers. A future simulation tier will contribute a `simulated`
+ * registers. The simulation tier (tests/e2e/vitest/protocol-simulation)
+ * does not yet feed this report; it will contribute a `simulated`
  * column via its own results file.
  */
 

--- a/scripts/protocol-coverage-report.ts
+++ b/scripts/protocol-coverage-report.ts
@@ -38,6 +38,10 @@ type SuiteInfo = {
   protocol: string;
   chainId: string;
   hardSkipped: boolean;
+  /** Scraped `const PROTOCOL` value when it disagrees with the suite's
+   *  directory name; surfaced as a loud mismatch instead of dropping or
+   *  silently trusting either side. */
+  scrapedProtocol?: string;
 };
 
 type SuiteResult = VitestAssertionCounts & {
@@ -72,18 +76,26 @@ function discoverSuites(): SuiteInfo[] {
         continue;
       }
       const src = readFileSync(file, "utf8");
-      const protocol = src.match(/const PROTOCOL = "([^"]+)"/)?.[1];
+      // The directory name is the protocol: the layout is
+      // protocol-coverage/<protocol>/<chain-name>/coverage.test.ts. The
+      // source is still scraped for CHAIN_ID (chain directories are
+      // names, not ids) and for the PROTOCOL const so a suite whose
+      // const drifted from its directory is reported, not dropped.
+      const scraped = src.match(/const PROTOCOL = "([^"]+)"/)?.[1];
       const chainId = src.match(/const CHAIN_ID = "([^"]+)"/)?.[1];
-      if (!(protocol && chainId)) {
-        continue;
-      }
       suites.push({
         path: file,
-        protocol,
-        chainId,
+        protocol: proto.name,
+        // A suite with no scrapeable CHAIN_ID joins no registry chain
+        // row, so it surfaces in orphanSuites instead of silently
+        // vanishing from the report.
+        chainId: chainId ?? "unparsed",
         // describe.skip( is an unconditional disable; describe.skipIf( is
         // the normal infra gate and does not count as hard-skipped.
         hardSkipped: /describe\.skip\(/.test(src),
+        ...(scraped && scraped !== proto.name
+          ? { scrapedProtocol: scraped }
+          : {}),
       });
     }
   }
@@ -107,12 +119,29 @@ function parseResults(file: string): Map<string, SuiteResult> {
   return bySuite;
 }
 
+type ProtocolMismatch = {
+  path: string;
+  protocol: string;
+  scrapedProtocol: string;
+};
+
 function buildRows(results?: Map<string, SuiteResult>): {
   rows: ChainRow[];
   noHarness: Array<{ protocol: string; actions: number }>;
   orphanSuites: Array<{ path: string; protocol: string; chainId: string }>;
+  protocolMismatches: ProtocolMismatch[];
 } {
   const suites = discoverSuites();
+  const protocolMismatches: ProtocolMismatch[] = [];
+  for (const s of suites) {
+    if (s.scrapedProtocol) {
+      protocolMismatches.push({
+        path: s.path,
+        protocol: s.protocol,
+        scrapedProtocol: s.scrapedProtocol,
+      });
+    }
+  }
   const rows: ChainRow[] = [];
   const noHarness: Array<{ protocol: string; actions: number }> = [];
   // Suites consumed by a (registered protocol, testData chain) row. Any
@@ -165,7 +194,7 @@ function buildRows(results?: Map<string, SuiteResult>): {
   const orphanSuites = suites
     .filter((s) => !consumed.has(s.path))
     .map((s) => ({ path: s.path, protocol: s.protocol, chainId: s.chainId }));
-  return { rows, noHarness, orphanSuites };
+  return { rows, noHarness, orphanSuites, protocolMismatches };
 }
 
 function pad(value: string | number, width: number): string {
@@ -181,7 +210,8 @@ function main(): void {
       ? parseResults(args[resultsIdx + 1])
       : undefined;
 
-  const { rows, noHarness, orphanSuites } = buildRows(results);
+  const { rows, noHarness, orphanSuites, protocolMismatches } =
+    buildRows(results);
   const registryTotal = getRegisteredProtocols().reduce(
     (n, d) => n + d.actions.length,
     0
@@ -197,6 +227,7 @@ function main(): void {
     suitesMissing: rows.filter((r) => r.suite === "none").length,
     protocolsWithoutHarness: noHarness,
     orphanSuites,
+    protocolMismatches,
     executed: results
       ? rows.reduce((n, r) => n + (r.result?.executed ?? 0), 0)
       : undefined,
@@ -238,6 +269,11 @@ function main(): void {
   if (orphanSuites.length > 0) {
     lines.push(
       `ORPHANED suites (on disk but no registry testData chain matches them): ${orphanSuites.map((s) => `${s.protocol}/${s.chainId}`).join(", ")}`
+    );
+  }
+  if (protocolMismatches.length > 0) {
+    lines.push(
+      `PROTOCOL MISMATCH (const PROTOCOL disagrees with the suite's directory): ${protocolMismatches.map((m) => `${m.path} (dir "${m.protocol}" vs const "${m.scrapedProtocol}")`).join(", ")}`
     );
   }
   if (results) {

--- a/scripts/protocol-coverage-report.ts
+++ b/scripts/protocol-coverage-report.ts
@@ -153,7 +153,12 @@ function buildRows(results?: Map<string, SuiteResult>): {
   for (const def of getRegisteredProtocols()) {
     const chainIds = Object.keys(def.testData ?? {});
     const protoSuites = suites.filter((s) => s.protocol === def.slug);
-    if (chainIds.length === 0 && protoSuites.length === 0) {
+    // An unparseable suite (no scrapeable CHAIN_ID) joins no chain row,
+    // so it cannot stand in for a harness: only parseable suites keep a
+    // no-testData protocol out of the no-harness list. The unparseable
+    // suite itself still surfaces in orphanSuites.
+    const parseable = protoSuites.filter((s) => s.chainId !== "unparsed");
+    if (chainIds.length === 0 && parseable.length === 0) {
       noHarness.push({ protocol: def.slug, actions: def.actions.length });
       continue;
     }
@@ -165,7 +170,17 @@ function buildRows(results?: Map<string, SuiteResult>): {
       const runnable = plan.filter((c) => c.kind === "run").length;
       const skippedCases = plan.filter((c) => c.kind === "skip");
       const expectations = def.testData?.[chainId]?.expectations ?? {};
-      const suite = protoSuites.find((s) => s.chainId === chainId);
+      // Join by directory name first, then fall back to the scraped
+      // const PROTOCOL: a suite whose directory was renamed while the
+      // const kept the registered slug still runs under vitest as this
+      // protocol, so it must keep its row (and its executed counts)
+      // instead of splitting into none + orphan. The mismatch itself is
+      // still reported loudly via protocolMismatches.
+      const suite =
+        protoSuites.find((s) => s.chainId === chainId) ??
+        suites.find(
+          (s) => s.scrapedProtocol === def.slug && s.chainId === chainId
+        );
       if (suite) {
         consumed.add(suite.path);
       }

--- a/scripts/protocol-coverage-report.ts
+++ b/scripts/protocol-coverage-report.ts
@@ -24,7 +24,7 @@ import { readdirSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import "../protocols";
 import { getRegisteredProtocols } from "../lib/protocol-registry";
-import { planPhaseFixtures } from "../tests/e2e/vitest/protocol-coverage/_shared/plan";
+import { planPhaseFixtures } from "../lib/test-data/plan";
 import {
   countAssertions,
   type VitestAssertionCounts,

--- a/tests/e2e/vitest/protocol-coverage/_shared/funding.ts
+++ b/tests/e2e/vitest/protocol-coverage/_shared/funding.ts
@@ -39,6 +39,25 @@ export const ERC20_ABI = [
   "function approve(address spender, uint256 amount) returns (bool)",
 ];
 
+/**
+ * Run `fn` with `address` impersonated on an anvil fork, guaranteeing
+ * anvil_stopImpersonatingAccount runs even when the callback throws.
+ * Shared by the fork provisioning paths below and the Tier 1 simulation
+ * harness so the impersonate/stop bracket cannot drift between copies.
+ */
+export async function withImpersonation<T>(
+  provider: ethers.JsonRpcProvider,
+  address: string,
+  fn: (signer: ethers.JsonRpcSigner) => Promise<T>
+): Promise<T> {
+  await provider.send("anvil_impersonateAccount", [address]);
+  try {
+    return await fn(await provider.getSigner(address));
+  } finally {
+    await provider.send("anvil_stopImpersonatingAccount", [address]);
+  }
+}
+
 // chains.defaultPrimaryRpc is bootstrap-time data; memoize per process so a
 // test session opening 3+ helpers (ensureNativeGas + one per requiredTokens)
 // pays one Postgres round-trip per chain on the first miss and zero on every
@@ -102,7 +121,7 @@ export async function ensureNativeGas(
     // anvil_setBalance sets the balance to an absolute value in hex wei.
     await provider.send("anvil_setBalance", [
       address,
-      "0x" + topUpWei.toString(16),
+      `0x${topUpWei.toString(16)}`,
     ]);
     return;
   }
@@ -215,9 +234,7 @@ async function ensureErc20OnFork(
     whale.address,
     "0x8ac7230489e80000",
   ]);
-  await provider.send("anvil_impersonateAccount", [whale.address]);
-  try {
-    const whaleSigner = await provider.getSigner(whale.address);
+  await withImpersonation(provider, whale.address, async (whaleSigner) => {
     const tokenAsWhale = new ethers.Contract(
       tokenEntry.address,
       ERC20_ABI,
@@ -225,9 +242,7 @@ async function ensureErc20OnFork(
     );
     const tx = await tokenAsWhale.transfer(walletAddress, gap);
     await tx.wait();
-  } finally {
-    await provider.send("anvil_stopImpersonatingAccount", [whale.address]);
-  }
+  });
 }
 
 /**
@@ -277,15 +292,11 @@ async function mintViaFaucetOnFork(
   }
   const args = bindFaucetArgs(fn, tokenEntry.address, walletAddress, gap);
 
-  await provider.send("anvil_impersonateAccount", [walletAddress]);
-  try {
-    const signer = await provider.getSigner(walletAddress);
+  await withImpersonation(provider, walletAddress, async (signer) => {
     const contract = new ethers.Contract(faucet.contract, abi, signer);
     const tx = await contract[faucet.functionName](...args);
     await tx.wait();
-  } finally {
-    await provider.send("anvil_stopImpersonatingAccount", [walletAddress]);
-  }
+  });
 }
 
 /**

--- a/tests/e2e/vitest/protocol-coverage/_shared/run-fixture.ts
+++ b/tests/e2e/vitest/protocol-coverage/_shared/run-fixture.ts
@@ -1,5 +1,5 @@
 /**
- * Per-action test runner for protocol-coverage (KEEP-458).
+ * Per-action test runner for protocol-coverage.
  *
  * Iterates registered actions for the (protocol, chain), builds a Manual-
  * trigger workflow on the fly via `buildActionWorkflow`, inserts it, fires
@@ -25,11 +25,6 @@ import {
 } from "@/tests/utils/db";
 import { checkOutputExpectation, fetchNodeOutput } from "./oracle";
 import type { SharedCtx } from "./setup";
-
-// Planning logic lives in lib/test-data/plan (vitest-free) so the coverage
-// report CLI can share it; re-exported here to keep existing import sites
-// working.
-export { type FixtureCase, planPhaseFixtures } from "@/lib/test-data/plan";
 
 const TIMEOUT_MS = 120_000;
 

--- a/tests/e2e/vitest/protocol-coverage/_shared/run-fixture.ts
+++ b/tests/e2e/vitest/protocol-coverage/_shared/run-fixture.ts
@@ -15,6 +15,7 @@ import {
   buildActionWorkflow,
   toWebhookTriggered,
 } from "@/lib/test-data/build-workflow";
+import { planPhaseFixtures } from "@/lib/test-data/plan";
 import {
   createApiKey,
   createTestWorkflow,
@@ -23,12 +24,12 @@ import {
   waitForWorkflowExecution,
 } from "@/tests/utils/db";
 import { checkOutputExpectation, fetchNodeOutput } from "./oracle";
-import { planPhaseFixtures } from "./plan";
 import type { SharedCtx } from "./setup";
 
-// Planning logic lives in ./plan (vitest-free) so the coverage report CLI
-// can share it; re-exported here to keep existing import sites working.
-export { type FixtureCase, planPhaseFixtures } from "./plan";
+// Planning logic lives in lib/test-data/plan (vitest-free) so the coverage
+// report CLI can share it; re-exported here to keep existing import sites
+// working.
+export { type FixtureCase, planPhaseFixtures } from "@/lib/test-data/plan";
 
 const TIMEOUT_MS = 120_000;
 

--- a/tests/e2e/vitest/protocol-simulation/_shared/simulate.ts
+++ b/tests/e2e/vitest/protocol-simulation/_shared/simulate.ts
@@ -30,13 +30,13 @@ import {
   encodeBoundAction,
   encodeSetupSteps,
 } from "@/lib/test-data/encode-action";
+import { planPhaseFixtures } from "@/lib/test-data/plan";
 import { structureAbiOutputs } from "@/plugins/web3/steps/structure-abi-result";
 import {
   ERC20_ABI,
   ensureErc20Acquired,
 } from "../../protocol-coverage/_shared/funding";
 import { checkOutputExpectation } from "../../protocol-coverage/_shared/oracle";
-import { planPhaseFixtures } from "../../protocol-coverage/_shared/plan";
 
 /** Fixed simulation wallet: any address works under impersonation; fixed
  *  keeps behavior reproducible across runs. Distinct from anvil's dev

--- a/tests/e2e/vitest/protocol-simulation/_shared/simulate.ts
+++ b/tests/e2e/vitest/protocol-simulation/_shared/simulate.ts
@@ -161,11 +161,8 @@ async function runRead(
     Interface["decodeFunctionResult"]
   >[0];
   const decoded = encoded.iface.decodeFunctionResult(fragment, ret);
-  const outputs =
-    JSON.parse((fragment as { format: (f: string) => string }).format("json"))
-      .outputs ?? [];
   const values = serializeResult([...decoded]);
-  return structureAbiOutputs(values as unknown[], outputs);
+  return structureAbiOutputs(values as unknown[], encoded.abiOutputs);
 }
 
 export function runSimulation(opts: {

--- a/tests/e2e/vitest/protocol-simulation/_shared/simulate.ts
+++ b/tests/e2e/vitest/protocol-simulation/_shared/simulate.ts
@@ -35,6 +35,7 @@ import { structureAbiOutputs } from "@/plugins/web3/steps/structure-abi-result";
 import {
   ERC20_ABI,
   ensureErc20Acquired,
+  withImpersonation,
 } from "../../protocol-coverage/_shared/funding";
 import { checkOutputExpectation } from "../../protocol-coverage/_shared/oracle";
 
@@ -51,17 +52,13 @@ async function sendImpersonatedOnce(
   from: string,
   tx: { to: string; data?: string; value?: bigint }
 ): Promise<void> {
-  await provider.send("anvil_impersonateAccount", [from]);
-  try {
-    const signer = await provider.getSigner(from);
+  await withImpersonation(provider, from, async (signer) => {
     const sent = await signer.sendTransaction(tx);
     const receipt = await sent.wait();
     if (!receipt || receipt.status !== 1) {
       throw new Error(`impersonated tx to ${tx.to} reverted`);
     }
-  } finally {
-    await provider.send("anvil_stopImpersonatingAccount", [from]);
-  }
+  });
 }
 
 async function impersonatedSend(

--- a/tests/integration/_shared/build-calldata.ts
+++ b/tests/integration/_shared/build-calldata.ts
@@ -1,41 +1,42 @@
 /**
  * Shared calldata builder for protocol on-chain integration tests.
  *
- * Every protocol's on-chain integration test does the same six steps to
- * turn a (protocol, action slug, sample inputs, chain) tuple into the
- * `{ to, data }` pair eth_call needs:
+ * Validating wrapper around the shared encode kernel in
+ * lib/test-data/encode-action.ts (encodeFromConfig), which owns the
+ * production pipeline: encode transforms, fragment resolution (overload
+ * and flattened-tuple arity handling), reshapeArgsForAbi,
+ * coerceArgsForAbi, and Interface encoding. On top of the kernel this
+ * wrapper keeps the test-facing contract:
  *
- *   1. Find the action by slug.
- *   2. Resolve the contract and its address for the target chain.
- *   3. Map sampleInputs to rawArgs via input.name.
- *   4. reshapeArgsForAbi against the function's ABI (re-wraps flattened
- *      tuple components into the object ethers.js expects).
- *   5. Encode calldata via ethers.Interface.
- *   6. Return { to, data, action, contract } for the caller to assert on.
+ *   - rejects sampleInputs keys the action does not declare, so a typo
+ *     in a test fixture fails loudly instead of encoding a default;
+ *   - honors `toOverride` unconditionally and throws when no address
+ *     resolves (the kernel resolves "" instead of throwing);
+ *   - keeps its own error messages for unknown action / missing ABI /
+ *     missing function, which tests/unit/build-calldata.test.ts pins;
+ *   - offers the `coerceArgs: false` escape hatch reproducing the
+ *     pre-coerce encoding (reshape only) so regression tests can pin
+ *     the trap the default pipeline disarms.
  *
  * `chainId` is required so the helper cannot silently pick a wrong
- * chain when a protocol is deployed on multiple. `toOverride` is
- * opt-in for contracts marked `userSpecifiedAddress` (e.g. a Uniswap
- * V3 pool whose address is computed per pair at runtime).
- *
- * Per-protocol assertion patterns stay in their own test files; this
- * module deliberately handles only the calldata-encoding half of the
- * test setup.
+ * chain when a protocol is deployed on multiple. Per-protocol assertion
+ * patterns stay in their own test files; this module deliberately
+ * handles only the calldata-encoding half of the test setup.
  */
 
-import { ethers } from "ethers";
-import {
-  coerceArgsForAbi,
-  type FunctionAbiEntry,
-  reshapeArgsForAbi,
-} from "@/lib/abi/struct-args";
+import { reshapeArgsForAbi } from "@/lib/abi/struct-args";
 import type {
   ProtocolAction,
   ProtocolContract,
   ProtocolDefinition,
 } from "@/lib/protocol-registry";
+import {
+  encodeFromConfig,
+  fragmentFor,
+  ifaceFor,
+} from "@/lib/test-data/encode-action";
 
-type AbiEntry = FunctionAbiEntry & {
+type AbiEntry = {
   type: string;
   name?: string;
 };
@@ -54,7 +55,8 @@ export type BuildCalldataParams = {
   actionSlug: string;
   /** Map of input name to stringly-typed value. Must not contain keys
    *  that the action does not declare; unknown keys throw. Missing
-   *  declared keys fall back to `inp.default ?? ""`. */
+   *  declared keys (and explicitly empty values) fall back to
+   *  `inp.default ?? ""`. */
   sampleInputs: Record<string, string>;
   /** Chain ID string as it appears in `protocol.contracts[key].addresses`.
    *  Required; mistakes here are silent bugs (wrong contract on wrong
@@ -119,24 +121,30 @@ export function buildCalldata(params: BuildCalldataParams): Calldata {
     );
   }
 
-  const rawArgs = action.inputs.map(
-    (inp) => sampleInputs[inp.name] ?? inp.default ?? ""
-  );
-
   const parsedAbi = JSON.parse(contract.abi) as AbiEntry[];
-  const functionAbi = parsedAbi.find(
+  const hasFunction = parsedAbi.some(
     (f) => f.type === "function" && f.name === action.function
   );
-  if (!functionAbi) {
+  if (!hasFunction) {
     throw new Error(
       `Function ${action.function} not found in ABI for contract ${action.contract}`
     );
   }
-  const reshaped = reshapeArgsForAbi(rawArgs, functionAbi);
-  const args =
-    coerceArgs === false ? reshaped : coerceArgsForAbi(reshaped, functionAbi);
-  const iface = new ethers.Interface(parsedAbi);
-  const data = iface.encodeFunctionData(action.function, args);
 
+  if (coerceArgs === false) {
+    // Escape hatch: same fragment resolution as the kernel, but skip
+    // coerceArgsForAbi (and encode transforms) to reproduce the raw
+    // pre-coerce encoding the regression tests assert on.
+    const iface = ifaceFor(protocol, action);
+    const { ethersFragment, abi } = fragmentFor(iface, action);
+    const rawArgs: unknown[] = action.inputs.map(
+      (inp) => sampleInputs[inp.name] ?? inp.default ?? ""
+    );
+    const args = reshapeArgsForAbi(rawArgs, abi);
+    const data = iface.encodeFunctionData(ethersFragment as never, args);
+    return { to, data, action, contract };
+  }
+
+  const { data } = encodeFromConfig(protocol, action, chainId, sampleInputs);
   return { to, data, action, contract };
 }

--- a/tests/integration/_shared/build-calldata.ts
+++ b/tests/integration/_shared/build-calldata.ts
@@ -56,7 +56,7 @@ export type BuildCalldataParams = {
   /** Map of input name to stringly-typed value. Must not contain keys
    *  that the action does not declare; unknown keys throw. Missing
    *  declared keys (and explicitly empty values) fall back to
-   *  `inp.default ?? ""`. */
+   *  `inp.default ?? ""` on both encoding paths. */
   sampleInputs: Record<string, string>;
   /** Chain ID string as it appears in `protocol.contracts[key].addresses`.
    *  Required; mistakes here are silent bugs (wrong contract on wrong
@@ -75,8 +75,10 @@ export type BuildCalldataParams = {
    * silently encodes `"false"` as `true` without coercion.
    *
    * Defaults to `true` so tests match the production encoding pipeline
-   * by default. Pass `false` only to deliberately exercise the
-   * pre-coerce shape (e.g. a regression test asserting the trap exists).
+   * by default. Pass `false` to skip `coerceArgsForAbi` and the
+   * registered encode transforms (reshape only), reproducing the raw
+   * pre-coerce encoding (e.g. for a regression test asserting the trap
+   * exists).
    */
   coerceArgs?: boolean;
 };
@@ -137,9 +139,10 @@ export function buildCalldata(params: BuildCalldataParams): Calldata {
     // pre-coerce encoding the regression tests assert on.
     const iface = ifaceFor(protocol, action);
     const { ethersFragment, abi } = fragmentFor(iface, action);
-    const rawArgs: unknown[] = action.inputs.map(
-      (inp) => sampleInputs[inp.name] ?? inp.default ?? ""
-    );
+    const rawArgs: unknown[] = action.inputs.map((inp) => {
+      const raw = sampleInputs[inp.name];
+      return raw === undefined || raw === "" ? (inp.default ?? "") : raw;
+    });
     const args = reshapeArgsForAbi(rawArgs, abi);
     const data = iface.encodeFunctionData(ethersFragment as never, args);
     return { to, data, action, contract };

--- a/tests/unit/plan-phase-fixtures.test.ts
+++ b/tests/unit/plan-phase-fixtures.test.ts
@@ -13,7 +13,7 @@ import type {
   ProtocolAction,
   ProtocolDefinition,
 } from "@/lib/protocol-registry";
-import { planPhaseFixtures } from "@/tests/e2e/vitest/protocol-coverage/_shared/run-fixture";
+import { planPhaseFixtures } from "@/lib/test-data/plan";
 
 function makeAction(
   slug: string,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,7 +45,6 @@
     "scripts/seed/fixtures/dev-workflows.ts",
     "scripts/dev-mint-session.ts",
     "scripts/dev-login.ts",
-    "scripts/dev-login-browser.ts",
-    "scripts/protocol-coverage-report.ts"
+    "scripts/dev-login-browser.ts"
   ]
 }


### PR DESCRIPTION
## Summary

Five structural cleanups confirmed by the adversarial review of the tiered protocol-coverage work, landed as one commit each. No behavior change to any test assertion: Tier 0 goldens are byte-identical throughout.

## Changes

- The fixture planner moves from tests/ to lib/test-data/, deleting the tsconfig exclude and .dockerignore entries for the coverage report script and restoring its type-checking (it had been invisible to tsc).
- One shared withImpersonation bracket replaces three drifted copies of the anvil impersonation idiom; the simulation tier's retry-once-on-revert semantics are unchanged.
- Dead EncodedAction fields removed; the parsed ABI outputs are retained once instead of re-derived per read.
- buildCalldata now delegates encoding to the encode-action kernel and keeps only its validation layer, ending the two-parallel-encoders drift (registered encode transforms now apply on that path; verified idempotent for the only existing transform).
- The coverage report derives each suite's protocol from its directory and reports scrape mismatches loudly instead of silently dropping suites.

## Test Plan

- [x] Tier 0 golden-calldata suite: 476 passed after every commit, goldens byte-identical (UPDATE_GOLDENS never set)
- [x] Full unit suite: 15,356 passed
- [x] tsc clean including the newly-included report script; biome clean on changed files
- [x] Tier 1 fork sweep: 202/203 (single failure was a 30s cold-read timeout against the new archive upstream, passes warm; zero reverts)
- [x] Ephemeral e2e round on this PR