### PR TITLE
fix(executor): classify error-finalized executions in updateExecutionStatus

### DIFF
--- a/keeperhub-executor/lib/db-helpers.test.ts
+++ b/keeperhub-executor/lib/db-helpers.test.ts
@@ -1,0 +1,144 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// A transitive lib import (the classifier -> lib/logging) is server-only; stub
+// the guard so db-helpers imports under vitest, same pattern as the other
+// executor suites.
+vi.mock("server-only", () => ({}));
+
+// The terminal-counter emit dynamic-imports the prometheus collector and hits
+// the DB for the org slug. Stub it so these tests stay a focused unit on the
+// row write; a separate assertion checks it is invoked with the persisted
+// classification.
+const { recordTerminalSampleMock } = vi.hoisted(() => ({
+  recordTerminalSampleMock: vi.fn(),
+}));
+vi.mock("./terminal-counters", () => ({
+  recordTerminalSample: recordTerminalSampleMock,
+}));
+
+import type { DbSchema } from "./db-helpers";
+import { updateExecutionStatus } from "./db-helpers";
+
+type SetData = Record<string, unknown>;
+
+type UpdateBuilder = {
+  set: (data: SetData) => UpdateBuilder;
+  where: () => UpdateBuilder;
+  returning: () => Promise<Array<{ workflowId: string }>>;
+};
+
+type MockDb = {
+  db: PostgresJsDatabase<DbSchema>;
+  captured: { setData: SetData | null };
+};
+
+/**
+ * Minimal fake of the drizzle chain updateExecutionStatus uses
+ * (db.update(...).set(...).where(...).returning(...)). `returningRows` controls
+ * whether the guarded CAS matched a row: a non-empty array simulates the
+ * backstop winning the terminal transition, an empty array simulates a no-op
+ * because the engine already closed the row.
+ */
+function makeDb(returningRows: Array<{ workflowId: string }>): MockDb {
+  const captured: { setData: SetData | null } = { setData: null };
+  const builder: UpdateBuilder = {
+    set(data: SetData): UpdateBuilder {
+      captured.setData = data;
+      return builder;
+    },
+    where(): UpdateBuilder {
+      return builder;
+    },
+    returning(): Promise<Array<{ workflowId: string }>> {
+      return Promise.resolve(returningRows);
+    },
+  };
+  const db = { update: (): UpdateBuilder => builder };
+  return { db: db as unknown as PostgresJsDatabase<DbSchema>, captured };
+}
+
+describe("updateExecutionStatus classification", () => {
+  beforeEach(() => {
+    recordTerminalSampleMock.mockReset();
+  });
+
+  it("promotes a confidently system failure to system_error and persists the classification", async () => {
+    const { db, captured } = makeDb([{ workflowId: "wf1" }]);
+
+    await updateExecutionStatus(db, "e1", "error", {
+      error: "Workflow terminated by SIGTERM signal",
+    });
+
+    expect(captured.setData).toMatchObject({
+      status: "system_error",
+      error: "Workflow terminated by SIGTERM signal",
+      errorType: "system",
+      errorCategory: "infrastructure",
+      errorCode: "P-0003",
+    });
+    expect(captured.setData?.completedAt).toBeInstanceOf(Date);
+    expect(recordTerminalSampleMock).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        workflowId: "wf1",
+        status: "system_error",
+        errorType: "system",
+        errorCategory: "infrastructure",
+      })
+    );
+  });
+
+  it("keeps status=error for a user-classified failure and writes error_type=user", async () => {
+    const { db, captured } = makeDb([{ workflowId: "wf1" }]);
+
+    await updateExecutionStatus(db, "e1", "error", {
+      error: "Unresolved template reference {{@node1.output}}",
+    });
+
+    expect(captured.setData).toMatchObject({
+      status: "error",
+      errorType: "user",
+      errorCategory: "configuration",
+      errorCode: null,
+    });
+  });
+
+  it("writes a default classification (error_type=system) for an unmatched message without promoting", async () => {
+    const { db, captured } = makeDb([{ workflowId: "wf1" }]);
+
+    await updateExecutionStatus(db, "e1", "error", {
+      error: "totally unrecognized boom",
+    });
+
+    expect(captured.setData).toMatchObject({
+      status: "error",
+      errorType: "system",
+      errorCategory: "workflow_engine",
+      errorCode: "C-0001",
+    });
+  });
+
+  it("does not emit a terminal sample when the guarded update matched no row", async () => {
+    const { db } = makeDb([]);
+
+    await updateExecutionStatus(db, "e1", "error", { error: "boom" });
+
+    expect(recordTerminalSampleMock).not.toHaveBeenCalled();
+  });
+
+  it("does not classify or set error columns for a non-error status", async () => {
+    const { db, captured } = makeDb([{ workflowId: "wf1" }]);
+
+    await updateExecutionStatus(db, "e1", "success", { output: { ok: true } });
+
+    expect(captured.setData?.status).toBe("success");
+    expect(captured.setData).not.toHaveProperty("errorType");
+    expect(captured.setData).not.toHaveProperty("errorCategory");
+    expect(captured.setData).not.toHaveProperty("errorCode");
+    expect(recordTerminalSampleMock).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ status: "success" })
+    );
+  });
+});

--- a/keeperhub-executor/lib/db-helpers.ts
+++ b/keeperhub-executor/lib/db-helpers.ts
@@ -6,7 +6,15 @@ import {
   workflowSchedules,
   type workflows,
 } from "../../lib/db/schema";
+import {
+  classifyExecutionError,
+  isDefaultClassification,
+} from "../../lib/errors/classify";
 import type { ErrorCode } from "../../lib/errors/error-codes";
+import {
+  isErrorStatus,
+  statusForErrorType,
+} from "../../lib/errors/execution-status";
 import { calculateTotalSteps } from "../../lib/workflow/executor/progress";
 import type { WorkflowEdge, WorkflowNode } from "../../lib/workflow/store";
 import type { executeWorkflow } from "../../lib/workflow/executor/executor.workflow";
@@ -64,12 +72,39 @@ export async function updateExecutionStatus(
   status: "running" | "success" | "error" | "cancelled",
   result?: { output?: unknown; error?: string }
 ): Promise<void> {
+  // Classify the failure so the backstop row carries error_category /
+  // error_type / error_code, exactly like the engine's own finalize
+  // (logWorkflowCompleteDb). Without this, executions the executor closes on
+  // its own (consumer-crash backstop, SIGTERM shutdown, engine-write-lost)
+  // land with a NULL classification and drop out of error_type-filtered
+  // dashboards even though recordTerminalSample already counts them.
+  const classification =
+    status === "error" ? classifyExecutionError(result?.error) : null;
+
+  // Mirror logWorkflowCompleteDb: a confidently system-classified failure
+  // persists as system_error so it stays filterable apart from user/workflow
+  // errors; an unmatched failure that only defaulted to "system" keeps the
+  // plain "error" status (its error_type is still written as "system"). The
+  // engine and this backstop must produce the same row shape for the same
+  // failure so a lost engine write is closed identically.
+  const persistedStatus =
+    status === "error"
+      ? statusForErrorType(
+          classification && !isDefaultClassification(classification)
+            ? classification.errorType
+            : null
+        )
+      : status;
+
+  const isTerminal =
+    persistedStatus === "success" || isErrorStatus(persistedStatus);
+
   const updateData: Record<string, unknown> = {
-    status,
+    status: persistedStatus,
     updatedAt: new Date(),
   };
 
-  if (status === "success" || status === "error") {
+  if (isTerminal) {
     updateData.completedAt = new Date();
   }
   if (result?.output !== undefined) {
@@ -77,6 +112,11 @@ export async function updateExecutionStatus(
   }
   if (result?.error) {
     updateData.error = result.error;
+  }
+  if (classification) {
+    updateData.errorCategory = classification.errorCategory;
+    updateData.errorType = classification.errorType;
+    updateData.errorCode = classification.code;
   }
 
   // Only transition a row that has not already reached a terminal state. The
@@ -107,15 +147,19 @@ export async function updateExecutionStatus(
   // above excludes every terminal state), so this backstop is the execution's
   // first and only terminal transition and must emit the terminal counters
   // the engine would have emitted. Cancellation is intentionally not counted
-  // (the finished counter tracks success/error outcomes only).
+  // (the finished counter tracks success/error outcomes only). Pass the
+  // classification we persisted so the counter labels are guaranteed to match
+  // the row's error_type / error_category.
   if (
     updated.length > 0 &&
-    (status === "success" || status === "error")
+    (persistedStatus === "success" || isErrorStatus(persistedStatus))
   ) {
     await recordTerminalSample(db, {
       workflowId: updated[0].workflowId,
-      status,
+      status: persistedStatus,
       errorMessage: result?.error,
+      errorType: classification?.errorType,
+      errorCategory: classification?.errorCategory,
     });
   }
 }

--- a/tests/unit/apply-execution-result.test.ts
+++ b/tests/unit/apply-execution-result.test.ts
@@ -39,7 +39,11 @@ vi.mock("../../lib/workflow/executor/progress", () => ({
 
 vi.mock("../../lib/workflow/store", () => ({}));
 
-vi.mock("../../lib/errors/error-codes", () => ({}));
+// updateExecutionStatus now classifies the error, and classifyExecutionError's
+// default branch reads DEFAULT_SYSTEM_ERROR_CODE, so the mock must provide it.
+vi.mock("../../lib/errors/error-codes", () => ({
+  DEFAULT_SYSTEM_ERROR_CODE: "C-0001",
+}));
 
 vi.mock("../../keeperhub-executor/lib/serialize", () => ({
   toJsonSafe: (v: unknown) => v,


### PR DESCRIPTION
## Problem

The executor backstop `updateExecutionStatus` wrote `status='error'` rows without setting `error_category` / `error_type` / `error_code`. Around 8% of managed-client error rows landed with a NULL classification and silently dropped out of `error_type`-filtered dashboards. The terminal counter (`keeperhub_workflow_execution_errors_created_total`) already fired via `recordTerminalSample`, so only the persisted row columns were missing.

Every in-app finalization path (`logWorkflowCompleteDb`, the execute/webhook/MCP/reaper routes) and the phantom/dispatch helpers (`failExecutionAsSystemError`, `resolvePhantomToError`) already classify. The one remaining gap was this executor backstop, which all three runner/in-process error paths funnel through: result-fail (`applyExecutionResult`), SIGTERM shutdown, and the fatal catches.

## Fix

On the error path, classify the failure and persist the three columns, mirroring `logWorkflowCompleteDb`:

- A confidently system-classified failure is promoted to `system_error` (e.g. a SIGTERM-terminated row becomes `infrastructure` / `system_error`, code `P-0003`), so the executor backstop closes a lost engine write with the same row shape the engine would have written.
- An unmatched default keeps `status='error'` with `error_type='system'`.
- The same classification is passed into `recordTerminalSample` so the counter labels are guaranteed to match the row.

No schema/migration change - the `error_category` / `error_type` / `error_code` columns already exist.

## Tests

New `keeperhub-executor/lib/db-helpers.test.ts` covers: system-confident promotion to `system_error`, user-classified failure staying `error`, unmatched default staying `error` with `error_type='system'`, emit-once no-op when the guarded CAS matches no row, and the non-error path leaving classification columns untouched.

Local: executor suite green (91 tests incl. the 5 new), `type-check` clean.

## Verification

Post-deploy, re-run the pre/post split: managed-org `status IN ('error','system_error')` rows with `error_type IS NULL` should approach 0 for runs finalized by the executor backstop.