### PR TITLE
ci: check out repo before local eks-connect action in PR-env cleanup

### DIFF
--- a/.github/workflows/cleanup-pr-environment.yaml
+++ b/.github/workflows/cleanup-pr-environment.yaml
@@ -56,6 +56,17 @@ jobs:
       NAMESPACE: pr-${{ github.event.pull_request.number }}
 
     steps:
+      # The eks-connect step below is a local action, so the repo must be
+      # checked out first. Without this every cleanup run fails at
+      # "Can't find 'action.yml' under .github/actions/eks-connect".
+      # Check out the PR's base branch: on closed events the PR merge ref
+      # may already be gone, and the action code should come from the
+      # trusted base rather than the PR head.
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:


### PR DESCRIPTION
## Summary

Every run of the Cleanup PR Environment workflow currently fails at the Connect to EKS step with:

> Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under .github/actions/eks-connect. Did you forget to run actions/checkout before running your local action?

The cleanup job references the local eks-connect composite action but never checks out the repository. All 6 of today's runs failed this way (every PR close since the eks-connect refactor), so PR namespaces are not being cleaned up.

## Fix

Add an actions/checkout step before the AWS/EKS steps, pinned to the PR's base branch ref:
- on closed events the PR merge ref may already be deleted, so checking out the default merge ref can fail
- the action code should come from the trusted base branch rather than the PR head

## Note

This commit was originally pushed to the PR 1726 branch a few minutes after that PR merged, so it never landed on staging; this PR re-lands it cleanly.