### PR TITLE
fix(ci): checkout repo before eks-connect in cleanup and seed jobs

### DIFF
--- a/.github/workflows/cleanup-pr-environment.yaml
+++ b/.github/workflows/cleanup-pr-environment.yaml
@@ -56,6 +56,11 @@ jobs:
       NAMESPACE: pr-${{ github.event.pull_request.number }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -1437,6 +1437,11 @@ jobs:
       CLUSTER_NAME: ${{ vars.TO_CLUSTER_NAME }}
       NAMESPACE: pr-${{ github.event.pull_request.number }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:


### PR DESCRIPTION
## Problem

Two CI jobs invoke the local composite action `./.github/actions/eks-connect` (the SSM-jump connector) **without running `actions/checkout` first**, so the action files are not on the runner and the step fails immediately:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '.../.github/actions/eks-connect'.
Did you forget to run actions/checkout before running your local action?
```

Affected jobs:
- `cleanup-pr-environment.yaml` -> `cleanup`
- `deploy-pr-environment.yaml` -> `seed-load-test-users`

This fails on every run today (independent of the endpoint being public), so PR environments are not torn down on close (leaking namespaces, Helm releases and Postgres clusters), and the load-test seed job fails. It also has to be fixed before the cluster endpoint is restricted, or these jobs stay broken.

Example failing run: https://github.com/KeeperHub/keeperhub/actions/runs/28874290561/job/85645078957

## Fix

Add a checkout as the first step of both jobs (the only jobs across the 7 eks-connect workflows that were missing it - the other 10 cluster-touching jobs already check out):
- `cleanup` runs on PR close, so it checks out the base ref (always present, carries the action)
- `seed-load-test-users` mirrors its sibling jobs and checks out the PR head sha

Both jobs only need the action files on disk; their cluster work is all inline `kubectl`/`helm`.

## Verification

- Job-level audit across all workflows: after the fix, zero cluster-touching jobs are missing checkout-before-eks-connect
- `actionlint -shellcheck=""` (the maintainability CI check) passes across all workflows
- YAML parses clean