### PR TITLE
test(e2e): assert trigger selection by class, deselect via Escape

### DIFF
--- a/tests/e2e/playwright/schedule-trigger.test.ts
+++ b/tests/e2e/playwright/schedule-trigger.test.ts
@@ -1,9 +1,7 @@
 import { expect, test } from "./fixtures";
 import { gotoCanvas } from "./utils/workflow";
 
-// Top-level regex patterns
 const SELECTED_CLASS_REGEX = /selected/;
-const DATA_SELECTED_REGEX = /true/;
 
 test.describe("Schedule Trigger", () => {
   test.beforeEach(async ({ page }) => {
@@ -65,23 +63,13 @@ test.describe("Schedule Trigger", () => {
     const triggerNode = page.locator(".react-flow__node-trigger").first();
     if (await triggerNode.isVisible()) {
       await triggerNode.click();
-      // Wait for selection state to update
-      await expect(triggerNode).toHaveAttribute(
-        "data-selected",
-        DATA_SELECTED_REGEX
-      );
+      // React Flow marks selection with the "selected" class, not an attribute.
+      await expect(triggerNode).toHaveClass(SELECTED_CLASS_REGEX);
 
-      // Click elsewhere to deselect
-      const canvas = page.locator('[data-testid="workflow-canvas"]');
-      const canvasBox = await canvas.boundingBox();
-      if (canvasBox) {
-        await page.mouse.click(canvasBox.x + 50, canvasBox.y + 50);
-        // Wait for deselection
-        await expect(triggerNode).not.toHaveAttribute(
-          "data-selected",
-          DATA_SELECTED_REGEX
-        );
-      }
+      // Deselect with Escape (same as getWebhookUrl); a pane click is
+      // intercepted by the left flyout and the top promo banner overlays.
+      await page.keyboard.press("Escape");
+      await expect(triggerNode).not.toHaveClass(SELECTED_CLASS_REGEX);
     }
 
     // Verify node count is preserved


### PR DESCRIPTION
## What

The staging e2e run had one hard failure: `schedule-trigger` › "workflow canvas maintains state after trigger configuration". It asserted a `data-selected="true"` attribute that React Flow never sets (selection is marked with the `selected` class). Once the canvas actually loads, that assertion trips.

## Changes

- Assert selection with `toHaveClass(/selected/)`, matching the sibling tests in the same file and `workflow.test.ts`.
- Deselect with `Escape` (as `getWebhookUrl` already does) instead of a pane click, which the left flyout and the top promo banner intercept.
- Drop the now-unused `data-selected` regex.

## Verification

Ran the previously-failing test 3x against a local production build (`pnpm start`, `CI=1`, `NEXT_BUILD_MODE=production`, `TEST_API_KEY`, `keeperhub_test`): all pass, no flake.

## Note

The same staging run also listed `auth:164`, `invitations:78`, and `workflow:130` as flaky; they pass on retry (CI `retries: 2`) and are not regressions.
