### PR TITLE
fix: remove duplicate MAINNET_CHAIN_ID declaration in safe-roles fork test

### DIFF
--- a/tests/e2e/vitest/safe-roles-orchestrator-fork.test.ts
+++ b/tests/e2e/vitest/safe-roles-orchestrator-fork.test.ts
@@ -208,7 +208,6 @@ import {
   FORK_URL,
   getFork,
   isForkReachable,
-  MAINNET_CHAIN_ID,
 } from "./safe-fork-helpers";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Staging CI (e2e-tests / e2e-vitest-ephemeral) has been failing since the merge of #1724 with an esbuild transform error:

    tests/e2e/vitest/safe-roles-orchestrator-fork.test.ts:211:2
    ERROR: The symbol "MAINNET_CHAIN_ID" has already been declared

A Copilot Autofix commit on the merged branch added a local const MAINNET_CHAIN_ID = 1 to satisfy a code-scanning finding about use-before-declaration, but the file already imports the same symbol from ./safe-fork-helpers in a mid-file import block, leaving it declared twice.

The original finding was a false positive (ESM imports are hoisted), but the added const is harmless on its own, so this PR resolves the duplicate by removing MAINNET_CHAIN_ID from the import list and keeping the local const. safe-fork-helpers exports the identical value (1), so behavior is unchanged and the code-scanning finding stays satisfied.

## Changes

- Remove MAINNET_CHAIN_ID from the ./safe-fork-helpers import list in tests/e2e/vitest/safe-roles-orchestrator-fork.test.ts (one-line deletion)

## Testing

- CI on this PR verifies the suite compiles and runs; the failure was a compile-time error, so the failing job reproduces/validates directly.

Note for reviewers: the same mid-file import pattern exists for the @/lib/safe/roles-orchestrator block in this file. If code scanning flags it again, it should be dismissed as a false positive (imports hoist) rather than autofixed.