### PR TITLE
refactor(metrics): remove dead chain label from workflow executions counter

### DIFF
--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -298,16 +298,14 @@ export async function POST(
       createdHere = true;
     }
 
-    // Record per-(trigger_type, chain) start of a workflow execution. Drives the
+    // Record per-trigger_type start of a workflow execution. Drives the
     // Grafana "zero executions in N min" alert family (see KEEP-556). Skipped
     // when the executor pre-created the row - it already incremented on its
     // side in that case.
     if (createdHere) {
-      const chainLabel = workflow.chain ?? "_unknown";
       const metrics = getMetricsCollector();
       metrics.incrementCounter(MetricNames.WORKFLOW_EXECUTIONS_STARTED_TOTAL, {
         [LabelKeys.TRIGGER_TYPE]: triggerType,
-        [LabelKeys.CHAIN]: chainLabel,
       });
     }
 

--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -414,12 +414,10 @@ export async function POST(
 
     console.log("[Webhook] Created execution:", execution.id);
 
-    // Record per-(trigger_type, chain) start of a workflow execution. See KEEP-556.
-    const chainLabel = workflow.chain ?? "_unknown";
+    // Record per-trigger_type start of a workflow execution. See KEEP-556.
     const metrics = getMetricsCollector();
     metrics.incrementCounter(MetricNames.WORKFLOW_EXECUTIONS_STARTED_TOTAL, {
       [LabelKeys.TRIGGER_TYPE]: "webhook",
-      [LabelKeys.CHAIN]: chainLabel,
     });
 
     // Resolve org slug + plan for log labels (cached per request)

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -570,7 +570,6 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
     MetricNames.WORKFLOW_EXECUTIONS_STARTED_TOTAL,
     {
       [LabelKeys.TRIGGER_TYPE]: triggerType,
-      [LabelKeys.CHAIN]: workflow.chain ?? "_unknown",
     }
   );
 

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -801,18 +801,17 @@ const pluginInvocations = getOrCreateCounter(
 );
 
 // Runtime counter incremented exactly once per workflow_executions row creation,
-// labelled by trigger_type (block | schedule | event | manual | webhook | scheduled)
-// and chain (the workflows.chain column; "_unknown" when null). Used by the
-// Grafana "zero executions in N min" alert family - increase()[window] == 0 with
-// no_data_state="Alerting" fires when a (trigger_type, chain) pair stalls.
+// labelled by trigger_type (block | schedule | event | manual | webhook | scheduled).
+// Used by the Grafana "zero executions in N min" alert family - increase()[window]
+// == 0 with no_data_state="Alerting" fires when a trigger_type stalls.
 //
 // Distinct from "workflow.executions.total" (a DB-sourced gauge of all-time counts
 // by status+org_slug) - that metric is computed via SQL in updateDbMetrics().
 const workflowExecutionsStartedTotal = getOrCreateCounter(
   apiRegistry,
   "keeperhub_workflow_executions_started_total",
-  "Workflow executions started (counter), labelled by trigger_type and chain",
-  ["trigger_type", "chain"]
+  "Workflow executions started (counter), labelled by trigger_type",
+  ["trigger_type"]
 );
 
 // KEEP-612 detection signal. lib/safe-fetch.ts increments this every time

--- a/lib/metrics/types.ts
+++ b/lib/metrics/types.ts
@@ -228,7 +228,6 @@ export const LabelKeys = {
   PLUGIN_NAME: "plugin_name",
   ACTION_NAME: "action_name",
   TRIGGER_TYPE: "trigger_type",
-  CHAIN: "chain",
   STATUS: "status",
   STATUS_CODE: "status_code",
   ERROR_TYPE: "error_type",


### PR DESCRIPTION
## What

Removes the `chain` label from the `keeperhub_workflow_executions_started_total` counter.

## Why

The label was sourced from the deprecated `workflows.chain` column, which is null for essentially all executing workflows (only the MCP listing API ever writes it). It was therefore always `_unknown`, so the per-chain zero-execution detection it was intended for never actually sliced per chain.

## Changes

- Drop `chain` from the counter registration and the `LabelKeys` map (`lib/metrics/`).
- Remove the label at all three emit sites: `keeperhub-executor/index.ts`, the webhook route, and the execute route.

Per-chain block-stall detection is still provided by the Block Dispatcher Chain Silent alert (real dispatcher metric); Zero Finished Global backstops overall execution health. The matching Grafana query cleanup ships as a separate infrastructure PR.

The `workflows.chain` column itself is retained for now - it is still read by agentic-wallet payment-chain classification. Removing it is tracked as a follow-up.

## Testing

- `pnpm check`, `pnpm type-check` clean
- `pnpm test:unit` (15,810) and `pnpm test:executor` (86) green
- `pnpm build` compiles + generates static pages
- `pnpm check:api-docs` no drift
