### PR TITLE
fix(executor): bound workflow-runner pod ephemeral storage

### DIFF
--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -710,6 +710,17 @@ executor:
     JOB_ACTIVE_DEADLINE:
       type: kv
       value: "300"
+    # Ephemeral-storage bounds for runner Job pods. The request lets the
+    # scheduler spread runners across nodes instead of packing one node's root
+    # volume; the limit (mirrored by the runner's /tmp emptyDir sizeLimit) evicts
+    # a single over-limit runner before the node trips DiskPressure. Starting
+    # values - retune from observed /tmp usage.
+    RUNNER_EPHEMERAL_STORAGE_REQUEST:
+      type: kv
+      value: "1Gi"
+    RUNNER_EPHEMERAL_STORAGE_LIMIT:
+      type: kv
+      value: "2Gi"
     EXECUTION_MODE:
       type: kv
       value: "isolated"

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -710,17 +710,17 @@ executor:
     JOB_ACTIVE_DEADLINE:
       type: kv
       value: "300"
-    # Ephemeral-storage bounds for runner Job pods. The request lets the
-    # scheduler spread runners across nodes instead of packing one node's root
-    # volume; the limit (mirrored by the runner's /tmp emptyDir sizeLimit) evicts
-    # a single over-limit runner before the node trips DiskPressure. Starting
-    # values - retune from observed /tmp usage.
+    # Ephemeral-storage guardrail for runner Job pods (mirrored by the runner's
+    # /tmp emptyDir sizeLimit). Live staging runners use ~2 MiB each, so the 1Gi
+    # limit is a runaway-/tmp guard, not the disk-pressure fix (that is node image
+    # GC + disk headroom in the eks-cluster workspace). Retune if a legitimate
+    # data-heavy workflow needs a larger /tmp.
     RUNNER_EPHEMERAL_STORAGE_REQUEST:
       type: kv
-      value: "1Gi"
+      value: "64Mi"
     RUNNER_EPHEMERAL_STORAGE_LIMIT:
       type: kv
-      value: "2Gi"
+      value: "1Gi"
     EXECUTION_MODE:
       type: kv
       value: "isolated"

--- a/keeperhub-executor/config.ts
+++ b/keeperhub-executor/config.ts
@@ -48,17 +48,19 @@ export const CONFIG = {
   // same name; this prefix is the executor Helm release fullname.
   runnerSecretPrefix:
     process.env.RUNNER_SECRET_PREFIX || "keeperhub-executor-common",
-  // Ephemeral-storage request/limit for runner pods. The request lets the
-  // scheduler account for node disk and spread runners instead of packing them
-  // onto one node; the limit (matched by the /tmp emptyDir sizeLimit, the runner's
-  // only writable path under readOnlyRootFilesystem) makes kubelet evict a single
-  // over-limit runner before the whole node trips DiskPressure. Starting values -
-  // calibrate against measured runner /tmp usage. Env-overridable, read once at
-  // start, so retuning takes an env update + restart, no code deploy.
+  // Ephemeral-storage guardrail for runner pods, matched by the /tmp emptyDir
+  // sizeLimit (the runner's only writable path under readOnlyRootFilesystem).
+  // The limit makes kubelet evict a single pod that writes pathologically much
+  // to /tmp before it can threaten the node root volume; the request is a small
+  // honest floor for scheduler/kubelet accounting. Sized from measurement:
+  // sampling live staging runners showed ~2 MiB of ephemeral use each, so the
+  // node disk pressure is driven by accumulated container images, not these
+  // pods - the 1Gi limit is a ~500x runaway guard that never touches a normal
+  // run. Env-overridable, read once at start (retune = env update + restart).
   runnerEphemeralStorageRequest:
-    process.env.RUNNER_EPHEMERAL_STORAGE_REQUEST || "1Gi",
+    process.env.RUNNER_EPHEMERAL_STORAGE_REQUEST || "64Mi",
   runnerEphemeralStorageLimit:
-    process.env.RUNNER_EPHEMERAL_STORAGE_LIMIT || "2Gi",
+    process.env.RUNNER_EPHEMERAL_STORAGE_LIMIT || "1Gi",
   // Finished runner pods hold their /tmp emptyDir + logs on the node until the
   // TTL controller deletes them. Kept short so a busy node reclaims that disk in
   // minutes rather than accumulating an hour of churn (the DiskPressure flap on

--- a/keeperhub-executor/config.ts
+++ b/keeperhub-executor/config.ts
@@ -48,7 +48,23 @@ export const CONFIG = {
   // same name; this prefix is the executor Helm release fullname.
   runnerSecretPrefix:
     process.env.RUNNER_SECRET_PREFIX || "keeperhub-executor-common",
-  jobTtlSeconds: Number(process.env.JOB_TTL_SECONDS) || 3600,
+  // Ephemeral-storage request/limit for runner pods. The request lets the
+  // scheduler account for node disk and spread runners instead of packing them
+  // onto one node; the limit (matched by the /tmp emptyDir sizeLimit, the runner's
+  // only writable path under readOnlyRootFilesystem) makes kubelet evict a single
+  // over-limit runner before the whole node trips DiskPressure. Starting values -
+  // calibrate against measured runner /tmp usage. Env-overridable, read once at
+  // start, so retuning takes an env update + restart, no code deploy.
+  runnerEphemeralStorageRequest:
+    process.env.RUNNER_EPHEMERAL_STORAGE_REQUEST || "1Gi",
+  runnerEphemeralStorageLimit:
+    process.env.RUNNER_EPHEMERAL_STORAGE_LIMIT || "2Gi",
+  // Finished runner pods hold their /tmp emptyDir + logs on the node until the
+  // TTL controller deletes them. Kept short so a busy node reclaims that disk in
+  // minutes rather than accumulating an hour of churn (the DiskPressure flap on
+  // 2026-07-07). activeDeadlineSeconds caps a live run at 300s, so 300s here means
+  // a pod is gone ~5 min after it finishes.
+  jobTtlSeconds: Number(process.env.JOB_TTL_SECONDS) || 300,
   jobActiveDeadline: Number(process.env.JOB_ACTIVE_DEADLINE) || 300,
   maxConcurrentJobs: Number(process.env.MAX_CONCURRENT_JOBS) || 1,
 

--- a/keeperhub-executor/k8s-job.test.ts
+++ b/keeperhub-executor/k8s-job.test.ts
@@ -34,8 +34,8 @@ vi.mock("./config", () => ({
     runnerSecretPrefix: "keeperhub-executor-common",
     runnerImage: "runner:latest",
     imagePullPolicy: "Never",
-    runnerEphemeralStorageRequest: "1Gi",
-    runnerEphemeralStorageLimit: "2Gi",
+    runnerEphemeralStorageRequest: "64Mi",
+    runnerEphemeralStorageLimit: "1Gi",
     jobTtlSeconds: 300,
     jobActiveDeadline: 300,
     maxConcurrentJobs: 5,
@@ -393,17 +393,18 @@ describe("createWorkflowJob", () => {
 
     const job = getSubmittedJob();
     const resources = job.spec?.template?.spec?.containers?.[0]?.resources;
-    // Request drives scheduler spread; limit drives per-pod eviction before
-    // the node trips DiskPressure.
-    expect(resources?.requests?.["ephemeral-storage"]).toBe("1Gi");
-    expect(resources?.limits?.["ephemeral-storage"]).toBe("2Gi");
+    // Small honest floor for the request; the limit is a runaway-/tmp guard
+    // (normal runners use ~2 MiB) that evicts a single pathological pod before
+    // it can threaten the node root volume.
+    expect(resources?.requests?.["ephemeral-storage"]).toBe("64Mi");
+    expect(resources?.limits?.["ephemeral-storage"]).toBe("1Gi");
 
     // The only writable medium (/tmp emptyDir) is capped at the pod limit so a
     // runaway runner is evicted on its own disk, not the shared node volume.
     const tmpVolume = job.spec?.template?.spec?.volumes?.find(
       (v) => v.name === "tmp"
     );
-    expect(tmpVolume?.emptyDir?.sizeLimit).toBe("2Gi");
+    expect(tmpVolume?.emptyDir?.sizeLimit).toBe("1Gi");
   });
 
   it("keeps finished runner pods only briefly so node disk is reclaimed fast", async () => {

--- a/keeperhub-executor/k8s-job.test.ts
+++ b/keeperhub-executor/k8s-job.test.ts
@@ -34,7 +34,9 @@ vi.mock("./config", () => ({
     runnerSecretPrefix: "keeperhub-executor-common",
     runnerImage: "runner:latest",
     imagePullPolicy: "Never",
-    jobTtlSeconds: 3600,
+    runnerEphemeralStorageRequest: "1Gi",
+    runnerEphemeralStorageLimit: "2Gi",
+    jobTtlSeconds: 300,
     jobActiveDeadline: 300,
     maxConcurrentJobs: 5,
   },
@@ -379,5 +381,39 @@ describe("createWorkflowJob", () => {
 
     const envVars = getJobEnvVars(job);
     expect(getEnvVar(envVars, "TMPDIR")).toBe("/tmp");
+  });
+
+  it("bounds runner disk with ephemeral-storage requests/limits and a matching /tmp sizeLimit", async () => {
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: {},
+      triggerType: "schedule",
+    });
+
+    const job = getSubmittedJob();
+    const resources = job.spec?.template?.spec?.containers?.[0]?.resources;
+    // Request drives scheduler spread; limit drives per-pod eviction before
+    // the node trips DiskPressure.
+    expect(resources?.requests?.["ephemeral-storage"]).toBe("1Gi");
+    expect(resources?.limits?.["ephemeral-storage"]).toBe("2Gi");
+
+    // The only writable medium (/tmp emptyDir) is capped at the pod limit so a
+    // runaway runner is evicted on its own disk, not the shared node volume.
+    const tmpVolume = job.spec?.template?.spec?.volumes?.find(
+      (v) => v.name === "tmp"
+    );
+    expect(tmpVolume?.emptyDir?.sizeLimit).toBe("2Gi");
+  });
+
+  it("keeps finished runner pods only briefly so node disk is reclaimed fast", async () => {
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: {},
+      triggerType: "schedule",
+    });
+
+    expect(getSubmittedJob().spec?.ttlSecondsAfterFinished).toBe(300);
   });
 });

--- a/keeperhub-executor/k8s-job.ts
+++ b/keeperhub-executor/k8s-job.ts
@@ -217,13 +217,29 @@ export async function createWorkflowJob(params: {
               },
               volumeMounts: [{ name: "tmp", mountPath: "/tmp" }],
               resources: {
-                requests: { memory: "160Mi", cpu: "200m" },
-                limits: { memory: "320Mi", cpu: "750m" },
+                requests: {
+                  memory: "160Mi",
+                  cpu: "200m",
+                  "ephemeral-storage": CONFIG.runnerEphemeralStorageRequest,
+                },
+                limits: {
+                  memory: "320Mi",
+                  cpu: "750m",
+                  "ephemeral-storage": CONFIG.runnerEphemeralStorageLimit,
+                },
               },
             },
           ],
-          // Sole writable path under readOnlyRootFilesystem; backs TMPDIR.
-          volumes: [{ name: "tmp", emptyDir: {} }],
+          // Sole writable path under readOnlyRootFilesystem; backs TMPDIR. The
+          // sizeLimit caps this medium at the pod's ephemeral-storage limit so a
+          // runaway runner is evicted on its own disk instead of filling the
+          // node root volume and tripping node-wide DiskPressure.
+          volumes: [
+            {
+              name: "tmp",
+              emptyDir: { sizeLimit: CONFIG.runnerEphemeralStorageLimit },
+            },
+          ],
         },
       },
     },

--- a/specs/workflow-execution-runtime.md
+++ b/specs/workflow-execution-runtime.md
@@ -305,7 +305,7 @@ metadata:
     workflow-id: ${workflowId}
     execution-id: ${executionId}
 spec:
-  ttlSecondsAfterFinished: 3600  # Cleanup after 1 hour
+  ttlSecondsAfterFinished: 300    # Delete finished pods fast to release node disk (env JOB_TTL_SECONDS)
   backoffLimit: 0                 # No retries (handle in app)
   activeDeadlineSeconds: 300      # 5 minute timeout
   template:
@@ -335,13 +335,22 @@ spec:
                 secretKeyRef:
                   name: keeperhub-secrets
                   key: integration-encryption-key
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp        # sole writable path (readOnlyRootFilesystem)
           resources:
             requests:
-              memory: "128Mi"
-              cpu: "100m"
+              memory: "160Mi"
+              cpu: "200m"
+              ephemeral-storage: "1Gi"   # lets the scheduler spread runners off a hot node (env RUNNER_EPHEMERAL_STORAGE_REQUEST)
             limits:
-              memory: "512Mi"
-              cpu: "500m"
+              memory: "320Mi"
+              cpu: "750m"
+              ephemeral-storage: "2Gi"   # evicts a single over-limit runner before node DiskPressure (env RUNNER_EPHEMERAL_STORAGE_LIMIT)
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: "2Gi"       # caps the runner's write medium at the pod's ephemeral-storage limit
 ```
 
 ---
@@ -370,8 +379,9 @@ Workflows need access to:
 ### Resource Limits
 
 - Set `resources.limits` to prevent runaway workflows
+- Set an `ephemeral-storage` request + limit and a matching `/tmp` emptyDir `sizeLimit` so runner disk is bounded: the request spreads pods across nodes, the limit evicts a single over-limit runner instead of letting it fill the shared node root volume and trip node-wide DiskPressure
 - Set `activeDeadlineSeconds` for timeout
-- Set `ttlSecondsAfterFinished` for cleanup
+- Set `ttlSecondsAfterFinished` low so finished pods release their `/tmp` disk within minutes
 
 ---
 

--- a/specs/workflow-execution-runtime.md
+++ b/specs/workflow-execution-runtime.md
@@ -342,15 +342,15 @@ spec:
             requests:
               memory: "160Mi"
               cpu: "200m"
-              ephemeral-storage: "1Gi"   # lets the scheduler spread runners off a hot node (env RUNNER_EPHEMERAL_STORAGE_REQUEST)
+              ephemeral-storage: "64Mi"  # honest floor for accounting (env RUNNER_EPHEMERAL_STORAGE_REQUEST)
             limits:
               memory: "320Mi"
               cpu: "750m"
-              ephemeral-storage: "2Gi"   # evicts a single over-limit runner before node DiskPressure (env RUNNER_EPHEMERAL_STORAGE_LIMIT)
+              ephemeral-storage: "1Gi"   # runaway-/tmp guard (~2 MiB normal); evicts a pathological pod before it threatens the node (env RUNNER_EPHEMERAL_STORAGE_LIMIT)
       volumes:
         - name: tmp
           emptyDir:
-            sizeLimit: "2Gi"       # caps the runner's write medium at the pod's ephemeral-storage limit
+            sizeLimit: "1Gi"       # caps the runner's write medium at the pod's ephemeral-storage limit
 ```
 
 ---
@@ -379,7 +379,7 @@ Workflows need access to:
 ### Resource Limits
 
 - Set `resources.limits` to prevent runaway workflows
-- Set an `ephemeral-storage` request + limit and a matching `/tmp` emptyDir `sizeLimit` so runner disk is bounded: the request spreads pods across nodes, the limit evicts a single over-limit runner instead of letting it fill the shared node root volume and trip node-wide DiskPressure
+- Set an `ephemeral-storage` limit and a matching `/tmp` emptyDir `sizeLimit` so a pod that writes pathologically much to `/tmp` (normal runners use ~2 MiB) is evicted on its own disk before it can fill the shared node root volume. Node-level disk pressure from accumulated container images is handled separately (kubelet image GC + node disk sizing), not here
 - Set `activeDeadlineSeconds` for timeout
 - Set `ttlSecondsAfterFinished` low so finished pods release their `/tmp` disk within minutes
 


### PR DESCRIPTION
## Problem

Staging EKS nodes flapped through `DiskPressure` (~13x over ~4.75 days), evicting keeperhub pods node-wide. Investigation on the live cluster found the driver is the **node image filesystem**: ~45 GiB of accumulated container images on a 64 GiB root volume, retained because the default 85% image-GC threshold rarely triggered. The primary fix is node-level (image GC + disk headroom) and lives in the infrastructure repo.

This PR adds a defensive per-pod disk guardrail so a single pathological workflow that writes a lot to `/tmp` (the runner's only writable path under `readOnlyRootFilesystem`, node-backed) is evicted on its own before it can threaten the shared node volume.

## Sizing (measured, not guessed)

Sampled live staging runner pods via the kubelet `stats/summary` API: per-pod ephemeral-storage and `/tmp` emptyDir usage both max out at **~2 MiB** (n=27). Values are set as a guardrail, not to the working set:

- `ephemeral-storage` request `64Mi` (honest accounting floor)
- `ephemeral-storage` limit `1Gi` and matching `/tmp` emptyDir `sizeLimit` `1Gi` (~500x the observed max; evicts a runaway pod, never a normal run)
- env-overridable via `RUNNER_EPHEMERAL_STORAGE_REQUEST` / `_LIMIT`

Also lowers the `JOB_TTL_SECONDS` code default 3600 -> 300 for local/PR envs (staging already runs 120 via helm).

## Test

- `pnpm check`, `pnpm type-check`: pass
- `vitest run keeperhub-executor/k8s-job.test.ts`: 19 passed (incl. 2 new)