### PR TITLE
fix(executor): set runner ephemeral-storage guardrail for prod and PR envs

### DIFF
--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -708,6 +708,17 @@ executor:
     JOB_ACTIVE_DEADLINE:
       type: kv
       value: "300"
+    # Ephemeral-storage guardrail for runner Job pods (mirrored by the runner's
+    # /tmp emptyDir sizeLimit). Runners use ~2 MiB each, so the 1Gi limit is a
+    # runaway-/tmp guard, not the disk-pressure fix (that is node image GC + disk
+    # headroom in the eks-cluster workspace). Retune if a legitimate data-heavy
+    # workflow needs a larger /tmp.
+    RUNNER_EPHEMERAL_STORAGE_REQUEST:
+      type: kv
+      value: "64Mi"
+    RUNNER_EPHEMERAL_STORAGE_LIMIT:
+      type: kv
+      value: "1Gi"
     EXECUTION_MODE:
       type: kv
       value: "isolated"

--- a/deploy/pr-environment/executor.template.yaml
+++ b/deploy/pr-environment/executor.template.yaml
@@ -130,6 +130,15 @@ env:
   JOB_ACTIVE_DEADLINE:
     type: kv
     value: "300"
+  # Ephemeral-storage guardrail for runner Job pods (mirrored by the runner's
+  # /tmp emptyDir sizeLimit). Runners use ~2 MiB each, so the 1Gi limit is a
+  # runaway-/tmp guard. Retune if a PR workflow legitimately needs a larger /tmp.
+  RUNNER_EPHEMERAL_STORAGE_REQUEST:
+    type: kv
+    value: "64Mi"
+  RUNNER_EPHEMERAL_STORAGE_LIMIT:
+    type: kv
+    value: "1Gi"
   EXECUTION_MODE:
     type: kv
     value: "isolated"


### PR DESCRIPTION
## What

Staging already carries the runner ephemeral-storage guardrail (request 64Mi, limit 1Gi, mirrored by the `/tmp` emptyDir sizeLimit in `k8s-job.ts`). This adds the same `RUNNER_EPHEMERAL_STORAGE_*` values to the two environments that were missing them:

- `deploy/keeperhub-stack/prod/values.yaml` - prod executor (takes effect on the next staging->prod release).
- `deploy/pr-environment/executor.template.yaml` - per-PR ephemeral environments.

## Sizing

Measured, not guessed: live staging runners use ~2 MiB of ephemeral each (kubelet stats/summary), so 1Gi is a ~500x runaway-`/tmp` guard, never a normal-run limit. The node-level disk-pressure fix (image GC + disk headroom) lives in the infrastructure repo.

No code change - values only, following the existing env pattern.