### PR TITLE
fix(cron): stagger maintenance job schedules

### DIFF
--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -504,7 +504,7 @@ app:
           repository: ${ECR_REGISTRY}/keeperhub-prod
           tag: app-${IMAGE_TAG}
           imagePullPolicy: Always
-        schedule: "*/10 * * * *" # every 10 minutes
+        schedule: "3-59/10 * * * *" # every 10 minutes, offset by 3 minutes
         command: ["/bin/sh"]
         args:
           - "/app/deploy/scripts/reaper.sh"
@@ -558,7 +558,7 @@ app:
           repository: ${ECR_REGISTRY}/keeperhub-prod
           tag: app-${IMAGE_TAG}
           imagePullPolicy: Always
-        schedule: "*/5 * * * *" # every 5 minutes
+        schedule: "1-59/5 * * * *" # every 5 minutes, offset by 1 minute
         command: ["/bin/sh"]
         args:
           - "/app/deploy/scripts/reaper.sh"
@@ -585,7 +585,7 @@ app:
           repository: ${ECR_REGISTRY}/keeperhub-prod
           tag: app-${IMAGE_TAG}
           imagePullPolicy: Always
-        schedule: "*/30 * * * *" # every 30 minutes
+        schedule: "8,38 * * * *" # every 30 minutes, offset by 8 minutes
         command: ["/bin/sh"]
         args:
           - "/app/deploy/scripts/reaper.sh"

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -506,7 +506,7 @@ app:
           repository: ${ECR_REGISTRY}/keeperhub-staging
           tag: app-${IMAGE_TAG}
           imagePullPolicy: Always
-        schedule: "*/10 * * * *" # every 10 minutes
+        schedule: "3-59/10 * * * *" # every 10 minutes, offset by 3 minutes
         command: ["/bin/sh"]
         args:
           - "/app/deploy/scripts/reaper.sh"
@@ -560,7 +560,7 @@ app:
           repository: ${ECR_REGISTRY}/keeperhub-staging
           tag: app-${IMAGE_TAG}
           imagePullPolicy: Always
-        schedule: "*/5 * * * *" # every 5 minutes
+        schedule: "1-59/5 * * * *" # every 5 minutes, offset by 1 minute
         command: ["/bin/sh"]
         args:
           - "/app/deploy/scripts/reaper.sh"
@@ -587,7 +587,7 @@ app:
           repository: ${ECR_REGISTRY}/keeperhub-staging
           tag: app-${IMAGE_TAG}
           imagePullPolicy: Always
-        schedule: "*/30 * * * *" # every 30 minutes
+        schedule: "8,38 * * * *" # every 30 minutes, offset by 8 minutes
         command: ["/bin/sh"]
         args:
           - "/app/deploy/scripts/reaper.sh"


### PR DESCRIPTION
The reaper, security-behavioral-scan, and scan-cache-sweeper CronJobs all ran at the same time in at least 2 occasions today at the top of the hour, coinciding also with some workflow executions. This caused a peak database write load and was the root cause behind 2 "KeeperHub System Error by Category" alerts (incidents #33101 and #33103).

This change offsets the three jobs' schedules in both prod and staging values.yaml so none of them land on minute 0 or on any multiple of 5 (avoiding the common 5/10/15/20/30/45-minute workflow schedule ticks), and staggers them off each other as well.