### PR TITLE
fix(executor): add retry and backoff to the execution-start compare-and-swap

### DIFF
--- a/keeperhub-executor/lib/db-helpers.test.ts
+++ b/keeperhub-executor/lib/db-helpers.test.ts
@@ -1,5 +1,5 @@
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // A transitive lib import (the classifier -> lib/logging) is server-only; stub
 // the guard so db-helpers imports under vitest, same pattern as the other
@@ -18,7 +18,11 @@ vi.mock("./terminal-counters", () => ({
 }));
 
 import type { DbSchema } from "./db-helpers";
-import { updateExecutionStatus } from "./db-helpers";
+import {
+  claimPendingForExecution,
+  claimPhantomForExecution,
+  updateExecutionStatus,
+} from "./db-helpers";
 
 type SetData = Record<string, unknown>;
 
@@ -140,5 +144,112 @@ describe("updateExecutionStatus classification", () => {
       db,
       expect.objectContaining({ status: "success" })
     );
+  });
+});
+
+type ClaimRow = { id: string };
+type ClaimBehavior = () => Promise<ClaimRow[]>;
+
+/**
+ * Fake of the drizzle chains the claim helpers use: the gated CAS
+ * (db.update(...).set(...).where(...).returning(...)) and the point lookup in
+ * classifyClaimMiss (db.select(...).from(...).where(...).limit(...)). Each
+ * returning() call consumes the next queued behavior (the last one repeats),
+ * so a test can fail the first attempt and resolve the retry. `missRows` is
+ * what the disambiguating select returns after a zero-row CAS.
+ */
+function makeClaimDb(
+  behaviors: ClaimBehavior[],
+  missRows: ClaimRow[] = []
+): { db: PostgresJsDatabase<DbSchema>; updateCalls: () => number } {
+  let updateCalls = 0;
+  const updateBuilder = {
+    set: () => updateBuilder,
+    where: () => updateBuilder,
+    returning: () => {
+      const behavior = behaviors[Math.min(updateCalls, behaviors.length - 1)];
+      updateCalls++;
+      return behavior();
+    },
+  };
+  const db = {
+    update: () => updateBuilder,
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve(missRows),
+        }),
+      }),
+    }),
+  };
+  return {
+    db: db as unknown as PostgresJsDatabase<DbSchema>,
+    updateCalls: () => updateCalls,
+  };
+}
+
+function transientDbError(code: string): Error {
+  return Object.assign(new Error(`transient ${code}`), { code });
+}
+
+describe("execution-claim CAS retry", () => {
+  beforeEach(() => {
+    // The retry loop logs each transient miss; keep the suite output clean.
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("retries a transient DB error and then claims (pending path)", async () => {
+    const { db, updateCalls } = makeClaimDb([
+      () => Promise.reject(transientDbError("08006")),
+      () => Promise.resolve([{ id: "e1" }]),
+    ]);
+
+    await expect(claimPendingForExecution(db, "e1")).resolves.toBe("claimed");
+    expect(updateCalls()).toBe(2);
+  });
+
+  it("retries a transient DB error and then claims (phantom path)", async () => {
+    const { db, updateCalls } = makeClaimDb([
+      () => Promise.reject(transientDbError("CONNECTION_CLOSED")),
+      () => Promise.resolve([{ id: "e1" }]),
+    ]);
+
+    await expect(
+      claimPhantomForExecution(db, "e1", { field: 1 }, "hash")
+    ).resolves.toBe("claimed");
+    expect(updateCalls()).toBe(2);
+  });
+
+  it("gives up after the attempt cap on a persistent transient error and rethrows", async () => {
+    const { db, updateCalls } = makeClaimDb([
+      () => Promise.reject(transientDbError("ECONNRESET")),
+    ]);
+
+    await expect(claimPendingForExecution(db, "e1")).rejects.toMatchObject({
+      code: "ECONNRESET",
+    });
+    expect(updateCalls()).toBe(3);
+  });
+
+  it("does not retry a non-transient error", async () => {
+    const { db, updateCalls } = makeClaimDb([
+      () => Promise.reject(new Error("syntax error at or near")),
+    ]);
+
+    await expect(claimPendingForExecution(db, "e1")).rejects.toThrow(
+      "syntax error"
+    );
+    expect(updateCalls()).toBe(1);
+  });
+
+  it("classifies a clean zero-row CAS miss without retrying", async () => {
+    const { db, updateCalls } = makeClaimDb([() => Promise.resolve([])], []);
+
+    await expect(claimPendingForExecution(db, "e1")).resolves.toBe("not_found");
+    expect(updateCalls()).toBe(1);
   });
 });

--- a/keeperhub-executor/lib/db-helpers.ts
+++ b/keeperhub-executor/lib/db-helpers.ts
@@ -50,6 +50,101 @@ export type ClaimOutcome = "claimed" | "already_advanced" | "not_found";
  */
 const REAPED_NEVER_RAN_CODES: ErrorCode[] = ["P-0001", "P-0005"];
 
+// The execution-start CAS UPDATE runs on the hot dispatch path. A
+// transient DB error there (dropped connection, statement timeout under the
+// top-of-minute load spike) would otherwise propagate to the processMessage
+// backstop, which promotes it to a terminal system_error and deletes the SQS
+// message - a sub-second blip becomes an alerting failure with no redelivery.
+// Retrying the idempotent CAS a couple of times with short backoff lets that
+// blip resolve and the execution proceed normally.
+const CLAIM_MAX_ATTEMPTS = 3; // initial attempt + 2 retries
+const CLAIM_BACKOFF_BASE_MS = 50;
+const CLAIM_BACKOFF_MAX_MS = 400;
+const CLAIM_BACKOFF_JITTER_MS = 50;
+
+// Driver/socket error codes and SQLSTATEs that signal a transient connection or
+// contention failure worth retrying. Anything else (a real bug, a constraint
+// violation) re-throws immediately so it surfaces fast rather than being masked
+// by a retry loop.
+const TRANSIENT_DB_ERROR_CODES: ReadonlySet<string> = new Set([
+  // postgres.js connection-lifecycle errors
+  "CONNECTION_CLOSED",
+  "CONNECTION_ENDED",
+  "CONNECTION_DESTROYED",
+  "CONNECTION_CONNECT_TIMEOUT",
+  "CONNECT_TIMEOUT",
+  // node socket errors
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "EPIPE",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  // SQLSTATE class 08 - connection exception
+  "08000",
+  "08001",
+  "08003",
+  "08004",
+  "08006",
+  // SQLSTATE - admin shutdown / crash / too many connections
+  "57P01",
+  "57P02",
+  "57P03",
+  "53300",
+  // SQLSTATE - serialization failure / deadlock
+  "40001",
+  "40P01",
+]);
+
+function isTransientDbError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" && TRANSIENT_DB_ERROR_CODES.has(code);
+}
+
+function claimBackoffMs(attempt: number): number {
+  const exponential = CLAIM_BACKOFF_BASE_MS * 2 ** attempt;
+  const capped = Math.min(exponential, CLAIM_BACKOFF_MAX_MS);
+  return capped + Math.floor(Math.random() * CLAIM_BACKOFF_JITTER_MS);
+}
+
+/**
+ * Run a claim CAS UPDATE, retrying a transient connection/contention error a
+ * bounded number of times with short backoff. A non-transient error re-throws
+ * immediately; a transient error that outlives every attempt re-throws so the
+ * processMessage backstop still fails the execution (a genuinely-down DB is a
+ * real system error). The CAS is idempotent under its gated WHERE, so a retry is
+ * safe: if a prior attempt committed before the connection dropped, the row has
+ * already advanced and the retry simply matches zero rows (the caller then reads
+ * it as already_advanced and drops the duplicate).
+ */
+async function runClaimWithRetry<T>(
+  op: () => PromiseLike<T[]>,
+  executionId: string
+): Promise<T[]> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < CLAIM_MAX_ATTEMPTS; attempt++) {
+    try {
+      return await op();
+    } catch (error) {
+      lastError = error;
+      if (!isTransientDbError(error) || attempt === CLAIM_MAX_ATTEMPTS - 1) {
+        throw error;
+      }
+      const backoff = claimBackoffMs(attempt);
+      console.warn(
+        `[Claim] Transient DB error claiming execution ${executionId} (attempt ${attempt + 1}/${CLAIM_MAX_ATTEMPTS}), retrying in ${backoff}ms:`,
+        error
+      );
+      await new Promise((resolve) => setTimeout(resolve, backoff));
+    }
+  }
+  // Unreachable: the loop returns on success or throws on the final attempt.
+  throw lastError;
+}
+
 /**
  * After a gated CAS matched zero rows, disambiguate "row exists but not in the
  * expected status" from "no such row" with a single point lookup on the id PK.
@@ -251,35 +346,39 @@ export async function claimPhantomForExecution(
   input: Record<string, unknown>,
   executedWorkflowHash: string
 ): Promise<ClaimOutcome> {
-  const result = await db
-    .update(workflowExecutions)
-    // The phantom was created billable=false (it had not run yet); claiming it
-    // means it is now a real execution, so it becomes billable like any
-    // owner-initiated run. Stamp the hash of the definition the executor just
-    // loaded so the run links to its workflow_history version. Clear any reaper
-    // stamp when re-claiming a reaped-never-ran row.
-    .set({
-      status: "pending",
-      input,
-      billable: true,
-      executedWorkflowHash,
-      error: null,
-      errorCode: null,
-      completedAt: null,
-    })
-    .where(
-      and(
-        eq(workflowExecutions.id, executionId),
-        or(
-          eq(workflowExecutions.status, "phantom"),
+  const result = await runClaimWithRetry(
+    () =>
+      db
+        .update(workflowExecutions)
+        // The phantom was created billable=false (it had not run yet); claiming
+        // it means it is now a real execution, so it becomes billable like any
+        // owner-initiated run. Stamp the hash of the definition the executor
+        // just loaded so the run links to its workflow_history version. Clear
+        // any reaper stamp when re-claiming a reaped-never-ran row.
+        .set({
+          status: "pending",
+          input,
+          billable: true,
+          executedWorkflowHash,
+          error: null,
+          errorCode: null,
+          completedAt: null,
+        })
+        .where(
           and(
-            eq(workflowExecutions.status, "system_error"),
-            inArray(workflowExecutions.errorCode, REAPED_NEVER_RAN_CODES)
+            eq(workflowExecutions.id, executionId),
+            or(
+              eq(workflowExecutions.status, "phantom"),
+              and(
+                eq(workflowExecutions.status, "system_error"),
+                inArray(workflowExecutions.errorCode, REAPED_NEVER_RAN_CODES)
+              )
+            )
           )
         )
-      )
-    )
-    .returning({ id: workflowExecutions.id });
+        .returning({ id: workflowExecutions.id }),
+    executionId
+  );
   if (result.length > 0) {
     return "claimed";
   }
@@ -301,23 +400,32 @@ export async function claimPendingForExecution(
   db: PostgresJsDatabase<DbSchema>,
   executionId: string
 ): Promise<ClaimOutcome> {
-  const result = await db
-    .update(workflowExecutions)
-    // Clear any reaper stamp when re-claiming a reaped-never-ran row.
-    .set({ status: "running", error: null, errorCode: null, completedAt: null })
-    .where(
-      and(
-        eq(workflowExecutions.id, executionId),
-        or(
-          eq(workflowExecutions.status, "pending"),
+  const result = await runClaimWithRetry(
+    () =>
+      db
+        .update(workflowExecutions)
+        // Clear any reaper stamp when re-claiming a reaped-never-ran row.
+        .set({
+          status: "running",
+          error: null,
+          errorCode: null,
+          completedAt: null,
+        })
+        .where(
           and(
-            eq(workflowExecutions.status, "system_error"),
-            inArray(workflowExecutions.errorCode, REAPED_NEVER_RAN_CODES)
+            eq(workflowExecutions.id, executionId),
+            or(
+              eq(workflowExecutions.status, "pending"),
+              and(
+                eq(workflowExecutions.status, "system_error"),
+                inArray(workflowExecutions.errorCode, REAPED_NEVER_RAN_CODES)
+              )
+            )
           )
         )
-      )
-    )
-    .returning({ id: workflowExecutions.id });
+        .returning({ id: workflowExecutions.id }),
+    executionId
+  );
   if (result.length > 0) {
     return "claimed";
   }


### PR DESCRIPTION
## Summary

The execution-start compare-and-swap (the gated UPDATE that flips a workflow_executions row from pending to running, and the phantom-to-pending variant) runs on the hot dispatch path with no retry. When that UPDATE throws a transient DB error - a dropped connection or statement timeout during the top-of-minute load spike - the exception propagates uncaught to the single catch-all in processMessage, which marks the row system_error and deletes the SQS message rather than leaving it for redelivery. A sub-second glitch is thereby promoted to a terminal, alerting failure with no recovery.

This wraps both CAS UPDATEs in a bounded retry with short backoff, so the common case (a blip where the UPDATE never committed) succeeds on a later attempt and the execution proceeds normally.

## Changes

- `keeperhub-executor/lib/db-helpers.ts`: new `runClaimWithRetry` helper wrapping the UPDATEs in `claimPendingForExecution` (pending to running) and `claimPhantomForExecution` (phantom to pending). Bounded to 3 attempts with exponential backoff plus jitter (50ms base, 400ms cap). Retries only classified-transient failures (postgres.js connection-lifecycle codes, node socket codes, SQLSTATE class 08 connection exceptions, admin-shutdown/too-many-connections 57P0x/53300, and serialization/deadlock 40001/40P01). Non-transient errors re-throw immediately so real bugs surface fast; a transient error that outlives every attempt re-throws so the existing processMessage backstop still fails the execution.
- `keeperhub-executor/lib/db-helpers.test.ts`: 5 unit tests - transient-then-claim on both the pending and phantom paths, persistent-transient exhausting the cap and rethrowing, non-transient not retried, and a clean zero-row miss classified without retry.

## Why the retry is safe

The CAS is idempotent under its gated WHERE. If a prior attempt committed before the connection dropped, the row has already advanced and the retry matches zero rows - the caller reads that back as `already_advanced` and drops the duplicate, exactly as it already does for a concurrent claim.

## Testing

Not run locally (no node toolchain on this host); CI exercises the executor unit suite. The retry classifier and backoff are covered by the added unit tests.