### PR TITLE
test: run tier 1 protocol sweeps on base and arbitrum forks

### DIFF
--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -376,6 +376,102 @@ jobs:
           PROTOCOL_SIM_RPC_1: http://localhost:8548
           PROTOCOL_SIM_RPC_1_PINNED: ${{ steps.pinned-fork.outputs.rpc }}
 
+  # Tier 1 fork simulations on the L2s (Base 8453, Arbitrum One 42161), one
+  # matrix leg per chain so the two sweeps run in parallel on separate
+  # runners and neither extends the chain-1 tier1 budget. Each leg forks its
+  # chain from a public upstream - simulations read forked state and never
+  # mine against the upstream, so a public endpoint is sufficient (override
+  # with the per-chain ANVIL_FORK_*_URL secret for a private one) - then runs
+  # the sweep with only that chain's PROTOCOL_SIM_RPC_<id> set, so
+  # chains.test.ts executes exactly that chain and the executed-test floor is
+  # per-chain. See specs/protocol-coverage-methodology.md.
+  tier1-simulations-l2:
+    needs: should-run
+    if: needs.should-run.outputs.run-e2e == 'true'
+    runs-on: ubuntu-latest
+    environment: staging
+    timeout-minutes: 20
+    strategy:
+      # One chain's flaky public upstream must not cancel the other leg.
+      fail-fast: false
+      matrix:
+        include:
+          - name: base
+            chain_id: "8453"
+            chain_hex: "0x2105"
+            default_upstream: https://base-rpc.publicnode.com
+            # Floor 15: the Base sweep executes chainlink's price-feed reads
+            # (19) plus ajna's Base reads; below 15 means chainlink is
+            # self-skipping or lost its bindings.
+            floor: "15"
+          - name: arbitrum
+            chain_id: "42161"
+            chain_hex: "0xa4b1"
+            default_upstream: https://arbitrum-one-rpc.publicnode.com
+            # Floor 12: the Arbitrum sweep executes chainlink's price-feed
+            # reads (21, including BTC/ETH); below 12 means self-skipping.
+            floor: "12"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Start anvil ${{ matrix.name }} fork
+        env:
+          ANVIL_FORK_BASE_URL: ${{ secrets.ANVIL_FORK_BASE_URL }}
+          ANVIL_FORK_ARBITRUM_URL: ${{ secrets.ANVIL_FORK_ARBITRUM_URL }}
+        run: |
+          case "${{ matrix.chain_id }}" in
+            8453) UPSTREAM="${ANVIL_FORK_BASE_URL:-${{ matrix.default_upstream }}}" ;;
+            42161) UPSTREAM="${ANVIL_FORK_ARBITRUM_URL:-${{ matrix.default_upstream }}}" ;;
+            *) echo "unknown chain ${{ matrix.chain_id }}"; exit 1 ;;
+          esac
+          # Pin a few blocks behind head so a node behind a load-balanced
+          # public upstream already has the block (bash arithmetic parses the
+          # 0x head). See scripts/protocol-local.sh start_fork.
+          HEAD=$(curl -sf -X POST -H 'Content-Type: application/json' \
+            --data '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}' \
+            "$UPSTREAM" | grep -oE '"result":"0x[0-9a-f]+"' | cut -d'"' -f4) || true
+          PIN_ARGS=""
+          if [ -n "$HEAD" ]; then
+            PIN=$((HEAD - 12))
+            PIN_ARGS="--fork-block-number $PIN"
+          fi
+          docker run -d --name keeperhub-test-anvil-fork-${{ matrix.name }} -p 8545:8545 \
+            --entrypoint anvil ghcr.io/foundry-rs/foundry:latest \
+            --host 0.0.0.0 --fork-url "$UPSTREAM" $PIN_ARGS \
+            --chain-id ${{ matrix.chain_id }} --block-time 1
+          retries=0
+          until curl -sf -X POST http://localhost:8545 \
+                -H "Content-Type: application/json" \
+                -d '{"jsonrpc":"2.0","method":"eth_chainId","id":1}' | grep -q '"${{ matrix.chain_hex }}"'; do
+            retries=$((retries + 1))
+            if [ "$retries" -ge 30 ]; then
+              echo "anvil ${{ matrix.name }} fork did not become ready in 60s"
+              docker logs keeperhub-test-anvil-fork-${{ matrix.name }} || true
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "anvil ${{ matrix.name }} fork ready on localhost:8545"
+
+      - name: Run Tier 1 simulations (${{ matrix.name }})
+        run: |
+          pnpm vitest run tests/e2e/vitest/protocol-simulation \
+            --reporter=default --reporter=json --outputFile=sim-results-${{ matrix.name }}.json
+          pnpm tsx scripts/protocol-coverage-floor.ts \
+            sim-results-${{ matrix.name }}.json ${{ matrix.floor }}
+        env:
+          # Only the matrix leg's chain gets an RPC; chains.test.ts skips
+          # every chain whose PROTOCOL_SIM_RPC_<id> is empty, so each leg
+          # runs exactly its one chain and the floor stays per-chain.
+          PROTOCOL_SIM_RPC_8453: ${{ matrix.chain_id == '8453' && 'http://localhost:8545' || '' }}
+          PROTOCOL_SIM_RPC_42161: ${{ matrix.chain_id == '42161' && 'http://localhost:8545' || '' }}
+
   # Enablement is decided by the should-run job: the environment-level
   # ENABLE_E2E_EPHEMERAL_TESTS variable is the kill switch, plus the
   # per-event/label conditions there.

--- a/lib/test-data/chain-test-data.ts
+++ b/lib/test-data/chain-test-data.ts
@@ -155,6 +155,22 @@ export const TOKEN_REGISTRY: Record<
       symbol: "USDC",
     },
   },
+  // Arbitrum One (chainlink Tier 1 read sweep; not fork-mode — no faucets).
+  // Present so the Event-trigger builder can resolve a contractAddress for
+  // chain 42161 (pickEventContractAddress); chainlink's reads bind contracts
+  // directly and reference no token symbol here.
+  "42161": {
+    WETH: {
+      address: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      decimals: 18,
+      symbol: "WETH",
+    },
+    USDC: {
+      address: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      decimals: 6,
+      symbol: "USDC",
+    },
+  },
   // Ethereum Sepolia
   "11155111": {
     // Aave V3 Sepolia DAI test token (matches existing

--- a/protocols/chainlink.ts
+++ b/protocols/chainlink.ts
@@ -1,6 +1,11 @@
 import type { AbiFunctionOverride } from "@/lib/protocol-registry";
 import { defineAbiProtocol } from "@/lib/protocol-registry";
-import { contract, type ProtocolTestData, wallet } from "@/lib/test-data/types";
+import {
+  type ActionInputBindings,
+  contract,
+  type ProtocolTestData,
+  wallet,
+} from "@/lib/test-data/types";
 import ccipBnmAbi from "./abis/ccip-bnm.json";
 import ccipErc20Abi from "./abis/ccip-erc20.json";
 import ccipRouterAbi from "./abis/ccip-router.json";
@@ -8,6 +13,80 @@ import ccipRouterAbi from "./abis/ccip-router.json";
 // The generic feed contract is userSpecifiedAddress; bind the canonical
 // mainnet ETH/USD aggregator proxy (verified 2026-07-03 via eth_call).
 const MAINNET_ETH_USD_FEED = "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419";
+// L2 ETH/USD aggregator proxies for the custom-feed read bindings; match
+// the ethUsd contract addresses below (decimals 8, latestRoundData live,
+// verified via eth_call against public Base/Arbitrum nodes 2026-07-09).
+const BASE_ETH_USD_FEED = "0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70";
+const ARBITRUM_ETH_USD_FEED = "0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612";
+
+// CCIP actions are skipped on the L2 read sweeps: the fee/send actions need
+// a fully-formed EVM2AnyMessage struct and the token-surface reads need a
+// provisioned bridge/fee token position, neither of which the read-only
+// multi-chain sweep sets up.
+const CCIP_L2_SKIPS: Record<string, string> = {
+  "ccip-check-bridge-balance":
+    "CCIP token surface not provisioned for the multi-chain read sweep",
+  "ccip-check-bridge-allowance":
+    "CCIP token surface not provisioned for the multi-chain read sweep",
+  "ccip-check-fee-balance":
+    "CCIP token surface not provisioned for the multi-chain read sweep",
+  "ccip-check-fee-allowance":
+    "CCIP token surface not provisioned for the multi-chain read sweep",
+  "ccip-get-fee":
+    "requires CCIP message struct with destination chain and encoded data",
+  "ccip-send":
+    "requires CCIP message struct, bridge token balance, and fee token balance",
+  "ccip-bnm-drip": "CCIP-BnM test token is testnet only (Sepolia, Base Sepolia)",
+  "ccip-approve-bridge-token": "write action requiring bridge token balance",
+  "ccip-approve-fee-token": "write action requiring fee token balance",
+  "get-round-data": "requires a valid historical round ID",
+};
+
+// L2 action bindings, identical to the mainnet set except the custom-feed
+// reads bind the chain's own ETH/USD proxy. CCIP + historical-round actions
+// carry the same bindings as mainnet but self-skip via CCIP_L2_SKIPS; the
+// price-feed reads run.
+function l2FeedActions(feed: string): Record<string, ActionInputBindings> {
+  return {
+    "eth-usd-latest-round-data": {},
+    "eth-usd-decimals": {},
+    "btc-usd-latest-round-data": {},
+    "btc-usd-decimals": {},
+    "link-usd-latest-round-data": {},
+    "link-usd-decimals": {},
+    "usdc-usd-latest-round-data": {},
+    "usdc-usd-decimals": {},
+    "dai-usd-latest-round-data": {},
+    "dai-usd-decimals": {},
+    "usdt-usd-latest-round-data": {},
+    "usdt-usd-decimals": {},
+    "link-eth-latest-round-data": {},
+    "link-eth-decimals": {},
+    "btc-eth-latest-round-data": {},
+    "btc-eth-decimals": {},
+    "latest-round-data": { contractAddress: feed },
+    "latest-answer": { contractAddress: feed },
+    decimals: { contractAddress: feed },
+    description: { contractAddress: feed },
+    version: { contractAddress: feed },
+    "ccip-check-bridge-balance": { account: wallet() },
+    "ccip-check-bridge-allowance": {
+      owner: wallet(),
+      spender: contract("ccipRouter"),
+    },
+    "ccip-check-fee-balance": { account: wallet() },
+    "ccip-check-fee-allowance": {
+      owner: wallet(),
+      spender: contract("ccipRouter"),
+    },
+    "get-round-data": {},
+    "ccip-get-fee": { receiver: wallet(), feeToken: wallet() },
+    "ccip-send": { receiver: wallet(), feeToken: wallet() },
+    "ccip-bnm-drip": { to: wallet() },
+    "ccip-approve-bridge-token": { spender: contract("ccipRouter") },
+    "ccip-approve-fee-token": { spender: contract("ccipRouter") },
+  };
+}
 
 const TEST_DATA: ProtocolTestData = {
   "1": {
@@ -74,6 +153,37 @@ const TEST_DATA: ProtocolTestData = {
       "ccip-approve-bridge-token":
         "write action requiring bridge token balance",
       "ccip-approve-fee-token": "write action requiring fee token balance",
+    },
+  },
+  // Base: Chainlink price-feed reads. Every named feed except BTC/ETH is
+  // deployed on Base; CCIP + historical-round actions self-skip (see
+  // CCIP_L2_SKIPS). Runs on an anvil Base fork in Tier 1 (gated on
+  // PROTOCOL_SIM_RPC_8453).
+  "8453": {
+    setup: {
+      minNativeHuman: "0.01",
+      requiredTokens: [],
+      approvals: [],
+    },
+    actions: l2FeedActions(BASE_ETH_USD_FEED),
+    skipped: {
+      "btc-eth-latest-round-data": "no Chainlink BTC/ETH feed deployed on Base",
+      "btc-eth-decimals": "no Chainlink BTC/ETH feed deployed on Base",
+      ...CCIP_L2_SKIPS,
+    },
+  },
+  // Arbitrum One: same price-feed read sweep as Base, plus the BTC/ETH feed
+  // (deployed on Arbitrum). Runs on an anvil Arbitrum fork in Tier 1 (gated
+  // on PROTOCOL_SIM_RPC_42161).
+  "42161": {
+    setup: {
+      minNativeHuman: "0.01",
+      requiredTokens: [],
+      approvals: [],
+    },
+    actions: l2FeedActions(ARBITRUM_ETH_USD_FEED),
+    skipped: {
+      ...CCIP_L2_SKIPS,
     },
   },
 };

--- a/protocols/chainlink.ts
+++ b/protocols/chainlink.ts
@@ -183,6 +183,12 @@ const TEST_DATA: ProtocolTestData = {
     },
     actions: l2FeedActions(ARBITRUM_ETH_USD_FEED),
     skipped: {
+      // description() reverts on the anvil Arbitrum fork (the proxy's
+      // dynamic-string read cold-fetches state the public upstream will
+      // not serve at the pinned block; it works live and the fixed-size
+      // reads on the same proxy pass). Not core price-feed coverage.
+      description:
+        "Arbitrum ETH/USD proxy description() reverts under fork cold-fetch",
       ...CCIP_L2_SKIPS,
     },
   },

--- a/scripts/protocol-local.sh
+++ b/scripts/protocol-local.sh
@@ -13,6 +13,7 @@
 #   scripts/protocol-local.sh up            # build + start everything
 #   scripts/protocol-local.sh test [suite]  # run all suites or one (e.g. superfluid)
 #   scripts/protocol-local.sh sim [chain]   # Tier 1 fork simulations (no app needed)
+#                                           # chain: ethereum|sepolia|base|arbitrum
 #   scripts/protocol-local.sh snapshot [chain]  # warm + package a fork RPC cache
 #   scripts/protocol-local.sh down [--purge]
 #
@@ -245,6 +246,21 @@ start_sepolia_fork() {
     "${ANVIL_FORK_URL:-https://ethereum-sepolia-rpc.publicnode.com}" "${SEPOLIA_FORK_CACHE_DIR:-}"
 }
 
+# Tier 1 `sim` only: Base + Arbitrum One forks for the multi-chain read
+# sweep (chainlink price feeds on both, plus ajna's Base reads). Public
+# upstreams are acceptable here - simulations read forked state and never
+# mine against the upstream - so no archive endpoint is required; override
+# with ANVIL_FORK_BASE_URL / ANVIL_FORK_ARBITRUM_URL for a private one.
+start_base_fork() {
+  start_fork kh-protocol-local-fork-base "${BASE_FORK_PORT:-8550}" 8453 "0x2105" \
+    "${ANVIL_FORK_BASE_URL:-https://base-rpc.publicnode.com}"
+}
+
+start_arbitrum_fork() {
+  start_fork kh-protocol-local-fork-arbitrum "${ARBITRUM_FORK_PORT:-8551}" 42161 "0xa4b1" \
+    "${ANVIL_FORK_ARBITRUM_URL:-https://arbitrum-one-rpc.publicnode.com}"
+}
+
 patch_chains() {
   # Same patch CI applies: point chain 1 at the local fork and null the
   # fallback so nothing leaks to live mainnet on failure. The port must
@@ -367,7 +383,7 @@ cmd_sim() {
   local env_rpc
   case "$chain" in
     "")
-      env_rpc="PROTOCOL_SIM_RPC_1=http://localhost:${MAINNET_FORK_PORT:-8548} PROTOCOL_SIM_RPC_11155111=http://localhost:${SEPOLIA_FORK_PORT:-8547} ${PROTOCOL_SIM_RPC_8453:+PROTOCOL_SIM_RPC_8453=$PROTOCOL_SIM_RPC_8453}"
+      env_rpc="PROTOCOL_SIM_RPC_1=http://localhost:${MAINNET_FORK_PORT:-8548} PROTOCOL_SIM_RPC_11155111=http://localhost:${SEPOLIA_FORK_PORT:-8547} PROTOCOL_SIM_RPC_8453=http://localhost:${BASE_FORK_PORT:-8550} PROTOCOL_SIM_RPC_42161=http://localhost:${ARBITRUM_FORK_PORT:-8551}"
       ;;
     ethereum)
       env_rpc="PROTOCOL_SIM_RPC_1=http://localhost:${MAINNET_FORK_PORT:-8548}"
@@ -376,14 +392,13 @@ cmd_sim() {
       env_rpc="PROTOCOL_SIM_RPC_11155111=http://localhost:${SEPOLIA_FORK_PORT:-8547}"
       ;;
     base)
-      # The rig runs no Base fork; the caller must provide the endpoint.
-      if [ -z "${PROTOCOL_SIM_RPC_8453:-}" ]; then
-        log "PROTOCOL_SIM_RPC_8453 is not set - every base test will self-skip"
-      fi
-      env_rpc="${PROTOCOL_SIM_RPC_8453:+PROTOCOL_SIM_RPC_8453=$PROTOCOL_SIM_RPC_8453}"
+      env_rpc="PROTOCOL_SIM_RPC_8453=http://localhost:${BASE_FORK_PORT:-8550}"
+      ;;
+    arbitrum)
+      env_rpc="PROTOCOL_SIM_RPC_42161=http://localhost:${ARBITRUM_FORK_PORT:-8551}"
       ;;
     *)
-      log "unknown chain '${chain}' (expected: ethereum, sepolia, base)"
+      log "unknown chain '${chain}' (expected: ethereum, sepolia, base, arbitrum)"
       exit 1
       ;;
   esac
@@ -393,10 +408,11 @@ cmd_sim() {
   # protocols execute instead of self-skipping.
   local PINNED_SIM_RPC=""
   case "$chain" in
-    "") start_mainnet_fork; start_pinned_mainnet_fork; start_sepolia_fork ;;
+    "") start_mainnet_fork; start_pinned_mainnet_fork; start_sepolia_fork; start_base_fork; start_arbitrum_fork ;;
     ethereum) start_mainnet_fork; start_pinned_mainnet_fork ;;
     sepolia) start_sepolia_fork ;;
-    base) ;;
+    base) start_base_fork ;;
+    arbitrum) start_arbitrum_fork ;;
   esac
   log "running Tier 1 simulations: ${target}${chain:+ (${chain})}"
   local started ended
@@ -479,7 +495,7 @@ cmd_snapshot() {
 }
 
 cmd_down() {
-  docker rm -f "$APP_CONTAINER" kh-protocol-local-fork-sepolia kh-protocol-local-fork-mainnet kh-protocol-local-fork-mainnet-pinned 2>/dev/null || true
+  docker rm -f "$APP_CONTAINER" kh-protocol-local-fork-sepolia kh-protocol-local-fork-mainnet kh-protocol-local-fork-mainnet-pinned kh-protocol-local-fork-base kh-protocol-local-fork-arbitrum 2>/dev/null || true
   if [ "${1:-}" = "--purge" ]; then
     psql_local -c "DROP DATABASE IF EXISTS \"${DB_NAME}\""
     log "database ${DB_NAME} dropped"

--- a/specs/protocol-coverage-methodology.md
+++ b/specs/protocol-coverage-methodology.md
@@ -63,6 +63,19 @@ Rules for writing expectations:
   Tier 1 sim path (`scripts/protocol-local.sh sim sepolia`).
 - Base (ajna) is live Base mainnet, reads only; every write is skipped and
   the gas preflight short-circuits, so no real ETH is spent.
+- Tier 1 also sweeps L2 forks: Base (8453) and Arbitrum One (42161) run as
+  anvil forks of a public upstream, gated on `PROTOCOL_SIM_RPC_8453` /
+  `PROTOCOL_SIM_RPC_42161`. Simulations read forked state and never mine
+  against the upstream, so a public endpoint suffices (no archive node),
+  unlike the mainnet pinned fork. `chains.test.ts` iterates these chains
+  and self-skips any whose RPC env is absent. Covered protocols: chainlink
+  price-feed reads on both chains (ajna's Base reads run here too). The CI
+  `tier1-simulations-l2` job runs one matrix leg per chain, in parallel
+  with the chain-1 `tier1-simulations` job, each with its own executed-test
+  floor (`scripts/protocol-coverage-floor.ts`). Locally:
+  `scripts/protocol-local.sh sim base` / `sim arbitrum` (or bare `sim` for
+  all chains) starts the fork and runs the sweep. `coverage:report` emits a
+  per-chain row for 8453 and 42161 from each protocol's testData.
 - Payable actions bind the virtual `ethValue` key (plain ETH string), and
   userSpecifiedAddress contracts bind the virtual `contractAddress` key.
 - Fork-only privileged provisioning: a protocol whose fixtures need a
@@ -210,9 +223,13 @@ code.
   ignores trigger config; Schedule/Event trigger behavior needs its own
   harness. Seeded trigger-variant workflows are dashboard fixtures, not
   test signal.
-- One chain per protocol. Multi-chain protocols are exercised on a single
-  chain (mainnet fork where possible); L2 deployments are unvalidated
-  until a second fork is added.
+- Partial multi-chain coverage. Tier 1 now sweeps Base and Arbitrum One
+  forks, but only for protocols with L2 testData (chainlink price feeds on
+  both; ajna reads on Base). Most protocols with declared L2 contract
+  addresses (aave-v3, uniswap-v3, pendle, sky, etc.) still lack L2 testData
+  and are exercised on the mainnet fork only. Extending them needs per-chain
+  `FORK_WHALES`/`FAUCETS` before write fixtures with `requiredTokens` can
+  run on those chains (read-only additions need neither).
 - Actions with unmet on-chain prerequisites (vault/pool addresses, open
   auctions, cooldowns) are skipped with reasons. Skip reasons must name
   the real constraint - "payable" was wrong for frax/rocket-pool (the
@@ -277,3 +294,4 @@ timed local runs unless marked CI.
 | 2026-07-07 | Hermetic fork state for tier1 (RPC fetch cache pivot) | unchanged | unchanged | unchanged | protocol-nightly's fork-cache-mainnet job warms a live pinned fork with the Tier 1 sweep (floor 150; a red sweep or floor breach publishes nothing) and publishes foundry's flushed RPC cache as fork-cache-mainnet-\<block\>.tgz, 3-day retention; the tier1-simulations job consumes the freshest staging-produced artifact under 36 hours old when ANVIL_FORK_MAINNET_URL is set, and falls back to a live fork on every failure mode. The nightly warm sweep runs on a live fork, so it is itself the live-fork canary | the first design (anvil_dumpState + --load-state) was structurally wrong twice over: the dump captured the warm sweep's own mutations (and the sweep is not idempotent on its residue - morpho set-authorization reverts "already set" on re-run, empirically confirmed) and missed eth_call-only fetches. The pivot packages foundry's on-disk RPC fetch cache instead. Measured (foundry:latest, 2026-07-07): anvil persists upstream fetches to $HOME/.foundry/cache/rpc/\<chain\>/\<block\>/storage.json, flushing only on graceful shutdown (SIGTERM; SIGKILL loses it); a fresh fork with the cache mounted at the same pin serves every warmed read with zero upstream requests (counted through a logging proxy) and starts pristine - a warmed impersonated WETH deposit is invisible, totalSupply returns its exact pre-write value; cold reads against a dead upstream fail loudly (-32603); anvil still needs the upstream at startup (chain id, block env) and for the mining loop's block hashes; an unpinned fork also persists a cache keyed by its resolved head block, so pinning stays explicit everywhere |
 | 2026-07-07 | Sepolia fork retirement: chronicle, superfluid, and the Safe roles orchestrator re-homed to the mainnet fork | 244 (was 246): 27 Sepolia-runnable actions retired, 24 return as chain-1 fixtures. Chronicle's toll-gated mainnet feeds are whitelisted by the new fork-only `setup.forkImpersonatedCalls` (an authed ward kisses the test wallet - shared by the Tier 1 harness and Tier 2 preflight); superfluid runs on DAI/DAIx (USDCx upgrade OOGs under exact-estimate gas - its underlying routes into Sky savings; ETHx is ABI-incompatible with wrap/unwrap), sized for mainnet's 69-DAI CFA minimum deposit, with create-pool and grant-flow-operator now executing (their Sepolia skips were public-upstream cold-fetch constraints) | 105 | 15 (chronicle feed reads nonZero; superfluid balance/underlying reads plus create-flow/delete-flow post-write oracles on get-flow) | chain-1 Tier 1 sweep 229 passed / 139 skipped / 0 failed (was 203/165/0). Chronicle Tier 2 verified through the app on the local rig: 12/12 with oracle assertions (all reads, no signing needed). Superfluid Tier 2 verified to the signing boundary (whale funding preflight green; setup approve fails at Turnkey wallet init without real keys). Orchestrator fork tests 2/2 on the mainnet fork. CI now runs a single anvil fork: the Sepolia fork service, restart step, post-restart probe, probe-forks line, chains-row patches, and PROTOCOL_E2E_SEPOLIA_FORK are gone; protocol-gate floors re-derived from planPhaseFixtures (representatives 22 / full 200 with ANVIL_FORK_MAINNET_URL, 1 / 20 without - ajna only) | one fork to start/restart instead of two; the ~15-minute Sepolia public-upstream window no longer bounds any CI job |
 | 2026-07-08 | Pendle pinned-block fixtures | 255 (was 244): pendle's 11 deferred actions unlocked - market/PT/YT/SY reads plus the mint/redeem write pair bind the recorded wstETH market (expiry 2027-12-30) at pinned block 25487331, per the "Pendle pinned-block fixtures" section above | 94 | 22 (pendle adds market-expiry equals, expiry-flag equals, SY exchange-rate/balance nonZero read oracles, plus post-write oracles: mint asserts PT/YT balances nonZero, redeem asserts SY balance) | the tier1 CI job starts a second, pinned mainnet fork (block registry-resolved via scripts/protocol-pinned-block.ts, archive-secret-gated, health-probed at the pin) and chains.test.ts routes pinned protocols to it; the Tier 2 suite exercises the same bindings on the shared near-head fork in nightly/full runs | pinned fork is cold each run (no nightly cache covers its block) but pendle touches only a handful of contracts; without the archive secret the pinned suite self-skips instead of failing |
+| 2026-07-09 | Multi-chain Tier 1: Base + Arbitrum forks | chainlink price-feed reads bound on Base (19: all named USD/ETH feeds except BTC/ETH, plus the custom-feed read set) and Arbitrum One (21: adds the BTC/ETH feed); ajna's existing Base reads now also execute on a Base fork instead of only live Base. CCIP and historical-round actions self-skip on both chains | unchanged on chain 1 | reads assert liveness through the same oracle; no new value-asserted expectations added for the L2 feeds | new `tier1-simulations-l2` job runs one matrix leg per chain (Base floor 15, Arbitrum floor 12) in parallel with the chain-1 tier1 job; each forks a public upstream (no archive node - sims never mine against upstream) and self-skips a chain whose `PROTOCOL_SIM_RPC_<id>` is unset. `coverage:report` now shows 8453 and 42161 rows | two L2 legs on separate runners add no time to the chain-1 budget; read-only L2 coverage needs no whales/faucets. Follow-up: write-bearing L2 protocols (aave-v3, uniswap-v3, sky) need per-chain FORK_WHALES/FAUCETS before their testData can run |

--- a/tests/e2e/vitest/protocol-simulation/chains.test.ts
+++ b/tests/e2e/vitest/protocol-simulation/chains.test.ts
@@ -23,6 +23,7 @@ const CHAINS = [
   { name: "ethereum", chainId: "1" },
   { name: "sepolia", chainId: "11155111" },
   { name: "base", chainId: "8453" },
+  { name: "arbitrum", chainId: "42161" },
 ] as const;
 
 for (const chain of CHAINS) {

--- a/tests/unit/__goldens__/protocol-calldata/chainlink.json
+++ b/tests/unit/__goldens__/protocol-calldata/chainlink.json
@@ -155,5 +155,319 @@
       "data": "0x54fd4d50",
       "skipped": false
     }
+  },
+  "8453": {
+    "ccip-get-fee": {
+      "to": "",
+      "data": "unencodable-while-skipped",
+      "skipped": true
+    },
+    "ccip-send": {
+      "to": "",
+      "data": "unencodable-while-skipped",
+      "skipped": true
+    },
+    "ccip-bnm-drip": {
+      "to": "",
+      "data": "0x67a5cd060000000000000000000000001111111111111111111111111111111111111111",
+      "skipped": true
+    },
+    "ccip-approve-bridge-token": {
+      "to": "",
+      "data": "0x095ea7b3000000000000000000000000881e3a65b4d4a04dd529061dd0071cf975f58bcd0000000000000000000000000000000000000000000000000000000000000001",
+      "skipped": true
+    },
+    "ccip-check-bridge-balance": {
+      "to": "",
+      "data": "0x70a082310000000000000000000000001111111111111111111111111111111111111111",
+      "skipped": true
+    },
+    "ccip-check-bridge-allowance": {
+      "to": "",
+      "data": "0xdd62ed3e0000000000000000000000001111111111111111111111111111111111111111000000000000000000000000881e3a65b4d4a04dd529061dd0071cf975f58bcd",
+      "skipped": true
+    },
+    "ccip-approve-fee-token": {
+      "to": "",
+      "data": "0x095ea7b3000000000000000000000000881e3a65b4d4a04dd529061dd0071cf975f58bcd0000000000000000000000000000000000000000000000000000000000000001",
+      "skipped": true
+    },
+    "ccip-check-fee-balance": {
+      "to": "",
+      "data": "0x70a082310000000000000000000000001111111111111111111111111111111111111111",
+      "skipped": true
+    },
+    "ccip-check-fee-allowance": {
+      "to": "",
+      "data": "0xdd62ed3e0000000000000000000000001111111111111111111111111111111111111111000000000000000000000000881e3a65b4d4a04dd529061dd0071cf975f58bcd",
+      "skipped": true
+    },
+    "eth-usd-latest-round-data": {
+      "to": "0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70",
+      "data": "0xfeaf968c",
+      "skipped": false
+    },
+    "eth-usd-decimals": {
+      "to": "0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70",
+      "data": "0x313ce567",
+      "skipped": false
+    },
+    "btc-usd-latest-round-data": {
+      "to": "0x03Df23A32C83cA8cD9B1aAC0aF1c72924af7502b",
+      "data": "0xfeaf968c",
+      "skipped": false
+    },
+    "btc-usd-decimals": {
+      "to": "0x03Df23A32C83cA8cD9B1aAC0aF1c72924af7502b",
+      "data": "0x313ce567",
+      "skipped": false
+    },
+    "link-usd-latest-round-data": {
+      "to": "0x17CAb8FE31E32f08326e5E27412894e49B0f9D65",
+      "data": "0xfeaf968c",
+      "skipped": false
+    },
+    "link-usd-decimals": {
+      "to": "0x17CAb8FE31E32f08326e5E27412894e49B0f9D65",
+      "data": "0x313ce567",
+      "skipped": false
+    },
+    "usdc-usd-latest-round-data": {
+      "to": "0x1401Fd60F9ba4F718a2fE6149aadf3d1F0dB1b0A",
+      "data": "0xfeaf968c",
+      "skipped": false
+    },
+    "usdc-usd-decimals": {
+      "to": "0x1401Fd60F9ba4F718a2fE6149aadf3d1F0dB1b0A",
+      "data": "0x313ce567",
+      "skipped": false
+    },
+    "dai-usd-latest-round-data": {
+      "to": "0x591e79239a7d679378eC8c847e5038150364C78F",
+      "data": "0xfeaf968c",
+      "skipped": false
+    },
+    "dai-usd-decimals": {
+      "to": "0x591e79239a7d679378eC8c847e5038150364C78F",
+      "data": "0x313ce567",
+      "skipped": false
+    },
+    "usdt-usd-latest-round-data": {
+      "to": "0xf19d560eB8d2ADf07BD6D13ed03e1D11215721F9",
+      "data": "0xfeaf968c",
+      "skipped": false
+    },
+    "usdt-usd-decimals": {
+      "to": "0xf19d560eB8d2ADf07BD6D13ed03e1D11215721F9",
+      "data": "0x313ce567",
+      "skipped": false
+    },
+    "link-eth-latest-round-data": {
+      "to": "0xc5E65227fe3385B88468F9A01600017cDC9F3A12",
+      "data": "0xfeaf968c",
+      "skipped": false
+    },
+    "link-eth-decimals": {
+      "to": "0xc5E65227fe3385B88468F9A01600017cDC9F3A12",
+      "data": "0x313ce567",
+      "skipped": false
+    },
+    "btc-eth-latest-round-data": {
+      "to": "",
+      "data": "0xfeaf968c",
+      "skipped": true
+    },
+    "btc-eth-decimals": {
+      "to": "",
+      "data": "0x313ce567",
+      "skipped": true
+    },
+    "latest-round-data": {
+      "to": "0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70",
+      "data": "0xfeaf968c",
+      "skipped": false
+    },
+    "get-round-data": {
+      "to": "",
+      "data": "0x9a6fc8f50000000000000000000000000000000000000000000000000000000000000001",
+      "skipped": true
+    },
+    "latest-answer": {
+      "to": "0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70",
+      "data": "0x50d25bcd",
+      "skipped": false
+    },
+    "decimals": {
+      "to": "0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70",
+      "data": "0x313ce567",
+      "skipped": false
+    },
+    "description": {
+      "to": "0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70",
+      "data": "0x7284e416",
+      "skipped": false
+    },
+    "version": {
+      "to": "0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70",
+      "data": "0x54fd4d50",
+      "skipped": false
+    }
+  },
+  "42161": {
+    "ccip-get-fee": {
+      "to": "",
+      "data": "unencodable-while-skipped",
+      "skipped": true
+    },
+    "ccip-send": {
+      "to": "",
+      "data": "unencodable-while-skipped",
+      "skipped": true
+    },
+    "ccip-bnm-drip": {
+      "to": "",
+      "data": "0x67a5cd060000000000000000000000001111111111111111111111111111111111111111",
+      "skipped": true
+    },
+    "ccip-approve-bridge-token": {
+      "to": "",
+      "data": "0x095ea7b3000000000000000000000000141fa059441e0ca23ce184b6a78bafd2a517dde80000000000000000000000000000000000000000000000000000000000000001",
+      "skipped": true
+    },
+    "ccip-check-bridge-balance": {
+      "to": "",
+      "data": "0x70a082310000000000000000000000001111111111111111111111111111111111111111",
+      "skipped": true
+    },
+    "ccip-check-bridge-allowance": {
+      "to": "",
+      "data": "0xdd62ed3e0000000000000000000000001111111111111111111111111111111111111111000000000000000000000000141fa059441e0ca23ce184b6a78bafd2a517dde8",
+      "skipped": true
+    },
+    "ccip-approve-fee-token": {
+      "to": "",
+      "data": "0x095ea7b3000000000000000000000000141fa059441e0ca23ce184b6a78bafd2a517dde80000000000000000000000000000000000000000000000000000000000000001",
+      "skipped": true
+    },
+    "ccip-check-fee-balance": {
+      "to": "",
+      "data": "0x70a082310000000000000000000000001111111111111111111111111111111111111111",
+      "skipped": true
+    },
+    "ccip-check-fee-allowance": {
+      "to": "",
+      "data": "0xdd62ed3e0000000000000000000000001111111111111111111111111111111111111111000000000000000000000000141fa059441e0ca23ce184b6a78bafd2a517dde8",
+      "skipped": true
+    },
+    "eth-usd-latest-round-data": {
+      "to": "0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612",
+      "data": "0xfeaf968c",
+      "skipped": false
+    },
+    "eth-usd-decimals": {
+      "to": "0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612",
+      "data": "0x313ce567",
+      "skipped": false
+    },
+    "btc-usd-latest-round-data": {
+      "to": "0x06047dD6f43552831BB51319917DC0C99c29A44c",
+      "data": "0xfeaf968c",
+      "skipped": false
+    },
+    "btc-usd-decimals": {
+      "to": "0x06047dD6f43552831BB51319917DC0C99c29A44c",
+      "data": "0x313ce567",
+      "skipped": false
+    },
+    "link-usd-latest-round-data": {
+      "to": "0x3EAbF62EB761BD86c71d07AdBb1A9183FeC24064",
+      "data": "0xfeaf968c",
+      "skipped": false
+    },
+    "link-usd-decimals": {
+      "to": "0x3EAbF62EB761BD86c71d07AdBb1A9183FeC24064",
+      "data": "0x313ce567",
+      "skipped": false
+    },
+    "usdc-usd-latest-round-data": {
+      "to": "0x50834F3163758fcC1Df9973b6e91f0F0F0434aD3",
+      "data": "0xfeaf968c",
+      "skipped": false
+    },
+    "usdc-usd-decimals": {
+      "to": "0x50834F3163758fcC1Df9973b6e91f0F0F0434aD3",
+      "data": "0x313ce567",
+      "skipped": false
+    },
+    "dai-usd-latest-round-data": {
+      "to": "0xc5C8E77B397E531B8EC06BFb0048328B30E9eCfB",
+      "data": "0xfeaf968c",
+      "skipped": false
+    },
+    "dai-usd-decimals": {
+      "to": "0xc5C8E77B397E531B8EC06BFb0048328B30E9eCfB",
+      "data": "0x313ce567",
+      "skipped": false
+    },
+    "usdt-usd-latest-round-data": {
+      "to": "0x3f3f5dF88dC9F13eac63DF89EC16ef6e7E25DdE7",
+      "data": "0xfeaf968c",
+      "skipped": false
+    },
+    "usdt-usd-decimals": {
+      "to": "0x3f3f5dF88dC9F13eac63DF89EC16ef6e7E25DdE7",
+      "data": "0x313ce567",
+      "skipped": false
+    },
+    "link-eth-latest-round-data": {
+      "to": "0xb7c8Fb1dB45007F98A68Da0588e1AA524C317f27",
+      "data": "0xfeaf968c",
+      "skipped": false
+    },
+    "link-eth-decimals": {
+      "to": "0xb7c8Fb1dB45007F98A68Da0588e1AA524C317f27",
+      "data": "0x313ce567",
+      "skipped": false
+    },
+    "btc-eth-latest-round-data": {
+      "to": "0xc5a90A6d7e4Af242dA238FFe279e9f2BA0c64B2e",
+      "data": "0xfeaf968c",
+      "skipped": false
+    },
+    "btc-eth-decimals": {
+      "to": "0xc5a90A6d7e4Af242dA238FFe279e9f2BA0c64B2e",
+      "data": "0x313ce567",
+      "skipped": false
+    },
+    "latest-round-data": {
+      "to": "0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612",
+      "data": "0xfeaf968c",
+      "skipped": false
+    },
+    "get-round-data": {
+      "to": "",
+      "data": "0x9a6fc8f50000000000000000000000000000000000000000000000000000000000000001",
+      "skipped": true
+    },
+    "latest-answer": {
+      "to": "0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612",
+      "data": "0x50d25bcd",
+      "skipped": false
+    },
+    "decimals": {
+      "to": "0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612",
+      "data": "0x313ce567",
+      "skipped": false
+    },
+    "description": {
+      "to": "0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612",
+      "data": "0x7284e416",
+      "skipped": false
+    },
+    "version": {
+      "to": "0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612",
+      "data": "0x54fd4d50",
+      "skipped": false
+    }
   }
 }

--- a/tests/unit/__goldens__/protocol-calldata/chainlink.json
+++ b/tests/unit/__goldens__/protocol-calldata/chainlink.json
@@ -462,7 +462,7 @@
     "description": {
       "to": "0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612",
       "data": "0x7284e416",
-      "skipped": false
+      "skipped": true
     },
     "version": {
       "to": "0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612",


### PR DESCRIPTION
## What

Extends the Tier 1 fork-simulation sweep from Ethereum-only to two L2s:
Base (8453) and Arbitrum One (42161). Every registry action for a covered
(protocol, chain) is executed directly against an anvil fork of that chain.

- `chains.test.ts` now iterates Base and Arbitrum in addition to Ethereum
  and Sepolia, gating each on `PROTOCOL_SIM_RPC_<chainId>` so a chain whose
  RPC is absent self-skips rather than failing.
- New `tier1-simulations-l2` CI job runs one matrix leg per chain, in
  parallel with the existing chain-1 `tier1-simulations` job, each with its
  own executed-test floor. Two separate runners mean the L2 legs add no time
  to the chain-1 budget.
- `scripts/protocol-local.sh` gains `start_base_fork` / `start_arbitrum_fork`
  and wires `sim base` / `sim arbitrum` (and bare `sim`) to start them.
- `coverage:report` now emits per-chain rows for 8453 and 42161, derived
  automatically from each protocol's testData.

## Why

Every protocol was previously simulated on a single mainnet fork; L2
deployments were unvalidated. The harness was already parameterized per
chain, so this is fork plumbing plus L2 testData. Simulations read forked
state and never mine against the upstream, so public Base/Arbitrum RPC
endpoints are sufficient here (no archive node), unlike the mainnet pinned
fork.

## Coverage gained

- chainlink: price-feed reads bound on both chains. Base runs all named
  USD/ETH feeds except BTC/ETH (no Base deployment) plus the custom-feed
  read set (19 reads); Arbitrum adds the BTC/ETH feed (21 reads). CCIP and
  historical-round actions self-skip on both.
- ajna: its existing Base reads now also execute against a Base fork in
  Tier 1, not only against live Base in Tier 2.

Per-chain executed-test floors: Base 15, Arbitrum 12.

## Notes

- Both legs default to public upstreams (`base-rpc.publicnode.com`,
  `arbitrum-one-rpc.publicnode.com`); a per-chain `ANVIL_FORK_*_URL` secret
  overrides for a private endpoint. Neither chain is gated off - both feeds
  were verified live (decimals 8, latestRoundData responding).
- Read-only L2 coverage needs no whales or faucets. Write-bearing L2
  protocols (aave-v3, uniswap-v3, sky, etc.) that declare L2 contract
  addresses still need per-chain FORK_WHALES/FAUCETS before their write
  testData can run on these chains; that is deliberately left as follow-up.
