### PR TITLE
feat: enable PodDisruptionBudgets for stack critical services

### DIFF
--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -135,7 +135,7 @@ jobs:
           timeout: 15m0s
           name: ${{ env.SERVICE_NAME }}
           chart-repository: https://techops-services.github.io/helm-charts
-          version: 0.2.0
+          version: 0.3.0
           atomic: true
 
       - name: Wait for deployment health check

--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -54,6 +54,10 @@ app:
 
   replicaCount: 2
 
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+
   service:
     enabled: true
     name: keeperhub-prod
@@ -828,6 +832,10 @@ schedule:
 
   replicaCount: 1
 
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+
   service:
     enabled: true
     name: keeperhub-scheduler-prod
@@ -940,6 +948,10 @@ block:
   # 3. Filters blocks by workflow interval and enqueues matches to SQS
 
   replicaCount: 1
+
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
 
   service:
     enabled: true

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -54,6 +54,10 @@ app:
 
   replicaCount: 1
 
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+
   service:
     enabled: true
     name: keeperhub-staging
@@ -830,6 +834,10 @@ schedule:
 
   replicaCount: 1
 
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+
   service:
     enabled: true
     name: keeperhub-scheduler-staging
@@ -942,6 +950,10 @@ block:
   # 3. Filters blocks by workflow interval and enqueues matches to SQS
 
   replicaCount: 1
+
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
 
   service:
     enabled: true


### PR DESCRIPTION
## What

Enable the common chart's opt-in PodDisruptionBudget (`minAvailable: 1`) for the app, schedule dispatcher and block dispatcher components in both the staging and prod `keeperhub-stack` values, and bump the umbrella chart pin `0.2.0 -> 0.3.0` to pick up the PDB-capable subchart.

## Why

Without PDBs, a node drain can evict these services below their availability floor, briefly taking single-replica critical services to zero during routine node replacements. The PDBs make the scheduler wait for rescheduled pods instead of taking the last replica.

## Verification

Rendered the umbrella chart with these values and confirmed exactly three PodDisruptionBudgets are produced (app, schedule, block), each selector matching its Deployment's pod selector. Depends on the `common` / `keeperhub-stack` chart release (helm-charts) being published first.