### PR TITLE
fix(docs): allow /quickstart route in docs middleware

### DIFF
--- a/docs-site/middleware.ts
+++ b/docs-site/middleware.ts
@@ -8,6 +8,7 @@ const VALID_ROUTES = new Set([
   "api",
   "cli",
   "getting-started",
+  "quickstart",
   "intro",
   "keeper-runs",
   "keepers",


### PR DESCRIPTION
## Problem

The **Hackathon Quickstart** entry in the docs sidebar (above Getting Started) links to `/quickstart` and returns a 404, even though the page exists.

## Root cause

The docs site is Nextra, but `docs-site/middleware.ts` guards navigation with a hand-maintained `VALID_ROUTES` allowlist and rewrites anything not in it to `/404`. The nav entry (`docs/_meta.ts`) and the page (`docs/quickstart.md`) were both added, but `quickstart` was never added to the allowlist, so every visit to `/quickstart` was rewritten to `/404` before reaching the page component.

## Fix

Add `quickstart` to `VALID_ROUTES`. One-line change; the section and its content already exist.

Note: this allowlist duplicates the content-directory routing and must be hand-synced, so the next new top-level docs page will hit the same trap. Worth a follow-up to derive the allowlist from the content dir, tracked separately.