### PR TITLE
fix: shard protocol-coverage e2e sweep and fix ethena write timeouts

### DIFF
--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -748,10 +748,30 @@ jobs:
     # Same gate as e2e-vitest-ephemeral: build-app skipped (Docker path)
     # or succeeded admits this job; failed or cancelled blocks it.
     if: ${{ !cancelled() && needs.should-run.outputs.run-e2e == 'true' && (needs.build-app.result == 'success' || needs.build-app.result == 'skipped') }}
-    # Suites run concurrently with 10-minute setup hooks (cold archive
-    # fan-outs on a fresh fork); 45 min bounds a hung run without a
-    # 6-hour default runaway.
-    timeout-minutes: 45
+    # The suites share one anvil mainnet fork and one wallet, so they run
+    # serially within a shard (vitest fileParallelism is off). The full sweep
+    # is ~50 min serial and does not fit one runner, so the protocols are
+    # split across shards balanced by measured runtime, keeping the two
+    # ~10-minute suites (pendle, superfluid) in different shards. The
+    # protocol-coverage-floor job merges the shard results and enforces the
+    # executed floor + suite completeness across the whole sweep. Adding a
+    # protocol means adding it to a shard below; the completeness guard fails
+    # the run if a suite is left unassigned. 25 min bounds a hung shard.
+    timeout-minutes: 25
+    strategy:
+      # One slow or flaky shard must not cancel the others, and the floor
+      # job needs every shard's results to judge the sweep.
+      fail-fast: false
+      matrix:
+        include:
+          - shard: 1
+            suites: superfluid/ethereum chronicle/ethereum rocket-pool/ethereum uniswap/ethereum
+          - shard: 2
+            suites: pendle/ethereum safe/ethereum chainlink/ethereum wrapped/ethereum
+          - shard: 3
+            suites: ethena/ethereum curve/ethereum frax-ether-v2/ethereum spark/ethereum
+          - shard: 4
+            suites: aave-v3/ethereum lido/ethereum sky/ethereum yearn/ethereum ajna/base morpho/ethereum
     runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && inputs.caller_event != 'pull_request' && 'arc-keeperhub-build' || 'ubuntu-latest' }}
     # Always staging: e2e validates against test credentials, never prod.
     environment: staging
@@ -950,33 +970,19 @@ jobs:
           # suites never depend on step ordering for correct RPCs.
           PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d keeperhub_test \
             -c "UPDATE chains SET default_primary_rpc = 'http://localhost:8548', default_fallback_rpc = NULL WHERE chain_id = 1"
-          pnpm vitest run tests/e2e/vitest/protocol-coverage \
-            --reporter=default --reporter=json --outputFile=protocol-results.json
-          # Executed-test floor: every suite self-skips when its infra
-          # gates are absent, so a green exit code alone can mean "ran
-          # nothing" (that is how coverage silently collapsed to ~35
-          # executed tests). Fails when executed tests drop below the
-          # floor; publishes run/skip counts to the step summary.
-          #
-          # Derivation (2026-07-07, from planPhaseFixtures - see
-          # specs/protocol-coverage-methodology.md). Representatives mode
-          # executes exactly one action per runnable (suite, phase) pair:
-          # 21 pairs across the 16 active mainnet-fork suites (morpho is
-          # hard-skipped; safe/chronicle/sky and others have no runnable
-          # write) plus ajna's single read pair = 22. Full mode executes
-          # every runnable action: 207 on the mainnet suites + 25 ajna
-          # reads = 232; floor 200 leaves margin for individual fixtures
-          # moving to documented skips without a same-PR floor bump.
-          # Without ANVIL_FORK_MAINNET_URL every mainnet suite self-skips
-          # and only ajna runs (25 reads, 1 representative), so the floor
-          # drops with the gate instead of failing the job spuriously.
-          if [ -n "${ANVIL_FORK_MAINNET_URL:-}" ]; then
-            if [ "${PROTOCOL_E2E_REPRESENTATIVES:-}" = "1" ]; then FLOOR=22; else FLOOR=200; fi
-          else
-            if [ "${PROTOCOL_E2E_REPRESENTATIVES:-}" = "1" ]; then FLOOR=1; else FLOOR=20; fi
-          fi
-          pnpm tsx scripts/protocol-coverage-floor.ts protocol-results.json "$FLOOR"
+          # Run only this shard's suites (assigned in the matrix above). The
+          # executed floor and suite completeness are enforced across the
+          # whole sweep by the protocol-coverage-floor job, which merges
+          # every shard's JSON, since a single shard cannot judge either.
+          SUITES=""
+          for suite in $SUITE_DIRS; do
+            SUITES="$SUITES tests/e2e/vitest/protocol-coverage/$suite/coverage.test.ts"
+          done
+          pnpm vitest run $SUITES \
+            --reporter=default --reporter=json --outputFile="protocol-results-${SHARD}.json"
         env:
+          SHARD: ${{ matrix.shard }}
+          SUITE_DIRS: ${{ matrix.suites }}
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/keeperhub_test
           BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
           WORKFLOW_TARGET_WORLD: "@workflow/world-postgres"
@@ -1046,16 +1052,87 @@ jobs:
           docker rm -f keeperhub-app || true
           rm -f /tmp/keeperhub-app.env
 
-      - name: Upload test results
+      # Always upload this shard's JSON so protocol-coverage-floor can merge
+      # it, even when a shard fails: the floor and completeness guards need
+      # every shard's results to judge the sweep.
+      - name: Upload shard results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: protocol-coverage-shard-${{ matrix.shard }}
+          path: protocol-results-${{ matrix.shard }}.json
+          retention-days: 7
+
+      - name: Upload debug bundle
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: protocol-coverage-results
+          name: protocol-coverage-debug-${{ matrix.shard }}
           path: |
-            protocol-results.json
+            protocol-results-${{ matrix.shard }}.json
             test-results/
             coverage/
           retention-days: 7
+
+  # Merge the sharded protocol-coverage results and enforce the sweep-wide
+  # guards: the executed-test floor (suites self-skip when infra gates are
+  # absent, so a green shard can mean "ran nothing") and suite completeness
+  # (a suite left out of every shard's list would silently vanish). Runs only
+  # when all shards succeed; a shard's own test failures fail the run
+  # directly via that shard's non-zero vitest exit.
+  protocol-coverage-floor:
+    needs: [should-run, protocol-coverage-ephemeral]
+    runs-on: ubuntu-latest
+    environment: staging
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Download shard results
+        uses: actions/download-artifact@v7
+        with:
+          pattern: protocol-coverage-shard-*
+          path: shard-results
+          merge-multiple: true
+
+      - name: Enforce floor and suite completeness
+        env:
+          ANVIL_FORK_MAINNET_URL: ${{ secrets.ANVIL_FORK_MAINNET_URL }}
+          PROTOCOL_E2E_REPRESENTATIVES: ${{ (inputs.caller_event || github.event_name) == 'pull_request' && '1' || '' }}
+        run: |
+          # Suite completeness first: a coverage.test.ts left out of every
+          # shard's list would silently vanish from the sweep.
+          pnpm tsx scripts/protocol-coverage-completeness.ts shard-results/*.json
+          # Executed-test floor: every suite self-skips when its infra gates
+          # are absent, so a green run can mean "ran nothing" (that is how
+          # coverage silently collapsed to ~35 executed tests). Fails when
+          # merged executed tests drop below the floor; publishes run/skip
+          # counts to the step summary.
+          #
+          # Derivation (2026-07-07, from planPhaseFixtures - see
+          # specs/protocol-coverage-methodology.md). Representatives mode
+          # executes exactly one action per runnable (suite, phase) pair:
+          # 21 pairs across the 16 active mainnet-fork suites (morpho is
+          # hard-skipped; safe/chronicle/sky and others have no runnable
+          # write) plus ajna's single read pair = 22. Full mode executes
+          # every runnable action: 207 on the mainnet suites + 25 ajna
+          # reads = 232; floor 200 leaves margin for individual fixtures
+          # moving to documented skips without a same-PR floor bump.
+          # Without ANVIL_FORK_MAINNET_URL every mainnet suite self-skips
+          # and only ajna runs (25 reads, 1 representative), so the floor
+          # drops with the gate instead of failing the job spuriously.
+          if [ -n "${ANVIL_FORK_MAINNET_URL:-}" ]; then
+            if [ "${PROTOCOL_E2E_REPRESENTATIVES:-}" = "1" ]; then FLOOR=22; else FLOOR=200; fi
+          else
+            if [ "${PROTOCOL_E2E_REPRESENTATIVES:-}" = "1" ]; then FLOOR=1; else FLOOR=20; fi
+          fi
+          pnpm tsx scripts/protocol-coverage-floor.ts shard-results/*.json "$FLOOR"
 
   # Playwright E2E tests (browser-based, single worker, serial within the suite).
   # Runs in parallel with the Vitest job (each has its own ephemeral Postgres).

--- a/protocols/ethena.ts
+++ b/protocols/ethena.ts
@@ -98,6 +98,15 @@ export default defineAbiProtocol({
         "vault-withdraw": { receiver: wallet(), owner: wallet() },
         "vault-redeem": { receiver: wallet(), owner: wallet() },
       },
+      // approve-usde exercises the app's real approve-token path (the same
+      // one the setup above fabricates around) and unstake claims through
+      // the silo; both fan out cold contract state on a fresh fork and run
+      // past the default two-minute wait, so give them the same headroom as
+      // lido approve-steth / curve crv-approve.
+      executionWaitMs: {
+        "approve-usde": 240_000,
+        unstake: 240_000,
+      },
       fabrications: {
         // cooldown-shares runs immediately before unstake in registry
         // order and re-arms the cooldown timer (86400s on mainnet,

--- a/scripts/protocol-coverage-completeness.ts
+++ b/scripts/protocol-coverage-completeness.ts
@@ -1,0 +1,81 @@
+/**
+ * Suite-completeness guard for the sharded protocol-coverage sweep.
+ *
+ * The suites are hand-assigned to shards in e2e-tests-ephemeral.yml, so a
+ * newly added `coverage.test.ts` that nobody wires into a shard would run
+ * in none of them and silently vanish from coverage. This reads the merged
+ * shard JSON results, compares the suites that actually loaded against every
+ * `coverage.test.ts` on disk, and fails when any suite ran in zero shards.
+ *
+ * Runs in CI with only node builtins available (no dependencies).
+ *
+ * Usage: tsx scripts/protocol-coverage-completeness.ts <vitest.json...>
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { VitestJsonResults } from "./vitest-assertion-counts";
+
+const SUITE_ROOT = "tests/e2e/vitest/protocol-coverage";
+const SUITE_FILE = "coverage.test.ts";
+const MARKER = "protocol-coverage/";
+
+// Reduce any absolute or relative path to its `<protocol>/<chain>/file` tail
+// so on-disk discovery and vitest's absolute result paths compare equal.
+function toSuiteKey(path: string): string {
+  const idx = path.lastIndexOf(MARKER);
+  const tail = idx === -1 ? path : path.slice(idx + MARKER.length);
+  return tail.replace(/^[/\\]+/, "");
+}
+
+function discoverSuites(): string[] {
+  const entries = readdirSync(SUITE_ROOT, {
+    recursive: true,
+    encoding: "utf8",
+  });
+  return entries
+    .filter((e) => e.endsWith(SUITE_FILE))
+    .map((e) => toSuiteKey(join(SUITE_ROOT, e)));
+}
+
+function ranSuites(files: string[]): Set<string> {
+  const ran = new Set<string>();
+  for (const file of files) {
+    const raw = JSON.parse(readFileSync(file, "utf8")) as VitestJsonResults;
+    for (const tr of raw.testResults ?? []) {
+      if (tr.name) {
+        ran.add(toSuiteKey(tr.name));
+      }
+    }
+  }
+  return ran;
+}
+
+function main(): void {
+  const files = process.argv.slice(2);
+  if (files.length === 0) {
+    process.stderr.write(
+      "usage: tsx scripts/protocol-coverage-completeness.ts <vitest.json...>\n"
+    );
+    process.exit(2);
+  }
+  const discovered = discoverSuites();
+  const ran = ranSuites(files);
+  const missing = discovered.filter((s) => !ran.has(s)).sort();
+
+  process.stdout.write(
+    `Suite completeness: ${discovered.length - missing.length}/${discovered.length} suites ran across ${files.length} shard result file(s)\n`
+  );
+
+  if (missing.length > 0) {
+    process.stderr.write(
+      `FAIL: ${missing.length} coverage suite(s) ran in no shard - add them to a ` +
+        "shard's suite list in e2e-tests-ephemeral.yml:\n" +
+        missing.map((s) => `  - ${s}`).join("\n") +
+        "\n"
+    );
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/protocol-coverage-floor.ts
+++ b/scripts/protocol-coverage-floor.ts
@@ -18,10 +18,15 @@ import {
 } from "./vitest-assertion-counts";
 
 function main(): void {
-  const [file, floorArg] = process.argv.slice(2);
-  if (!(file && floorArg)) {
+  // All args except the last are vitest JSON files; the last is the floor.
+  // One file keeps the single-suite behaviour; several are merged so a
+  // sharded run checks the floor against the whole sweep, not one shard.
+  const args = process.argv.slice(2);
+  const floorArg = args.pop();
+  const files = args;
+  if (!(files.length && floorArg)) {
     process.stderr.write(
-      "usage: tsx scripts/protocol-coverage-floor.ts <vitest.json> <floor>\n"
+      "usage: tsx scripts/protocol-coverage-floor.ts <vitest.json...> <floor>\n"
     );
     process.exit(2);
   }
@@ -34,8 +39,12 @@ function main(): void {
     );
     process.exit(2);
   }
-  const raw = JSON.parse(readFileSync(file, "utf8")) as VitestJsonResults;
-  const { executed, passed, failed, skipped } = countTotals(raw);
+  const testResults: NonNullable<VitestJsonResults["testResults"]> = [];
+  for (const file of files) {
+    const raw = JSON.parse(readFileSync(file, "utf8")) as VitestJsonResults;
+    testResults.push(...(raw.testResults ?? []));
+  }
+  const { executed, passed, failed, skipped } = countTotals({ testResults });
 
   const summary = `Protocol coverage: executed ${executed} (passed ${passed}, failed ${failed}), skipped ${skipped}, floor ${floor}`;
   process.stdout.write(`${summary}\n`);


### PR DESCRIPTION
## Why

The `protocol-coverage-ephemeral` job has been failing on `staging`: it exceeded the 45 minute job timeout and was cancelled mid-run.

Root cause: the suites share one anvil mainnet fork and one wallet, so they run serially (vitest `fileParallelism` is off). The full push sweep is ~50 minutes of wall-clock and never finished. Two real failures were also hiding under the timeout: ethena `approve-usde` and `unstake` timed out at the default 120s execution wait.

## What

- Split `protocol-coverage-ephemeral` into a 4-way matrix balanced by measured runtime, with the two ~10 minute suites (pendle, superfluid) placed in different shards. The slowest shard runs ~13 minutes of tests, so the job now fits a 25 minute bound instead of overrunning 45.
- Add a `protocol-coverage-floor` job that downloads all shard result JSONs, merges them, and runs the sweep-wide guards a single shard cannot: the executed floor (unchanged FLOOR=200 semantics) and a new suite-completeness check that fails when any `coverage.test.ts` ran in no shard. That closes the gap where a newly added suite left out of the shard lists would silently vanish.
- `scripts/protocol-coverage-floor.ts` now accepts multiple result files; single-file callers (tier1) are unchanged.
- Give ethena `approve-usde` and `unstake` a 240s execution wait, matching lido `approve-steth` and curve `crv-approve`, which exercise the same slow fork-write path.

## Validation

Local: the shard split covers all 18 suites with no overlap or drops, the merge and floor are correct, and the completeness guard passes at 18/18 and fails loudly (naming the missing suites) when a shard is absent. Type-check passes. The full fork-backed run, the ethena fix, and real per-shard timing are exercised by CI.