### PR TITLE
fix: raise sky approve write execution wait to 240s

### DIFF
--- a/protocols/sky.ts
+++ b/protocols/sky.ts
@@ -326,6 +326,14 @@ export default defineAbiProtocol({
           owner: wallet(),
         },
       },
+      // approve-dai and approve-usds run the app's real approve-token path,
+      // which fans out cold token state on a fresh fork and runs past the
+      // default two-minute wait; give them the same headroom as ethena
+      // approve-usde / lido approve-steth / curve crv-approve.
+      executionWaitMs: {
+        "approve-dai": 240_000,
+        "approve-usds": 240_000,
+      },
     },
   },
 


### PR DESCRIPTION
## Why

After #1753 sharded the protocol-coverage sweep so it finishes instead of hitting the 45 minute job timeout, the first full staging run surfaced a latent failure: sky `approve-dai` and `approve-usds` both timed out at the default 120s execution wait. sky was one of the suites that never ran inside the old timeout, so the failure was masked until the sweep started completing.

The execution returned null (still running at 120s) rather than a terminal failure, and the app logs show the sponsored transaction path failing over to slower direct signing. That is the same slow fork-write signature already handled for ethena `approve-usde`, lido `approve-steth`, and curve `crv-approve`.

## What

Give sky `approve-dai` and `approve-usds` a 240s execution wait, matching those three.

Scanned every protocol for approve-style writes without an override: the only other two (safe `approve-hash`, uniswap-v3 `approve-position`) are already skipped or non-runnable in the sweep, so sky is the only real gap.

## Validation

Type-check passes. The real confirmation is the next full staging push run (PR runs use the fast representatives sweep), the same signal that first surfaced this failure.