### PR TITLE
fix: persist two_factor_enabled on 2FA re-enrollment

### DIFF
--- a/app/api/user/totp/enroll/route.ts
+++ b/app/api/user/totp/enroll/route.ts
@@ -182,15 +182,32 @@ export async function POST(request: Request): Promise<NextResponse> {
         .update(twoFactorTable)
         .set({ backupCodes: encryptedBackupCodes })
         .where(eq(twoFactorTable.userId, userId));
-      // /setup writes the two_factor row out-of-band, so Better Auth's
-      // verifyTOTP verifies the code but never flips this flag (it only does so
-      // for enrollments it initiated). getEnrolledFactors reads exactly this
-      // column, so set it explicitly here -- at verify time -- or TOTP would
-      // forever read as "not enrolled". Mirrors the pending-signup path below.
+      // /setup writes the row pending (verified=false), so verifyTOTP above
+      // runs Better Auth's own enable path (updateUser + session rotation) and
+      // flips two_factor_enabled. Repeat it here as an idempotent backstop, then
+      // assert it landed: getEnrolledFactors reads exactly this column, so a
+      // silently-lost write would loop the user through /enroll-mfa forever.
       await db
         .update(users)
         .set({ twoFactorEnabled: true })
         .where(eq(users.id, userId));
+      const [enrolledRow] = await db
+        .select({ twoFactorEnabled: users.twoFactorEnabled })
+        .from(users)
+        .where(eq(users.id, userId))
+        .limit(1);
+      if (enrolledRow?.twoFactorEnabled !== true) {
+        logSystemError(
+          ErrorCategory.AUTH,
+          "[TOTP Enroll] two_factor_enabled did not persist after verify",
+          new Error("two_factor_enabled still false post-enroll"),
+          { endpoint: "/api/user/totp/enroll", user_id: userId }
+        );
+        return NextResponse.json(
+          { error: "Enrollment could not be completed. Please try again." },
+          { status: HttpStatus.INTERNAL_SERVER_ERROR }
+        );
+      }
       const newRawToken = extractNewSessionToken(
         readAllSetCookies(verifyHeaders)
       );
@@ -313,9 +330,13 @@ export async function POST(request: Request): Promise<NextResponse> {
     // authenticate, while the absence of the pending cookie (which
     // we are about to clear) means they could not retry enrollment.
     await db.transaction(async (tx) => {
+      // This path verifies with the custom verifyUserTotp above, not Better
+      // Auth, so it must mark the row verified itself. /setup writes it pending
+      // (verified=false); leaving it false would make Better Auth's sign-in
+      // verify reject the factor with TOTP_NOT_ENABLED on the user's next login.
       await tx
         .update(twoFactorTable)
-        .set({ backupCodes: encryptedBackupCodes })
+        .set({ backupCodes: encryptedBackupCodes, verified: true })
         .where(eq(twoFactorTable.userId, userId));
       await tx
         .update(users)

--- a/app/api/user/totp/setup/route.ts
+++ b/app/api/user/totp/setup/route.ts
@@ -197,6 +197,13 @@ export async function POST(request: Request): Promise<NextResponse> {
     // Replaces the older DELETE-then-INSERT pattern which could
     // produce duplicate rows under concurrent calls (React StrictMode
     // fires open-effects twice in dev). One enrollment per user.
+    // Write the row pending (verified=false). The column defaults to true so
+    // sign-in verify never issues a redundant update, but a freshly generated
+    // secret has not been confirmed yet: leaving it true makes Better Auth's
+    // verify-totp skip its own enable path (it only enables when
+    // verified !== true), which strands re-enrollment. Starting false lets that
+    // path run on the first correct code, flipping verified + two_factor_enabled
+    // together. It returns to true the moment enrollment completes.
     const enrolledAt = new Date();
     await db
       .insert(twoFactorTable)
@@ -207,6 +214,7 @@ export async function POST(request: Request): Promise<NextResponse> {
         backupCodes: null,
         name,
         enrolledAt,
+        verified: false,
       })
       .onConflictDoUpdate({
         target: twoFactorTable.userId,
@@ -215,6 +223,7 @@ export async function POST(request: Request): Promise<NextResponse> {
           backupCodes: null,
           name,
           enrolledAt,
+          verified: false,
         },
       });
 

--- a/tests/integration/totp-enroll-route.test.ts
+++ b/tests/integration/totp-enroll-route.test.ts
@@ -11,6 +11,7 @@ const {
   mockGetSession,
   mockHashSessionToken,
   updateCalls,
+  selectRows,
 } = vi.hoisted(() => ({
   mockResolveCaller: vi.fn(),
   mockVerifyTOTP: vi.fn(),
@@ -20,6 +21,10 @@ const {
     table: unknown;
     value: unknown;
     where: { column: unknown; value: unknown };
+  }>,
+  // Rows returned by the read-after-write assert on users.two_factor_enabled.
+  selectRows: [{ twoFactorEnabled: true }] as Array<{
+    twoFactorEnabled: boolean;
   }>,
 }));
 
@@ -48,6 +53,13 @@ vi.mock("@/lib/db", () => ({
           updateCalls.push({ table, value, where });
           return Promise.resolve(undefined);
         }),
+      })),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve(selectRows)),
+        })),
       })),
     })),
   },
@@ -118,6 +130,8 @@ function isSessionsUpdate(call: { where: { column: unknown } }): boolean {
 beforeEach(() => {
   vi.clearAllMocks();
   updateCalls.length = 0;
+  selectRows.length = 0;
+  selectRows.push({ twoFactorEnabled: true });
   process.env.BETTER_AUTH_SECRET = "test-better-auth-secret-1234567890";
   mockResolveCaller.mockResolvedValue({
     kind: "session",
@@ -169,5 +183,35 @@ describe("POST /api/user/totp/enroll (session path requires_mfa scope)", () => {
       (call) => call.where.column === "sessions.userId"
     );
     expect(broadClears).toHaveLength(0);
+  });
+
+  it("flips two_factor_enabled on the users row during a session enroll", async () => {
+    mockVerifyTOTP.mockResolvedValue({
+      headers: headersWithSessionCookie(
+        "better-auth.session_token=rawtok123.sigABC; Path=/; HttpOnly"
+      ),
+    });
+
+    const response = await POST(buildRequest());
+
+    expect(response.status).toBe(200);
+    const enableUpdate = updateCalls.find(
+      (call) => call.where.column === "users.id"
+    );
+    expect(enableUpdate?.value).toEqual({ twoFactorEnabled: true });
+  });
+
+  it("returns 500 when two_factor_enabled did not persist after verify", async () => {
+    mockVerifyTOTP.mockResolvedValue({
+      headers: headersWithSessionCookie(
+        "better-auth.session_token=rawtok123.sigABC; Path=/; HttpOnly"
+      ),
+    });
+    selectRows.length = 0;
+    selectRows.push({ twoFactorEnabled: false });
+
+    const response = await POST(buildRequest());
+
+    expect(response.status).toBe(500);
   });
 });


### PR DESCRIPTION
## Problem

Re-enabling TOTP after disabling it stranded users in the `/enroll-mfa` loop. `two_factor.verified` defaults to `true`, so better-auth's `verify-totp` skipped its own enable path (it only enables when `verified !== true`) and the app's manual `two_factor_enabled` write did not persist. Every enrollment gate reads that flag straight from the DB, saw `false`, and force-routed the user back to `/enroll-mfa`. Symptom on prod: nine `totp.enrolled` "succeeded" audit events with the flag never flipping. First-time signup worked because it enrolls through a different, committed-transaction path.

## Fix

- **setup**: write the row pending (`verified = false`) so better-auth runs its own enable path (`updateUser` + session rotation) on the first valid code, which flips `verified` and `two_factor_enabled` together.
- **enroll (pending-signup)**: set `verified = true` inside the existing transaction, since that path verifies with the custom verifier rather than better-auth. Leaving it `false` would make better-auth reject the factor at the user's next sign-in.
- **enroll (session)**: keep the flag write as an idempotent backstop and add a read-after-write assert on `two_factor_enabled` before returning 200, returning 500 otherwise so a lost write surfaces as an error instead of a silent loop.

## Notes

- Existing enrollments keep `verified = true` and are unaffected. No migration or backfill.
- Accounts currently stuck self-heal on their next enrollment attempt (reopening the wizard rewrites the row pending).

## Tests

Extended the enroll integration test: asserts the session enroll flips the flag on the users row, and asserts a 500 when the flag does not persist. Existing setup/enroll/authorize-action/two-factor suites pass.