### PR TITLE
fix: raise pendle protocol-coverage setup wait for three serial approvals

### DIFF
--- a/protocols/pendle.ts
+++ b/protocols/pendle.ts
@@ -44,7 +44,10 @@ const TEST_DATA: ProtocolTestData = {
       // Three real signed txs through the app; each has been observed
       // to take 100-220s under CI's shared-wallet contention on a cold
       // fork, so the single-tx 300s default cannot fit this setup.
-      executionWaitMs: 600_000,
+      // 600_000 was too tight: three worst-case approvals total ~660s and
+      // raced the wait, so a fully successful setup still timed out at the
+      // boundary. 900_000 clears the worst case with margin.
+      executionWaitMs: 900_000,
     },
     actions: {
       "get-ve-pendle-balance": { user: wallet() },


### PR DESCRIPTION
## Problem

The prod CI Pipeline went red on `protocol-coverage-ephemeral (2, pendle/...)`, blocking deploy. It reproduced identically across two runs (original + a re-run of the same run), so it is not a transient flake.

## Root cause

Pendle's protocol-coverage `beforeAll` setup submits three serial on-chain `approve-token` writes (SY_WSTETH, PT_WSTETH, YT_WSTETH to the router). On the cold anvil mainnet fork each write lazy-loads contract state from a throttled public upstream and takes 100-220s. Three serial writes total ~10 min, but `setup.executionWaitMs` was `600_000` (10 min), so the wait raced the execution.

On the re-run all three approvals actually **succeeded** (execution status `success`, completed right at the 10-min mark) but `waitForWorkflowExecution` had already given up, throwing `setup workflow failed for pendle/1: timeout`. Both runs capped at an identical 655s.

## Fix

Raise pendle's `setup.executionWaitMs` from `600_000` to `900_000` (chain 1), giving ~5 min of margin over the worst-case observed ~660s. This mirrors the in-pattern remediation already applied to other protocols for the same cold-fork write-latency issue: #1753 (ethena write timeouts) and #1754 (raise sky approve wait to 240s).

## Verification

- Single numeric-literal change in a typed field; no type or lint impact (biome on the changed lines is clean; the only biome complaints on this file are pre-existing and identical on unchanged `staging`).
- Authoritative validation is this PR's CI protocol-coverage sweep.

Failing run: https://github.com/KeeperHub/keeperhub/actions/runs/29059077392