### PR TITLE
feat: run schedule and block dispatchers with leader election and 2 replicas

### DIFF
--- a/app/api/internal/executions/route.ts
+++ b/app/api/internal/executions/route.ts
@@ -52,7 +52,17 @@ export async function POST(request: Request): Promise<NextResponse> {
   }
 
   const body = JSON.parse(rawBody);
-  const { workflowId, userId, input, status, triggerSource } = body;
+  const { workflowId, userId, input, status, triggerSource, dispatchKey } =
+    body;
+
+  // Optional dispatch-idempotency key. When two dispatcher replicas
+  // overlap (failover / rolling restart) or a catch-up window re-runs an
+  // occurrence, both compute the same key; the unique index turns the second
+  // insert into a no-op so only one phantom row (and one SQS message) exists.
+  const dispatchKeyValue: string | null =
+    typeof dispatchKey === "string" && dispatchKey.length > 0
+      ? dispatchKey
+      : null;
 
   // A phantom row represents an expected-but-unstarted trigger that the
   // scheduler/event-tracker pre-creates; the executor later upgrades it to
@@ -109,7 +119,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   const source = resolveTriggerSource(triggerSource);
   const attribution = buildAttribution({ request, source });
 
-  const [execution] = await withBackstopCapture(
+  const inserted = await withBackstopCapture(
     { workflowId, userId: ownerId, source },
     () =>
       db
@@ -124,6 +134,7 @@ export async function POST(request: Request): Promise<NextResponse> {
           // billable as before.
           billable: !isPhantom,
           input: input || {},
+          dispatchKey: dispatchKeyValue,
           ...attribution,
           // Tie the run to the workflow version that fired it. For phantoms the
           // executor restamps this with the definition it actually loads at run
@@ -133,8 +144,40 @@ export async function POST(request: Request): Promise<NextResponse> {
             workflow.edges
           ),
         })
+        // No-op if another dispatcher already created a row for this dispatch
+        // key. NULL keys never conflict (Postgres treats them as distinct).
+        .onConflictDoNothing({ target: workflowExecutions.dispatchKey })
         .returning({ id: workflowExecutions.id })
   );
 
-  return NextResponse.json({ executionId: execution.id }, { status: 201 });
+  const created = inserted[0];
+  if (created) {
+    return NextResponse.json(
+      { executionId: created.id, alreadyExisted: false },
+      { status: 201 }
+    );
+  }
+
+  // Conflict: a row already exists for this dispatch key. Return its id and
+  // flag it so the caller skips the duplicate SQS send. Only reachable with a
+  // non-null key, so the lookup is well-defined.
+  const [existing] = await db
+    .select({ id: workflowExecutions.id })
+    .from(workflowExecutions)
+    .where(eq(workflowExecutions.dispatchKey, dispatchKeyValue as string))
+    .limit(1);
+
+  if (existing) {
+    return NextResponse.json(
+      { executionId: existing.id, alreadyExisted: true },
+      { status: 200 }
+    );
+  }
+
+  // Conflict reported but the row is gone (deleted between insert and lookup).
+  // Fail loudly rather than silently dropping the trigger.
+  return NextResponse.json(
+    { error: "Failed to create execution" },
+    { status: 500 }
+  );
 }

--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -143,6 +143,12 @@ app:
       - apiGroups: [""]
         resources: ["pods/log"]
         verbs: ["get"]
+      # Leader election for the schedule and block dispatchers. They share this
+      # service account, so the Lease permission lives here (one owner of the
+      # Role) rather than on a second SA that would need its own IRSA role-arn.
+      - apiGroups: ["coordination.k8s.io"]
+        resources: ["leases"]
+        verbs: ["get", "create", "update"]
 
   podAnnotations:
     reloader.stakater.com/auto: "true"
@@ -855,7 +861,9 @@ schedule:
   # 3. Evaluates cron expressions against current time
   # 4. Sends matching schedules to SQS queue for execution
 
-  replicaCount: 1
+  # Two replicas with Kubernetes Lease leader election (only the leader
+  # dispatches); a node roll or crash no longer drops dispatch to zero.
+  replicaCount: 2
 
   podDisruptionBudget:
     enabled: true
@@ -936,6 +944,15 @@ schedule:
     SQS_QUEUE_URL:
       type: kv
       value: "https://sqs.us-east-2.amazonaws.com/${AWS_ACCOUNT_ID}/keeperhub-workflow-queue-prod"
+    # Leader election: only the pod holding the Lease dispatches. Namespace and
+    # holder identity are resolved in-pod (service account file + hostname), so
+    # nothing environment-scoped is hardcoded here.
+    LEADER_ELECTION_ENABLED:
+      type: kv
+      value: "true"
+    LEASE_NAME:
+      type: kv
+      value: "schedule-dispatcher-leader"
     # Health check server port
     HEALTH_PORT:
       type: kv
@@ -972,7 +989,10 @@ block:
   # 2. Maintains WebSocket connections to each chain's WSS endpoint
   # 3. Filters blocks by workflow interval and enqueues matches to SQS
 
-  replicaCount: 1
+  # Two replicas with Kubernetes Lease leader election (only the leader opens
+  # WebSocket subscriptions and enqueues); a node roll no longer drops block
+  # monitoring to zero.
+  replicaCount: 2
 
   podDisruptionBudget:
     enabled: true
@@ -1061,6 +1081,15 @@ block:
     SOCKET_MAX_AGE_MS:
       type: kv
       value: "3600000"
+    # Leader election: only the pod holding the Lease opens chain subscriptions
+    # and enqueues. Namespace and holder identity are resolved in-pod (service
+    # account file + hostname), so nothing environment-scoped is hardcoded here.
+    LEADER_ELECTION_ENABLED:
+      type: kv
+      value: "true"
+    LEASE_NAME:
+      type: kv
+      value: "block-dispatcher-leader"
     # Health check server port
     HEALTH_PORT:
       type: kv

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -143,6 +143,12 @@ app:
       - apiGroups: [""]
         resources: ["pods/log"]
         verbs: ["get"]
+      # Leader election for the schedule and block dispatchers. They share this
+      # service account, so the Lease permission lives here (one owner of the
+      # Role) rather than on a second SA that would need its own IRSA role-arn.
+      - apiGroups: ["coordination.k8s.io"]
+        resources: ["leases"]
+        verbs: ["get", "create", "update"]
 
   podAnnotations:
     reloader.stakater.com/auto: "true"
@@ -856,7 +862,9 @@ schedule:
   # 3. Evaluates cron expressions against current time
   # 4. Sends matching schedules to SQS queue for execution
 
-  replicaCount: 1
+  # Two replicas with Kubernetes Lease leader election (only the leader
+  # dispatches); a node roll or crash no longer drops dispatch to zero.
+  replicaCount: 2
 
   podDisruptionBudget:
     enabled: true
@@ -937,6 +945,15 @@ schedule:
     SQS_QUEUE_URL:
       type: kv
       value: "https://sqs.us-east-1.amazonaws.com/${AWS_ACCOUNT_ID}/keeperhub-workflow-queue-staging"
+    # Leader election: only the pod holding the Lease dispatches. Namespace and
+    # holder identity are resolved in-pod (service account file + hostname), so
+    # nothing environment-scoped is hardcoded here.
+    LEADER_ELECTION_ENABLED:
+      type: kv
+      value: "true"
+    LEASE_NAME:
+      type: kv
+      value: "schedule-dispatcher-leader"
     # Health check server port
     HEALTH_PORT:
       type: kv
@@ -973,7 +990,10 @@ block:
   # 2. Maintains WebSocket connections to each chain's WSS endpoint
   # 3. Filters blocks by workflow interval and enqueues matches to SQS
 
-  replicaCount: 1
+  # Two replicas with Kubernetes Lease leader election (only the leader opens
+  # WebSocket subscriptions and enqueues); a node roll no longer drops block
+  # monitoring to zero.
+  replicaCount: 2
 
   podDisruptionBudget:
     enabled: true
@@ -1062,6 +1082,15 @@ block:
     SOCKET_MAX_AGE_MS:
       type: kv
       value: "3600000"
+    # Leader election: only the pod holding the Lease opens chain subscriptions
+    # and enqueues. Namespace and holder identity are resolved in-pod (service
+    # account file + hostname), so nothing environment-scoped is hardcoded here.
+    LEADER_ELECTION_ENABLED:
+      type: kv
+      value: "true"
+    LEASE_NAME:
+      type: kv
+      value: "block-dispatcher-leader"
     # Health check server port
     HEALTH_PORT:
       type: kv

--- a/drizzle/0130_keep_974_dispatch_key.sql
+++ b/drizzle/0130_keep_974_dispatch_key.sql
@@ -1,0 +1,24 @@
+-- @requires-db-prep
+-- KEEP-974: dispatch-idempotency key for the schedule/block dispatchers.
+--
+-- The dispatchers now run two replicas with leader election. To guarantee no
+-- duplicate SQS dispatch across failover / rolling restart, each dispatched
+-- occurrence carries a stable dispatch_key
+-- (schedule:<scheduleId>:<occurrenceIso> / block:<workflowId>:<chainId>:<blockNumber>).
+-- The create-phantom insert is ON CONFLICT DO NOTHING on the unique index
+-- below, so an overlapping leader or a catch-up window that re-runs an
+-- occurrence collides and skips its enqueue instead of creating a second run.
+-- NULL keys (manual/webhook/direct rows) are treated as distinct by Postgres
+-- and never collide.
+--
+-- The column ADD is cheap. The UNIQUE index build is the reason for the
+-- @requires-db-prep gate: workflow_executions is a multi-million-row table, so
+-- on prod/staging an operator builds it CONCURRENTLY out-of-band before merge
+-- (CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ...); the plain statement
+-- below is then a no-op (IF NOT EXISTS). On dev / PR-env DBs the table is small
+-- so the in-migration build is fine. The new column is entirely NULL at build
+-- time, so the unique build cannot find a duplicate.
+ALTER TABLE "workflow_executions" ADD COLUMN IF NOT EXISTS "dispatch_key" text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_workflow_executions_dispatch_key"
+  ON "workflow_executions" ("dispatch_key");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -911,6 +911,13 @@
       "when": 1783515380001,
       "tag": "0129_keep_906_trial_started_at",
       "breakpoints": true
+    },
+    {
+      "idx": 130,
+      "version": "7",
+      "when": 1784120180000,
+      "tag": "0130_keep_974_dispatch_key",
+      "breakpoints": true
     }
   ]
 }

--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -792,7 +792,25 @@ export class ChainMonitor {
     blockNumber: number,
     block: { hash: string; timestamp: number; parentHash: string },
   ): Promise<void> {
-    const executionId = await createPhantomExecution(wf.id, "block", wf.userId);
+    // Stable per (workflow, chain, block) key. Two leaders that
+    // overlap on failover, or both process the same block, collide on the
+    // unique index so only one enqueue lands. The in-memory lastProcessedBlock
+    // dedup only guards a single instance, so this is what covers 2 replicas.
+    const dispatchKey = `block:${wf.id}:${this.chainId}:${blockNumber}`;
+    const { executionId, alreadyExisted } = await createPhantomExecution(
+      wf.id,
+      "block",
+      wf.userId,
+      dispatchKey,
+    );
+
+    if (alreadyExisted) {
+      console.log(
+        `[BlockMonitor:${this.chainName}] Skipping duplicate dispatch for ${dispatchKey} (already enqueued)`,
+      );
+      return;
+    }
+
     try {
       await enqueueBlockTrigger({
         executionId,

--- a/keeperhub-scheduler/block-dispatcher/index.ts
+++ b/keeperhub-scheduler/block-dispatcher/index.ts
@@ -26,6 +26,10 @@ import {
   RECONCILE_INTERVAL_MS,
   SQS_QUEUE_URL,
 } from "../lib/config.js";
+import {
+  type LeaderElectionHandle,
+  runWithLeaderElection,
+} from "../lib/leader-election.js";
 import { metrics, registry } from "../lib/metrics.js";
 import type { BlockWorkflow, ChainConfig } from "../lib/types.js";
 import { fetchBlockWorkflows } from "./api-client.js";
@@ -37,6 +41,10 @@ class BlockMonitorService {
   private isShuttingDown = false;
 
   async start(): Promise<void> {
+    // Reset the shutdown flag so the service is restartable: on failover the
+    // same process may lose leadership (stop()) and later regain it (start()).
+    this.isShuttingDown = false;
+
     console.log(
       `[BlockMonitorService] Starting (reconcile every ${RECONCILE_INTERVAL_MS}ms)`,
     );
@@ -252,6 +260,22 @@ async function main(): Promise<void> {
 
   const service = new BlockMonitorService();
 
+  // Gate chain monitoring on leadership: with 2 replicas only the elected
+  // leader opens WebSocket subscriptions and enqueues, otherwise every block
+  // triggers once per replica (and doubles upstream RPC/WSS load). On losing
+  // leadership the standby tears its monitors down via service.stop().
+  const election: LeaderElectionHandle = runWithLeaderElection({
+    leaseName: process.env.LEASE_NAME ?? "block-dispatcher-leader",
+    onStartedLeading: async () => {
+      console.log("[BlockDispatcher] Became leader — starting monitors");
+      await service.start();
+    },
+    onStoppedLeading: async () => {
+      console.log("[BlockDispatcher] Lost leadership — stopping monitors");
+      await service.stop();
+    },
+  });
+
   // Start health check server
   const healthApp = express();
   const HEALTH_PORT = process.env.HEALTH_PORT || 3050;
@@ -262,6 +286,7 @@ async function main(): Promise<void> {
     res.status(statusCode).json({
       status: health.healthy ? "ok" : "degraded",
       service: "block-dispatcher",
+      leader: election.isLeader(),
       timestamp: new Date().toISOString(),
       monitors: health.monitors,
     });
@@ -284,8 +309,18 @@ async function main(): Promise<void> {
   });
 
   // Shutdown handler
+  let shuttingDown = false;
   const shutdownHandler = async () => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
     console.log("\n[BlockDispatcher] Shutting down...");
+    // Release the lease first so a standby can take over promptly, then tear
+    // down our own monitors and close.
+    await election.stop().catch(() => {
+      // best-effort; the lease expires on its own if release fails
+    });
     await service.stop();
     healthServer.close(() => {
       console.log("[BlockDispatcher] Health server closed");
@@ -301,9 +336,6 @@ async function main(): Promise<void> {
       "[Security] SIGUSR1 received; inspector activation suppressed",
     );
   });
-
-  // Start monitoring
-  await service.start();
 }
 
 main().catch((error: unknown) => {

--- a/keeperhub-scheduler/lib/leader-election.ts
+++ b/keeperhub-scheduler/lib/leader-election.ts
@@ -1,0 +1,372 @@
+/**
+ * Kubernetes-native leader election for the dispatchers.
+ *
+ * Both dispatchers run 2 replicas for availability, but only one may dispatch
+ * to SQS at a time: two active replicas would double-enqueue and every
+ * scheduled/block-triggered workflow would run twice (the queue is a standard,
+ * non-FIFO SQS queue with no dedup). Election picks a single leader; the
+ * standby idles and takes over when the leader's node/pod goes away.
+ *
+ * The mechanism is the coordination.k8s.io/v1 Lease object - the same primitive
+ * kube-controller-manager and controller-runtime operators use. No external
+ * store (etcd/Zookeeper/Redis) is added: the cluster's API server already
+ * backs it. The renew/acquire loop mirrors client-go's leaderelection:
+ *
+ *   - The leader renews the Lease every retryPeriod.
+ *   - If it cannot renew within renewDeadline it relinquishes leadership and
+ *     stops dispatching. Because renewDeadline < leaseDuration, a standby
+ *     cannot acquire the Lease until after the old leader has already stopped,
+ *     leaving a gap where nobody dispatches rather than an overlap where two do.
+ *
+ * The renew gap plus the dispatch-idempotency key on the phantom-execution row
+ * together guarantee no duplicate dispatch across failover and rolling restart.
+ */
+
+import { readFileSync } from "node:fs";
+import { hostname } from "node:os";
+import {
+  ApiException,
+  CoordinationV1Api,
+  KubeConfig,
+  type V1Lease,
+  V1MicroTime,
+} from "@kubernetes/client-node";
+
+const NAMESPACE_FILE =
+  "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+
+export interface LeaderElectionConfig {
+  /** Lease object name. Each dispatcher uses its own so they elect separately. */
+  leaseName: string;
+  /** Namespace of the Lease. Resolved from the pod's service account if omitted. */
+  namespace?: string;
+  /** Unique per-pod identity. Defaults to the pod hostname (the pod name in k8s). */
+  holderIdentity?: string;
+  /** Seconds a Lease is valid without renewal before a standby may take over. */
+  leaseDurationSeconds?: number;
+  /** Seconds the leader keeps trying to renew before relinquishing leadership. */
+  renewDeadlineSeconds?: number;
+  /** Seconds between acquire/renew attempts. */
+  retryPeriodSeconds?: number;
+  /** Called once when this instance becomes the leader. */
+  onStartedLeading: () => void | Promise<void>;
+  /** Called when this instance loses leadership (renew failed, or on shutdown). */
+  onStoppedLeading: () => void | Promise<void>;
+}
+
+/** Handle returned by {@link runWithLeaderElection}. */
+export interface LeaderElectionHandle {
+  /** True while this instance holds the Lease and may dispatch. */
+  isLeader(): boolean;
+  /** Stop the loop and best-effort release the Lease so a standby takes over. */
+  stop(): Promise<void>;
+}
+
+const DEFAULT_LEASE_DURATION_SECONDS = 15;
+const DEFAULT_RENEW_DEADLINE_SECONDS = 10;
+const DEFAULT_RETRY_PERIOD_SECONDS = 2;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function apiErrorCode(error: unknown): number | undefined {
+  return error instanceof ApiException ? error.code : undefined;
+}
+
+/**
+ * Resolve the namespace to create the Lease in. Fails closed rather than
+ * defaulting to "default": a Lease in the wrong namespace would silently split
+ * the election (two leaders, one per namespace) and reintroduce double-dispatch.
+ */
+function resolveNamespace(explicit?: string): string {
+  const fromArg = explicit ?? process.env.LEASE_NAMESPACE;
+  if (fromArg) {
+    return fromArg;
+  }
+  try {
+    const fromFile = readFileSync(NAMESPACE_FILE, "utf8").trim();
+    if (fromFile) {
+      return fromFile;
+    }
+  } catch {
+    // fall through to the explicit failure below
+  }
+  throw new Error(
+    "Leader election namespace could not be resolved (no LEASE_NAMESPACE and no in-cluster service account namespace file)",
+  );
+}
+
+export class LeaderElector implements LeaderElectionHandle {
+  private readonly api: CoordinationV1Api;
+  private readonly namespace: string;
+  private readonly identity: string;
+  private readonly leaseName: string;
+  private readonly leaseDurationSeconds: number;
+  private readonly renewDeadlineMs: number;
+  private readonly retryPeriodMs: number;
+  private readonly onStartedLeading: () => void | Promise<void>;
+  private readonly onStoppedLeading: () => void | Promise<void>;
+
+  private leading = false;
+  private stopped = false;
+  /** Wall-clock ms of the last successful acquire/renew. */
+  private lastRenewMs = 0;
+
+  constructor(config: LeaderElectionConfig) {
+    const leaseDuration =
+      config.leaseDurationSeconds ?? DEFAULT_LEASE_DURATION_SECONDS;
+    const renewDeadline =
+      config.renewDeadlineSeconds ?? DEFAULT_RENEW_DEADLINE_SECONDS;
+    const retryPeriod =
+      config.retryPeriodSeconds ?? DEFAULT_RETRY_PERIOD_SECONDS;
+
+    if (renewDeadline >= leaseDuration) {
+      throw new Error(
+        `renewDeadlineSeconds (${renewDeadline}) must be less than leaseDurationSeconds (${leaseDuration}); otherwise a standby could acquire the Lease before the old leader relinquishes it`,
+      );
+    }
+    if (retryPeriod >= renewDeadline) {
+      throw new Error(
+        `retryPeriodSeconds (${retryPeriod}) must be less than renewDeadlineSeconds (${renewDeadline})`,
+      );
+    }
+
+    const kc = new KubeConfig();
+    kc.loadFromDefault();
+    this.api = kc.makeApiClient(CoordinationV1Api);
+    this.namespace = resolveNamespace(config.namespace);
+    this.identity = config.holderIdentity ?? hostname();
+    this.leaseName = config.leaseName;
+    this.leaseDurationSeconds = leaseDuration;
+    this.renewDeadlineMs = renewDeadline * 1000;
+    this.retryPeriodMs = retryPeriod * 1000;
+    this.onStartedLeading = config.onStartedLeading;
+    this.onStoppedLeading = config.onStoppedLeading;
+  }
+
+  isLeader(): boolean {
+    return this.leading;
+  }
+
+  /** Runs the acquire/renew loop until {@link stop} is called. */
+  async run(): Promise<void> {
+    console.log(
+      `[LeaderElection] Starting for lease "${this.leaseName}" in namespace "${this.namespace}" as "${this.identity}"`,
+    );
+    while (!this.stopped) {
+      const acquired = await this.tryAcquireOrRenew();
+      if (acquired) {
+        this.lastRenewMs = Date.now();
+        if (!this.leading) {
+          this.leading = true;
+          console.log(
+            `[LeaderElection] Acquired leadership of "${this.leaseName}"`,
+          );
+          await this.safelyInvoke(this.onStartedLeading, "onStartedLeading");
+        }
+      } else if (this.leading) {
+        // Keep leadership through transient failures until renewDeadline lapses.
+        // Past that a standby may take over, so we must stop first.
+        if (Date.now() - this.lastRenewMs > this.renewDeadlineMs) {
+          this.leading = false;
+          console.warn(
+            `[LeaderElection] Failed to renew "${this.leaseName}" within renewDeadline; relinquishing leadership`,
+          );
+          await this.safelyInvoke(this.onStoppedLeading, "onStoppedLeading");
+        }
+      }
+      await sleep(this.retryPeriodMs);
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    if (this.leading) {
+      this.leading = false;
+      await this.releaseLease();
+      await this.safelyInvoke(this.onStoppedLeading, "onStoppedLeading");
+    }
+  }
+
+  /**
+   * Attempt to acquire (or renew) the Lease. Returns true if this instance
+   * holds it after the call. Contention and transient API errors return false.
+   */
+  private async tryAcquireOrRenew(): Promise<boolean> {
+    try {
+      const lease = await this.readLease();
+      const now = new V1MicroTime();
+
+      if (!lease) {
+        await this.api.createNamespacedLease({
+          namespace: this.namespace,
+          body: {
+            metadata: { name: this.leaseName, namespace: this.namespace },
+            spec: {
+              holderIdentity: this.identity,
+              leaseDurationSeconds: this.leaseDurationSeconds,
+              acquireTime: now,
+              renewTime: now,
+              leaseTransitions: 0,
+            },
+          },
+        });
+        return true;
+      }
+
+      const spec = lease.spec ?? {};
+      const heldByUs = spec.holderIdentity === this.identity;
+      const renewMs = spec.renewTime ? new Date(spec.renewTime).getTime() : 0;
+      const durationSeconds =
+        spec.leaseDurationSeconds ?? this.leaseDurationSeconds;
+      const expired = Date.now() - renewMs > durationSeconds * 1000;
+
+      if (!heldByUs && !expired) {
+        // Someone else holds a still-valid Lease.
+        return false;
+      }
+
+      lease.spec = {
+        ...spec,
+        holderIdentity: this.identity,
+        leaseDurationSeconds: this.leaseDurationSeconds,
+        renewTime: now,
+        acquireTime: heldByUs ? (spec.acquireTime ?? now) : now,
+        leaseTransitions: heldByUs
+          ? (spec.leaseTransitions ?? 0)
+          : (spec.leaseTransitions ?? 0) + 1,
+      };
+
+      // resourceVersion on the read object makes this a compare-and-swap: a
+      // racing holder that wrote first bumps the version and this 409s.
+      await this.api.replaceNamespacedLease({
+        name: this.leaseName,
+        namespace: this.namespace,
+        body: lease,
+      });
+      return true;
+    } catch (error) {
+      const code = apiErrorCode(error);
+      if (code === 409) {
+        // Lost the compare-and-swap race to another candidate.
+        return false;
+      }
+      console.warn(
+        `[LeaderElection] Acquire/renew attempt for "${this.leaseName}" failed:`,
+        error instanceof Error ? error.message : error,
+      );
+      return false;
+    }
+  }
+
+  private async readLease(): Promise<V1Lease | null> {
+    try {
+      return await this.api.readNamespacedLease({
+        name: this.leaseName,
+        namespace: this.namespace,
+      });
+    } catch (error) {
+      if (apiErrorCode(error) === 404) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Best-effort release on graceful shutdown: clear the holder so a standby
+   * acquires immediately instead of waiting out the full leaseDuration.
+   */
+  private async releaseLease(): Promise<void> {
+    try {
+      const lease = await this.readLease();
+      if (!lease || lease.spec?.holderIdentity !== this.identity) {
+        return;
+      }
+      lease.spec = {
+        ...lease.spec,
+        holderIdentity: undefined,
+        renewTime: undefined,
+        acquireTime: undefined,
+      };
+      await this.api.replaceNamespacedLease({
+        name: this.leaseName,
+        namespace: this.namespace,
+        body: lease,
+      });
+      console.log(`[LeaderElection] Released lease "${this.leaseName}"`);
+    } catch (error) {
+      console.warn(
+        `[LeaderElection] Failed to release lease "${this.leaseName}" (it will expire naturally):`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
+
+  private async safelyInvoke(
+    fn: () => void | Promise<void>,
+    label: string,
+  ): Promise<void> {
+    try {
+      await fn();
+    } catch (error) {
+      console.error(
+        `[LeaderElection] ${label} callback threw:`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
+}
+
+/**
+ * Run the given callbacks under leader election when it is enabled, otherwise
+ * run as the sole leader.
+ *
+ * Election is opt-in via LEADER_ELECTION_ENABLED=true so local dev and the
+ * integration harness (no cluster, no Lease API) keep running as a single
+ * dispatcher. In staging/prod the umbrella values set the flag and inject the
+ * lease name; the pod's service account provides namespace and RBAC.
+ */
+export function runWithLeaderElection(
+  config: LeaderElectionConfig,
+): LeaderElectionHandle {
+  const enabled = process.env.LEADER_ELECTION_ENABLED === "true";
+
+  if (!enabled) {
+    console.log(
+      "[LeaderElection] Disabled (LEADER_ELECTION_ENABLED != true); running as sole leader",
+    );
+    let leading = true;
+    void Promise.resolve(config.onStartedLeading()).catch((error: unknown) => {
+      console.error(
+        "[LeaderElection] onStartedLeading callback threw:",
+        error instanceof Error ? error.message : error,
+      );
+    });
+    return {
+      isLeader: () => leading,
+      stop: async () => {
+        if (leading) {
+          leading = false;
+          await Promise.resolve(config.onStoppedLeading()).catch(() => {
+            // shutdown path; nothing else to do
+          });
+        }
+      },
+    };
+  }
+
+  const elector = new LeaderElector(config);
+  // Run the loop detached; the caller drives lifecycle via the handle and its
+  // onStartedLeading/onStoppedLeading callbacks.
+  void elector.run().catch((error: unknown) => {
+    console.error(
+      "[LeaderElection] Election loop crashed:",
+      error instanceof Error ? error.message : error,
+    );
+    // Exit so the orchestrator restarts us rather than running leaderless.
+    process.exit(1);
+  });
+  return elector;
+}

--- a/keeperhub-scheduler/lib/phantom.ts
+++ b/keeperhub-scheduler/lib/phantom.ts
@@ -22,36 +22,59 @@ export type PhantomTriggerSource = "schedule" | "block";
 /** Failure codes the scheduler assigns when an enqueue fails. */
 export type SchedulerErrorCode = "CS-0001" | "BS-0001" | "N-0002";
 
+/** Result of a phantom pre-create attempt. */
+export interface PhantomCreateResult {
+  /** Id of the phantom row, or undefined when the call failed. */
+  executionId?: string;
+  /**
+   * True when a row already existed for this dispatch key, i.e. another
+   * dispatcher (an overlapping leader on failover/rollout, or a catch-up window
+   * re-running the occurrence) already created and enqueued it. The caller must
+   * then skip its own enqueue to avoid a duplicate SQS message.
+   */
+  alreadyExisted: boolean;
+}
+
 /**
- * Pre-create a phantom execution row. Returns its id, or undefined when the
- * call fails (the caller then enqueues without an id and the executor inserts
- * its own row).
+ * Pre-create a phantom execution row. Returns its id and whether a row already
+ * existed for the given dispatch key. On failure returns
+ * `{ alreadyExisted: false }` with no id, so the caller falls back to the
+ * legacy id-less enqueue (the executor inserts its own row).
+ *
+ * `dispatchKey` is a stable per-occurrence idempotency key. When
+ * two dispatchers compute the same key the unique index on the row makes the
+ * second insert a no-op and this returns `alreadyExisted: true`.
  */
 export async function createPhantomExecution(
   workflowId: string,
   triggerSource: PhantomTriggerSource,
   userId?: string,
-): Promise<string | undefined> {
+  dispatchKey?: string,
+): Promise<PhantomCreateResult> {
   try {
-    const result = await apiRequest<{ executionId: string }>(
-      "/api/internal/executions",
-      {
-        method: "POST",
-        body: JSON.stringify({
-          workflowId,
-          userId,
-          status: "phantom",
-          triggerSource,
-        }),
-      },
-    );
-    return result.executionId;
+    const result = await apiRequest<{
+      executionId: string;
+      alreadyExisted?: boolean;
+    }>("/api/internal/executions", {
+      method: "POST",
+      body: JSON.stringify({
+        workflowId,
+        userId,
+        status: "phantom",
+        triggerSource,
+        dispatchKey,
+      }),
+    });
+    return {
+      executionId: result.executionId,
+      alreadyExisted: result.alreadyExisted ?? false,
+    };
   } catch (error) {
     console.warn(
       `[Phantom] Failed to pre-create execution for workflow ${workflowId}:`,
       error,
     );
-    return undefined;
+    return { alreadyExisted: false };
   }
 }
 

--- a/keeperhub-scheduler/package.json
+++ b/keeperhub-scheduler/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.1038.0",
+    "@kubernetes/client-node": "^1.0.0",
     "cron-parser": "^5.4.0",
     "ethers": "^6.16.0",
     "express": "^4.21.2",

--- a/keeperhub-scheduler/pnpm-lock.yaml
+++ b/keeperhub-scheduler/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       '@aws-sdk/client-sqs':
         specifier: ^3.1038.0
         version: 3.1044.0
+      '@kubernetes/client-node':
+        specifier: ^1.0.0
+        version: 1.4.0
       cron-parser:
         specifier: ^5.4.0
         version: 5.5.0
@@ -406,6 +409,21 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
+  '@jsep-plugin/assignment@1.3.0':
+    resolution: {integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@jsep-plugin/regex@1.0.4':
+    resolution: {integrity: sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@kubernetes/client-node@1.4.0':
+    resolution: {integrity: sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==}
+
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
     peerDependencies:
@@ -723,6 +741,12 @@ packages:
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
@@ -740,6 +764,9 @@ packages:
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/stream-buffers@3.0.8':
+    resolution: {integrity: sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==}
 
   '@vitest/expect@4.1.2':
     resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
@@ -777,12 +804,67 @@ packages:
   aes-js@4.0.0-beta.5:
     resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.4:
+    resolution: {integrity: sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-path@3.1.1:
+    resolution: {integrity: sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==}
+
+  bare-stream@2.13.3:
+    resolution: {integrity: sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.5:
+    resolution: {integrity: sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==}
 
   bintrees@1.0.2:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
@@ -809,6 +891,10 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
@@ -840,6 +926,19 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -863,6 +962,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -876,6 +978,10 @@ packages:
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.27.7:
@@ -897,6 +1003,9 @@ packages:
     resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
     engines: {node: '>=14.0.0'}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -904,6 +1013,9 @@ packages:
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-xml-builder@1.1.9:
     resolution: {integrity: sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==}
@@ -924,6 +1036,10 @@ packages:
   finalhandler@1.3.2:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -960,9 +1076,21 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hpagent@1.2.0:
+    resolution: {integrity: sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==}
+    engines: {node: '>=14'}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -975,9 +1103,34 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '>=8.21.0'
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+    hasBin: true
+
+  jsep@1.4.0:
+    resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
+    engines: {node: '>= 10.16.0'}
+
+  jsonpath-plus@10.4.0:
+    resolution: {integrity: sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1099,6 +1252,18 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  oauth4webapi@3.8.6:
+    resolution: {integrity: sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -1109,6 +1274,12 @@ packages:
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  openid-client@6.8.4:
+    resolution: {integrity: sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -1143,6 +1314,9 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
@@ -1157,6 +1331,9 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rfc4648@1.5.4:
+    resolution: {integrity: sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==}
 
   rolldown@1.1.2:
     resolution: {integrity: sha512-x0CrQQqCXWGeI8dTvFfN/Dnv3yMKT9hv5jFjlOreKAx9wqLq9wz7VvLLHyaAXC90/CpggTu9SisSbsJJTPSjNQ==}
@@ -1199,6 +1376,18 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1213,11 +1402,30 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  stream-buffers@3.0.3:
+    resolution: {integrity: sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==}
+    engines: {node: '>= 0.10.0'}
+
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
 
+  tar-fs@3.1.3:
+    resolution: {integrity: sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==}
+
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
   tdigest@0.1.2:
     resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1241,6 +1449,9 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tslib@2.7.0:
     resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
@@ -1358,10 +1569,19 @@ packages:
       jsdom:
         optional: true
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -1880,6 +2100,41 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
+  '@jsep-plugin/assignment@1.3.0(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
+  '@jsep-plugin/regex@1.0.4(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
+  '@kubernetes/client-node@1.4.0':
+    dependencies:
+      '@types/js-yaml': 4.0.9
+      '@types/node': 24.12.2
+      '@types/node-fetch': 2.6.13
+      '@types/stream-buffers': 3.0.8
+      form-data: 4.0.6
+      hpagent: 1.2.0
+      isomorphic-ws: 5.0.0(ws@8.21.0)
+      js-yaml: 4.3.0
+      jsonpath-plus: 10.4.0
+      node-fetch: 2.7.0
+      openid-client: 6.8.4
+      rfc4648: 1.5.4
+      socks-proxy-agent: 8.0.5
+      stream-buffers: 3.0.3
+      tar-fs: 3.1.3
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - encoding
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -2266,6 +2521,13 @@ snapshots:
 
   '@types/http-errors@2.0.5': {}
 
+  '@types/js-yaml@4.0.9': {}
+
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 24.12.2
+      form-data: 4.0.6
+
   '@types/node@22.7.5':
     dependencies:
       undici-types: 6.19.8
@@ -2285,6 +2547,10 @@ snapshots:
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
+      '@types/node': 24.12.2
+
+  '@types/stream-buffers@3.0.8':
+    dependencies:
       '@types/node': 24.12.2
 
   '@vitest/expect@4.1.2':
@@ -2335,9 +2601,46 @@ snapshots:
 
   aes-js@4.0.0-beta.5: {}
 
+  agent-base@7.1.4: {}
+
+  argparse@2.0.1: {}
+
   array-flatten@1.1.1: {}
 
   assertion-error@2.0.1: {}
+
+  asynckit@0.4.0: {}
+
+  b4a@1.8.1: {}
+
+  bare-events@2.9.1: {}
+
+  bare-fs@4.7.4:
+    dependencies:
+      bare-events: 2.9.1
+      bare-path: 3.1.1
+      bare-stream: 2.13.3(bare-events@2.9.1)
+      bare-url: 2.4.5
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-path@3.1.1: {}
+
+  bare-stream@2.13.3(bare-events@2.9.1):
+    dependencies:
+      b4a: 1.8.1
+      streamx: 2.28.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.5:
+    dependencies:
+      bare-path: 3.1.1
 
   bintrees@1.0.2: {}
 
@@ -2374,6 +2677,10 @@ snapshots:
 
   chai@6.2.2: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   content-disposition@0.5.4:
     dependencies:
       safe-buffer: 5.2.1
@@ -2394,6 +2701,12 @@ snapshots:
     dependencies:
       ms: 2.0.0
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  delayed-stream@1.0.0: {}
+
   depd@2.0.0: {}
 
   destroy@1.2.0: {}
@@ -2410,6 +2723,10 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -2419,6 +2736,13 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -2470,6 +2794,12 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   expect-type@1.3.0: {}
 
   express@4.22.1:
@@ -2508,6 +2838,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fast-fifo@1.3.2: {}
+
   fast-xml-builder@1.1.9:
     dependencies:
       path-expression-matcher: 1.5.0
@@ -2534,6 +2866,14 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
 
   forwarded@0.2.0: {}
 
@@ -2570,9 +2910,19 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hpagent@1.2.0: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -2588,7 +2938,27 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  ip-address@10.2.0: {}
+
   ipaddr.js@1.9.1: {}
+
+  isomorphic-ws@5.0.0(ws@8.21.0):
+    dependencies:
+      ws: 8.21.0
+
+  jose@6.2.3: {}
+
+  js-yaml@4.3.0:
+    dependencies:
+      argparse: 2.0.1
+
+  jsep@1.4.0: {}
+
+  jsonpath-plus@10.4.0:
+    dependencies:
+      '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
+      '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
+      jsep: 1.4.0
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -2669,6 +3039,12 @@ snapshots:
 
   negotiator@0.6.3: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  oauth4webapi@3.8.6: {}
+
   object-inspect@1.13.4: {}
 
   obug@2.1.1: {}
@@ -2676,6 +3052,15 @@ snapshots:
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  openid-client@6.8.4:
+    dependencies:
+      jose: 6.2.3
+      oauth4webapi: 3.8.6
 
   parseurl@1.3.3: {}
 
@@ -2705,6 +3090,11 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
@@ -2719,6 +3109,8 @@ snapshots:
       unpipe: 1.0.0
 
   resolve-pkg-maps@1.0.0: {}
+
+  rfc4648@1.5.4: {}
 
   rolldown@1.1.2:
     dependencies:
@@ -2804,6 +3196,21 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.2.0
+      smart-buffer: 4.2.0
+
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
@@ -2812,11 +3219,58 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  stream-buffers@3.0.3: {}
+
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   strnum@2.2.3: {}
+
+  tar-fs@3.1.3:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.2.0
+    optionalDependencies:
+      bare-fs: 4.7.4
+      bare-path: 3.1.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.7.4
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
 
   tdigest@0.1.2:
     dependencies:
       bintrees: 1.0.2
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   tinybench@2.9.0: {}
 
@@ -2835,6 +3289,8 @@ snapshots:
   tinyrainbow@3.1.0: {}
 
   toidentifier@1.0.1: {}
+
+  tr46@0.0.3: {}
 
   tslib@2.7.0: {}
 
@@ -2905,9 +3361,18 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrappy@1.0.2: {}
 
   ws@8.21.0: {}

--- a/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
@@ -320,10 +320,24 @@ export async function dispatch(
         // KEEP-693: pre-create a phantom row (best-effort) so the run is
         // visible even if it never reaches the executor, and carry its id on
         // the message so the executor upgrades that row instead of inserting.
-        const executionId = await createPhantomExecution(
+        // The dispatch key is stable for a given (schedule, occurrence), so an
+        // overlapping leader or a catch-up window that
+        // recomputes this occurrence collides on the unique index and we skip
+        // the duplicate enqueue below.
+        const dispatchKey = `schedule:${schedule.id}:${occurrence.toISOString()}`;
+        const { executionId, alreadyExisted } = await createPhantomExecution(
           schedule.workflowId,
           "schedule",
+          undefined,
+          dispatchKey,
         );
+
+        if (alreadyExisted) {
+          console.log(
+            `[${runId}] Skipping duplicate dispatch for ${dispatchKey} (already enqueued)`,
+          );
+          continue;
+        }
 
         try {
           await sendToQueue({

--- a/keeperhub-scheduler/schedule-dispatcher/index.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/index.ts
@@ -24,6 +24,10 @@
 import "../log-facade.js";
 import express from "express";
 import { KEEPERHUB_URL, SQS_QUEUE_URL } from "../lib/config.js";
+import {
+  type LeaderElectionHandle,
+  runWithLeaderElection,
+} from "../lib/leader-election.js";
 import { dispatch } from "./dispatch.js";
 import { registry } from "./metrics.js";
 
@@ -67,6 +71,79 @@ function msUntilNextTick(): number {
   return 60_000 - msIntoMinute + TICK_OFFSET_MS;
 }
 
+/**
+ * Drives the aligned minute-boundary dispatch loop, but only while this
+ * instance is the leader. `start()` is called on acquiring leadership and
+ * `stop()` on losing it, so a standby holds an idle ticker and never dispatches.
+ */
+class ScheduleTicker {
+  // lastTickAt tracks the `now` of the previous pass so each tick's window
+  // covers exactly (lastTickAt, now] — no gaps, no double-fires. It resets to
+  // null when leadership (re)starts, so the first pass uses a synthetic
+  // (now - 60s, now] window and recovers any occurrence missed during handover.
+  private lastTickAt: Date | null = null;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private stopped = true;
+
+  constructor(private readonly isLeader: () => boolean) {}
+
+  start(): void {
+    if (!this.stopped) {
+      return;
+    }
+    this.stopped = false;
+    this.lastTickAt = null;
+    console.log("[Dispatcher] Became leader — running initial dispatch...");
+    void this.runOnce(null).then(() => this.scheduleNext());
+  }
+
+  stop(): void {
+    if (this.stopped) {
+      return;
+    }
+    this.stopped = true;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    console.log("[Dispatcher] Stopped dispatching (no longer leader)");
+  }
+
+  private scheduleNext(): void {
+    if (this.stopped) {
+      return;
+    }
+    const delay = msUntilNextTick();
+    this.timer = setTimeout(() => {
+      void this.tick();
+    }, delay);
+  }
+
+  private async tick(): Promise<void> {
+    if (this.stopped) {
+      return;
+    }
+    const prevTick = this.lastTickAt;
+    this.lastTickAt = new Date();
+    await this.runOnce(prevTick);
+    this.scheduleNext();
+  }
+
+  private async runOnce(prevTick: Date | null): Promise<void> {
+    // Defense in depth: a timer may fire in the narrow window between losing
+    // leadership and stop() landing. Never dispatch unless we still hold it.
+    if (!this.isLeader()) {
+      console.warn("[Dispatcher] Skipping dispatch: not leader");
+      return;
+    }
+    try {
+      await dispatch(prevTick);
+    } catch (error) {
+      console.error("[Dispatcher] Dispatch failed:", error);
+    }
+  }
+}
+
 async function main(): Promise<void> {
   if (!process.env.INTERNAL_SERVICE_HMAC_SECRET) {
     throw new Error("INTERNAL_SERVICE_HMAC_SECRET is required");
@@ -78,6 +155,24 @@ async function main(): Promise<void> {
     `[Dispatcher] Tick offset: ${TICK_OFFSET_MS}ms past minute boundary`,
   );
 
+  // Gate dispatching on leadership: with 2 replicas only the elected leader may
+  // dispatch, otherwise every schedule fires once per replica. `leading` lets
+  // the ticker double-check leadership before a queued tick actually dispatches.
+  let leading = false;
+  const ticker = new ScheduleTicker(() => leading);
+
+  const election: LeaderElectionHandle = runWithLeaderElection({
+    leaseName: process.env.LEASE_NAME ?? "schedule-dispatcher-leader",
+    onStartedLeading: () => {
+      leading = true;
+      ticker.start();
+    },
+    onStoppedLeading: () => {
+      leading = false;
+      ticker.stop();
+    },
+  });
+
   const healthApp = express();
   const HEALTH_PORT = process.env.HEALTH_PORT || 3060;
 
@@ -85,6 +180,7 @@ async function main(): Promise<void> {
     res.status(200).json({
       status: "ok",
       service: "schedule-dispatcher",
+      leader: election.isLeader(),
       timestamp: new Date().toISOString(),
     });
   });
@@ -105,12 +201,26 @@ async function main(): Promise<void> {
     );
   });
 
+  let shuttingDown = false;
   const shutdownHandler = (): void => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
     console.log("\n[Dispatcher] Shutting down...");
-    healthServer.close(() => {
-      console.log("[Dispatcher] Health server closed");
-      process.exit(0);
-    });
+    ticker.stop();
+    // Release the lease so a standby takes over promptly, then close.
+    void election
+      .stop()
+      .catch(() => {
+        // best-effort; the lease expires on its own if release fails
+      })
+      .finally(() => {
+        healthServer.close(() => {
+          console.log("[Dispatcher] Health server closed");
+          process.exit(0);
+        });
+      });
   };
 
   process.on("SIGINT", shutdownHandler);
@@ -121,55 +231,6 @@ async function main(): Promise<void> {
       "[Security] SIGUSR1 received; inspector activation suppressed",
     );
   });
-
-  // lastTickAt tracks the `now` of the previous pass so each tick's window
-  // covers exactly (lastTickAt, now] — no gaps, no double-fires. It resets
-  // to null on pod restart, which makes the first pass use a synthetic
-  // (now - 60s, now] window (safe: at most one occurrence can be missed).
-  let lastTickAt: Date | null = null;
-
-  // Run the initial tick immediately to catch any schedules due at boot,
-  // then align subsequent ticks to the wall-clock minute boundary.
-  console.log("[Dispatcher] Running initial dispatch...");
-  try {
-    await dispatch(lastTickAt);
-  } catch (error) {
-    console.error("[Dispatcher] Initial dispatch failed:", error);
-  }
-  // The initial dispatch does not update lastTickAt — on pod restart we want
-  // the first aligned tick to use the synthetic window so it can recover any
-  // occurrence that may have been missed since the last pod's final tick.
-
-  const alignDelay = msUntilNextTick();
-  console.log(
-    `[Dispatcher] Aligning to minute boundary — first aligned tick in ${alignDelay}ms`,
-  );
-
-  // Self-scheduling setTimeout: after each tick recompute the delay to the
-  // next minute boundary. This naturally absorbs drift from slow DB queries
-  // without accumulating phase error the way a fixed setInterval would.
-  const scheduleTick = async (): Promise<void> => {
-    const prevTick = lastTickAt;
-    lastTickAt = new Date();
-
-    try {
-      await dispatch(prevTick);
-    } catch (error) {
-      console.error("[Dispatcher] Dispatch failed:", error);
-    }
-
-    setTimeout(() => {
-      scheduleTick().catch((error: unknown) => {
-        console.error("[Dispatcher] Tick scheduling error:", error);
-      });
-    }, msUntilNextTick());
-  };
-
-  setTimeout(() => {
-    scheduleTick().catch((error: unknown) => {
-      console.error("[Dispatcher] First aligned tick error:", error);
-    });
-  }, alignDelay);
 }
 
 main().catch((error: unknown) => {

--- a/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
+++ b/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
@@ -159,6 +159,8 @@ describe("ChainMonitor", () => {
     vi.stubEnv("PRIMARY_PROBE_INTERVAL_MS", "1000");
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.clearAllMocks();
+    // Default: fresh phantom, no dedup hit. Tests override per case.
+    createPhantomExecution.mockResolvedValue({ alreadyExisted: false });
     providerInstances = [];
     providerFactory = (url) => new MockProvider(url);
   });
@@ -264,7 +266,10 @@ describe("ChainMonitor", () => {
 
     // KEEP-693: phantom pre-creation wiring.
     it("pre-creates a phantom and carries its id on the block message", async () => {
-      createPhantomExecution.mockResolvedValueOnce("exec_ph");
+      createPhantomExecution.mockResolvedValueOnce({
+        executionId: "exec_ph",
+        alreadyExisted: false,
+      });
       const monitor = new ChainMonitor({
         chain: makeChain(),
         workflows: [makeWorkflow()],
@@ -282,14 +287,41 @@ describe("ChainMonitor", () => {
         "wf-1",
         "block",
         "user-1",
+        expect.stringMatching(/^block:wf-1:\d+:10$/),
       );
       expect(enqueueBlockTrigger).toHaveBeenCalledWith(
         expect.objectContaining({ executionId: "exec_ph" }),
       );
     });
 
+    // An overlapping leader / re-processed block must not double-enqueue.
+    it("skips the enqueue when the dispatch key already exists (dedup)", async () => {
+      createPhantomExecution.mockResolvedValueOnce({
+        executionId: "exec_existing",
+        alreadyExisted: true,
+      });
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+
+      const { enqueueBlockTrigger } = await import(
+        "../../block-dispatcher/sqs-enqueue.js"
+      );
+      vi.mocked(enqueueBlockTrigger).mockClear();
+      latestProvider().emitBlock(10);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(enqueueBlockTrigger).not.toHaveBeenCalled();
+    });
+
     it("marks the phantom failed with BS-0001 when the enqueue fails", async () => {
-      createPhantomExecution.mockResolvedValueOnce("exec_ph");
+      createPhantomExecution.mockResolvedValueOnce({
+        executionId: "exec_ph",
+        alreadyExisted: false,
+      });
       const { enqueueBlockTrigger } = await import(
         "../../block-dispatcher/sqs-enqueue.js"
       );

--- a/keeperhub-scheduler/tests/unit/leader-election.test.ts
+++ b/keeperhub-scheduler/tests/unit/leader-election.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// In-memory fake of the coordination.k8s.io Lease API, shared across every
+// makeApiClient() call so multiple electors contend for the same lease exactly
+// as two pods would against a real API server. resourceVersion drives the
+// optimistic-concurrency (compare-and-swap) 409 on replace.
+// ---------------------------------------------------------------------------
+
+const store = vi.hoisted(() => {
+  const leases = new Map<string, unknown>();
+  return {
+    leases,
+    reset(): void {
+      leases.clear();
+    },
+  };
+});
+
+vi.mock("@kubernetes/client-node", () => {
+  class ApiException extends Error {
+    constructor(public code: number) {
+      super(`ApiException ${code}`);
+    }
+  }
+  class V1MicroTime extends Date {}
+
+  type Lease = {
+    metadata: { name: string; namespace: string; resourceVersion?: string };
+    spec: Record<string, unknown>;
+  };
+
+  class FakeCoordinationV1Api {
+    async readNamespacedLease({ name }: { name: string }): Promise<Lease> {
+      const found = store.leases.get(name);
+      if (!found) {
+        throw new ApiException(404);
+      }
+      return structuredClone(found) as Lease;
+    }
+
+    async createNamespacedLease({ body }: { body: Lease }): Promise<Lease> {
+      const name = body.metadata.name;
+      if (store.leases.get(name)) {
+        throw new ApiException(409);
+      }
+      const created = structuredClone(body) as Lease;
+      created.metadata.resourceVersion = "1";
+      store.leases.set(name, created);
+      return structuredClone(created);
+    }
+
+    async replaceNamespacedLease({
+      name,
+      body,
+    }: {
+      name: string;
+      body: Lease;
+    }): Promise<Lease> {
+      const existing = store.leases.get(name) as Lease | undefined;
+      if (!existing) {
+        throw new ApiException(404);
+      }
+      if (body.metadata.resourceVersion !== existing.metadata.resourceVersion) {
+        throw new ApiException(409);
+      }
+      const updated = structuredClone(body) as Lease;
+      updated.metadata.resourceVersion = String(
+        Number(existing.metadata.resourceVersion ?? "0") + 1,
+      );
+      store.leases.set(name, updated);
+      return structuredClone(updated);
+    }
+  }
+
+  class KubeConfig {
+    loadFromDefault(): void {
+      // no-op in tests
+    }
+    makeApiClient(): FakeCoordinationV1Api {
+      return new FakeCoordinationV1Api();
+    }
+  }
+
+  return {
+    ApiException,
+    V1MicroTime,
+    KubeConfig,
+    CoordinationV1Api: FakeCoordinationV1Api,
+  };
+});
+
+import { LeaderElector } from "../../lib/leader-election.js";
+
+// Sub-second durations keep the test fast while preserving the required
+// ordering retryPeriod < renewDeadline < leaseDuration.
+const TIMING = {
+  leaseDurationSeconds: 0.12,
+  renewDeadlineSeconds: 0.06,
+  retryPeriodSeconds: 0.02,
+};
+
+interface Tracker {
+  elector: LeaderElector;
+  startedCount: number;
+  stoppedCount: number;
+}
+
+function makeElector(
+  identity: string,
+  liveLeaders: Set<string>,
+  onConcurrent: (n: number) => void,
+): Tracker {
+  const tracker: Tracker = {
+    startedCount: 0,
+    stoppedCount: 0,
+    elector: undefined as unknown as LeaderElector,
+  };
+  tracker.elector = new LeaderElector({
+    leaseName: "test-leader",
+    namespace: "test-ns",
+    holderIdentity: identity,
+    ...TIMING,
+    onStartedLeading: () => {
+      tracker.startedCount += 1;
+      liveLeaders.add(identity);
+      onConcurrent(liveLeaders.size);
+    },
+    onStoppedLeading: () => {
+      tracker.stoppedCount += 1;
+      liveLeaders.delete(identity);
+    },
+  });
+  return tracker;
+}
+
+describe("LeaderElector", () => {
+  beforeEach(() => {
+    store.reset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("elects exactly one leader when two instances contend", async () => {
+    const live = new Set<string>();
+    let maxConcurrent = 0;
+    const track = (n: number): void => {
+      maxConcurrent = Math.max(maxConcurrent, n);
+    };
+
+    const a = makeElector("pod-a", live, track);
+    const b = makeElector("pod-b", live, track);
+    void a.elector.run().catch(() => undefined);
+    void b.elector.run().catch(() => undefined);
+
+    await vi.waitFor(() => {
+      expect(a.elector.isLeader() || b.elector.isLeader()).toBe(true);
+    });
+    // Give the follower several retry periods to (wrongly) grab it too.
+    await new Promise((r) => setTimeout(r, 100));
+
+    const leaders = [a, b].filter((t) => t.elector.isLeader());
+    expect(leaders).toHaveLength(1);
+    expect(maxConcurrent).toBe(1);
+    expect(store.leases.get("test-leader")).toBeDefined();
+
+    await a.elector.stop();
+    await b.elector.stop();
+  });
+
+  it("fails over to the standby when the leader stops", async () => {
+    const live = new Set<string>();
+    let maxConcurrent = 0;
+    const track = (n: number): void => {
+      maxConcurrent = Math.max(maxConcurrent, n);
+    };
+
+    const a = makeElector("pod-a", live, track);
+    const b = makeElector("pod-b", live, track);
+    void a.elector.run().catch(() => undefined);
+    void b.elector.run().catch(() => undefined);
+
+    await vi.waitFor(() => {
+      expect(a.elector.isLeader() || b.elector.isLeader()).toBe(true);
+    });
+    const leader = a.elector.isLeader() ? a : b;
+    const standby = leader === a ? b : a;
+
+    await leader.elector.stop();
+
+    await vi.waitFor(
+      () => {
+        expect(standby.elector.isLeader()).toBe(true);
+      },
+      { timeout: 2000 },
+    );
+    expect(maxConcurrent).toBe(1);
+
+    await standby.elector.stop();
+  });
+
+  it("keeps renewing the lease while it holds leadership", async () => {
+    const live = new Set<string>();
+    const a = makeElector("pod-a", live, () => undefined);
+    void a.elector.run().catch(() => undefined);
+
+    await vi.waitFor(() => {
+      expect(a.elector.isLeader()).toBe(true);
+    });
+
+    const firstRenew = (
+      store.leases.get("test-leader") as { spec: { renewTime: string } }
+    ).spec.renewTime;
+
+    // After several renew cycles the stored renewTime must advance and the
+    // start callback must not have fired again (leadership is continuous).
+    await new Promise((r) => setTimeout(r, 100));
+    const laterRenew = (
+      store.leases.get("test-leader") as { spec: { renewTime: string } }
+    ).spec.renewTime;
+
+    expect(new Date(laterRenew).getTime()).toBeGreaterThan(
+      new Date(firstRenew).getTime(),
+    );
+    expect(a.elector.isLeader()).toBe(true);
+    expect(a.startedCount).toBe(1);
+
+    await a.elector.stop();
+  });
+});

--- a/keeperhub-scheduler/tests/unit/phantom.test.ts
+++ b/keeperhub-scheduler/tests/unit/phantom.test.ts
@@ -18,9 +18,9 @@ describe("createPhantomExecution", () => {
   it("POSTs a phantom row and returns the new execution id", async () => {
     apiRequest.mockResolvedValue({ executionId: "exec_123" });
 
-    const id = await createPhantomExecution("wf_1", "schedule");
+    const result = await createPhantomExecution("wf_1", "schedule");
 
-    expect(id).toBe("exec_123");
+    expect(result).toEqual({ executionId: "exec_123", alreadyExisted: false });
     const [path, options] = apiRequest.mock.calls[0];
     expect(path).toBe("/api/internal/executions");
     expect(options.method).toBe("POST");
@@ -31,22 +31,42 @@ describe("createPhantomExecution", () => {
     });
   });
 
-  it("forwards userId when provided (block path)", async () => {
+  it("forwards userId and dispatchKey when provided (block path)", async () => {
     apiRequest.mockResolvedValue({ executionId: "exec_456" });
 
-    await createPhantomExecution("wf_1", "block", "owner_1");
+    await createPhantomExecution("wf_1", "block", "owner_1", "block:wf_1:1:99");
 
     const body = JSON.parse(apiRequest.mock.calls[0][1].body);
     expect(body.userId).toBe("owner_1");
     expect(body.triggerSource).toBe("block");
+    expect(body.dispatchKey).toBe("block:wf_1:1:99");
   });
 
-  it("returns undefined when the API call fails (best-effort)", async () => {
+  it("reports alreadyExisted when the API returns it (dedup hit)", async () => {
+    apiRequest.mockResolvedValue({
+      executionId: "exec_existing",
+      alreadyExisted: true,
+    });
+
+    const result = await createPhantomExecution(
+      "wf_1",
+      "schedule",
+      undefined,
+      "schedule:s1:2026-01-01T00:00:00.000Z",
+    );
+
+    expect(result).toEqual({
+      executionId: "exec_existing",
+      alreadyExisted: true,
+    });
+  });
+
+  it("returns no id and alreadyExisted=false when the API call fails", async () => {
     apiRequest.mockRejectedValue(new Error("api down"));
 
-    const id = await createPhantomExecution("wf_1", "schedule");
+    const result = await createPhantomExecution("wf_1", "schedule");
 
-    expect(id).toBeUndefined();
+    expect(result).toEqual({ alreadyExisted: false });
   });
 });
 

--- a/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
+++ b/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
@@ -440,6 +440,9 @@ describe("dispatch", () => {
     vi.setSystemTime(new Date("2024-01-15T09:00:01Z"));
     createPhantomExecution.mockReset();
     failPhantomExecution.mockReset();
+    // Default: a fresh phantom row, no dedup hit. Tests that assert the id or
+    // the dedup-skip path override this.
+    createPhantomExecution.mockResolvedValue({ alreadyExisted: false });
   });
 
   afterEach(() => {
@@ -727,7 +730,10 @@ describe("dispatch", () => {
 
   // KEEP-693: phantom pre-creation wiring.
   it("pre-creates a phantom row and carries its id on the message", async () => {
-    createPhantomExecution.mockResolvedValue("exec_ph");
+    createPhantomExecution.mockResolvedValue({
+      executionId: "exec_ph",
+      alreadyExisted: false,
+    });
     stubFetch([
       {
         id: "sched-1",
@@ -740,15 +746,47 @@ describe("dispatch", () => {
 
     await dispatch();
 
-    expect(createPhantomExecution).toHaveBeenCalledWith("wf-1", "schedule");
+    expect(createPhantomExecution).toHaveBeenCalledWith(
+      "wf-1",
+      "schedule",
+      undefined,
+      expect.stringMatching(/^schedule:sched-1:2024-01-15T09:00:00/),
+    );
     const command = mockedSqsSend.mock.calls[0][0] as SendMessageCommand;
     expect(JSON.parse(command.input.MessageBody ?? "")).toMatchObject({
       executionId: "exec_ph",
     });
   });
 
+  // An overlapping leader / catch-up window that recomputes the same occurrence
+  // gets alreadyExisted and must not enqueue a second message.
+  it("skips the enqueue when the dispatch key already exists (dedup)", async () => {
+    createPhantomExecution.mockResolvedValue({
+      executionId: "exec_existing",
+      alreadyExisted: true,
+    });
+    stubFetch([
+      {
+        id: "sched-1",
+        workflowId: "wf-1",
+        cronExpression: "0 9 * * *",
+        timezone: "UTC",
+      },
+    ]);
+    mockedSqsSend.mockResolvedValue(sqsOkResponse);
+
+    const result = await dispatch();
+
+    expect(result).toEqual({ evaluated: 1, triggered: 0, errors: 0 });
+    expect(mockedSqsSend).not.toHaveBeenCalled();
+    expect(failPhantomExecution).not.toHaveBeenCalled();
+  });
+
   it("marks the phantom failed with CS-0001 when the enqueue fails", async () => {
-    createPhantomExecution.mockResolvedValue("exec_ph");
+    createPhantomExecution.mockResolvedValue({
+      executionId: "exec_ph",
+      alreadyExisted: false,
+    });
     stubFetch([
       {
         id: "sched-1",
@@ -770,7 +808,7 @@ describe("dispatch", () => {
   });
 
   it("still enqueues (id-less) when phantom creation fails", async () => {
-    createPhantomExecution.mockResolvedValue(undefined);
+    createPhantomExecution.mockResolvedValue({ alreadyExisted: false });
     stubFetch([
       {
         id: "sched-1",

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -723,6 +723,19 @@ export const workflowExecutions = pgTable(
      * the full stored snapshot without duplicating the graph per execution.
      */
     executedWorkflowHash: text("executed_workflow_hash"),
+    /**
+     * Dispatch-idempotency key. The schedule and block dispatchers
+     * run two replicas with leader election; this key makes a duplicate
+     * dispatch a no-op instead of a second SQS message and a second run. The
+     * dispatcher sets a stable per-occurrence value
+     * (`schedule:<scheduleId>:<occurrenceIso>` / `block:<workflowId>:<chainId>:<blockNumber>`)
+     * and the create-phantom insert is `ON CONFLICT DO NOTHING` on the unique
+     * index below, so an overlapping leader or a catch-up window that re-runs an
+     * occurrence collides and skips its enqueue. Null for rows with no dedup key
+     * (manual/webhook/direct); Postgres treats those NULLs as distinct so they
+     * never collide.
+     */
+    dispatchKey: text("dispatch_key"),
   },
   (table) => [
     index("idx_workflow_executions_status").on(table.status),
@@ -731,6 +744,9 @@ export const workflowExecutions = pgTable(
     index("idx_workflow_executions_executed_hash").on(
       table.executedWorkflowHash
     ),
+    // Idempotency guard for dispatch dedup; NULL keys are distinct so only real
+    // per-occurrence keys are constrained.
+    uniqueIndex("idx_workflow_executions_dispatch_key").on(table.dispatchKey),
   ]
 );
 

--- a/tests/integration/internal-executions-route.test.ts
+++ b/tests/integration/internal-executions-route.test.ts
@@ -60,6 +60,11 @@ let mockWorkflow: {
 let mockExistingExecution: { id: string; status: string } | null;
 let insertedValues: Record<string, unknown> | null;
 let updatedSet: Record<string, unknown> | null;
+// Rows the create INSERT's .onConflictDoNothing().returning() resolves to.
+// Empty simulates a dispatch-key conflict (another dispatcher won the race).
+let mockInsertReturning: Array<{ id: string }> = [{ id: "exec_created" }];
+// Rows the dedup fallback SELECT resolves to when the insert conflicted.
+let mockSelectResult: Array<{ id: string }> = [];
 // Rows the PATCH terminal UPDATE's .returning() resolves to; seed with
 // workflowId + previousStatus to exercise the counter-emission gate.
 let mockUpdateReturning: Array<{
@@ -81,9 +86,19 @@ vi.mock("@/lib/db", () => ({
       values: (values: Record<string, unknown>) => {
         insertedValues = values;
         return {
-          returning: () => [{ id: "exec_created" }],
+          onConflictDoNothing: () => ({
+            returning: () => mockInsertReturning,
+          }),
         };
       },
+    })),
+    // Dedup fallback lookup when the insert conflicts on dispatch_key.
+    select: vi.fn(() => ({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve(mockSelectResult),
+        }),
+      }),
     })),
     // PATCH chains .set().from(prevExecution).where().returning() for the
     // pre-update-status self-join.
@@ -103,7 +118,11 @@ vi.mock("@/lib/db", () => ({
 }));
 
 vi.mock("@/lib/db/schema", () => ({
-  workflowExecutions: { id: "id", status: "status" },
+  workflowExecutions: {
+    id: "id",
+    status: "status",
+    dispatchKey: "dispatch_key",
+  },
   workflows: { id: "id" },
 }));
 
@@ -169,6 +188,8 @@ describe("POST /api/internal/executions", () => {
       userId: "wf_owner",
     };
     insertedValues = null;
+    mockInsertReturning = [{ id: "exec_created" }];
+    mockSelectResult = [];
     enforceExecutionLimit.mockResolvedValue({ blocked: false });
     enforceWorkflowFeatures.mockResolvedValue({ blocked: false });
   });
@@ -224,6 +245,65 @@ describe("POST /api/internal/executions", () => {
     );
 
     expect(buildAttribution).toHaveBeenCalledWith(sourceArg("internal"));
+  });
+
+  it("persists the dispatch key and returns alreadyExisted=false on create", async () => {
+    const response = await POST(
+      postRequest({
+        workflowId: "wf_1",
+        status: "phantom",
+        triggerSource: "schedule",
+        dispatchKey: "schedule:sched_1:2026-01-01T00:00:00.000Z",
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.alreadyExisted).toBe(false);
+    expect(insertedValues?.dispatchKey).toBe(
+      "schedule:sched_1:2026-01-01T00:00:00.000Z"
+    );
+  });
+
+  it("stores a null dispatch key when none is supplied", async () => {
+    await POST(postRequest({ workflowId: "wf_1", status: "phantom" }));
+    expect(insertedValues?.dispatchKey).toBeNull();
+  });
+
+  it("returns the existing row with alreadyExisted=true on a dispatch-key conflict", async () => {
+    // Insert no-ops (conflict) -> returning is empty; the fallback lookup finds
+    // the row the winning dispatcher already created.
+    mockInsertReturning = [];
+    mockSelectResult = [{ id: "exec_existing" }];
+
+    const response = await POST(
+      postRequest({
+        workflowId: "wf_1",
+        status: "phantom",
+        triggerSource: "schedule",
+        dispatchKey: "schedule:sched_1:2026-01-01T00:00:00.000Z",
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.alreadyExisted).toBe(true);
+    expect(data.executionId).toBe("exec_existing");
+  });
+
+  it("returns 500 if the insert conflicts but the row cannot be found", async () => {
+    mockInsertReturning = [];
+    mockSelectResult = [];
+
+    const response = await POST(
+      postRequest({
+        workflowId: "wf_1",
+        status: "phantom",
+        dispatchKey: "schedule:sched_1:2026-01-01T00:00:00.000Z",
+      })
+    );
+
+    expect(response.status).toBe(500);
   });
 
   it("returns 400 when workflowId is missing", async () => {


### PR DESCRIPTION
## Why

The schedule dispatcher and block dispatcher each ran a single replica, so a node roll or a crash briefly took dispatch to zero. That is a single point of failure for the public zero-execution SLO (the same pattern that caused a Statuspage incident on a recent Karpenter node roll).

This runs both dispatchers as two replicas with leader election so only the elected leader dispatches to SQS and a standby takes over on failover.

## Approach

**Leader election - Kubernetes-native, no new infrastructure.** Uses the `Lease` object (`coordination.k8s.io/v1`) via `@kubernetes/client-node` - the same primitive controllers use, backed by the cluster's own API server. No etcd/Zookeeper/Redis, and no Postgres advisory lock. The acquire/renew loop follows client-go semantics (`leaseDuration 15s > renewDeadline 10s > retryPeriod 2s`), so a standby cannot acquire the lease until after the old leader has already relinquished it - a gap where nobody dispatches rather than an overlap where two do. Holder identity comes from the pod hostname and the namespace from the service account file, so nothing environment-scoped is hardcoded. Election is gated by `LEADER_ELECTION_ENABLED`, so local dev still runs as a sole leader.

**Dispatch-idempotency key - the actual no-duplicate guarantee.** The workflow queue is a standard, non-FIFO SQS queue with no dedup, so election alone cannot mathematically prevent a brief overlap during failover or rollout. Each dispatched occurrence now carries a stable `dispatch_key` (`schedule:<scheduleId>:<occurrenceIso>` / `block:<workflowId>:<chainId>:<blockNumber>`). The create-phantom insert is `ON CONFLICT DO NOTHING` on a new unique index, so an overlapping leader - or a catch-up window that recomputes an occurrence - skips its enqueue instead of double-running. NULL keys (manual/webhook/direct rows) are distinct in Postgres and never collide.

## Changes

- `keeperhub-scheduler/lib/leader-election.ts` (new) plus wiring in both dispatcher entrypoints; both dispatch only while leader, `/health` reports leadership, and readiness is deliberately not gated on it so the standby stays Ready for its PodDisruptionBudget.
- `workflow_executions` gains a nullable `dispatch_key` column and a unique index (migration `0129`, marked `@requires-db-prep` because the table is large). `POST /api/internal/executions` returns `alreadyExisted` and the dispatchers skip the duplicate send.
- `keeperhub-stack` values (staging + prod): `replicaCount: 2` for both dispatchers, the lease env, and the leases RBAC rule added to the shared app service account (avoids a second service account that would need its own IRSA role-arn). PodDisruptionBudgets were already in place.

## Testing

- Scheduler: lint + typecheck + full unit suite (140 tests), including new leader-election tests (single leader among contenders, failover to standby, continuous renewal) and dedup-skip tests for both dispatchers.
- App: type-check clean; internal-executions route integration suite (20 tests) including the new create/conflict/alreadyExisted cases; biome clean on changed files.
- Migration `0129` DDL applied and functionally validated against a local Postgres: two NULL keys both insert, a duplicate real key returns zero rows (which the route reads as `alreadyExisted`), one row survives per key.
- Both env values render with `helm template` and pass `helm lint`.

## Before merge

- Set the `db-prepped-staging` label - an operator builds the unique index with `CREATE UNIQUE INDEX CONCURRENTLY` out-of-band first (the in-migration statement is then a no-op via `IF NOT EXISTS`).
- Post-deploy on staging: confirm exactly one lease holder (`kubectl get lease schedule-dispatcher-leader`), run a failover drill (delete the leader pod, confirm the standby takes over and no duplicate executions), then promote to prod.
