### PR TITLE
feat(executor): capture dropped SQS messages to a dead-letter queue

### DIFF
--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -694,6 +694,9 @@ executor:
     SQS_QUEUE_URL:
       type: kv
       value: "https://sqs.us-east-2.amazonaws.com/${AWS_ACCOUNT_ID}/keeperhub-workflow-queue-prod"
+    SQS_DLQ_URL:
+      type: kv
+      value: "https://sqs.us-east-2.amazonaws.com/${AWS_ACCOUNT_ID}/keeperhub-workflow-queue-prod-dlq"
     RUNNER_IMAGE:
       type: kv
       value: "${ECR_REGISTRY}/keeperhub-prod:workflow-runner-${IMAGE_TAG}"

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -696,6 +696,9 @@ executor:
     SQS_QUEUE_URL:
       type: kv
       value: "https://sqs.us-east-1.amazonaws.com/${AWS_ACCOUNT_ID}/keeperhub-workflow-queue-staging"
+    SQS_DLQ_URL:
+      type: kv
+      value: "https://sqs.us-east-1.amazonaws.com/${AWS_ACCOUNT_ID}/keeperhub-workflow-queue-staging-dlq"
     RUNNER_IMAGE:
       type: kv
       value: "${ECR_REGISTRY}/keeperhub-staging:workflow-runner-${IMAGE_TAG}"

--- a/deploy/pr-environment/executor.template.yaml
+++ b/deploy/pr-environment/executor.template.yaml
@@ -81,6 +81,9 @@ env:
   SQS_QUEUE_URL:
     type: kv
     value: "http://localstack.pr-${PR_NUMBER}.svc.cluster.local:4566/000000000000/keeperhub-workflow-queue"
+  SQS_DLQ_URL:
+    type: kv
+    value: "http://localstack.pr-${PR_NUMBER}.svc.cluster.local:4566/000000000000/keeperhub-workflow-queue-dlq"
   # PR deploys do not build a workflow-runner image per-sha (see commit
   # message of the matrix-trim: "satellite services use pre-built
   # staging images"). The runner therefore points at the rolling

--- a/deploy/pr-environment/localstack.template.yaml
+++ b/deploy/pr-environment/localstack.template.yaml
@@ -8,11 +8,14 @@ metadata:
 data:
   init-sqs.sh: |
     #!/bin/bash
-    echo "Creating SQS queue..."
+    echo "Creating SQS queues..."
+    awslocal sqs create-queue \
+      --queue-name keeperhub-workflow-queue-dlq \
+      --attributes MessageRetentionPeriod=1209600
     awslocal sqs create-queue \
       --queue-name keeperhub-workflow-queue \
       --attributes VisibilityTimeout=300
-    echo "SQS queue created successfully"
+    echo "SQS queues created successfully"
 
 ---
 apiVersion: apps/v1

--- a/keeperhub-executor/config.ts
+++ b/keeperhub-executor/config.ts
@@ -31,6 +31,13 @@ export const CONFIG = {
   sqsQueueUrl:
     process.env.SQS_QUEUE_URL ||
     "http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/keeperhub-workflow-queue",
+  // Dead-letter queue for messages rejected without ever being processed
+  // (malformed JSON, or a forged/invalid message dropped in enforce mode). When
+  // set, those are copied here before being deleted from the main queue so they
+  // are retained for audit instead of vanishing behind a log line. Unset (the
+  // default) preserves the previous delete-only behaviour, so the executor can
+  // ship ahead of the queue being provisioned.
+  sqsDlqUrl: process.env.SQS_DLQ_URL,
 
   runnerImage: process.env.RUNNER_IMAGE || "keeperhub-runner:latest",
   imagePullPolicy: process.env.IMAGE_PULL_POLICY || "Never",

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -30,6 +30,7 @@ import {
   type Message,
   type MessageAttributeValue,
   ReceiveMessageCommand,
+  SendMessageCommand,
   SQSClient,
 } from "@aws-sdk/client-sqs";
 import { and, eq, inArray } from "drizzle-orm";
@@ -638,6 +639,44 @@ export function evaluateSqsMessageAuth(
   return { failure: null, stale };
 }
 
+// Reject a message that was never processed - malformed JSON, or a forged /
+// invalid message dropped in enforce mode. When a DLQ is configured, copy the
+// raw message (body + original attributes, plus a reason) into it before
+// deleting from the main queue, so the rejected message is retained for audit
+// rather than vanishing behind a log line. A redrive policy cannot capture
+// these: the delete removes the message on first receive, so it never reaches
+// maxReceiveCount. Falls back to a plain delete when SQS_DLQ_URL is unset.
+async function dropMessage(message: Message, reason: string): Promise<void> {
+  if (CONFIG.sqsDlqUrl && message.Body) {
+    try {
+      await sqs.send(
+        new SendMessageCommand({
+          QueueUrl: CONFIG.sqsDlqUrl,
+          MessageBody: message.Body,
+          MessageAttributes: {
+            ...message.MessageAttributes,
+            "X-KH-Reason": { DataType: "String", StringValue: reason },
+          },
+        })
+      );
+    } catch (error) {
+      // A DLQ hiccup must never strand the message on the main queue - fall
+      // through to the delete so a bad payload cannot wedge the poll loop.
+      console.error(
+        `[Executor] Failed to copy dropped message (${reason}) to DLQ:`,
+        error
+      );
+    }
+  }
+
+  await sqs.send(
+    new DeleteMessageCommand({
+      QueueUrl: CONFIG.sqsQueueUrl,
+      ReceiptHandle: message.ReceiptHandle,
+    })
+  );
+}
+
 export async function processMessage(
   message: Message,
   // The message processor is injectable so tests can drive the success and
@@ -654,20 +693,16 @@ export async function processMessage(
     body = JSON.parse(message.Body);
   } catch {
     console.error("[Executor] Malformed message body, deleting:", message.Body);
-    await sqs.send(
-      new DeleteMessageCommand({
-        QueueUrl: CONFIG.sqsQueueUrl,
-        ReceiptHandle: message.ReceiptHandle,
-      })
-    );
+    await dropMessage(message, "malformed_json");
     return;
   }
 
   // Authenticate + validate the message before it can drive a
   // fund-moving execution. In "warn" mode we record metrics but still process
   // (so shipping this ahead of every producer signing cannot cause an outage);
-  // in "enforce" mode a hard failure drops the message (no DLQ configured, and a
-  // forged/corrupt message cannot be made valid by redelivery).
+  // in "enforce" mode a hard failure drops the message - a forged/corrupt
+  // message cannot be made valid by redelivery, so it is copied to the DLQ (when
+  // configured) for audit and removed from the main queue.
   if (CONFIG.sqsHmacMode !== "off") {
     const auth = evaluateSqsMessageAuth(
       message.Body,
@@ -698,12 +733,7 @@ export async function processMessage(
         `[Executor] SQS message rejected (${failure}, mode=${CONFIG.sqsHmacMode}) for workflow ${body.workflowId}`
       );
       if (CONFIG.sqsHmacMode === "enforce") {
-        await sqs.send(
-          new DeleteMessageCommand({
-            QueueUrl: CONFIG.sqsQueueUrl,
-            ReceiptHandle: message.ReceiptHandle,
-          })
-        );
+        await dropMessage(message, failure);
         return;
       }
     }

--- a/keeperhub-executor/process-message-dlq.test.ts
+++ b/keeperhub-executor/process-message-dlq.test.ts
@@ -1,0 +1,191 @@
+import type { Message } from "@aws-sdk/client-sqs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Same lightweight harness as process-message-auth.test.ts, but the SQS mock
+// also captures SendMessageCommand so we can assert the DLQ copy, and records
+// each command's constructor input so a send can be told apart from a delete.
+const { sendMock } = vi.hoisted(() => ({ sendMock: vi.fn() }));
+
+vi.mock("server-only", () => ({}));
+vi.mock("./in-process", () => ({ executeInProcess: vi.fn() }));
+vi.mock("./k8s-job", () => ({ createWorkflowJob: vi.fn() }));
+vi.mock("./api-execute", () => ({ executeViaApi: vi.fn() }));
+vi.mock("./execution-mode", () => ({ resolveDispatchTarget: vi.fn() }));
+vi.mock("./billing-guard", () => ({ checkExecutionLimitForExecutor: vi.fn() }));
+vi.mock("./feature-guard", () => ({
+  checkWorkflowFeaturesForExecutor: vi.fn(),
+}));
+vi.mock("@aws-sdk/client-sqs", () => ({
+  SQSClient: class {
+    send = sendMock;
+  },
+  DeleteMessageCommand: class {
+    kind = "delete";
+    input: Record<string, unknown>;
+    constructor(input: Record<string, unknown>) {
+      this.input = input;
+    }
+  },
+  SendMessageCommand: class {
+    kind = "send";
+    input: Record<string, unknown>;
+    constructor(input: Record<string, unknown>) {
+      this.input = input;
+    }
+  },
+  ReceiveMessageCommand: class {},
+}));
+
+import { signSqsMessageAttributes } from "../lib/sqs-message-auth";
+import { CONFIG } from "./config";
+import { processMessage } from "./index";
+
+const DLQ_URL = "https://sqs.test/000000000000/keeperhub-workflow-queue-dlq";
+
+const VALID = {
+  triggerType: "schedule",
+  workflowId: "wf1",
+  scheduleId: "s1",
+  triggerTime: "2026-01-01T00:00:00.000Z",
+};
+
+function signed(body: unknown): Message {
+  const str = JSON.stringify(body);
+  return {
+    Body: str,
+    ReceiptHandle: "rh-1",
+    MessageAttributes: signSqsMessageAttributes("scheduler", CONFIG.sqsQueueUrl, str),
+  } as Message;
+}
+
+function unsigned(body: unknown): Message {
+  return { Body: JSON.stringify(body), ReceiptHandle: "rh-1" } as Message;
+}
+
+type Sent = { kind: string; input: Record<string, unknown> };
+function sends(): Sent[] {
+  return sendMock.mock.calls.map((c) => c[0] as Sent);
+}
+
+let savedMode: typeof CONFIG.sqsHmacMode;
+let savedDlqUrl: string | undefined;
+let savedSecret: string | undefined;
+
+beforeEach(() => {
+  sendMock.mockReset();
+  savedMode = CONFIG.sqsHmacMode;
+  savedDlqUrl = CONFIG.sqsDlqUrl;
+  savedSecret = process.env.INTERNAL_SERVICE_HMAC_SECRET;
+  process.env.INTERNAL_SERVICE_HMAC_SECRET = "test-secret";
+  CONFIG.sqsDlqUrl = DLQ_URL;
+});
+
+afterEach(() => {
+  CONFIG.sqsHmacMode = savedMode;
+  CONFIG.sqsDlqUrl = savedDlqUrl;
+  process.env.INTERNAL_SERVICE_HMAC_SECRET = savedSecret;
+});
+
+describe("processMessage DLQ capture", () => {
+  it("copies an enforce-mode unsigned drop to the DLQ before deleting", async () => {
+    CONFIG.sqsHmacMode = "enforce";
+    const run = vi.fn().mockResolvedValue(undefined);
+    const msg = unsigned(VALID);
+
+    await processMessage(msg, run);
+
+    expect(run).not.toHaveBeenCalled();
+    const calls = sends();
+    expect(calls).toHaveLength(2);
+    // The DLQ copy happens first, then the delete from the main queue.
+    expect(calls[0].kind).toBe("send");
+    expect(calls[0].input.QueueUrl).toBe(DLQ_URL);
+    expect(calls[0].input.MessageBody).toBe(msg.Body);
+    const attrs = calls[0].input.MessageAttributes as Record<
+      string,
+      { StringValue?: string }
+    >;
+    expect(attrs["X-KH-Reason"].StringValue).toBe("unsigned");
+    expect(calls[1].kind).toBe("delete");
+    expect(calls[1].input.QueueUrl).toBe(CONFIG.sqsQueueUrl);
+    expect(calls[1].input.ReceiptHandle).toBe("rh-1");
+  });
+
+  it("tags a tampered-signature drop with its failure reason and keeps its attributes", async () => {
+    CONFIG.sqsHmacMode = "enforce";
+    const run = vi.fn().mockResolvedValue(undefined);
+    const msg = signed(VALID);
+    msg.Body = JSON.stringify({ ...VALID, workflowId: "victim" });
+
+    await processMessage(msg, run);
+
+    const calls = sends();
+    expect(calls).toHaveLength(2);
+    const attrs = calls[0].input.MessageAttributes as Record<
+      string,
+      { StringValue?: string }
+    >;
+    expect(attrs["X-KH-Reason"].StringValue).toBe("bad_signature");
+    // Original signing attributes ride along for forensic review.
+    expect(attrs["X-KH-Signature"]).toBeDefined();
+  });
+
+  it("copies a malformed-JSON drop to the DLQ regardless of HMAC mode", async () => {
+    CONFIG.sqsHmacMode = "off";
+    const run = vi.fn().mockResolvedValue(undefined);
+    const msg = { Body: "{not-json", ReceiptHandle: "rh-1" } as Message;
+
+    await processMessage(msg, run);
+
+    expect(run).not.toHaveBeenCalled();
+    const calls = sends();
+    expect(calls).toHaveLength(2);
+    expect(calls[0].kind).toBe("send");
+    expect(calls[0].input.MessageBody).toBe("{not-json");
+    const attrs = calls[0].input.MessageAttributes as Record<
+      string,
+      { StringValue?: string }
+    >;
+    expect(attrs["X-KH-Reason"].StringValue).toBe("malformed_json");
+  });
+
+  it("deletes without a DLQ copy when SQS_DLQ_URL is unset", async () => {
+    CONFIG.sqsDlqUrl = undefined;
+    CONFIG.sqsHmacMode = "enforce";
+    const run = vi.fn().mockResolvedValue(undefined);
+
+    await processMessage(unsigned(VALID), run);
+
+    const calls = sends();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].kind).toBe("delete");
+  });
+
+  it("still deletes from the main queue when the DLQ copy fails", async () => {
+    CONFIG.sqsHmacMode = "enforce";
+    // The DLQ send rejects; the subsequent delete resolves.
+    sendMock.mockRejectedValueOnce(new Error("dlq unreachable"));
+    const run = vi.fn().mockResolvedValue(undefined);
+
+    await processMessage(unsigned(VALID), run);
+
+    const calls = sends();
+    expect(calls).toHaveLength(2);
+    expect(calls[0].kind).toBe("send");
+    expect(calls[1].kind).toBe("delete");
+    expect(calls[1].input.QueueUrl).toBe(CONFIG.sqsQueueUrl);
+  });
+
+  it("does not route a successfully processed message to the DLQ", async () => {
+    CONFIG.sqsHmacMode = "enforce";
+    const run = vi.fn().mockResolvedValue(undefined);
+
+    await processMessage(signed(VALID), run);
+
+    expect(run).toHaveBeenCalledOnce();
+    const calls = sends();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].kind).toBe("delete");
+    expect(calls[0].input.QueueUrl).toBe(CONFIG.sqsQueueUrl);
+  });
+});


### PR DESCRIPTION
## What

When the executor rejects a message without ever processing it - malformed JSON that cannot be parsed, or a forged/invalid message dropped in enforce mode - it previously deleted the message with only a log line, leaving no record it existed.

This adds dead-letter-queue capture: when `SQS_DLQ_URL` is set, the executor copies the raw message (body + original attributes + an `X-KH-Reason` attribute) to the DLQ before deleting it from the main queue, so rejected messages are retained for audit. A DLQ send failure never strands the message on the main queue. When `SQS_DLQ_URL` is unset the behaviour is unchanged (delete-only), so this is safe to ship ahead of the DLQ being provisioned.

## Changes

- `keeperhub-executor/config.ts`: optional `SQS_DLQ_URL`.
- `keeperhub-executor/index.ts`: a `dropMessage` helper wired into the malformed-JSON and enforce-mode drop sites.
- `deploy/keeperhub-stack/{staging,prod}/values.yaml`: `SQS_DLQ_URL` on the executor.
- `deploy/pr-environment/`: create the DLQ in LocalStack + wire `SQS_DLQ_URL`.
- Tests for the capture on enforce-mode and malformed drops, the delete-only fallback, and that a successfully processed message is not routed to the DLQ.

## Notes

- The DLQ + redrive policy live in the infrastructure repo and are applied first.
- A queue-level redrive policy alone cannot capture these drops: they are explicit deletes on first receive, so they never reach `maxReceiveCount`. The executor copies them explicitly instead.
- The executor runs in `warn` mode today, so the enforce-mode capture is pre-positioned for when enforce is enabled; the malformed-JSON capture is active immediately.
