### PR TITLE
test: expand Tier 1 event-decode coverage to 26/31

### DIFF
--- a/protocols/aerodrome.ts
+++ b/protocols/aerodrome.ts
@@ -53,6 +53,18 @@ const TEST_DATA: ProtocolTestData = {
       "get-all-pools-length": [{ nonZero: true }],
       "get-pool-for-pair": [{ field: "pool", notEmpty: true }],
     },
+    // The Base event emitter wraps ETH for the pool swap and pulls AERO from
+    // the veAERO escrow under impersonation, then drives a swap, a lock, a
+    // vote, a lock/withdraw, and an epoch distribute - six of the seven events.
+    // gauge-created stays skipped: every whitelisted Base pair already has a
+    // gauge, so emitting it would need a freshly deployed token to pair and
+    // gauge, which the self-contained emitter does not set up.
+    events: {
+      skipped: {
+        "gauge-created":
+          "Voter.createGauge emits GaugeCreated only for a pool that has no gauge yet; every whitelisted Base pair already has one, so a fresh emission would require deploying a throwaway token to pair and gauge",
+      },
+    },
   },
 };
 
@@ -517,9 +529,9 @@ export default defineAbiProtocol({
           inputs: [
             { name: "provider", type: "address", indexed: true },
             { name: "tokenId", type: "uint256", indexed: true },
+            { name: "depositType", type: "uint8", indexed: true },
             { name: "value", type: "uint256", indexed: false },
             { name: "locktime", type: "uint256", indexed: false },
-            { name: "depositType", type: "uint256", indexed: false },
             { name: "ts", type: "uint256", indexed: false },
           ],
         },

--- a/protocols/pendle.ts
+++ b/protocols/pendle.ts
@@ -122,31 +122,16 @@ const TEST_DATA: ProtocolTestData = {
         { read: "get-sy-balance", expect: { nonZero: true } },
       ],
     },
-    // Market and reward events fire on operations this testData binds no
-    // write action for (AMM swap/liquidity; reward/interest claim), so no
-    // fixture emits them. yt-mint / yt-burn ARE emittable via the pinned-fork
-    // mint-py-from-sy / redeem-py-to-sy fixtures, but the event harness runs
-    // lightweight self-contained emitters and does not yet perform pendle's
-    // pinned-fork setup provisioning (whale-funded SY plus router approvals);
-    // deferred follow-up.
+    // The event emitter mints fresh SY from wstETH and drives the YT and
+    // market directly (low-level mint/swap/burn, YT mintPY/redeemPY, and an
+    // interest claim after a time warp), covering seven of the eight events.
+    // redeem-rewards stays skipped: the wstETH market carries no external
+    // reward tokens, so YT.redeemDueInterestAndRewards emits RedeemInterest
+    // but never RedeemRewards.
     events: {
       skipped: {
-        "market-swap":
-          "fires on a Pendle market AMM swap; testData binds no swap write action, so no fixture emits it",
-        "market-mint":
-          "fires on Pendle market add-liquidity; testData binds no add-liquidity write action, so no fixture emits it",
-        "market-burn":
-          "fires on Pendle market remove-liquidity; testData binds no remove-liquidity write action, so no fixture emits it",
-        "update-implied-rate":
-          "fires on a Pendle market state change (swap/liquidity); testData binds no such write action, so no fixture emits it",
-        "yt-mint":
-          "emittable via the pinned-fork mint-py-from-sy fixture, but the event harness does not yet run pendle's pinned-fork setup provisioning (whale-funded SY plus router approvals); deferred follow-up",
-        "yt-burn":
-          "emittable via the pinned-fork redeem-py-to-sy fixture, but the event harness does not yet run pendle's pinned-fork setup provisioning (whale-funded SY plus router approvals); deferred follow-up",
         "redeem-rewards":
-          "fires on YT redeemDueInterestAndRewards; testData binds no reward-claim write action, so no fixture emits it",
-        "redeem-interest":
-          "fires on YT redeemDueInterestAndRewards; testData binds no interest-claim write action, so no fixture emits it",
+          "YT.redeemDueInterestAndRewards emits RedeemRewards only when the market has external reward tokens; the wstETH market has none, so the log never fires",
       },
     },
   },
@@ -263,13 +248,16 @@ export default defineAbiProtocol({
         balanceOf: {
           slug: "get-ve-pendle-balance",
           label: "Get vePENDLE Balance",
-          description:
-            "Check the vePENDLE voting power balance of an address",
+          description: "Check the vePENDLE voting power balance of an address",
           inputs: {
             user: { label: "Wallet Address" },
           },
           outputs: {
-            result: { name: "balance", label: "vePENDLE Balance", decimals: 18 },
+            result: {
+              name: "balance",
+              label: "vePENDLE Balance",
+              decimals: 18,
+            },
           },
         },
         totalSupplyStored: {
@@ -412,7 +400,11 @@ export default defineAbiProtocol({
             account: { label: "Wallet Address" },
           },
           outputs: {
-            result: { name: "balance", label: "LP Token Balance", decimals: 18 },
+            result: {
+              name: "balance",
+              label: "LP Token Balance",
+              decimals: 18,
+            },
           },
         },
         activeBalance: {

--- a/tests/e2e/vitest/protocol-simulation/_shared/simulate-events.ts
+++ b/tests/e2e/vitest/protocol-simulation/_shared/simulate-events.ts
@@ -24,15 +24,16 @@
  */
 
 import {
+  Contract,
+  concat,
   Interface,
+  id,
   JsonRpcProvider,
   type Log,
+  parseEther,
   type TransactionReceipt,
   ZeroAddress,
   ZeroHash,
-  concat,
-  id,
-  parseEther,
   zeroPadValue,
 } from "ethers";
 import { beforeAll, expect, test } from "vitest";
@@ -42,7 +43,10 @@ import {
   type ProtocolEvent,
 } from "@/lib/protocol-registry";
 import { encodeBoundAction } from "@/lib/test-data/encode-action";
-import { withImpersonation } from "../../protocol-coverage/_shared/funding";
+import {
+  ensureErc20Acquired,
+  withImpersonation,
+} from "../../protocol-coverage/_shared/funding";
 import { SIM_WALLET } from "./simulate";
 
 // Emitting a fresh Safe plus a handful of self-called state transitions runs
@@ -113,7 +117,10 @@ function assertEventDecodes(event: ProtocolEvent, logs: readonly Log[]): void {
   if (!match) {
     return;
   }
-  const parsed = iface.parseLog({ topics: [...match.topics], data: match.data });
+  const parsed = iface.parseLog({
+    topics: [...match.topics],
+    data: match.data,
+  });
   expect(parsed, `parseLog returned null for ${event.slug}`).not.toBeNull();
   if (!parsed) {
     return;
@@ -131,7 +138,11 @@ function assertEventDecodes(event: ProtocolEvent, logs: readonly Log[]): void {
 
 // -- Emitters ----------------------------------------------------------------
 
-type Emitter = (provider: JsonRpcProvider, chainId: string) => Promise<Log[]>;
+type Emitter = (
+  provider: JsonRpcProvider,
+  chainId: string,
+  rpcUrl: string
+) => Promise<Log[]>;
 
 /** rETH deposit: the existing write fixture. depositPool.deposit emits
  *  DepositReceived and the rETH mint it triggers emits TokensMinted. */
@@ -308,10 +319,338 @@ async function emitSafe(
   return logs;
 }
 
+// -- Pendle (pinned mainnet fork) --------------------------------------------
+// The wstETH market's registry SY "whale" is the market itself, so acquiring SY
+// that way would drain its reserves and break the low-level receipt checks.
+// Instead mint fresh SY from wstETH (its real whale), then drive the YT and
+// market directly: every market event fires on a low-level call once the tokens
+// are positioned (Uniswap-V2 style), avoiding the router's diamond selectors.
+const PENDLE_MARKET = "0x34280882267ffa6383B363E278B027Be083bBe3b";
+const PENDLE_SY = "0xcbC72d92b2dc8187414F6734718563898740C0BC";
+const PENDLE_PT = "0xb253Eff1104802b97aC7E3aC9FdD73AecE295a2c";
+const PENDLE_YT = "0x04B7Fa1e727d7290D6E24fA9b426d0c940283a95";
+const PENDLE_WSTETH = "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0";
+const PENDLE_ERC20 = new Interface([
+  "function transfer(address,uint256) returns (bool)",
+  "function approve(address,uint256) returns (bool)",
+  "function balanceOf(address) view returns (uint256)",
+]);
+const PENDLE_SY_IFACE = new Interface([
+  "function deposit(address receiver, address tokenIn, uint256 amountTokenToDeposit, uint256 minSharesOut) returns (uint256)",
+]);
+const PENDLE_YT_IFACE = new Interface([
+  "function mintPY(address receiverPT, address receiverYT) returns (uint256)",
+  "function redeemPY(address receiver) returns (uint256)",
+  "function redeemDueInterestAndRewards(address user, bool redeemInterest, bool redeemRewards) returns (uint256, uint256[])",
+]);
+const PENDLE_MARKET_IFACE = new Interface([
+  "function mint(address receiver, uint256 netSyDesired, uint256 netPtDesired) returns (uint256,uint256,uint256)",
+  "function burn(address receiverSy, address receiverPt, uint256 netLpToBurn) returns (uint256,uint256)",
+  "function swapExactPtForSy(address receiver, uint256 exactPtIn, bytes data) returns (uint256,uint256)",
+  "function balanceOf(address) view returns (uint256)",
+  "function readState(address) view returns (tuple(int256 totalPt,int256 totalSy,int256 totalLp,address treasury,int256 scalarRoot,uint256 expiry,uint256 lnFeeRateRoot,uint256 reserveFeePercent,uint256 lastLnImpliedRate))",
+]);
+
+async function emitPendle(
+  provider: JsonRpcProvider,
+  chainId: string,
+  rpcUrl: string
+): Promise<Log[]> {
+  const logs: Log[] = [];
+  const push = async (to: string, data: string) => {
+    const r = await sendAndWait(provider, SIM_WALLET, { to, data });
+    logs.push(...r.logs);
+  };
+  const balOf = (token: string): Promise<bigint> =>
+    new Contract(token, PENDLE_ERC20, provider).balanceOf(
+      SIM_WALLET
+    ) as Promise<bigint>;
+
+  // Fresh SY from wstETH (real whale), leaving the market's reserves intact.
+  await ensureErc20Acquired(chainId, SIM_WALLET, "WSTETH", "60", rpcUrl);
+  await push(
+    PENDLE_WSTETH,
+    PENDLE_ERC20.encodeFunctionData("approve", [
+      PENDLE_SY,
+      parseEther("1000000"),
+    ])
+  );
+  await push(
+    PENDLE_SY,
+    PENDLE_SY_IFACE.encodeFunctionData("deposit", [
+      SIM_WALLET,
+      PENDLE_WSTETH,
+      parseEther("50"),
+      ZERO,
+    ])
+  );
+
+  // yt-mint: split SY into PT + YT via the YT contract.
+  await push(
+    PENDLE_SY,
+    PENDLE_ERC20.encodeFunctionData("transfer", [PENDLE_YT, parseEther("6")])
+  );
+  await push(
+    PENDLE_YT,
+    PENDLE_YT_IFACE.encodeFunctionData("mintPY", [SIM_WALLET, SIM_WALLET])
+  );
+
+  // market-mint (+ update-implied-rate): low-level add sized to the pool ratio.
+  // The market's low-level mint measures received SY as (token balance -
+  // accounted totalSy); that difference is negative natively and grows if a
+  // prior suite drained the market (its registry SY whale is the market
+  // itself), so overshoot by the live gap plus a buffer to guarantee the
+  // receipt check clears.
+  const marketContract = new Contract(
+    PENDLE_MARKET,
+    PENDLE_MARKET_IFACE,
+    provider
+  );
+  const st = await marketContract.readState(
+    "0x0000000000000000000000000000000000000000"
+  );
+  const marketSyBalance = (await new Contract(
+    PENDLE_SY,
+    PENDLE_ERC20,
+    provider
+  ).balanceOf(PENDLE_MARKET)) as bigint;
+  const accountedSy = BigInt(st.totalSy);
+  const gap =
+    accountedSy > marketSyBalance ? accountedSy - marketSyBalance : ZERO;
+  const netPt = parseEther("1");
+  const netSy = (netPt * accountedSy) / BigInt(st.totalPt);
+  await push(
+    PENDLE_SY,
+    PENDLE_ERC20.encodeFunctionData("transfer", [
+      PENDLE_MARKET,
+      netSy + gap + parseEther("3"),
+    ])
+  );
+  await push(
+    PENDLE_PT,
+    PENDLE_ERC20.encodeFunctionData("transfer", [PENDLE_MARKET, netPt])
+  );
+  await push(
+    PENDLE_MARKET,
+    PENDLE_MARKET_IFACE.encodeFunctionData("mint", [SIM_WALLET, netSy, netPt])
+  );
+  const lp = (await new Contract(
+    PENDLE_MARKET,
+    PENDLE_MARKET_IFACE,
+    provider
+  ).balanceOf(SIM_WALLET)) as bigint;
+
+  // market-swap (+ update-implied-rate): low-level PT -> SY swap.
+  await push(
+    PENDLE_PT,
+    PENDLE_ERC20.encodeFunctionData("transfer", [
+      PENDLE_MARKET,
+      parseEther("1"),
+    ])
+  );
+  await push(
+    PENDLE_MARKET,
+    PENDLE_MARKET_IFACE.encodeFunctionData("swapExactPtForSy", [
+      SIM_WALLET,
+      parseEther("1"),
+      "0x",
+    ])
+  );
+
+  // market-burn: low-level burn of the LP just minted.
+  if (lp > ZERO) {
+    await push(
+      PENDLE_MARKET,
+      PENDLE_ERC20.encodeFunctionData("transfer", [PENDLE_MARKET, lp])
+    );
+    await push(
+      PENDLE_MARKET,
+      PENDLE_MARKET_IFACE.encodeFunctionData("burn", [
+        SIM_WALLET,
+        SIM_WALLET,
+        lp,
+      ])
+    );
+  }
+
+  // yt-burn: recombine equal PT + YT back into SY.
+  const ptBal = await balOf(PENDLE_PT);
+  const ytBal = await balOf(PENDLE_YT);
+  const eq = ptBal < ytBal ? ptBal : ytBal;
+  await push(
+    PENDLE_PT,
+    PENDLE_ERC20.encodeFunctionData("transfer", [PENDLE_YT, eq])
+  );
+  await push(
+    PENDLE_YT,
+    PENDLE_ERC20.encodeFunctionData("transfer", [PENDLE_YT, eq])
+  );
+  await push(
+    PENDLE_YT,
+    PENDLE_YT_IFACE.encodeFunctionData("redeemPY", [SIM_WALLET])
+  );
+
+  // redeem-interest: advance time so SY interest accrues, then claim. The
+  // wstETH market carries no external reward tokens, so RedeemRewards never
+  // fires (a documented skip); RedeemInterest does.
+  await provider.send("evm_increaseTime", [7 * 24 * 3600]);
+  await provider.send("evm_mine", []);
+  await push(
+    PENDLE_YT,
+    PENDLE_YT_IFACE.encodeFunctionData("redeemDueInterestAndRewards", [
+      SIM_WALLET,
+      true,
+      true,
+    ])
+  );
+  return logs;
+}
+
+// -- Aerodrome (Base fork) ---------------------------------------------------
+// Pool ops need no whale (wrap ETH for WETH); AERO comes from the veAERO escrow
+// under impersonation. Locks/vote/distribute drive the Voter + VotingEscrow.
+const AERO_ROUTER = "0xcF77a3Ba9A5CA399B7c97c74d54e5b1Beb874E43";
+const AERO_VOTER = "0x16613524e02ad97eDfeF371bC883F2F5d6C480A5";
+const AERO_ESCROW = "0xeBf418Fe2512e7E6bd9b87a8F0f294aCDC67e6B4";
+const AERO_POOL = "0xcDAC0d6c6C59727a65F871236188350531885C43"; // WETH/USDC volatile
+const AERO_FACTORY = "0x420DD381b31aEf6683db6B902084cB0FFECe40Da";
+const AERO_AERO = "0x940181a94A35A4569E4529A3CDfB74e38FD98631";
+const AERO_WETH = "0x4200000000000000000000000000000000000006";
+const AERO_USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+const AERO_TEN_ETH_HEX = "0x8ac7230489e80000";
+const AERO_ERC20 = new Interface([
+  "function transfer(address,uint256) returns (bool)",
+  "function approve(address,uint256) returns (bool)",
+]);
+const AERO_WETH_IFACE = new Interface(["function deposit() payable"]);
+const AERO_ROUTER_IFACE = new Interface([
+  "function swapExactTokensForTokens(uint256 amountIn, uint256 amountOutMin, (address from,address to,bool stable,address factory)[] routes, address to, uint256 deadline) returns (uint256[])",
+]);
+const AERO_VE_IFACE = new Interface([
+  "function createLock(uint256 _value, uint256 _lockDuration) returns (uint256)",
+  "function withdraw(uint256 _tokenId)",
+]);
+const AERO_VOTER_IFACE = new Interface([
+  "function vote(uint256 _tokenId, address[] _poolVote, uint256[] _weights)",
+  "function gauges(address) view returns (address)",
+  "function distribute(address[] _gauges)",
+]);
+const AERO_DEPOSIT_TOPIC = id(
+  "Deposit(address,uint256,uint8,uint256,uint256,uint256)"
+);
+
+async function emitAerodrome(provider: JsonRpcProvider): Promise<Log[]> {
+  const logs: Log[] = [];
+  const push = async (to: string, data: string, value = ZERO) => {
+    const r = await sendAndWait(provider, SIM_WALLET, { to, data, value });
+    logs.push(...r.logs);
+    return r;
+  };
+  const tokenIdFrom = (recLogs: readonly Log[]): bigint => {
+    const dep = recLogs.find((l) => l.topics[0] === AERO_DEPOSIT_TOPIC);
+    return dep ? BigInt(dep.topics[2]) : ZERO;
+  };
+
+  // Top up beyond the harness's 10 ETH so wrapping leaves gas headroom.
+  await provider.send("anvil_setBalance", [
+    SIM_WALLET,
+    "0x56bc75e2d63100000", // 100 ETH
+  ]);
+  // WETH by wrapping ETH; AERO from the escrow (gas-funded via setBalance).
+  await push(
+    AERO_WETH,
+    AERO_WETH_IFACE.encodeFunctionData("deposit", []),
+    parseEther("10")
+  );
+  await provider.send("anvil_setBalance", [AERO_ESCROW, AERO_TEN_ETH_HEX]);
+  const aeroFund = await sendAndWait(provider, AERO_ESCROW, {
+    to: AERO_AERO,
+    data: AERO_ERC20.encodeFunctionData("transfer", [
+      SIM_WALLET,
+      parseEther("5000"),
+    ]),
+  });
+  logs.push(...aeroFund.logs);
+
+  // pool-swap + pool-sync: WETH -> USDC through the volatile pool.
+  await push(
+    AERO_WETH,
+    AERO_ERC20.encodeFunctionData("approve", [
+      AERO_ROUTER,
+      parseEther("1000000"),
+    ])
+  );
+  await push(
+    AERO_ROUTER,
+    AERO_ROUTER_IFACE.encodeFunctionData("swapExactTokensForTokens", [
+      parseEther("2"),
+      ZERO,
+      [[AERO_WETH, AERO_USDC, false, AERO_FACTORY]],
+      SIM_WALLET,
+      BigInt(4_102_444_800),
+    ])
+  );
+
+  // ve-deposit: lock AERO for a year (voting power for the vote below).
+  await push(
+    AERO_AERO,
+    AERO_ERC20.encodeFunctionData("approve", [
+      AERO_ESCROW,
+      parseEther("1000000"),
+    ])
+  );
+  const lock1 = await push(
+    AERO_ESCROW,
+    AERO_VE_IFACE.encodeFunctionData("createLock", [
+      parseEther("1000"),
+      BigInt(365 * 24 * 3600),
+    ])
+  );
+  const id1 = tokenIdFrom(lock1.logs);
+
+  // voter-voted: past the epoch distribute window, vote for the WETH/USDC pool.
+  await provider.send("evm_increaseTime", [2 * 24 * 3600]);
+  await provider.send("evm_mine", []);
+  await push(
+    AERO_VOTER,
+    AERO_VOTER_IFACE.encodeFunctionData("vote", [id1, [AERO_POOL], [ONE]])
+  );
+
+  // ve-withdraw: a short lock, warped past expiry, then withdrawn.
+  const lock2 = await push(
+    AERO_ESCROW,
+    AERO_VE_IFACE.encodeFunctionData("createLock", [
+      parseEther("100"),
+      BigInt(7 * 24 * 3600),
+    ])
+  );
+  const id2 = tokenIdFrom(lock2.logs);
+  await provider.send("evm_increaseTime", [8 * 24 * 3600]);
+  await provider.send("evm_mine", []);
+  await push(AERO_ESCROW, AERO_VE_IFACE.encodeFunctionData("withdraw", [id2]));
+
+  // distribute-reward: a fresh epoch, then distribute emissions to the voted
+  // gauge (permissionless; drives minter.updatePeriod).
+  const gauge = (await new Contract(
+    AERO_VOTER,
+    AERO_VOTER_IFACE,
+    provider
+  ).gauges(AERO_POOL)) as string;
+  await provider.send("evm_increaseTime", [7 * 24 * 3600]);
+  await provider.send("evm_mine", []);
+  await push(
+    AERO_VOTER,
+    AERO_VOTER_IFACE.encodeFunctionData("distribute", [[gauge]])
+  );
+  return logs;
+}
+
 const EMITTERS: Record<string, Emitter> = {
   "rocket-pool": emitRocketPool,
   lido: emitLido,
   safe: emitSafe,
+  pendle: emitPendle,
+  aerodrome: emitAerodrome,
 };
 
 export function runEventSimulation(opts: {
@@ -345,7 +684,7 @@ export function runEventSimulation(opts: {
         SIM_WALLET,
         "0x8ac7230489e80000",
       ]);
-      collected = await emitter(provider, opts.chainId);
+      collected = await emitter(provider, opts.chainId, opts.rpcUrl);
     }, EMIT_TIMEOUT_MS);
   }
 


### PR DESCRIPTION
## Summary

Adds self-contained Tier 1 event emitters for **pendle** (pinned mainnet fork) and **aerodrome** (Base fork), raising event-decode coverage from **13 to 26 of 31** registered protocol events. Every newly covered event is validated end-to-end on a real fork (emit a real log, then assert the registry's event ABI fragment decodes it), not merely unskipped.

`coverage:report` events line, after:

```
events: 26 covered / 31 total | skipped: 5
  aerodrome     6/7 covered, 1 skipped (chain 8453)
  lido          1/1 covered, 0 skipped (chain 1)
  pendle        7/8 covered, 1 skipped (chain 1)
  rocket-pool   2/3 covered, 1 skipped (chain 1)
  safe          10/12 covered, 2 skipped (chain 1)
```

## Pendle (7/8)

Mints fresh SY from wstETH (its real whale) - the registry SY whale is the market itself, so acquiring SY that way would drain reserves and break the low-level receipt checks - then drives the YT and market directly. Market mint/swap/burn use the low-level transfer-then-call interface to avoid the router diamond-proxy selector encoding. The market-mint SY overshoot is sized to the live accounted-vs-balance gap so it survives the action sim draining the shared pinned fork first (verified by draining 15 SY and re-running green).

## Aerodrome (6/7)

Wraps ETH for the pool swap and pulls AERO from the veAERO escrow under impersonation, then drives a swap, a year lock, a vote, a short lock/warp/withdraw, and an epoch distribute.

Also fixes the aerodrome `Deposit` event definition: `depositType` is an indexed `uint8` in position 3 on-chain, not a trailing non-indexed `uint256`. The prior definition produced a topic0 that never matched a real veAERO deposit log, so the production Event trigger could not decode veAERO deposits. The Base event harness now proves the corrected fragment decodes.

## Skips (5, each with an on-chain reason)

- pendle `redeem-rewards`: the wstETH market has no external reward tokens, so `RedeemRewards` never fires.
- aerodrome `gauge-created`: every whitelisted Base pair already has a gauge; emitting it would need a freshly deployed token to pair and gauge.
- safe `sign-msg` / `execution-failure`, rocket-pool `tokens-burned`: unchanged pre-existing skips (delegatecall path, revert-path, redeem-collateral constraints the harness cannot produce).

## Validation

- Full harness run across mainnet + pinned + Base forks: **26 passed | 5 skipped**.
- No regression to the existing mainnet events (safe/rocket-pool/lido: 13 pass).
- Tier 0 calldata goldens: 480 pass (unaffected; events are not in goldens).
- type-check clean.

## CI wiring

No workflow changes needed: the `tier1-simulations` job already runs `events.test.ts` on the pinned fork (pendle), and the `tier1-simulations-l2` Base leg runs it with `PROTOCOL_SIM_RPC_8453` set (aerodrome). The aerodrome emitter uses only impersonation and cheatcodes (no archive storage reads), so it works on the public Base upstream.