### PR TITLE
feat(tempo): add scheduled-payment and dex-swap steps

### DIFF
--- a/app/api/workflows/events/route.ts
+++ b/app/api/workflows/events/route.ts
@@ -9,6 +9,25 @@ import type { WorkflowNode } from "@/lib/workflow/store";
 import { WorkflowTriggerEnum } from "@/lib/workflow/store";
 import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
 
+// The Tempo Payment Received trigger always watches the fixed TIP-20
+// TransferWithMemo event. The event-tracker's mapper needs an ABI + event name
+// on the trigger config to build a subscription, so we inject them here rather
+// than surfacing ABI/event pickers to the user.
+const TEMPO_TRANSFER_WITH_MEMO_EVENT = "TransferWithMemo";
+const TEMPO_TRANSFER_WITH_MEMO_ABI = JSON.stringify([
+  {
+    type: "event",
+    name: "TransferWithMemo",
+    anonymous: false,
+    inputs: [
+      { name: "from", type: "address", indexed: true },
+      { name: "to", type: "address", indexed: true },
+      { name: "value", type: "uint256", indexed: false },
+      { name: "memo", type: "bytes32", indexed: true },
+    ],
+  },
+]);
+
 /**
  * Internal endpoint for workers to fetch active Event-type workflows.
  * Returns only enabled workflows with Event trigger type. Authentication
@@ -64,18 +83,31 @@ export async function GET(request: Request) {
             return null;
           }
 
-          // Check if trigger type is Event
+          // Admit Event triggers and the Tempo Payment Received trigger; both
+          // register through the event-tracker as on-chain log subscriptions.
           const triggerType = triggerNode.data?.config?.triggerType as
             | string
             | undefined;
 
-          if (triggerType !== WorkflowTriggerEnum.EVENT) {
+          const isEventTrigger = triggerType === WorkflowTriggerEnum.EVENT;
+          const isTempoPaymentTrigger =
+            triggerType === WorkflowTriggerEnum.TEMPO_PAYMENT;
+          if (!(isEventTrigger || isTempoPaymentTrigger)) {
             return null;
           }
 
-          // Try to infer contract address from protocol and event slug
           const config = triggerNode.data?.config;
-          if (config && !config.contractAddress) {
+
+          // Inject the fixed TransferWithMemo ABI + event name for the Tempo
+          // trigger so the mapper can build the subscription. contractAddress
+          // (the token) and network come from the user's config.
+          if (isTempoPaymentTrigger && config) {
+            config.contractABI = TEMPO_TRANSFER_WITH_MEMO_ABI;
+            config.eventName = TEMPO_TRANSFER_WITH_MEMO_EVENT;
+          }
+
+          // Try to infer contract address from protocol and event slug
+          if (isEventTrigger && config && !config.contractAddress) {
             const protocolSlug = config._eventProtocolSlug as
               | string
               | undefined;

--- a/components/workflow/config/trigger-config.tsx
+++ b/components/workflow/config/trigger-config.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Box, Boxes, Clock, Copy, Play, Webhook } from "lucide-react";
+import {
+  ArrowDownToLine,
+  Box,
+  Boxes,
+  Clock,
+  Copy,
+  Play,
+  Webhook,
+} from "lucide-react";
 import Image from "next/image";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -106,6 +114,12 @@ export function TriggerConfig({
               <div className="flex items-center gap-2">
                 <Box className="h-4 w-4" />
                 Block
+              </div>
+            </SelectItem>
+            <SelectItem value="Tempo Payment Received">
+              <div className="flex items-center gap-2">
+                <ArrowDownToLine className="h-4 w-4" />
+                Tempo Payment Received
               </div>
             </SelectItem>
           </SelectContent>
@@ -285,6 +299,52 @@ export function TriggerConfig({
                 </p>
               </div>
             </>
+          );
+        })()}
+      {/* Tempo Payment Received fields */}
+      {config?.triggerType === "Tempo Payment Received" &&
+        (() => {
+          const tempoFields: ActionConfigField[] = [
+            {
+              key: "network",
+              label: "Network",
+              type: "chain-select",
+              chainTypeFilter: "evm",
+              allowedChainIds: ["4217", "42431"],
+              placeholder: "Select a Tempo network",
+              required: true,
+            },
+            {
+              key: "contractAddress",
+              label: "Stablecoin Token",
+              type: "template-input",
+              placeholder: "0x... token contract to watch",
+              required: true,
+            },
+            {
+              key: "recipientAddress",
+              label: "Deposit Address",
+              type: "template-input",
+              placeholder: "0x... the address that receives payments",
+              required: true,
+            },
+            {
+              key: "memo",
+              label: "Memo Filter",
+              type: "template-input",
+              placeholder: "INV-1042 or 0x... (optional)",
+              helpTip:
+                "Only fire when the transfer memo matches. A 0x + 64-hex value matches exactly; a shorter string matches as a prefix.",
+            },
+          ];
+
+          return (
+            <ActionConfigRenderer
+              config={config}
+              disabled={disabled}
+              fields={tempoFields}
+              onUpdateConfig={handleConfigValue}
+            />
           );
         })()}
     </>

--- a/components/workflow/nodes/trigger-node.tsx
+++ b/components/workflow/nodes/trigger-node.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import type { NodeProps } from "@xyflow/react";
-import { Box, Boxes, Check, Clock, Play, Webhook, XCircle } from "lucide-react";
+import {
+  ArrowDownToLine,
+  Box,
+  Boxes,
+  Check,
+  Clock,
+  Play,
+  Webhook,
+  XCircle,
+} from "lucide-react";
 import Image from "next/image";
 import { type ElementType, memo } from "react";
 import { Node } from "@/components/ai-elements/node";
@@ -34,6 +43,7 @@ export const TriggerNode = memo(({ data, selected, id }: TriggerNodeProps) => {
     [WorkflowTriggerEnum.WEBHOOK]: Webhook,
     [WorkflowTriggerEnum.EVENT]: Boxes, // keeperhub custom field //
     [WorkflowTriggerEnum.BLOCK]: Box, // keeperhub custom field //
+    [WorkflowTriggerEnum.TEMPO_PAYMENT]: ArrowDownToLine, // keeperhub custom field //
   };
 
   const TriggerIcon = triggerIcons[triggerType as WorkflowTriggerType] || Play;

--- a/keeperhub-events/event-tracker/lib/types.ts
+++ b/keeperhub-events/event-tracker/lib/types.ts
@@ -31,6 +31,10 @@ export interface RawWorkflowNodeConfig {
   contractABI?: string;
   triggerType?: string;
   contractAddress?: string;
+  // Tempo Payment Received trigger: the watched deposit address and an optional
+  // memo filter, applied as post-decode predicates in the listener.
+  recipientAddress?: string;
+  memo?: string;
 }
 
 export interface RawWorkflowNode {

--- a/keeperhub-events/event-tracker/src/listener/event-listener.ts
+++ b/keeperhub-events/event-tracker/src/listener/event-listener.ts
@@ -1,5 +1,6 @@
 import type { SQSClient } from "@aws-sdk/client-sqs";
 import type { ethers } from "ethers";
+import { hexlify, toUtf8Bytes } from "ethers";
 import {
   createPhantomExecution,
   failPhantomExecution,
@@ -27,6 +28,49 @@ import { formatError } from "./format-error";
 
 const DEFAULT_JITTER_MS = 10_000;
 
+/** A full pre-hashed bytes32 memo (0x + 64 hex), matched exactly. */
+const BYTES32_HEX = /^0x[0-9a-fA-F]{64}$/;
+
+/**
+ * Post-decode filter for the Tempo Payment Received trigger. Returns true
+ * (forward the event) when no filter is set. Otherwise the decoded `to` must
+ * equal the watched deposit address (case-insensitive), and the decoded `memo`
+ * must match the configured filter: an exact bytes32 for a 0x + 64-hex value,
+ * or a utf8 prefix otherwise (the transfer step right-pads a plain-text memo
+ * into the bytes32, so a utf8-hex prefix aligns on byte boundaries).
+ */
+export function paymentEventMatches(params: {
+  to: unknown;
+  memo: unknown;
+  recipientFilter?: string;
+  memoFilter?: string;
+}): boolean {
+  const { to, memo, recipientFilter, memoFilter } = params;
+
+  if (recipientFilter) {
+    if (
+      typeof to !== "string" ||
+      to.toLowerCase() !== recipientFilter.toLowerCase()
+    ) {
+      return false;
+    }
+  }
+
+  if (memoFilter) {
+    if (typeof memo !== "string") {
+      return false;
+    }
+    const memoHex = memo.toLowerCase();
+    if (BYTES32_HEX.test(memoFilter)) {
+      return memoHex === memoFilter.toLowerCase();
+    }
+    const prefixHex = hexlify(toUtf8Bytes(memoFilter));
+    return memoHex.startsWith(prefixHex.toLowerCase());
+  }
+
+  return true;
+}
+
 export interface EventListenerOptions {
   workflowId: string;
   userId: string;
@@ -38,6 +82,13 @@ export interface EventListenerOptions {
   eventName: string;
   eventsAbiStrings: string[];
   rawEventsAbi: AbiEvent[];
+
+  /**
+   * Optional post-decode filters (Tempo Payment Received trigger). Undefined
+   * for generic Event triggers, which forward every matching event.
+   */
+  recipientFilter?: string;
+  memoFilter?: string;
 
   sqs: SQSClient;
   sqsQueueUrl: string;
@@ -112,6 +163,15 @@ export class EventListener {
     return this.started;
   }
 
+  private matchesFilters(parsed: ethers.LogDescription): boolean {
+    return paymentEventMatches({
+      to: parsed.args?.to as unknown,
+      memo: parsed.args?.memo as unknown,
+      recipientFilter: this.opts.recipientFilter,
+      memoFilter: this.opts.memoFilter,
+    });
+  }
+
   private async onLog(log: ethers.Log): Promise<void> {
     try {
       const iface = getInterface(this.opts.eventsAbiStrings);
@@ -120,6 +180,12 @@ export class EventListener {
         data: log.data,
       });
       if (!parsed || parsed.name !== this.opts.eventName) {
+        return;
+      }
+
+      // Post-decode filtering for the Tempo Payment Received trigger. No-op
+      // when neither filter is set (generic Event triggers forward everything).
+      if (!this.matchesFilters(parsed)) {
         return;
       }
 

--- a/keeperhub-events/event-tracker/src/listener/registry.ts
+++ b/keeperhub-events/event-tracker/src/listener/registry.ts
@@ -38,6 +38,14 @@ export interface WorkflowRegistration {
   eventsAbiStrings: string[];
   rawEventsAbi: AbiEvent[];
   /**
+   * Optional post-decode filters for the Tempo Payment Received trigger.
+   * `recipientFilter` matches the decoded `to` arg; `memoFilter` matches the
+   * decoded `memo` (exact for a 0x + 64-hex value, prefix otherwise). Undefined
+   * for generic Event triggers, which never filter on decoded args.
+   */
+  recipientFilter?: string;
+  memoFilter?: string;
+  /**
    * Stable hash over the listener-affecting fields of this registration.
    * Produced by `workflow-mapper.hashRegistration` and used by the Phase 4
    * reconciler to detect config changes (contract swap, event rename, ABI

--- a/keeperhub-events/event-tracker/src/listener/workflow-mapper.ts
+++ b/keeperhub-events/event-tracker/src/listener/workflow-mapper.ts
@@ -154,6 +154,18 @@ export function buildRegistration(
   const userId = typeof workflow.userId === "string" ? workflow.userId : "";
   const workflowName = typeof workflow.name === "string" ? workflow.name : "";
 
+  // Optional post-decode filters carried by the Tempo Payment Received trigger.
+  // Undefined for generic Event triggers, which never filter on decoded args.
+  const recipientFilter =
+    typeof config.recipientAddress === "string" &&
+    config.recipientAddress.length > 0
+      ? config.recipientAddress
+      : undefined;
+  const memoFilter =
+    typeof config.memo === "string" && config.memo.length > 0
+      ? config.memo
+      : undefined;
+
   const registration: Omit<WorkflowRegistration, "configHash"> = {
     workflowId,
     userId,
@@ -165,6 +177,8 @@ export function buildRegistration(
     eventName,
     eventsAbiStrings,
     rawEventsAbi,
+    recipientFilter,
+    memoFilter,
   };
   return {
     ...registration,
@@ -192,6 +206,8 @@ export function hashRegistration(
     eventName: reg.eventName,
     eventsAbiStrings: reg.eventsAbiStrings,
     userId: reg.userId,
+    recipientFilter: reg.recipientFilter ?? null,
+    memoFilter: reg.memoFilter ?? null,
   });
   return createHash("sha256").update(canonical).digest("hex");
 }

--- a/keeperhub-events/event-tracker/tests/unit/tempo-payment-filter.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/tempo-payment-filter.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { paymentEventMatches } from "../../src/listener/event-listener";
+
+const TO = "0x1111111111111111111111111111111111111111";
+const OTHER = "0x2222222222222222222222222222222222222222";
+// "INV-1042" utf8, right-padded into a bytes32 (Solidity bytes32-string form).
+const MEMO_INV1042 = `0x494e562d31303432${"0".repeat(48)}`;
+const HASH = `0x${"ab".repeat(32)}`;
+
+describe("paymentEventMatches", () => {
+  it("forwards everything when no filter is set", () => {
+    expect(paymentEventMatches({ to: TO, memo: MEMO_INV1042 })).toBe(true);
+    expect(paymentEventMatches({ to: undefined, memo: undefined })).toBe(true);
+  });
+
+  it("matches the recipient case-insensitively", () => {
+    expect(
+      paymentEventMatches({ to: TO.toUpperCase(), recipientFilter: TO })
+    ).toBe(true);
+    expect(paymentEventMatches({ to: OTHER, recipientFilter: TO })).toBe(false);
+    expect(paymentEventMatches({ to: 123, recipientFilter: TO })).toBe(false);
+  });
+
+  it("matches a full bytes32 memo exactly", () => {
+    expect(
+      paymentEventMatches({ to: TO, memo: HASH, memoFilter: HASH })
+    ).toBe(true);
+    expect(
+      paymentEventMatches({
+        to: TO,
+        memo: HASH.toUpperCase(),
+        memoFilter: HASH,
+      })
+    ).toBe(true);
+    expect(
+      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: HASH })
+    ).toBe(false);
+  });
+
+  it("matches a plain-text memo as a utf8 prefix", () => {
+    expect(
+      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: "INV-104" })
+    ).toBe(true);
+    expect(
+      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: "INV-1042" })
+    ).toBe(true);
+    expect(
+      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: "ABC" })
+    ).toBe(false);
+    expect(
+      paymentEventMatches({ to: TO, memo: 42, memoFilter: "INV" })
+    ).toBe(false);
+  });
+
+  it("requires both filters to pass when both are set", () => {
+    expect(
+      paymentEventMatches({
+        to: TO,
+        memo: MEMO_INV1042,
+        recipientFilter: TO,
+        memoFilter: "INV-104",
+      })
+    ).toBe(true);
+    expect(
+      paymentEventMatches({
+        to: OTHER,
+        memo: MEMO_INV1042,
+        recipientFilter: TO,
+        memoFilter: "INV-104",
+      })
+    ).toBe(false);
+    expect(
+      paymentEventMatches({
+        to: TO,
+        memo: MEMO_INV1042,
+        recipientFilter: TO,
+        memoFilter: "ZZZ",
+      })
+    ).toBe(false);
+  });
+});

--- a/keeperhub-events/event-tracker/tests/unit/tempo-payment-filter.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/tempo-payment-filter.test.ts
@@ -15,41 +15,49 @@ describe("paymentEventMatches", () => {
 
   it("matches the recipient case-insensitively", () => {
     expect(
-      paymentEventMatches({ to: TO.toUpperCase(), recipientFilter: TO })
+      paymentEventMatches({ to: TO.toUpperCase(), recipientFilter: TO }),
     ).toBe(true);
     expect(paymentEventMatches({ to: OTHER, recipientFilter: TO })).toBe(false);
     expect(paymentEventMatches({ to: 123, recipientFilter: TO })).toBe(false);
   });
 
   it("matches a full bytes32 memo exactly", () => {
-    expect(
-      paymentEventMatches({ to: TO, memo: HASH, memoFilter: HASH })
-    ).toBe(true);
+    expect(paymentEventMatches({ to: TO, memo: HASH, memoFilter: HASH })).toBe(
+      true,
+    );
     expect(
       paymentEventMatches({
         to: TO,
         memo: HASH.toUpperCase(),
         memoFilter: HASH,
-      })
+      }),
     ).toBe(true);
     expect(
-      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: HASH })
+      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: HASH }),
     ).toBe(false);
   });
 
   it("matches a plain-text memo as a utf8 prefix", () => {
     expect(
-      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: "INV-104" })
+      paymentEventMatches({
+        to: TO,
+        memo: MEMO_INV1042,
+        memoFilter: "INV-104",
+      }),
     ).toBe(true);
     expect(
-      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: "INV-1042" })
+      paymentEventMatches({
+        to: TO,
+        memo: MEMO_INV1042,
+        memoFilter: "INV-1042",
+      }),
     ).toBe(true);
     expect(
-      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: "ABC" })
+      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: "ABC" }),
     ).toBe(false);
-    expect(
-      paymentEventMatches({ to: TO, memo: 42, memoFilter: "INV" })
-    ).toBe(false);
+    expect(paymentEventMatches({ to: TO, memo: 42, memoFilter: "INV" })).toBe(
+      false,
+    );
   });
 
   it("requires both filters to pass when both are set", () => {
@@ -59,7 +67,7 @@ describe("paymentEventMatches", () => {
         memo: MEMO_INV1042,
         recipientFilter: TO,
         memoFilter: "INV-104",
-      })
+      }),
     ).toBe(true);
     expect(
       paymentEventMatches({
@@ -67,7 +75,7 @@ describe("paymentEventMatches", () => {
         memo: MEMO_INV1042,
         recipientFilter: TO,
         memoFilter: "INV-104",
-      })
+      }),
     ).toBe(false);
     expect(
       paymentEventMatches({
@@ -75,7 +83,7 @@ describe("paymentEventMatches", () => {
         memo: MEMO_INV1042,
         recipientFilter: TO,
         memoFilter: "ZZZ",
-      })
+      }),
     ).toBe(false);
   });
 });

--- a/lib/mcp/trigger-input-schema.ts
+++ b/lib/mcp/trigger-input-schema.ts
@@ -66,6 +66,7 @@ export function detectListingTriggerType(nodes: unknown): TriggerKind {
       return "webhook";
     case WorkflowTriggerEnum.EVENT:
     case WorkflowTriggerEnum.BLOCK:
+    case WorkflowTriggerEnum.TEMPO_PAYMENT:
       return "on-chain-event";
     default:
       return "manual";

--- a/lib/mcp/workflow-schema-constants.ts
+++ b/lib/mcp/workflow-schema-constants.ts
@@ -227,6 +227,33 @@ export const TRIGGERS = {
         "string - ISO timestamp when the block was detected (available on all trigger types)",
     },
   },
+  "Tempo Payment Received": {
+    triggerType: "Tempo Payment Received",
+    label: "Tempo Payment Received",
+    description:
+      "Fires when a TIP-20 TransferWithMemo payment lands on a watched Tempo address, with an optional memo filter for invoice matching",
+    requiredFields: {
+      network: 'string - Tempo chain ID ("4217" mainnet, "42431" Moderato)',
+      contractAddress:
+        "string - TIP-20 stablecoin token contract to watch for payments",
+      recipientAddress:
+        "string - The deposit address to match against the transfer recipient",
+    },
+    optionalFields: {
+      memo: "string - Only fire when the transfer memo matches. A 0x + 64-hex value matches exactly; a shorter string matches as a prefix",
+    },
+    outputFields: {
+      "args.from": "string - Sender address of the payment",
+      "args.to": "string - Recipient address (the watched deposit address)",
+      "args.value": "string - Amount transferred, in the token's smallest unit",
+      "args.memo": "string - The bytes32 memo attached to the transfer",
+      transactionHash: "string - Hash of the payment transaction",
+      blockNumber: "number - Block height the payment landed in",
+      address: "string - The TIP-20 token contract that emitted the event",
+      triggeredAt:
+        "string - ISO timestamp when the payment was detected (available on all trigger types)",
+    },
+  },
 } as const;
 
 // =============================================================================

--- a/lib/rpc/rpc-config.ts
+++ b/lib/rpc/rpc-config.ts
@@ -35,6 +35,8 @@ export const PUBLIC_RPCS = {
   BASE_SEPOLIA: "https://sepolia.base.org",
   TEMPO_TESTNET: "https://rpc.testnet.tempo.xyz",
   TEMPO_MAINNET: "https://rpc.tempo.xyz",
+  TEMPO_TESTNET_WSS: "wss://rpc.moderato.tempo.xyz",
+  TEMPO_MAINNET_WSS: "wss://rpc.tempo.xyz",
   BSC_MAINNET: "https://bsc-dataseed.binance.org",
   BSC_MAINNET_FALLBACK: "https://rpc.ankr.com/bsc",
   BSC_TESTNET: "https://bsc-testnet-rpc.publicnode.com",
@@ -81,6 +83,11 @@ export type ChainConfigEntry = {
   fallbackEnvKey: string;
   publicDefault: string;
   publicFallback?: string;
+  // Public WebSocket defaults. Only set for chains that publish a reliable
+  // public WSS endpoint (e.g. Tempo). getWssUrl falls back to these when the
+  // JSON config has no WSS URL, mirroring publicDefault on the HTTP path.
+  publicWssDefault?: string;
+  publicWssFallback?: string;
 };
 
 export const CHAIN_CONFIG: Record<number, ChainConfigEntry> = {
@@ -119,6 +126,7 @@ export const CHAIN_CONFIG: Record<number, ChainConfigEntry> = {
     envKey: "CHAIN_TEMPO_TESTNET_PRIMARY_RPC",
     fallbackEnvKey: "CHAIN_TEMPO_TESTNET_FALLBACK_RPC",
     publicDefault: PUBLIC_RPCS.TEMPO_TESTNET,
+    publicWssDefault: PUBLIC_RPCS.TEMPO_TESTNET_WSS,
   },
   // Tempo Mainnet
   4217: {
@@ -126,6 +134,7 @@ export const CHAIN_CONFIG: Record<number, ChainConfigEntry> = {
     envKey: "CHAIN_TEMPO_MAINNET_PRIMARY_RPC",
     fallbackEnvKey: "CHAIN_TEMPO_MAINNET_FALLBACK_RPC",
     publicDefault: PUBLIC_RPCS.TEMPO_MAINNET,
+    publicWssDefault: PUBLIC_RPCS.TEMPO_MAINNET_WSS,
   },
   // BNB Chain (BSC) Mainnet
   56: {
@@ -444,14 +453,20 @@ export function getWssUrl(options: GetWssUrlOptions): string | undefined {
   const { rpcConfig, jsonKey, type } = options;
   const entry = rpcConfig[jsonKey];
 
-  if (!entry) {
-    return;
+  const fromJson =
+    type === "primary" ? entry?.primaryWssUrl : entry?.fallbackWssUrl;
+  if (fromJson) {
+    return fromJson;
   }
 
-  if (type === "primary") {
-    return entry.primaryWssUrl;
-  }
-  return entry.fallbackWssUrl;
+  // Fall back to the chain's public WSS default (mirrors the HTTP publicDefault
+  // path). Only chains that publish a reliable public WSS endpoint set this.
+  const chainEntry = Object.values(CHAIN_CONFIG).find(
+    (c) => c.jsonKey === jsonKey
+  );
+  return type === "primary"
+    ? chainEntry?.publicWssDefault
+    : chainEntry?.publicWssFallback;
 }
 
 /**

--- a/lib/web3/gas-strategy.ts
+++ b/lib/web3/gas-strategy.ts
@@ -586,6 +586,15 @@ export class AdaptiveGasStrategy {
         minPriorityFeeGwei: 4.0,
         maxPriorityFeeGwei: 500,
       },
+      // Tempo mainnet -- fees paid in a TIP-20 stablecoin, estimates are
+      // accurate, so an L2-like 1.5x limit multiplier is enough headroom.
+      4217: {
+        gasLimitMultiplier: 1.5,
+      },
+      // Tempo Moderato testnet
+      42431: {
+        gasLimitMultiplier: 1.5,
+      },
     };
 
     return overrides[chainId] || {};

--- a/lib/workflow/editor/trigger-output-fields.ts
+++ b/lib/workflow/editor/trigger-output-fields.ts
@@ -150,6 +150,36 @@ export function getBlockTriggerOutputFields(): OutputField[] {
 }
 
 /**
+ * Get output fields for the Tempo Payment Received trigger. The watched event
+ * is the fixed TIP-20 `TransferWithMemo(from, to, value, memo)`, so the decoded
+ * args are known up front (no ABI needed).
+ */
+export function getTempoPaymentOutputFields(): OutputField[] {
+  return [
+    { field: "args.from", description: "Sender address of the payment" },
+    {
+      field: "args.to",
+      description: "Recipient address (the watched deposit address)",
+    },
+    {
+      field: "args.value",
+      description: "Amount transferred, in the token's smallest unit",
+    },
+    {
+      field: "args.memo",
+      description: "The bytes32 memo attached to the transfer",
+    },
+    { field: "transactionHash", description: "Hash of the payment transaction" },
+    { field: "blockNumber", description: "Block height the payment landed in" },
+    {
+      field: "address",
+      description: "The TIP-20 token contract that emitted the event",
+    },
+    TRIGGERED_AT_FIELD,
+  ];
+}
+
+/**
  * Get output fields for a trigger node based on its configuration
  */
 export function getTriggerOutputFields(
@@ -158,6 +188,10 @@ export function getTriggerOutputFields(
 ): OutputField[] {
   if (triggerType === "Block") {
     return getBlockTriggerOutputFields();
+  }
+
+  if (triggerType === "Tempo Payment Received") {
+    return getTempoPaymentOutputFields();
   }
 
   if (triggerType === "Event") {

--- a/lib/workflow/store.ts
+++ b/lib/workflow/store.ts
@@ -16,6 +16,7 @@ export enum WorkflowTriggerEnum {
   WEBHOOK = "Webhook",
   EVENT = "Event", // keeperhub custom field //
   BLOCK = "Block", // keeperhub custom field //
+  TEMPO_PAYMENT = "Tempo Payment Received", // keeperhub custom field //
 }
 
 export type WorkflowTriggerType = `${WorkflowTriggerEnum}`;
@@ -31,7 +32,8 @@ export function shouldShowEnableSwitch(
     triggerType === WorkflowTriggerEnum.EVENT ||
     triggerType === WorkflowTriggerEnum.SCHEDULE ||
     triggerType === WorkflowTriggerEnum.BLOCK ||
-    triggerType === WorkflowTriggerEnum.WEBHOOK
+    triggerType === WorkflowTriggerEnum.WEBHOOK ||
+    triggerType === WorkflowTriggerEnum.TEMPO_PAYMENT
   );
 }
 

--- a/plugins/tempo/index.ts
+++ b/plugins/tempo/index.ts
@@ -29,7 +29,6 @@ const tempoPlugin: IntegrationPlugin = {
       description:
         "Send a TIP-20 stablecoin payment on Tempo carrying an on-chain bytes32 memo (e.g. an invoice or pay-run reference)",
       category: "Tempo",
-      requiresCredentials: true,
       stepFunction: "transferWithMemoStep",
       stepImportPath: "transfer-with-memo",
       outputFields: [
@@ -107,7 +106,6 @@ const tempoPlugin: IntegrationPlugin = {
       description:
         "Pay many recipients in one atomic Tempo transaction, each payment stamped with its own memo. All payments settle together or none do.",
       category: "Tempo",
-      requiresCredentials: true,
       stepFunction: "batchPayoutStep",
       stepImportPath: "batch-payout",
       outputFields: [
@@ -179,7 +177,6 @@ const tempoPlugin: IntegrationPlugin = {
       description:
         "Market-swap one Tempo stablecoin for another on the enshrined DEX, protected by a minimum-output slippage floor",
       category: "Tempo",
-      requiresCredentials: true,
       stepFunction: "dexSwapStep",
       stepImportPath: "dex-swap",
       outputFields: [
@@ -266,7 +263,6 @@ const tempoPlugin: IntegrationPlugin = {
       description:
         "Send a stablecoin payment bounded to an inclusion window (valid-after / valid-before) so it only lands during the intended timeframe",
       category: "Tempo",
-      requiresCredentials: true,
       stepFunction: "schedulePaymentStep",
       stepImportPath: "schedule-payment",
       outputFields: [

--- a/plugins/tempo/index.ts
+++ b/plugins/tempo/index.ts
@@ -173,6 +173,196 @@ const tempoPlugin: IntegrationPlugin = {
         },
       ],
     },
+    {
+      slug: "dex-swap",
+      label: "Swap Stablecoins",
+      description:
+        "Market-swap one Tempo stablecoin for another on the enshrined DEX, protected by a minimum-output slippage floor",
+      category: "Tempo",
+      requiresCredentials: true,
+      stepFunction: "dexSwapStep",
+      stepImportPath: "dex-swap",
+      outputFields: [
+        { field: "success", description: "Whether the swap succeeded" },
+        {
+          field: "transactionHash",
+          description: "The transaction hash of the swap",
+        },
+        {
+          field: "transactionLink",
+          description: "Explorer link to view the transaction",
+        },
+        { field: "from", description: "The swapping wallet address" },
+        { field: "tokenIn", description: "Symbol of the token sold" },
+        { field: "tokenOut", description: "Symbol of the token bought" },
+        { field: "amountIn", description: "Amount sold (human-readable)" },
+        {
+          field: "quotedOut",
+          description: "Quoted output amount at execution time (human-readable)",
+        },
+        {
+          field: "minAmountOut",
+          description:
+            "Minimum output enforced after slippage (human-readable)",
+        },
+        { field: "chainId", description: "The Tempo chain id used" },
+        { field: "error", description: "Error message if the swap failed" },
+      ],
+      configFields: [
+        {
+          key: "network",
+          label: "Network",
+          type: "chain-select",
+          chainTypeFilter: "evm",
+          allowedChainIds: TEMPO_CHAIN_IDS,
+          placeholder: "Select a Tempo network",
+          required: true,
+        },
+        {
+          key: "tokenInConfig",
+          label: "Sell Token",
+          type: "token-select",
+          networkField: "network",
+          required: true,
+        },
+        {
+          key: "tokenOutConfig",
+          label: "Buy Token",
+          type: "token-select",
+          networkField: "network",
+          required: true,
+        },
+        {
+          key: "amountIn",
+          label: "Amount to Sell",
+          type: "template-input",
+          placeholder: "1000 or {{NodeName.amount}}",
+          example: "1000",
+          required: true,
+        },
+        {
+          type: "group",
+          label: "Advanced",
+          defaultExpanded: false,
+          fields: [
+            {
+              key: "slippageBps",
+              label: "Max Slippage (bps)",
+              type: "number",
+              placeholder: "50",
+              defaultValue: "50",
+              min: 0,
+              max: 9999,
+              helpTip:
+                "Maximum slippage in basis points (50 = 0.5%). The swap reverts if the output falls below this floor.",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      slug: "schedule-payment",
+      label: "Scheduled Payment",
+      description:
+        "Send a stablecoin payment bounded to an inclusion window (valid-after / valid-before) so it only lands during the intended timeframe",
+      category: "Tempo",
+      requiresCredentials: true,
+      stepFunction: "schedulePaymentStep",
+      stepImportPath: "schedule-payment",
+      outputFields: [
+        { field: "success", description: "Whether the payment succeeded" },
+        {
+          field: "transactionHash",
+          description: "The transaction hash of the payment",
+        },
+        {
+          field: "transactionLink",
+          description: "Explorer link to view the transaction",
+        },
+        { field: "from", description: "The sending wallet address" },
+        { field: "to", description: "The recipient address" },
+        { field: "amount", description: "The amount paid (human-readable)" },
+        {
+          field: "memo",
+          description: "The bytes32 memo attached to the payment",
+        },
+        {
+          field: "validAfter",
+          description:
+            "Earliest inclusion time enforced (unix seconds), or null",
+        },
+        {
+          field: "validBefore",
+          description: "Latest inclusion time enforced (unix seconds)",
+        },
+        { field: "chainId", description: "The Tempo chain id used" },
+        { field: "error", description: "Error message if the payment failed" },
+      ],
+      configFields: [
+        {
+          key: "network",
+          label: "Network",
+          type: "chain-select",
+          chainTypeFilter: "evm",
+          allowedChainIds: TEMPO_CHAIN_IDS,
+          placeholder: "Select a Tempo network",
+          required: true,
+        },
+        {
+          key: "tokenConfig",
+          label: "Token",
+          type: "token-select",
+          networkField: "network",
+          required: true,
+        },
+        {
+          key: "amount",
+          label: "Amount",
+          type: "template-input",
+          placeholder: "100.50 or {{NodeName.amount}}",
+          example: "100.50",
+          required: true,
+        },
+        {
+          key: "recipientAddress",
+          label: "Recipient Address",
+          type: "template-input",
+          placeholder: "0x... or {{NodeName.address}}",
+          example: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+          required: true,
+        },
+        {
+          key: "memo",
+          label: "Memo",
+          type: "template-input",
+          placeholder: "INV-1042 or 0x... (32-byte hex)",
+          helpTip: "Attached on-chain as an indexed bytes32 topic.",
+        },
+        {
+          type: "group",
+          label: "Inclusion Window",
+          defaultExpanded: true,
+          fields: [
+            {
+              key: "validAfter",
+              label: "Valid After",
+              type: "template-input",
+              placeholder: "2026-07-31T09:00:00Z or unix seconds",
+              helpTip:
+                "Earliest time the payment may be included. Leave blank for no lower bound. Must not be in the future (v1 broadcasts during this run).",
+            },
+            {
+              key: "validBefore",
+              label: "Valid Before",
+              type: "template-input",
+              placeholder: "2026-07-31T17:00:00Z or unix seconds",
+              helpTip:
+                "Deadline after which the payment can no longer be included. Defaults to 15 minutes from now.",
+            },
+          ],
+        },
+      ],
+    },
   ],
 };
 

--- a/plugins/tempo/steps/batch-payout.ts
+++ b/plugins/tempo/steps/batch-payout.ts
@@ -171,6 +171,7 @@ async function stepHandler(input: BatchPayoutInput): Promise<BatchPayoutResult> 
       chainId,
       calls,
       feeToken: token.address,
+      executionId: _context?.executionId,
     });
 
     const transactionLink = await buildTempoTxLink(chainId, hash);

--- a/plugins/tempo/steps/dex-swap.ts
+++ b/plugins/tempo/steps/dex-swap.ts
@@ -152,6 +152,7 @@ async function stepHandler(input: DexSwapInput): Promise<DexSwapResult> {
       chainId,
       calls: [call],
       feeToken: tokenIn.address,
+      executionId: _context?.executionId,
     });
 
     const transactionLink = await buildTempoTxLink(chainId, hash);

--- a/plugins/tempo/steps/dex-swap.ts
+++ b/plugins/tempo/steps/dex-swap.ts
@@ -1,0 +1,196 @@
+import "server-only";
+
+import { ethers } from "ethers";
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { getErrorMessage } from "@/lib/utils";
+import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
+import {
+  type StepInput,
+  withStepLogging,
+} from "@/lib/workflow/executor/step-handler";
+import {
+  buildSwapExactAmountInCall,
+  signAndBroadcastTempoTx,
+} from "./tempo-tx-core";
+import {
+  assertTempoChain,
+  buildTempoTxLink,
+  quoteTempoSwap,
+  resolveTempoToken,
+} from "./tempo-step-helpers";
+
+const MAX_UINT128 = (BigInt(1) << BigInt(128)) - BigInt(1);
+const DEFAULT_SLIPPAGE_BPS = 50; // 0.5%
+const BPS_DENOMINATOR = 10_000;
+
+export type DexSwapInput = StepInput & {
+  network: string;
+  tokenInConfig: string | Record<string, unknown>;
+  tokenOutConfig: string | Record<string, unknown>;
+  amountIn: string;
+  slippageBps?: string | number;
+};
+
+export type DexSwapResult =
+  | {
+      success: true;
+      transactionHash: string;
+      transactionLink: string;
+      from: string;
+      tokenIn: string;
+      tokenOut: string;
+      amountIn: string;
+      quotedOut: string;
+      minAmountOut: string;
+      chainId: number;
+    }
+  | { success: false; error: string };
+
+function parseSlippageBps(raw: string | number | undefined): number | null {
+  if (raw === undefined || raw === "") {
+    return DEFAULT_SLIPPAGE_BPS;
+  }
+  const value = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isFinite(value) || value < 0 || value >= BPS_DENOMINATOR) {
+    return null;
+  }
+  return Math.floor(value);
+}
+
+async function stepHandler(input: DexSwapInput): Promise<DexSwapResult> {
+  const { network, tokenInConfig, tokenOutConfig, amountIn, _context } = input;
+
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(network);
+    assertTempoChain(chainId);
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  if (!amountIn || amountIn.trim() === "") {
+    return { success: false, error: "Amount is required" };
+  }
+  const slippageBps = parseSlippageBps(input.slippageBps);
+  if (slippageBps === null) {
+    return {
+      success: false,
+      error: "Slippage must be between 0 and 9999 basis points",
+    };
+  }
+
+  if (!(_context?.executionId || _context?.organizationId)) {
+    return {
+      success: false,
+      error: "Execution ID or organization ID is required",
+    };
+  }
+  const orgCtx = await resolveOrganizationContext(
+    _context,
+    "[Tempo DEX Swap]",
+    "dex-swap"
+  );
+  if (!orgCtx.success) {
+    return orgCtx;
+  }
+
+  try {
+    const rpcManager = await getRpcProvider({
+      chainId,
+      userId: orgCtx.userId,
+    });
+    const [tokenIn, tokenOut] = await Promise.all([
+      resolveTempoToken(tokenInConfig, chainId, rpcManager),
+      resolveTempoToken(tokenOutConfig, chainId, rpcManager),
+    ]);
+    if (tokenIn.address.toLowerCase() === tokenOut.address.toLowerCase()) {
+      return {
+        success: false,
+        error: "tokenIn and tokenOut must be different tokens",
+      };
+    }
+
+    const amountInRaw = ethers.parseUnits(amountIn, tokenIn.decimals);
+    if (amountInRaw <= BigInt(0)) {
+      return { success: false, error: "Amount must be greater than zero" };
+    }
+    if (amountInRaw > MAX_UINT128) {
+      return {
+        success: false,
+        error: "Amount exceeds the uint128 limit supported by the DEX",
+      };
+    }
+
+    const quotedOut = await quoteTempoSwap(
+      rpcManager,
+      tokenIn.address,
+      tokenOut.address,
+      amountInRaw
+    );
+    if (quotedOut <= BigInt(0)) {
+      return {
+        success: false,
+        error: `No DEX liquidity for ${tokenIn.symbol} to ${tokenOut.symbol}`,
+      };
+    }
+    const minAmountOut =
+      (quotedOut * BigInt(BPS_DENOMINATOR - slippageBps)) /
+      BigInt(BPS_DENOMINATOR);
+
+    const call = buildSwapExactAmountInCall(
+      tokenIn.address,
+      tokenOut.address,
+      amountInRaw,
+      minAmountOut
+    );
+    const { hash, from } = await signAndBroadcastTempoTx({
+      organizationId: orgCtx.organizationId,
+      userId: orgCtx.userId,
+      chainId,
+      calls: [call],
+      feeToken: tokenIn.address,
+    });
+
+    const transactionLink = await buildTempoTxLink(chainId, hash);
+    return {
+      success: true,
+      transactionHash: hash,
+      transactionLink,
+      from,
+      tokenIn: tokenIn.symbol,
+      tokenOut: tokenOut.symbol,
+      amountIn,
+      quotedOut: ethers.formatUnits(quotedOut, tokenOut.decimals),
+      minAmountOut: ethers.formatUnits(minAmountOut, tokenOut.decimals),
+      chainId,
+    };
+  } catch (error) {
+    logUserError(
+      ErrorCategory.TRANSACTION,
+      "[Tempo DEX Swap] dex-swap failed",
+      error,
+      { plugin_name: "tempo", action_name: "dex-swap" }
+    );
+    return { success: false, error: getErrorMessage(error) };
+  }
+}
+
+export async function dexSwapStep(input: DexSwapInput): Promise<DexSwapResult> {
+  "use step";
+
+  return withPluginMetrics(
+    {
+      pluginName: "tempo",
+      actionName: "dex-swap",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => stepHandler(input))
+  );
+}
+
+dexSwapStep.maxRetries = 0;
+
+export const _integrationType = "tempo";

--- a/plugins/tempo/steps/schedule-payment.ts
+++ b/plugins/tempo/steps/schedule-payment.ts
@@ -1,0 +1,216 @@
+import "server-only";
+
+import { ethers } from "ethers";
+import type { Hex } from "viem";
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { getErrorMessage } from "@/lib/utils";
+import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
+import {
+  type StepInput,
+  withStepLogging,
+} from "@/lib/workflow/executor/step-handler";
+import {
+  buildTransferWithMemoCall,
+  normalizeMemo,
+  signAndBroadcastTempoTx,
+} from "./tempo-tx-core";
+import {
+  assertTempoChain,
+  buildTempoTxLink,
+  resolveTempoToken,
+} from "./tempo-step-helpers";
+
+// v1 broadcasts within the triggering run, so the window bounds inclusion time,
+// it does not defer the send. Default the deadline to a short window when unset.
+const DEFAULT_WINDOW_SEC = 900; // 15 minutes
+const UNIX_SECONDS = /^\d+$/;
+const MILLIS_THRESHOLD = 1e12;
+
+export type SchedulePaymentInput = StepInput & {
+  network: string;
+  tokenConfig: string | Record<string, unknown>;
+  amount: string;
+  recipientAddress: string;
+  memo?: string;
+  validAfter?: string;
+  validBefore?: string;
+};
+
+export type SchedulePaymentResult =
+  | {
+      success: true;
+      transactionHash: string;
+      transactionLink: string;
+      from: string;
+      to: string;
+      amount: string;
+      memo: string;
+      validAfter: number | null;
+      validBefore: number;
+      chainId: number;
+    }
+  | { success: false; error: string };
+
+/**
+ * Parse an ISO datetime or unix timestamp into unix seconds. Returns undefined
+ * when the field is blank; throws on an unparseable value.
+ */
+function parseTimestamp(raw: string | undefined): number | undefined {
+  if (!raw || raw.trim() === "") {
+    return;
+  }
+  const value = raw.trim();
+  if (UNIX_SECONDS.test(value)) {
+    const numeric = Number(value);
+    return numeric > MILLIS_THRESHOLD ? Math.floor(numeric / 1000) : numeric;
+  }
+  const millis = Date.parse(value);
+  if (Number.isNaN(millis)) {
+    throw new Error(
+      `Invalid date "${value}": use an ISO datetime (2026-07-31T17:00:00Z) or a unix timestamp.`
+    );
+  }
+  return Math.floor(millis / 1000);
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: linear guard chain over the payment window
+async function stepHandler(
+  input: SchedulePaymentInput
+): Promise<SchedulePaymentResult> {
+  const { network, tokenConfig, amount, recipientAddress, memo, _context } =
+    input;
+
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(network);
+    assertTempoChain(chainId);
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  if (!ethers.isAddress(recipientAddress)) {
+    return {
+      success: false,
+      error: `Invalid recipient address: ${recipientAddress}`,
+    };
+  }
+  if (!amount || amount.trim() === "") {
+    return { success: false, error: "Amount is required" };
+  }
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  let validAfterSec: number | undefined;
+  let validBeforeSec: number;
+  try {
+    validAfterSec = parseTimestamp(input.validAfter);
+    validBeforeSec = parseTimestamp(input.validBefore) ?? nowSec + DEFAULT_WINDOW_SEC;
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  if (validBeforeSec <= nowSec) {
+    return {
+      success: false,
+      error: "The payment window (validBefore) is already in the past.",
+    };
+  }
+  if (validAfterSec !== undefined && validAfterSec > nowSec) {
+    return {
+      success: false,
+      error:
+        "validAfter is in the future. Scheduled payments broadcast during this run, so trigger the workflow within the window; deferred pre-signing is not yet supported.",
+    };
+  }
+  if (validAfterSec !== undefined && validBeforeSec <= validAfterSec) {
+    return {
+      success: false,
+      error: "validBefore must be after validAfter.",
+    };
+  }
+
+  if (!(_context?.executionId || _context?.organizationId)) {
+    return {
+      success: false,
+      error: "Execution ID or organization ID is required",
+    };
+  }
+  const orgCtx = await resolveOrganizationContext(
+    _context,
+    "[Tempo Scheduled Payment]",
+    "schedule-payment"
+  );
+  if (!orgCtx.success) {
+    return orgCtx;
+  }
+
+  try {
+    const rpcManager = await getRpcProvider({
+      chainId,
+      userId: orgCtx.userId,
+    });
+    const token = await resolveTempoToken(tokenConfig, chainId, rpcManager);
+    const amountRaw = ethers.parseUnits(amount, token.decimals);
+    const recipient = ethers.getAddress(recipientAddress) as Hex;
+    const memoBytes = normalizeMemo(memo);
+
+    const call = buildTransferWithMemoCall(
+      token.address,
+      recipient,
+      amountRaw,
+      memoBytes
+    );
+    const { hash, from } = await signAndBroadcastTempoTx({
+      organizationId: orgCtx.organizationId,
+      userId: orgCtx.userId,
+      chainId,
+      calls: [call],
+      feeToken: token.address,
+      validAfter: validAfterSec,
+      validBefore: validBeforeSec,
+    });
+
+    const transactionLink = await buildTempoTxLink(chainId, hash);
+    return {
+      success: true,
+      transactionHash: hash,
+      transactionLink,
+      from,
+      to: recipient,
+      amount,
+      memo: memoBytes,
+      validAfter: validAfterSec ?? null,
+      validBefore: validBeforeSec,
+      chainId,
+    };
+  } catch (error) {
+    logUserError(
+      ErrorCategory.TRANSACTION,
+      "[Tempo Scheduled Payment] schedule-payment failed",
+      error,
+      { plugin_name: "tempo", action_name: "schedule-payment" }
+    );
+    return { success: false, error: getErrorMessage(error) };
+  }
+}
+
+export async function schedulePaymentStep(
+  input: SchedulePaymentInput
+): Promise<SchedulePaymentResult> {
+  "use step";
+
+  return withPluginMetrics(
+    {
+      pluginName: "tempo",
+      actionName: "schedule-payment",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => stepHandler(input))
+  );
+}
+
+schedulePaymentStep.maxRetries = 0;
+
+export const _integrationType = "tempo";

--- a/plugins/tempo/steps/schedule-payment.ts
+++ b/plugins/tempo/steps/schedule-payment.ts
@@ -26,6 +26,10 @@ import {
 // v1 broadcasts within the triggering run, so the window bounds inclusion time,
 // it does not defer the send. Default the deadline to a short window when unset.
 const DEFAULT_WINDOW_SEC = 900; // 15 minutes
+// A window closing sooner than this can lapse before the payment is signed,
+// broadcast, and included, so reject it upfront instead of letting it time out
+// after the receipt wait.
+const MIN_INCLUSION_BUFFER_SEC = 60;
 const UNIX_SECONDS = /^\d+$/;
 const MILLIS_THRESHOLD = 1e12;
 
@@ -111,10 +115,11 @@ async function stepHandler(
     return { success: false, error: getErrorMessage(error) };
   }
 
-  if (validBeforeSec <= nowSec) {
+  if (validBeforeSec < nowSec + MIN_INCLUSION_BUFFER_SEC) {
     return {
       success: false,
-      error: "The payment window (validBefore) is already in the past.",
+      error:
+        "The payment window closes too soon: validBefore must be at least 60 seconds ahead so the payment can be signed and settle before it lapses.",
     };
   }
   if (validAfterSec !== undefined && validAfterSec > nowSec) {

--- a/plugins/tempo/steps/schedule-payment.ts
+++ b/plugins/tempo/steps/schedule-payment.ts
@@ -170,6 +170,7 @@ async function stepHandler(
       feeToken: token.address,
       validAfter: validAfterSec,
       validBefore: validBeforeSec,
+      executionId: _context?.executionId,
     });
 
     const transactionLink = await buildTempoTxLink(chainId, hash);

--- a/plugins/tempo/steps/tempo-step-helpers.ts
+++ b/plugins/tempo/steps/tempo-step-helpers.ts
@@ -12,12 +12,17 @@ import { db } from "@/lib/db";
 import { explorerConfigs, supportedTokens } from "@/lib/db/schema";
 import { getTransactionUrl } from "@/lib/explorer";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
-import { isTempoChain } from "./tempo-tx-core";
+import { isTempoChain, TEMPO_STABLECOIN_DEX } from "./tempo-tx-core";
 
 const ERC20_META_ABI = [
   "function decimals() view returns (uint8)",
   "function symbol() view returns (string)",
 ] as const;
+
+const DEX_QUOTE_ABI = [
+  "function quoteSwapExactAmountIn(address tokenIn, address tokenOut, uint128 amountIn) view returns (uint128 amountOut)",
+] as const;
+const dexInterface = new ethers.Interface(DEX_QUOTE_ABI);
 
 export type TempoToken = { address: Hex; decimals: number; symbol: string };
 
@@ -113,6 +118,32 @@ export async function resolveTempoToken(
   }
 
   throw new Error("Could not resolve the selected token to a contract address");
+}
+
+/**
+ * Quote a stablecoin-DEX swap: how much `tokenOut` a given `amountIn` of
+ * `tokenIn` buys right now. A view call against the enshrined DEX precompile,
+ * routed through RPC failover. The caller applies the slippage floor.
+ */
+export async function quoteTempoSwap(
+  rpcManager: RpcProviderManager,
+  tokenIn: string,
+  tokenOut: string,
+  amountIn: bigint
+): Promise<bigint> {
+  const data = dexInterface.encodeFunctionData("quoteSwapExactAmountIn", [
+    tokenIn,
+    tokenOut,
+    amountIn,
+  ]);
+  const raw = await rpcManager.executeWithFailover((provider) =>
+    provider.call({ to: TEMPO_STABLECOIN_DEX, data })
+  );
+  const [amountOut] = dexInterface.decodeFunctionResult(
+    "quoteSwapExactAmountIn",
+    raw
+  );
+  return BigInt(amountOut);
 }
 
 export function assertTempoChain(chainId: number): void {

--- a/plugins/tempo/steps/tempo-tx-core.ts
+++ b/plugins/tempo/steps/tempo-tx-core.ts
@@ -55,16 +55,29 @@ const nonceInterface = new ethers.Interface(NONCE_ABI);
 const MAX_UINT256 = (BigInt(1) << BigInt(256)) - BigInt(1);
 
 /**
- * Fixed nonce lane for KeeperHub-initiated Tempo transactions. A stable,
- * KeeperHub-specific 2D-nonce key keeps our sequence out of lane 0 (the
- * protocol nonce) and the max-uint256 lane (the expiring marker). Concurrent
- * sends from the same wallet on this lane race on the read-then-sign; that is
- * an accepted v1 limitation for the monthly-cadence payout flows (mainnet
- * hardening is a follow-up).
+ * Derive a unique 2D-nonce lane for a single send. Tempo's nonce manager keeps
+ * an independent sequence per (account, key), so giving every broadcast its own
+ * key removes the read-then-sign race: two concurrent sends from one wallet
+ * never share a lane, so neither reads a nonce the other is about to consume.
+ *
+ * The key is namespaced under a KeeperHub-specific prefix and salted with random
+ * bytes, so it stays unique even when two sends share an execution (parallel
+ * branches) or carry no execution id. The execution id is folded in only so a
+ * lane traces back to its run in logs. The result is mapped into
+ * [1, MAX_UINT256 - 1] to stay off lane 0 (the protocol nonce) and the
+ * max-uint256 expiring-marker lane.
  */
-const KEEPERHUB_TEMPO_NONCE_KEY = BigInt(
-  ethers.keccak256(ethers.toUtf8Bytes("keeperhub:tempo:nonce-lane:v1"))
-);
+export function deriveTempoNonceKey(executionId: string | undefined): bigint {
+  const salt = ethers.hexlify(ethers.randomBytes(16));
+  const raw = BigInt(
+    ethers.keccak256(
+      ethers.toUtf8Bytes(
+        `keeperhub:tempo:nonce-lane:v2:${executionId ?? "adhoc"}:${salt}`
+      )
+    )
+  );
+  return (raw % (MAX_UINT256 - BigInt(1))) + BigInt(1);
+}
 
 const RECEIPT_TIMEOUT_MS = 60_000;
 const RECEIPT_POLL_INTERVAL_MS = 1500;
@@ -95,6 +108,8 @@ export type SignAndBroadcastParams = {
   /** Optional inclusion window (unix seconds) for scheduled payments. */
   validAfter?: number;
   validBefore?: number;
+  /** Execution id, folded into the per-send nonce lane for traceability. */
+  executionId?: string;
 };
 
 export type SignAndBroadcastResult = { hash: string; from: string };
@@ -310,9 +325,14 @@ export async function signAndBroadcastTempoTx(
   }
   const from = toChecksumAddress(wallet.walletAddress);
 
+  // A fresh lane per send: concurrent sends from this wallet never share a
+  // 2D-nonce sequence, so the read below cannot return a nonce another send is
+  // about to consume.
+  const nonceKey = deriveTempoNonceKey(params.executionId);
+
   const rpcManager = await getRpcProvider({ chainId, userId });
   const [nonce, estimatedGas] = await Promise.all([
-    readTempoNonce(rpcManager, from, KEEPERHUB_TEMPO_NONCE_KEY),
+    readTempoNonce(rpcManager, from, nonceKey),
     estimateTempoGas(rpcManager, from, calls),
   ]);
 
@@ -332,7 +352,7 @@ export async function signAndBroadcastTempoTx(
     chainId,
     calls: calls.map((c) => ({ to: c.to, data: c.data })),
     nonce,
-    nonceKey: KEEPERHUB_TEMPO_NONCE_KEY,
+    nonceKey,
     feeToken,
     gas: gasConfig.gasLimit,
     maxFeePerGas: gasConfig.maxFeePerGas,

--- a/plugins/tempo/steps/tempo-tx-core.ts
+++ b/plugins/tempo/steps/tempo-tx-core.ts
@@ -43,6 +43,10 @@ import { getOrganizationWallet } from "@/lib/web3/wallet-helpers";
 /** Tempo nonce-manager precompile (viem/tempo Addresses.nonceManager). */
 const TEMPO_NONCE_MANAGER = "0x4e4F4E4345000000000000000000000000000000";
 
+/** Tempo enshrined stablecoin DEX precompile (viem/tempo Addresses.stablecoinDex). */
+export const TEMPO_STABLECOIN_DEX =
+  "0xdec0000000000000000000000000000000000000" as const;
+
 const NONCE_ABI = [
   "function getNonce(address account, uint256 nonceKey) view returns (uint64)",
 ] as const;
@@ -88,6 +92,9 @@ export type SignAndBroadcastParams = {
   calls: TempoCall[];
   /** TIP-20 stablecoin the fee is drawn from (usually the transferred token). */
   feeToken: Hex;
+  /** Optional inclusion window (unix seconds) for scheduled payments. */
+  validAfter?: number;
+  validBefore?: number;
 };
 
 export type SignAndBroadcastResult = { hash: string; from: string };
@@ -111,6 +118,27 @@ export function buildTransferWithMemoCall(
     args: [recipient, amountRaw, memo],
   });
   return { to: token, data };
+}
+
+/**
+ * Encode a `swapExactAmountIn(tokenIn, tokenOut, amountIn, minAmountOut)` call
+ * against the enshrined stablecoin DEX precompile. The DEX pulls tokenIn from
+ * the wallet and settles tokenOut back to it (hybrid balance model), so this is
+ * a single call with no approve/deposit; the swap reverts if the output would
+ * fall below `minAmountOut`.
+ */
+export function buildSwapExactAmountInCall(
+  tokenIn: Hex,
+  tokenOut: Hex,
+  amountIn: bigint,
+  minAmountOut: bigint
+): TempoCall {
+  const data = encodeFunctionData({
+    abi: Abis.stablecoinDex,
+    functionName: "swapExactAmountIn",
+    args: [tokenIn, tokenOut, amountIn, minAmountOut],
+  });
+  return { to: TEMPO_STABLECOIN_DEX, data };
 }
 
 /**
@@ -309,6 +337,8 @@ export async function signAndBroadcastTempoTx(
     gas: gasConfig.gasLimit,
     maxFeePerGas: gasConfig.maxFeePerGas,
     maxPriorityFeePerGas: gasConfig.maxPriorityFeePerGas,
+    validAfter: params.validAfter,
+    validBefore: params.validBefore,
   });
 
   const sighash = TxEnvelopeTempo.getSignPayload(envelope);

--- a/plugins/tempo/steps/tempo-tx-core.ts
+++ b/plugins/tempo/steps/tempo-tx-core.ts
@@ -17,7 +17,9 @@
  * Fee model: no gas token. Fees are paid in a TIP-20 stablecoin set via the
  * envelope's `feeToken` field, drawn from the wallet's own balance. Turnkey
  * Gas Station sponsorship does not cover Tempo, so there is no sponsored path
- * here -- the wallet pays its own fees.
+ * here -- the wallet pays its own fees. Gas limit and fee prices come from the
+ * shared AdaptiveGasStrategy (per-call eth_estimateGas times the chain
+ * multiplier for the limit; live feeHistory for the prices), not constants.
  *
  * Nonce model: a persistent 2D nonce read from the nonce-manager precompile.
  * The TIP-1009 expiring-nonce marker used by the sponsored MPP path is only
@@ -35,6 +37,7 @@ import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import { resolveSignerMode, SIGNER_MODE } from "@/lib/safe/signer-resolver";
 import { getTurnkeySignerConfig } from "@/lib/turnkey/turnkey-client";
+import { getGasStrategy } from "@/lib/web3/gas-strategy";
 import { getOrganizationWallet } from "@/lib/web3/wallet-helpers";
 
 /** Tempo nonce-manager precompile (viem/tempo Addresses.nonceManager). */
@@ -58,12 +61,6 @@ const MAX_UINT256 = (BigInt(1) << BigInt(256)) - BigInt(1);
 const KEEPERHUB_TEMPO_NONCE_KEY = BigInt(
   ethers.keccak256(ethers.toUtf8Bytes("keeperhub:tempo:nonce-lane:v1"))
 );
-
-/** Conservative fee defaults. Tempo's observed base fee runs ~20 gwei. */
-const DEFAULT_MAX_FEE_PER_GAS = BigInt(50_000_000_000); // 50 gwei
-const DEFAULT_MAX_PRIORITY_FEE_PER_GAS = BigInt(1_000_000_000); // 1 gwei
-const GAS_BASE = BigInt(120_000);
-const GAS_PER_CALL = BigInt(120_000);
 
 const RECEIPT_TIMEOUT_MS = 60_000;
 const RECEIPT_POLL_INTERVAL_MS = 1500;
@@ -91,9 +88,6 @@ export type SignAndBroadcastParams = {
   calls: TempoCall[];
   /** TIP-20 stablecoin the fee is drawn from (usually the transferred token). */
   feeToken: Hex;
-  gas?: bigint;
-  maxFeePerGas?: bigint;
-  maxPriorityFeePerGas?: bigint;
 };
 
 export type SignAndBroadcastResult = { hash: string; from: string };
@@ -144,8 +138,29 @@ export function normalizeMemo(memo?: string): Hex {
   }
 }
 
-function defaultGas(callCount: number): bigint {
-  return GAS_BASE + GAS_PER_CALL * BigInt(Math.max(callCount, 1));
+/**
+ * Estimate execution gas for the batch by summing per-call estimates. The
+ * atomic 0x76 envelope is not directly estimable via eth_estimateGas, so each
+ * call is estimated as a standalone call from the wallet; summing slightly
+ * over-counts the shared intrinsic cost, which is safe (on Tempo the fee is
+ * charged on gas used, not the limit). The AdaptiveGasStrategy multiplier then
+ * adds the safety margin on top.
+ */
+async function estimateTempoGas(
+  rpcManager: RpcProviderManager,
+  from: string,
+  calls: TempoCall[]
+): Promise<bigint> {
+  let total = BigInt(0);
+  for (const call of calls) {
+    const gas = await rpcManager.executeWithFailover(
+      (provider) =>
+        provider.estimateGas({ from, to: call.to, data: call.data }),
+      "preflight"
+    );
+    total += gas;
+  }
+  return total;
 }
 
 async function readTempoNonce(
@@ -268,10 +283,21 @@ export async function signAndBroadcastTempoTx(
   const from = toChecksumAddress(wallet.walletAddress);
 
   const rpcManager = await getRpcProvider({ chainId, userId });
-  const nonce = await readTempoNonce(
-    rpcManager,
-    from,
-    KEEPERHUB_TEMPO_NONCE_KEY
+  const [nonce, estimatedGas] = await Promise.all([
+    readTempoNonce(rpcManager, from, KEEPERHUB_TEMPO_NONCE_KEY),
+    estimateTempoGas(rpcManager, from, calls),
+  ]);
+
+  // Gas limit (estimate x chain multiplier) and EIP-1559 fee prices come from
+  // the shared adaptive strategy, so Tempo tracks live network state the same
+  // way every other EVM write step does.
+  const gasConfig = await getGasStrategy().getGasConfig(
+    rpcManager.getProvider(),
+    estimatedGas,
+    chainId,
+    undefined,
+    undefined,
+    rpcManager
   );
 
   const envelope = TxEnvelopeTempo.from({
@@ -280,10 +306,9 @@ export async function signAndBroadcastTempoTx(
     nonce,
     nonceKey: KEEPERHUB_TEMPO_NONCE_KEY,
     feeToken,
-    gas: params.gas ?? defaultGas(calls.length),
-    maxFeePerGas: params.maxFeePerGas ?? DEFAULT_MAX_FEE_PER_GAS,
-    maxPriorityFeePerGas:
-      params.maxPriorityFeePerGas ?? DEFAULT_MAX_PRIORITY_FEE_PER_GAS,
+    gas: gasConfig.gasLimit,
+    maxFeePerGas: gasConfig.maxFeePerGas,
+    maxPriorityFeePerGas: gasConfig.maxPriorityFeePerGas,
   });
 
   const sighash = TxEnvelopeTempo.getSignPayload(envelope);

--- a/plugins/tempo/steps/transfer-with-memo.ts
+++ b/plugins/tempo/steps/transfer-with-memo.ts
@@ -105,6 +105,7 @@ async function stepHandler(
       chainId,
       calls: [call],
       feeToken: token.address,
+      executionId: _context?.executionId,
     });
 
     const transactionLink = await buildTempoTxLink(chainId, hash);

--- a/scripts/seed/fixtures/tempo-templates.ts
+++ b/scripts/seed/fixtures/tempo-templates.ts
@@ -1,0 +1,351 @@
+/**
+ * Tempo demo workflow templates.
+ *
+ * Three deployable, publicly-listed templates that exercise the Tempo plugin
+ * end to end: Invoice Reconciliation (payment-received trigger + memo match),
+ * Contractor Batch Payroll (atomic batch payout), and Treasury Sweep (DEX swap
+ * plus windowed disbursement). Seeded via seed-tempo-templates.ts and surfaced
+ * through /api/workflows/public + MCP deploy_template.
+ *
+ * Clone-time fields (deposit address, payee API, recipients, amounts, notify
+ * email) are seeded as `{{placeholder}}` tokens rather than empty strings: an
+ * empty required field makes the cloned workflow fail save-validation, whereas
+ * a template token passes validation and reads as "replace me". The cloner
+ * swaps each token for a concrete value or an upstream-node reference. Seeded
+ * against Tempo Moderato testnet (42431); to point a clone at mainnet, flip the
+ * network to 4217 and swap the token addresses.
+ */
+
+import { computeAutoLayout } from "@/lib/workflow/editor/auto-layout";
+import {
+  buildActionNode,
+  buildConditionNode,
+  buildEdge,
+  buildTriggerNode,
+  type WorkflowNodeJson,
+} from "@/lib/workflow/node-builders";
+
+const TEMPO_TESTNET = "42431";
+// PathUSD (enshrined) and AlphaUSD on Moderato, both 6-decimal stablecoins.
+const PATH_USD = "0x20c0000000000000000000000000000000000000";
+const ALPHA_USD = "0x20c0000000000000000000000000000000000001";
+
+export type TempoTemplateFixture = {
+  id: string;
+  listedSlug: string;
+  name: string;
+  description: string;
+  category: string;
+  chain: string;
+  inputSchema: Record<string, unknown>;
+  nodes: unknown[];
+  edges: unknown[];
+};
+
+/**
+ * Email notification node. Built inline (not via `buildEmailNode`) so the
+ * config carries only the action's own fields. `buildEmailNode` also writes
+ * `useKeeperHubApiKey`, which is a plugin form field rather than an action
+ * config field: the save-time validator rejects it as an unknown field, and it
+ * cannot be cleared from the node config panel. The send-email step always uses
+ * the KeeperHub API key regardless, so omitting it changes nothing at runtime.
+ */
+function buildTempoEmailNode(
+  id: string,
+  to: string,
+  subject: string,
+  body: string,
+  yOffset: number
+): WorkflowNodeJson {
+  return buildActionNode(
+    id,
+    "Send Email Alert",
+    "Send an email notification",
+    {
+      actionType: "sendgrid/send-email",
+      emailTo: to,
+      emailSubject: subject,
+      emailBody: body,
+    },
+    yOffset
+  );
+}
+
+function withAutoLayout(fixture: TempoTemplateFixture): TempoTemplateFixture {
+  const positions = computeAutoLayout(
+    fixture.nodes as unknown as Parameters<typeof computeAutoLayout>[0],
+    fixture.edges as unknown as Parameters<typeof computeAutoLayout>[1]
+  );
+  const nodes = (fixture.nodes as WorkflowNodeJson[]).map((node) => {
+    const pos = positions.get(node.id);
+    return pos ? { ...node, position: pos } : node;
+  });
+  return { ...fixture, nodes };
+}
+
+const RAW_FIXTURES: TempoTemplateFixture[] = [
+  {
+    id: "tempo-invoice-reconciliation",
+    listedSlug: "tempo-invoice-reconciliation",
+    name: "Tempo Invoice Reconciliation",
+    description:
+      "When a stablecoin payment lands on your Tempo deposit address whose memo matches an open invoice, mark it paid in your accounting system and email the customer a receipt.",
+    category: "Payments",
+    chain: TEMPO_TESTNET,
+    inputSchema: {
+      type: "object",
+      properties: {
+        depositAddress: {
+          type: "string",
+          description: "Your Tempo deposit address to watch for payments",
+        },
+        accountingApiUrl: {
+          type: "string",
+          description: "URL your workflow POSTs to when an invoice is paid",
+        },
+        notifyEmail: {
+          type: "string",
+          description: "Email address that receives the payment receipt",
+        },
+      },
+      required: ["depositAddress"],
+    },
+    nodes: [
+      buildTriggerNode("trigger-1", {
+        triggerType: "Tempo Payment Received",
+        network: TEMPO_TESTNET,
+        contractAddress: PATH_USD,
+        recipientAddress: "",
+        memo: "",
+      }),
+      buildConditionNode(
+        "step-1",
+        {
+          condition: "{{@trigger-1:Tempo Payment Received.args.value}} >= 0",
+          group: {
+            id: "group-1",
+            logic: "AND",
+            rules: [
+              {
+                id: "rule-1",
+                leftOperand:
+                  "{{@trigger-1:Tempo Payment Received.args.value}}",
+                operator: ">=",
+                rightOperand: "0",
+              },
+            ],
+          },
+        },
+        400
+      ),
+      buildActionNode(
+        "step-2",
+        "Mark Invoice Paid",
+        "POST to your accounting API to mark the invoice paid",
+        {
+          actionType: "HTTP Request",
+          method: "POST",
+          url: "{{accountingApiUrl}}",
+          body: '{"memo":"{{@trigger-1:Tempo Payment Received.args.memo}}","amount":"{{@trigger-1:Tempo Payment Received.args.value}}"}',
+        },
+        600
+      ),
+      buildTempoEmailNode(
+        "step-3",
+        "{{notifyEmail}}",
+        "Payment received",
+        "We received your payment on Tempo. View it on explore.testnet.tempo.xyz. Thank you!",
+        800
+      ),
+    ],
+    edges: [
+      buildEdge("trigger-1", "step-1"),
+      buildEdge("step-1", "step-2", "true"),
+      buildEdge("step-2", "step-3"),
+    ],
+  },
+
+  {
+    id: "tempo-contractor-batch-payroll",
+    listedSlug: "tempo-contractor-batch-payroll",
+    name: "Tempo Contractor Batch Payroll",
+    description:
+      "On the first of every month, pay your contractors their stablecoin amounts on Tempo in a single atomic batch transaction, each stamped with the pay-run id, and email yourself the confirmation.",
+    category: "Payments",
+    chain: TEMPO_TESTNET,
+    inputSchema: {
+      type: "object",
+      properties: {
+        payeeApiUrl: {
+          type: "string",
+          description: "URL returning the approved payee list as JSON",
+        },
+        notifyEmail: {
+          type: "string",
+          description: "Email address that receives the payroll confirmation",
+        },
+      },
+      required: [],
+    },
+    nodes: [
+      buildTriggerNode("trigger-1", {
+        triggerType: "Schedule",
+        scheduleCron: "0 9 1 * *",
+        scheduleTimezone: "UTC",
+      }),
+      buildActionNode(
+        "step-1",
+        "Fetch Payees",
+        "Fetch the approved payee list from your payroll API",
+        { actionType: "HTTP Request", method: "GET", url: "{{payeeApiUrl}}" },
+        400
+      ),
+      buildActionNode(
+        "step-2",
+        "Batch Payout",
+        "Pay all contractors in one atomic Tempo transaction",
+        {
+          actionType: "tempo/batch-payout",
+          network: TEMPO_TESTNET,
+          tokenConfig: PATH_USD,
+          payouts: "{{@step-1:Fetch Payees.body}}",
+          memo: "PAYRUN",
+        },
+        600
+      ),
+      buildActionNode(
+        "step-3",
+        "Confirm Transaction",
+        "Fetch the batch transaction details",
+        {
+          actionType: "web3/get-transaction",
+          network: TEMPO_TESTNET,
+          transactionHash: "{{@step-2:Batch Payout.transactionHash}}",
+        },
+        800
+      ),
+      buildTempoEmailNode(
+        "step-4",
+        "{{notifyEmail}}",
+        "Payroll run complete",
+        "Your contractor payroll ran on Tempo. Transaction: {{@step-2:Batch Payout.transactionLink}}",
+        1000
+      ),
+    ],
+    edges: [
+      buildEdge("trigger-1", "step-1"),
+      buildEdge("step-1", "step-2"),
+      buildEdge("step-2", "step-3"),
+      buildEdge("step-3", "step-4"),
+    ],
+  },
+
+  {
+    id: "tempo-treasury-sweep",
+    listedSlug: "tempo-treasury-sweep",
+    name: "Tempo Treasury Sweep",
+    description:
+      "Every morning, if your Tempo operating wallet holds more than your buffer, swap the excess into your treasury stablecoin on the native DEX and schedule the owner disbursement to land during business hours.",
+    category: "Treasury",
+    chain: TEMPO_TESTNET,
+    inputSchema: {
+      type: "object",
+      properties: {
+        operatingWallet: {
+          type: "string",
+          description: "The operating wallet whose balance is swept",
+        },
+        excessAmount: {
+          type: "string",
+          description: "Amount of the operating stablecoin to swap into treasury",
+        },
+        disbursementAmount: {
+          type: "string",
+          description: "Amount to disburse to the owner after the swap",
+        },
+        disbursementRecipient: {
+          type: "string",
+          description: "Owner address that receives the scheduled disbursement",
+        },
+      },
+      required: [],
+    },
+    nodes: [
+      buildTriggerNode("trigger-1", {
+        triggerType: "Schedule",
+        scheduleCron: "0 8 * * *",
+        scheduleTimezone: "UTC",
+      }),
+      buildActionNode(
+        "step-1",
+        "Check Balance",
+        "Read the operating wallet's stablecoin balance",
+        {
+          actionType: "web3/check-token-balance",
+          network: TEMPO_TESTNET,
+          address: "{{operatingWallet}}",
+          tokenConfig: PATH_USD,
+        },
+        400
+      ),
+      buildConditionNode(
+        "step-2",
+        {
+          condition:
+            "{{@step-1:Check Balance.balance.balanceRaw}} > 50000000000",
+          group: {
+            id: "group-1",
+            logic: "AND",
+            rules: [
+              {
+                id: "rule-1",
+                leftOperand:
+                  "{{@step-1:Check Balance.balance.balanceRaw}}",
+                operator: ">",
+                rightOperand: "50000000000",
+              },
+            ],
+          },
+        },
+        600
+      ),
+      buildActionNode(
+        "step-3",
+        "Swap Excess",
+        "Swap the excess into the treasury stablecoin on the native DEX",
+        {
+          actionType: "tempo/dex-swap",
+          network: TEMPO_TESTNET,
+          tokenInConfig: PATH_USD,
+          tokenOutConfig: ALPHA_USD,
+          amountIn: "{{excessAmount}}",
+          slippageBps: 50,
+        },
+        800
+      ),
+      buildActionNode(
+        "step-4",
+        "Schedule Disbursement",
+        "Schedule the owner disbursement to land during business hours",
+        {
+          actionType: "tempo/schedule-payment",
+          network: TEMPO_TESTNET,
+          tokenConfig: ALPHA_USD,
+          amount: "{{disbursementAmount}}",
+          recipientAddress: "{{disbursementRecipient}}",
+          memo: "owner-disbursement",
+        },
+        1000
+      ),
+    ],
+    edges: [
+      buildEdge("trigger-1", "step-1"),
+      buildEdge("step-1", "step-2"),
+      buildEdge("step-2", "step-3", "true"),
+      buildEdge("step-3", "step-4"),
+    ],
+  },
+];
+
+export const TEMPO_TEMPLATE_FIXTURES: TempoTemplateFixture[] =
+  RAW_FIXTURES.map(withAutoLayout);

--- a/scripts/seed/seed-tempo-templates.ts
+++ b/scripts/seed/seed-tempo-templates.ts
@@ -1,0 +1,165 @@
+#!/usr/bin/env tsx
+
+/**
+ * Seed the three Tempo demo workflow templates as listed, public,
+ * deployable workflows (invoice reconciliation, batch payroll, treasury
+ * sweep). They surface automatically through /api/workflows/public and MCP
+ * deploy_template.
+ *
+ * Templates are seeded with `enabled: false`: they are clone targets, not
+ * live workflows. A cloner configures their copy (deposit address, payee API,
+ * recipients, amounts) and enables it.
+ *
+ * Idempotent, matching the onboarding seeder:
+ *   - Insert when the stable id is absent.
+ *   - Refresh when the seeder last touched the row (seededAt ~ updatedAt).
+ *   - Skip when the user has edited it since (updatedAt diverges from seededAt).
+ *
+ * Standalone usage:
+ *   pnpm tsx scripts/seed/seed-tempo-templates.ts [--user=<email>]
+ */
+
+import "dotenv/config";
+
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+
+import { getDatabaseUrl } from "../../lib/db/connection-utils";
+import { member, users, workflows } from "../../lib/db/schema";
+import { TEMPO_TEMPLATE_FIXTURES } from "./fixtures/tempo-templates";
+
+/** Gap in ms between seededAt and updatedAt that indicates a user edit. */
+const USER_EDIT_EPSILON_MS = 5_000;
+
+type Identity = { userId: string; orgId: string };
+type SeedResult = { created: number; refreshed: number; skipped: number };
+
+export async function seedTempoTemplates(
+  db: ReturnType<typeof drizzle>,
+  identity: Identity
+): Promise<SeedResult> {
+  const result: SeedResult = { created: 0, refreshed: 0, skipped: 0 };
+  const now = new Date();
+
+  for (const fixture of TEMPO_TEMPLATE_FIXTURES) {
+    const base = {
+      name: fixture.name,
+      description: fixture.description,
+      userId: identity.userId,
+      organizationId: identity.orgId,
+      nodes: fixture.nodes,
+      edges: fixture.edges,
+      visibility: "public" as const,
+      enabled: false,
+      featured: false,
+      isListed: true,
+      listedSlug: fixture.listedSlug,
+      listedAt: now,
+      inputSchema: fixture.inputSchema,
+      priceUsdcPerCall: "0",
+      category: fixture.category,
+      chain: fixture.chain,
+      seededAt: now,
+      updatedAt: now,
+      deletedAt: null,
+    };
+
+    const existing = await db
+      .select({
+        id: workflows.id,
+        updatedAt: workflows.updatedAt,
+        seededAt: workflows.seededAt,
+      })
+      .from(workflows)
+      .where(eq(workflows.id, fixture.id))
+      .limit(1);
+
+    if (!existing[0]) {
+      await db
+        .insert(workflows)
+        .values({ id: fixture.id, createdAt: now, ...base });
+      result.created++;
+      continue;
+    }
+
+    const row = existing[0];
+    const updatedMs = row.updatedAt?.getTime() ?? 0;
+    const seededMs = row.seededAt?.getTime() ?? 0;
+    const userEdited =
+      row.seededAt === null || updatedMs - seededMs > USER_EDIT_EPSILON_MS;
+    if (userEdited) {
+      result.skipped++;
+      continue;
+    }
+
+    await db.update(workflows).set(base).where(eq(workflows.id, fixture.id));
+    result.refreshed++;
+  }
+
+  return result;
+}
+
+async function resolveIdentity(
+  db: ReturnType<typeof drizzle>,
+  email: string
+): Promise<Identity | null> {
+  const userRow = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1);
+  if (!userRow[0]) {
+    // biome-ignore lint/suspicious/noConsole: seed script CLI output
+    console.log(`User not found: ${email} -- skipping Tempo template seed`);
+    return null;
+  }
+  const memberRow = await db
+    .select({ organizationId: member.organizationId })
+    .from(member)
+    .where(eq(member.userId, userRow[0].id))
+    .limit(1);
+  if (!memberRow[0]) {
+    // biome-ignore lint/suspicious/noConsole: seed script CLI output
+    console.log(`User ${email} has no organization -- skipping`);
+    return null;
+  }
+  return { userId: userRow[0].id, orgId: memberRow[0].organizationId };
+}
+
+async function main(): Promise<void> {
+  const emailArg = process.argv
+    .slice(2)
+    .find((a) => a.startsWith("--user="))
+    ?.split("=")[1];
+  const email = emailArg ?? process.env.SEED_EMAIL ?? "dev@keeperhub.local";
+
+  const client = postgres(getDatabaseUrl(), { max: 1 });
+  const db = drizzle(client);
+  try {
+    const identity = await resolveIdentity(db, email);
+    if (!identity) {
+      return;
+    }
+    const result = await seedTempoTemplates(db, identity);
+    // biome-ignore lint/suspicious/noConsole: seed script CLI output
+    console.log(
+      `Tempo templates -> org ${identity.orgId}: created ${result.created}, refreshed ${result.refreshed}, skipped ${result.skipped}`
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+const isMain =
+  process.argv[1] &&
+  (process.argv[1].endsWith("seed-tempo-templates.ts") ||
+    process.argv[1].endsWith("seed-tempo-templates.js"));
+
+if (isMain) {
+  main().catch((err: unknown) => {
+    // biome-ignore lint/suspicious/noConsole: seed script CLI output
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tests/unit/tempo-dex-swap.test.ts
+++ b/tests/unit/tempo-dex-swap.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/workflow/executor/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
+  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
+}));
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { TRANSACTION: "transaction" },
+  logUserError: vi.fn(),
+}));
+vi.mock("@/lib/utils", () => ({
+  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+}));
+
+const mockGetChainIdFromNetwork = vi.fn();
+vi.mock("@/lib/rpc/network-utils", () => ({
+  getChainIdFromNetwork: (...args: unknown[]) =>
+    mockGetChainIdFromNetwork(...args),
+}));
+
+const mockGetRpcProvider = vi.fn();
+vi.mock("@/lib/rpc/provider-factory", () => ({
+  getRpcProvider: (...args: unknown[]) => mockGetRpcProvider(...args),
+}));
+
+const mockResolveOrganizationContext = vi.fn();
+vi.mock("@/lib/web3/resolve-org-context", () => ({
+  resolveOrganizationContext: (...args: unknown[]) =>
+    mockResolveOrganizationContext(...args),
+}));
+
+const mockAssertTempoChain = vi.fn();
+const mockResolveTempoToken = vi.fn();
+const mockQuoteTempoSwap = vi.fn();
+const mockBuildTempoTxLink = vi.fn();
+vi.mock("@/plugins/tempo/steps/tempo-step-helpers", () => ({
+  assertTempoChain: (...args: unknown[]) => mockAssertTempoChain(...args),
+  resolveTempoToken: (...args: unknown[]) => mockResolveTempoToken(...args),
+  quoteTempoSwap: (...args: unknown[]) => mockQuoteTempoSwap(...args),
+  buildTempoTxLink: (...args: unknown[]) => mockBuildTempoTxLink(...args),
+}));
+
+const mockSignAndBroadcast = vi.fn();
+const mockBuildSwapCall = vi.fn();
+vi.mock("@/plugins/tempo/steps/tempo-tx-core", () => ({
+  signAndBroadcastTempoTx: (...args: unknown[]) => mockSignAndBroadcast(...args),
+  buildSwapExactAmountInCall: (...args: unknown[]) => mockBuildSwapCall(...args),
+}));
+
+import { type DexSwapInput, dexSwapStep } from "@/plugins/tempo/steps/dex-swap";
+
+const USDC = "0x20c0000000000000000000000000000000000001";
+const ALPHA = "0x20c0000000000000000000000000000000000002";
+
+function baseInput(overrides: Partial<DexSwapInput> = {}): DexSwapInput {
+  return {
+    network: "tempo-testnet",
+    tokenInConfig: { supportedTokenId: "usdc" },
+    tokenOutConfig: { supportedTokenId: "alpha" },
+    amountIn: "100",
+    _context: { organizationId: "org1", executionId: "exec1" },
+    ...overrides,
+  } as DexSwapInput;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetChainIdFromNetwork.mockReturnValue(42_431);
+  mockAssertTempoChain.mockReturnValue(undefined);
+  mockResolveOrganizationContext.mockResolvedValue({
+    success: true,
+    organizationId: "org1",
+    userId: "u1",
+  });
+  mockGetRpcProvider.mockResolvedValue({});
+  mockResolveTempoToken.mockImplementation((config: { supportedTokenId?: string }) =>
+    config?.supportedTokenId === "usdc"
+      ? Promise.resolve({ address: USDC, decimals: 6, symbol: "USDC" })
+      : Promise.resolve({ address: ALPHA, decimals: 6, symbol: "AlphaUSD" })
+  );
+  mockQuoteTempoSwap.mockResolvedValue(BigInt(99_000_000)); // 99 out
+  mockBuildSwapCall.mockReturnValue({ to: "0xdec0", data: "0xswap" });
+  mockSignAndBroadcast.mockResolvedValue({ hash: "0xhash", from: "0xFROM" });
+  mockBuildTempoTxLink.mockResolvedValue("https://explorer/tx/0xhash");
+});
+
+describe("dexSwapStep", () => {
+  it("quotes, applies the slippage floor, and swaps", async () => {
+    const res = await dexSwapStep(baseInput());
+
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.transactionHash).toBe("0xhash");
+      expect(res.tokenIn).toBe("USDC");
+      expect(res.tokenOut).toBe("AlphaUSD");
+      expect(res.quotedOut).toBe("99.0");
+      // 99 * (1 - 0.005) = 98.505
+      expect(res.minAmountOut).toBe("98.505");
+    }
+    // 100 in (6 decimals), minAmountOut = 99e6 * 9950 / 10000
+    expect(mockBuildSwapCall).toHaveBeenCalledWith(
+      USDC,
+      ALPHA,
+      BigInt(100_000_000),
+      BigInt(98_505_000)
+    );
+    expect(mockSignAndBroadcast).toHaveBeenCalledWith(
+      expect.objectContaining({ feeToken: USDC, chainId: 42_431 })
+    );
+  });
+
+  it("rejects swapping a token for itself", async () => {
+    const res = await dexSwapStep(
+      baseInput({ tokenOutConfig: { supportedTokenId: "usdc" } })
+    );
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error).toContain("must be different");
+    }
+    expect(mockSignAndBroadcast).not.toHaveBeenCalled();
+  });
+
+  it("rejects an out-of-range slippage", async () => {
+    const res = await dexSwapStep(baseInput({ slippageBps: 10_000 }));
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error).toContain("Slippage");
+    }
+    expect(mockSignAndBroadcast).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the pair has no liquidity", async () => {
+    mockQuoteTempoSwap.mockResolvedValue(BigInt(0));
+    const res = await dexSwapStep(baseInput());
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error).toContain("No DEX liquidity");
+    }
+    expect(mockSignAndBroadcast).not.toHaveBeenCalled();
+  });
+
+  it("requires an amount", async () => {
+    const res = await dexSwapStep(baseInput({ amountIn: "" }));
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error).toContain("Amount is required");
+    }
+  });
+
+  it("surfaces a swap failure as a step error", async () => {
+    mockSignAndBroadcast.mockRejectedValue(new Error("swap reverted"));
+    const res = await dexSwapStep(baseInput());
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error).toContain("reverted");
+    }
+  });
+});

--- a/tests/unit/tempo-schedule-payment.test.ts
+++ b/tests/unit/tempo-schedule-payment.test.ts
@@ -45,7 +45,8 @@ const mockSignAndBroadcast = vi.fn();
 const mockBuildCall = vi.fn();
 const mockNormalizeMemo = vi.fn();
 vi.mock("@/plugins/tempo/steps/tempo-tx-core", () => ({
-  signAndBroadcastTempoTx: (...args: unknown[]) => mockSignAndBroadcast(...args),
+  signAndBroadcastTempoTx: (...args: unknown[]) =>
+    mockSignAndBroadcast(...args),
   buildTransferWithMemoCall: (...args: unknown[]) => mockBuildCall(...args),
   normalizeMemo: (...args: unknown[]) => mockNormalizeMemo(...args),
 }));
@@ -145,15 +146,34 @@ describe("schedulePaymentStep", () => {
     expect(mockSignAndBroadcast).not.toHaveBeenCalled();
   });
 
-  it("rejects a validBefore already in the past", async () => {
+  it("rejects a validBefore in the past (inside the inclusion buffer)", async () => {
     const res = await schedulePaymentStep(
       baseInput({ validBefore: String(NOW_SEC - 10) })
     );
     expect(res.success).toBe(false);
     if (!res.success) {
-      expect(res.error).toContain("past");
+      expect(res.error).toContain("too soon");
     }
     expect(mockSignAndBroadcast).not.toHaveBeenCalled();
+  });
+
+  it("rejects a validBefore that closes inside the inclusion buffer", async () => {
+    const res = await schedulePaymentStep(
+      baseInput({ validBefore: String(NOW_SEC + 10) })
+    );
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error).toContain("too soon");
+    }
+    expect(mockSignAndBroadcast).not.toHaveBeenCalled();
+  });
+
+  it("accepts a validBefore just past the inclusion buffer", async () => {
+    const res = await schedulePaymentStep(
+      baseInput({ validBefore: String(NOW_SEC + 61) })
+    );
+    expect(res.success).toBe(true);
+    expect(mockSignAndBroadcast).toHaveBeenCalledTimes(1);
   });
 
   it("rejects an unparseable date", async () => {

--- a/tests/unit/tempo-schedule-payment.test.ts
+++ b/tests/unit/tempo-schedule-payment.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/workflow/executor/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
+  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
+}));
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { TRANSACTION: "transaction" },
+  logUserError: vi.fn(),
+}));
+vi.mock("@/lib/utils", () => ({
+  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+}));
+
+const mockGetChainIdFromNetwork = vi.fn();
+vi.mock("@/lib/rpc/network-utils", () => ({
+  getChainIdFromNetwork: (...args: unknown[]) =>
+    mockGetChainIdFromNetwork(...args),
+}));
+
+const mockGetRpcProvider = vi.fn();
+vi.mock("@/lib/rpc/provider-factory", () => ({
+  getRpcProvider: (...args: unknown[]) => mockGetRpcProvider(...args),
+}));
+
+const mockResolveOrganizationContext = vi.fn();
+vi.mock("@/lib/web3/resolve-org-context", () => ({
+  resolveOrganizationContext: (...args: unknown[]) =>
+    mockResolveOrganizationContext(...args),
+}));
+
+const mockAssertTempoChain = vi.fn();
+const mockResolveTempoToken = vi.fn();
+const mockBuildTempoTxLink = vi.fn();
+vi.mock("@/plugins/tempo/steps/tempo-step-helpers", () => ({
+  assertTempoChain: (...args: unknown[]) => mockAssertTempoChain(...args),
+  resolveTempoToken: (...args: unknown[]) => mockResolveTempoToken(...args),
+  buildTempoTxLink: (...args: unknown[]) => mockBuildTempoTxLink(...args),
+}));
+
+const mockSignAndBroadcast = vi.fn();
+const mockBuildCall = vi.fn();
+const mockNormalizeMemo = vi.fn();
+vi.mock("@/plugins/tempo/steps/tempo-tx-core", () => ({
+  signAndBroadcastTempoTx: (...args: unknown[]) => mockSignAndBroadcast(...args),
+  buildTransferWithMemoCall: (...args: unknown[]) => mockBuildCall(...args),
+  normalizeMemo: (...args: unknown[]) => mockNormalizeMemo(...args),
+}));
+
+import {
+  type SchedulePaymentInput,
+  schedulePaymentStep,
+} from "@/plugins/tempo/steps/schedule-payment";
+
+const USDC = "0x20c0000000000000000000000000000000000001";
+const RECIPIENT = "0x1111111111111111111111111111111111111111";
+const NOW_SEC = 1_800_000_000;
+
+function baseInput(
+  overrides: Partial<SchedulePaymentInput> = {}
+): SchedulePaymentInput {
+  return {
+    network: "tempo-testnet",
+    tokenConfig: { supportedTokenId: "usdc" },
+    amount: "500",
+    recipientAddress: RECIPIENT,
+    memo: "PAYRUN-2026-07",
+    _context: { organizationId: "org1", executionId: "exec1" },
+    ...overrides,
+  } as SchedulePaymentInput;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW_SEC * 1000);
+  mockGetChainIdFromNetwork.mockReturnValue(42_431);
+  mockAssertTempoChain.mockReturnValue(undefined);
+  mockResolveOrganizationContext.mockResolvedValue({
+    success: true,
+    organizationId: "org1",
+    userId: "u1",
+  });
+  mockGetRpcProvider.mockResolvedValue({});
+  mockResolveTempoToken.mockResolvedValue({
+    address: USDC,
+    decimals: 6,
+    symbol: "USDC",
+  });
+  mockNormalizeMemo.mockReturnValue("0xMEMO");
+  mockBuildCall.mockReturnValue({ to: USDC, data: "0xdata" });
+  mockSignAndBroadcast.mockResolvedValue({ hash: "0xhash", from: "0xFROM" });
+  mockBuildTempoTxLink.mockResolvedValue("https://explorer/tx/0xhash");
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("schedulePaymentStep", () => {
+  it("signs with the explicit inclusion window", async () => {
+    const res = await schedulePaymentStep(
+      baseInput({ validBefore: String(NOW_SEC + 3600) })
+    );
+
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.transactionHash).toBe("0xhash");
+      expect(res.validBefore).toBe(NOW_SEC + 3600);
+      expect(res.validAfter).toBeNull();
+    }
+    const args = mockSignAndBroadcast.mock.calls[0][0];
+    expect(args.validBefore).toBe(NOW_SEC + 3600);
+    expect(args.validAfter).toBeUndefined();
+  });
+
+  it("defaults validBefore to a short window when unset", async () => {
+    await schedulePaymentStep(baseInput());
+    const args = mockSignAndBroadcast.mock.calls[0][0];
+    expect(args.validBefore).toBe(NOW_SEC + 900);
+  });
+
+  it("passes an explicit validAfter through", async () => {
+    await schedulePaymentStep(
+      baseInput({
+        validAfter: String(NOW_SEC - 60),
+        validBefore: String(NOW_SEC + 3600),
+      })
+    );
+    const args = mockSignAndBroadcast.mock.calls[0][0];
+    expect(args.validAfter).toBe(NOW_SEC - 60);
+  });
+
+  it("rejects a validAfter in the future (no deferred broadcast)", async () => {
+    const res = await schedulePaymentStep(
+      baseInput({ validAfter: String(NOW_SEC + 1000) })
+    );
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error).toContain("validAfter is in the future");
+    }
+    expect(mockSignAndBroadcast).not.toHaveBeenCalled();
+  });
+
+  it("rejects a validBefore already in the past", async () => {
+    const res = await schedulePaymentStep(
+      baseInput({ validBefore: String(NOW_SEC - 10) })
+    );
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error).toContain("past");
+    }
+    expect(mockSignAndBroadcast).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unparseable date", async () => {
+    const res = await schedulePaymentStep(
+      baseInput({ validBefore: "not-a-date" })
+    );
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error).toContain("Invalid date");
+    }
+  });
+
+  it("rejects an invalid recipient", async () => {
+    const res = await schedulePaymentStep(
+      baseInput({ recipientAddress: "nope" })
+    );
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error).toContain("Invalid recipient");
+    }
+  });
+});

--- a/tests/unit/tempo-tx-core.test.ts
+++ b/tests/unit/tempo-tx-core.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
 import { decodeFunctionData } from "viem";
 import { Abis } from "viem/tempo";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
@@ -26,6 +26,7 @@ vi.mock("@/lib/logging", () => ({
 
 import {
   buildTransferWithMemoCall,
+  deriveTempoNonceKey,
   isTempoChain,
   normalizeMemo,
 } from "@/plugins/tempo/steps/tempo-tx-core";
@@ -33,6 +34,38 @@ import {
 const ZERO_MEMO = `0x${"0".repeat(64)}`;
 const USDC = "0x20c0000000000000000000000000000000000001" as const;
 const RECIPIENT = "0x1111111111111111111111111111111111111111" as const;
+const TOO_LONG_MEMO = /too long/;
+
+describe("deriveTempoNonceKey", () => {
+  const MAX_UINT256 = (BigInt(1) << BigInt(256)) - BigInt(1);
+
+  it("gives concurrent sends from one wallet their own lanes", () => {
+    // Two sends in the same execution get distinct 2D-nonce lanes, so neither
+    // reads a nonce the other is about to consume and both can land.
+    const a = deriveTempoNonceKey("exec-1");
+    const b = deriveTempoNonceKey("exec-1");
+    expect(a).not.toBe(b);
+  });
+
+  it("produces a unique lane on every call, with or without an execution id", () => {
+    const keys = new Set(
+      Array.from({ length: 1000 }, (_, i) =>
+        deriveTempoNonceKey(i % 2 === 0 ? "exec" : undefined)
+      )
+    );
+    expect(keys.size).toBe(1000);
+  });
+
+  it("stays off lane 0 and the max-uint256 marker lane", () => {
+    const keys = Array.from({ length: 1000 }, () =>
+      deriveTempoNonceKey(undefined)
+    );
+    for (const key of keys) {
+      expect(key > BigInt(0)).toBe(true);
+      expect(key < MAX_UINT256).toBe(true);
+    }
+  });
+});
 
 describe("isTempoChain", () => {
   it("accepts Tempo mainnet and Moderato testnet", () => {
@@ -67,14 +100,19 @@ describe("normalizeMemo", () => {
   });
 
   it("throws when a plain-text memo exceeds 31 bytes", () => {
-    expect(() => normalizeMemo("x".repeat(32))).toThrow(/too long/);
+    expect(() => normalizeMemo("x".repeat(32))).toThrow(TOO_LONG_MEMO);
   });
 });
 
 describe("buildTransferWithMemoCall", () => {
   it("targets the token and encodes transferWithMemo(to, value, memo)", () => {
     const memo = normalizeMemo("INV-1042");
-    const call = buildTransferWithMemoCall(USDC, RECIPIENT, BigInt(1_500_000), memo);
+    const call = buildTransferWithMemoCall(
+      USDC,
+      RECIPIENT,
+      BigInt(1_500_000),
+      memo
+    );
 
     expect(call.to).toBe(USDC);
     const decoded = decodeFunctionData({ abi: Abis.tip20, data: call.data });

--- a/tests/unit/validate-workflow-structural.test.ts
+++ b/tests/unit/validate-workflow-structural.test.ts
@@ -99,9 +99,16 @@ function buildLargeWorkflowFixture(nodeCount: number): ValidatorWorkflow {
 // ---------------------------------------------------------------------------
 
 describe("TRIGGERS exports", () => {
-  it("has exactly the 5 expected trigger keys", () => {
+  it("has exactly the 6 expected trigger keys", () => {
     const keys = Object.keys(TRIGGERS).sort();
-    expect(keys).toEqual(["Block", "Event", "Manual", "Schedule", "Webhook"]);
+    expect(keys).toEqual([
+      "Block",
+      "Event",
+      "Manual",
+      "Schedule",
+      "Tempo Payment Received",
+      "Webhook",
+    ]);
   });
 
   it("Event trigger outputFields contain eventName and address (Pitfall 2 guard)", () => {


### PR DESCRIPTION
## Summary

Second and final tranche of the Tempo plugin write surface, stacked on the
memo-transfer and batch-payout branch:

- **schedule-payment**: a stablecoin transfer bounded by a `validAfter` /
  `validBefore` inclusion window (unix seconds or ISO datetime). v1 broadcasts
  during the triggering run, so the window bounds inclusion rather than
  deferring the send; `validBefore` defaults to a short deadline.
- **dex-swap**: a market swap between two Tempo stablecoins on the enshrined DEX
  precompile. Quotes via `quoteSwapExactAmountIn`, applies a basis-point
  slippage floor, then `swapExactAmountIn` (no approve or deposit; the DEX pulls
  from and settles to the wallet).

It also swaps the plugin's gas handling from hardcoded constants to the shared
`AdaptiveGasStrategy` (per-call `eth_estimateGas` times the chain multiplier for
the limit, live fee history for the prices) and registers Tempo in the
strategy's per-chain overrides.

## How it works

Both steps sit on the existing `tempo-tx-core` (Turnkey signing of the native
0x76 envelope, persistent 2D nonce, self-paid fees in a stablecoin).
`schedule-payment` adds the optional window fields to the envelope; `dex-swap`
adds the DEX call builder and an on-chain quote helper.

## Testing

- Unit tests for both steps plus the gas rewire; full unit suite green;
  type-check clean.
- Verified live on Tempo Moderato testnet as real workflow executions:
  schedule-payment landed with the window set and honored, and dex-swap swapped
  PathUSD for AlphaUSD with the slippage floor applied. The transfer-with-memo
  and batch-payout steps from the base branch were verified the same way.

## Known follow-up

Concurrent sends from the same wallet share one 2D-nonce lane and can collide
(one succeeds, the other fails `nonce too low`). Tracked separately; the
hardening is out of scope here.

## Base branch

Stacked on the transfer / batch branch; retarget to staging once that merges.
