### PR TITLE
feat(tempo): add the Tempo Payment Received trigger

### DIFF
--- a/app/api/workflows/events/route.ts
+++ b/app/api/workflows/events/route.ts
@@ -9,6 +9,25 @@ import type { WorkflowNode } from "@/lib/workflow/store";
 import { WorkflowTriggerEnum } from "@/lib/workflow/store";
 import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
 
+// The Tempo Payment Received trigger always watches the fixed TIP-20
+// TransferWithMemo event. The event-tracker's mapper needs an ABI + event name
+// on the trigger config to build a subscription, so we inject them here rather
+// than surfacing ABI/event pickers to the user.
+const TEMPO_TRANSFER_WITH_MEMO_EVENT = "TransferWithMemo";
+const TEMPO_TRANSFER_WITH_MEMO_ABI = JSON.stringify([
+  {
+    type: "event",
+    name: "TransferWithMemo",
+    anonymous: false,
+    inputs: [
+      { name: "from", type: "address", indexed: true },
+      { name: "to", type: "address", indexed: true },
+      { name: "value", type: "uint256", indexed: false },
+      { name: "memo", type: "bytes32", indexed: true },
+    ],
+  },
+]);
+
 /**
  * Internal endpoint for workers to fetch active Event-type workflows.
  * Returns only enabled workflows with Event trigger type. Authentication
@@ -64,18 +83,31 @@ export async function GET(request: Request) {
             return null;
           }
 
-          // Check if trigger type is Event
+          // Admit Event triggers and the Tempo Payment Received trigger; both
+          // register through the event-tracker as on-chain log subscriptions.
           const triggerType = triggerNode.data?.config?.triggerType as
             | string
             | undefined;
 
-          if (triggerType !== WorkflowTriggerEnum.EVENT) {
+          const isEventTrigger = triggerType === WorkflowTriggerEnum.EVENT;
+          const isTempoPaymentTrigger =
+            triggerType === WorkflowTriggerEnum.TEMPO_PAYMENT;
+          if (!(isEventTrigger || isTempoPaymentTrigger)) {
             return null;
           }
 
-          // Try to infer contract address from protocol and event slug
           const config = triggerNode.data?.config;
-          if (config && !config.contractAddress) {
+
+          // Inject the fixed TransferWithMemo ABI + event name for the Tempo
+          // trigger so the mapper can build the subscription. contractAddress
+          // (the token) and network come from the user's config.
+          if (isTempoPaymentTrigger && config) {
+            config.contractABI = TEMPO_TRANSFER_WITH_MEMO_ABI;
+            config.eventName = TEMPO_TRANSFER_WITH_MEMO_EVENT;
+          }
+
+          // Try to infer contract address from protocol and event slug
+          if (isEventTrigger && config && !config.contractAddress) {
             const protocolSlug = config._eventProtocolSlug as
               | string
               | undefined;

--- a/components/workflow/config/trigger-config.tsx
+++ b/components/workflow/config/trigger-config.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Box, Boxes, Clock, Copy, Play, Webhook } from "lucide-react";
+import {
+  ArrowDownToLine,
+  Box,
+  Boxes,
+  Clock,
+  Copy,
+  Play,
+  Webhook,
+} from "lucide-react";
 import Image from "next/image";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -106,6 +114,12 @@ export function TriggerConfig({
               <div className="flex items-center gap-2">
                 <Box className="h-4 w-4" />
                 Block
+              </div>
+            </SelectItem>
+            <SelectItem value="Tempo Payment Received">
+              <div className="flex items-center gap-2">
+                <ArrowDownToLine className="h-4 w-4" />
+                Tempo Payment Received
               </div>
             </SelectItem>
           </SelectContent>
@@ -285,6 +299,52 @@ export function TriggerConfig({
                 </p>
               </div>
             </>
+          );
+        })()}
+      {/* Tempo Payment Received fields */}
+      {config?.triggerType === "Tempo Payment Received" &&
+        (() => {
+          const tempoFields: ActionConfigField[] = [
+            {
+              key: "network",
+              label: "Network",
+              type: "chain-select",
+              chainTypeFilter: "evm",
+              allowedChainIds: ["4217", "42431"],
+              placeholder: "Select a Tempo network",
+              required: true,
+            },
+            {
+              key: "contractAddress",
+              label: "Stablecoin Token",
+              type: "template-input",
+              placeholder: "0x... token contract to watch",
+              required: true,
+            },
+            {
+              key: "recipientAddress",
+              label: "Deposit Address",
+              type: "template-input",
+              placeholder: "0x... the address that receives payments",
+              required: true,
+            },
+            {
+              key: "memo",
+              label: "Memo Filter",
+              type: "template-input",
+              placeholder: "INV-1042 or 0x... (optional)",
+              helpTip:
+                "Only fire when the transfer memo matches. A 0x + 64-hex value matches exactly; a shorter string matches as a prefix.",
+            },
+          ];
+
+          return (
+            <ActionConfigRenderer
+              config={config}
+              disabled={disabled}
+              fields={tempoFields}
+              onUpdateConfig={handleConfigValue}
+            />
           );
         })()}
     </>

--- a/components/workflow/nodes/trigger-node.tsx
+++ b/components/workflow/nodes/trigger-node.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import type { NodeProps } from "@xyflow/react";
-import { Box, Boxes, Check, Clock, Play, Webhook, XCircle } from "lucide-react";
+import {
+  ArrowDownToLine,
+  Box,
+  Boxes,
+  Check,
+  Clock,
+  Play,
+  Webhook,
+  XCircle,
+} from "lucide-react";
 import Image from "next/image";
 import { type ElementType, memo } from "react";
 import { Node } from "@/components/ai-elements/node";
@@ -34,6 +43,7 @@ export const TriggerNode = memo(({ data, selected, id }: TriggerNodeProps) => {
     [WorkflowTriggerEnum.WEBHOOK]: Webhook,
     [WorkflowTriggerEnum.EVENT]: Boxes, // keeperhub custom field //
     [WorkflowTriggerEnum.BLOCK]: Box, // keeperhub custom field //
+    [WorkflowTriggerEnum.TEMPO_PAYMENT]: ArrowDownToLine, // keeperhub custom field //
   };
 
   const TriggerIcon = triggerIcons[triggerType as WorkflowTriggerType] || Play;

--- a/keeperhub-events/event-tracker/lib/types.ts
+++ b/keeperhub-events/event-tracker/lib/types.ts
@@ -31,6 +31,10 @@ export interface RawWorkflowNodeConfig {
   contractABI?: string;
   triggerType?: string;
   contractAddress?: string;
+  // Tempo Payment Received trigger: the watched deposit address and an optional
+  // memo filter, applied as post-decode predicates in the listener.
+  recipientAddress?: string;
+  memo?: string;
 }
 
 export interface RawWorkflowNode {

--- a/keeperhub-events/event-tracker/src/listener/event-listener.ts
+++ b/keeperhub-events/event-tracker/src/listener/event-listener.ts
@@ -1,5 +1,6 @@
 import type { SQSClient } from "@aws-sdk/client-sqs";
 import type { ethers } from "ethers";
+import { hexlify, toUtf8Bytes } from "ethers";
 import {
   createPhantomExecution,
   failPhantomExecution,
@@ -27,6 +28,49 @@ import { formatError } from "./format-error";
 
 const DEFAULT_JITTER_MS = 10_000;
 
+/** A full pre-hashed bytes32 memo (0x + 64 hex), matched exactly. */
+const BYTES32_HEX = /^0x[0-9a-fA-F]{64}$/;
+
+/**
+ * Post-decode filter for the Tempo Payment Received trigger. Returns true
+ * (forward the event) when no filter is set. Otherwise the decoded `to` must
+ * equal the watched deposit address (case-insensitive), and the decoded `memo`
+ * must match the configured filter: an exact bytes32 for a 0x + 64-hex value,
+ * or a utf8 prefix otherwise (the transfer step right-pads a plain-text memo
+ * into the bytes32, so a utf8-hex prefix aligns on byte boundaries).
+ */
+export function paymentEventMatches(params: {
+  to: unknown;
+  memo: unknown;
+  recipientFilter?: string;
+  memoFilter?: string;
+}): boolean {
+  const { to, memo, recipientFilter, memoFilter } = params;
+
+  if (recipientFilter) {
+    if (
+      typeof to !== "string" ||
+      to.toLowerCase() !== recipientFilter.toLowerCase()
+    ) {
+      return false;
+    }
+  }
+
+  if (memoFilter) {
+    if (typeof memo !== "string") {
+      return false;
+    }
+    const memoHex = memo.toLowerCase();
+    if (BYTES32_HEX.test(memoFilter)) {
+      return memoHex === memoFilter.toLowerCase();
+    }
+    const prefixHex = hexlify(toUtf8Bytes(memoFilter));
+    return memoHex.startsWith(prefixHex.toLowerCase());
+  }
+
+  return true;
+}
+
 export interface EventListenerOptions {
   workflowId: string;
   userId: string;
@@ -38,6 +82,13 @@ export interface EventListenerOptions {
   eventName: string;
   eventsAbiStrings: string[];
   rawEventsAbi: AbiEvent[];
+
+  /**
+   * Optional post-decode filters (Tempo Payment Received trigger). Undefined
+   * for generic Event triggers, which forward every matching event.
+   */
+  recipientFilter?: string;
+  memoFilter?: string;
 
   sqs: SQSClient;
   sqsQueueUrl: string;
@@ -112,6 +163,15 @@ export class EventListener {
     return this.started;
   }
 
+  private matchesFilters(parsed: ethers.LogDescription): boolean {
+    return paymentEventMatches({
+      to: parsed.args?.to as unknown,
+      memo: parsed.args?.memo as unknown,
+      recipientFilter: this.opts.recipientFilter,
+      memoFilter: this.opts.memoFilter,
+    });
+  }
+
   private async onLog(log: ethers.Log): Promise<void> {
     try {
       const iface = getInterface(this.opts.eventsAbiStrings);
@@ -120,6 +180,12 @@ export class EventListener {
         data: log.data,
       });
       if (!parsed || parsed.name !== this.opts.eventName) {
+        return;
+      }
+
+      // Post-decode filtering for the Tempo Payment Received trigger. No-op
+      // when neither filter is set (generic Event triggers forward everything).
+      if (!this.matchesFilters(parsed)) {
         return;
       }
 

--- a/keeperhub-events/event-tracker/src/listener/registry.ts
+++ b/keeperhub-events/event-tracker/src/listener/registry.ts
@@ -38,6 +38,14 @@ export interface WorkflowRegistration {
   eventsAbiStrings: string[];
   rawEventsAbi: AbiEvent[];
   /**
+   * Optional post-decode filters for the Tempo Payment Received trigger.
+   * `recipientFilter` matches the decoded `to` arg; `memoFilter` matches the
+   * decoded `memo` (exact for a 0x + 64-hex value, prefix otherwise). Undefined
+   * for generic Event triggers, which never filter on decoded args.
+   */
+  recipientFilter?: string;
+  memoFilter?: string;
+  /**
    * Stable hash over the listener-affecting fields of this registration.
    * Produced by `workflow-mapper.hashRegistration` and used by the Phase 4
    * reconciler to detect config changes (contract swap, event rename, ABI

--- a/keeperhub-events/event-tracker/src/listener/workflow-mapper.ts
+++ b/keeperhub-events/event-tracker/src/listener/workflow-mapper.ts
@@ -154,6 +154,18 @@ export function buildRegistration(
   const userId = typeof workflow.userId === "string" ? workflow.userId : "";
   const workflowName = typeof workflow.name === "string" ? workflow.name : "";
 
+  // Optional post-decode filters carried by the Tempo Payment Received trigger.
+  // Undefined for generic Event triggers, which never filter on decoded args.
+  const recipientFilter =
+    typeof config.recipientAddress === "string" &&
+    config.recipientAddress.length > 0
+      ? config.recipientAddress
+      : undefined;
+  const memoFilter =
+    typeof config.memo === "string" && config.memo.length > 0
+      ? config.memo
+      : undefined;
+
   const registration: Omit<WorkflowRegistration, "configHash"> = {
     workflowId,
     userId,
@@ -165,6 +177,8 @@ export function buildRegistration(
     eventName,
     eventsAbiStrings,
     rawEventsAbi,
+    recipientFilter,
+    memoFilter,
   };
   return {
     ...registration,
@@ -192,6 +206,8 @@ export function hashRegistration(
     eventName: reg.eventName,
     eventsAbiStrings: reg.eventsAbiStrings,
     userId: reg.userId,
+    recipientFilter: reg.recipientFilter ?? null,
+    memoFilter: reg.memoFilter ?? null,
   });
   return createHash("sha256").update(canonical).digest("hex");
 }

--- a/keeperhub-events/event-tracker/tests/unit/tempo-payment-filter.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/tempo-payment-filter.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { paymentEventMatches } from "../../src/listener/event-listener";
+
+const TO = "0x1111111111111111111111111111111111111111";
+const OTHER = "0x2222222222222222222222222222222222222222";
+// "INV-1042" utf8, right-padded into a bytes32 (Solidity bytes32-string form).
+const MEMO_INV1042 = `0x494e562d31303432${"0".repeat(48)}`;
+const HASH = `0x${"ab".repeat(32)}`;
+
+describe("paymentEventMatches", () => {
+  it("forwards everything when no filter is set", () => {
+    expect(paymentEventMatches({ to: TO, memo: MEMO_INV1042 })).toBe(true);
+    expect(paymentEventMatches({ to: undefined, memo: undefined })).toBe(true);
+  });
+
+  it("matches the recipient case-insensitively", () => {
+    expect(
+      paymentEventMatches({ to: TO.toUpperCase(), recipientFilter: TO })
+    ).toBe(true);
+    expect(paymentEventMatches({ to: OTHER, recipientFilter: TO })).toBe(false);
+    expect(paymentEventMatches({ to: 123, recipientFilter: TO })).toBe(false);
+  });
+
+  it("matches a full bytes32 memo exactly", () => {
+    expect(
+      paymentEventMatches({ to: TO, memo: HASH, memoFilter: HASH })
+    ).toBe(true);
+    expect(
+      paymentEventMatches({
+        to: TO,
+        memo: HASH.toUpperCase(),
+        memoFilter: HASH,
+      })
+    ).toBe(true);
+    expect(
+      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: HASH })
+    ).toBe(false);
+  });
+
+  it("matches a plain-text memo as a utf8 prefix", () => {
+    expect(
+      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: "INV-104" })
+    ).toBe(true);
+    expect(
+      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: "INV-1042" })
+    ).toBe(true);
+    expect(
+      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: "ABC" })
+    ).toBe(false);
+    expect(
+      paymentEventMatches({ to: TO, memo: 42, memoFilter: "INV" })
+    ).toBe(false);
+  });
+
+  it("requires both filters to pass when both are set", () => {
+    expect(
+      paymentEventMatches({
+        to: TO,
+        memo: MEMO_INV1042,
+        recipientFilter: TO,
+        memoFilter: "INV-104",
+      })
+    ).toBe(true);
+    expect(
+      paymentEventMatches({
+        to: OTHER,
+        memo: MEMO_INV1042,
+        recipientFilter: TO,
+        memoFilter: "INV-104",
+      })
+    ).toBe(false);
+    expect(
+      paymentEventMatches({
+        to: TO,
+        memo: MEMO_INV1042,
+        recipientFilter: TO,
+        memoFilter: "ZZZ",
+      })
+    ).toBe(false);
+  });
+});

--- a/keeperhub-events/event-tracker/tests/unit/tempo-payment-filter.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/tempo-payment-filter.test.ts
@@ -15,41 +15,49 @@ describe("paymentEventMatches", () => {
 
   it("matches the recipient case-insensitively", () => {
     expect(
-      paymentEventMatches({ to: TO.toUpperCase(), recipientFilter: TO })
+      paymentEventMatches({ to: TO.toUpperCase(), recipientFilter: TO }),
     ).toBe(true);
     expect(paymentEventMatches({ to: OTHER, recipientFilter: TO })).toBe(false);
     expect(paymentEventMatches({ to: 123, recipientFilter: TO })).toBe(false);
   });
 
   it("matches a full bytes32 memo exactly", () => {
-    expect(
-      paymentEventMatches({ to: TO, memo: HASH, memoFilter: HASH })
-    ).toBe(true);
+    expect(paymentEventMatches({ to: TO, memo: HASH, memoFilter: HASH })).toBe(
+      true,
+    );
     expect(
       paymentEventMatches({
         to: TO,
         memo: HASH.toUpperCase(),
         memoFilter: HASH,
-      })
+      }),
     ).toBe(true);
     expect(
-      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: HASH })
+      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: HASH }),
     ).toBe(false);
   });
 
   it("matches a plain-text memo as a utf8 prefix", () => {
     expect(
-      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: "INV-104" })
+      paymentEventMatches({
+        to: TO,
+        memo: MEMO_INV1042,
+        memoFilter: "INV-104",
+      }),
     ).toBe(true);
     expect(
-      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: "INV-1042" })
+      paymentEventMatches({
+        to: TO,
+        memo: MEMO_INV1042,
+        memoFilter: "INV-1042",
+      }),
     ).toBe(true);
     expect(
-      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: "ABC" })
+      paymentEventMatches({ to: TO, memo: MEMO_INV1042, memoFilter: "ABC" }),
     ).toBe(false);
-    expect(
-      paymentEventMatches({ to: TO, memo: 42, memoFilter: "INV" })
-    ).toBe(false);
+    expect(paymentEventMatches({ to: TO, memo: 42, memoFilter: "INV" })).toBe(
+      false,
+    );
   });
 
   it("requires both filters to pass when both are set", () => {
@@ -59,7 +67,7 @@ describe("paymentEventMatches", () => {
         memo: MEMO_INV1042,
         recipientFilter: TO,
         memoFilter: "INV-104",
-      })
+      }),
     ).toBe(true);
     expect(
       paymentEventMatches({
@@ -67,7 +75,7 @@ describe("paymentEventMatches", () => {
         memo: MEMO_INV1042,
         recipientFilter: TO,
         memoFilter: "INV-104",
-      })
+      }),
     ).toBe(false);
     expect(
       paymentEventMatches({
@@ -75,7 +83,7 @@ describe("paymentEventMatches", () => {
         memo: MEMO_INV1042,
         recipientFilter: TO,
         memoFilter: "ZZZ",
-      })
+      }),
     ).toBe(false);
   });
 });

--- a/lib/mcp/trigger-input-schema.ts
+++ b/lib/mcp/trigger-input-schema.ts
@@ -66,6 +66,7 @@ export function detectListingTriggerType(nodes: unknown): TriggerKind {
       return "webhook";
     case WorkflowTriggerEnum.EVENT:
     case WorkflowTriggerEnum.BLOCK:
+    case WorkflowTriggerEnum.TEMPO_PAYMENT:
       return "on-chain-event";
     default:
       return "manual";

--- a/lib/mcp/workflow-schema-constants.ts
+++ b/lib/mcp/workflow-schema-constants.ts
@@ -227,6 +227,33 @@ export const TRIGGERS = {
         "string - ISO timestamp when the block was detected (available on all trigger types)",
     },
   },
+  "Tempo Payment Received": {
+    triggerType: "Tempo Payment Received",
+    label: "Tempo Payment Received",
+    description:
+      "Fires when a TIP-20 TransferWithMemo payment lands on a watched Tempo address, with an optional memo filter for invoice matching",
+    requiredFields: {
+      network: 'string - Tempo chain ID ("4217" mainnet, "42431" Moderato)',
+      contractAddress:
+        "string - TIP-20 stablecoin token contract to watch for payments",
+      recipientAddress:
+        "string - The deposit address to match against the transfer recipient",
+    },
+    optionalFields: {
+      memo: "string - Only fire when the transfer memo matches. A 0x + 64-hex value matches exactly; a shorter string matches as a prefix",
+    },
+    outputFields: {
+      "args.from": "string - Sender address of the payment",
+      "args.to": "string - Recipient address (the watched deposit address)",
+      "args.value": "string - Amount transferred, in the token's smallest unit",
+      "args.memo": "string - The bytes32 memo attached to the transfer",
+      transactionHash: "string - Hash of the payment transaction",
+      blockNumber: "number - Block height the payment landed in",
+      address: "string - The TIP-20 token contract that emitted the event",
+      triggeredAt:
+        "string - ISO timestamp when the payment was detected (available on all trigger types)",
+    },
+  },
 } as const;
 
 // =============================================================================

--- a/lib/rpc/rpc-config.ts
+++ b/lib/rpc/rpc-config.ts
@@ -35,6 +35,8 @@ export const PUBLIC_RPCS = {
   BASE_SEPOLIA: "https://sepolia.base.org",
   TEMPO_TESTNET: "https://rpc.testnet.tempo.xyz",
   TEMPO_MAINNET: "https://rpc.tempo.xyz",
+  TEMPO_TESTNET_WSS: "wss://rpc.moderato.tempo.xyz",
+  TEMPO_MAINNET_WSS: "wss://rpc.tempo.xyz",
   BSC_MAINNET: "https://bsc-dataseed.binance.org",
   BSC_MAINNET_FALLBACK: "https://rpc.ankr.com/bsc",
   BSC_TESTNET: "https://bsc-testnet-rpc.publicnode.com",
@@ -81,6 +83,11 @@ export type ChainConfigEntry = {
   fallbackEnvKey: string;
   publicDefault: string;
   publicFallback?: string;
+  // Public WebSocket defaults. Only set for chains that publish a reliable
+  // public WSS endpoint (e.g. Tempo). getWssUrl falls back to these when the
+  // JSON config has no WSS URL, mirroring publicDefault on the HTTP path.
+  publicWssDefault?: string;
+  publicWssFallback?: string;
 };
 
 export const CHAIN_CONFIG: Record<number, ChainConfigEntry> = {
@@ -119,6 +126,7 @@ export const CHAIN_CONFIG: Record<number, ChainConfigEntry> = {
     envKey: "CHAIN_TEMPO_TESTNET_PRIMARY_RPC",
     fallbackEnvKey: "CHAIN_TEMPO_TESTNET_FALLBACK_RPC",
     publicDefault: PUBLIC_RPCS.TEMPO_TESTNET,
+    publicWssDefault: PUBLIC_RPCS.TEMPO_TESTNET_WSS,
   },
   // Tempo Mainnet
   4217: {
@@ -126,6 +134,7 @@ export const CHAIN_CONFIG: Record<number, ChainConfigEntry> = {
     envKey: "CHAIN_TEMPO_MAINNET_PRIMARY_RPC",
     fallbackEnvKey: "CHAIN_TEMPO_MAINNET_FALLBACK_RPC",
     publicDefault: PUBLIC_RPCS.TEMPO_MAINNET,
+    publicWssDefault: PUBLIC_RPCS.TEMPO_MAINNET_WSS,
   },
   // BNB Chain (BSC) Mainnet
   56: {
@@ -444,14 +453,20 @@ export function getWssUrl(options: GetWssUrlOptions): string | undefined {
   const { rpcConfig, jsonKey, type } = options;
   const entry = rpcConfig[jsonKey];
 
-  if (!entry) {
-    return;
+  const fromJson =
+    type === "primary" ? entry?.primaryWssUrl : entry?.fallbackWssUrl;
+  if (fromJson) {
+    return fromJson;
   }
 
-  if (type === "primary") {
-    return entry.primaryWssUrl;
-  }
-  return entry.fallbackWssUrl;
+  // Fall back to the chain's public WSS default (mirrors the HTTP publicDefault
+  // path). Only chains that publish a reliable public WSS endpoint set this.
+  const chainEntry = Object.values(CHAIN_CONFIG).find(
+    (c) => c.jsonKey === jsonKey
+  );
+  return type === "primary"
+    ? chainEntry?.publicWssDefault
+    : chainEntry?.publicWssFallback;
 }
 
 /**

--- a/lib/workflow/editor/trigger-output-fields.ts
+++ b/lib/workflow/editor/trigger-output-fields.ts
@@ -150,6 +150,36 @@ export function getBlockTriggerOutputFields(): OutputField[] {
 }
 
 /**
+ * Get output fields for the Tempo Payment Received trigger. The watched event
+ * is the fixed TIP-20 `TransferWithMemo(from, to, value, memo)`, so the decoded
+ * args are known up front (no ABI needed).
+ */
+export function getTempoPaymentOutputFields(): OutputField[] {
+  return [
+    { field: "args.from", description: "Sender address of the payment" },
+    {
+      field: "args.to",
+      description: "Recipient address (the watched deposit address)",
+    },
+    {
+      field: "args.value",
+      description: "Amount transferred, in the token's smallest unit",
+    },
+    {
+      field: "args.memo",
+      description: "The bytes32 memo attached to the transfer",
+    },
+    { field: "transactionHash", description: "Hash of the payment transaction" },
+    { field: "blockNumber", description: "Block height the payment landed in" },
+    {
+      field: "address",
+      description: "The TIP-20 token contract that emitted the event",
+    },
+    TRIGGERED_AT_FIELD,
+  ];
+}
+
+/**
  * Get output fields for a trigger node based on its configuration
  */
 export function getTriggerOutputFields(
@@ -158,6 +188,10 @@ export function getTriggerOutputFields(
 ): OutputField[] {
   if (triggerType === "Block") {
     return getBlockTriggerOutputFields();
+  }
+
+  if (triggerType === "Tempo Payment Received") {
+    return getTempoPaymentOutputFields();
   }
 
   if (triggerType === "Event") {

--- a/lib/workflow/store.ts
+++ b/lib/workflow/store.ts
@@ -16,6 +16,7 @@ export enum WorkflowTriggerEnum {
   WEBHOOK = "Webhook",
   EVENT = "Event", // keeperhub custom field //
   BLOCK = "Block", // keeperhub custom field //
+  TEMPO_PAYMENT = "Tempo Payment Received", // keeperhub custom field //
 }
 
 export type WorkflowTriggerType = `${WorkflowTriggerEnum}`;
@@ -31,7 +32,8 @@ export function shouldShowEnableSwitch(
     triggerType === WorkflowTriggerEnum.EVENT ||
     triggerType === WorkflowTriggerEnum.SCHEDULE ||
     triggerType === WorkflowTriggerEnum.BLOCK ||
-    triggerType === WorkflowTriggerEnum.WEBHOOK
+    triggerType === WorkflowTriggerEnum.WEBHOOK ||
+    triggerType === WorkflowTriggerEnum.TEMPO_PAYMENT
   );
 }
 

--- a/plugins/tempo/index.ts
+++ b/plugins/tempo/index.ts
@@ -29,7 +29,6 @@ const tempoPlugin: IntegrationPlugin = {
       description:
         "Send a TIP-20 stablecoin payment on Tempo carrying an on-chain bytes32 memo (e.g. an invoice or pay-run reference)",
       category: "Tempo",
-      requiresCredentials: true,
       stepFunction: "transferWithMemoStep",
       stepImportPath: "transfer-with-memo",
       outputFields: [
@@ -107,7 +106,6 @@ const tempoPlugin: IntegrationPlugin = {
       description:
         "Pay many recipients in one atomic Tempo transaction, each payment stamped with its own memo. All payments settle together or none do.",
       category: "Tempo",
-      requiresCredentials: true,
       stepFunction: "batchPayoutStep",
       stepImportPath: "batch-payout",
       outputFields: [
@@ -179,7 +177,6 @@ const tempoPlugin: IntegrationPlugin = {
       description:
         "Market-swap one Tempo stablecoin for another on the enshrined DEX, protected by a minimum-output slippage floor",
       category: "Tempo",
-      requiresCredentials: true,
       stepFunction: "dexSwapStep",
       stepImportPath: "dex-swap",
       outputFields: [
@@ -266,7 +263,6 @@ const tempoPlugin: IntegrationPlugin = {
       description:
         "Send a stablecoin payment bounded to an inclusion window (valid-after / valid-before) so it only lands during the intended timeframe",
       category: "Tempo",
-      requiresCredentials: true,
       stepFunction: "schedulePaymentStep",
       stepImportPath: "schedule-payment",
       outputFields: [

--- a/plugins/tempo/steps/batch-payout.ts
+++ b/plugins/tempo/steps/batch-payout.ts
@@ -171,6 +171,7 @@ async function stepHandler(input: BatchPayoutInput): Promise<BatchPayoutResult> 
       chainId,
       calls,
       feeToken: token.address,
+      executionId: _context?.executionId,
     });
 
     const transactionLink = await buildTempoTxLink(chainId, hash);

--- a/plugins/tempo/steps/dex-swap.ts
+++ b/plugins/tempo/steps/dex-swap.ts
@@ -152,6 +152,7 @@ async function stepHandler(input: DexSwapInput): Promise<DexSwapResult> {
       chainId,
       calls: [call],
       feeToken: tokenIn.address,
+      executionId: _context?.executionId,
     });
 
     const transactionLink = await buildTempoTxLink(chainId, hash);

--- a/plugins/tempo/steps/schedule-payment.ts
+++ b/plugins/tempo/steps/schedule-payment.ts
@@ -170,6 +170,7 @@ async function stepHandler(
       feeToken: token.address,
       validAfter: validAfterSec,
       validBefore: validBeforeSec,
+      executionId: _context?.executionId,
     });
 
     const transactionLink = await buildTempoTxLink(chainId, hash);

--- a/plugins/tempo/steps/tempo-tx-core.ts
+++ b/plugins/tempo/steps/tempo-tx-core.ts
@@ -55,16 +55,29 @@ const nonceInterface = new ethers.Interface(NONCE_ABI);
 const MAX_UINT256 = (BigInt(1) << BigInt(256)) - BigInt(1);
 
 /**
- * Fixed nonce lane for KeeperHub-initiated Tempo transactions. A stable,
- * KeeperHub-specific 2D-nonce key keeps our sequence out of lane 0 (the
- * protocol nonce) and the max-uint256 lane (the expiring marker). Concurrent
- * sends from the same wallet on this lane race on the read-then-sign; that is
- * an accepted v1 limitation for the monthly-cadence payout flows (mainnet
- * hardening is a follow-up).
+ * Derive a unique 2D-nonce lane for a single send. Tempo's nonce manager keeps
+ * an independent sequence per (account, key), so giving every broadcast its own
+ * key removes the read-then-sign race: two concurrent sends from one wallet
+ * never share a lane, so neither reads a nonce the other is about to consume.
+ *
+ * The key is namespaced under a KeeperHub-specific prefix and salted with random
+ * bytes, so it stays unique even when two sends share an execution (parallel
+ * branches) or carry no execution id. The execution id is folded in only so a
+ * lane traces back to its run in logs. The result is mapped into
+ * [1, MAX_UINT256 - 1] to stay off lane 0 (the protocol nonce) and the
+ * max-uint256 expiring-marker lane.
  */
-const KEEPERHUB_TEMPO_NONCE_KEY = BigInt(
-  ethers.keccak256(ethers.toUtf8Bytes("keeperhub:tempo:nonce-lane:v1"))
-);
+export function deriveTempoNonceKey(executionId: string | undefined): bigint {
+  const salt = ethers.hexlify(ethers.randomBytes(16));
+  const raw = BigInt(
+    ethers.keccak256(
+      ethers.toUtf8Bytes(
+        `keeperhub:tempo:nonce-lane:v2:${executionId ?? "adhoc"}:${salt}`
+      )
+    )
+  );
+  return (raw % (MAX_UINT256 - BigInt(1))) + BigInt(1);
+}
 
 const RECEIPT_TIMEOUT_MS = 60_000;
 const RECEIPT_POLL_INTERVAL_MS = 1500;
@@ -95,6 +108,8 @@ export type SignAndBroadcastParams = {
   /** Optional inclusion window (unix seconds) for scheduled payments. */
   validAfter?: number;
   validBefore?: number;
+  /** Execution id, folded into the per-send nonce lane for traceability. */
+  executionId?: string;
 };
 
 export type SignAndBroadcastResult = { hash: string; from: string };
@@ -310,9 +325,14 @@ export async function signAndBroadcastTempoTx(
   }
   const from = toChecksumAddress(wallet.walletAddress);
 
+  // A fresh lane per send: concurrent sends from this wallet never share a
+  // 2D-nonce sequence, so the read below cannot return a nonce another send is
+  // about to consume.
+  const nonceKey = deriveTempoNonceKey(params.executionId);
+
   const rpcManager = await getRpcProvider({ chainId, userId });
   const [nonce, estimatedGas] = await Promise.all([
-    readTempoNonce(rpcManager, from, KEEPERHUB_TEMPO_NONCE_KEY),
+    readTempoNonce(rpcManager, from, nonceKey),
     estimateTempoGas(rpcManager, from, calls),
   ]);
 
@@ -332,7 +352,7 @@ export async function signAndBroadcastTempoTx(
     chainId,
     calls: calls.map((c) => ({ to: c.to, data: c.data })),
     nonce,
-    nonceKey: KEEPERHUB_TEMPO_NONCE_KEY,
+    nonceKey,
     feeToken,
     gas: gasConfig.gasLimit,
     maxFeePerGas: gasConfig.maxFeePerGas,

--- a/plugins/tempo/steps/transfer-with-memo.ts
+++ b/plugins/tempo/steps/transfer-with-memo.ts
@@ -105,6 +105,7 @@ async function stepHandler(
       chainId,
       calls: [call],
       feeToken: token.address,
+      executionId: _context?.executionId,
     });
 
     const transactionLink = await buildTempoTxLink(chainId, hash);

--- a/scripts/seed/fixtures/tempo-templates.ts
+++ b/scripts/seed/fixtures/tempo-templates.ts
@@ -1,0 +1,351 @@
+/**
+ * Tempo demo workflow templates.
+ *
+ * Three deployable, publicly-listed templates that exercise the Tempo plugin
+ * end to end: Invoice Reconciliation (payment-received trigger + memo match),
+ * Contractor Batch Payroll (atomic batch payout), and Treasury Sweep (DEX swap
+ * plus windowed disbursement). Seeded via seed-tempo-templates.ts and surfaced
+ * through /api/workflows/public + MCP deploy_template.
+ *
+ * Clone-time fields (deposit address, payee API, recipients, amounts, notify
+ * email) are seeded as `{{placeholder}}` tokens rather than empty strings: an
+ * empty required field makes the cloned workflow fail save-validation, whereas
+ * a template token passes validation and reads as "replace me". The cloner
+ * swaps each token for a concrete value or an upstream-node reference. Seeded
+ * against Tempo Moderato testnet (42431); to point a clone at mainnet, flip the
+ * network to 4217 and swap the token addresses.
+ */
+
+import { computeAutoLayout } from "@/lib/workflow/editor/auto-layout";
+import {
+  buildActionNode,
+  buildConditionNode,
+  buildEdge,
+  buildTriggerNode,
+  type WorkflowNodeJson,
+} from "@/lib/workflow/node-builders";
+
+const TEMPO_TESTNET = "42431";
+// PathUSD (enshrined) and AlphaUSD on Moderato, both 6-decimal stablecoins.
+const PATH_USD = "0x20c0000000000000000000000000000000000000";
+const ALPHA_USD = "0x20c0000000000000000000000000000000000001";
+
+export type TempoTemplateFixture = {
+  id: string;
+  listedSlug: string;
+  name: string;
+  description: string;
+  category: string;
+  chain: string;
+  inputSchema: Record<string, unknown>;
+  nodes: unknown[];
+  edges: unknown[];
+};
+
+/**
+ * Email notification node. Built inline (not via `buildEmailNode`) so the
+ * config carries only the action's own fields. `buildEmailNode` also writes
+ * `useKeeperHubApiKey`, which is a plugin form field rather than an action
+ * config field: the save-time validator rejects it as an unknown field, and it
+ * cannot be cleared from the node config panel. The send-email step always uses
+ * the KeeperHub API key regardless, so omitting it changes nothing at runtime.
+ */
+function buildTempoEmailNode(
+  id: string,
+  to: string,
+  subject: string,
+  body: string,
+  yOffset: number
+): WorkflowNodeJson {
+  return buildActionNode(
+    id,
+    "Send Email Alert",
+    "Send an email notification",
+    {
+      actionType: "sendgrid/send-email",
+      emailTo: to,
+      emailSubject: subject,
+      emailBody: body,
+    },
+    yOffset
+  );
+}
+
+function withAutoLayout(fixture: TempoTemplateFixture): TempoTemplateFixture {
+  const positions = computeAutoLayout(
+    fixture.nodes as unknown as Parameters<typeof computeAutoLayout>[0],
+    fixture.edges as unknown as Parameters<typeof computeAutoLayout>[1]
+  );
+  const nodes = (fixture.nodes as WorkflowNodeJson[]).map((node) => {
+    const pos = positions.get(node.id);
+    return pos ? { ...node, position: pos } : node;
+  });
+  return { ...fixture, nodes };
+}
+
+const RAW_FIXTURES: TempoTemplateFixture[] = [
+  {
+    id: "tempo-invoice-reconciliation",
+    listedSlug: "tempo-invoice-reconciliation",
+    name: "Tempo Invoice Reconciliation",
+    description:
+      "When a stablecoin payment lands on your Tempo deposit address whose memo matches an open invoice, mark it paid in your accounting system and email the customer a receipt.",
+    category: "Payments",
+    chain: TEMPO_TESTNET,
+    inputSchema: {
+      type: "object",
+      properties: {
+        depositAddress: {
+          type: "string",
+          description: "Your Tempo deposit address to watch for payments",
+        },
+        accountingApiUrl: {
+          type: "string",
+          description: "URL your workflow POSTs to when an invoice is paid",
+        },
+        notifyEmail: {
+          type: "string",
+          description: "Email address that receives the payment receipt",
+        },
+      },
+      required: ["depositAddress"],
+    },
+    nodes: [
+      buildTriggerNode("trigger-1", {
+        triggerType: "Tempo Payment Received",
+        network: TEMPO_TESTNET,
+        contractAddress: PATH_USD,
+        recipientAddress: "",
+        memo: "",
+      }),
+      buildConditionNode(
+        "step-1",
+        {
+          condition: "{{@trigger-1:Tempo Payment Received.args.value}} >= 0",
+          group: {
+            id: "group-1",
+            logic: "AND",
+            rules: [
+              {
+                id: "rule-1",
+                leftOperand:
+                  "{{@trigger-1:Tempo Payment Received.args.value}}",
+                operator: ">=",
+                rightOperand: "0",
+              },
+            ],
+          },
+        },
+        400
+      ),
+      buildActionNode(
+        "step-2",
+        "Mark Invoice Paid",
+        "POST to your accounting API to mark the invoice paid",
+        {
+          actionType: "HTTP Request",
+          method: "POST",
+          url: "{{accountingApiUrl}}",
+          body: '{"memo":"{{@trigger-1:Tempo Payment Received.args.memo}}","amount":"{{@trigger-1:Tempo Payment Received.args.value}}"}',
+        },
+        600
+      ),
+      buildTempoEmailNode(
+        "step-3",
+        "{{notifyEmail}}",
+        "Payment received",
+        "We received your payment on Tempo. View it on explore.testnet.tempo.xyz. Thank you!",
+        800
+      ),
+    ],
+    edges: [
+      buildEdge("trigger-1", "step-1"),
+      buildEdge("step-1", "step-2", "true"),
+      buildEdge("step-2", "step-3"),
+    ],
+  },
+
+  {
+    id: "tempo-contractor-batch-payroll",
+    listedSlug: "tempo-contractor-batch-payroll",
+    name: "Tempo Contractor Batch Payroll",
+    description:
+      "On the first of every month, pay your contractors their stablecoin amounts on Tempo in a single atomic batch transaction, each stamped with the pay-run id, and email yourself the confirmation.",
+    category: "Payments",
+    chain: TEMPO_TESTNET,
+    inputSchema: {
+      type: "object",
+      properties: {
+        payeeApiUrl: {
+          type: "string",
+          description: "URL returning the approved payee list as JSON",
+        },
+        notifyEmail: {
+          type: "string",
+          description: "Email address that receives the payroll confirmation",
+        },
+      },
+      required: [],
+    },
+    nodes: [
+      buildTriggerNode("trigger-1", {
+        triggerType: "Schedule",
+        scheduleCron: "0 9 1 * *",
+        scheduleTimezone: "UTC",
+      }),
+      buildActionNode(
+        "step-1",
+        "Fetch Payees",
+        "Fetch the approved payee list from your payroll API",
+        { actionType: "HTTP Request", method: "GET", url: "{{payeeApiUrl}}" },
+        400
+      ),
+      buildActionNode(
+        "step-2",
+        "Batch Payout",
+        "Pay all contractors in one atomic Tempo transaction",
+        {
+          actionType: "tempo/batch-payout",
+          network: TEMPO_TESTNET,
+          tokenConfig: PATH_USD,
+          payouts: "{{@step-1:Fetch Payees.body}}",
+          memo: "PAYRUN",
+        },
+        600
+      ),
+      buildActionNode(
+        "step-3",
+        "Confirm Transaction",
+        "Fetch the batch transaction details",
+        {
+          actionType: "web3/get-transaction",
+          network: TEMPO_TESTNET,
+          transactionHash: "{{@step-2:Batch Payout.transactionHash}}",
+        },
+        800
+      ),
+      buildTempoEmailNode(
+        "step-4",
+        "{{notifyEmail}}",
+        "Payroll run complete",
+        "Your contractor payroll ran on Tempo. Transaction: {{@step-2:Batch Payout.transactionLink}}",
+        1000
+      ),
+    ],
+    edges: [
+      buildEdge("trigger-1", "step-1"),
+      buildEdge("step-1", "step-2"),
+      buildEdge("step-2", "step-3"),
+      buildEdge("step-3", "step-4"),
+    ],
+  },
+
+  {
+    id: "tempo-treasury-sweep",
+    listedSlug: "tempo-treasury-sweep",
+    name: "Tempo Treasury Sweep",
+    description:
+      "Every morning, if your Tempo operating wallet holds more than your buffer, swap the excess into your treasury stablecoin on the native DEX and schedule the owner disbursement to land during business hours.",
+    category: "Treasury",
+    chain: TEMPO_TESTNET,
+    inputSchema: {
+      type: "object",
+      properties: {
+        operatingWallet: {
+          type: "string",
+          description: "The operating wallet whose balance is swept",
+        },
+        excessAmount: {
+          type: "string",
+          description: "Amount of the operating stablecoin to swap into treasury",
+        },
+        disbursementAmount: {
+          type: "string",
+          description: "Amount to disburse to the owner after the swap",
+        },
+        disbursementRecipient: {
+          type: "string",
+          description: "Owner address that receives the scheduled disbursement",
+        },
+      },
+      required: [],
+    },
+    nodes: [
+      buildTriggerNode("trigger-1", {
+        triggerType: "Schedule",
+        scheduleCron: "0 8 * * *",
+        scheduleTimezone: "UTC",
+      }),
+      buildActionNode(
+        "step-1",
+        "Check Balance",
+        "Read the operating wallet's stablecoin balance",
+        {
+          actionType: "web3/check-token-balance",
+          network: TEMPO_TESTNET,
+          address: "{{operatingWallet}}",
+          tokenConfig: PATH_USD,
+        },
+        400
+      ),
+      buildConditionNode(
+        "step-2",
+        {
+          condition:
+            "{{@step-1:Check Balance.balance.balanceRaw}} > 50000000000",
+          group: {
+            id: "group-1",
+            logic: "AND",
+            rules: [
+              {
+                id: "rule-1",
+                leftOperand:
+                  "{{@step-1:Check Balance.balance.balanceRaw}}",
+                operator: ">",
+                rightOperand: "50000000000",
+              },
+            ],
+          },
+        },
+        600
+      ),
+      buildActionNode(
+        "step-3",
+        "Swap Excess",
+        "Swap the excess into the treasury stablecoin on the native DEX",
+        {
+          actionType: "tempo/dex-swap",
+          network: TEMPO_TESTNET,
+          tokenInConfig: PATH_USD,
+          tokenOutConfig: ALPHA_USD,
+          amountIn: "{{excessAmount}}",
+          slippageBps: 50,
+        },
+        800
+      ),
+      buildActionNode(
+        "step-4",
+        "Schedule Disbursement",
+        "Schedule the owner disbursement to land during business hours",
+        {
+          actionType: "tempo/schedule-payment",
+          network: TEMPO_TESTNET,
+          tokenConfig: ALPHA_USD,
+          amount: "{{disbursementAmount}}",
+          recipientAddress: "{{disbursementRecipient}}",
+          memo: "owner-disbursement",
+        },
+        1000
+      ),
+    ],
+    edges: [
+      buildEdge("trigger-1", "step-1"),
+      buildEdge("step-1", "step-2"),
+      buildEdge("step-2", "step-3", "true"),
+      buildEdge("step-3", "step-4"),
+    ],
+  },
+];
+
+export const TEMPO_TEMPLATE_FIXTURES: TempoTemplateFixture[] =
+  RAW_FIXTURES.map(withAutoLayout);

--- a/scripts/seed/seed-tempo-templates.ts
+++ b/scripts/seed/seed-tempo-templates.ts
@@ -1,0 +1,165 @@
+#!/usr/bin/env tsx
+
+/**
+ * Seed the three Tempo demo workflow templates as listed, public,
+ * deployable workflows (invoice reconciliation, batch payroll, treasury
+ * sweep). They surface automatically through /api/workflows/public and MCP
+ * deploy_template.
+ *
+ * Templates are seeded with `enabled: false`: they are clone targets, not
+ * live workflows. A cloner configures their copy (deposit address, payee API,
+ * recipients, amounts) and enables it.
+ *
+ * Idempotent, matching the onboarding seeder:
+ *   - Insert when the stable id is absent.
+ *   - Refresh when the seeder last touched the row (seededAt ~ updatedAt).
+ *   - Skip when the user has edited it since (updatedAt diverges from seededAt).
+ *
+ * Standalone usage:
+ *   pnpm tsx scripts/seed/seed-tempo-templates.ts [--user=<email>]
+ */
+
+import "dotenv/config";
+
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+
+import { getDatabaseUrl } from "../../lib/db/connection-utils";
+import { member, users, workflows } from "../../lib/db/schema";
+import { TEMPO_TEMPLATE_FIXTURES } from "./fixtures/tempo-templates";
+
+/** Gap in ms between seededAt and updatedAt that indicates a user edit. */
+const USER_EDIT_EPSILON_MS = 5_000;
+
+type Identity = { userId: string; orgId: string };
+type SeedResult = { created: number; refreshed: number; skipped: number };
+
+export async function seedTempoTemplates(
+  db: ReturnType<typeof drizzle>,
+  identity: Identity
+): Promise<SeedResult> {
+  const result: SeedResult = { created: 0, refreshed: 0, skipped: 0 };
+  const now = new Date();
+
+  for (const fixture of TEMPO_TEMPLATE_FIXTURES) {
+    const base = {
+      name: fixture.name,
+      description: fixture.description,
+      userId: identity.userId,
+      organizationId: identity.orgId,
+      nodes: fixture.nodes,
+      edges: fixture.edges,
+      visibility: "public" as const,
+      enabled: false,
+      featured: false,
+      isListed: true,
+      listedSlug: fixture.listedSlug,
+      listedAt: now,
+      inputSchema: fixture.inputSchema,
+      priceUsdcPerCall: "0",
+      category: fixture.category,
+      chain: fixture.chain,
+      seededAt: now,
+      updatedAt: now,
+      deletedAt: null,
+    };
+
+    const existing = await db
+      .select({
+        id: workflows.id,
+        updatedAt: workflows.updatedAt,
+        seededAt: workflows.seededAt,
+      })
+      .from(workflows)
+      .where(eq(workflows.id, fixture.id))
+      .limit(1);
+
+    if (!existing[0]) {
+      await db
+        .insert(workflows)
+        .values({ id: fixture.id, createdAt: now, ...base });
+      result.created++;
+      continue;
+    }
+
+    const row = existing[0];
+    const updatedMs = row.updatedAt?.getTime() ?? 0;
+    const seededMs = row.seededAt?.getTime() ?? 0;
+    const userEdited =
+      row.seededAt === null || updatedMs - seededMs > USER_EDIT_EPSILON_MS;
+    if (userEdited) {
+      result.skipped++;
+      continue;
+    }
+
+    await db.update(workflows).set(base).where(eq(workflows.id, fixture.id));
+    result.refreshed++;
+  }
+
+  return result;
+}
+
+async function resolveIdentity(
+  db: ReturnType<typeof drizzle>,
+  email: string
+): Promise<Identity | null> {
+  const userRow = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1);
+  if (!userRow[0]) {
+    // biome-ignore lint/suspicious/noConsole: seed script CLI output
+    console.log(`User not found: ${email} -- skipping Tempo template seed`);
+    return null;
+  }
+  const memberRow = await db
+    .select({ organizationId: member.organizationId })
+    .from(member)
+    .where(eq(member.userId, userRow[0].id))
+    .limit(1);
+  if (!memberRow[0]) {
+    // biome-ignore lint/suspicious/noConsole: seed script CLI output
+    console.log(`User ${email} has no organization -- skipping`);
+    return null;
+  }
+  return { userId: userRow[0].id, orgId: memberRow[0].organizationId };
+}
+
+async function main(): Promise<void> {
+  const emailArg = process.argv
+    .slice(2)
+    .find((a) => a.startsWith("--user="))
+    ?.split("=")[1];
+  const email = emailArg ?? process.env.SEED_EMAIL ?? "dev@keeperhub.local";
+
+  const client = postgres(getDatabaseUrl(), { max: 1 });
+  const db = drizzle(client);
+  try {
+    const identity = await resolveIdentity(db, email);
+    if (!identity) {
+      return;
+    }
+    const result = await seedTempoTemplates(db, identity);
+    // biome-ignore lint/suspicious/noConsole: seed script CLI output
+    console.log(
+      `Tempo templates -> org ${identity.orgId}: created ${result.created}, refreshed ${result.refreshed}, skipped ${result.skipped}`
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+const isMain =
+  process.argv[1] &&
+  (process.argv[1].endsWith("seed-tempo-templates.ts") ||
+    process.argv[1].endsWith("seed-tempo-templates.js"));
+
+if (isMain) {
+  main().catch((err: unknown) => {
+    // biome-ignore lint/suspicious/noConsole: seed script CLI output
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tests/unit/tempo-tx-core.test.ts
+++ b/tests/unit/tempo-tx-core.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
 import { decodeFunctionData } from "viem";
 import { Abis } from "viem/tempo";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
@@ -26,6 +26,7 @@ vi.mock("@/lib/logging", () => ({
 
 import {
   buildTransferWithMemoCall,
+  deriveTempoNonceKey,
   isTempoChain,
   normalizeMemo,
 } from "@/plugins/tempo/steps/tempo-tx-core";
@@ -33,6 +34,38 @@ import {
 const ZERO_MEMO = `0x${"0".repeat(64)}`;
 const USDC = "0x20c0000000000000000000000000000000000001" as const;
 const RECIPIENT = "0x1111111111111111111111111111111111111111" as const;
+const TOO_LONG_MEMO = /too long/;
+
+describe("deriveTempoNonceKey", () => {
+  const MAX_UINT256 = (BigInt(1) << BigInt(256)) - BigInt(1);
+
+  it("gives concurrent sends from one wallet their own lanes", () => {
+    // Two sends in the same execution get distinct 2D-nonce lanes, so neither
+    // reads a nonce the other is about to consume and both can land.
+    const a = deriveTempoNonceKey("exec-1");
+    const b = deriveTempoNonceKey("exec-1");
+    expect(a).not.toBe(b);
+  });
+
+  it("produces a unique lane on every call, with or without an execution id", () => {
+    const keys = new Set(
+      Array.from({ length: 1000 }, (_, i) =>
+        deriveTempoNonceKey(i % 2 === 0 ? "exec" : undefined)
+      )
+    );
+    expect(keys.size).toBe(1000);
+  });
+
+  it("stays off lane 0 and the max-uint256 marker lane", () => {
+    const keys = Array.from({ length: 1000 }, () =>
+      deriveTempoNonceKey(undefined)
+    );
+    for (const key of keys) {
+      expect(key > BigInt(0)).toBe(true);
+      expect(key < MAX_UINT256).toBe(true);
+    }
+  });
+});
 
 describe("isTempoChain", () => {
   it("accepts Tempo mainnet and Moderato testnet", () => {
@@ -67,14 +100,19 @@ describe("normalizeMemo", () => {
   });
 
   it("throws when a plain-text memo exceeds 31 bytes", () => {
-    expect(() => normalizeMemo("x".repeat(32))).toThrow(/too long/);
+    expect(() => normalizeMemo("x".repeat(32))).toThrow(TOO_LONG_MEMO);
   });
 });
 
 describe("buildTransferWithMemoCall", () => {
   it("targets the token and encodes transferWithMemo(to, value, memo)", () => {
     const memo = normalizeMemo("INV-1042");
-    const call = buildTransferWithMemoCall(USDC, RECIPIENT, BigInt(1_500_000), memo);
+    const call = buildTransferWithMemoCall(
+      USDC,
+      RECIPIENT,
+      BigInt(1_500_000),
+      memo
+    );
 
     expect(call.to).toBe(USDC);
     const decoded = decodeFunctionData({ abi: Abis.tip20, data: call.data });

--- a/tests/unit/validate-workflow-structural.test.ts
+++ b/tests/unit/validate-workflow-structural.test.ts
@@ -99,9 +99,16 @@ function buildLargeWorkflowFixture(nodeCount: number): ValidatorWorkflow {
 // ---------------------------------------------------------------------------
 
 describe("TRIGGERS exports", () => {
-  it("has exactly the 5 expected trigger keys", () => {
+  it("has exactly the 6 expected trigger keys", () => {
     const keys = Object.keys(TRIGGERS).sort();
-    expect(keys).toEqual(["Block", "Event", "Manual", "Schedule", "Webhook"]);
+    expect(keys).toEqual([
+      "Block",
+      "Event",
+      "Manual",
+      "Schedule",
+      "Tempo Payment Received",
+      "Webhook",
+    ]);
   });
 
   it("Event trigger outputFields contain eventName and address (Pitfall 2 guard)", () => {


### PR DESCRIPTION
## Summary

Add a dedicated "Tempo Payment Received" workflow trigger that fires when a
TIP-20 TransferWithMemo payment lands on a watched deposit address, with an
optional memo filter for invoice matching. Stacked on the scheduled-payment /
dex-swap branch.

Three parts:

- **WSS seeding**: the event-tracker's workflow-mapper requires a `wss://` URL
  per chain or it skips the workflow, and `getWssUrl` had no public-default
  fallback, so Tempo seeded with a null WSS. Add public WSS defaults for Tempo
  (`wss://rpc.moderato.tempo.xyz` for 42431, `wss://rpc.tempo.xyz` for 4217) and
  let `getWssUrl` fall back to them, mirroring the HTTP `publicDefault` path.
- **Trigger surface**: a new trigger type threaded through the enum, node icon,
  config UI (network + token + deposit address + optional memo, no ABI pickers),
  fixed `from` / `to` / `amount` / `memo` output fields, the TRIGGERS registry,
  and the on-chain-event input mapping. The internal events endpoint admits the
  trigger and injects the fixed `TransferWithMemo` ABI + event name so the
  tracker can build the subscription. The executor is unchanged (reuses the
  event path).
- **Filtering**: in the event-tracker listener, a post-decode predicate drops
  events whose decoded `to` is not the watched address, or whose `memo` does not
  match (an exact bytes32 for a 0x + 64-hex value, a utf8 prefix otherwise).
  Generic Event triggers set neither filter and forward everything as before.

## Testing

- Main-repo and event-tracker type-check + lint clean. Unit tests cover the
  memo / recipient matcher (exact, prefix, recipient, both-filter cases).
- Verified live on Tempo Moderato testnet: the tracker subscribed over WSS,
  detected a real TransferWithMemo to the watched address, matched the recipient
  filter, and fired the workflow with the decoded from / to / amount / memo as
  its input.

## Base branch

Stacked on the scheduled-payment / dex-swap branch; retarget to staging once
that merges.
