### PR TITLE
feat(deploy): give the queue components their own service accounts

### DIFF
--- a/.github/workflows/deploy-events.yaml
+++ b/.github/workflows/deploy-events.yaml
@@ -33,6 +33,7 @@ jobs:
       NAMESPACE: keeperhub
       TRACKER_ECR_NAME: keeperhub-event-${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
       TRACKER_HELM_FILE: deploy/event-tracker/${{ github.ref_name == 'prod' && 'prod' || 'staging' }}/values.yaml
+      EVENTS_SERVICE_ACCOUNT_ROLE_ARN: ${{ vars.TO_EVENTS_ROLE_ARN }}
 
     steps:
       - name: Checkout
@@ -106,10 +107,12 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
           AWS_ACCOUNT_ID: ${{ vars.TO_AWS_ACCOUNT_ID }}
+          EVENTS_SERVICE_ACCOUNT_ROLE_ARN: ${{ env.EVENTS_SERVICE_ACCOUNT_ROLE_ARN }}
         run: |
           sed -i "s|\${ECR_REGISTRY}|${ECR_REGISTRY}|g" "$TRACKER_HELM_FILE"
           sed -i "s|\${IMAGE_TAG}|${IMAGE_TAG}|g" "$TRACKER_HELM_FILE"
           sed -i "s|\${AWS_ACCOUNT_ID}|${AWS_ACCOUNT_ID}|g" "$TRACKER_HELM_FILE"
+          sed -i "s|\${EVENTS_SERVICE_ACCOUNT_ROLE_ARN}|${EVENTS_SERVICE_ACCOUNT_ROLE_ARN}|g" "$TRACKER_HELM_FILE"
 
       - name: Configure kubectl
         if: steps.skip.outputs.skip_deploy != 'true'
@@ -132,5 +135,11 @@ jobs:
           timeout: 5m0s
           name: keeperhub-event
           chart-repository: https://techops-services.github.io/helm-charts
-          version: 0.2.1
+          # 0.5.0 is the first version that hard-fails the render when the
+          # service account's IRSA role-arn is empty or malformed. The tracker
+          # now creates its own service account, so without this the annotation
+          # would silently render blank if the role-arn variable were unset and
+          # the pod would fall back to the node role. Rendered output is
+          # otherwise identical to 0.2.1 apart from an opt-in helm test hook.
+          version: 0.5.0
           atomic: true

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -42,6 +42,8 @@ jobs:
       NAMESPACE: keeperhub
       SERVICE_NAME: keeperhub
       SERVICE_ACCOUNT_ROLE_ARN: ${{ vars.TO_SERVICE_ACCOUNT_ROLE_ARN }}
+      EXECUTOR_SERVICE_ACCOUNT_ROLE_ARN: ${{ vars.TO_EXECUTOR_ROLE_ARN }}
+      SCHEDULER_SERVICE_ACCOUNT_ROLE_ARN: ${{ vars.TO_SCHEDULER_ROLE_ARN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -91,11 +93,15 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
           SERVICE_ACCOUNT_ROLE_ARN: ${{ env.SERVICE_ACCOUNT_ROLE_ARN }}
+          EXECUTOR_SERVICE_ACCOUNT_ROLE_ARN: ${{ env.EXECUTOR_SERVICE_ACCOUNT_ROLE_ARN }}
+          SCHEDULER_SERVICE_ACCOUNT_ROLE_ARN: ${{ env.SCHEDULER_SERVICE_ACCOUNT_ROLE_ARN }}
           AWS_ACCOUNT_ID: ${{ vars.TO_AWS_ACCOUNT_ID }}
         run: |
           sed -i "s|\${ECR_REGISTRY}|${ECR_REGISTRY}|g" "$HELM_FILE"
           sed -i "s|\${IMAGE_TAG}|${IMAGE_TAG}|g" "$HELM_FILE"
           sed -i "s|\${SERVICE_ACCOUNT_ROLE_ARN}|${SERVICE_ACCOUNT_ROLE_ARN}|g" "$HELM_FILE"
+          sed -i "s|\${EXECUTOR_SERVICE_ACCOUNT_ROLE_ARN}|${EXECUTOR_SERVICE_ACCOUNT_ROLE_ARN}|g" "$HELM_FILE"
+          sed -i "s|\${SCHEDULER_SERVICE_ACCOUNT_ROLE_ARN}|${SCHEDULER_SERVICE_ACCOUNT_ROLE_ARN}|g" "$HELM_FILE"
           sed -i "s|\${AWS_ACCOUNT_ID}|${AWS_ACCOUNT_ID}|g" "$HELM_FILE"
 
       - name: Configure kubectl

--- a/deploy/event-tracker/prod/values.yaml
+++ b/deploy/event-tracker/prod/values.yaml
@@ -22,9 +22,18 @@ image:
 deployment:
   enabled: true
 
+# Own service account + IRSA role rather than the shared app one, so queue
+# access can be scoped per producer. The role currently carries the same broad
+# queue policy as the shared one, so this repoint cannot lose access; it is
+# narrowed to send-only later.
 serviceAccount:
-  create: false
-  name: keeperhub-prod
+  create: true
+  requireRoleArn: true
+  irsaCheck:
+    enabled: true
+  annotations:
+    eks.amazonaws.com/role-arn: ${EVENTS_SERVICE_ACCOUNT_ROLE_ARN}
+  name: keeperhub-events-prod
 
 podAnnotations:
   reloader.stakater.com/auto: "true"

--- a/deploy/event-tracker/staging/values.yaml
+++ b/deploy/event-tracker/staging/values.yaml
@@ -22,9 +22,18 @@ image:
 deployment:
   enabled: true
 
+# Own service account + IRSA role rather than the shared app one, so queue
+# access can be scoped per producer. The role currently carries the same broad
+# queue policy as the shared one, so this repoint cannot lose access; it is
+# narrowed to send-only later.
 serviceAccount:
-  create: false
-  name: keeperhub-staging
+  create: true
+  requireRoleArn: true
+  irsaCheck:
+    enabled: true
+  annotations:
+    eks.amazonaws.com/role-arn: ${EVENTS_SERVICE_ACCOUNT_ROLE_ARN}
+  name: keeperhub-events-staging
 
 podAnnotations:
   reloader.stakater.com/auto: "true"

--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -675,9 +675,19 @@ executor:
     initContainers:
       - *irsa_preflight
 
+  # Own service account + IRSA role, so queue access can be scoped to the
+  # consumer role independently of the producers. The role currently carries the
+  # same broad queue policy as the shared one, so this repoint cannot lose
+  # access; it is narrowed to receive/delete-only once every component is
+  # confirmed running on its own role.
   serviceAccount:
-    create: false
-    name: keeperhub-prod
+    create: true
+    requireRoleArn: true
+    irsaCheck:
+      enabled: true
+    annotations:
+      eks.amazonaws.com/role-arn: ${EXECUTOR_SERVICE_ACCOUNT_ROLE_ARN}
+    name: keeperhub-executor-prod
 
   podAnnotations:
     reloader.stakater.com/auto: "true"
@@ -894,10 +904,18 @@ schedule:
     initContainers:
       - *irsa_preflight
 
-  # Use the same service account as main app
+  # Owns the scheduler service account, which the block dispatcher below shares -
+  # both are the same logical producer and sign with the same caller. The role
+  # currently carries the same broad queue policy as the shared one, so this
+  # repoint cannot lose access; it is narrowed to send-only later.
   serviceAccount:
-    create: false
-    name: keeperhub-prod
+    create: true
+    requireRoleArn: true
+    irsaCheck:
+      enabled: true
+    annotations:
+      eks.amazonaws.com/role-arn: ${SCHEDULER_SERVICE_ACCOUNT_ROLE_ARN}
+    name: keeperhub-scheduler-prod
 
   podAnnotations:
     reloader.stakater.com/auto: "true"
@@ -1023,10 +1041,11 @@ block:
     initContainers:
       - *irsa_preflight
 
-  # Use the same service account as main app
+  # Shares the scheduler service account created by the schedule component above
+  # (same logical producer), so it is referenced here rather than created.
   serviceAccount:
     create: false
-    name: keeperhub-prod
+    name: keeperhub-scheduler-prod
 
   podAnnotations:
     reloader.stakater.com/auto: "true"

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -676,9 +676,19 @@ executor:
     initContainers:
       - *irsa_preflight
 
+  # Own service account + IRSA role, so queue access can be scoped to the
+  # consumer role independently of the producers. The role currently carries the
+  # same broad queue policy as the shared one, so this repoint cannot lose
+  # access; it is narrowed to receive/delete-only once every component is
+  # confirmed running on its own role.
   serviceAccount:
-    create: false
-    name: keeperhub-staging
+    create: true
+    requireRoleArn: true
+    irsaCheck:
+      enabled: true
+    annotations:
+      eks.amazonaws.com/role-arn: ${EXECUTOR_SERVICE_ACCOUNT_ROLE_ARN}
+    name: keeperhub-executor-staging
 
   podAnnotations:
     reloader.stakater.com/auto: "true"
@@ -895,10 +905,18 @@ schedule:
     initContainers:
       - *irsa_preflight
 
-  # Use the same service account as main app
+  # Owns the scheduler service account, which the block dispatcher below shares -
+  # both are the same logical producer and sign with the same caller. The role
+  # currently carries the same broad queue policy as the shared one, so this
+  # repoint cannot lose access; it is narrowed to send-only later.
   serviceAccount:
-    create: false
-    name: keeperhub-staging
+    create: true
+    requireRoleArn: true
+    irsaCheck:
+      enabled: true
+    annotations:
+      eks.amazonaws.com/role-arn: ${SCHEDULER_SERVICE_ACCOUNT_ROLE_ARN}
+    name: keeperhub-scheduler-staging
 
   podAnnotations:
     reloader.stakater.com/auto: "true"
@@ -1024,10 +1042,11 @@ block:
     initContainers:
       - *irsa_preflight
 
-  # Use the same service account as main app
+  # Shares the scheduler service account created by the schedule component above
+  # (same logical producer), so it is referenced here rather than created.
   serviceAccount:
     create: false
-    name: keeperhub-staging
+    name: keeperhub-scheduler-staging
 
   podAnnotations:
     reloader.stakater.com/auto: "true"


### PR DESCRIPTION
## What

The executor, both scheduler dispatchers and the event tracker all shared the app's service account, so each assumed a single IAM role holding **both** send and receive on the workflow queue. IRSA binds one role to one service account subject, so scoping queue access per component requires splitting the service accounts first. This does that split.

| Component | Service account | Change |
| --- | --- | --- |
| app | `keeperhub-<env>` | unchanged |
| executor | `keeperhub-executor-<env>` | new, own IRSA role |
| schedule dispatcher | `keeperhub-scheduler-<env>` | new, own IRSA role (creates it) |
| block dispatcher | `keeperhub-scheduler-<env>` | shares the scheduler's (same logical producer) |
| event tracker | `keeperhub-events-<env>` | new, own IRSA role |
| metrics collector | `keeperhub-<env>` | unchanged - not a queue participant |

Each new account is annotated with its own IRSA role, injected at deploy time from a per-environment variable exactly the way the app's already is. The IAM roles already exist in both environments and **currently carry the same broad queue policy as the shared role**, so this repoint cannot lose access whatever a component turns out to need. They get narrowed to send-only / receive-only in a follow-up, once every component is confirmed running on its own role.

PR environments are untouched and stay on their single shared account.

## Event tracker chart bump (0.2.1 -> 0.5.0)

Required, not incidental: 0.5.0 is the first version whose `serviceAccount` template hard-fails the render when the role-arn is empty or malformed. At 0.2.1 `requireRoleArn` is silently ignored, so if the role-arn variable were ever unset the annotation would render blank and the pod would quietly fall back to the node role.

Verified the bump is otherwise a no-op by diffing rendered output at both versions with identical values: the manifests are identical apart from 0.5.0 adding an opt-in `helm test` hook.

## Validation

Rendered the real charts (umbrella + common) against both environments' values with the actual role ARNs:

- correct service accounts created, and every workload binds to the intended one
- fail-closed proven: substituting an empty role-arn makes helm refuse to render (`role-arn is missing or malformed: ""`) rather than shipping a credential-less pod
- no cross-environment tokens in either values file
- `actionlint` and YAML validation clean

The six per-environment deploy variables are already set and verified to match the Terraform outputs, so the deploy has real ARNs to substitute.
