### PR TITLE
feat(tempo): add demo workflow templates

### DIFF
--- a/plugins/tempo/index.ts
+++ b/plugins/tempo/index.ts
@@ -29,7 +29,6 @@ const tempoPlugin: IntegrationPlugin = {
       description:
         "Send a TIP-20 stablecoin payment on Tempo carrying an on-chain bytes32 memo (e.g. an invoice or pay-run reference)",
       category: "Tempo",
-      requiresCredentials: true,
       stepFunction: "transferWithMemoStep",
       stepImportPath: "transfer-with-memo",
       outputFields: [
@@ -107,7 +106,6 @@ const tempoPlugin: IntegrationPlugin = {
       description:
         "Pay many recipients in one atomic Tempo transaction, each payment stamped with its own memo. All payments settle together or none do.",
       category: "Tempo",
-      requiresCredentials: true,
       stepFunction: "batchPayoutStep",
       stepImportPath: "batch-payout",
       outputFields: [
@@ -179,7 +177,6 @@ const tempoPlugin: IntegrationPlugin = {
       description:
         "Market-swap one Tempo stablecoin for another on the enshrined DEX, protected by a minimum-output slippage floor",
       category: "Tempo",
-      requiresCredentials: true,
       stepFunction: "dexSwapStep",
       stepImportPath: "dex-swap",
       outputFields: [
@@ -266,7 +263,6 @@ const tempoPlugin: IntegrationPlugin = {
       description:
         "Send a stablecoin payment bounded to an inclusion window (valid-after / valid-before) so it only lands during the intended timeframe",
       category: "Tempo",
-      requiresCredentials: true,
       stepFunction: "schedulePaymentStep",
       stepImportPath: "schedule-payment",
       outputFields: [

--- a/plugins/tempo/steps/batch-payout.ts
+++ b/plugins/tempo/steps/batch-payout.ts
@@ -171,6 +171,7 @@ async function stepHandler(input: BatchPayoutInput): Promise<BatchPayoutResult> 
       chainId,
       calls,
       feeToken: token.address,
+      executionId: _context?.executionId,
     });
 
     const transactionLink = await buildTempoTxLink(chainId, hash);

--- a/plugins/tempo/steps/dex-swap.ts
+++ b/plugins/tempo/steps/dex-swap.ts
@@ -152,6 +152,7 @@ async function stepHandler(input: DexSwapInput): Promise<DexSwapResult> {
       chainId,
       calls: [call],
       feeToken: tokenIn.address,
+      executionId: _context?.executionId,
     });
 
     const transactionLink = await buildTempoTxLink(chainId, hash);

--- a/plugins/tempo/steps/schedule-payment.ts
+++ b/plugins/tempo/steps/schedule-payment.ts
@@ -170,6 +170,7 @@ async function stepHandler(
       feeToken: token.address,
       validAfter: validAfterSec,
       validBefore: validBeforeSec,
+      executionId: _context?.executionId,
     });
 
     const transactionLink = await buildTempoTxLink(chainId, hash);

--- a/plugins/tempo/steps/tempo-tx-core.ts
+++ b/plugins/tempo/steps/tempo-tx-core.ts
@@ -55,16 +55,29 @@ const nonceInterface = new ethers.Interface(NONCE_ABI);
 const MAX_UINT256 = (BigInt(1) << BigInt(256)) - BigInt(1);
 
 /**
- * Fixed nonce lane for KeeperHub-initiated Tempo transactions. A stable,
- * KeeperHub-specific 2D-nonce key keeps our sequence out of lane 0 (the
- * protocol nonce) and the max-uint256 lane (the expiring marker). Concurrent
- * sends from the same wallet on this lane race on the read-then-sign; that is
- * an accepted v1 limitation for the monthly-cadence payout flows (mainnet
- * hardening is a follow-up).
+ * Derive a unique 2D-nonce lane for a single send. Tempo's nonce manager keeps
+ * an independent sequence per (account, key), so giving every broadcast its own
+ * key removes the read-then-sign race: two concurrent sends from one wallet
+ * never share a lane, so neither reads a nonce the other is about to consume.
+ *
+ * The key is namespaced under a KeeperHub-specific prefix and salted with random
+ * bytes, so it stays unique even when two sends share an execution (parallel
+ * branches) or carry no execution id. The execution id is folded in only so a
+ * lane traces back to its run in logs. The result is mapped into
+ * [1, MAX_UINT256 - 1] to stay off lane 0 (the protocol nonce) and the
+ * max-uint256 expiring-marker lane.
  */
-const KEEPERHUB_TEMPO_NONCE_KEY = BigInt(
-  ethers.keccak256(ethers.toUtf8Bytes("keeperhub:tempo:nonce-lane:v1"))
-);
+export function deriveTempoNonceKey(executionId: string | undefined): bigint {
+  const salt = ethers.hexlify(ethers.randomBytes(16));
+  const raw = BigInt(
+    ethers.keccak256(
+      ethers.toUtf8Bytes(
+        `keeperhub:tempo:nonce-lane:v2:${executionId ?? "adhoc"}:${salt}`
+      )
+    )
+  );
+  return (raw % (MAX_UINT256 - BigInt(1))) + BigInt(1);
+}
 
 const RECEIPT_TIMEOUT_MS = 60_000;
 const RECEIPT_POLL_INTERVAL_MS = 1500;
@@ -95,6 +108,8 @@ export type SignAndBroadcastParams = {
   /** Optional inclusion window (unix seconds) for scheduled payments. */
   validAfter?: number;
   validBefore?: number;
+  /** Execution id, folded into the per-send nonce lane for traceability. */
+  executionId?: string;
 };
 
 export type SignAndBroadcastResult = { hash: string; from: string };
@@ -310,9 +325,14 @@ export async function signAndBroadcastTempoTx(
   }
   const from = toChecksumAddress(wallet.walletAddress);
 
+  // A fresh lane per send: concurrent sends from this wallet never share a
+  // 2D-nonce sequence, so the read below cannot return a nonce another send is
+  // about to consume.
+  const nonceKey = deriveTempoNonceKey(params.executionId);
+
   const rpcManager = await getRpcProvider({ chainId, userId });
   const [nonce, estimatedGas] = await Promise.all([
-    readTempoNonce(rpcManager, from, KEEPERHUB_TEMPO_NONCE_KEY),
+    readTempoNonce(rpcManager, from, nonceKey),
     estimateTempoGas(rpcManager, from, calls),
   ]);
 
@@ -332,7 +352,7 @@ export async function signAndBroadcastTempoTx(
     chainId,
     calls: calls.map((c) => ({ to: c.to, data: c.data })),
     nonce,
-    nonceKey: KEEPERHUB_TEMPO_NONCE_KEY,
+    nonceKey,
     feeToken,
     gas: gasConfig.gasLimit,
     maxFeePerGas: gasConfig.maxFeePerGas,

--- a/plugins/tempo/steps/transfer-with-memo.ts
+++ b/plugins/tempo/steps/transfer-with-memo.ts
@@ -105,6 +105,7 @@ async function stepHandler(
       chainId,
       calls: [call],
       feeToken: token.address,
+      executionId: _context?.executionId,
     });
 
     const transactionLink = await buildTempoTxLink(chainId, hash);

--- a/scripts/seed/fixtures/tempo-templates.ts
+++ b/scripts/seed/fixtures/tempo-templates.ts
@@ -1,0 +1,351 @@
+/**
+ * Tempo demo workflow templates.
+ *
+ * Three deployable, publicly-listed templates that exercise the Tempo plugin
+ * end to end: Invoice Reconciliation (payment-received trigger + memo match),
+ * Contractor Batch Payroll (atomic batch payout), and Treasury Sweep (DEX swap
+ * plus windowed disbursement). Seeded via seed-tempo-templates.ts and surfaced
+ * through /api/workflows/public + MCP deploy_template.
+ *
+ * Clone-time fields (deposit address, payee API, recipients, amounts, notify
+ * email) are seeded as `{{placeholder}}` tokens rather than empty strings: an
+ * empty required field makes the cloned workflow fail save-validation, whereas
+ * a template token passes validation and reads as "replace me". The cloner
+ * swaps each token for a concrete value or an upstream-node reference. Seeded
+ * against Tempo Moderato testnet (42431); to point a clone at mainnet, flip the
+ * network to 4217 and swap the token addresses.
+ */
+
+import { computeAutoLayout } from "@/lib/workflow/editor/auto-layout";
+import {
+  buildActionNode,
+  buildConditionNode,
+  buildEdge,
+  buildTriggerNode,
+  type WorkflowNodeJson,
+} from "@/lib/workflow/node-builders";
+
+const TEMPO_TESTNET = "42431";
+// PathUSD (enshrined) and AlphaUSD on Moderato, both 6-decimal stablecoins.
+const PATH_USD = "0x20c0000000000000000000000000000000000000";
+const ALPHA_USD = "0x20c0000000000000000000000000000000000001";
+
+export type TempoTemplateFixture = {
+  id: string;
+  listedSlug: string;
+  name: string;
+  description: string;
+  category: string;
+  chain: string;
+  inputSchema: Record<string, unknown>;
+  nodes: unknown[];
+  edges: unknown[];
+};
+
+/**
+ * Email notification node. Built inline (not via `buildEmailNode`) so the
+ * config carries only the action's own fields. `buildEmailNode` also writes
+ * `useKeeperHubApiKey`, which is a plugin form field rather than an action
+ * config field: the save-time validator rejects it as an unknown field, and it
+ * cannot be cleared from the node config panel. The send-email step always uses
+ * the KeeperHub API key regardless, so omitting it changes nothing at runtime.
+ */
+function buildTempoEmailNode(
+  id: string,
+  to: string,
+  subject: string,
+  body: string,
+  yOffset: number
+): WorkflowNodeJson {
+  return buildActionNode(
+    id,
+    "Send Email Alert",
+    "Send an email notification",
+    {
+      actionType: "sendgrid/send-email",
+      emailTo: to,
+      emailSubject: subject,
+      emailBody: body,
+    },
+    yOffset
+  );
+}
+
+function withAutoLayout(fixture: TempoTemplateFixture): TempoTemplateFixture {
+  const positions = computeAutoLayout(
+    fixture.nodes as unknown as Parameters<typeof computeAutoLayout>[0],
+    fixture.edges as unknown as Parameters<typeof computeAutoLayout>[1]
+  );
+  const nodes = (fixture.nodes as WorkflowNodeJson[]).map((node) => {
+    const pos = positions.get(node.id);
+    return pos ? { ...node, position: pos } : node;
+  });
+  return { ...fixture, nodes };
+}
+
+const RAW_FIXTURES: TempoTemplateFixture[] = [
+  {
+    id: "tempo-invoice-reconciliation",
+    listedSlug: "tempo-invoice-reconciliation",
+    name: "Tempo Invoice Reconciliation",
+    description:
+      "When a stablecoin payment lands on your Tempo deposit address whose memo matches an open invoice, mark it paid in your accounting system and email the customer a receipt.",
+    category: "Payments",
+    chain: TEMPO_TESTNET,
+    inputSchema: {
+      type: "object",
+      properties: {
+        depositAddress: {
+          type: "string",
+          description: "Your Tempo deposit address to watch for payments",
+        },
+        accountingApiUrl: {
+          type: "string",
+          description: "URL your workflow POSTs to when an invoice is paid",
+        },
+        notifyEmail: {
+          type: "string",
+          description: "Email address that receives the payment receipt",
+        },
+      },
+      required: ["depositAddress"],
+    },
+    nodes: [
+      buildTriggerNode("trigger-1", {
+        triggerType: "Tempo Payment Received",
+        network: TEMPO_TESTNET,
+        contractAddress: PATH_USD,
+        recipientAddress: "",
+        memo: "",
+      }),
+      buildConditionNode(
+        "step-1",
+        {
+          condition: "{{@trigger-1:Tempo Payment Received.args.value}} >= 0",
+          group: {
+            id: "group-1",
+            logic: "AND",
+            rules: [
+              {
+                id: "rule-1",
+                leftOperand:
+                  "{{@trigger-1:Tempo Payment Received.args.value}}",
+                operator: ">=",
+                rightOperand: "0",
+              },
+            ],
+          },
+        },
+        400
+      ),
+      buildActionNode(
+        "step-2",
+        "Mark Invoice Paid",
+        "POST to your accounting API to mark the invoice paid",
+        {
+          actionType: "HTTP Request",
+          method: "POST",
+          url: "{{accountingApiUrl}}",
+          body: '{"memo":"{{@trigger-1:Tempo Payment Received.args.memo}}","amount":"{{@trigger-1:Tempo Payment Received.args.value}}"}',
+        },
+        600
+      ),
+      buildTempoEmailNode(
+        "step-3",
+        "{{notifyEmail}}",
+        "Payment received",
+        "We received your payment on Tempo. View it on explore.testnet.tempo.xyz. Thank you!",
+        800
+      ),
+    ],
+    edges: [
+      buildEdge("trigger-1", "step-1"),
+      buildEdge("step-1", "step-2", "true"),
+      buildEdge("step-2", "step-3"),
+    ],
+  },
+
+  {
+    id: "tempo-contractor-batch-payroll",
+    listedSlug: "tempo-contractor-batch-payroll",
+    name: "Tempo Contractor Batch Payroll",
+    description:
+      "On the first of every month, pay your contractors their stablecoin amounts on Tempo in a single atomic batch transaction, each stamped with the pay-run id, and email yourself the confirmation.",
+    category: "Payments",
+    chain: TEMPO_TESTNET,
+    inputSchema: {
+      type: "object",
+      properties: {
+        payeeApiUrl: {
+          type: "string",
+          description: "URL returning the approved payee list as JSON",
+        },
+        notifyEmail: {
+          type: "string",
+          description: "Email address that receives the payroll confirmation",
+        },
+      },
+      required: [],
+    },
+    nodes: [
+      buildTriggerNode("trigger-1", {
+        triggerType: "Schedule",
+        scheduleCron: "0 9 1 * *",
+        scheduleTimezone: "UTC",
+      }),
+      buildActionNode(
+        "step-1",
+        "Fetch Payees",
+        "Fetch the approved payee list from your payroll API",
+        { actionType: "HTTP Request", method: "GET", url: "{{payeeApiUrl}}" },
+        400
+      ),
+      buildActionNode(
+        "step-2",
+        "Batch Payout",
+        "Pay all contractors in one atomic Tempo transaction",
+        {
+          actionType: "tempo/batch-payout",
+          network: TEMPO_TESTNET,
+          tokenConfig: PATH_USD,
+          payouts: "{{@step-1:Fetch Payees.body}}",
+          memo: "PAYRUN",
+        },
+        600
+      ),
+      buildActionNode(
+        "step-3",
+        "Confirm Transaction",
+        "Fetch the batch transaction details",
+        {
+          actionType: "web3/get-transaction",
+          network: TEMPO_TESTNET,
+          transactionHash: "{{@step-2:Batch Payout.transactionHash}}",
+        },
+        800
+      ),
+      buildTempoEmailNode(
+        "step-4",
+        "{{notifyEmail}}",
+        "Payroll run complete",
+        "Your contractor payroll ran on Tempo. Transaction: {{@step-2:Batch Payout.transactionLink}}",
+        1000
+      ),
+    ],
+    edges: [
+      buildEdge("trigger-1", "step-1"),
+      buildEdge("step-1", "step-2"),
+      buildEdge("step-2", "step-3"),
+      buildEdge("step-3", "step-4"),
+    ],
+  },
+
+  {
+    id: "tempo-treasury-sweep",
+    listedSlug: "tempo-treasury-sweep",
+    name: "Tempo Treasury Sweep",
+    description:
+      "Every morning, if your Tempo operating wallet holds more than your buffer, swap the excess into your treasury stablecoin on the native DEX and schedule the owner disbursement to land during business hours.",
+    category: "Treasury",
+    chain: TEMPO_TESTNET,
+    inputSchema: {
+      type: "object",
+      properties: {
+        operatingWallet: {
+          type: "string",
+          description: "The operating wallet whose balance is swept",
+        },
+        excessAmount: {
+          type: "string",
+          description: "Amount of the operating stablecoin to swap into treasury",
+        },
+        disbursementAmount: {
+          type: "string",
+          description: "Amount to disburse to the owner after the swap",
+        },
+        disbursementRecipient: {
+          type: "string",
+          description: "Owner address that receives the scheduled disbursement",
+        },
+      },
+      required: [],
+    },
+    nodes: [
+      buildTriggerNode("trigger-1", {
+        triggerType: "Schedule",
+        scheduleCron: "0 8 * * *",
+        scheduleTimezone: "UTC",
+      }),
+      buildActionNode(
+        "step-1",
+        "Check Balance",
+        "Read the operating wallet's stablecoin balance",
+        {
+          actionType: "web3/check-token-balance",
+          network: TEMPO_TESTNET,
+          address: "{{operatingWallet}}",
+          tokenConfig: PATH_USD,
+        },
+        400
+      ),
+      buildConditionNode(
+        "step-2",
+        {
+          condition:
+            "{{@step-1:Check Balance.balance.balanceRaw}} > 50000000000",
+          group: {
+            id: "group-1",
+            logic: "AND",
+            rules: [
+              {
+                id: "rule-1",
+                leftOperand:
+                  "{{@step-1:Check Balance.balance.balanceRaw}}",
+                operator: ">",
+                rightOperand: "50000000000",
+              },
+            ],
+          },
+        },
+        600
+      ),
+      buildActionNode(
+        "step-3",
+        "Swap Excess",
+        "Swap the excess into the treasury stablecoin on the native DEX",
+        {
+          actionType: "tempo/dex-swap",
+          network: TEMPO_TESTNET,
+          tokenInConfig: PATH_USD,
+          tokenOutConfig: ALPHA_USD,
+          amountIn: "{{excessAmount}}",
+          slippageBps: 50,
+        },
+        800
+      ),
+      buildActionNode(
+        "step-4",
+        "Schedule Disbursement",
+        "Schedule the owner disbursement to land during business hours",
+        {
+          actionType: "tempo/schedule-payment",
+          network: TEMPO_TESTNET,
+          tokenConfig: ALPHA_USD,
+          amount: "{{disbursementAmount}}",
+          recipientAddress: "{{disbursementRecipient}}",
+          memo: "owner-disbursement",
+        },
+        1000
+      ),
+    ],
+    edges: [
+      buildEdge("trigger-1", "step-1"),
+      buildEdge("step-1", "step-2"),
+      buildEdge("step-2", "step-3", "true"),
+      buildEdge("step-3", "step-4"),
+    ],
+  },
+];
+
+export const TEMPO_TEMPLATE_FIXTURES: TempoTemplateFixture[] =
+  RAW_FIXTURES.map(withAutoLayout);

--- a/scripts/seed/seed-tempo-templates.ts
+++ b/scripts/seed/seed-tempo-templates.ts
@@ -1,0 +1,165 @@
+#!/usr/bin/env tsx
+
+/**
+ * Seed the three Tempo demo workflow templates as listed, public,
+ * deployable workflows (invoice reconciliation, batch payroll, treasury
+ * sweep). They surface automatically through /api/workflows/public and MCP
+ * deploy_template.
+ *
+ * Templates are seeded with `enabled: false`: they are clone targets, not
+ * live workflows. A cloner configures their copy (deposit address, payee API,
+ * recipients, amounts) and enables it.
+ *
+ * Idempotent, matching the onboarding seeder:
+ *   - Insert when the stable id is absent.
+ *   - Refresh when the seeder last touched the row (seededAt ~ updatedAt).
+ *   - Skip when the user has edited it since (updatedAt diverges from seededAt).
+ *
+ * Standalone usage:
+ *   pnpm tsx scripts/seed/seed-tempo-templates.ts [--user=<email>]
+ */
+
+import "dotenv/config";
+
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+
+import { getDatabaseUrl } from "../../lib/db/connection-utils";
+import { member, users, workflows } from "../../lib/db/schema";
+import { TEMPO_TEMPLATE_FIXTURES } from "./fixtures/tempo-templates";
+
+/** Gap in ms between seededAt and updatedAt that indicates a user edit. */
+const USER_EDIT_EPSILON_MS = 5_000;
+
+type Identity = { userId: string; orgId: string };
+type SeedResult = { created: number; refreshed: number; skipped: number };
+
+export async function seedTempoTemplates(
+  db: ReturnType<typeof drizzle>,
+  identity: Identity
+): Promise<SeedResult> {
+  const result: SeedResult = { created: 0, refreshed: 0, skipped: 0 };
+  const now = new Date();
+
+  for (const fixture of TEMPO_TEMPLATE_FIXTURES) {
+    const base = {
+      name: fixture.name,
+      description: fixture.description,
+      userId: identity.userId,
+      organizationId: identity.orgId,
+      nodes: fixture.nodes,
+      edges: fixture.edges,
+      visibility: "public" as const,
+      enabled: false,
+      featured: false,
+      isListed: true,
+      listedSlug: fixture.listedSlug,
+      listedAt: now,
+      inputSchema: fixture.inputSchema,
+      priceUsdcPerCall: "0",
+      category: fixture.category,
+      chain: fixture.chain,
+      seededAt: now,
+      updatedAt: now,
+      deletedAt: null,
+    };
+
+    const existing = await db
+      .select({
+        id: workflows.id,
+        updatedAt: workflows.updatedAt,
+        seededAt: workflows.seededAt,
+      })
+      .from(workflows)
+      .where(eq(workflows.id, fixture.id))
+      .limit(1);
+
+    if (!existing[0]) {
+      await db
+        .insert(workflows)
+        .values({ id: fixture.id, createdAt: now, ...base });
+      result.created++;
+      continue;
+    }
+
+    const row = existing[0];
+    const updatedMs = row.updatedAt?.getTime() ?? 0;
+    const seededMs = row.seededAt?.getTime() ?? 0;
+    const userEdited =
+      row.seededAt === null || updatedMs - seededMs > USER_EDIT_EPSILON_MS;
+    if (userEdited) {
+      result.skipped++;
+      continue;
+    }
+
+    await db.update(workflows).set(base).where(eq(workflows.id, fixture.id));
+    result.refreshed++;
+  }
+
+  return result;
+}
+
+async function resolveIdentity(
+  db: ReturnType<typeof drizzle>,
+  email: string
+): Promise<Identity | null> {
+  const userRow = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1);
+  if (!userRow[0]) {
+    // biome-ignore lint/suspicious/noConsole: seed script CLI output
+    console.log(`User not found: ${email} -- skipping Tempo template seed`);
+    return null;
+  }
+  const memberRow = await db
+    .select({ organizationId: member.organizationId })
+    .from(member)
+    .where(eq(member.userId, userRow[0].id))
+    .limit(1);
+  if (!memberRow[0]) {
+    // biome-ignore lint/suspicious/noConsole: seed script CLI output
+    console.log(`User ${email} has no organization -- skipping`);
+    return null;
+  }
+  return { userId: userRow[0].id, orgId: memberRow[0].organizationId };
+}
+
+async function main(): Promise<void> {
+  const emailArg = process.argv
+    .slice(2)
+    .find((a) => a.startsWith("--user="))
+    ?.split("=")[1];
+  const email = emailArg ?? process.env.SEED_EMAIL ?? "dev@keeperhub.local";
+
+  const client = postgres(getDatabaseUrl(), { max: 1 });
+  const db = drizzle(client);
+  try {
+    const identity = await resolveIdentity(db, email);
+    if (!identity) {
+      return;
+    }
+    const result = await seedTempoTemplates(db, identity);
+    // biome-ignore lint/suspicious/noConsole: seed script CLI output
+    console.log(
+      `Tempo templates -> org ${identity.orgId}: created ${result.created}, refreshed ${result.refreshed}, skipped ${result.skipped}`
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+const isMain =
+  process.argv[1] &&
+  (process.argv[1].endsWith("seed-tempo-templates.ts") ||
+    process.argv[1].endsWith("seed-tempo-templates.js"));
+
+if (isMain) {
+  main().catch((err: unknown) => {
+    // biome-ignore lint/suspicious/noConsole: seed script CLI output
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tests/unit/tempo-tx-core.test.ts
+++ b/tests/unit/tempo-tx-core.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
 import { decodeFunctionData } from "viem";
 import { Abis } from "viem/tempo";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
@@ -26,6 +26,7 @@ vi.mock("@/lib/logging", () => ({
 
 import {
   buildTransferWithMemoCall,
+  deriveTempoNonceKey,
   isTempoChain,
   normalizeMemo,
 } from "@/plugins/tempo/steps/tempo-tx-core";
@@ -33,6 +34,38 @@ import {
 const ZERO_MEMO = `0x${"0".repeat(64)}`;
 const USDC = "0x20c0000000000000000000000000000000000001" as const;
 const RECIPIENT = "0x1111111111111111111111111111111111111111" as const;
+const TOO_LONG_MEMO = /too long/;
+
+describe("deriveTempoNonceKey", () => {
+  const MAX_UINT256 = (BigInt(1) << BigInt(256)) - BigInt(1);
+
+  it("gives concurrent sends from one wallet their own lanes", () => {
+    // Two sends in the same execution get distinct 2D-nonce lanes, so neither
+    // reads a nonce the other is about to consume and both can land.
+    const a = deriveTempoNonceKey("exec-1");
+    const b = deriveTempoNonceKey("exec-1");
+    expect(a).not.toBe(b);
+  });
+
+  it("produces a unique lane on every call, with or without an execution id", () => {
+    const keys = new Set(
+      Array.from({ length: 1000 }, (_, i) =>
+        deriveTempoNonceKey(i % 2 === 0 ? "exec" : undefined)
+      )
+    );
+    expect(keys.size).toBe(1000);
+  });
+
+  it("stays off lane 0 and the max-uint256 marker lane", () => {
+    const keys = Array.from({ length: 1000 }, () =>
+      deriveTempoNonceKey(undefined)
+    );
+    for (const key of keys) {
+      expect(key > BigInt(0)).toBe(true);
+      expect(key < MAX_UINT256).toBe(true);
+    }
+  });
+});
 
 describe("isTempoChain", () => {
   it("accepts Tempo mainnet and Moderato testnet", () => {
@@ -67,14 +100,19 @@ describe("normalizeMemo", () => {
   });
 
   it("throws when a plain-text memo exceeds 31 bytes", () => {
-    expect(() => normalizeMemo("x".repeat(32))).toThrow(/too long/);
+    expect(() => normalizeMemo("x".repeat(32))).toThrow(TOO_LONG_MEMO);
   });
 });
 
 describe("buildTransferWithMemoCall", () => {
   it("targets the token and encodes transferWithMemo(to, value, memo)", () => {
     const memo = normalizeMemo("INV-1042");
-    const call = buildTransferWithMemoCall(USDC, RECIPIENT, BigInt(1_500_000), memo);
+    const call = buildTransferWithMemoCall(
+      USDC,
+      RECIPIENT,
+      BigInt(1_500_000),
+      memo
+    );
 
     expect(call.to).toBe(USDC);
     const decoded = decodeFunctionData({ abi: Abis.tip20, data: call.data });


### PR DESCRIPTION
## Summary

Add three listed, public, deployable Tempo demo templates and an idempotent seeder, plus a config-panel fix so Tempo actions reuse the org wallet instead of prompting for a connection.

- **Templates**: invoice reconciliation (payment-received trigger + memo match), contractor batch payroll (atomic batch payout), and treasury sweep (DEX swap + windowed disbursement). Seeded as public, disabled clone targets and surfaced through `/api/workflows/public` and MCP `deploy_template`.
- **Savable clones**: clone-time fields are seeded as `{{placeholder}}` tokens rather than empty strings, so a cloned workflow passes save-validation. The email nodes are built without the sendgrid `useKeeperHubApiKey` form-field key, which the action-config validator otherwise rejects as an unknown field.
- **Connection fix**: the Tempo write actions declared `requiresCredentials`, so the config panel rendered the generic "Add connection" credential picker even though Tempo signs with the org Turnkey wallet at runtime with no connection row. Dropping the per-action flag removes the picker; the wallet is used implicitly, matching the web3 read actions.

## Seeding

The seeder is standalone for now (`pnpm tsx scripts/seed/seed-tempo-templates.ts`). Wiring it into dev-bootstrap and the deploy post-seed step, matching the onboarding seeder, is a follow-up.

## Base branch

Stacked on the Tempo Payment Received trigger branch; retarget to staging once that merges.