### PR TITLE
fix(tempo): partition the 2D-nonce lane per send to stop concurrent collisions

### DIFF
--- a/plugins/tempo/steps/batch-payout.ts
+++ b/plugins/tempo/steps/batch-payout.ts
@@ -171,6 +171,7 @@ async function stepHandler(input: BatchPayoutInput): Promise<BatchPayoutResult> 
       chainId,
       calls,
       feeToken: token.address,
+      executionId: _context?.executionId,
     });
 
     const transactionLink = await buildTempoTxLink(chainId, hash);

--- a/plugins/tempo/steps/dex-swap.ts
+++ b/plugins/tempo/steps/dex-swap.ts
@@ -152,6 +152,7 @@ async function stepHandler(input: DexSwapInput): Promise<DexSwapResult> {
       chainId,
       calls: [call],
       feeToken: tokenIn.address,
+      executionId: _context?.executionId,
     });
 
     const transactionLink = await buildTempoTxLink(chainId, hash);

--- a/plugins/tempo/steps/schedule-payment.ts
+++ b/plugins/tempo/steps/schedule-payment.ts
@@ -170,6 +170,7 @@ async function stepHandler(
       feeToken: token.address,
       validAfter: validAfterSec,
       validBefore: validBeforeSec,
+      executionId: _context?.executionId,
     });
 
     const transactionLink = await buildTempoTxLink(chainId, hash);

--- a/plugins/tempo/steps/tempo-tx-core.ts
+++ b/plugins/tempo/steps/tempo-tx-core.ts
@@ -55,16 +55,29 @@ const nonceInterface = new ethers.Interface(NONCE_ABI);
 const MAX_UINT256 = (BigInt(1) << BigInt(256)) - BigInt(1);
 
 /**
- * Fixed nonce lane for KeeperHub-initiated Tempo transactions. A stable,
- * KeeperHub-specific 2D-nonce key keeps our sequence out of lane 0 (the
- * protocol nonce) and the max-uint256 lane (the expiring marker). Concurrent
- * sends from the same wallet on this lane race on the read-then-sign; that is
- * an accepted v1 limitation for the monthly-cadence payout flows (mainnet
- * hardening is a follow-up).
+ * Derive a unique 2D-nonce lane for a single send. Tempo's nonce manager keeps
+ * an independent sequence per (account, key), so giving every broadcast its own
+ * key removes the read-then-sign race: two concurrent sends from one wallet
+ * never share a lane, so neither reads a nonce the other is about to consume.
+ *
+ * The key is namespaced under a KeeperHub-specific prefix and salted with random
+ * bytes, so it stays unique even when two sends share an execution (parallel
+ * branches) or carry no execution id. The execution id is folded in only so a
+ * lane traces back to its run in logs. The result is mapped into
+ * [1, MAX_UINT256 - 1] to stay off lane 0 (the protocol nonce) and the
+ * max-uint256 expiring-marker lane.
  */
-const KEEPERHUB_TEMPO_NONCE_KEY = BigInt(
-  ethers.keccak256(ethers.toUtf8Bytes("keeperhub:tempo:nonce-lane:v1"))
-);
+export function deriveTempoNonceKey(executionId: string | undefined): bigint {
+  const salt = ethers.hexlify(ethers.randomBytes(16));
+  const raw = BigInt(
+    ethers.keccak256(
+      ethers.toUtf8Bytes(
+        `keeperhub:tempo:nonce-lane:v2:${executionId ?? "adhoc"}:${salt}`
+      )
+    )
+  );
+  return (raw % (MAX_UINT256 - BigInt(1))) + BigInt(1);
+}
 
 const RECEIPT_TIMEOUT_MS = 60_000;
 const RECEIPT_POLL_INTERVAL_MS = 1500;
@@ -95,6 +108,8 @@ export type SignAndBroadcastParams = {
   /** Optional inclusion window (unix seconds) for scheduled payments. */
   validAfter?: number;
   validBefore?: number;
+  /** Execution id, folded into the per-send nonce lane for traceability. */
+  executionId?: string;
 };
 
 export type SignAndBroadcastResult = { hash: string; from: string };
@@ -310,9 +325,14 @@ export async function signAndBroadcastTempoTx(
   }
   const from = toChecksumAddress(wallet.walletAddress);
 
+  // A fresh lane per send: concurrent sends from this wallet never share a
+  // 2D-nonce sequence, so the read below cannot return a nonce another send is
+  // about to consume.
+  const nonceKey = deriveTempoNonceKey(params.executionId);
+
   const rpcManager = await getRpcProvider({ chainId, userId });
   const [nonce, estimatedGas] = await Promise.all([
-    readTempoNonce(rpcManager, from, KEEPERHUB_TEMPO_NONCE_KEY),
+    readTempoNonce(rpcManager, from, nonceKey),
     estimateTempoGas(rpcManager, from, calls),
   ]);
 
@@ -332,7 +352,7 @@ export async function signAndBroadcastTempoTx(
     chainId,
     calls: calls.map((c) => ({ to: c.to, data: c.data })),
     nonce,
-    nonceKey: KEEPERHUB_TEMPO_NONCE_KEY,
+    nonceKey,
     feeToken,
     gas: gasConfig.gasLimit,
     maxFeePerGas: gasConfig.maxFeePerGas,

--- a/plugins/tempo/steps/transfer-with-memo.ts
+++ b/plugins/tempo/steps/transfer-with-memo.ts
@@ -105,6 +105,7 @@ async function stepHandler(
       chainId,
       calls: [call],
       feeToken: token.address,
+      executionId: _context?.executionId,
     });
 
     const transactionLink = await buildTempoTxLink(chainId, hash);

--- a/tests/unit/tempo-tx-core.test.ts
+++ b/tests/unit/tempo-tx-core.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
 import { decodeFunctionData } from "viem";
 import { Abis } from "viem/tempo";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
@@ -26,6 +26,7 @@ vi.mock("@/lib/logging", () => ({
 
 import {
   buildTransferWithMemoCall,
+  deriveTempoNonceKey,
   isTempoChain,
   normalizeMemo,
 } from "@/plugins/tempo/steps/tempo-tx-core";
@@ -33,6 +34,38 @@ import {
 const ZERO_MEMO = `0x${"0".repeat(64)}`;
 const USDC = "0x20c0000000000000000000000000000000000001" as const;
 const RECIPIENT = "0x1111111111111111111111111111111111111111" as const;
+const TOO_LONG_MEMO = /too long/;
+
+describe("deriveTempoNonceKey", () => {
+  const MAX_UINT256 = (BigInt(1) << BigInt(256)) - BigInt(1);
+
+  it("gives concurrent sends from one wallet their own lanes", () => {
+    // Two sends in the same execution get distinct 2D-nonce lanes, so neither
+    // reads a nonce the other is about to consume and both can land.
+    const a = deriveTempoNonceKey("exec-1");
+    const b = deriveTempoNonceKey("exec-1");
+    expect(a).not.toBe(b);
+  });
+
+  it("produces a unique lane on every call, with or without an execution id", () => {
+    const keys = new Set(
+      Array.from({ length: 1000 }, (_, i) =>
+        deriveTempoNonceKey(i % 2 === 0 ? "exec" : undefined)
+      )
+    );
+    expect(keys.size).toBe(1000);
+  });
+
+  it("stays off lane 0 and the max-uint256 marker lane", () => {
+    const keys = Array.from({ length: 1000 }, () =>
+      deriveTempoNonceKey(undefined)
+    );
+    for (const key of keys) {
+      expect(key > BigInt(0)).toBe(true);
+      expect(key < MAX_UINT256).toBe(true);
+    }
+  });
+});
 
 describe("isTempoChain", () => {
   it("accepts Tempo mainnet and Moderato testnet", () => {
@@ -67,14 +100,19 @@ describe("normalizeMemo", () => {
   });
 
   it("throws when a plain-text memo exceeds 31 bytes", () => {
-    expect(() => normalizeMemo("x".repeat(32))).toThrow(/too long/);
+    expect(() => normalizeMemo("x".repeat(32))).toThrow(TOO_LONG_MEMO);
   });
 });
 
 describe("buildTransferWithMemoCall", () => {
   it("targets the token and encodes transferWithMemo(to, value, memo)", () => {
     const memo = normalizeMemo("INV-1042");
-    const call = buildTransferWithMemoCall(USDC, RECIPIENT, BigInt(1_500_000), memo);
+    const call = buildTransferWithMemoCall(
+      USDC,
+      RECIPIENT,
+      BigInt(1_500_000),
+      memo
+    );
 
     expect(call.to).toBe(USDC);
     const decoded = decodeFunctionData({ abi: Abis.tip20, data: call.data });


### PR DESCRIPTION
## Summary

Fixes the concurrent-send nonce race in the Tempo plugin. Every send read the nonce from one fixed 2D-nonce lane before signing, so two sends from the same wallet running at once read the same value and one broadcast a stale nonce (`NONCE_EXPIRED`). Observed live running batch-payout and schedule-payment back to back.

Tempo's nonce manager keeps an independent sequence per `(account, key)`, so the fix partitions rather than locks: `deriveTempoNonceKey` gives every send its own lane, so concurrent sends never share a sequence and the read can't return a nonce another send is about to consume. No lock, no DB, works across executor instances.

- The lane is random-salted (so it stays unique even for parallel sends within one execution), folds in the execution id for traceability, and is mapped off lane 0 and the max-uint256 marker lane.
- Each write step (transfer-with-memo, batch-payout, dex-swap, schedule-payment) threads its execution id into the send.

## Testing

- Unit: concurrent sends get distinct lanes; 1000 calls yield 1000 unique lanes; every lane stays within bounds.
- Live on Moderato testnet: two concurrent sends from one wallet both mined, each on its own lane (nonce 0). The same pair previously failed one send with `NONCE_EXPIRED`.

## Base branch

Stacked on the demo-templates branch; retarget to staging as the stack merges.