### PR TITLE
fix(deploy): give the split service accounts their Kubernetes RBAC

### DIFF
--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -688,6 +688,19 @@ executor:
     annotations:
       eks.amazonaws.com/role-arn: ${EXECUTOR_SERVICE_ACCOUNT_ROLE_ARN}
     name: keeperhub-executor-prod
+    # The executor spawns the workflow runner Jobs and reads their pods/logs, so
+    # it needs its own Role once it stops sharing the app's service account.
+    # Without these it authenticates to AWS fine but gets 403 from the K8s API.
+    rules:
+      - apiGroups: ["batch"]
+        resources: ["jobs"]
+        verbs: ["create", "get", "list", "watch", "delete"]
+      - apiGroups: [""]
+        resources: ["pods"]
+        verbs: ["get", "list", "watch"]
+      - apiGroups: [""]
+        resources: ["pods/log"]
+        verbs: ["get"]
 
   podAnnotations:
     reloader.stakater.com/auto: "true"
@@ -916,6 +929,13 @@ schedule:
     annotations:
       eks.amazonaws.com/role-arn: ${SCHEDULER_SERVICE_ACCOUNT_ROLE_ARN}
     name: keeperhub-scheduler-prod
+    # Leader election for the schedule and block dispatchers, which share this
+    # service account. This Role owns the Lease permission now that they no
+    # longer run under the app's service account.
+    rules:
+      - apiGroups: ["coordination.k8s.io"]
+        resources: ["leases"]
+        verbs: ["get", "create", "update"]
 
   podAnnotations:
     reloader.stakater.com/auto: "true"

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -689,6 +689,19 @@ executor:
     annotations:
       eks.amazonaws.com/role-arn: ${EXECUTOR_SERVICE_ACCOUNT_ROLE_ARN}
     name: keeperhub-executor-staging
+    # The executor spawns the workflow runner Jobs and reads their pods/logs, so
+    # it needs its own Role once it stops sharing the app's service account.
+    # Without these it authenticates to AWS fine but gets 403 from the K8s API.
+    rules:
+      - apiGroups: ["batch"]
+        resources: ["jobs"]
+        verbs: ["create", "get", "list", "watch", "delete"]
+      - apiGroups: [""]
+        resources: ["pods"]
+        verbs: ["get", "list", "watch"]
+      - apiGroups: [""]
+        resources: ["pods/log"]
+        verbs: ["get"]
 
   podAnnotations:
     reloader.stakater.com/auto: "true"
@@ -917,6 +930,13 @@ schedule:
     annotations:
       eks.amazonaws.com/role-arn: ${SCHEDULER_SERVICE_ACCOUNT_ROLE_ARN}
     name: keeperhub-scheduler-staging
+    # Leader election for the schedule and block dispatchers, which share this
+    # service account. This Role owns the Lease permission now that they no
+    # longer run under the app's service account.
+    rules:
+      - apiGroups: ["coordination.k8s.io"]
+        resources: ["leases"]
+        verbs: ["get", "create", "update"]
 
   podAnnotations:
     reloader.stakater.com/auto: "true"


### PR DESCRIPTION
## Problem

Staging is currently broken and this restores it.

The service account split moved the executor and both dispatchers off the app's service account, but only carried over the **AWS/IRSA** half. The shared account also owned a Role granting Kubernetes permissions those components depend on. Once they moved to their own accounts they authenticated to AWS fine and then got 403 from the API server:

- **executor**: `jobs.batch is forbidden: User "system:serviceaccount:keeperhub:keeperhub-executor-staging" cannot create resource "jobs"` -> the workflow runner Jobs are never created, so no workflow completes (0 completions over 90 minutes, every received message failing).
- **schedule + block dispatchers**: `[LeaderElection] Acquire/renew attempt ... failed: HTTP-Code: 403` -> neither replica can take its Lease, so schedule and block triggers stop firing.

Production was never promoted and is unaffected.

## Fix

Give each new service account the rules it actually needs, so the chart renders a Role and RoleBinding per account:

| Service account | Rules |
| --- | --- |
| `keeperhub-executor-<env>` | `batch/jobs` (create, get, list, watch, delete), `pods` (get, list, watch), `pods/log` (get) |
| `keeperhub-scheduler-<env>` | `coordination.k8s.io/leases` (get, create, update) - leader election, shared by both dispatchers |
| `keeperhub-events-<env>` | none - the tracker does not call the Kubernetes API |

The app's service account keeps its rules unchanged.

## Verification

Rendered the umbrella chart against both environments' values and confirmed the Roles and RoleBindings that were missing:

- `keeperhub-executor-<env>-role` (jobs, pods, pods/log) bound to `keeperhub-executor-<env>`
- `keeperhub-scheduler-<env>-role` (leases) bound to `keeperhub-scheduler-<env>`
- `keeperhub-<env>-role` unchanged, still bound to the app's account

Both environments render symmetrically. This is the check the original change was missing: it verified the service accounts and their pod bindings, but never the Roles and RoleBindings.
