### PR TITLE
feat: add Transfer SPL Token action for Solana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,11 @@ packages/*/dist/
 .claude/test-*-output.txt
 .claude/worktrees/
 
+# Locally generated Solana devnet payer keypair
+# (scripts/solana-devnet-spl-fixture.ts). Devnet-only and worthless, but it is
+# still a private key and must never be committed.
+.claude/.solana-devnet-payer.json
+
 # Local protocol-coverage rig and tier output (scripts/protocol-local.sh,
 # vitest --outputFile dumps); pattern, not filenames, so new tiers cannot
 # leak results artifacts into the repo again

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,14 @@
-# Reject packages published less than 3 days ago to mitigate supply chain attacks
-minimum-release-age=3d
+# Reject packages published less than 3 days ago to mitigate supply chain attacks.
+# The value is a NUMBER OF MINUTES - pnpm computes `minimumReleaseAge * 60 * 1e3`
+# to get milliseconds. 4320 = 3 days. It was previously "3d", which is not a
+# duration pnpm parses: "3d" * 60 * 1e3 is NaN, and every comparison against NaN
+# is false, so no version was ever judged mature and every newly resolved package
+# was rejected regardless of age (e.g. a version released 316 days ago was refused
+# for not meeting the "3 day" minimum). Existing installs were unaffected because
+# the lockfile pins them and `pnpm install` resolves nothing; only `pnpm add` and
+# lockfile regeneration hit the gate. Several exclusions below were added to work
+# around that and may no longer be needed.
+minimum-release-age=4320
 # Zodiac Roles SDK + deployments registry are maintained by Gnosis Guild and
 # pinned here; skip the release-age gate for this dep (same reason we accept
 # their audited contracts on-chain).

--- a/lib/web3/chain-adapter/evm.ts
+++ b/lib/web3/chain-adapter/evm.ts
@@ -1,5 +1,7 @@
 import { ethers } from "ethers";
+import { logWarn } from "@/lib/logging";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
+import { getErrorMessage } from "@/lib/utils";
 import { submitSignedTransactionWithFailover } from "@/lib/web3/submit-signed";
 import type { AdaptiveGasStrategy, GasConfig } from "../gas-strategy";
 import type { NonceManager, NonceSession } from "../nonce-manager";
@@ -265,12 +267,32 @@ export class EvmChainAdapter implements ChainAdapter {
     return await rpcManager.executeWithFailover(operation, operationType);
   }
 
+  // The explorer URL is cosmetic. A failure building it (e.g. the explorer-config
+  // lookup throwing) must never propagate: transfer steps call this after the
+  // transaction is already mined, inside the try/catch that maps a throw to a
+  // failed result, so a throw here would report a completed transfer as failed.
   async getTransactionUrl(txHash: string): Promise<string> {
-    return buildChainTransactionUrl(this.chainId, txHash);
+    try {
+      return await buildChainTransactionUrl(this.chainId, txHash);
+    } catch (error) {
+      logWarn(
+        `[EvmChainAdapter] Failed to build transaction explorer URL: ${getErrorMessage(error)}`,
+        { chain_id: String(this.chainId) }
+      );
+      return "";
+    }
   }
 
   async getAddressUrl(address: string): Promise<string> {
-    return buildChainAddressUrl(this.chainId, address);
+    try {
+      return await buildChainAddressUrl(this.chainId, address);
+    } catch (error) {
+      logWarn(
+        `[EvmChainAdapter] Failed to build address explorer URL: ${getErrorMessage(error)}`,
+        { chain_id: String(this.chainId) }
+      );
+      return "";
+    }
   }
 
   private async confirmTransaction(

--- a/lib/web3/chain-adapter/solana.ts
+++ b/lib/web3/chain-adapter/solana.ts
@@ -5,9 +5,11 @@ import {
   VersionedTransaction,
 } from "@solana/web3.js";
 import type { ethers } from "ethers";
+import { logWarn } from "@/lib/logging";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import type { RpcOperationType } from "@/lib/rpc/providers/index";
 import type { SolanaProviderManager } from "@/lib/rpc/providers/solana";
+import { getErrorMessage } from "@/lib/utils";
 import type { NonceSession } from "../nonce-manager";
 import {
   normalizeSolanaTransaction,
@@ -246,11 +248,31 @@ export class SolanaChainAdapter implements ChainAdapter {
     return manager.executeWithFailover(operation, operationType);
   }
 
-  getTransactionUrl(txHash: string): Promise<string> {
-    return Promise.resolve(buildChainTransactionUrl(this.chainId, txHash));
+  // The explorer URL is cosmetic. A failure building it (e.g. the explorer-config
+  // lookup throwing) must never propagate: by the time a transfer step calls this
+  // the transaction is already on-chain, and a throw here would flip a completed
+  // transfer's result to failed. Callers treat "" as "no link available".
+  async getTransactionUrl(txHash: string): Promise<string> {
+    try {
+      return await buildChainTransactionUrl(this.chainId, txHash);
+    } catch (error) {
+      logWarn(
+        `[SolanaChainAdapter] Failed to build transaction explorer URL: ${getErrorMessage(error)}`,
+        { chain_id: String(this.chainId) }
+      );
+      return "";
+    }
   }
 
-  getAddressUrl(address: string): Promise<string> {
-    return Promise.resolve(buildChainAddressUrl(this.chainId, address));
+  async getAddressUrl(address: string): Promise<string> {
+    try {
+      return await buildChainAddressUrl(this.chainId, address);
+    } catch (error) {
+      logWarn(
+        `[SolanaChainAdapter] Failed to build address explorer URL: ${getErrorMessage(error)}`,
+        { chain_id: String(this.chainId) }
+      );
+      return "";
+    }
   }
 }

--- a/lib/web3/solana-fees.ts
+++ b/lib/web3/solana-fees.ts
@@ -1,0 +1,15 @@
+import "server-only";
+
+/**
+ * Solana base transaction fee: 5000 lamports per signature.
+ *
+ * Reserved on top of the transfer amount in Solana balance preflights. Without
+ * it a max-balance transfer passes preflight and then fails at inclusion for
+ * not covering its own fee.
+ *
+ * This assumes a single signature, which holds for the transfers that use it:
+ * the organization wallet is both fee payer and transfer authority, and
+ * creating an associated token account needs no additional signer. A future
+ * multi-signer path must multiply by the signature count.
+ */
+export const SOLANA_BASE_FEE_LAMPORTS = BigInt(5000);

--- a/lib/web3/wallet-helpers.ts
+++ b/lib/web3/wallet-helpers.ts
@@ -3,11 +3,11 @@ import { TurnkeySigner } from "@turnkey/ethers";
 import { and, eq } from "drizzle-orm";
 import type { ethers } from "ethers";
 import { toChecksumAddress } from "@/lib/address-utils";
+import { TurnkeySolanaSigner } from "@/lib/agentic-wallet/solana-turnkey-signer";
 import { db } from "@/lib/db";
 import { type OrganizationWallet, organizationWallets } from "@/lib/db/schema";
 import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
 import { getTurnkeySignerConfig } from "@/lib/turnkey/turnkey-client";
-import { TurnkeySolanaSigner } from "@/lib/agentic-wallet/solana-turnkey-signer";
 import type { SolanaTransactionSigner } from "@/lib/web3/chain-adapter/types";
 
 /**
@@ -101,16 +101,29 @@ export function buildSolanaSignerFromWallet(
   if (!wallet.solanaAddress) {
     throw new Error(
       "[Solana] Organization wallet has no provisioned Solana address. " +
-      "The wallet was created before Solana support was added. " +
-      "Contact support to add a Solana account to this wallet."
+        "The wallet was created before Solana support was added. " +
+        "Contact support to add a Solana account to this wallet."
     );
   }
   return new TurnkeySolanaSigner(wallet.turnkeySubOrgId, wallet.solanaAddress);
 }
 
+/**
+ * Resolves an organization's Solana signer and its provisioned address in one
+ * fetch. Throws if the wallet is missing or has no Solana account; callers wrap
+ * this in their own error shape. Shared by the Solana transfer paths.
+ */
+export async function initializeSolanaWallet(
+  organizationId: string
+): Promise<{ signer: SolanaTransactionSigner; address: string }> {
+  const wallet = await getOrganizationWallet(organizationId);
+  const signer = buildSolanaSignerFromWallet(wallet);
+  // buildSolanaSignerFromWallet throws when solanaAddress is absent.
+  return { signer, address: wallet.solanaAddress as string };
+}
+
 export async function initializeSolanaWalletSigner(
   organizationId: string
 ): Promise<SolanaTransactionSigner> {
-  const wallet = await getOrganizationWallet(organizationId);
-  return buildSolanaSignerFromWallet(wallet);
+  return (await initializeSolanaWallet(organizationId)).signer;
 }

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@sentry/nextjs": "^10.47.0",
     "@slack/web-api": "^7.15.0",
+    "@solana/spl-token": "^0.4.15",
     "@solana/web3.js": "^1.98.4",
     "@turnkey/crypto": "^2.8.13",
     "@turnkey/ethers": "^1.3.27",

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -333,6 +333,102 @@ const web3Plugin: IntegrationPlugin = {
       ],
     },
     {
+      slug: "transfer-spl-token",
+      label: "Transfer SPL Token",
+      description:
+        "Transfer SPL tokens on Solana from your wallet to a recipient address",
+      category: "Web3",
+      requiresCredentials: true,
+      stepFunction: "transferSplTokenStep",
+      stepImportPath: "transfer-spl-token",
+      outputFields: [
+        {
+          field: "success",
+          description: "Whether the transfer succeeded",
+        },
+        {
+          field: "transactionHash",
+          description: "The transaction signature of the successful transfer",
+        },
+        {
+          field: "transactionLink",
+          description: "Explorer link to view the transaction",
+        },
+        {
+          field: "amount",
+          description: "The amount transferred (human-readable)",
+        },
+        {
+          field: "mint",
+          description: "The SPL token mint address",
+        },
+        {
+          field: "decimals",
+          description: "The mint's decimals, read from the mint account",
+        },
+        {
+          field: "recipient",
+          description: "The recipient wallet address",
+        },
+        {
+          field: "recipientTokenAccount",
+          description:
+            "The recipient's associated token account that received the transfer",
+        },
+        {
+          field: "createdRecipientAccount",
+          description:
+            "Whether the recipient's token account was created by this transfer (the sender pays its rent)",
+        },
+        {
+          field: "error",
+          description: "Error message if the transfer failed",
+        },
+      ],
+      configFields: [
+        {
+          key: "network",
+          label: "Network",
+          type: "chain-select",
+          chainTypeFilter: "solana",
+          placeholder: "Select network",
+          required: true,
+        },
+        {
+          // Keyed "mint" rather than "mintAddress" on purpose: the field
+          // renderer treats any key ending in "address" as an EVM address,
+          // applying checksum formatting and an Ethereum-only address book to
+          // what is a base58 mint.
+          key: "mint",
+          label: "Token Mint",
+          type: "template-input",
+          placeholder: "Mint address or {{NodeName.mint}}",
+          example: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          helpTip:
+            "The SPL token's mint address (base58). Decimals are read from the mint account at execution time.",
+          required: true,
+        },
+        {
+          key: "amount",
+          label: "Amount",
+          type: "template-input",
+          placeholder: "100.50 or {{NodeName.amount}}",
+          example: "100.50",
+          required: true,
+        },
+        {
+          // No isAddressField: it would validate against an Ethereum address
+          // pattern and reject every valid base58 Solana address.
+          key: "recipientAddress",
+          label: "Recipient Address",
+          type: "template-input",
+          placeholder: "Solana address or {{NodeName.address}}",
+          example: "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+          required: true,
+        },
+      ],
+    },
+    {
       slug: "read-contract",
       label: "Read Contract",
       description: "Read data from a smart contract (view/pure functions)",

--- a/plugins/web3/steps/transfer-funds-core.ts
+++ b/plugins/web3/steps/transfer-funds-core.ts
@@ -39,6 +39,7 @@ import {
 } from "@/lib/web3/decode-revert-error";
 import { resolveGasLimitOverrides } from "@/lib/web3/gas-defaults";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
+import { SOLANA_BASE_FEE_LAMPORTS } from "@/lib/web3/solana-fees";
 import { resolveSponsoredSendError } from "@/lib/web3/sponsored-send-error";
 import { executeSponsoredTransaction } from "@/lib/web3/sponsored-transaction-manager";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
@@ -46,10 +47,6 @@ import {
   type TransactionContext,
   withNonceSession,
 } from "@/lib/web3/transaction-manager";
-
-// Solana base transaction fee: 5000 lamports per signature. Reserved on top of
-// the transfer amount in the native-SOL balance preflight.
-const SOLANA_BASE_FEE_LAMPORTS = BigInt(5000);
 
 export type TransferFundsCoreInput = {
   network: string;

--- a/plugins/web3/steps/transfer-funds-core.ts
+++ b/plugins/web3/steps/transfer-funds-core.ts
@@ -14,9 +14,8 @@ import { chains, explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getTransactionUrl } from "@/lib/explorer";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import {
-  buildSolanaSignerFromWallet,
-  getOrganizationWallet,
   getOrganizationWalletAddress,
+  initializeSolanaWallet,
   initializeWalletSigner,
 } from "@/lib/web3/wallet-helpers";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
@@ -498,13 +497,12 @@ async function transferFundsSolana(args: {
   }
   const { organizationId } = orgCtx;
 
-  // 5. Get signer and wallet row (one fetch, one validation check)
+  // 5. Get signer and wallet address (one fetch, one validation check)
   let solanaSigner: SolanaTransactionSigner;
   let orgSolanaAddress: string;
   try {
-    const wallet = await getOrganizationWallet(organizationId);
-    solanaSigner = buildSolanaSignerFromWallet(wallet);
-    orgSolanaAddress = wallet.solanaAddress!;
+    ({ signer: solanaSigner, address: orgSolanaAddress } =
+      await initializeSolanaWallet(organizationId));
   } catch (error) {
     return {
       success: false,

--- a/plugins/web3/steps/transfer-spl-token-core.ts
+++ b/plugins/web3/steps/transfer-spl-token-core.ts
@@ -1,11 +1,13 @@
 import "server-only";
 
 import {
+  ACCOUNT_SIZE,
   AccountState,
   ASSOCIATED_TOKEN_PROGRAM_ID,
   createAssociatedTokenAccountIdempotentInstruction,
   createTransferCheckedInstruction,
   ExtensionType,
+  getAccountLen,
   getAccountLenForMint,
   getAssociatedTokenAddressSync,
   getDefaultAccountState,
@@ -337,7 +339,12 @@ async function runPreflight(args: {
 
   const needsRecipientAta = !recipientAtaInfo;
 
-  const rent = await resolveRentLamports(adapter, mintAccount, needsRecipientAta);
+  const rent = await resolveRentLamports(
+    adapter,
+    mintAccount,
+    programId,
+    needsRecipientAta
+  );
   if ("error" in rent) {
     return rent;
   }
@@ -355,9 +362,28 @@ async function runPreflight(args: {
   return { needsRecipientAta };
 }
 
+/**
+ * The on-chain length of the associated token account the ATA program will
+ * create. getAccountLenForMint covers only the account extensions the mint
+ * implies; on Token-2022 the ATA program also always adds ImmutableOwner, which
+ * that helper omits. Add it so the rent estimate is not short: as the first
+ * account extension it introduces the account-type byte too, otherwise it is one
+ * more zero-value TLV (4 bytes).
+ */
+function ataAccountLen(mintAccount: Mint, programId: PublicKey): number {
+  const baseLen = getAccountLenForMint(mintAccount);
+  if (!programId.equals(TOKEN_2022_PROGRAM_ID)) {
+    return baseLen;
+  }
+  return baseLen === ACCOUNT_SIZE
+    ? getAccountLen([ExtensionType.ImmutableOwner])
+    : baseLen + 4;
+}
+
 async function resolveRentLamports(
   adapter: SolanaChainAdapter,
   mintAccount: Mint,
+  programId: PublicKey,
   needsRecipientAta: boolean
 ): Promise<{ lamports: bigint } | { error: string }> {
   if (!needsRecipientAta) {
@@ -365,14 +391,10 @@ async function resolveRentLamports(
   }
 
   try {
-    // getAccountLenForMint, not the fixed 165-byte helper: Token-2022 accounts
-    // size from the mint's extensions. It ignores the ImmutableOwner the ATA
-    // program adds, so this slightly under-estimates; the preflight is advisory
-    // and the on-chain create pulls what it actually needs.
     const lamports = await adapter.executeWithSolanaFailover(
       (connection) =>
         connection.getMinimumBalanceForRentExemption(
-          getAccountLenForMint(mintAccount)
+          ataAccountLen(mintAccount, programId)
         ),
       "read"
     );

--- a/plugins/web3/steps/transfer-spl-token-core.ts
+++ b/plugins/web3/steps/transfer-spl-token-core.ts
@@ -31,10 +31,7 @@ import type { SolanaTransactionSigner } from "@/lib/web3/chain-adapter/types";
 import type { NonceSession } from "@/lib/web3/nonce-manager";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
 import { SOLANA_BASE_FEE_LAMPORTS } from "@/lib/web3/solana-fees";
-import {
-  buildSolanaSignerFromWallet,
-  getOrganizationWallet,
-} from "@/lib/web3/wallet-helpers";
+import { initializeSolanaWallet } from "@/lib/web3/wallet-helpers";
 
 /**
  * Serializing a legacy Transaction requires a recentBlockhash and a feePayer or
@@ -229,10 +226,7 @@ async function resolveWallet(
   { signer: SolanaTransactionSigner; address: string } | { error: string }
 > {
   try {
-    const wallet = await getOrganizationWallet(organizationId);
-    const signer = buildSolanaSignerFromWallet(wallet);
-    // buildSolanaSignerFromWallet throws when solanaAddress is absent.
-    return { signer, address: wallet.solanaAddress as string };
+    return await initializeSolanaWallet(organizationId);
   } catch (error) {
     return {
       error: `Failed to initialize Solana wallet: ${getErrorMessage(error)}`,

--- a/plugins/web3/steps/transfer-spl-token-core.ts
+++ b/plugins/web3/steps/transfer-spl-token-core.ts
@@ -1,0 +1,570 @@
+import "server-only";
+
+import {
+  AccountState,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  createAssociatedTokenAccountIdempotentInstruction,
+  createTransferCheckedInstruction,
+  ExtensionType,
+  getAccountLenForMint,
+  getAssociatedTokenAddressSync,
+  getDefaultAccountState,
+  getExtensionTypes,
+  type Mint,
+  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+  unpackAccount,
+  unpackMint,
+} from "@solana/spl-token";
+import type { AccountInfo } from "@solana/web3.js";
+import { PublicKey, Transaction } from "@solana/web3.js";
+import { ethers } from "ethers";
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { isSolanaChain } from "@/lib/rpc/provider-factory";
+import { getErrorMessage } from "@/lib/utils";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
+import type { SolanaChainAdapter } from "@/lib/web3/chain-adapter/solana";
+import type { SolanaTransactionSigner } from "@/lib/web3/chain-adapter/types";
+import type { NonceSession } from "@/lib/web3/nonce-manager";
+import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
+import { SOLANA_BASE_FEE_LAMPORTS } from "@/lib/web3/solana-fees";
+import {
+  buildSolanaSignerFromWallet,
+  getOrganizationWallet,
+} from "@/lib/web3/wallet-helpers";
+
+/**
+ * Serializing a legacy Transaction requires a recentBlockhash and a feePayer or
+ * serialize() throws. SolanaChainAdapter.sendTransaction overwrites the
+ * blockhash with a freshly fetched one before signing, so this placeholder never
+ * reaches the signer or the chain. PublicKey.default is 32 zero bytes, which is
+ * valid base58 and satisfies the serializer.
+ */
+const PLACEHOLDER_BLOCKHASH = PublicKey.default.toBase58();
+
+/**
+ * Mint extensions that a plain transferChecked cannot honour. Rejecting them up
+ * front turns an opaque simulation failure into an actionable error.
+ */
+const UNSUPPORTED_EXTENSIONS = new Map<ExtensionType, string>([
+  [
+    ExtensionType.TransferHook,
+    "the mint has a transfer hook, which requires resolving extra accounts",
+  ],
+  [ExtensionType.NonTransferable, "the mint is non-transferable"],
+]);
+
+export type TransferSplTokenCoreInput = {
+  network: string;
+  mint: string;
+  recipientAddress: string;
+  amount: string;
+  _context?: { executionId?: string; organizationId?: string };
+};
+
+export type TransferSplTokenResult =
+  | {
+      success: true;
+      transactionHash: string;
+      transactionLink: string;
+      gasUsed: string;
+      gasUsedUnits: string;
+      effectiveGasPrice: string;
+      amount: string;
+      recipient: string;
+      mint: string;
+      decimals: number;
+      recipientTokenAccount: string;
+      createdRecipientAccount: boolean;
+    }
+  | { success: false; error: string };
+
+type SolanaAccount = AccountInfo<Buffer> | null;
+
+type TransferContext = {
+  adapter: SolanaChainAdapter;
+  chainId: number;
+  ownerPk: PublicKey;
+  ownerAddress: string;
+  recipientPk: PublicKey;
+  mintPk: PublicKey;
+  amount: string;
+  solanaSigner: SolanaTransactionSigner;
+};
+
+/**
+ * Exported for dispatch-routing tests, mirroring isSolanaTransferPath in
+ * transfer-funds-core.ts.
+ */
+export function isSplTransferPath(chainId: number): boolean {
+  return isSolanaChain(chainId);
+}
+
+function parsePublicKey(value: string): PublicKey | null {
+  try {
+    return new PublicKey(value);
+  } catch {
+    return null;
+  }
+}
+
+function isTokenProgram(programId: PublicKey): boolean {
+  return (
+    programId.equals(TOKEN_PROGRAM_ID) || programId.equals(TOKEN_2022_PROGRAM_ID)
+  );
+}
+
+/**
+ * Returns the reason a mint cannot be transferred, or null when it can.
+ */
+function findUnsupportedExtension(mint: Mint): string | null {
+  const extensions = getExtensionTypes(mint.tlvData);
+
+  for (const extension of extensions) {
+    const reason = UNSUPPORTED_EXTENSIONS.get(extension);
+    if (reason) {
+      return reason;
+    }
+  }
+
+  if (extensions.includes(ExtensionType.DefaultAccountState)) {
+    if (getDefaultAccountState(mint)?.state === AccountState.Frozen) {
+      return "the mint freezes new token accounts by default";
+    }
+  }
+
+  return null;
+}
+
+function parseAmount(
+  amount: string,
+  decimals: number
+): { raw: bigint } | { error: string } {
+  try {
+    const raw = ethers.parseUnits(amount.trim(), decimals);
+    if (raw < BigInt(0)) {
+      return { error: `Invalid token amount: ${amount}` };
+    }
+    return { raw };
+  } catch {
+    return { error: `Invalid token amount: ${amount}` };
+  }
+}
+
+/**
+ * Builds the transfer as a prebuilt serialized transaction. SolanaChainAdapter
+ * rejects executeContractCall (Solana has no ABI-encoded calls), so serialized
+ * bytes in request.data are the only way onto its Turnkey signing and
+ * submit/failover path.
+ */
+function buildSerializedTransfer(args: {
+  ownerPk: PublicKey;
+  recipientPk: PublicKey;
+  mintPk: PublicKey;
+  senderAta: PublicKey;
+  recipientAta: PublicKey;
+  programId: PublicKey;
+  amountRaw: bigint;
+  decimals: number;
+  needsRecipientAta: boolean;
+}): string {
+  const transaction = new Transaction();
+
+  if (args.needsRecipientAta) {
+    // Idempotent: if the account appears between our read and inclusion, this
+    // no-ops instead of failing the whole transfer.
+    transaction.add(
+      createAssociatedTokenAccountIdempotentInstruction(
+        args.ownerPk,
+        args.recipientAta,
+        args.recipientPk,
+        args.mintPk,
+        args.programId,
+        ASSOCIATED_TOKEN_PROGRAM_ID
+      )
+    );
+  }
+
+  // transferChecked over transfer: it re-validates decimals on-chain, so a bad
+  // decimals read fails loudly instead of moving a wrong amount, and Token-2022
+  // rejects plain transfer for transfer-fee mints.
+  transaction.add(
+    createTransferCheckedInstruction(
+      args.senderAta,
+      args.mintPk,
+      args.recipientAta,
+      args.ownerPk,
+      args.amountRaw,
+      args.decimals,
+      [],
+      args.programId
+    )
+  );
+
+  transaction.feePayer = args.ownerPk;
+  transaction.recentBlockhash = PLACEHOLDER_BLOCKHASH;
+
+  return transaction
+    .serialize({ requireAllSignatures: false, verifySignatures: false })
+    .toString("base64");
+}
+
+async function resolveWallet(
+  organizationId: string
+): Promise<
+  { signer: SolanaTransactionSigner; address: string } | { error: string }
+> {
+  try {
+    const wallet = await getOrganizationWallet(organizationId);
+    const signer = buildSolanaSignerFromWallet(wallet);
+    // buildSolanaSignerFromWallet throws when solanaAddress is absent.
+    return { signer, address: wallet.solanaAddress as string };
+  } catch (error) {
+    return {
+      error: `Failed to initialize Solana wallet: ${getErrorMessage(error)}`,
+    };
+  }
+}
+
+/**
+ * Reads the mint account. Its owner is the source of truth for legacy SPL vs
+ * Token-2022; unpackMint validates that owner and parses Token-2022 TLV data.
+ */
+async function resolveMint(
+  adapter: SolanaChainAdapter,
+  mintPk: PublicKey
+): Promise<{ mint: Mint; programId: PublicKey } | { error: string }> {
+  let mintInfo: SolanaAccount;
+  try {
+    mintInfo = await adapter.executeWithSolanaFailover(
+      (connection) => connection.getAccountInfo(mintPk, "confirmed"),
+      "read"
+    );
+  } catch (error) {
+    return { error: `Failed to read mint account: ${getErrorMessage(error)}` };
+  }
+
+  if (!mintInfo) {
+    return { error: `Mint account not found: ${mintPk.toBase58()}` };
+  }
+
+  const programId = mintInfo.owner;
+  if (!isTokenProgram(programId)) {
+    return {
+      error: `${mintPk.toBase58()} is not an SPL token mint (owned by ${programId.toBase58()})`,
+    };
+  }
+
+  return { mint: unpackMint(mintPk, mintInfo, programId), programId };
+}
+
+async function runPreflight(args: {
+  adapter: SolanaChainAdapter;
+  ownerAddress: string;
+  senderAta: PublicKey;
+  recipientAta: PublicKey;
+  recipientPk: PublicKey;
+  programId: PublicKey;
+  mintAccount: Mint;
+  amountRaw: bigint;
+}): Promise<{ needsRecipientAta: boolean } | { error: string }> {
+  const { adapter, senderAta, recipientAta, programId, mintAccount, amountRaw } =
+    args;
+
+  let accounts: SolanaAccount[];
+  try {
+    accounts = await adapter.executeWithSolanaFailover(
+      (connection) =>
+        connection.getMultipleAccountsInfo(
+          [senderAta, recipientAta, args.recipientPk],
+          "confirmed"
+        ),
+      "read"
+    );
+  } catch (error) {
+    return { error: `Failed to read token accounts: ${getErrorMessage(error)}` };
+  }
+
+  const [senderInfo, recipientAtaInfo, recipientInfo] = accounts;
+
+  // A recipient address that is itself a token account means the caller pasted
+  // a token account instead of a wallet; the ATA derived from it would be
+  // unrecoverable.
+  if (recipientInfo && isTokenProgram(recipientInfo.owner)) {
+    return { error: "Recipient must be a wallet address, not a token account" };
+  }
+
+  if (!senderInfo) {
+    return {
+      error: `Wallet has no token account for mint ${mintAccount.address.toBase58()}`,
+    };
+  }
+
+  const senderAccount = unpackAccount(senderAta, senderInfo, programId);
+  if (senderAccount.amount < amountRaw) {
+    return {
+      error: `Insufficient token balance. Have: ${senderAccount.amount.toString()}, Need: ${amountRaw.toString()} (raw units)`,
+    };
+  }
+
+  const needsRecipientAta = !recipientAtaInfo;
+
+  const rent = await resolveRentLamports(adapter, mintAccount, needsRecipientAta);
+  if ("error" in rent) {
+    return rent;
+  }
+
+  const solCheck = await checkSolBalance({
+    adapter,
+    ownerAddress: args.ownerAddress,
+    rentLamports: rent.lamports,
+    needsRecipientAta,
+  });
+  if (solCheck) {
+    return { error: solCheck };
+  }
+
+  return { needsRecipientAta };
+}
+
+async function resolveRentLamports(
+  adapter: SolanaChainAdapter,
+  mintAccount: Mint,
+  needsRecipientAta: boolean
+): Promise<{ lamports: bigint } | { error: string }> {
+  if (!needsRecipientAta) {
+    return { lamports: BigInt(0) };
+  }
+
+  try {
+    // getAccountLenForMint, not the fixed 165-byte helper: Token-2022 accounts
+    // size from the mint's extensions. It ignores the ImmutableOwner the ATA
+    // program adds, so this slightly under-estimates; the preflight is advisory
+    // and the on-chain create pulls what it actually needs.
+    const lamports = await adapter.executeWithSolanaFailover(
+      (connection) =>
+        connection.getMinimumBalanceForRentExemption(
+          getAccountLenForMint(mintAccount)
+        ),
+      "read"
+    );
+    return { lamports: BigInt(lamports) };
+  } catch (error) {
+    return { error: `Failed to read rent exemption: ${getErrorMessage(error)}` };
+  }
+}
+
+/** Returns an error message, or null when the balance covers fee plus rent. */
+async function checkSolBalance(args: {
+  adapter: SolanaChainAdapter;
+  ownerAddress: string;
+  rentLamports: bigint;
+  needsRecipientAta: boolean;
+}): Promise<string | null> {
+  try {
+    const balance = await args.adapter.getBalance(undefined, args.ownerAddress);
+    const required = SOLANA_BASE_FEE_LAMPORTS + args.rentLamports;
+    if (balance >= required) {
+      return null;
+    }
+    const breakdown = args.needsRecipientAta
+      ? `${SOLANA_BASE_FEE_LAMPORTS.toString()} fee + ${args.rentLamports.toString()} rent for the recipient's new token account`
+      : `${SOLANA_BASE_FEE_LAMPORTS.toString()} fee`;
+    return `Insufficient SOL balance. Have: ${balance.toString()} lamports, Need: ${required.toString()} lamports (${breakdown})`;
+  } catch (error) {
+    return `Failed to check SOL balance: ${getErrorMessage(error)}`;
+  }
+}
+
+async function executeTransfer(
+  ctx: TransferContext
+): Promise<TransferSplTokenResult> {
+  const { adapter, chainId, ownerPk, recipientPk, mintPk, amount } = ctx;
+
+  const resolved = await resolveMint(adapter, mintPk);
+  if ("error" in resolved) {
+    return { success: false, error: resolved.error };
+  }
+  const { mint: mintAccount, programId } = resolved;
+
+  const unsupported = findUnsupportedExtension(mintAccount);
+  if (unsupported) {
+    return {
+      success: false,
+      error: `Cannot transfer ${mintPk.toBase58()}: ${unsupported}`,
+    };
+  }
+
+  const parsed = parseAmount(amount, mintAccount.decimals);
+  if ("error" in parsed) {
+    return { success: false, error: parsed.error };
+  }
+
+  const senderAta = getAssociatedTokenAddressSync(
+    mintPk,
+    ownerPk,
+    false,
+    programId,
+    ASSOCIATED_TOKEN_PROGRAM_ID
+  );
+  // Recipients may legitimately be program-owned (PDA) accounts, so off-curve
+  // owners are allowed here.
+  const recipientAta = getAssociatedTokenAddressSync(
+    mintPk,
+    recipientPk,
+    true,
+    programId,
+    ASSOCIATED_TOKEN_PROGRAM_ID
+  );
+
+  const preflight = await runPreflight({
+    adapter,
+    ownerAddress: ctx.ownerAddress,
+    senderAta,
+    recipientAta,
+    recipientPk,
+    programId,
+    mintAccount,
+    amountRaw: parsed.raw,
+  });
+  if ("error" in preflight) {
+    return { success: false, error: preflight.error };
+  }
+
+  const data = buildSerializedTransfer({
+    ownerPk,
+    recipientPk,
+    mintPk,
+    senderAta,
+    recipientAta,
+    programId,
+    amountRaw: parsed.raw,
+    decimals: mintAccount.decimals,
+    needsRecipientAta: preflight.needsRecipientAta,
+  });
+
+  try {
+    // gasOverrides is deliberately empty. With an override set,
+    // normalizeSolanaTransaction takes its decompile/compileToV0Message branch
+    // and silently rewrites this legacy transaction as v0 - a path Turnkey's
+    // Solana signer has never been exercised against. Left empty, it only
+    // normalizes the fee payer, which already equals the signer, so the
+    // serialized bytes pass through untouched. A compute budget, if ever
+    // needed, belongs in the instructions built above.
+    const receipt = await adapter.sendTransaction(
+      undefined as unknown as ethers.Signer, // unused by SolanaChainAdapter
+      { to: recipientPk.toBase58(), data },
+      undefined as unknown as NonceSession, // unused by SolanaChainAdapter
+      { solanaSigner: ctx.solanaSigner, gasOverrides: {} }
+    );
+
+    const transactionLink = await adapter.getTransactionUrl(receipt.hash);
+
+    return {
+      success: true,
+      transactionHash: receipt.hash,
+      transactionLink,
+      // Mirrors the native Solana path: the lamport fee is not computed, and the
+      // raw compute-unit fields are returned instead.
+      gasUsed: "0",
+      gasUsedUnits: receipt.gasUsed.toString(),
+      effectiveGasPrice: receipt.effectiveGasPrice.toString(),
+      amount,
+      recipient: recipientPk.toBase58(),
+      mint: mintPk.toBase58(),
+      decimals: mintAccount.decimals,
+      recipientTokenAccount: recipientAta.toBase58(),
+      createdRecipientAccount: preflight.needsRecipientAta,
+    };
+  } catch (error) {
+    logUserError(
+      ErrorCategory.TRANSACTION,
+      "[Transfer SPL Token] Transaction failed",
+      error,
+      {
+        plugin_name: "web3",
+        action_name: "transfer-spl-token",
+        chain_id: String(chainId),
+      }
+    );
+    return { success: false, error: getErrorMessage(error) };
+  }
+}
+
+export async function transferSplTokenCore(
+  input: TransferSplTokenCoreInput
+): Promise<TransferSplTokenResult> {
+  const { network, mint, recipientAddress, amount, _context } = input;
+
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(network);
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  if (!isSplTransferPath(chainId)) {
+    return {
+      success: false,
+      error: `Transfer SPL Token is only supported on Solana networks, got: ${network}`,
+    };
+  }
+
+  if (!amount || amount.trim() === "") {
+    return { success: false, error: "Amount is required" };
+  }
+
+  const mintPk = parsePublicKey(mint);
+  if (!mintPk) {
+    return { success: false, error: `Invalid Solana mint address: ${mint}` };
+  }
+
+  const recipientPk = parsePublicKey(recipientAddress);
+  if (!recipientPk) {
+    return {
+      success: false,
+      error: `Invalid Solana recipient address: ${recipientAddress}`,
+    };
+  }
+
+  if (!(_context?.executionId || _context?.organizationId)) {
+    return {
+      success: false,
+      error: "Execution ID or organization ID is required",
+    };
+  }
+
+  const orgCtx = await resolveOrganizationContext(
+    _context,
+    "[Transfer SPL Token]",
+    "transfer-spl-token"
+  );
+  if (!orgCtx.success) {
+    return orgCtx;
+  }
+
+  const wallet = await resolveWallet(orgCtx.organizationId);
+  if ("error" in wallet) {
+    return { success: false, error: wallet.error };
+  }
+
+  const ownerPk = parsePublicKey(wallet.address);
+  if (!ownerPk) {
+    return {
+      success: false,
+      error: `Organization wallet has an invalid Solana address: ${wallet.address}`,
+    };
+  }
+
+  return await executeTransfer({
+    adapter: getChainAdapter(chainId) as SolanaChainAdapter,
+    chainId,
+    ownerPk,
+    ownerAddress: wallet.address,
+    recipientPk,
+    mintPk,
+    amount,
+    solanaSigner: wallet.signer,
+  });
+}

--- a/plugins/web3/steps/transfer-spl-token-core.ts
+++ b/plugins/web3/steps/transfer-spl-token-core.ts
@@ -143,8 +143,11 @@ function parseAmount(
 ): { raw: bigint } | { error: string } {
   try {
     const raw = ethers.parseUnits(amount.trim(), decimals);
-    if (raw < BigInt(0)) {
-      return { error: `Invalid token amount: ${amount}` };
+    // Reject zero as well as negatives: a zero transfer moves nothing but, when
+    // the recipient has no token account, still spends the sender's SOL creating
+    // an empty one - a silent cost for a no-op reported as success.
+    if (raw <= BigInt(0)) {
+      return { error: `Token amount must be greater than zero: ${amount}` };
     }
     return { raw };
   } catch {

--- a/plugins/web3/steps/transfer-spl-token-core.ts
+++ b/plugins/web3/steps/transfer-spl-token-core.ts
@@ -268,7 +268,15 @@ async function resolveMint(
     };
   }
 
-  return { mint: unpackMint(mintPk, mintInfo, programId), programId };
+  // unpackMint throws on an account that is owned by a token program but is not
+  // a well-formed mint - e.g. a token account address pasted into the mint field.
+  try {
+    return { mint: unpackMint(mintPk, mintInfo, programId), programId };
+  } catch (error) {
+    return {
+      error: `${mintPk.toBase58()} is not a valid SPL mint: ${getErrorMessage(error)}`,
+    };
+  }
 }
 
 async function runPreflight(args: {
@@ -313,7 +321,14 @@ async function runPreflight(args: {
     };
   }
 
-  const senderAccount = unpackAccount(senderAta, senderInfo, programId);
+  let senderAccount: ReturnType<typeof unpackAccount>;
+  try {
+    senderAccount = unpackAccount(senderAta, senderInfo, programId);
+  } catch (error) {
+    return {
+      error: `Failed to read the wallet's token account: ${getErrorMessage(error)}`,
+    };
+  }
   if (senderAccount.amount < amountRaw) {
     return {
       error: `Insufficient token balance. Have: ${senderAccount.amount.toString()}, Need: ${amountRaw.toString()} (raw units)`,

--- a/plugins/web3/steps/transfer-spl-token-core.ts
+++ b/plugins/web3/steps/transfer-spl-token-core.ts
@@ -97,7 +97,6 @@ type TransferContext = {
   adapter: SolanaChainAdapter;
   chainId: number;
   ownerPk: PublicKey;
-  ownerAddress: string;
   recipientPk: PublicKey;
   mintPk: PublicKey;
   amount: string;
@@ -283,7 +282,7 @@ async function resolveMint(
 
 async function runPreflight(args: {
   adapter: SolanaChainAdapter;
-  ownerAddress: string;
+  ownerPk: PublicKey;
   senderAta: PublicKey;
   recipientAta: PublicKey;
   recipientPk: PublicKey;
@@ -296,10 +295,12 @@ async function runPreflight(args: {
 
   let accounts: SolanaAccount[];
   try {
+    // The owner's account is read in the same batch so its lamports feed the SOL
+    // preflight without a separate getBalance round-trip.
     accounts = await adapter.executeWithSolanaFailover(
       (connection) =>
         connection.getMultipleAccountsInfo(
-          [senderAta, recipientAta, args.recipientPk],
+          [senderAta, recipientAta, args.recipientPk, args.ownerPk],
           "confirmed"
         ),
       "read"
@@ -308,7 +309,7 @@ async function runPreflight(args: {
     return { error: `Failed to read token accounts: ${getErrorMessage(error)}` };
   }
 
-  const [senderInfo, recipientAtaInfo, recipientInfo] = accounts;
+  const [senderInfo, recipientAtaInfo, recipientInfo, ownerInfo] = accounts;
 
   // A recipient address that is itself a token account means the caller pasted
   // a token account instead of a wallet; the ATA derived from it would be
@@ -349,9 +350,8 @@ async function runPreflight(args: {
     return rent;
   }
 
-  const solCheck = await checkSolBalance({
-    adapter,
-    ownerAddress: args.ownerAddress,
+  const solCheck = checkSolBalance({
+    balanceLamports: BigInt(ownerInfo?.lamports ?? 0),
     rentLamports: rent.lamports,
     needsRecipientAta,
   });
@@ -405,25 +405,19 @@ async function resolveRentLamports(
 }
 
 /** Returns an error message, or null when the balance covers fee plus rent. */
-async function checkSolBalance(args: {
-  adapter: SolanaChainAdapter;
-  ownerAddress: string;
+function checkSolBalance(args: {
+  balanceLamports: bigint;
   rentLamports: bigint;
   needsRecipientAta: boolean;
-}): Promise<string | null> {
-  try {
-    const balance = await args.adapter.getBalance(undefined, args.ownerAddress);
-    const required = SOLANA_BASE_FEE_LAMPORTS + args.rentLamports;
-    if (balance >= required) {
-      return null;
-    }
-    const breakdown = args.needsRecipientAta
-      ? `${SOLANA_BASE_FEE_LAMPORTS.toString()} fee + ${args.rentLamports.toString()} rent for the recipient's new token account`
-      : `${SOLANA_BASE_FEE_LAMPORTS.toString()} fee`;
-    return `Insufficient SOL balance. Have: ${balance.toString()} lamports, Need: ${required.toString()} lamports (${breakdown})`;
-  } catch (error) {
-    return `Failed to check SOL balance: ${getErrorMessage(error)}`;
+}): string | null {
+  const required = SOLANA_BASE_FEE_LAMPORTS + args.rentLamports;
+  if (args.balanceLamports >= required) {
+    return null;
   }
+  const breakdown = args.needsRecipientAta
+    ? `${SOLANA_BASE_FEE_LAMPORTS.toString()} fee + ${args.rentLamports.toString()} rent for the recipient's new token account`
+    : `${SOLANA_BASE_FEE_LAMPORTS.toString()} fee`;
+  return `Insufficient SOL balance. Have: ${args.balanceLamports.toString()} lamports, Need: ${required.toString()} lamports (${breakdown})`;
 }
 
 async function executeTransfer(
@@ -469,7 +463,7 @@ async function executeTransfer(
 
   const preflight = await runPreflight({
     adapter,
-    ownerAddress: ctx.ownerAddress,
+    ownerPk,
     senderAta,
     recipientAta,
     recipientPk,
@@ -610,7 +604,6 @@ export async function transferSplTokenCore(
     adapter: getChainAdapter(chainId) as SolanaChainAdapter,
     chainId,
     ownerPk,
-    ownerAddress: wallet.address,
     recipientPk,
     mintPk,
     amount,

--- a/plugins/web3/steps/transfer-spl-token-core.ts
+++ b/plugins/web3/steps/transfer-spl-token-core.ts
@@ -44,8 +44,13 @@ import {
 const PLACEHOLDER_BLOCKHASH = PublicKey.default.toBase58();
 
 /**
- * Mint extensions that a plain transferChecked cannot honour. Rejecting them up
- * front turns an opaque simulation failure into an actionable error.
+ * Mint extensions we decline to transfer. TransferHook and NonTransferable make
+ * a plain transferChecked fail outright. TransferFeeConfig does not - the mint
+ * transfers fine, but the program withholds a fee so the recipient receives less
+ * than the requested amount; without reading and reporting the net figure the
+ * step would overstate what was transferred, so v1 rejects these rather than
+ * report a wrong amount. Rejecting up front turns each case into an actionable
+ * error instead of an opaque simulation failure or a silent accounting gap.
  */
 const UNSUPPORTED_EXTENSIONS = new Map<ExtensionType, string>([
   [
@@ -53,6 +58,10 @@ const UNSUPPORTED_EXTENSIONS = new Map<ExtensionType, string>([
     "the mint has a transfer hook, which requires resolving extra accounts",
   ],
   [ExtensionType.NonTransferable, "the mint is non-transferable"],
+  [
+    ExtensionType.TransferFeeConfig,
+    "the mint charges a transfer fee, so the recipient would receive less than the requested amount",
+  ],
 ]);
 
 export type TransferSplTokenCoreInput = {

--- a/plugins/web3/steps/transfer-spl-token.ts
+++ b/plugins/web3/steps/transfer-spl-token.ts
@@ -1,0 +1,42 @@
+import "server-only";
+
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import {
+  type StepInput,
+  withStepLogging,
+} from "@/lib/workflow/executor/step-handler";
+import type {
+  TransferSplTokenCoreInput,
+  TransferSplTokenResult,
+} from "./transfer-spl-token-core";
+import { transferSplTokenCore } from "./transfer-spl-token-core";
+
+export type {
+  TransferSplTokenCoreInput,
+  TransferSplTokenResult,
+} from "./transfer-spl-token-core";
+
+export type TransferSplTokenInput = StepInput & TransferSplTokenCoreInput;
+
+/**
+ * Transfer SPL Token Step
+ * Transfers SPL tokens on Solana from the organization wallet to a recipient.
+ */
+export async function transferSplTokenStep(
+  input: TransferSplTokenInput
+): Promise<TransferSplTokenResult> {
+  "use step";
+
+  return withPluginMetrics(
+    {
+      pluginName: "web3",
+      actionName: "transfer-spl-token",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => transferSplTokenCore(input))
+  );
+}
+
+transferSplTokenStep.maxRetries = 0;
+
+export const _integrationType = "web3";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,7 +60,7 @@ importers:
         version: 3.1025.0
       '@coinbase/x402':
         specifier: ^2.1.0
-        version: 2.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+        version: 2.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@kubernetes/client-node':
         specifier: ^1.4.0
         version: 1.4.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -118,6 +118,9 @@ importers:
       '@slack/web-api':
         specifier: ^7.15.0
         version: 7.15.0
+      '@solana/spl-token':
+        specifier: ^0.4.15
+        version: 0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js':
         specifier: ^1.98.4
         version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -153,7 +156,7 @@ importers:
         version: 5.0.169(zod@4.3.6)
       better-auth:
         specifier: ^1.6.13
-        version: 1.6.13(j2xketw6rlxob6dbrbg6nxdtzi)
+        version: 1.6.13(77cba3da0dfc06152e54975f3c0a4b5f)
       bs58:
         specifier: ^6.0.0
         version: 6.0.0
@@ -739,24 +742,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.10':
     resolution: {integrity: sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.10':
     resolution: {integrity: sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.10':
     resolution: {integrity: sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.10':
     resolution: {integrity: sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ==}
@@ -1662,89 +1669,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2043,42 +2066,49 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
     resolution: {integrity: sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-openharmony-arm64@1.1.1':
     resolution: {integrity: sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==}
@@ -2162,24 +2192,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.7':
     resolution: {integrity: sha512-qyogG9QtBzWxgJfeGBvOEHI3851gTfCF3wLZ5RDLTBJGAmE9p1qDwKCOdrBrvBzRvYDT+gUDp72pzlSEfAXgNA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.7':
     resolution: {integrity: sha512-Vhe4ZDuBpmMogrGi5D4R2Kq4JAQlj6+wvgaFYy31zfES0zPmt6TLA+cuYpM/OLrPZjo2MYQTHVqNUSCR6+fDZQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.7':
     resolution: {integrity: sha512-srvian89JahFLw1YLBEuhvPJ0DO5lpUeJQMXy4xYo7g628ZlNgXdNkqoxSAv9OYrBfByh6vxISMwW/mRbzCY+g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.7':
     resolution: {integrity: sha512-GX3wvLpULFuRFJzwHaKfm7QZJ18F4ZSuxlPJ96BoBglCzBmdSjyeBKF+ZhWhvL/ckxNfLnNa7bsObO2ipYpszw==}
@@ -2534,41 +2568,49 @@ packages:
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
@@ -3486,131 +3528,157 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -4065,9 +4133,18 @@ packages:
       typescript:
         optional: true
 
+  '@solana/buffer-layout-utils@0.3.0':
+    resolution: {integrity: sha512-MuQOCC1j0np1xH9yAv0ZWWfwvr7Bt7Sz4LId11Wi4wDdAmJ+lobE+vHg/mZmGcihF0BIkqVBNxGmlv8QE5DrtA==}
+    engines: {node: '>= 10'}
+
   '@solana/buffer-layout@4.0.1':
     resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
     engines: {node: '>=5.10'}
+
+  '@solana/codecs-core@2.0.0-rc.1':
+    resolution: {integrity: sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==}
+    peerDependencies:
+      typescript: '>=5'
 
   '@solana/codecs-core@2.3.0':
     resolution: {integrity: sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==}
@@ -4084,6 +4161,11 @@ packages:
       typescript:
         optional: true
 
+  '@solana/codecs-data-structures@2.0.0-rc.1':
+    resolution: {integrity: sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==}
+    peerDependencies:
+      typescript: '>=5'
+
   '@solana/codecs-data-structures@5.5.1':
     resolution: {integrity: sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==}
     engines: {node: '>=20.18.0'}
@@ -4092,6 +4174,11 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/codecs-numbers@2.0.0-rc.1':
+    resolution: {integrity: sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==}
+    peerDependencies:
+      typescript: '>=5'
 
   '@solana/codecs-numbers@2.3.0':
     resolution: {integrity: sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==}
@@ -4108,6 +4195,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/codecs-strings@2.0.0-rc.1':
+    resolution: {integrity: sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5'
+
   '@solana/codecs-strings@5.5.1':
     resolution: {integrity: sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==}
     engines: {node: '>=20.18.0'}
@@ -4120,6 +4213,11 @@ packages:
       typescript:
         optional: true
 
+  '@solana/codecs@2.0.0-rc.1':
+    resolution: {integrity: sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==}
+    peerDependencies:
+      typescript: '>=5'
+
   '@solana/codecs@5.5.1':
     resolution: {integrity: sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==}
     engines: {node: '>=20.18.0'}
@@ -4128,6 +4226,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/errors@2.0.0-rc.1':
+    resolution: {integrity: sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5'
 
   '@solana/errors@2.3.0':
     resolution: {integrity: sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==}
@@ -4217,6 +4321,11 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/options@2.0.0-rc.1':
+    resolution: {integrity: sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==}
+    peerDependencies:
+      typescript: '>=5'
 
   '@solana/options@5.5.1':
     resolution: {integrity: sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==}
@@ -4371,6 +4480,24 @@ packages:
       typescript:
         optional: true
 
+  '@solana/spl-token-group@0.0.7':
+    resolution: {integrity: sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.3
+
+  '@solana/spl-token-metadata@0.1.6':
+    resolution: {integrity: sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.3
+
+  '@solana/spl-token@0.4.15':
+    resolution: {integrity: sha512-3Lof3mNov8NVQ3PalIWb1Jgr/TZ6lYM+/sexv2TLqdhNFVth2OfWmH3d7QucgMjSbokkjNiNlRr6I8Fd269uaw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.5
+
   '@solana/subscribable@5.5.1':
     resolution: {integrity: sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ==}
     engines: {node: '>=20.18.0'}
@@ -4483,24 +4610,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.3':
     resolution: {integrity: sha512-j4SJniZ/qaZ5g8op+p1G9K1z22s/EYGg1UXIb3+Cg4nsxEpF5uSIGEE4mHUfA70L0BR9wKT2QF/zv3vkhfpX4g==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.3':
     resolution: {integrity: sha512-aKttAZnz8YB1VJwPQZtyU8Uk0BfMP63iDMkvjhJzRZVgySmqt/apWSdnoIcZlUoGheBrcqbMC17GGUmur7OT5A==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.3':
     resolution: {integrity: sha512-oe8FctPu1gnUsdtGJRO2rvOUIkkIIaHqsO9xxN0bTR7dFTlPTGi2Fhk1tnvXeyAvCPxLIcwD8phzKg6wLv9yug==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.3':
     resolution: {integrity: sha512-L9AjzP2ZQ/Xh58e0lTRMLvEDrcJpR7GwZqAtIeNLcTK7JVE+QineSyHp0kLkO1rttCHyCy0U74kDTj0dRz6raA==}
@@ -4587,24 +4718,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -5631,6 +5766,13 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  bigint-buffer@1.1.5:
+    resolution: {integrity: sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==}
+    engines: {node: '>= 10.0.0'}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   bin-version-check@5.1.0:
     resolution: {integrity: sha512-bYsvMqJ8yNGILLz1KP9zKLzQ6YpljV3ln1gqhuLkUtyfGi3qXKGuK2p+U4NAvjVFzDFiBBtOpCOSFNuYYEGZ5g==}
     engines: {node: '>=12'}
@@ -5638,6 +5780,9 @@ packages:
   bin-version@6.0.0:
     resolution: {integrity: sha512-nk5wEsP4RiKjG+vF+uG8lFsEn4d7Y6FVDamzzftSunXOoOcOOkzcWdKVlGgFFwlUQCj63SgnUkLLGF8v7lufhw==}
     engines: {node: '>=12'}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   bintrees@1.0.2:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
@@ -5927,6 +6072,10 @@ packages:
   command-line-usage@6.1.3:
     resolution: {integrity: sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==}
     engines: {node: '>=8.0.0'}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
 
   commander@14.0.2:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
@@ -6635,6 +6784,9 @@ packages:
     resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
 
+  fastestsmallesttextencoderdecoder@1.0.22:
+    resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -6656,6 +6808,9 @@ packages:
   file-type@22.0.1:
     resolution: {integrity: sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==}
     engines: {node: '>=22'}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   filelist@1.0.4:
     resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
@@ -7354,24 +7509,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -10383,11 +10542,11 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@coinbase/cdp-sdk@1.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@coinbase/cdp-sdk@1.47.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@solana-program/system': 0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
-      '@solana-program/token': 0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
-      '@solana/kit': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana-program/system': 0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@solana-program/token': 0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       abitype: 1.0.6(typescript@5.9.3)(zod@3.25.76)
       axios: 1.16.0
       axios-retry: 4.5.0(axios@1.16.0)
@@ -10403,9 +10562,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@coinbase/x402@2.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@coinbase/x402@2.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@coinbase/cdp-sdk': 1.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@coinbase/cdp-sdk': 1.47.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@x402/core': 2.9.0
       viem: 2.47.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 3.25.76
@@ -13501,32 +13660,32 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
+  '@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
-      '@solana/kit': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
-  '@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
+  '@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
-      '@solana/kit': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
-  '@solana/accounts@5.5.1(typescript@5.9.3)':
+  '@solana/accounts@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/codecs-core': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 5.5.1(typescript@5.9.3)
       '@solana/rpc-spec': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@5.5.1(typescript@5.9.3)':
+  '@solana/addresses@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/assertions': 5.5.1(typescript@5.9.3)
       '@solana/codecs-core': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 5.5.1(typescript@5.9.3)
       '@solana/nominal-types': 5.5.1(typescript@5.9.3)
     optionalDependencies:
@@ -13540,9 +13699,26 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@solana/buffer-layout-utils@0.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      bigint-buffer: 1.1.5
+      bignumber.js: 9.3.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
   '@solana/buffer-layout@4.0.1':
     dependencies:
       buffer: 6.0.3
+
+  '@solana/codecs-core@2.0.0-rc.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
+      typescript: 5.9.3
 
   '@solana/codecs-core@2.3.0(typescript@5.9.3)':
     dependencies:
@@ -13555,12 +13731,25 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@solana/codecs-data-structures@2.0.0-rc.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
+      typescript: 5.9.3
+
   '@solana/codecs-data-structures@5.5.1(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 5.5.1(typescript@5.9.3)
       '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
       '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs-numbers@2.0.0-rc.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
       typescript: 5.9.3
 
   '@solana/codecs-numbers@2.3.0(typescript@5.9.3)':
@@ -13576,25 +13765,51 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-strings@5.5.1(typescript@5.9.3)':
+  '@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
+      fastestsmallesttextencoderdecoder: 1.0.22
+      typescript: 5.9.3
+
+  '@solana/codecs-strings@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 5.5.1(typescript@5.9.3)
       '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
       '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
+      fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.9.3
 
-  '@solana/codecs@5.5.1(typescript@5.9.3)':
+  '@solana/codecs@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/options': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/codecs@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 5.5.1(typescript@5.9.3)
       '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
       '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
-      '@solana/options': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/options': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/errors@2.0.0-rc.1(typescript@5.9.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 12.1.0
+      typescript: 5.9.3
 
   '@solana/errors@2.3.0(typescript@5.9.3)':
     dependencies:
@@ -13617,14 +13832,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/instruction-plans@5.5.1(typescript@5.9.3)':
+  '@solana/instruction-plans@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 5.5.1(typescript@5.9.3)
       '@solana/instructions': 5.5.1(typescript@5.9.3)
-      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/promises': 5.5.1(typescript@5.9.3)
-      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
-      '@solana/transactions': 5.5.1(typescript@5.9.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -13637,11 +13852,11 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/keys@5.5.1(typescript@5.9.3)':
+  '@solana/keys@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/assertions': 5.5.1(typescript@5.9.3)
       '@solana/codecs-core': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 5.5.1(typescript@5.9.3)
       '@solana/nominal-types': 5.5.1(typescript@5.9.3)
     optionalDependencies:
@@ -13649,30 +13864,30 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@solana/accounts': 5.5.1(typescript@5.9.3)
-      '@solana/addresses': 5.5.1(typescript@5.9.3)
-      '@solana/codecs': 5.5.1(typescript@5.9.3)
+      '@solana/accounts': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 5.5.1(typescript@5.9.3)
       '@solana/functional': 5.5.1(typescript@5.9.3)
-      '@solana/instruction-plans': 5.5.1(typescript@5.9.3)
+      '@solana/instruction-plans': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/instructions': 5.5.1(typescript@5.9.3)
-      '@solana/keys': 5.5.1(typescript@5.9.3)
-      '@solana/offchain-messages': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/offchain-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/plugin-core': 5.5.1(typescript@5.9.3)
-      '@solana/programs': 5.5.1(typescript@5.9.3)
-      '@solana/rpc': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-api': 5.5.1(typescript@5.9.3)
+      '@solana/programs': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-api': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-parsed-types': 5.5.1(typescript@5.9.3)
       '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
-      '@solana/signers': 5.5.1(typescript@5.9.3)
-      '@solana/sysvars': 5.5.1(typescript@5.9.3)
-      '@solana/transaction-confirmation': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
-      '@solana/transactions': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/signers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-confirmation': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -13684,27 +13899,38 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/offchain-messages@5.5.1(typescript@5.9.3)':
+  '@solana/offchain-messages@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/codecs-core': 5.5.1(typescript@5.9.3)
       '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
       '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 5.5.1(typescript@5.9.3)
-      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/nominal-types': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/options@5.5.1(typescript@5.9.3)':
+  '@solana/options@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/options@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 5.5.1(typescript@5.9.3)
       '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
       '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -13715,9 +13941,9 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/programs@5.5.1(typescript@5.9.3)':
+  '@solana/programs@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -13728,19 +13954,19 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-api@5.5.1(typescript@5.9.3)':
+  '@solana/rpc-api@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/codecs-core': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 5.5.1(typescript@5.9.3)
-      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-parsed-types': 5.5.1(typescript@5.9.3)
       '@solana/rpc-spec': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-transformers': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
-      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
-      '@solana/transactions': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-transformers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -13761,15 +13987,15 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-subscriptions-api@5.5.1(typescript@5.9.3)':
+  '@solana/rpc-subscriptions-api@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@5.9.3)
-      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-transformers': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
-      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
-      '@solana/transactions': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-transformers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -13797,18 +14023,18 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-subscriptions@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@solana/rpc-subscriptions@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/errors': 5.5.1(typescript@5.9.3)
       '@solana/fast-stable-stringify': 5.5.1(typescript@5.9.3)
       '@solana/functional': 5.5.1(typescript@5.9.3)
       '@solana/promises': 5.5.1(typescript@5.9.3)
       '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-subscriptions-api': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions-api': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-subscriptions-channel-websocket': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-transformers': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-transformers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/subscribable': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -13817,13 +14043,13 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/rpc-transformers@5.5.1(typescript@5.9.3)':
+  '@solana/rpc-transformers@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 5.5.1(typescript@5.9.3)
       '@solana/functional': 5.5.1(typescript@5.9.3)
       '@solana/nominal-types': 5.5.1(typescript@5.9.3)
       '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -13838,12 +14064,12 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-types@5.5.1(typescript@5.9.3)':
+  '@solana/rpc-types@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/codecs-core': 5.5.1(typescript@5.9.3)
       '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 5.5.1(typescript@5.9.3)
       '@solana/nominal-types': 5.5.1(typescript@5.9.3)
     optionalDependencies:
@@ -13851,37 +14077,68 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc@5.5.1(typescript@5.9.3)':
+  '@solana/rpc@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 5.5.1(typescript@5.9.3)
       '@solana/fast-stable-stringify': 5.5.1(typescript@5.9.3)
       '@solana/functional': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-api': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-api': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-spec': 5.5.1(typescript@5.9.3)
       '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-transformers': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-transformers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-transport-http': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@5.5.1(typescript@5.9.3)':
+  '@solana/signers@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/codecs-core': 5.5.1(typescript@5.9.3)
       '@solana/errors': 5.5.1(typescript@5.9.3)
       '@solana/instructions': 5.5.1(typescript@5.9.3)
-      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/nominal-types': 5.5.1(typescript@5.9.3)
-      '@solana/offchain-messages': 5.5.1(typescript@5.9.3)
-      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
-      '@solana/transactions': 5.5.1(typescript@5.9.3)
+      '@solana/offchain-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/spl-token-group@0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - typescript
+
+  '@solana/spl-token-metadata@0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - typescript
+
+  '@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/buffer-layout-utils': 0.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/spl-token-group': 0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
 
   '@solana/subscribable@5.5.1(typescript@5.9.3)':
     dependencies:
@@ -13889,29 +14146,29 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/sysvars@5.5.1(typescript@5.9.3)':
+  '@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/accounts': 5.5.1(typescript@5.9.3)
-      '@solana/codecs': 5.5.1(typescript@5.9.3)
+      '@solana/accounts': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-confirmation@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@solana/transaction-confirmation@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 5.5.1(typescript@5.9.3)
-      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/promises': 5.5.1(typescript@5.9.3)
-      '@solana/rpc': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
-      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
-      '@solana/transactions': 5.5.1(typescript@5.9.3)
+      '@solana/rpc': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -13919,9 +14176,9 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/transaction-messages@5.5.1(typescript@5.9.3)':
+  '@solana/transaction-messages@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/codecs-core': 5.5.1(typescript@5.9.3)
       '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
       '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
@@ -13929,26 +14186,26 @@ snapshots:
       '@solana/functional': 5.5.1(typescript@5.9.3)
       '@solana/instructions': 5.5.1(typescript@5.9.3)
       '@solana/nominal-types': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@5.5.1(typescript@5.9.3)':
+  '@solana/transactions@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/codecs-core': 5.5.1(typescript@5.9.3)
       '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
       '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 5.5.1(typescript@5.9.3)
       '@solana/functional': 5.5.1(typescript@5.9.3)
       '@solana/instructions': 5.5.1(typescript@5.9.3)
-      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/nominal-types': 5.5.1(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
-      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -15700,7 +15957,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.42: {}
 
-  better-auth@1.6.13(j2xketw6rlxob6dbrbg6nxdtzi):
+  better-auth@1.6.13(77cba3da0dfc06152e54975f3c0a4b5f):
     dependencies:
       '@better-auth/core': 1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.4.0)
       '@better-auth/drizzle-adapter': 1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))
@@ -15748,6 +16005,12 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  bigint-buffer@1.1.5:
+    dependencies:
+      bindings: 1.5.0
+
+  bignumber.js@9.3.1: {}
+
   bin-version-check@5.1.0:
     dependencies:
       bin-version: 6.0.0
@@ -15758,6 +16021,10 @@ snapshots:
     dependencies:
       execa: 5.1.1
       find-versions: 5.1.0
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
 
   bintrees@1.0.2: {}
 
@@ -16119,6 +16386,8 @@ snapshots:
       chalk: 2.4.2
       table-layout: 1.0.2
       typical: 5.2.0
+
+  commander@12.1.0: {}
 
   commander@14.0.2: {}
 
@@ -16843,6 +17112,8 @@ snapshots:
       path-expression-matcher: 1.5.0
       strnum: 2.2.3
 
+  fastestsmallesttextencoderdecoder@1.0.22: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -16869,6 +17140,8 @@ snapshots:
       uint8array-extras: 1.5.0
     transitivePeerDependencies:
       - supports-color
+
+  file-uri-to-path@1.0.0: {}
 
   filelist@1.0.4:
     dependencies:

--- a/scripts/solana-devnet-spl-fixture.ts
+++ b/scripts/solana-devnet-spl-fixture.ts
@@ -7,9 +7,9 @@
  * Turnkey, not by a local key), so this script only arranges the on-chain state
  * and prints the mint address to paste into the workflow node.
  *
- * A locally generated payer keypair funds and owns the mint. It is devnet-only
- * and holds no real value; it is cached so repeat runs reuse the same mint
- * authority rather than re-airdropping.
+ * The payer funds and owns the mint. It comes from SOLANA_FUNDER_KEY (base58 or
+ * a JSON byte array, e.g. a shared funded wallet loaded from .env); with no
+ * funder set it falls back to a cached locally generated devnet keypair.
  *
  * Usage:
  *   npx tsx scripts/solana-devnet-spl-fixture.ts <org-solana-address>
@@ -17,10 +17,11 @@
  *   npx tsx scripts/solana-devnet-spl-fixture.ts <org-solana-address> --mint <existing-mint>
  */
 
+import "dotenv/config";
+
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
-  createAssociatedTokenAccountIdempotent,
   createMint,
   getOrCreateAssociatedTokenAccount,
   mintTo,
@@ -31,7 +32,11 @@ import {
   Keypair,
   LAMPORTS_PER_SOL,
   PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
 } from "@solana/web3.js";
+import bs58 from "bs58";
 
 const DEVNET_RPC = process.env.SOLANA_DEVNET_RPC ?? "https://api.devnet.solana.com";
 const PAYER_KEY_PATH = join(process.cwd(), ".claude", ".solana-devnet-payer.json");
@@ -79,8 +84,36 @@ function parseArgs(): Args {
   };
 }
 
-/** Loads the cached devnet payer, generating one on first run. */
+/** Parses a secret key given as base58 or a JSON byte array. */
+function keypairFromSecret(raw: string): Keypair {
+  const trimmed = raw.trim();
+  const secret = trimmed.startsWith("[")
+    ? Uint8Array.from(JSON.parse(trimmed) as number[])
+    : bs58.decode(trimmed);
+  return Keypair.fromSecretKey(secret);
+}
+
+/**
+ * Resolves the payer/mint-authority keypair. Prefers SOLANA_FUNDER_KEY (a shared
+ * funded wallet, e.g. loaded from .env), so repeat runs draw from one topped-up
+ * account instead of re-airdropping. Falls back to a cached locally generated
+ * devnet keypair for zero-config use when no funder is configured.
+ */
 function loadPayer(): Keypair {
+  const funderKey = process.env.SOLANA_FUNDER_KEY;
+  if (funderKey) {
+    try {
+      const payer = keypairFromSecret(funderKey);
+      console.log("Using funder from SOLANA_FUNDER_KEY");
+      return payer;
+    } catch {
+      console.error(
+        "SOLANA_FUNDER_KEY is set but is not valid base58 or a JSON byte array"
+      );
+      process.exit(1);
+    }
+  }
+
   if (existsSync(PAYER_KEY_PATH)) {
     const secret = JSON.parse(readFileSync(PAYER_KEY_PATH, "utf8")) as number[];
     return Keypair.fromSecretKey(Uint8Array.from(secret));
@@ -137,6 +170,50 @@ async function ensureFunded(
   }
 }
 
+/**
+ * Tops `dest` up to `targetSol` by transferring the shortfall from the funder.
+ * This is how test/org wallets get funded - straight from the funder, not the
+ * rate-limited faucet.
+ */
+async function topUpFromFunder(
+  connection: Connection,
+  funder: Keypair,
+  dest: PublicKey,
+  targetSol: number,
+  label: string
+): Promise<void> {
+  const balance = await connection.getBalance(dest);
+  const targetLamports = targetSol * LAMPORTS_PER_SOL;
+
+  if (balance >= targetLamports) {
+    console.log(`${label} has ${balance / LAMPORTS_PER_SOL} SOL - no top-up needed`);
+    return;
+  }
+
+  const shortfall = targetLamports - balance;
+  const funderBalance = await connection.getBalance(funder.publicKey);
+  if (funderBalance < shortfall) {
+    console.error(
+      `Funder has ${funderBalance / LAMPORTS_PER_SOL} SOL, not enough to send ${shortfall / LAMPORTS_PER_SOL} to ${label}. Top up the funder: ${funder.publicKey.toBase58()}`
+    );
+    process.exit(1);
+  }
+
+  console.log(`Transferring ${shortfall / LAMPORTS_PER_SOL} SOL to ${label}...`);
+  const tx = new Transaction().add(
+    SystemProgram.transfer({
+      fromPubkey: funder.publicKey,
+      toPubkey: dest,
+      lamports: shortfall,
+    })
+  );
+  await sendAndConfirmTransaction(connection, tx, [funder], {
+    commitment: "confirmed",
+  });
+  const updated = await connection.getBalance(dest);
+  console.log(`${label} now has ${updated / LAMPORTS_PER_SOL} SOL`);
+}
+
 async function main(): Promise<void> {
   const args = parseArgs();
 
@@ -155,9 +232,12 @@ async function main(): Promise<void> {
   console.log(`Payer:  ${payer.publicKey.toBase58()}`);
   console.log(`Org:    ${orgPk.toBase58()}\n`);
 
-  await ensureFunded(connection, payer.publicKey, PAYER_TARGET_SOL, "payer");
-  // The org wallet pays its own transfer fee and any recipient-ATA rent.
-  await ensureFunded(connection, orgPk, ORG_TARGET_SOL, "org wallet");
+  // The funder must hold SOL itself. When it is a configured funder wallet this
+  // is a no-op; the airdrop path only bootstraps a locally generated fallback.
+  await ensureFunded(connection, payer.publicKey, PAYER_TARGET_SOL, "funder");
+  // The org/test wallet pays its own transfer fee and any recipient-ATA rent,
+  // funded straight from the funder rather than the faucet.
+  await topUpFromFunder(connection, payer, orgPk, ORG_TARGET_SOL, "org wallet");
 
   const mint = args.existingMint
     ? new PublicKey(args.existingMint)

--- a/scripts/solana-devnet-spl-fixture.ts
+++ b/scripts/solana-devnet-spl-fixture.ts
@@ -1,0 +1,217 @@
+/**
+ * Sets up a Solana devnet fixture for exercising the Transfer SPL Token action
+ * end to end: funds the organization wallet with devnet SOL, creates a fresh SPL
+ * mint, and mints a starting balance into the wallet's associated token account.
+ *
+ * The transfer itself runs through the app (the organization wallet is signed by
+ * Turnkey, not by a local key), so this script only arranges the on-chain state
+ * and prints the mint address to paste into the workflow node.
+ *
+ * A locally generated payer keypair funds and owns the mint. It is devnet-only
+ * and holds no real value; it is cached so repeat runs reuse the same mint
+ * authority rather than re-airdropping.
+ *
+ * Usage:
+ *   npx tsx scripts/solana-devnet-spl-fixture.ts <org-solana-address>
+ *   npx tsx scripts/solana-devnet-spl-fixture.ts <org-solana-address> --decimals 6 --amount 1000
+ *   npx tsx scripts/solana-devnet-spl-fixture.ts <org-solana-address> --mint <existing-mint>
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import {
+  createAssociatedTokenAccountIdempotent,
+  createMint,
+  getOrCreateAssociatedTokenAccount,
+  mintTo,
+  TOKEN_PROGRAM_ID,
+} from "@solana/spl-token";
+import {
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+} from "@solana/web3.js";
+
+const DEVNET_RPC = process.env.SOLANA_DEVNET_RPC ?? "https://api.devnet.solana.com";
+const PAYER_KEY_PATH = join(process.cwd(), ".claude", ".solana-devnet-payer.json");
+
+// Devnet faucet ceiling per request; airdrops above this are rejected outright.
+const MAX_AIRDROP_SOL = 2;
+// Enough for the mint account, the ATAs, and transaction fees.
+const PAYER_TARGET_SOL = 2;
+// The org wallet only pays fees plus rent for a recipient ATA (~0.002 SOL).
+const ORG_TARGET_SOL = 0.5;
+
+type Args = {
+  orgAddress: string;
+  decimals: number;
+  amount: number;
+  existingMint?: string;
+};
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  const positional = argv.filter((a) => !a.startsWith("--"));
+  const orgAddress = positional[0];
+
+  if (!orgAddress) {
+    console.error(
+      "Usage: npx tsx scripts/solana-devnet-spl-fixture.ts <org-solana-address> [--decimals 6] [--amount 1000] [--mint <address>]"
+    );
+    console.error(
+      "\nThe org Solana address is shown in the wallet overlay, or:\n" +
+        "  psql -c \"select solana_address from organization_wallets where organization_id = '<id>'\""
+    );
+    process.exit(1);
+  }
+
+  const flag = (name: string): string | undefined => {
+    const i = argv.indexOf(`--${name}`);
+    return i === -1 ? undefined : argv[i + 1];
+  };
+
+  return {
+    orgAddress,
+    decimals: Number(flag("decimals") ?? 6),
+    amount: Number(flag("amount") ?? 1000),
+    existingMint: flag("mint"),
+  };
+}
+
+/** Loads the cached devnet payer, generating one on first run. */
+function loadPayer(): Keypair {
+  if (existsSync(PAYER_KEY_PATH)) {
+    const secret = JSON.parse(readFileSync(PAYER_KEY_PATH, "utf8")) as number[];
+    return Keypair.fromSecretKey(Uint8Array.from(secret));
+  }
+
+  const payer = Keypair.generate();
+  mkdirSync(dirname(PAYER_KEY_PATH), { recursive: true });
+  writeFileSync(PAYER_KEY_PATH, JSON.stringify(Array.from(payer.secretKey)));
+  console.log(`Generated a devnet payer at ${PAYER_KEY_PATH}`);
+  return payer;
+}
+
+/** Tops an account up to `targetSol`, tolerating a rate-limited faucet. */
+async function ensureFunded(
+  connection: Connection,
+  address: PublicKey,
+  targetSol: number,
+  label: string
+): Promise<void> {
+  const balance = await connection.getBalance(address);
+  const targetLamports = targetSol * LAMPORTS_PER_SOL;
+
+  if (balance >= targetLamports) {
+    console.log(`${label} has ${balance / LAMPORTS_PER_SOL} SOL - no airdrop needed`);
+    return;
+  }
+
+  const wanted = Math.min(targetSol, MAX_AIRDROP_SOL) * LAMPORTS_PER_SOL;
+  console.log(`Airdropping ${wanted / LAMPORTS_PER_SOL} SOL to ${label}...`);
+
+  try {
+    const signature = await connection.requestAirdrop(address, wanted);
+    const latest = await connection.getLatestBlockhash("confirmed");
+    await connection.confirmTransaction(
+      { signature, ...latest },
+      "confirmed"
+    );
+    const updated = await connection.getBalance(address);
+    console.log(`${label} now has ${updated / LAMPORTS_PER_SOL} SOL`);
+  } catch (error) {
+    // The public devnet faucet rate-limits aggressively. A funded-enough account
+    // is fine; an empty one is not.
+    const current = await connection.getBalance(address);
+    if (current === 0) {
+      console.error(
+        `Airdrop failed and ${label} has no SOL: ${error instanceof Error ? error.message : String(error)}\n` +
+          "The devnet faucet is rate-limited. Use https://faucet.solana.com or retry later."
+      );
+      process.exit(1);
+    }
+    console.log(
+      `Airdrop failed but ${label} already holds ${current / LAMPORTS_PER_SOL} SOL - continuing`
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+
+  let orgPk: PublicKey;
+  try {
+    orgPk = new PublicKey(args.orgAddress);
+  } catch {
+    console.error(`Not a valid Solana address: ${args.orgAddress}`);
+    process.exit(1);
+  }
+
+  const connection = new Connection(DEVNET_RPC, "confirmed");
+  const payer = loadPayer();
+
+  console.log(`RPC:    ${DEVNET_RPC}`);
+  console.log(`Payer:  ${payer.publicKey.toBase58()}`);
+  console.log(`Org:    ${orgPk.toBase58()}\n`);
+
+  await ensureFunded(connection, payer.publicKey, PAYER_TARGET_SOL, "payer");
+  // The org wallet pays its own transfer fee and any recipient-ATA rent.
+  await ensureFunded(connection, orgPk, ORG_TARGET_SOL, "org wallet");
+
+  const mint = args.existingMint
+    ? new PublicKey(args.existingMint)
+    : await createMint(
+        connection,
+        payer,
+        payer.publicKey, // mint authority
+        null, // no freeze authority: a frozen mint cannot be transferred
+        args.decimals,
+        undefined,
+        undefined,
+        TOKEN_PROGRAM_ID
+      );
+
+  console.log(`\nMint:   ${mint.toBase58()}${args.existingMint ? " (existing)" : " (created)"}`);
+
+  const orgAta = await getOrCreateAssociatedTokenAccount(
+    connection,
+    payer, // the payer funds the org's ATA rent, not the org
+    mint,
+    orgPk,
+    true, // allowOwnerOffCurve: the org wallet may be program-owned
+    "confirmed",
+    undefined,
+    TOKEN_PROGRAM_ID
+  );
+
+  const raw = BigInt(Math.round(args.amount * 10 ** args.decimals));
+  await mintTo(
+    connection,
+    payer,
+    mint,
+    orgAta.address,
+    payer,
+    raw,
+    [],
+    undefined,
+    TOKEN_PROGRAM_ID
+  );
+
+  const balance = await connection.getTokenAccountBalance(orgAta.address);
+
+  console.log(`Org ATA: ${orgAta.address.toBase58()}`);
+  console.log(`Balance: ${balance.value.uiAmountString} (${args.decimals} decimals)`);
+  console.log("\nReady. In the workflow builder:");
+  console.log("  1. Add a Transfer SPL Token node");
+  console.log("  2. Network:        Solana Devnet");
+  console.log(`  3. Token Mint:     ${mint.toBase58()}`);
+  console.log("  4. Amount:         1");
+  console.log(`  5. Recipient:      ${Keypair.generate().publicKey.toBase58()}  (a fresh key - exercises recipient-ATA creation)`);
+  console.log(`\nInspect: https://solscan.io/token/${mint.toBase58()}?cluster=devnet`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/integration/transfer-spl-token-devnet.test.ts
+++ b/tests/integration/transfer-spl-token-devnet.test.ts
@@ -1,0 +1,181 @@
+import "dotenv/config";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  createMint,
+  getAccount,
+  getAssociatedTokenAddressSync,
+  getOrCreateAssociatedTokenAccount,
+  mintTo,
+  TOKEN_PROGRAM_ID,
+} from "@solana/spl-token";
+import { Connection, Keypair, type PublicKey } from "@solana/web3.js";
+
+// Boundaries swapped so the real transferSplTokenCore runs against live devnet:
+// the org wallet is a local keypair (via SolanaKeypairSigner, the same interface
+// Turnkey implements) and the adapter is a real devnet SolanaChainAdapter.
+// Everything KEEP-984 adds - mint read, program detection, ATA derivation,
+// transferChecked, serialization, and the adapter submit path - is exercised.
+const holder = vi.hoisted(() => ({
+  senderBytes: [] as number[],
+  senderAddress: "",
+}));
+
+vi.mock("@/lib/web3/resolve-org-context", () => ({
+  resolveOrganizationContext: vi.fn(async () => ({
+    success: true,
+    organizationId: "devnet-test",
+    userId: "devnet-test",
+  })),
+}));
+
+// The transfer succeeds before the adapter builds a cosmetic explorer URL, which
+// in production reads explorer_configs from the DB. There is no DB here, so stub
+// the lookup to return nothing (yielding an empty transactionLink).
+vi.mock("@/lib/db", () => ({
+  db: { query: { explorerConfigs: { findFirst: vi.fn(async () => null) } } },
+}));
+
+vi.mock("@/lib/web3/wallet-helpers", async () => {
+  const { SolanaKeypairSigner } = await import("@/lib/web3/solana-signer");
+  const { Keypair: Kp } = await import("@solana/web3.js");
+  return {
+    getOrganizationWallet: vi.fn(async () => ({
+      solanaAddress: holder.senderAddress,
+      turnkeySubOrgId: "devnet-test",
+    })),
+    buildSolanaSignerFromWallet: vi.fn(
+      () =>
+        new SolanaKeypairSigner(
+          Kp.fromSecretKey(Uint8Array.from(holder.senderBytes))
+        )
+    ),
+  };
+});
+
+vi.mock("@/lib/web3/chain-adapter", async () => {
+  const { SolanaChainAdapter } = await import(
+    "@/lib/web3/chain-adapter/solana"
+  );
+  const { getSolanaProviderFromUrls } = await import(
+    "@/lib/rpc/provider-factory"
+  );
+  const { PUBLIC_RPCS } = await import("@/lib/rpc/rpc-config");
+  return {
+    getChainAdapter: vi.fn(
+      () =>
+        new SolanaChainAdapter(103, () =>
+          getSolanaProviderFromUrls(
+            PUBLIC_RPCS.SOLANA_DEVNET,
+            undefined,
+            "Solana Devnet"
+          )
+        )
+    ),
+  };
+});
+
+import { transferSplTokenCore } from "@/plugins/web3/steps/transfer-spl-token-core";
+
+const DEVNET = "https://api.devnet.solana.com";
+const DECIMALS = 6;
+const ONE_TOKEN = BigInt(10 ** DECIMALS);
+
+// A live devnet transfer needs a funded keypair; skipped otherwise so CI stays
+// offline. Provide it as a JSON byte array (Solana CLI format).
+describe.skipIf(!process.env.SOLANA_DEVNET_TEST_KEYPAIR)(
+  "transferSplTokenCore live devnet",
+  () => {
+    let connection: Connection;
+    let sender: Keypair;
+    let mint: PublicKey;
+    let recipient: PublicKey;
+
+    beforeAll(async () => {
+      connection = new Connection(DEVNET, "confirmed");
+      sender = Keypair.fromSecretKey(
+        Uint8Array.from(
+          JSON.parse(process.env.SOLANA_DEVNET_TEST_KEYPAIR as string)
+        )
+      );
+      holder.senderBytes = Array.from(sender.secretKey);
+      holder.senderAddress = sender.publicKey.toBase58();
+
+      // Fresh mint (sender is authority) + a starting balance in the sender's ATA.
+      mint = await createMint(
+        connection,
+        sender,
+        sender.publicKey,
+        null,
+        DECIMALS,
+        undefined,
+        { commitment: "confirmed" },
+        TOKEN_PROGRAM_ID
+      );
+      const senderAta = await getOrCreateAssociatedTokenAccount(
+        connection,
+        sender,
+        mint,
+        sender.publicKey,
+        false,
+        "confirmed",
+        undefined,
+        TOKEN_PROGRAM_ID
+      );
+      await mintTo(
+        connection,
+        sender,
+        mint,
+        senderAta.address,
+        sender,
+        ONE_TOKEN * BigInt(5),
+        [],
+        { commitment: "confirmed" },
+        TOKEN_PROGRAM_ID
+      );
+
+      // Fresh recipient - exercises recipient-ATA creation on the transfer.
+      recipient = Keypair.generate().publicKey;
+    }, 120_000);
+
+    it("transfers an SPL token to a fresh recipient and lands it on-chain", async () => {
+      const result = await transferSplTokenCore({
+        network: "solana-devnet",
+        mint: mint.toBase58(),
+        recipientAddress: recipient.toBase58(),
+        amount: "1",
+        _context: { organizationId: "devnet-test" },
+      });
+
+      if (!result.success) {
+        throw new Error(`transfer failed: ${result.error}`);
+      }
+      console.log(
+        `\nSPL transfer landed: https://solscan.io/tx/${result.transactionHash}?cluster=devnet\n` +
+          `  mint ${result.mint}\n  recipient ${result.recipient}\n  recipient ATA ${result.recipientTokenAccount}\n`
+      );
+      expect(result.success).toBe(true);
+      expect(result.createdRecipientAccount).toBe(true);
+      expect(result.decimals).toBe(DECIMALS);
+      expect(result.transactionHash).toMatch(/^[1-9A-HJ-NP-Za-km-z]{64,88}$/);
+
+      // Independent on-chain confirmation: the recipient ATA holds exactly 1 token.
+      const recipientAta = getAssociatedTokenAddressSync(
+        mint,
+        recipient,
+        true,
+        TOKEN_PROGRAM_ID
+      );
+      const account = await getAccount(
+        connection,
+        recipientAta,
+        "confirmed",
+        TOKEN_PROGRAM_ID
+      );
+      expect(account.amount).toBe(ONE_TOKEN);
+      expect(account.mint.toBase58()).toBe(mint.toBase58());
+    }, 120_000);
+  }
+);

--- a/tests/integration/transfer-spl-token-devnet.test.ts
+++ b/tests/integration/transfer-spl-token-devnet.test.ts
@@ -35,16 +35,12 @@ vi.mock("@/lib/web3/wallet-helpers", async () => {
   const { SolanaKeypairSigner } = await import("@/lib/web3/solana-signer");
   const { Keypair: Kp } = await import("@solana/web3.js");
   return {
-    getOrganizationWallet: vi.fn(async () => ({
-      solanaAddress: holder.senderAddress,
-      turnkeySubOrgId: "devnet-test",
+    initializeSolanaWallet: vi.fn(async () => ({
+      signer: new SolanaKeypairSigner(
+        Kp.fromSecretKey(Uint8Array.from(holder.senderBytes))
+      ),
+      address: holder.senderAddress,
     })),
-    buildSolanaSignerFromWallet: vi.fn(
-      () =>
-        new SolanaKeypairSigner(
-          Kp.fromSecretKey(Uint8Array.from(holder.senderBytes))
-        )
-    ),
   };
 });
 

--- a/tests/integration/transfer-spl-token-devnet.test.ts
+++ b/tests/integration/transfer-spl-token-devnet.test.ts
@@ -31,13 +31,6 @@ vi.mock("@/lib/web3/resolve-org-context", () => ({
   })),
 }));
 
-// The transfer succeeds before the adapter builds a cosmetic explorer URL, which
-// in production reads explorer_configs from the DB. There is no DB here, so stub
-// the lookup to return nothing (yielding an empty transactionLink).
-vi.mock("@/lib/db", () => ({
-  db: { query: { explorerConfigs: { findFirst: vi.fn(async () => null) } } },
-}));
-
 vi.mock("@/lib/web3/wallet-helpers", async () => {
   const { SolanaKeypairSigner } = await import("@/lib/web3/solana-signer");
   const { Keypair: Kp } = await import("@solana/web3.js");

--- a/tests/unit/evm-chain-adapter-explorer-url.test.ts
+++ b/tests/unit/evm-chain-adapter-explorer-url.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/web3/chain-adapter/explorer", () => ({
+  buildChainTransactionUrl: vi.fn(),
+  buildChainAddressUrl: vi.fn(),
+}));
+
+import { EvmChainAdapter } from "@/lib/web3/chain-adapter/evm";
+import {
+  buildChainAddressUrl,
+  buildChainTransactionUrl,
+} from "@/lib/web3/chain-adapter/explorer";
+
+const CHAIN_ID = 1;
+const TX_HASH = "0xabc";
+const ADDRESS = "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb";
+
+function makeAdapter(): EvmChainAdapter {
+  // gasStrategy and nonceManager are unused by the URL methods under test.
+  return new EvmChainAdapter(
+    CHAIN_ID,
+    {} as unknown as ConstructorParameters<typeof EvmChainAdapter>[1],
+    {} as unknown as ConstructorParameters<typeof EvmChainAdapter>[2]
+  );
+}
+
+describe("EvmChainAdapter explorer URLs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the built transaction URL", async () => {
+    vi.mocked(buildChainTransactionUrl).mockResolvedValue(
+      "https://etherscan.io/tx/0xabc"
+    );
+
+    await expect(makeAdapter().getTransactionUrl(TX_HASH)).resolves.toBe(
+      "https://etherscan.io/tx/0xabc"
+    );
+  });
+
+  it("degrades to empty string instead of throwing when the tx lookup fails", async () => {
+    // A transfer step calls this after the transaction is already mined, so a
+    // throw here would flip a completed transfer's result to failed.
+    vi.mocked(buildChainTransactionUrl).mockRejectedValue(
+      new Error("explorer config lookup failed")
+    );
+
+    await expect(makeAdapter().getTransactionUrl(TX_HASH)).resolves.toBe("");
+  });
+
+  it("degrades to empty string instead of throwing when the address lookup fails", async () => {
+    vi.mocked(buildChainAddressUrl).mockRejectedValue(
+      new Error("explorer config lookup failed")
+    );
+
+    await expect(makeAdapter().getAddressUrl(ADDRESS)).resolves.toBe("");
+  });
+});

--- a/tests/unit/solana-chain-adapter.test.ts
+++ b/tests/unit/solana-chain-adapter.test.ts
@@ -141,6 +141,19 @@ describe("SolanaChainAdapter", () => {
       const url = await adapter.getTransactionUrl(TEST_TX_HASH);
       expect(url).toBe("");
     });
+
+    it("degrades to empty string instead of throwing when the lookup fails", async () => {
+      // A transfer step calls this after the transaction is already on-chain, so
+      // a throw here would flip a completed transfer's result to failed.
+      vi.mocked(buildChainTransactionUrl).mockRejectedValue(
+        new Error("explorer config lookup failed")
+      );
+
+      const { factory } = createMockFactory();
+      const adapter = new SolanaChainAdapter(DEVNET_CHAIN_ID, factory);
+
+      await expect(adapter.getTransactionUrl(TEST_TX_HASH)).resolves.toBe("");
+    });
   });
 
   describe("getAddressUrl", () => {
@@ -168,6 +181,19 @@ describe("SolanaChainAdapter", () => {
 
       const url = await adapter.getAddressUrl(SYSTEM_PROGRAM_ADDRESS);
       expect(url).toBe("");
+    });
+
+    it("degrades to empty string instead of throwing when the lookup fails", async () => {
+      vi.mocked(buildChainAddressUrl).mockRejectedValue(
+        new Error("explorer config lookup failed")
+      );
+
+      const { factory } = createMockFactory();
+      const adapter = new SolanaChainAdapter(DEVNET_CHAIN_ID, factory);
+
+      await expect(adapter.getAddressUrl(SYSTEM_PROGRAM_ADDRESS)).resolves.toBe(
+        ""
+      );
     });
   });
 

--- a/tests/unit/transfer-funds-solana.test.ts
+++ b/tests/unit/transfer-funds-solana.test.ts
@@ -4,18 +4,14 @@ vi.mock("server-only", () => ({}));
 
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
-import {
-  buildSolanaSignerFromWallet,
-  getOrganizationWallet,
-} from "@/lib/web3/wallet-helpers";
+import { initializeSolanaWallet } from "@/lib/web3/wallet-helpers";
 import {
   isSolanaTransferPath,
   transferFundsCore,
 } from "@/plugins/web3/steps/transfer-funds-core";
 
 vi.mock("@/lib/web3/wallet-helpers", () => ({
-  getOrganizationWallet: vi.fn(),
-  buildSolanaSignerFromWallet: vi.fn(),
+  initializeSolanaWallet: vi.fn(),
   getOrganizationWalletAddress: vi.fn().mockResolvedValue("evm-wallet-address"),
 }));
 
@@ -59,12 +55,11 @@ describe("transferFundsCore - Solana early branch", () => {
       userId: "mock-user-id",
     } as any);
 
-    vi.mocked(getOrganizationWallet).mockResolvedValue({
-      solanaAddress: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
-    } as any);
-
     const mockSigner = { getPublicKey: vi.fn(), signTransaction: vi.fn() };
-    vi.mocked(buildSolanaSignerFromWallet).mockReturnValue(mockSigner as any);
+    vi.mocked(initializeSolanaWallet).mockResolvedValue({
+      signer: mockSigner,
+      address: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+    } as any);
 
     mockAdapter.getBalance.mockResolvedValue(BigInt(2_000_000_000)); // 2 SOL
     mockAdapter.sendTransaction.mockResolvedValue({
@@ -164,11 +159,10 @@ describe("transferFundsCore - Solana early branch", () => {
       organizationId: "mock-org-id",
     } as any);
 
-    vi.mocked(getOrganizationWallet).mockResolvedValue({
-      solanaAddress: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+    vi.mocked(initializeSolanaWallet).mockResolvedValue({
+      signer: {},
+      address: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
     } as any);
-
-    vi.mocked(buildSolanaSignerFromWallet).mockReturnValue({} as any);
 
     mockAdapter.getBalance.mockResolvedValue(BigInt(500_000_000)); // 0.5 SOL
 
@@ -191,11 +185,10 @@ describe("transferFundsCore - Solana early branch", () => {
       organizationId: "mock-org-id",
     } as any);
 
-    vi.mocked(getOrganizationWallet).mockResolvedValue({
-      solanaAddress: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+    vi.mocked(initializeSolanaWallet).mockResolvedValue({
+      signer: {},
+      address: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
     } as any);
-
-    vi.mocked(buildSolanaSignerFromWallet).mockReturnValue({} as any);
 
     // Balance equals the transfer amount exactly, leaving nothing for the
     // 5000-lamport base fee - must be rejected at preflight.

--- a/tests/unit/transfer-spl-token-action.test.ts
+++ b/tests/unit/transfer-spl-token-action.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { ActionConfigField } from "@/plugins/registry";
+import { findActionById } from "@/plugins/registry";
+
+/**
+ * Guards the non-obvious constraints in the Transfer SPL Token action
+ * definition. Each assertion protects against a specific, silent breakage - the
+ * file:line references are why these are not arbitrary.
+ */
+describe("web3/transfer-spl-token action definition", () => {
+  const action = findActionById("web3/transfer-spl-token");
+
+  function flatFields(): ActionConfigField[] {
+    const fields = action?.configFields ?? [];
+    return fields.flatMap((field) =>
+      field.type === "group" ? [field, ...field.fields] : [field]
+    );
+  }
+
+  function fieldByKey(key: string) {
+    return flatFields().find((field) => "key" in field && field.key === key);
+  }
+
+  it("is registered and discoverable in the action registry", () => {
+    expect(action).toBeDefined();
+    expect(action?.label).toBe("Transfer SPL Token");
+    // category drives grouping in the node palette (action-grid.tsx).
+    expect(action?.category).toBe("Web3");
+  });
+
+  it("restricts the Network field to Solana chains", () => {
+    // chain-select-field.tsx filters /api/chains by chain.chainType. The value is
+    // an unvalidated loose string: a typo silently yields an empty dropdown with
+    // no error, and nothing else in the suite asserts it.
+    const network = fieldByKey("network");
+    expect(network).toMatchObject({
+      type: "chain-select",
+      chainTypeFilter: "solana",
+    });
+  });
+
+  it("does not key the mint field so it ends in 'address'", () => {
+    // action-config-renderer.tsx treats any key ending in "address" as an EVM
+    // address: it applies toChecksumAddress() to the displayed value and attaches
+    // the Ethereum-only address book, whose Save button rejects base58 with
+    // "Please enter a valid Ethereum address first".
+    expect(fieldByKey("mint")).toBeDefined();
+    for (const field of flatFields()) {
+      if ("key" in field && field.key !== "recipientAddress") {
+        expect(field.key.toLowerCase().endsWith("address")).toBe(false);
+      }
+    }
+  });
+
+  it("never declares isAddressField", () => {
+    // action-config.ts validates declared address fields against
+    // ETH_ADDRESS_PATTERN, which rejects every valid base58 Solana address.
+    for (const field of flatFields()) {
+      expect("isAddressField" in field && field.isAddressField).toBeFalsy();
+    }
+  });
+
+  it("declares no EVM-only fields", () => {
+    for (const field of flatFields()) {
+      // gas-limit-multiplier posts to /api/gas/estimate with an EVM chainId, and
+      // Solana fees are lamports-per-signature plus optional priority fees.
+      expect(field.type).not.toBe("gas-limit-multiplier");
+      // showPrivateVariants renders private-mempool chain variants; Solana has none.
+      expect(
+        "showPrivateVariants" in field && field.showPrivateVariants
+      ).toBeFalsy();
+      // token-select is EVM-bound end to end: it checksums addresses, dedupes
+      // case-insensitively (base58 is case-sensitive), and validates via
+      // /api/validate-token, which is ethers.isAddress + ERC20 ABI.
+      expect(field.type).not.toBe("token-select");
+    }
+  });
+
+  it("points at the step function and import path the bundler expects", () => {
+    expect(action).toMatchObject({
+      stepFunction: "transferSplTokenStep",
+      stepImportPath: "transfer-spl-token",
+    });
+  });
+});

--- a/tests/unit/transfer-spl-token.test.ts
+++ b/tests/unit/transfer-spl-token.test.ts
@@ -511,4 +511,15 @@ describe("transferSplTokenCore", () => {
       error: expect.stringContaining("Invalid token amount"),
     });
   });
+
+  it("rejects a zero amount before building or sending anything", async () => {
+    const result = await transferSplTokenCore({ ...validInput, amount: "0" });
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining("greater than zero"),
+    });
+    // A zero transfer must never create the recipient's token account.
+    expect(mockAdapter.sendTransaction).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/transfer-spl-token.test.ts
+++ b/tests/unit/transfer-spl-token.test.ts
@@ -1,0 +1,514 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  ACCOUNT_SIZE,
+  AccountLayout,
+  AccountState,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  getAssociatedTokenAddressSync,
+  MINT_SIZE,
+  MintLayout,
+  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+} from "@solana/spl-token";
+import { Keypair, PublicKey, Transaction } from "@solana/web3.js";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
+import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
+import {
+  buildSolanaSignerFromWallet,
+  getOrganizationWallet,
+} from "@/lib/web3/wallet-helpers";
+import {
+  isSplTransferPath,
+  transferSplTokenCore,
+} from "@/plugins/web3/steps/transfer-spl-token-core";
+
+vi.mock("@/lib/web3/wallet-helpers", () => ({
+  getOrganizationWallet: vi.fn(),
+  buildSolanaSignerFromWallet: vi.fn(),
+  getOrganizationWalletAddress: vi.fn(),
+}));
+
+vi.mock("@/lib/web3/chain-adapter", () => ({
+  getChainAdapter: vi.fn(),
+}));
+
+vi.mock("@/lib/web3/resolve-org-context", () => ({
+  resolveOrganizationContext: vi.fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { VALIDATION: "validation", TRANSACTION: "transaction" },
+  logUserError: vi.fn(),
+}));
+
+// The transfer authority / fee payer. Fixed keys keep derived ATAs stable.
+const OWNER = new PublicKey("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU");
+const RECIPIENT = new PublicKey("7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU");
+const MINT = new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+
+const RENT_LAMPORTS = 2_039_280;
+const BASE_FEE = 5000;
+
+/** SPL TokenInstruction discriminators. */
+const IX_TRANSFER = 3;
+const IX_TRANSFER_CHECKED = 12;
+
+type MockAccount = { owner: PublicKey; data: Buffer } | null;
+
+function mintAccount(
+  decimals: number,
+  programId = TOKEN_PROGRAM_ID
+): MockAccount {
+  const data = Buffer.alloc(MINT_SIZE);
+  MintLayout.encode(
+    {
+      mintAuthorityOption: 1,
+      mintAuthority: OWNER,
+      supply: BigInt(1_000_000_000),
+      decimals,
+      isInitialized: true,
+      freezeAuthorityOption: 0,
+      freezeAuthority: PublicKey.default,
+    },
+    data
+  );
+  return { owner: programId, data };
+}
+
+function tokenAccount(
+  amount: bigint,
+  mint = MINT,
+  owner = OWNER,
+  programId = TOKEN_PROGRAM_ID
+): MockAccount {
+  const data = Buffer.alloc(ACCOUNT_SIZE);
+  AccountLayout.encode(
+    {
+      mint,
+      owner,
+      amount,
+      delegateOption: 0,
+      delegate: PublicKey.default,
+      delegatedAmount: BigInt(0),
+      state: AccountState.Initialized,
+      isNativeOption: 0,
+      isNative: BigInt(0),
+      closeAuthorityOption: 0,
+      closeAuthority: PublicKey.default,
+    },
+    data
+  );
+  return { owner: programId, data };
+}
+
+function decodeSentTransaction(sendTransaction: ReturnType<typeof vi.fn>) {
+  const request = sendTransaction.mock.calls[0][1];
+  return Transaction.from(Buffer.from(request.data, "base64"));
+}
+
+describe("transferSplTokenCore", () => {
+  let mockAdapter: {
+    getBalance: ReturnType<typeof vi.fn>;
+    sendTransaction: ReturnType<typeof vi.fn>;
+    getTransactionUrl: ReturnType<typeof vi.fn>;
+    executeWithSolanaFailover: ReturnType<typeof vi.fn>;
+  };
+  let mockConnection: {
+    getAccountInfo: ReturnType<typeof vi.fn>;
+    getMultipleAccountsInfo: ReturnType<typeof vi.fn>;
+    getMinimumBalanceForRentExemption: ReturnType<typeof vi.fn>;
+  };
+
+  const validInput = {
+    network: "solana-devnet",
+    mint: MINT.toBase58(),
+    recipientAddress: RECIPIENT.toBase58(),
+    amount: "1.5",
+    _context: { organizationId: "mock-org-id" },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockConnection = {
+      getAccountInfo: vi.fn().mockResolvedValue(mintAccount(6)),
+      getMultipleAccountsInfo: vi
+        .fn()
+        // [senderAta, recipientAta, recipientWallet]
+        .mockResolvedValue([
+          tokenAccount(BigInt(10_000_000)),
+          tokenAccount(BigInt(0), MINT, RECIPIENT),
+          null,
+        ]),
+      getMinimumBalanceForRentExemption: vi
+        .fn()
+        .mockResolvedValue(RENT_LAMPORTS),
+    };
+
+    mockAdapter = {
+      getBalance: vi.fn().mockResolvedValue(BigInt(2_000_000_000)),
+      sendTransaction: vi.fn().mockResolvedValue({
+        hash: "mock-signature",
+        gasUsed: BigInt(4521), // compute units
+        effectiveGasPrice: BigInt(10), // micro-lamports
+      }),
+      getTransactionUrl: vi
+        .fn()
+        .mockResolvedValue("https://solscan.io/tx/mock-signature"),
+      executeWithSolanaFailover: vi.fn((operation) =>
+        operation(mockConnection)
+      ),
+    };
+
+    vi.mocked(getChainAdapter).mockReturnValue(mockAdapter as never);
+    vi.mocked(resolveOrganizationContext).mockResolvedValue({
+      success: true,
+      organizationId: "mock-org-id",
+      userId: "mock-user-id",
+    } as never);
+    vi.mocked(getOrganizationWallet).mockResolvedValue({
+      solanaAddress: OWNER.toBase58(),
+    } as never);
+    vi.mocked(buildSolanaSignerFromWallet).mockReturnValue({
+      getPublicKey: vi.fn(),
+      signTransaction: vi.fn(),
+    } as never);
+  });
+
+  it("identifies Solana chain IDs", () => {
+    expect(isSplTransferPath(101)).toBe(true); // Solana Mainnet
+    expect(isSplTransferPath(103)).toBe(true); // Solana Devnet
+    expect(isSplTransferPath(1)).toBe(false); // EVM Ethereum
+    expect(isSplTransferPath(8453)).toBe(false); // EVM Base
+  });
+
+  it("transfers when the recipient token account already exists", async () => {
+    const result = await transferSplTokenCore(validInput);
+
+    expect(result).toMatchObject({
+      success: true,
+      transactionHash: "mock-signature",
+      transactionLink: "https://solscan.io/tx/mock-signature",
+      amount: "1.5",
+      mint: MINT.toBase58(),
+      decimals: 6,
+      recipient: RECIPIENT.toBase58(),
+      createdRecipientAccount: false,
+      gasUsed: "0",
+      gasUsedUnits: "4521",
+      effectiveGasPrice: "10",
+    });
+
+    const tx = decodeSentTransaction(mockAdapter.sendTransaction);
+    expect(tx.instructions).toHaveLength(1);
+    expect(tx.feePayer?.equals(OWNER)).toBe(true);
+  });
+
+  it("sets the placeholder blockhash and owner fee payer, which the adapter overwrites", async () => {
+    await transferSplTokenCore(validInput);
+
+    const tx = decodeSentTransaction(mockAdapter.sendTransaction);
+    // Serializing requires both; the adapter replaces the blockhash before
+    // signing. If this fails, check that nobody "fixed" the placeholder.
+    expect(tx.recentBlockhash).toBe(PublicKey.default.toBase58());
+    expect(tx.feePayer?.equals(OWNER)).toBe(true);
+  });
+
+  it("never passes gas overrides, so the normalizer cannot rewrite the tx as v0", async () => {
+    await transferSplTokenCore(validInput);
+
+    const options = mockAdapter.sendTransaction.mock.calls[0][3];
+    expect(options.gasOverrides).toEqual({});
+    expect(options.gasOverrides.gasLimitOverride).toBeUndefined();
+    expect(options.gasOverrides.priorityFeeOverride).toBeUndefined();
+  });
+
+  it("uses transferChecked rather than transfer", async () => {
+    await transferSplTokenCore(validInput);
+
+    const tx = decodeSentTransaction(mockAdapter.sendTransaction);
+    const transferIx = tx.instructions.at(-1);
+    expect(transferIx?.data[0]).toBe(IX_TRANSFER_CHECKED);
+    expect(transferIx?.data[0]).not.toBe(IX_TRANSFER);
+  });
+
+  it("derives the amount from the mint's decimals, not a fixed value", async () => {
+    // 1.5 at 6 decimals = 1_500_000 raw units, encoded LE after the discriminator.
+    await transferSplTokenCore(validInput);
+
+    const tx = decodeSentTransaction(mockAdapter.sendTransaction);
+    const transferIx = tx.instructions.at(-1);
+    expect(transferIx?.data.readBigUInt64LE(1)).toBe(BigInt(1_500_000));
+    expect(transferIx?.data[9]).toBe(6); // decimals byte
+  });
+
+  it("creates the recipient token account when it is missing, using Token-2022", async () => {
+    mockConnection.getAccountInfo.mockResolvedValue(
+      mintAccount(9, TOKEN_2022_PROGRAM_ID)
+    );
+    mockConnection.getMultipleAccountsInfo.mockResolvedValue([
+      tokenAccount(BigInt(10_000_000_000), MINT, OWNER, TOKEN_2022_PROGRAM_ID),
+      null, // recipient ATA missing
+      null,
+    ]);
+
+    const result = await transferSplTokenCore(validInput);
+
+    expect(result).toMatchObject({
+      success: true,
+      createdRecipientAccount: true,
+    });
+
+    const tx = decodeSentTransaction(mockAdapter.sendTransaction);
+    expect(tx.instructions).toHaveLength(2);
+    // The idempotent create must come first, or the transfer hits a missing account.
+    expect(
+      tx.instructions[0].programId.equals(ASSOCIATED_TOKEN_PROGRAM_ID)
+    ).toBe(true);
+    expect(tx.instructions[1].programId.equals(TOKEN_2022_PROGRAM_ID)).toBe(
+      true
+    );
+  });
+
+  it("routes to the token program that owns the mint", async () => {
+    mockConnection.getAccountInfo.mockResolvedValue(
+      mintAccount(6, TOKEN_2022_PROGRAM_ID)
+    );
+    mockConnection.getMultipleAccountsInfo.mockResolvedValue([
+      tokenAccount(BigInt(10_000_000), MINT, OWNER, TOKEN_2022_PROGRAM_ID),
+      tokenAccount(BigInt(0), MINT, RECIPIENT, TOKEN_2022_PROGRAM_ID),
+      null,
+    ]);
+
+    const result = await transferSplTokenCore(validInput);
+    expect(result.success).toBe(true);
+
+    const tx = decodeSentTransaction(mockAdapter.sendTransaction);
+    expect(tx.instructions[0].programId.equals(TOKEN_2022_PROGRAM_ID)).toBe(
+      true
+    );
+
+    // The recipient ATA must be derived under the same program.
+    const expectedAta = getAssociatedTokenAddressSync(
+      MINT,
+      RECIPIENT,
+      true,
+      TOKEN_2022_PROGRAM_ID,
+      ASSOCIATED_TOKEN_PROGRAM_ID
+    );
+    expect(
+      (result as { recipientTokenAccount: string }).recipientTokenAccount
+    ).toBe(expectedAta.toBase58());
+  });
+
+  it("rejects a non-Solana network without touching RPC", async () => {
+    const result = await transferSplTokenCore({
+      ...validInput,
+      network: "ethereum",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining("only supported on Solana networks"),
+    });
+    expect(mockAdapter.executeWithSolanaFailover).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid mint address without touching RPC", async () => {
+    const result = await transferSplTokenCore({
+      ...validInput,
+      mint: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // an ERC20 address
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining("Invalid Solana mint address"),
+    });
+    expect(mockAdapter.executeWithSolanaFailover).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid recipient address without touching RPC", async () => {
+    const result = await transferSplTokenCore({
+      ...validInput,
+      recipientAddress: "not-a-real-address",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining("Invalid Solana recipient address"),
+    });
+    expect(mockAdapter.executeWithSolanaFailover).not.toHaveBeenCalled();
+  });
+
+  it("reports a missing mint account", async () => {
+    mockConnection.getAccountInfo.mockResolvedValue(null);
+
+    const result = await transferSplTokenCore(validInput);
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining("Mint account not found"),
+    });
+  });
+
+  it("rejects a mint owned by neither token program", async () => {
+    mockConnection.getAccountInfo.mockResolvedValue({
+      owner: Keypair.generate().publicKey,
+      data: Buffer.alloc(MINT_SIZE),
+    });
+
+    const result = await transferSplTokenCore(validInput);
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining("is not an SPL token mint"),
+    });
+  });
+
+  it("reports when the sending wallet has no token account for the mint", async () => {
+    mockConnection.getMultipleAccountsInfo.mockResolvedValue([
+      null,
+      null,
+      null,
+    ]);
+
+    const result = await transferSplTokenCore(validInput);
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining("no token account for mint"),
+    });
+  });
+
+  it("reports insufficient token balance", async () => {
+    mockConnection.getMultipleAccountsInfo.mockResolvedValue([
+      tokenAccount(BigInt(1_000_000)), // 1.0 held, 1.5 requested
+      tokenAccount(BigInt(0), MINT, RECIPIENT),
+      null,
+    ]);
+
+    const result = await transferSplTokenCore(validInput);
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining("Insufficient token balance"),
+    });
+  });
+
+  it("rejects a recipient that is itself a token account", async () => {
+    mockConnection.getMultipleAccountsInfo.mockResolvedValue([
+      tokenAccount(BigInt(10_000_000)),
+      null,
+      tokenAccount(BigInt(0), MINT, RECIPIENT), // the recipient address IS a token account
+    ]);
+
+    const result = await transferSplTokenCore(validInput);
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining(
+        "must be a wallet address, not a token account"
+      ),
+    });
+  });
+
+  it("reports insufficient SOL for the transaction fee", async () => {
+    mockAdapter.getBalance.mockResolvedValue(BigInt(BASE_FEE - 1));
+
+    const result = await transferSplTokenCore(validInput);
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining("Insufficient SOL balance"),
+    });
+  });
+
+  it("reserves rent on top of the fee when creating the recipient account", async () => {
+    // Covers the fee but not the fee plus rent - the case unique to this path.
+    mockConnection.getMultipleAccountsInfo.mockResolvedValue([
+      tokenAccount(BigInt(10_000_000)),
+      null, // recipient ATA missing -> rent required
+      null,
+    ]);
+    mockAdapter.getBalance.mockResolvedValue(BigInt(BASE_FEE + 1));
+
+    const result = await transferSplTokenCore(validInput);
+
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toContain(
+      "Insufficient SOL balance"
+    );
+    expect((result as { error: string }).error).toContain("rent");
+    // Fee alone would have passed; rent is what makes it fail.
+    expect((result as { error: string }).error).toContain(
+      String(BASE_FEE + RENT_LAMPORTS)
+    );
+  });
+
+  it("does not charge rent when the recipient account already exists", async () => {
+    mockAdapter.getBalance.mockResolvedValue(BigInt(BASE_FEE));
+
+    const result = await transferSplTokenCore(validInput);
+
+    expect(result.success).toBe(true);
+    expect(
+      mockConnection.getMinimumBalanceForRentExemption
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns a clean error when the mint read fails", async () => {
+    mockConnection.getAccountInfo.mockRejectedValue(new Error("RPC down"));
+
+    const result = await transferSplTokenCore(validInput);
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining("Failed to read mint account"),
+    });
+  });
+
+  it("returns a clean error when the transaction fails to send", async () => {
+    mockAdapter.sendTransaction.mockRejectedValue(
+      new Error("Simulation failed")
+    );
+
+    const result = await transferSplTokenCore(validInput);
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining("Simulation failed"),
+    });
+  });
+
+  it("requires an execution or organization context", async () => {
+    const result = await transferSplTokenCore({
+      ...validInput,
+      _context: undefined,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining(
+        "Execution ID or organization ID is required"
+      ),
+    });
+  });
+
+  it("rejects an empty amount", async () => {
+    const result = await transferSplTokenCore({ ...validInput, amount: "  " });
+
+    expect(result).toEqual({ success: false, error: "Amount is required" });
+  });
+
+  it("rejects an unparseable amount", async () => {
+    const result = await transferSplTokenCore({ ...validInput, amount: "abc" });
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining("Invalid token amount"),
+    });
+  });
+});

--- a/tests/unit/transfer-spl-token.test.ts
+++ b/tests/unit/transfer-spl-token.test.ts
@@ -304,6 +304,11 @@ describe("transferSplTokenCore", () => {
     expect(tx.instructions[1].programId.equals(TOKEN_2022_PROGRAM_ID)).toBe(
       true
     );
+    // Rent must be sized for a Token-2022 ATA including the ImmutableOwner the
+    // ATA program adds (170 bytes), not the bare 165-byte account.
+    expect(
+      mockConnection.getMinimumBalanceForRentExemption
+    ).toHaveBeenCalledWith(170);
   });
 
   it("routes to the token program that owns the mint", async () => {

--- a/tests/unit/transfer-spl-token.test.ts
+++ b/tests/unit/transfer-spl-token.test.ts
@@ -7,7 +7,9 @@ import {
   AccountLayout,
   AccountState,
   ASSOCIATED_TOKEN_PROGRAM_ID,
+  ExtensionType,
   getAssociatedTokenAddressSync,
+  getMintLen,
   MINT_SIZE,
   MintLayout,
   TOKEN_2022_PROGRAM_ID,
@@ -76,6 +78,37 @@ function mintAccount(
     data
   );
   return { owner: programId, data };
+}
+
+/**
+ * A Token-2022 mint carrying a single extension. Only the TLV type header needs
+ * to be well-formed for getExtensionTypes to recognise it; the value is zeroed.
+ */
+function mintWithExtension(
+  decimals: number,
+  extension: ExtensionType
+): MockAccount {
+  const data = Buffer.alloc(getMintLen([extension]));
+  MintLayout.encode(
+    {
+      mintAuthorityOption: 1,
+      mintAuthority: OWNER,
+      supply: BigInt(1_000_000_000),
+      decimals,
+      isInitialized: true,
+      freezeAuthorityOption: 0,
+      freezeAuthority: PublicKey.default,
+    },
+    data
+  );
+  // TLV after the padded base mint: [accountType u8][type u16][len u16][value].
+  data.writeUInt8(1, ACCOUNT_SIZE); // AccountType.Mint
+  data.writeUInt16LE(extension, ACCOUNT_SIZE + 1); // extension type
+  data.writeUInt16LE(
+    getMintLen([extension]) - ACCOUNT_SIZE - 5,
+    ACCOUNT_SIZE + 3
+  ); // value length
+  return { owner: TOKEN_2022_PROGRAM_ID, data };
 }
 
 function tokenAccount(
@@ -366,6 +399,20 @@ describe("transferSplTokenCore", () => {
       success: false,
       error: expect.stringContaining("is not an SPL token mint"),
     });
+  });
+
+  it("rejects a transfer-fee mint rather than misreport the amount", async () => {
+    // The recipient of a fee mint receives less than the requested amount, which
+    // the step cannot report without reading the fee, so it declines the mint.
+    mockConnection.getAccountInfo.mockResolvedValue(
+      mintWithExtension(6, ExtensionType.TransferFeeConfig)
+    );
+
+    const result = await transferSplTokenCore(validInput);
+
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toContain("transfer fee");
+    expect(mockAdapter.sendTransaction).not.toHaveBeenCalled();
   });
 
   it("reports when the sending wallet has no token account for the mint", async () => {

--- a/tests/unit/transfer-spl-token.test.ts
+++ b/tests/unit/transfer-spl-token.test.ts
@@ -415,6 +415,22 @@ describe("transferSplTokenCore", () => {
     expect(mockAdapter.sendTransaction).not.toHaveBeenCalled();
   });
 
+  it("returns a clean error when the mint account is malformed", async () => {
+    // A token account address pasted into the mint field: owned by the token
+    // program (so isTokenProgram passes), but unpackMint throws. The step must
+    // return a clean error, not reject with an uncaught exception.
+    mockConnection.getAccountInfo.mockResolvedValue(
+      tokenAccount(BigInt(1), MINT, OWNER)
+    );
+
+    const result = await transferSplTokenCore(validInput);
+
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toContain(
+      "is not a valid SPL mint"
+    );
+  });
+
   it("reports when the sending wallet has no token account for the mint", async () => {
     mockConnection.getMultipleAccountsInfo.mockResolvedValue([
       null,

--- a/tests/unit/transfer-spl-token.test.ts
+++ b/tests/unit/transfer-spl-token.test.ts
@@ -58,7 +58,16 @@ const BASE_FEE = 5000;
 const IX_TRANSFER = 3;
 const IX_TRANSFER_CHECKED = 12;
 
-type MockAccount = { owner: PublicKey; data: Buffer } | null;
+type MockAccount = {
+  owner: PublicKey;
+  data: Buffer;
+  lamports?: number;
+} | null;
+
+/** A funded system account, for the owner slot of the preflight batch read. */
+function systemAccount(lamports: number): MockAccount {
+  return { owner: PublicKey.default, data: Buffer.alloc(0), lamports };
+}
 
 function mintAccount(
   decimals: number,
@@ -144,7 +153,6 @@ function decodeSentTransaction(sendTransaction: ReturnType<typeof vi.fn>) {
 
 describe("transferSplTokenCore", () => {
   let mockAdapter: {
-    getBalance: ReturnType<typeof vi.fn>;
     sendTransaction: ReturnType<typeof vi.fn>;
     getTransactionUrl: ReturnType<typeof vi.fn>;
     executeWithSolanaFailover: ReturnType<typeof vi.fn>;
@@ -170,11 +178,12 @@ describe("transferSplTokenCore", () => {
       getAccountInfo: vi.fn().mockResolvedValue(mintAccount(6)),
       getMultipleAccountsInfo: vi
         .fn()
-        // [senderAta, recipientAta, recipientWallet]
+        // [senderAta, recipientAta, recipientWallet, ownerWallet]
         .mockResolvedValue([
           tokenAccount(BigInt(10_000_000)),
           tokenAccount(BigInt(0), MINT, RECIPIENT),
           null,
+          systemAccount(2_000_000_000),
         ]),
       getMinimumBalanceForRentExemption: vi
         .fn()
@@ -182,7 +191,6 @@ describe("transferSplTokenCore", () => {
     };
 
     mockAdapter = {
-      getBalance: vi.fn().mockResolvedValue(BigInt(2_000_000_000)),
       sendTransaction: vi.fn().mockResolvedValue({
         hash: "mock-signature",
         gasUsed: BigInt(4521), // compute units
@@ -286,6 +294,7 @@ describe("transferSplTokenCore", () => {
       tokenAccount(BigInt(10_000_000_000), MINT, OWNER, TOKEN_2022_PROGRAM_ID),
       null, // recipient ATA missing
       null,
+      systemAccount(2_000_000_000),
     ]);
 
     const result = await transferSplTokenCore(validInput);
@@ -319,6 +328,7 @@ describe("transferSplTokenCore", () => {
       tokenAccount(BigInt(10_000_000), MINT, OWNER, TOKEN_2022_PROGRAM_ID),
       tokenAccount(BigInt(0), MINT, RECIPIENT, TOKEN_2022_PROGRAM_ID),
       null,
+      systemAccount(2_000_000_000),
     ]);
 
     const result = await transferSplTokenCore(validInput);
@@ -484,7 +494,13 @@ describe("transferSplTokenCore", () => {
   });
 
   it("reports insufficient SOL for the transaction fee", async () => {
-    mockAdapter.getBalance.mockResolvedValue(BigInt(BASE_FEE - 1));
+    // Recipient ATA exists (no rent); owner cannot even cover the fee.
+    mockConnection.getMultipleAccountsInfo.mockResolvedValue([
+      tokenAccount(BigInt(10_000_000)),
+      tokenAccount(BigInt(0), MINT, RECIPIENT),
+      null,
+      systemAccount(BASE_FEE - 1),
+    ]);
 
     const result = await transferSplTokenCore(validInput);
 
@@ -500,8 +516,8 @@ describe("transferSplTokenCore", () => {
       tokenAccount(BigInt(10_000_000)),
       null, // recipient ATA missing -> rent required
       null,
+      systemAccount(BASE_FEE + 1),
     ]);
-    mockAdapter.getBalance.mockResolvedValue(BigInt(BASE_FEE + 1));
 
     const result = await transferSplTokenCore(validInput);
 
@@ -517,7 +533,13 @@ describe("transferSplTokenCore", () => {
   });
 
   it("does not charge rent when the recipient account already exists", async () => {
-    mockAdapter.getBalance.mockResolvedValue(BigInt(BASE_FEE));
+    // Recipient ATA exists, so only the fee is required and no rent is read.
+    mockConnection.getMultipleAccountsInfo.mockResolvedValue([
+      tokenAccount(BigInt(10_000_000)),
+      tokenAccount(BigInt(0), MINT, RECIPIENT),
+      null,
+      systemAccount(BASE_FEE),
+    ]);
 
     const result = await transferSplTokenCore(validInput);
 

--- a/tests/unit/transfer-spl-token.test.ts
+++ b/tests/unit/transfer-spl-token.test.ts
@@ -18,19 +18,14 @@ import {
 import { Keypair, PublicKey, Transaction } from "@solana/web3.js";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
-import {
-  buildSolanaSignerFromWallet,
-  getOrganizationWallet,
-} from "@/lib/web3/wallet-helpers";
+import { initializeSolanaWallet } from "@/lib/web3/wallet-helpers";
 import {
   isSplTransferPath,
   transferSplTokenCore,
 } from "@/plugins/web3/steps/transfer-spl-token-core";
 
 vi.mock("@/lib/web3/wallet-helpers", () => ({
-  getOrganizationWallet: vi.fn(),
-  buildSolanaSignerFromWallet: vi.fn(),
-  getOrganizationWalletAddress: vi.fn(),
+  initializeSolanaWallet: vi.fn(),
 }));
 
 vi.mock("@/lib/web3/chain-adapter", () => ({
@@ -210,12 +205,9 @@ describe("transferSplTokenCore", () => {
       organizationId: "mock-org-id",
       userId: "mock-user-id",
     } as never);
-    vi.mocked(getOrganizationWallet).mockResolvedValue({
-      solanaAddress: OWNER.toBase58(),
-    } as never);
-    vi.mocked(buildSolanaSignerFromWallet).mockReturnValue({
-      getPublicKey: vi.fn(),
-      signTransaction: vi.fn(),
+    vi.mocked(initializeSolanaWallet).mockResolvedValue({
+      signer: { getPublicKey: vi.fn(), signTransaction: vi.fn() },
+      address: OWNER.toBase58(),
     } as never);
   });
 


### PR DESCRIPTION
Adds a **Transfer SPL Token** node so workflows can move fungible SPL tokens on Solana. Native SOL transfers already worked; SPL tokens had no path, because the Transfer ERC20 Token action pins its Network field to EVM chains and its core is ERC20-only.

## Why a separate node

A separate Solana-only action rather than widening the EVM one, so the two token models stay independent: an `0x` contract address with a `tokenConfig` JSON blob on EVM, versus a base58 mint on Solana.

The mint is a plain `template-input` keyed `mint`, not `token-select`. `token-select` is EVM-bound end to end - it checksums addresses, dedupes case-insensitively (base58 is case-sensitive), and validates through an `ethers.isAddress` + ERC20 ABI route - and `supported_tokens` has no Solana rows for it to offer, so the picker would render an empty list over a text box. The key avoids `mintAddress` because the field renderer treats any key ending in `address` as an EVM address field, which would checksum-format a base58 mint and attach an Ethereum-only address book. Net frontend change: one array literal.

## Implementation notes

- `SolanaChainAdapter.executeContractCall` rejects outright, so the transfer is built as a prebuilt serialized transaction passed through `request.data` - the only seam onto the existing Turnkey signing and submit/failover path. No new signing infra.
- **No gas overrides are passed, deliberately.** `normalizeSolanaTransaction` deserializes legacy bytes via `VersionedTransaction` (which does not throw on them), so it labels the transaction versioned. With an override set it would decompile and recompile to v0 - a path the Turnkey Solana signer has never been exercised against. A compute budget, if ever needed, belongs in the instructions at build time. The `isVersioned` mislabel is pre-existing and worth its own ticket.
- Token program is detected from the mint account's owner and threaded through ATA derivation and the instruction, so legacy SPL and Token-2022 both work. Mints a plain `transferChecked` cannot honour (transfer hook, non-transferable, frozen-by-default) are rejected with a specific error rather than an opaque simulation failure.
- `transferChecked` over `transfer`: it re-validates our RPC-derived decimals on-chain, so a bad read fails loudly instead of moving a wrong amount.
- A missing recipient token account is created idempotently. The sender pays the rent, so the SOL preflight reserves fee **plus** rent, not the fee alone.

## Please look closely at

**`.npmrc` (separate commit).** `minimum-release-age=3d` was silently broken: pnpm parses `minimumReleaseAge` as a number of minutes (`minimumReleaseAge * 60 * 1e3`), and `"3d" * 60 * 1e3` is `NaN`, so no version was ever judged mature and every newly resolved package was rejected regardless of age - a version released 316 days ago was refused for not meeting the "3 day" minimum. Existing installs were unaffected because the lockfile pins them, which is why it went unnoticed. Corrected to `4320`. This is a repo-wide supply-chain config change riding in a feature PR; several `minimum-release-age-exclude` entries were likely only workarounds for it and may now be removable (left out of scope).

**`@solana/spl-token` pulls in `bigint-buffer@1.1.5` (CVE-2025-3194)**, a buffer overflow in `toBigIntLE()` with no fixed version at any release. Assessed as not reachable here: the exploit needs an attacker-controlled buffer length, and `buffer-layout-utils` only ever passes fixed-size `blob(8)`/`blob(16)` slices. Impact is a crash, not RCE. Raising it explicitly so it is a decision rather than a Dependabot surprise.

## Testing

- `tests/unit/transfer-spl-token.test.ts` - 24 cases. `@solana/spl-token` and `@solana/web3.js` are left unmocked so assertions decode the actual produced bytes: instruction discriminator, fee payer, placeholder blockhash, and that mint decimals drive the amount.
- `tests/unit/transfer-spl-token-action.test.ts` - 6 cases guarding the non-obvious declaration invariants, each commented with the `file:line` it protects.
- Mutation-checked rather than trusted: flipping `chainTypeFilter` to `evm` fails 1 test; swapping `transferChecked` for `transfer` fails 9.
- The registry-wide suites (`features-egress-invariant`, `credential-map-coverage`, `workflow-action-type-transition`, `action-schemas-route`) pass with no edits. `transfer-funds-solana` still passes, confirming the fee-constant extraction did not disturb the native path.

**Not yet verified:** no real transfer has run on devnet. `scripts/solana-devnet-spl-fixture.ts` arranges the on-chain state for it, but its mint path is untested because the public devnet faucet is currently returning 429 (airdrop limit reached / faucet dry).

## Known gap, not addressed here

Following `transfer-token`, SPL transfers bypass the org value cap (`withStepValueCap` takes `amountEth`), so an org with a SOL cap has no cap on stablecoin movement. Flagging as a product decision rather than fixing it in this PR.
