### PR TITLE
fix: Bump resources for keeperhub-sandbox (staging only)

### DIFF
--- a/deploy/keeperhub-sandbox/staging/values.yaml
+++ b/deploy/keeperhub-sandbox/staging/values.yaml
@@ -71,10 +71,10 @@ serviceAccount:
 
 resources:
   requests:
-    cpu: 100m
+    cpu: 200m
     memory: 128Mi
   limits:
-    cpu: 500m
+    cpu: 1000m
     memory: 512Mi
 
 env:


### PR DESCRIPTION
We're getting many CPUThrottlingHigh alerts for it in staging.