### PR TITLE
feat: accept gzip-compressed CHAIN_RPC_CONFIG

### DIFF
--- a/lib/rpc/rpc-config.ts
+++ b/lib/rpc/rpc-config.ts
@@ -21,7 +21,8 @@
  *   }
  */
 
-import { logWarn } from "@/lib/logging";
+import { gunzipSync } from "node:zlib";
+import { ErrorCategory, logSystemError, logWarn } from "@/lib/logging";
 
 /**
  * Public RPC defaults (no API keys required)
@@ -363,6 +364,29 @@ export type ParseRpcConfigResult = {
 };
 
 /**
+ * Marks a gzip-compressed, base64-encoded CHAIN_RPC_CONFIG value ("KeeperHub
+ * GZip v1"). The chain-config delivery pipeline emits values with this prefix;
+ * legacy raw-JSON values (no prefix) are still accepted, so the producer and
+ * this consumer can roll out independently and roll back at any time. A raw
+ * JSON object always begins with "{", never this prefix, so detection is
+ * unambiguous.
+ */
+export const RPC_CONFIG_GZIP_PREFIX = "KHGZ1:";
+
+/**
+ * Decode a CHAIN_RPC_CONFIG value into its JSON string form. Prefixed values
+ * are base64-decoded then gunzipped; unprefixed values are returned unchanged.
+ * May throw if a prefixed value is not valid base64+gzip (handled by callers).
+ */
+function decodeRpcConfigValue(envValue: string): string {
+  if (envValue.startsWith(RPC_CONFIG_GZIP_PREFIX)) {
+    const base64 = envValue.slice(RPC_CONFIG_GZIP_PREFIX.length);
+    return gunzipSync(Buffer.from(base64, "base64")).toString("utf8");
+  }
+  return envValue;
+}
+
+/**
  * Parse JSON config from environment variable
  *
  * @param envValue - The CHAIN_RPC_CONFIG environment variable value
@@ -370,7 +394,7 @@ export type ParseRpcConfigResult = {
  */
 export function parseRpcConfig(envValue: string | undefined): RpcConfig {
   try {
-    return JSON.parse(envValue || "{}");
+    return JSON.parse(decodeRpcConfigValue(envValue || "{}"));
   } catch {
     return {};
   }
@@ -389,14 +413,29 @@ export function parseRpcConfigWithDetails(
     return { config: {} };
   }
 
+  const isCompressed = envValue.startsWith(RPC_CONFIG_GZIP_PREFIX);
+
   try {
-    const config = JSON.parse(envValue);
+    const config = JSON.parse(decodeRpcConfigValue(envValue));
     return { config };
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
     // Truncate raw value for logging (may contain sensitive URLs)
     const rawValue =
       envValue.length > 100 ? `${envValue.slice(0, 100)}...` : envValue;
+    // A value carrying the compression prefix that fails to decode is
+    // unambiguously a producer/consumer format mismatch (a bad deploy), never a
+    // normal state. Surface it to Sentry/Prometheus rather than let it fall
+    // through to the silent public-default RPC fallback an unprefixed parse
+    // failure gets.
+    if (isCompressed) {
+      logSystemError(
+        ErrorCategory.CONFIGURATION,
+        "[rpc-config] Failed to decode compressed CHAIN_RPC_CONFIG",
+        err,
+        { prefix: RPC_CONFIG_GZIP_PREFIX }
+      );
+    }
     return { config: {}, error, rawValue };
   }
 }

--- a/tests/unit/rpc-config.test.ts
+++ b/tests/unit/rpc-config.test.ts
@@ -4,15 +4,32 @@
  * Tests the priority chain: JSON config → individual env vars → public defaults
  */
 
+import { gzipSync } from "node:zlib";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logSystemError } from "@/lib/logging";
 import {
   getConfigValue,
   getRpcUrl,
   getWssUrl,
-  PUBLIC_RPCS,
   parseRpcConfig,
+  parseRpcConfigWithDetails,
+  PUBLIC_RPCS,
+  RPC_CONFIG_GZIP_PREFIX,
   type RpcConfig,
 } from "../../lib/rpc/rpc-config";
+
+vi.mock("@/lib/logging", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/logging")>();
+  return { ...actual, logSystemError: vi.fn(), logWarn: vi.fn() };
+});
+
+/** Compress a JSON string into the KHGZ1 wire format the pipeline emits. */
+function toCompressedValue(json: string): string {
+  return (
+    RPC_CONFIG_GZIP_PREFIX +
+    gzipSync(Buffer.from(json, "utf8"), { level: 9 }).toString("base64")
+  );
+}
 
 describe("RPC Config Resolution", () => {
   const originalEnv = process.env;
@@ -77,6 +94,67 @@ describe("RPC Config Resolution", () => {
       expect(config["solana-mainnet"]?.primaryRpcUrl).toBe(
         "https://solana.example.com"
       );
+    });
+  });
+
+  describe("parseRpcConfig compression (KHGZ1)", () => {
+    const sample = {
+      "eth-mainnet": {
+        chainId: 1,
+        primaryRpcUrl: "https://eth.example.com/v2/abc",
+      },
+      "solana-mainnet": {
+        chainId: 101,
+        primaryRpcUrl: "https://sol.example.com",
+        isEnabled: false,
+      },
+    };
+
+    it("should decode a gzip-compressed value to the same config as raw JSON", () => {
+      const json = JSON.stringify(sample);
+
+      expect(parseRpcConfig(toCompressedValue(json))).toEqual(
+        parseRpcConfig(json)
+      );
+    });
+
+    it("should decode a value produced by the CLI gzip -9 | base64 pipeline", () => {
+      // Golden blob generated with the exact producer recipe the chain-config
+      // workflow runs: printf '%s' "$MINIFIED" | gzip -9 | base64 -w0, prefixed.
+      // Locks the cross-repo format contract against the real CLI toolchain,
+      // not just Node's zlib round-tripping with itself.
+      const golden =
+        "KHGZ1:H4sIAAAAAAACA33MsQ6DIBRG4Xf5ZyqtI3sHV5M+wBVvA8kFCZCmxvDuZXQw3c7ynQNc3S2Qj5ErzAHrek8rzEMhZR8o73OyrywwcLWmYrTuZOAvhSQ82C3oz6hpsWgKZROKdP27/zl2dz5CwZdnpEW4yzdJ4dZ+VZ9k5KsAAAA=";
+
+      expect(parseRpcConfig(golden)).toEqual(sample);
+    });
+
+    it("should return empty object for a malformed compressed value", () => {
+      expect(parseRpcConfig(`${RPC_CONFIG_GZIP_PREFIX}not-real-gzip`)).toEqual(
+        {}
+      );
+    });
+
+    it("should surface a decode error and log it for a malformed compressed value", () => {
+      vi.mocked(logSystemError).mockClear();
+
+      const result = parseRpcConfigWithDetails(
+        `${RPC_CONFIG_GZIP_PREFIX}not-real-gzip`
+      );
+
+      expect(result.config).toEqual({});
+      expect(result.error).toBeDefined();
+      expect(logSystemError).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not log for an unprefixed (legacy) parse failure", () => {
+      vi.mocked(logSystemError).mockClear();
+
+      const result = parseRpcConfigWithDetails("not valid json {{{");
+
+      expect(result.config).toEqual({});
+      expect(result.error).toBeDefined();
+      expect(logSystemError).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Adds backward-compatible decoding of a compressed CHAIN_RPC_CONFIG value.

## What
- parseRpcConfig detects a KHGZ1: prefix and inflates the value (base64 -> gunzip) before JSON.parse; unprefixed values are still parsed as plain JSON.
- A value carrying the prefix that fails to decode is reported via logSystemError (Sentry + Prometheus) instead of silently falling back to public-default RPCs; unprefixed parse failures keep their existing quiet fallback.

## Why
The per-environment chain config is approaching the SSM Parameter Store Advanced-tier 8192-byte value limit. Storing it gzip-compressed keeps it well under the limit. This change lets the app read the compressed form; the config-delivery pipeline is switched to write it separately, so the two roll out independently and either can roll back on its own.

## Testing
- Added unit tests: KHGZ1 round-trip equals raw-JSON parse; decode of a golden blob produced by the exact gzip -9 | base64 pipeline; malformed compressed value falls back to {}; prefixed-decode failure is logged while an unprefixed failure is not.
- pnpm test (rpc-config): 61 passing. pnpm check and pnpm type-check clean.