### PR TITLE
fix: gate SPL Token node on Solana chain availability

### DIFF
--- a/components/workflow/config/action-grid.tsx
+++ b/components/workflow/config/action-grid.tsx
@@ -35,6 +35,7 @@ import { useIsTouch } from "@/hooks/use-touch";
 import type { FeatureDefinition } from "@/lib/features";
 import { resolveActionFeature } from "@/lib/features";
 import { cn } from "@/lib/utils";
+import { filterActionsByAvailableChainTypes } from "@/lib/workflow/action-chain-availability";
 import { nodesAtom } from "@/lib/workflow/store";
 import { getAllActions } from "@/plugins/registry";
 
@@ -80,15 +81,61 @@ const SYSTEM_ACTIONS: ActionType[] = [
   },
 ];
 
+/**
+ * The set of chain types (e.g. "evm", "solana") that have at least one enabled
+ * chain, from /api/chains. Returns undefined while loading or on failure so the
+ * palette falls back to showing every action (fail open). Server-only env flags
+ * cannot gate the client palette, so chain availability is the client-safe
+ * signal for whether a chain-type-specific node (e.g. Solana-only) should show.
+ */
+function useEnabledChainTypes(): ReadonlySet<string> | undefined {
+  const [chainTypes, setChainTypes] = useState<ReadonlySet<string> | undefined>(
+    undefined
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/chains")
+      .then((res) =>
+        res.ok ? res.json() : Promise.reject(new Error(`chains ${res.status}`))
+      )
+      .then((data: { chainType?: string }[]) => {
+        if (!cancelled) {
+          setChainTypes(
+            new Set(
+              data
+                .map((chain) => chain.chainType)
+                .filter((type): type is string => Boolean(type))
+            )
+          );
+        }
+      })
+      .catch(() => {
+        // Fail open: leave undefined so useAllActions shows every action.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return chainTypes;
+}
+
 // Combine System actions with plugin actions
 function useAllActions(): ActionType[] {
   const nodes = useAtomValue(nodesAtom);
   const hasForEach = nodes.some(
     (n) => n.data?.config?.actionType === "For Each"
   );
+  const enabledChainTypes = useEnabledChainTypes();
 
   return useMemo(() => {
-    const pluginActions = getAllActions();
+    // Hide nodes restricted to a chain type with no enabled chains (e.g. the
+    // Solana-only Transfer SPL Token node when Solana is off). While chain types
+    // are still loading, show all.
+    const pluginActions = enabledChainTypes
+      ? filterActionsByAvailableChainTypes(getAllActions(), enabledChainTypes)
+      : getAllActions();
 
     const mappedPluginActions: ActionType[] = pluginActions.map((action) => ({
       id: action.id,
@@ -103,7 +150,7 @@ function useAllActions(): ActionType[] {
       : SYSTEM_ACTIONS.filter((a) => a.id !== "Collect");
 
     return [...systemActions, ...mappedPluginActions];
-  }, [hasForEach]);
+  }, [hasForEach, enabledChainTypes]);
 }
 
 type ActionGridProps = {

--- a/lib/workflow/action-chain-availability.ts
+++ b/lib/workflow/action-chain-availability.ts
@@ -1,0 +1,42 @@
+import type { ActionConfigField } from "@/plugins/registry";
+
+/**
+ * The chain type an action's Network field is restricted to (its
+ * `chain-select` field's `chainTypeFilter`), or undefined when the action has no
+ * chain-type requirement. Looks inside field groups as well as top-level fields.
+ */
+export function actionRequiredChainType(
+  configFields: readonly ActionConfigField[] | undefined
+): string | undefined {
+  for (const field of configFields ?? []) {
+    if (field.type === "group") {
+      for (const inner of field.fields) {
+        if (inner.type === "chain-select" && inner.chainTypeFilter) {
+          return inner.chainTypeFilter;
+        }
+      }
+    } else if (field.type === "chain-select" && field.chainTypeFilter) {
+      return field.chainTypeFilter;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Drops actions whose Network field is restricted to a chain type that has no
+ * enabled chains, so the builder palette never offers a node the user cannot
+ * run - e.g. the Solana-only Transfer SPL Token node when no Solana chain is
+ * enabled. Actions without a chain-type requirement are always kept.
+ *
+ * Call this only once the enabled chain types are known; while they are still
+ * loading, show every action (fail open) rather than briefly hiding chain
+ * actions.
+ */
+export function filterActionsByAvailableChainTypes<
+  T extends { configFields?: readonly ActionConfigField[] },
+>(actions: readonly T[], enabledChainTypes: ReadonlySet<string>): T[] {
+  return actions.filter((action) => {
+    const required = actionRequiredChainType(action.configFields);
+    return required === undefined || enabledChainTypes.has(required);
+  });
+}

--- a/tests/unit/action-chain-availability.test.ts
+++ b/tests/unit/action-chain-availability.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  actionRequiredChainType,
+  filterActionsByAvailableChainTypes,
+} from "@/lib/workflow/action-chain-availability";
+import type { ActionConfigField } from "@/plugins/registry";
+
+function networkField(chainTypeFilter?: string): ActionConfigField {
+  return {
+    key: "network",
+    label: "Network",
+    type: "chain-select",
+    ...(chainTypeFilter ? { chainTypeFilter } : {}),
+  } as ActionConfigField;
+}
+
+const solanaAction = {
+  id: "web3/transfer-spl-token",
+  configFields: [networkField("solana")],
+};
+const evmAction = {
+  id: "web3/transfer-token",
+  configFields: [networkField("evm")],
+};
+const anyChainAction = {
+  id: "web3/transfer-funds",
+  configFields: [networkField()],
+};
+const noChainAction = {
+  id: "discord/send-message",
+  configFields: [
+    { key: "text", label: "Text", type: "template-input" } as ActionConfigField,
+  ],
+};
+const groupedSolana = {
+  id: "web3/grouped",
+  configFields: [
+    {
+      type: "group",
+      label: "Advanced",
+      fields: [networkField("solana")],
+    } as ActionConfigField,
+  ],
+};
+
+describe("actionRequiredChainType", () => {
+  it("reads the chainTypeFilter from a top-level Network field", () => {
+    expect(actionRequiredChainType(solanaAction.configFields)).toBe("solana");
+    expect(actionRequiredChainType(evmAction.configFields)).toBe("evm");
+  });
+
+  it("returns undefined when the action has no chain-type requirement", () => {
+    expect(
+      actionRequiredChainType(anyChainAction.configFields)
+    ).toBeUndefined();
+    expect(actionRequiredChainType(noChainAction.configFields)).toBeUndefined();
+    expect(actionRequiredChainType(undefined)).toBeUndefined();
+  });
+
+  it("finds the Network field nested inside a group", () => {
+    expect(actionRequiredChainType(groupedSolana.configFields)).toBe("solana");
+  });
+});
+
+describe("filterActionsByAvailableChainTypes", () => {
+  it("hides Solana-only actions when no Solana chain is enabled", () => {
+    const result = filterActionsByAvailableChainTypes(
+      [solanaAction, evmAction, noChainAction],
+      new Set(["evm"])
+    );
+    expect(result.map((a) => a.id)).toEqual([evmAction.id, noChainAction.id]);
+  });
+
+  it("keeps Solana actions when a Solana chain is enabled", () => {
+    const result = filterActionsByAvailableChainTypes(
+      [solanaAction, evmAction],
+      new Set(["evm", "solana"])
+    );
+    expect(result.map((a) => a.id)).toEqual([solanaAction.id, evmAction.id]);
+  });
+
+  it("always keeps actions with no chain-type requirement", () => {
+    const result = filterActionsByAvailableChainTypes(
+      [noChainAction, anyChainAction],
+      new Set()
+    );
+    expect(result.map((a) => a.id)).toEqual([
+      noChainAction.id,
+      anyChainAction.id,
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Hide the **Transfer SPL Token** action from the workflow-builder palette in environments where no Solana chain is enabled. The action stays registered - it remains executable and present in the MCP/action-schemas surfaces - only the visual palette drops it.

## Why

The action registers unconditionally, so it shows up in the builder palette even where Solana is not enabled. There a user could add the node, but the Network dropdown is empty (its `chainTypeFilter: "solana"` matches no enabled chain) and the node cannot run. Offering a node that cannot be configured or executed is a dead end.

A first attempt gated registration on the server-only `SOLANA_WALLET_PROVISIONING_ENABLED` flag. That approach is broken on two counts:
- Dropping the action from the registry also strips it from the build-time-generated `lib/step-registry.ts` (via `getAllIntegrations().actions`), so building with the flag off - its default at Docker build - makes the step unexecutable even when the flag is on at runtime.
- The palette (`action-grid.tsx`) is a client component; a server-only env var is `undefined` in the browser, so the gate would hide the node always, even when Solana is enabled.

## How

Filter the palette on chain availability, the client-safe signal:
- `lib/workflow/action-chain-availability.ts` - pure helpers. `actionRequiredChainType` reads an action's Network `chain-select` `chainTypeFilter` (top-level or inside a field group); `filterActionsByAvailableChainTypes` drops actions whose required chain type has no enabled chain. Actions with no chain-type requirement are always kept.
- `action-grid.tsx` - a `useEnabledChainTypes()` hook fetches `/api/chains` (which returns enabled chains only, each with a top-level `chainType`) and builds the set of available chain types. `useAllActions` filters plugin actions through the helper. While chains are still loading, or if the fetch fails, it shows every action (fail open) so EVM actions never flicker out.

This reuses the exact signal the Network dropdown already filters on, so palette visibility and dropdown contents stay consistent.

## Scope note

This gates on network (Solana chain enabled), not the wallet-provisioning flag, because a server-only flag provably cannot reach the client palette. In practice the two are coupled: Solana chains are only enabled where Solana support is turned on.

## Tests

`tests/unit/action-chain-availability.test.ts` - covers `actionRequiredChainType` (top-level and grouped Network fields, undefined when no chain requirement) and `filterActionsByAvailableChainTypes` (hides Solana-only when no Solana chain, keeps them when present, always keeps no-requirement actions). The registry-wide suites (`workflow-action-type-transition`, etc.) pass unchanged since the action is still registered.
