### PR TITLE
docs: correct webhook trigger-input template examples

### DIFF
--- a/lib/mcp/workflow-schema-constants.ts
+++ b/lib/mcp/workflow-schema-constants.ts
@@ -69,7 +69,7 @@ export const SYSTEM_ACTIONS = {
     requiredFields: {
       integrationId: "string - ID of the database integration",
       dbQuery:
-        "string - SQL query with inline template references for dynamic values. Use {{@nodeId:Label.field}} directly in the SQL string. Example: \"INSERT INTO logs (vault, price) VALUES ('{{@compute:Compare.bestVault}}', '{{@compute:Compare.bestPrice}}')\" or \"SELECT * FROM positions WHERE address = '{{@trigger:Trigger.data.address}}'\"",
+        "string - SQL query with inline template references for dynamic values. Use {{@nodeId:Label.field}} directly in the SQL string. Example: \"INSERT INTO logs (vault, price) VALUES ('{{@compute:Compare.bestVault}}', '{{@compute:Compare.bestPrice}}')\" or \"SELECT * FROM positions WHERE address = '{{@trigger-1:Trigger.address}}'\"",
     },
     optionalFields: {
       dbSchema: "string - JSON schema for result typing",
@@ -244,8 +244,9 @@ export const TEMPLATE_SYNTAX = {
         "Reference the 'balance' output from a node labeled 'Check Balance'",
     },
     {
-      template: "{{@trigger:Trigger.body.amount}}",
-      description: "Reference nested field 'amount' from webhook trigger body",
+      template: "{{@trigger-1:Trigger.amount}}",
+      description:
+        "Reference field 'amount' from a webhook (or manual) trigger. Trigger inputs are spread at the TOP LEVEL of the trigger output - there is no 'body' or 'data' wrapper - and the reference uses the trigger node's actual id (e.g. trigger-1), not a bare 'trigger' alias",
     },
     {
       template: "{{@http-1:Fetch Price.data.price}}",
@@ -271,6 +272,7 @@ export const TEMPLATE_SYNTAX = {
     "nodeId is the unique identifier of the node (visible in node settings)",
     "Label is the human-readable name shown on the node",
     "Nested fields use dot notation (e.g., data.nested.value)",
+    "Trigger inputs (webhook JSON body / event fields) are placed at the TOP LEVEL of the trigger output - reference them as {{@<triggerNodeId>:Trigger.<field>}} (e.g. {{@trigger-1:Trigger.amount}}), NOT {{@trigger:Trigger.body.<field>}}; the bare 'trigger' alias resolves only in calldata/event-trigger contexts, so use the trigger node's real id",
     "Tuple/struct outputs surface their components as NAMED fields - use result.<componentName> (e.g. result.liquidityIndex), NOT positional result[1]",
     "Bracket indexing [n] is only for ARRAY fields, applied inside the field path (e.g. result.items[0]); numeric indices only",
     "Condition expressions use this same reference and path grammar - never a bare step2[1] (this fails validation with an actionable error)",


### PR DESCRIPTION
## Summary

The `TEMPLATE_SYNTAX` reference and a `Database Query` example surfaced to MCP/AI builders used a webhook trigger-input form that does not resolve at runtime: `{{@trigger:Trigger.body.amount}}`. Two things are wrong with it, and together they made a correct workflow read as broken.

1. No `body`/`data` wrapper. For a Webhook (or Manual) trigger, the executor spreads the caller's JSON input at the TOP LEVEL of the trigger output (`lib/workflow/executor/executor.workflow.ts`), so the field is `Trigger.amount`, never `Trigger.body.amount`. Event triggers behave the same way.
2. The bare `@trigger` alias does not bind in action params. The template resolver keys on the node's real id (`lib/utils/template.ts`); a webhook/manual trigger node is `trigger-1`, so `{{@trigger:...}}` only resolves in the calldata/event path that has a dedicated alias handler. The generally-working form is `{{@<triggerNodeId>:Trigger.<field>}}`.

## Changes

`lib/mcp/workflow-schema-constants.ts`:
- `TEMPLATE_SYNTAX` webhook example: `{{@trigger:Trigger.body.amount}}` -> `{{@trigger-1:Trigger.amount}}`, with a description explaining the top-level-field + real-node-id rule.
- `Database Query` example: `{{@trigger:Trigger.data.address}}` -> `{{@trigger-1:Trigger.address}}`.
- Added a `notes` entry stating the rule generally (including the wrong form as an explicit "do not use").

Constants/doc-strings only - no runtime behavior changed. Confirmed these were the only two misleading examples; the markdown docs and event-trigger/calldata paths already use the correct top-level form.

## Scope note

Addresses GitHub #1783. The core defect (the non-resolving example) is fixed here. The issue also suggested adding a full end-to-end worked example to the public docs; that is a separate `docs/` addition and is intentionally not included in this constants-only change.

## Test Plan

- [ ] N/A - documentation strings in an exported constant; no logic to test
- [ ] biome check passes on the changed file