### PR TITLE
fix: direct-sign protocol-coverage e2e writes instead of Turnkey sponsorship

### DIFF
--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -141,7 +141,17 @@ jobs:
           CI: true
           TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
           NEXT_PUBLIC_BILLING_ENABLED: "true"
-          NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED: "true"
+          # Off for e2e: Turnkey Gas Station broadcasts via Turnkey's own
+          # infrastructure, which cannot reach the local anvil fork. Since
+          # 7359f703d ("confirm sponsored tx outcome before falling back to
+          # direct signing"), a sponsored fork write that Turnkey accepts but
+          # cannot confirm raises SponsoredTxPendingError and no longer falls
+          # back to direct signing, so fork writes whose outcome depends on
+          # fabricated state (e.g. ethena unstake after an elapsed-cooldown
+          # cheatcode) fail instead of executing. The fork wallet is already
+          # gas-funded via ensureNativeGas/anvil_setBalance, so direct signing
+          # works; nothing in tests/e2e asserts the sponsored path.
+          NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED: "false"
           # Inlined into the shared artifact at build time, so the
           # /api/ai/generate route is ungated in every consumer of the
           # artifact. The e2e vitest job's api-key-auth suite needs it;


### PR DESCRIPTION
## Problem

`protocol-coverage-ephemeral` (shard 3, ethena `unstake`) fails on staging with a Turnkey sponsorship timeout: `Sponsored transaction was submitted but not confirmed in time` / `Pre-flight simulation failed`.

## Root cause

The e2e app is built with `NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED=true`, so `write-contract` routes through Turnkey Gas Station, which broadcasts via **Turnkey's own infrastructure - it cannot reach the local anvil fork**. Since 7359f703d (`fix(web3): confirm sponsored tx outcome before falling back to direct signing`), a sponsored fork write that Turnkey accepts but cannot confirm raises `SponsoredTxPendingError` and **deliberately does not fall back** to direct signing (a correct production safeguard against duplicate broadcasts). On the fork this makes writes whose outcome depends on fabricated state - e.g. ethena `unstake` after the `elapsed-cooldown` cheatcode - fail instead of executing.

## Fix

Build the shared e2e artifact with `NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED=false` so all fork writes direct-sign against the anvil fork.

- The fork wallet is already gas-funded via `ensureNativeGas`/`anvil_setBalance`, so direct signing works without sponsorship.
- The passing tests already reach the fork via the sponsorship-fallback path; this just removes the doomed sponsorship attempt.
- No test in `tests/e2e/` asserts the sponsored path (verified).

Net effect across all e2e jobs: on-chain writes become deterministic direct-signs - faster and no longer flaky.

## Verification

Watch `protocol-coverage-ephemeral` (and the other e2e shards) on this PR.