### PR TITLE
fix(ui): apply global scrollbar styling override

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -158,8 +158,8 @@
 .thin-scrollbar::-webkit-scrollbar {
   -webkit-appearance: none !important;
   appearance: none !important;
-  width: 8px !important;
-  height: 8px !important;
+  width: 4px !important;
+  height: 4px !important;
 }
 .thin-scrollbar::-webkit-scrollbar-track {
   background: transparent !important;
@@ -170,8 +170,6 @@
     var(--color-muted-foreground) 60%,
     transparent
   ) !important;
-  background-clip: content-box !important;
-  border: 2px solid transparent !important;
   border-radius: 9999px !important;
 }
 .thin-scrollbar::-webkit-scrollbar-thumb:hover {
@@ -196,8 +194,8 @@
 *::-webkit-scrollbar {
   -webkit-appearance: none !important;
   appearance: none !important;
-  width: 8px !important;
-  height: 8px !important;
+  width: 4px !important;
+  height: 4px !important;
 }
 *::-webkit-scrollbar-track {
   background: transparent !important;
@@ -208,8 +206,6 @@
     var(--color-muted-foreground) 60%,
     transparent
   ) !important;
-  background-clip: content-box !important;
-  border: 2px solid transparent !important;
   border-radius: 9999px !important;
 }
 *::-webkit-scrollbar-thumb:hover {

--- a/app/globals.css
+++ b/app/globals.css
@@ -158,8 +158,8 @@
 .thin-scrollbar::-webkit-scrollbar {
   -webkit-appearance: none !important;
   appearance: none !important;
-  width: 12px !important;
-  height: 12px !important;
+  width: 8px !important;
+  height: 8px !important;
 }
 .thin-scrollbar::-webkit-scrollbar-track {
   background: transparent !important;
@@ -171,7 +171,7 @@
     transparent
   ) !important;
   background-clip: content-box !important;
-  border: 4px solid transparent !important;
+  border: 2px solid transparent !important;
   border-radius: 9999px !important;
 }
 .thin-scrollbar::-webkit-scrollbar-thumb:hover {
@@ -196,8 +196,8 @@
 *::-webkit-scrollbar {
   -webkit-appearance: none !important;
   appearance: none !important;
-  width: 12px !important;
-  height: 12px !important;
+  width: 8px !important;
+  height: 8px !important;
 }
 *::-webkit-scrollbar-track {
   background: transparent !important;
@@ -209,7 +209,7 @@
     transparent
   ) !important;
   background-clip: content-box !important;
-  border: 4px solid transparent !important;
+  border: 2px solid transparent !important;
   border-radius: 9999px !important;
 }
 *::-webkit-scrollbar-thumb:hover {

--- a/app/globals.css
+++ b/app/globals.css
@@ -182,6 +182,47 @@
   ) !important;
 }
 
+/* Global scrollbar override: style every native scrollbar app-wide so panels
+   that don't opt into .thin-scrollbar don't fall back to the default bar. */
+* {
+  scrollbar-width: thin !important;
+  scrollbar-color: color-mix(
+      in oklch,
+      var(--color-muted-foreground) 60%,
+      transparent
+    )
+    transparent !important;
+}
+*::-webkit-scrollbar {
+  -webkit-appearance: none !important;
+  appearance: none !important;
+  width: 12px !important;
+  height: 12px !important;
+}
+*::-webkit-scrollbar-track {
+  background: transparent !important;
+}
+*::-webkit-scrollbar-thumb {
+  background-color: color-mix(
+    in oklch,
+    var(--color-muted-foreground) 60%,
+    transparent
+  ) !important;
+  background-clip: content-box !important;
+  border: 4px solid transparent !important;
+  border-radius: 9999px !important;
+}
+*::-webkit-scrollbar-thumb:hover {
+  background-color: color-mix(
+    in oklch,
+    var(--color-muted-foreground) 85%,
+    transparent
+  ) !important;
+}
+*::-webkit-scrollbar-corner {
+  background: transparent !important;
+}
+
 /* This layer is by next-forge */
 @layer base {
   ::after,


### PR DESCRIPTION
## What

Adds a global scrollbar style override in `app/globals.css` so every native scrollbar app-wide gets the thin, rounded, muted-foreground look.

## Why

Scrollable panels that use `overflow-y-auto` without the opt-in `.thin-scrollbar` class fell back to the browser's default native scrollbar. On macOS with overlay/auto scrollbars this looks fine, but with always-visible scrollbars (other OSes/settings) it renders as a thick grey bar. The workflows list flyout (`components/flyout-panel.tsx`) is one such panel.

## How

- `* { scrollbar-width: thin; scrollbar-color: ... }` for Firefox
- `*::-webkit-scrollbar` / `-track` / `-thumb` / `-thumb:hover` / `-corner` for Chromium/WebKit, mirroring the existing `.thin-scrollbar` values (12px, transparent track, inset pill, muted-foreground 60% -> 85% on hover)
- Deliberately omits `scrollbar-gutter: stable` from the global rule to avoid reserving gutter space everywhere and shifting layouts. The existing `.thin-scrollbar` class is left intact.