### PR TITLE
feat: Solana block trigger output schema and solana-tracker rollout

### DIFF
--- a/.github/workflows/deploy-events.yaml
+++ b/.github/workflows/deploy-events.yaml
@@ -9,6 +9,7 @@ on:
     paths:
       - "keeperhub-events/**"
       - "deploy/event-tracker/**"
+      - "deploy/solana-tracker/**"
       - ".github/workflows/deploy-events.yaml"
   workflow_dispatch:
 
@@ -33,6 +34,7 @@ jobs:
       NAMESPACE: keeperhub
       TRACKER_ECR_NAME: keeperhub-event-${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
       TRACKER_HELM_FILE: deploy/event-tracker/${{ github.ref_name == 'prod' && 'prod' || 'staging' }}/values.yaml
+      SOLANA_HELM_FILE: deploy/solana-tracker/${{ github.ref_name == 'prod' && 'prod' || 'staging' }}/values.yaml
       EVENTS_SERVICE_ACCOUNT_ROLE_ARN: ${{ vars.TO_EVENTS_ROLE_ARN }}
 
     steps:
@@ -79,14 +81,16 @@ jobs:
         if: steps.skip.outputs.skip_build == 'true'
         run: |
           IMAGE_TAG="${{ steps.vars.outputs.sha_short }}"
-          if ! aws ecr describe-images \
-            --repository-name "$TRACKER_ECR_NAME" \
-            --image-ids "imageTag=event-${IMAGE_TAG}" \
-            --region "${{ env.REGION }}" >/dev/null 2>&1; then
-            echo "::error::Cannot skip build: event-${IMAGE_TAG} not found in ${TRACKER_ECR_NAME}. Remove [skip build] or push a build first."
-            exit 1
-          fi
-          echo "event-${IMAGE_TAG} exists in ${TRACKER_ECR_NAME}"
+          for prefix in event solana; do
+            if ! aws ecr describe-images \
+              --repository-name "$TRACKER_ECR_NAME" \
+              --image-ids "imageTag=${prefix}-${IMAGE_TAG}" \
+              --region "${{ env.REGION }}" >/dev/null 2>&1; then
+              echo "::error::Cannot skip build: ${prefix}-${IMAGE_TAG} not found in ${TRACKER_ECR_NAME}. Remove [skip build] or push a build first."
+              exit 1
+            fi
+            echo "${prefix}-${IMAGE_TAG} exists in ${TRACKER_ECR_NAME}"
+          done
 
       - name: Build and push event tracker image
         if: steps.skip.outputs.skip_build != 'true'
@@ -101,7 +105,7 @@ jobs:
           targets: events
           push: true
 
-      - name: Replace variables in Helm values file
+      - name: Replace variables in Helm values files
         if: steps.skip.outputs.skip_deploy != 'true'
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -113,6 +117,11 @@ jobs:
           sed -i "s|\${IMAGE_TAG}|${IMAGE_TAG}|g" "$TRACKER_HELM_FILE"
           sed -i "s|\${AWS_ACCOUNT_ID}|${AWS_ACCOUNT_ID}|g" "$TRACKER_HELM_FILE"
           sed -i "s|\${EVENTS_SERVICE_ACCOUNT_ROLE_ARN}|${EVENTS_SERVICE_ACCOUNT_ROLE_ARN}|g" "$TRACKER_HELM_FILE"
+          # solana-tracker reuses the events service account (create: false), so
+          # it has no role-arn placeholder - only image/registry/account.
+          sed -i "s|\${ECR_REGISTRY}|${ECR_REGISTRY}|g" "$SOLANA_HELM_FILE"
+          sed -i "s|\${IMAGE_TAG}|${IMAGE_TAG}|g" "$SOLANA_HELM_FILE"
+          sed -i "s|\${AWS_ACCOUNT_ID}|${AWS_ACCOUNT_ID}|g" "$SOLANA_HELM_FILE"
 
       - name: Configure kubectl
         if: steps.skip.outputs.skip_deploy != 'true'
@@ -141,5 +150,23 @@ jobs:
           # would silently render blank if the role-arn variable were unset and
           # the pod would fall back to the node role. Rendered output is
           # otherwise identical to 0.2.1 apart from an opt-in helm test hook.
+          version: 0.5.0
+          atomic: true
+
+      # Separate Helm release from event-tracker: same chart, its own values
+      # (solana image tag, port 3001, HTTP health probes) and its own image in
+      # the shared events ECR. Reuses the keeperhub-events service account, so
+      # no role-arn is required here.
+      - name: Deploy solana-tracker
+        if: steps.skip.outputs.skip_deploy != 'true'
+        uses: bitovi/github-actions-deploy-eks-helm@v1.2.12
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          config-files: ${{ env.SOLANA_HELM_FILE }}
+          chart-path: techops-services/common
+          namespace: ${{ env.NAMESPACE }}
+          timeout: 5m0s
+          name: keeperhub-solana
+          chart-repository: https://techops-services.github.io/helm-charts
           version: 0.5.0
           atomic: true

--- a/deploy/solana-tracker/prod/values.yaml
+++ b/deploy/solana-tracker/prod/values.yaml
@@ -1,0 +1,101 @@
+# Solana ingestion service (event + block triggers). Single-process reconciler:
+# 2+ replicas would subscribe to every chain WSS twice and dispatch duplicate
+# SQS messages, so this must stay 1.
+#
+# Reuses the event-tracker's service account (keeperhub-events-prod) + IRSA
+# role, Redis, and workflow queue - Solana ingestion has the same access needs
+# as the EVM event tracker, so no new AWS resources are required. Runs healthy
+# but idle until a Solana chain (101/103) with primary RPC + WSS is configured
+# in chain-config; the mapper skips chains without WSS and starts no ingestors.
+replicaCount: 1
+
+service:
+  enabled: true
+  name: keeperhub-solana-prod
+  port: 3001
+  type: ClusterIP
+  containerPort: 3001
+  tls:
+    enabled: false
+
+ingress:
+  enabled: false
+
+image:
+  repository: ${ECR_REGISTRY}/keeperhub-event-prod
+  tag: solana-${IMAGE_TAG}
+  pullPolicy: Always
+
+deployment:
+  enabled: true
+
+# Reuse the event-tracker service account + IRSA role (created by the
+# keeperhub-event release). create: false so this release only references it -
+# no new IAM role is provisioned for Solana.
+serviceAccount:
+  create: false
+  name: keeperhub-events-prod
+
+podAnnotations:
+  reloader.stakater.com/auto: "true"
+
+resources:
+  limits:
+    memory: 1Gi
+  requests:
+    cpu: 50m
+    memory: 256Mi
+
+env:
+  NODE_ENV:
+    type: kv
+    value: "production"
+  LOG_LEVEL:
+    type: kv
+    value: "info"
+  HEALTH_PORT:
+    type: kv
+    value: "3001"
+  KEEPERHUB_API_URL:
+    type: kv
+    value: "http://keeperhub-common:3000"
+  INTERNAL_SERVICE_HMAC_SECRET:
+    type: parameterStore
+    name: internal-service-hmac-secret
+    parameter_name: /eks/techops-prod/keeperhub/internal-service-hmac-secret
+  REDIS_HOST:
+    type: parameterStore
+    name: redis-host
+    parameter_name: /eks/techops-prod/keeperhub-events/redis-host
+  REDIS_PORT:
+    type: parameterStore
+    name: redis-port
+    parameter_name: /eks/techops-prod/keeperhub-events/redis-port
+  REDIS_PASSWORD:
+    type: parameterStore
+    name: redis-password
+    parameter_name: /eks/techops-prod/keeperhub-events/redis-password
+  SQS_QUEUE_URL:
+    type: kv
+    value: "https://sqs.us-east-2.amazonaws.com/${AWS_ACCOUNT_ID}/keeperhub-workflow-queue-prod"
+  AWS_REGION:
+    type: kv
+    value: "us-east-2"
+
+externalSecrets:
+  clusterSecretStoreName: techops-prod
+
+# solana-tracker serves an HTTP health server on HEALTH_PORT (unlike
+# event-tracker, which has no server and uses a pgrep exec probe).
+livenessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  httpGet:
+    path: /healthz
+    port: 3001
+readinessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  httpGet:
+    path: /healthz
+    port: 3001

--- a/deploy/solana-tracker/staging/values.yaml
+++ b/deploy/solana-tracker/staging/values.yaml
@@ -1,0 +1,101 @@
+# Solana ingestion service (event + block triggers). Single-process reconciler:
+# 2+ replicas would subscribe to every chain WSS twice and dispatch duplicate
+# SQS messages, so this must stay 1.
+#
+# Reuses the event-tracker's service account (keeperhub-events-staging) + IRSA
+# role, Redis, and workflow queue - Solana ingestion has the same access needs
+# as the EVM event tracker, so no new AWS resources are required. Runs healthy
+# but idle until a Solana chain (101/103) with primary RPC + WSS is configured
+# in chain-config; the mapper skips chains without WSS and starts no ingestors.
+replicaCount: 1
+
+service:
+  enabled: true
+  name: keeperhub-solana-staging
+  port: 3001
+  type: ClusterIP
+  containerPort: 3001
+  tls:
+    enabled: false
+
+ingress:
+  enabled: false
+
+image:
+  repository: ${ECR_REGISTRY}/keeperhub-event-staging
+  tag: solana-${IMAGE_TAG}
+  pullPolicy: Always
+
+deployment:
+  enabled: true
+
+# Reuse the event-tracker service account + IRSA role (created by the
+# keeperhub-event release). create: false so this release only references it -
+# no new IAM role is provisioned for Solana.
+serviceAccount:
+  create: false
+  name: keeperhub-events-staging
+
+podAnnotations:
+  reloader.stakater.com/auto: "true"
+
+resources:
+  limits:
+    memory: 512Mi
+  requests:
+    cpu: 50m
+    memory: 128Mi
+
+env:
+  NODE_ENV:
+    type: kv
+    value: "staging"
+  LOG_LEVEL:
+    type: kv
+    value: "info"
+  HEALTH_PORT:
+    type: kv
+    value: "3001"
+  KEEPERHUB_API_URL:
+    type: kv
+    value: "http://keeperhub-common:3000"
+  INTERNAL_SERVICE_HMAC_SECRET:
+    type: parameterStore
+    name: internal-service-hmac-secret
+    parameter_name: /eks/techops-staging/keeperhub/internal-service-hmac-secret
+  REDIS_HOST:
+    type: parameterStore
+    name: redis-host
+    parameter_name: /eks/techops-staging/keeperhub-events/redis-host
+  REDIS_PORT:
+    type: parameterStore
+    name: redis-port
+    parameter_name: /eks/techops-staging/keeperhub-events/redis-port
+  REDIS_PASSWORD:
+    type: parameterStore
+    name: redis-password
+    parameter_name: /eks/techops-staging/keeperhub-events/redis-password
+  SQS_QUEUE_URL:
+    type: kv
+    value: "https://sqs.us-east-1.amazonaws.com/${AWS_ACCOUNT_ID}/keeperhub-workflow-queue-staging"
+  AWS_REGION:
+    type: kv
+    value: "us-east-1"
+
+externalSecrets:
+  clusterSecretStoreName: techops-staging
+
+# solana-tracker serves an HTTP health server on HEALTH_PORT (unlike
+# event-tracker, which has no server and uses a pgrep exec probe).
+livenessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  httpGet:
+    path: /healthz
+    port: 3001
+readinessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  httpGet:
+    path: /healthz
+    port: 3001

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -34,7 +34,7 @@ group "default" {
 }
 
 group "events" {
-  targets = ["event-tracker"]
+  targets = ["event-tracker", "solana-tracker"]
 }
 
 group "scheduler" {
@@ -57,7 +57,7 @@ group "pipeline" {
 }
 
 group "all" {
-  targets = ["app", "migrator", "workflow-runner", "event-tracker", "schedule-dispatcher", "block-dispatcher", "executor", "sandbox", "metrics-collector"]
+  targets = ["app", "migrator", "workflow-runner", "event-tracker", "solana-tracker", "schedule-dispatcher", "block-dispatcher", "executor", "sandbox", "metrics-collector"]
 }
 
 target "app" {
@@ -165,6 +165,22 @@ target "event-tracker" {
   ])
   cache-from = ["type=registry,ref=${ECR_REGISTRY}/${EVENTS_ECR_TRACKER_REPO}:cache"]
   cache-to   = ["type=registry,ref=${ECR_REGISTRY}/${EVENTS_ECR_TRACKER_REPO}:cache,mode=max"]
+  attest     = []
+}
+
+# Solana ingestion (event + block triggers). Shares the events ECR repo, so all
+# tags/cache are "solana-" prefixed to avoid colliding with the event-tracker
+# images. Final Dockerfile stage is "runtime", so no explicit target is needed.
+target "solana-tracker" {
+  context    = "./keeperhub-events"
+  dockerfile = "solana-tracker/Dockerfile"
+  tags = compact([
+    "${ECR_REGISTRY}/${EVENTS_ECR_TRACKER_REPO}:solana-${IMAGE_TAG}",
+    "${ECR_REGISTRY}/${EVENTS_ECR_TRACKER_REPO}:solana-latest",
+    ENVIRONMENT_TAG != "" ? "${ECR_REGISTRY}/${EVENTS_ECR_TRACKER_REPO}:solana-${ENVIRONMENT_TAG}" : "",
+  ])
+  cache-from = ["type=registry,ref=${ECR_REGISTRY}/${EVENTS_ECR_TRACKER_REPO}:cache-solana"]
+  cache-to   = ["type=registry,ref=${ECR_REGISTRY}/${EVENTS_ECR_TRACKER_REPO}:cache-solana,mode=max"]
   attest     = []
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -489,6 +489,41 @@ services:
       - minikube
 
   # ===========================================================================
+  # Solana Tracker (keeperhub-events/solana-tracker)
+  # Unified Solana ingestion for event + block triggers; routes to the same SQS
+  # queue as event-tracker. Serves an HTTP health server on HEALTH_PORT.
+  # ===========================================================================
+  solana-tracker:
+    build:
+      context: ./keeperhub-events
+      dockerfile: solana-tracker/Dockerfile
+    container_name: keeperhub-solana-tracker
+    restart: unless-stopped
+    environment:
+      HEALTH_PORT: "3001"
+      LOG_LEVEL: info
+      KEEPERHUB_API_URL: http://keeperhub:3000
+      INTERNAL_SERVICE_HMAC_SECRET: ${INTERNAL_SERVICE_HMAC_SECRET:-bG9jYWwtZGV2LWludGVybmFsLXNlcnZpY2UtaG1hYzA=}
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      SQS_QUEUE_URL: http://localstack:4566/000000000000/keeperhub-workflow-queue
+      AWS_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_ENDPOINT_URL: http://localstack:4566
+      NODE_ENV: development
+    depends_on:
+      redis:
+        condition: service_started
+      localstack:
+        condition: service_healthy
+      app-dev:
+        condition: service_started
+    profiles:
+      - dev
+      - minikube
+
+  # ===========================================================================
   # Block Dispatcher (keeperhub-scheduler)
   # Monitors blockchain blocks and routes matching workflows to SQS
   # ===========================================================================

--- a/keeperhub-events/solana-tracker/package.json
+++ b/keeperhub-events/solana-tracker/package.json
@@ -16,6 +16,7 @@
     "test:unit": "vitest run tests/unit",
     "test:integration": "vitest run tests/integration",
     "e2e:injected": "tsx tests/e2e/injected.ts",
+    "e2e:injected-block": "tsx tests/e2e/injected-block.ts",
     "e2e:devnet": "tsx tests/e2e/devnet.ts"
   },
   "dependencies": {

--- a/keeperhub-events/solana-tracker/tests/e2e/injected-block.ts
+++ b/keeperhub-events/solana-tracker/tests/e2e/injected-block.ts
@@ -1,0 +1,100 @@
+import { SQS_QUEUE_URL } from "../../lib/config/environment";
+import { createPhantomExecution } from "../../lib/phantom";
+import { sqs } from "../../lib/sqs-client";
+import { logger } from "../../lib/utils/logger";
+import { enqueueWorkflowBlockTrigger } from "../../lib/workflow-sqs";
+import { fetchSolanaTriggers } from "../../src/discovery";
+import { buildRegistrations } from "../../src/mapper";
+import { matchBlocks } from "../../src/match/block-matcher";
+import type { NormalizedBlock } from "../../src/match/types";
+import { executionStatus, poll } from "./lib";
+
+/**
+ * Injected-block E2E for the Block trigger (deterministic). Mirrors injected.ts
+ * but drives the block path: discovery -> registration -> matchBlocks -> phantom
+ * -> SQS -> executor, injecting a synthetic block whose height divides the
+ * trigger's interval instead of polling a live chain. Proves the block
+ * trigger's SQS -> executor -> execution leg with no devnet dependency.
+ * Requires a live local stack (app-dev, localstack, redis, executor, Postgres).
+ */
+const WORKFLOW = process.env.E2E_WORKFLOW_ID ?? "dev_wf_block_on";
+const CHAIN_ID = Number(process.env.E2E_CHAIN_ID ?? "103");
+
+async function main(): Promise<void> {
+  const data = await fetchSolanaTriggers();
+  if (!data) {
+    throw new Error("discovery returned no data (is app-dev up + HMAC set?)");
+  }
+  const reg = buildRegistrations(data).find((r) => r.chainId === CHAIN_ID);
+  if (!reg) {
+    throw new Error(`no chain ${CHAIN_ID} registration from discovery`);
+  }
+  const trigger = reg.blockTriggers.find((t) => t.workflowId === WORKFLOW);
+  if (!trigger) {
+    throw new Error(
+      `${WORKFLOW} not found among chain ${CHAIN_ID} block triggers`,
+    );
+  }
+
+  // A synthetic block whose height is divisible by the trigger interval, so the
+  // real matcher fires. Block matching is height-based, so no transactions are
+  // needed.
+  const height = trigger.blockInterval * 1000;
+  const block: NormalizedBlock = {
+    slot: height + 1,
+    blockHeight: height,
+    blockhash: "e2e-injected-block",
+    blockTime: Math.floor(Date.now() / 1000),
+    parentSlot: height,
+    transactions: [],
+  };
+
+  const fire = matchBlocks(block, reg.blockTriggers).find(
+    (f) => f.workflowId === WORKFLOW,
+  );
+  if (!fire) {
+    throw new Error("matcher produced no fire for the injected block");
+  }
+
+  const executionId = await createPhantomExecution(
+    fire.workflowId,
+    fire.userId,
+    "block",
+    "scheduler",
+  );
+  if (!executionId) {
+    throw new Error("createPhantomExecution failed (check app-dev + HMAC)");
+  }
+  await enqueueWorkflowBlockTrigger(sqs, SQS_QUEUE_URL, {
+    executionId,
+    workflowId: fire.workflowId,
+    userId: fire.userId,
+    triggerData: fire.payload,
+  });
+  logger.log(
+    `[e2e-injected-block] enqueued execution ${executionId}; waiting for the executor...`,
+  );
+
+  const advanced = await poll(
+    () => executionStatus(executionId) !== "phantom",
+    45_000,
+  );
+  const finalStatus = executionStatus(executionId);
+  if (!advanced) {
+    logger.error(
+      `[e2e-injected-block] FAIL: execution ${executionId} stayed "phantom" - the executor did not consume the SQS message`,
+    );
+    process.exit(1);
+  }
+  logger.log(
+    `[e2e-injected-block] PASS: injected block -> matcher -> phantom -> SQS -> executor (final status=${finalStatus})`,
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  logger.error(
+    `[e2e-injected-block] error: ${err instanceof Error ? err.message : String(err)}`,
+  );
+  process.exit(1);
+});

--- a/lib/mcp/workflow-schema-constants.ts
+++ b/lib/mcp/workflow-schema-constants.ts
@@ -219,10 +219,22 @@ export const TRIGGERS = {
     },
     optionalFields: {},
     outputFields: {
-      blockNumber: "number - The block height",
-      blockHash: "string - Hash of the block",
-      blockTimestamp: "number - Unix timestamp of the block",
-      parentHash: "string - Hash of the parent block",
+      // EVM chains
+      blockNumber: "number - EVM: the block number",
+      blockHash: "string - EVM: hash of the block",
+      blockTimestamp: "number - EVM: Unix timestamp of the block",
+      parentHash: "string - EVM: hash of the parent block",
+      // Solana chains (fields emitted by the solana-tracker block payload;
+      // keep in sync with buildBlockPayload in
+      // keeperhub-events/solana-tracker/src/payload/block-payload.ts)
+      chainType: 'string - Solana: "solana"; absent on EVM block triggers',
+      slot: "number - Solana: the slot the block was produced in",
+      blockHeight:
+        "number - Solana: the block height (null for skipped/empty slots)",
+      blockhash:
+        "string - Solana: the block hash (note: lower-case, distinct from EVM blockHash)",
+      blockTime: "number - Solana: Unix timestamp of the block (may be null)",
+      parentSlot: "number - Solana: the parent slot",
       triggeredAt:
         "string - ISO timestamp when the block was detected (available on all trigger types)",
     },

--- a/tests/unit/block-trigger-output-schema.test.ts
+++ b/tests/unit/block-trigger-output-schema.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { TRIGGERS } from "@/lib/mcp/workflow-schema-constants";
+
+// The Solana block trigger's triggerData is produced by buildBlockPayload in
+// keeperhub-events/solana-tracker/src/payload/block-payload.ts. Those field
+// names must be documented in the Block trigger's outputFields so template
+// autocomplete ({{@trigger:...}}) and AI-generated Solana block workflows
+// reference fields that actually exist. This guards against the two drifting.
+const SOLANA_BLOCK_PAYLOAD_KEYS = [
+  "chainType",
+  "slot",
+  "blockHeight",
+  "blockhash",
+  "blockTime",
+  "parentSlot",
+] as const;
+
+const EVM_BLOCK_KEYS = [
+  "blockNumber",
+  "blockHash",
+  "blockTimestamp",
+  "parentHash",
+] as const;
+
+describe("Block trigger outputFields", () => {
+  const fields = TRIGGERS.Block.outputFields as Record<string, string>;
+
+  it("documents every Solana block payload field", () => {
+    for (const key of SOLANA_BLOCK_PAYLOAD_KEYS) {
+      expect(fields).toHaveProperty(key);
+    }
+  });
+
+  it("retains the EVM block fields (additive, not replaced)", () => {
+    for (const key of EVM_BLOCK_KEYS) {
+      expect(fields).toHaveProperty(key);
+    }
+  });
+
+  it("keeps triggeredAt (present on all trigger types)", () => {
+    expect(fields).toHaveProperty("triggeredAt");
+  });
+});


### PR DESCRIPTION
## Summary

Completes the Solana Block trigger. The ingestion, matching, and enqueue path already shipped with the Solana event work (the `solana-tracker` service serves both event and block triggers); this PR closes the two remaining gaps:

- **Product surface** - the Block trigger's output schema documented only EVM fields, so Solana block workflows and AI-generated workflows referenced field names the Solana `triggerData` does not have.
- **Rollout** - the `solana-tracker` service was built for PR environments only; it had no docker-bake target, no docker-compose service, and no staging/prod deploy, so the whole Solana ingestion vertical (event + block) never ran outside PR envs.

## Part A - Solana-aware Block trigger output schema

`TRIGGERS.Block.outputFields` now documents the Solana block payload fields (`chainType, slot, blockHeight, blockhash, blockTime, parentSlot`) alongside the existing EVM fields (additive, not replaced), so `{{@trigger:...}}` autocomplete and the AI/MCP schema surface the fields a Solana block trigger actually emits. Field names are kept in sync with `buildBlockPayload` (solana-tracker), guarded by a unit test.

## Part B - solana-tracker build + deploy rollout

- `docker-bake.hcl`: new `solana-tracker` target (shared events ECR, `solana-`-prefixed tags/cache), added to the `events` and `all` groups so the existing events build step picks it up.
- `deploy/solana-tracker/{staging,prod}/values.yaml`: Helm values overlays mirroring `event-tracker`, adapted for the reconciler - port/health `3001` with `httpGet /healthz` probes, `replicaCount: 1`, `solana-${IMAGE_TAG}` image. Reuses the `keeperhub-events-{staging,prod}` service account + IRSA role (`create: false`), so no new IAM/Terraform is required.
- `.github/workflows/deploy-events.yaml`: path filter, `SOLANA_HELM_FILE`, image-existence check, variable substitution, and a second `keeperhub-solana` Helm deploy step.
- `docker-compose.yml`: `solana-tracker` dev/minikube service for local parity.

## Prerequisite (not in this PR)

The service deploys **healthy but idle** until a Solana chain (101/103) with a primary RPC **and WSS** endpoint is configured in chain-config / Parameter Store - the mapper skips chains without WSS and starts no ingestors. That config is the last step to make triggers actually fire.

## Testing / validation

- 3 unit tests guard the Block output schema (`tests/unit/block-trigger-output-schema.test.ts`).
- Locally validated: `docker buildx bake --print events` resolves solana-tracker with the correct Dockerfile/tags; `docker compose config` accepts the new service; the values files and workflow are valid YAML. The real CI image build, Helm render (`techops-services/common` 0.5.0), and deploy exercise only on a push to `staging`/`prod`.
