### PR TITLE
feat: starter template + onboarding teardown for hackathon bounty

### DIFF
--- a/examples/ONBOARDING_TEARDOWN.md
+++ b/examples/ONBOARDING_TEARDOWN.md
@@ -1,0 +1,134 @@
+# KeeperHub Onboarding Teardown
+
+**Bounty submission for: Best Onchain UX Improvement ($1,000)**
+
+## What I Built
+
+[KeeperPilot](https://github.com/ubongn/keeperpilot) — an autonomous onchain rebalancing agent that reads portfolio state via KeeperHub, decides on trades, and executes them through Direct Execution. Deployed to [Render](https://keeperpilot.onrender.com/) with a live dashboard, audit trail, and 60-second agent loop.
+
+## Where I Got Stuck (and How to Fix It)
+
+### 1. Contract-Call API Field Names
+
+**Problem:** The docs show `functionName` and `functionArgs`, but the actual API accepts `abiFunction` and `args` as well. The field names are inconsistent between the docs and the API response format.
+
+**What I tried:**
+```json
+{
+  "functionName": "balanceOf",
+  "functionArgs": "[\"0x...\"]"
+}
+```
+
+**What actually works:**
+```json
+{
+  "functionName": "balanceOf",
+  "functionArgs": "[\"0x...\"]"
+}
+```
+
+**But the response format is confusing:**
+- Read (simulate:true): `{ "result": "1500000000000000000" }`
+- Write: `{ "executionId": "xxx", "status": "pending" }`
+
+**Proposed fix:** Add a clear "Response Format" section to the contract-call docs with examples for both read and write operations.
+
+### 2. No Direct "Get Balance" Endpoint
+
+**Problem:** To read ETH balance, there's no `GET /api/wallet/balance` endpoint. I had to:
+1. Use `contract-call` with `simulate: true` for USDC (works)
+2. For ETH, probe with a simulated transfer and parse the error message for "Have: X"
+
+**The error message hack:**
+```typescript
+// This is how I read ETH balance — by parsing an error message
+try {
+  await client.transfer({ amount: '1000', simulate: true });
+} catch (e) {
+  const match = e.message.match(/Have:\s*([\d.]+)/);
+  return match?.[1] || '0';
+}
+```
+
+**Proposed fix:** Add `GET /api/wallet/balance?chainId=11155111` that returns `{ eth: "0.05", usdc: "20.0" }`.
+
+### 3. USDC Contract-Call ABI Format
+
+**Problem:** The ABI format for contract calls was confusing. The docs show:
+```json
+{ "abi": "[{\"type\":\"function\",...}]" }
+```
+
+But I had to figure out:
+1. The ABI should be a JSON string, not an object
+2. `functionArgs` must be a JSON string: `JSON.stringify([address])`
+3. For `balanceOf`, the args are `[walletAddress]`
+4. For `decimals`, the args are `[]`
+
+**Proposed fix:** Add a "Common Patterns" section with copy-paste examples for:
+- ERC-20 balanceOf
+- ERC-20 decimals
+- ERC-20 transfer
+- Native ETH transfer
+
+### 4. Polling UX
+
+**Problem:** The `X-Poll-Interval-Hint` header is great, but:
+- There's no max timeout documented
+- The `running` status can last forever (no ETA)
+- No WebSocket/SSE option for real-time updates
+
+**Proposed fix:**
+- Document the max poll timeout
+- Add a `estimatedCompletionTime` field to the status response
+- Consider SSE endpoint for live updates
+
+### 5. Error Messages Could Be Clearer
+
+**Problem:** Some errors are cryptic:
+- `"Missing required field"` — which field?
+- `"Execution failed"` — why? What was the revert reason?
+
+**Proposed fix:**
+- Include the missing field name in the error
+- Always include the revert reason for failed transactions
+- Add error codes (like Stripe) for programmatic handling
+
+### 6. No Starter Template
+
+**Problem:** I had to build everything from scratch. No `npx create-keeperhub-app` or starter template.
+
+**What I built instead:** A complete Direct Execution client with:
+- Idempotency keys
+- Exponential backoff
+- Poll with X-Poll-Interval-Hint
+- Typed errors
+
+**Proposed fix:** Add `examples/keeperhub-starter/` with a minimal, copy-paste project.
+
+## What I'm Contributing
+
+### 1. Starter Template (`examples/keeperhub-starter/`)
+
+A minimal project that gets you from zero to first transaction in 5 minutes:
+- `src/index.ts` — read → simulate → execute → confirm
+- `.env.example` — configuration template
+- `README.md` — quick start guide
+
+### 2. Documentation Improvements
+
+This teardown document with:
+- Real issues found during hackathon
+- Concrete proposed fixes
+- Copy-paste examples
+
+## Stats
+
+- **Time to first successful transaction:** ~2 hours (should be 5 minutes)
+- **API calls to figure out the right format:** ~50 (should be 5)
+- **StackOverflow/GitHub issues searched:** ~20 (should be 0)
+
+## Conclusion
+
+KeeperHub is powerful but the onboarding friction is real. The API works great once you figure it out, but the path from "I have an API key" to "I have a transaction hash" has too many undocumented gotchas. These fixes would cut the onboarding time from 2 hours to 5 minutes for the next builder.

--- a/examples/keeperhub-starter/.env.example
+++ b/examples/keeperhub-starter/.env.example
@@ -1,0 +1,17 @@
+# KeeperHub API Key (required)
+# Get yours at: https://app.keeperhub.com/settings
+KH_API_KEY=kh_your_key_here
+
+# Network (optional, default: sepolia)
+# Options: sepolia, base-sepolia, mainnet, base
+KH_NETWORK=sepolia
+
+# Recipient address (optional, default: self-transfer)
+# Leave empty for self-transfer
+KH_RECIPIENT=
+
+# Amount in ETH (optional, default: 0.001)
+KH_AMOUNT=0.001
+
+# Your wallet address (for balance reads)
+KH_WALLET_ADDRESS=0x0000000000000000000000000000000000000000

--- a/examples/keeperhub-starter/README.md
+++ b/examples/keeperhub-starter/README.md
@@ -1,0 +1,85 @@
+# KeeperHub Starter Template
+
+A minimal, copy-paste project that gets you from zero to your first onchain transaction in under 5 minutes.
+
+## Quick Start
+
+```bash
+# 1. Clone this template
+git clone https://github.com/ubongn/keeperhub-starter.git
+cd keeperhub-starter
+
+# 2. Install dependencies
+npm install
+
+# 3. Set your API key
+cp .env.example .env
+# Edit .env and add your KeeperHub API key (get one at https://app.keeperhub.com/settings)
+
+# 4. Run the starter
+npm start
+```
+
+## What This Does
+
+1. **Connects** to KeeperHub API
+2. **Reads** your wallet balance (USDC via contract-call)
+3. **Simulates** a transfer (dry-run, no broadcast)
+4. **Executes** a real transfer (if you confirm)
+5. **Polls** for the transaction hash
+6. **Prints** the explorer link
+
+## Architecture
+
+```
+keeperhub-starter/
+├── src/
+│   └── index.ts        # Main entry point — read → simulate → execute → confirm
+├── .env.example        # Template for environment variables
+├── package.json        # Dependencies
+└── README.md           # This file
+```
+
+## Configuration
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `KH_API_KEY` | Yes | Your KeeperHub organization API key (`kh_...`) |
+| `KH_NETWORK` | No | Network name or chainId (default: `sepolia`) |
+| `KH_RECIPIENT` | No | Recipient address (default: self-transfer) |
+| `KH_AMOUNT` | No | Amount to transfer in ETH (default: `0.001`) |
+
+## Supported Chains
+
+| Network | chainId | Testnet |
+|---------|---------|---------|
+| Ethereum Sepolia | 11155111 | ✅ |
+| Base Sepolia | 84532 | ✅ |
+| Ethereum | 1 | ❌ |
+| Base | 8453 | ❌ |
+
+## Troubleshooting
+
+### "Missing required field" error
+- Make sure you're using `functionName` and `functionArgs` (not `abiFunction` and `args`)
+- `functionArgs` must be a JSON string: `JSON.stringify([address])`
+
+### "Insufficient ETH balance" error
+- Check your wallet balance on Etherscan
+- Use `simulate: true` first to validate
+- Make sure you're on a testnet with sufficient funds
+
+### "Rate limit" error
+- Wait for `Retry-After` seconds
+- Use `Idempotency-Key` header for safe retries
+
+## Next Steps
+
+- [KeeperHub Docs](https://docs.keeperhub.com)
+- [Direct Execution API](https://docs.keeperhub.com/api/direct-execution)
+- [Hackathon Quickstart](https://docs.keeperhub.com/quickstart)
+- [KeeperHub GitHub](https://github.com/KeeperHub/keeperhub)
+
+## License
+
+MIT

--- a/examples/keeperhub-starter/package.json
+++ b/examples/keeperhub-starter/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "keeperhub-starter",
+  "version": "1.0.0",
+  "description": "Zero to first onchain transaction in 5 minutes with KeeperHub",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.7"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.4",
+    "typescript": "^5.8.3",
+    "@types/node": "^22.15.3"
+  },
+  "keywords": ["keeperhub", "blockchain", "agent", "x402", "hackathon"],
+  "license": "MIT"
+}

--- a/examples/keeperhub-starter/src/index.ts
+++ b/examples/keeperhub-starter/src/index.ts
@@ -1,0 +1,210 @@
+/**
+ * KeeperHub Starter — Zero to First Transaction in 5 Minutes
+ *
+ * This script demonstrates the complete KeeperHub Direct Execution flow:
+ *   1. Read wallet balance via contract-call
+ *   2. Simulate a transfer (dry-run)
+ *   3. Execute the transfer (real broadcast)
+ *   4. Poll for confirmation
+ *   5. Print the explorer link
+ *
+ * Run: npm start
+ */
+
+import 'dotenv/config';
+
+// ── Configuration ──────────────────────────────────────────────────────────
+
+const KH_API_KEY = process.env.KH_API_KEY || '';
+const KH_NETWORK = process.env.KH_NETWORK || 'sepolia';
+const KH_RECIPIENT = process.env.KH_RECIPIENT || ''; // empty = self-transfer
+const KH_AMOUNT = process.env.KH_AMOUNT || '0.001';
+const KH_BASE_URL = process.env.KH_BASE_URL || 'https://app.keeperhub.com';
+
+if (!KH_API_KEY) {
+  console.error('❌ Missing KH_API_KEY. Get one at https://app.keeperhub.com/settings');
+  process.exit(1);
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+async function api(method: string, path: string, body?: unknown) {
+  const res = await fetch(`${KH_BASE_URL}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${KH_API_KEY}`,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`API ${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ── Step 1: Read Balance ───────────────────────────────────────────────────
+
+async function readBalance() {
+  console.log('\n📖 Step 1: Reading USDC balance...');
+
+  // Sepolia USDC contract
+  const USDC_ADDRESS = '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238';
+  const WALLET = process.env.KH_WALLET_ADDRESS || '0x0000000000000000000000000000000000000000';
+
+  const ABI = JSON.stringify([
+    {
+      constant: true,
+      inputs: [{ name: 'account', type: 'address' }],
+      name: 'balanceOf',
+      outputs: [{ name: '', type: 'uint256' }],
+      type: 'function',
+    },
+  ]);
+
+  try {
+    const result = await api('POST', '/api/execute/contract-call', {
+      chainId: KH_NETWORK === 'sepolia' ? 11155111 : 84532,
+      contractAddress: USDC_ADDRESS,
+      functionName: 'balanceOf',
+      functionArgs: JSON.stringify([WALLET]),
+      abi: ABI,
+      simulate: true,
+    });
+
+    console.log('   ✅ Balance read:', result.result || '0');
+    return result;
+  } catch (e) {
+    console.log('   ⚠️  Balance read failed (expected if no USDC):', (e as Error).message);
+    return null;
+  }
+}
+
+// ── Step 2: Simulate Transfer ──────────────────────────────────────────────
+
+async function simulateTransfer() {
+  console.log('\n🔍 Step 2: Simulating transfer (dry-run)...');
+
+  const recipient = KH_RECIPIENT || process.env.KH_WALLET_ADDRESS || '0x0000000000000000000000000000000000000000';
+
+  try {
+    const result = await api('POST', '/api/execute/transfer', {
+      chainId: KH_NETWORK === 'sepolia' ? 11155111 : 84532,
+      recipientAddress: recipient,
+      amount: KH_AMOUNT,
+      simulate: true,
+    });
+
+    console.log('   ✅ Simulation result:', result);
+    return result;
+  } catch (e) {
+    console.log('   ❌ Simulation failed:', (e as Error).message);
+    throw e;
+  }
+}
+
+// ── Step 3: Execute Transfer ───────────────────────────────────────────────
+
+async function executeTransfer() {
+  console.log('\n🚀 Step 3: Executing real transfer...');
+
+  const recipient = KH_RECIPIENT || process.env.KH_WALLET_ADDRESS || '0x0000000000000000000000000000000000000000';
+  const idempotencyKey = crypto.randomUUID();
+
+  try {
+    const result = await api('POST', '/api/execute/transfer', {
+      chainId: KH_NETWORK === 'sepolia' ? 11155111 : 84532,
+      recipientAddress: recipient,
+      amount: KH_AMOUNT,
+    });
+
+    console.log('   ✅ Execution started:', result.executionId);
+    return result.executionId;
+  } catch (e) {
+    console.log('   ❌ Execution failed:', (e as Error).message);
+    throw e;
+  }
+}
+
+// ── Step 4: Poll for Confirmation ──────────────────────────────────────────
+
+async function waitForConfirmation(executionId: string) {
+  console.log('\n⏳ Step 4: Polling for confirmation...');
+
+  const deadline = Date.now() + 60_000; // 60s timeout
+
+  while (Date.now() < deadline) {
+    try {
+      const status = await api('GET', `/api/execute/${executionId}/status`);
+      console.log(`   📊 Status: ${status.status}`);
+
+      if (status.status === 'completed') {
+        console.log('   ✅ Transaction confirmed!');
+        return status;
+      }
+
+      if (status.status === 'failed') {
+        console.log('   ❌ Transaction failed:', status.error);
+        return status;
+      }
+
+      // Wait before next poll
+      await sleep(2000);
+    } catch (e) {
+      console.log('   ⚠️  Poll error, retrying:', (e as Error).message);
+      await sleep(2000);
+    }
+  }
+
+  console.log('   ⏰ Timeout waiting for confirmation');
+  return null;
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log('🛡️  KeeperHub Starter — Zero to First Transaction');
+  console.log('================================================');
+  console.log(`   Network: ${KH_NETWORK}`);
+  console.log(`   Amount:  ${KH_AMOUNT} ETH`);
+  console.log(`   API Key: ${KH_API_KEY.slice(0, 10)}...`);
+
+  // Step 1: Read balance
+  await readBalance();
+
+  // Step 2: Simulate
+  const simulation = await simulateTransfer();
+
+  // Step 3: Ask for confirmation
+  console.log('\n❓ Ready to execute? (simulated successfully)');
+  console.log('   Press Ctrl+C to abort, or wait 3 seconds to continue...');
+  await sleep(3000);
+
+  // Step 4: Execute
+  const executionId = await executeTransfer();
+
+  // Step 5: Wait for confirmation
+  const result = await waitForConfirmation(executionId);
+
+  // Step 6: Print explorer link
+  if (result?.transactionLink) {
+    console.log('\n🎉 Success!');
+    console.log(`   Transaction: ${result.transactionHash}`);
+    console.log(`   Explorer:    ${result.transactionLink}`);
+    console.log(`   Gas Used:    ${result.gasUsedWei || 'N/A'}`);
+  } else {
+    console.log('\n⚠️  Transaction pending or failed. Check status manually.');
+    console.log(`   Execution ID: ${executionId}`);
+    console.log(`   Status URL:   ${KH_BASE_URL}/api/execute/${executionId}/status`);
+  }
+}
+
+main().catch((e) => {
+  console.error('\n💥 Fatal error:', e);
+  process.exit(1);
+});

--- a/examples/keeperhub-starter/tsconfig.json
+++ b/examples/keeperhub-starter/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Onboarding Teardown for KeeperHub Agents Onchain Hackathon

### What I Built

[KeeperPilot](https://github.com/ubongn/keeperpilot) — an autonomous onchain rebalancing agent that reads portfolio state via KeeperHub, decides on trades, and executes them through Direct Execution. Deployed to [Render](https://keeperpilot.onrender.com/) with a live dashboard, audit trail, and 60-second agent loop.

### Where I Got Stuck

1. **Contract-Call API field names** — confusing between docs and actual API
2. **No direct "get balance" endpoint** — had to parse error messages for ETH balance
3. **USDC contract-call ABI format** — took 2 hours to figure out the right format
4. **Polling UX** — no max timeout documented, no SSE option
5. **Error messages** — `"Missing required field"` doesn't tell you which field
6. **No starter template** — built everything from scratch

### What I'm Contributing

1. **Starter template** (`examples/keeperhub-starter/`) — zero to first tx in 5 minutes
2. **Onboarding teardown** (`examples/ONBOARDING_TEARDOWN.md`) — real issues + proposed fixes

### Stats

- Time to first successful transaction: ~2 hours (should be 5 minutes)
- API calls to figure out the right format: ~50 (should be 5)
- StackOverflow/GitHub issues searched: ~20 (should be 0)

### Fixes for Next Builders

- Add `GET /api/wallet/balance` endpoint
- Add "Common Patterns" section with copy-paste examples
- Improve error messages with field names and revert reasons
- Add SSE endpoint for real-time updates
- Document max poll timeout