### PR TITLE
fix: run disabled workflows on manual trigger in the executor

### DIFF
--- a/keeperhub-executor/in-process.ts
+++ b/keeperhub-executor/in-process.ts
@@ -4,6 +4,7 @@ import { buildExecutorInput } from "../lib/workflow/executor/build-executor-inpu
 import { executeWorkflow } from "../lib/workflow/executor/executor.workflow";
 import type { WorkflowEdge, WorkflowNode } from "../lib/workflow/store";
 import { loadWorkflowForExecution } from "../lib/workflow/load-for-execution";
+import type { ApiExecuteTriggerType } from "./api-execute";
 import type { DbSchema } from "./lib/db-helpers";
 import {
   applyExecutionResult,
@@ -21,10 +22,12 @@ export async function executeInProcess(params: {
   workflowId: string;
   executionId: string;
   input: Record<string, unknown>;
+  triggerType: ApiExecuteTriggerType;
   scheduleId?: string;
   db: PostgresJsDatabase<DbSchema>;
 }): Promise<void> {
-  const { workflowId, executionId, input, scheduleId, db } = params;
+  const { workflowId, executionId, input, triggerType, scheduleId, db } =
+    params;
   const startTime = Date.now();
 
   console.log("[Executor:InProcess] Starting workflow execution");
@@ -38,8 +41,14 @@ export async function executeInProcess(params: {
     // workflow could have been disabled, soft-deleted, deactivated, or its
     // owning org deactivated between dispatch and execution. Cancel rather than
     // run. The org owns the workflow, so org deactivation is the owner gate.
+    //
+    // Manual runs are the exception: the editor "Run" button must work on
+    // not-yet-enabled drafts, so manual triggers pass requireEnabled: false to
+    // match the interactive execute route. That only bypasses the "disabled"
+    // reason - deleted/deactivated/org-deactivated still block - so it stays
+    // safe. Automated triggers (schedule/event/block/webhook) keep the guard.
     const loaded = await loadWorkflowForExecution(workflowId, {
-      requireEnabled: true,
+      requireEnabled: triggerType !== "manual",
     });
     if (loaded.status === "not_found") {
       throw new Error(`Workflow not found: ${workflowId}`);

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -237,6 +237,7 @@ async function dispatchExecution(params: {
         workflowId,
         executionId,
         input,
+        triggerType,
         scheduleId,
         db,
       });
@@ -288,13 +289,19 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
   );
 
   // Load the workflow and evaluate its lifecycle state in one round-trip.
-  // A soft-deleted, disabled, or deactivated workflow - or one whose owning
-  // org is deactivated - must never execute, even if a stale schedule or
-  // queued message still references it. The block_executions DB trigger is the
+  // A soft-deleted or deactivated workflow - or one whose owning org is
+  // deactivated - must never execute, even if a stale schedule or queued
+  // message still references it. The block_executions DB trigger is the
   // INSERT-time backstop; this skips the work before it gets that far. The org
   // owns the workflow, so org deactivation is the owner gate.
+  //
+  // Manual runs are the exception: the editor "Run" button must work on
+  // not-yet-enabled drafts, so manual triggers pass requireEnabled: false to
+  // match the interactive execute route. That only bypasses the "disabled"
+  // reason - deleted/deactivated/org-deactivated still block - so it stays safe.
+  // Automated triggers (schedule/event/block/webhook) keep the enabled gate.
   const loaded = await loadWorkflowForExecution(workflowId, {
-    requireEnabled: true,
+    requireEnabled: triggerType !== "manual",
   });
   if (loaded.status === "not_found") {
     console.error(`[Executor] Workflow not found: ${workflowId}`);

--- a/keeperhub-executor/k8s-job.ts
+++ b/keeperhub-executor/k8s-job.ts
@@ -113,6 +113,7 @@ export async function createWorkflowJob(params: {
     { name: "WORKFLOW_ID", value: workflowId },
     { name: "EXECUTION_ID", value: executionId },
     { name: "WORKFLOW_INPUT", value: JSON.stringify(input) },
+    { name: "TRIGGER_TYPE", value: triggerType },
     // With readOnlyRootFilesystem the only writable path is the /tmp emptyDir
     // below. tsx/esbuild and any plugin temp writes resolve through TMPDIR, so
     // point it there to keep the runner working under the hardened context.

--- a/keeperhub-executor/workflow-runner.ts
+++ b/keeperhub-executor/workflow-runner.ts
@@ -36,6 +36,7 @@ import { executeWorkflow } from "../lib/workflow/executor/executor.workflow";
 import { SHUTDOWN_TIMEOUT_MS } from "../lib/workflow/executor/runner-constants";
 import type { WorkflowEdge, WorkflowNode } from "../lib/workflow/store";
 import { loadWorkflowForExecution } from "../lib/workflow/load-for-execution";
+import type { ApiExecuteTriggerType } from "./api-execute";
 import {
   applyExecutionResult,
   initializeExecutionProgress,
@@ -49,6 +50,7 @@ function validateEnv(): {
   workflowId: string;
   executionId: string;
   input: Record<string, unknown>;
+  triggerType?: ApiExecuteTriggerType;
   scheduleId?: string;
 } {
   const workflowId = process.env.WORKFLOW_ID;
@@ -83,6 +85,7 @@ function validateEnv(): {
     workflowId,
     executionId,
     input,
+    triggerType: process.env.TRIGGER_TYPE as ApiExecuteTriggerType | undefined,
     scheduleId: process.env.SCHEDULE_ID,
   };
 }
@@ -156,7 +159,8 @@ process.on("SIGINT", () => handleGracefulShutdown("SIGINT"));
 
 async function main(): Promise<void> {
   const startTime = Date.now();
-  const { workflowId, executionId, input, scheduleId } = validateEnv();
+  const { workflowId, executionId, input, triggerType, scheduleId } =
+    validateEnv();
 
   currentExecutionId = executionId;
   currentScheduleId = scheduleId ?? null;
@@ -178,8 +182,14 @@ async function main(): Promise<void> {
     // workflow could have been disabled, soft-deleted, deactivated, or its
     // owning org deactivated between dispatch and pod startup. Cancel rather
     // than run. The org owns the workflow, so org deactivation is the owner gate.
+    //
+    // Manual runs are the exception: the editor "Run" button must work on
+    // not-yet-enabled drafts, so manual triggers pass requireEnabled: false to
+    // match the interactive execute route. That only bypasses the "disabled"
+    // reason - deleted/deactivated/org-deactivated still block - so it stays
+    // safe. Automated triggers (schedule/event/block/webhook) keep the guard.
     const loaded = await loadWorkflowForExecution(workflowId, {
-      requireEnabled: true,
+      requireEnabled: triggerType !== "manual",
     });
     if (loaded.status === "not_found") {
       throw new Error(`Workflow not found: ${workflowId}`);


### PR DESCRIPTION
## Problem

Manual (editor "Run") execution of a disabled/draft workflow returned `404 Execution not found`. The interactive execute route intentionally loads disabled workflows (`requireEnabled: false`) so the editor Run button can test drafts, but when execution is dispatched to the executor (`WORKFLOW_DISPATCH_VIA_EXECUTOR=1`), the executor re-checked lifecycle state with a hardcoded `requireEnabled: true` and discarded the phantom row before it could advance.

## Fix

Gate the executor's enablement re-checks on the trigger type: `requireEnabled: triggerType !== "manual"`.

- Manual runs pass `requireEnabled: false`, matching the interactive execute route, so editor "Run" works on not-yet-enabled drafts.
- Automated triggers (schedule/event/block/webhook) keep the mid-flight-disable guard unchanged.
- Only the "disabled" reason is bypassed; deleted / deactivated / org-deactivated workflows still block.

Threads `triggerType` through the primary message gate (`processExecutorMessage`), the in-process path, and the K8s runner (via a new `TRIGGER_TYPE` pod env var).

## Testing

- `pnpm type-check` passes.
- Verified locally against the dev stack: a disabled workflow run via the editor Run path now executes to success (previously returned `404 Execution not found`), while enabled workflows and automated triggers are unaffected.
