### PR TITLE
chore: wire Solana wallet provisioning flag into staging and prod Helm

### DIFF
--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -29,6 +29,12 @@ app:
       type: parameterStore
       name: chain-rpc-config
       parameter_name: /eks/techops-prod/keeperhub/chain-rpc-config
+    # KEEP-988: gate Solana wallet provisioning at signup (Turnkey provisions an
+    # ed25519 Solana account alongside the EVM EOA). Off in prod until the prod
+    # Solana rollout; flip to "true" in a PR when ready.
+    SOLANA_WALLET_PROVISIONING_ENABLED:
+      type: kv
+      value: "false"
     TURNKEY_API_PUBLIC_KEY:
       type: parameterStore
       name: turnkey-api-public-key

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -29,6 +29,12 @@ app:
       type: parameterStore
       name: chain-rpc-config
       parameter_name: /eks/techops-staging/keeperhub/chain-rpc-config
+    # KEEP-988: gate Solana wallet provisioning at signup (Turnkey provisions an
+    # ed25519 Solana account alongside the EVM EOA). Enabled in staging; prod
+    # stays off until the prod Solana rollout (flip to "true" in a PR then).
+    SOLANA_WALLET_PROVISIONING_ENABLED:
+      type: kv
+      value: "true"
     TURNKEY_API_PUBLIC_KEY:
       type: parameterStore
       name: turnkey-api-public-key


### PR DESCRIPTION
## What

Wire `SOLANA_WALLET_PROVISIONING_ENABLED` into the app `shared_env` of both deploy environments:
- `deploy/keeperhub-stack/staging/values.yaml` → `true`
- `deploy/keeperhub-stack/prod/values.yaml` → `false`

## Why

`SOLANA_WALLET_PROVISIONING_ENABLED` gates Solana wallet provisioning at signup (Turnkey provisions an ed25519 Solana account alongside the EVM EOA). It defaults **off** and was set in **no** deploy config, so Solana provisioning is currently gated off in staging and prod even though the code is deployed.

This turns it **on in staging** (so the provisioning path can be validated against the now-Solana-enabled staging chain config) and leaves **prod off** until the prod Solana rollout.

## Rollout note

Enabling in prod is a deliberate follow-up: flip the prod value to `"true"` in a separate PR once the prod chain-config Solana enablement lands and the feature is signed off. The flag is a `kv` value here (not Parameter Store), so the prod flip is a one-line PR + redeploy.

## Scope

- Only the app `shared_env` block is touched (the auth session hook that runs provisioning). The executor component's env is intentionally left unchanged - it does not provision.
- Values-only change; no chart or code changes.
