### PR TITLE
chore: provision Solana wallets in PR environments

### DIFF
--- a/deploy/pr-environment/values.template.yaml
+++ b/deploy/pr-environment/values.template.yaml
@@ -16,6 +16,11 @@ shared_env: &shared_env
     type: parameterStore
     name: chain-rpc-config
     parameter_name: /eks/techops-staging/keeperhub/chain-rpc-config
+  # KEEP-988: PR environments exercise the Solana rollout end to end, so
+  # provision EVM + Solana wallets at signup (mirrors staging).
+  SOLANA_WALLET_PROVISIONING_ENABLED:
+    type: kv
+    value: "true"
 
 replicaCount: 1
 


### PR DESCRIPTION
## What

Add `SOLANA_WALLET_PROVISIONING_ENABLED: "true"` to the pr-environment template's `shared_env` (`deploy/pr-environment/values.template.yaml`).

## Why

PR environments exist to exercise features end to end, but the flag defaults off and was not set in the PR-env template - so PR envs provision **EVM-only** wallets and cannot test Solana wallet provisioning (or any Solana flow that needs a Solana wallet). This turns it on for all PR environments, matching staging (PR #1803).

Follow-up to PR #1803, which wired the flag into the staging (`true`) and prod (`false`) keeperhub-stack values.
