### PR TITLE
ci: provision Solana wallets in ephemeral e2e environments

### DIFF
--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -55,6 +55,10 @@ inputs:
     description: 'TURNKEY_ORGANIZATION_ID for the Turnkey-managed org wallet path'
     required: false
     default: ''
+  solana_wallet_provisioning_enabled:
+    description: 'SOLANA_WALLET_PROVISIONING_ENABLED - when "true", Turnkey sub-orgs are created with a Solana account alongside the EVM one. Unset leaves wallets EVM-only, so any suite touching a Solana address must set it.'
+    required: false
+    default: ''
   ai_prompt_enabled:
     description: 'NEXT_PUBLIC_AI_PROMPT_ENABLED - gates /api/ai/generate (e2e api-key-auth suite). Scoped per-job so AI UI is not surfaced elsewhere.'
     required: false
@@ -138,6 +142,7 @@ runs:
         TURNKEY_API_PUBLIC_KEY: ${{ inputs.turnkey_api_public_key }}
         TURNKEY_API_PRIVATE_KEY: ${{ inputs.turnkey_api_private_key }}
         TURNKEY_ORGANIZATION_ID: ${{ inputs.turnkey_organization_id }}
+        SOLANA_WALLET_PROVISIONING_ENABLED: ${{ inputs.solana_wallet_provisioning_enabled }}
         ALLOW_TEST_ENDPOINTS: ${{ inputs.allow_test_endpoints }}
         LOAD_TEST_BYPASS_TOKEN: ${{ inputs.load_test_bypass_token }}
         SAFE_FETCH_SHADOW: ${{ inputs.safe_fetch_shadow }}
@@ -158,6 +163,7 @@ runs:
           "CI=true" \
           "TEST_API_KEY=${TEST_API_KEY}" \
           "WORKFLOW_TARGET_WORLD=@workflow/world-postgres" \
+          "SOLANA_WALLET_PROVISIONING_ENABLED=${SOLANA_WALLET_PROVISIONING_ENABLED}" \
           > /tmp/keeperhub-app.env
 
         # Jobs that execute workflow step bundles (e.g. the credential-bundle
@@ -278,6 +284,7 @@ runs:
         TURNKEY_API_PUBLIC_KEY: ${{ inputs.turnkey_api_public_key }}
         TURNKEY_API_PRIVATE_KEY: ${{ inputs.turnkey_api_private_key }}
         TURNKEY_ORGANIZATION_ID: ${{ inputs.turnkey_organization_id }}
+        SOLANA_WALLET_PROVISIONING_ENABLED: ${{ inputs.solana_wallet_provisioning_enabled }}
         SANDBOX_BACKEND: remote
         SANDBOX_URL: http://localhost:8787
         # Present so the production captcha guard (lib/auth.ts) lets the server

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -644,6 +644,7 @@ jobs:
           turnkey_api_public_key: ${{ secrets.TURNKEY_API_PUBLIC_KEY }}
           turnkey_api_private_key: ${{ secrets.TURNKEY_API_PRIVATE_KEY }}
           turnkey_organization_id: ${{ secrets.TURNKEY_ORGANIZATION_ID }}
+          solana_wallet_provisioning_enabled: "true"
           # NEXT_PUBLIC_AI_PROMPT_ENABLED is baked into the build-app
           # artifact, so only the runtime AI provider env is set here.
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -931,6 +932,7 @@ jobs:
           turnkey_api_public_key: ${{ secrets.TURNKEY_API_PUBLIC_KEY }}
           turnkey_api_private_key: ${{ secrets.TURNKEY_API_PRIVATE_KEY }}
           turnkey_organization_id: ${{ secrets.TURNKEY_ORGANIZATION_ID }}
+          solana_wallet_provisioning_enabled: "true"
           # Shadow-mode SSRF so the app's setup workflows can reach the
           # localhost anvil mainnet fork (chain 1 -> :8548).
           safe_fetch_shadow: "true"
@@ -1239,6 +1241,7 @@ jobs:
           turnkey_api_public_key: ${{ secrets.TURNKEY_API_PUBLIC_KEY }}
           turnkey_api_private_key: ${{ secrets.TURNKEY_API_PRIVATE_KEY }}
           turnkey_organization_id: ${{ secrets.TURNKEY_ORGANIZATION_ID }}
+          solana_wallet_provisioning_enabled: "true"
           load_test_bypass_token: ${{ secrets.LOAD_TEST_BYPASS_TOKEN }}
           # Enable testEndpointsEnabled() so the strict-signin/start credential
           # rate-limit bypass honors playwright's X-Test-API-Key header (the


### PR DESCRIPTION
## Problem

`SOLANA_WALLET_PROVISIONING_ENABLED` reaches every environment except the ephemeral e2e harness:

| Environment | Flag |
|---|---|
| PR environments (`deploy/pr-environment/values.template.yaml`) | set |
| staging (`deploy/keeperhub-stack/staging/values.yaml`) | `true` |
| prod (`deploy/keeperhub-stack/prod/values.yaml`) | `false` |
| **ephemeral e2e** (`.github/actions/start-app`) | **absent** |

The app container therefore starts without it, `lib/turnkey/turnkey-operations.ts` takes the `EVM_ONLY_ACCOUNTS` branch, and every e2e test account is created with no Solana address. Observed during test-account setup on a recent run:

```
{"level":"error","msg":"[Turnkey] Solana account not found in wallet after creation; solanaAddress will be null",
 "error_category":"external_service","error_context":"Turnkey","service":"turnkey"}
```

## Impact

- The e2e suite cannot exercise any Solana wallet functionality - accounts silently carry `solanaAddress = null`, so a Solana wallet regression would pass e2e unnoticed.
- Every ephemeral run emits an error-level log and an `errors.external.service.total` counter for this, which devalues both signals.

PR environments, staging and prod are unaffected; they already receive the flag.

## Change

- `start-app` action: new `solana_wallet_provisioning_enabled` input, wired into the Docker path (step `env` block plus `/tmp/keeperhub-app.env`) and the bare-metal path `env` block.
- `e2e-tests-ephemeral.yml`: passes `"true"` from all three `Start application` steps (`e2e-vitest-ephemeral`, `protocol-coverage-ephemeral`, `e2e-playwright-ephemeral`).

Additive only - 10 insertions, no deletions, no behaviour change for any caller that does not pass the input (it defaults to empty, which is the current behaviour).

The value is a plain `true`/`false` string with no special characters, so it goes in the env file rather than the `-e` escape hatch reserved for JSON/base64 values.

## Why all three jobs

All three provision Turnkey wallets and would hit the same branch. Setting it uniformly avoids one e2e environment silently differing from the others. If you would rather scope it to just the Playwright job where the error was observed, that is a one-line change.

## Validation

- Both YAML files parse.
- Every input passed to `start-app` across the workflow is declared by the action (checked programmatically, not by eye - an earlier iteration wrongly inserted the input into non-`start-app` steps and this check caught it).
- Full effect is only observable on a real ephemeral run, since the flag is consumed by the app container at startup.
