### PR TITLE
fix: close Solana spending-cap bypass and add a per-chain Solana value cap

### DIFF
--- a/app/api/analytics/spend-cap/route.ts
+++ b/app/api/analytics/spend-cap/route.ts
@@ -31,12 +31,20 @@ export const GET = requireOrganization(
 );
 
 /**
- * Set or clear the organization's daily value cap (native wei).
+ * Set or clear the organization's daily value caps.
+ *
+ * Two independent caps, each optional in the body:
+ *   dailyValueCapWei             EVM, wei      (18 decimals)
+ *   dailySolanaValueCapLamports  Solana, lamports (9 decimals)
+ *
+ * An omitted field is left unchanged; an explicit null clears that cap
+ * (unlimited). Partial updates matter here: the two caps are edited by separate
+ * controls, so treating an absent field as "clear" would let saving one cap
+ * silently remove the other.
  *
  * Gated by `organization:update` (admin/owner) over the session. A leaked `kh_`
  * API key or MCP OAuth token authenticates a different layer and never satisfies
  * the org session context, so a compromised key cannot raise its own ceiling.
- * A null `dailyValueCapWei` clears the cap (unlimited).
  */
 export const PUT = requirePermission(
   "organization",
@@ -50,42 +58,106 @@ export const PUT = requirePermission(
       );
     }
 
-    let body: { dailyValueCapWei?: unknown };
+    let body: {
+      dailyValueCapWei?: unknown;
+      dailySolanaValueCapLamports?: unknown;
+    };
     try {
-      body = (await req.json()) as { dailyValueCapWei?: unknown };
+      body = (await req.json()) as typeof body;
     } catch {
       return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
     }
 
-    const raw = body.dailyValueCapWei;
-    let dailyValueCapWei: string | null;
-    if (raw === null) {
-      dailyValueCapWei = null;
-    } else if (typeof raw === "string" && NON_NEGATIVE_INTEGER.test(raw)) {
-      dailyValueCapWei = raw;
-    } else {
+    const wei = parseCapField(body, "dailyValueCapWei", "wei");
+    if ("error" in wei) {
+      return NextResponse.json(wei.error, { status: 400 });
+    }
+    const lamports = parseCapField(
+      body,
+      "dailySolanaValueCapLamports",
+      "lamports"
+    );
+    if ("error" in lamports) {
+      return NextResponse.json(lamports.error, { status: 400 });
+    }
+
+    if (!(wei.present || lamports.present)) {
       return NextResponse.json(
         {
           error:
-            "dailyValueCapWei must be a non-negative integer wei string, or null to clear the cap",
-          field: "dailyValueCapWei",
+            "Provide dailyValueCapWei and/or dailySolanaValueCapLamports (null clears a cap)",
         },
         { status: 400 }
       );
     }
 
+    // Only columns explicitly present in the body are written, so updating one
+    // cap never clears the other.
+    const set: Record<string, unknown> = { updatedAt: new Date() };
+    if (wei.present) {
+      set.dailyValueCapWei = wei.value;
+    }
+    if (lamports.present) {
+      set.dailySolanaValueCapLamports = lamports.value;
+    }
+
     try {
       await db
         .insert(organizationSpendCaps)
-        .values({ organizationId, dailyValueCapWei })
+        .values({
+          organizationId,
+          dailyValueCapWei: wei.present ? wei.value : null,
+          dailySolanaValueCapLamports: lamports.present ? lamports.value : null,
+        })
         .onConflictDoUpdate({
           target: organizationSpendCaps.organizationId,
-          set: { dailyValueCapWei, updatedAt: new Date() },
+          set,
         });
     } catch (error: unknown) {
       return apiError(error, "Failed to update spend cap");
     }
 
-    return NextResponse.json({ dailyValueCapWei }, { status: 200 });
+    return NextResponse.json(
+      {
+        ...(wei.present ? { dailyValueCapWei: wei.value } : {}),
+        ...(lamports.present
+          ? { dailySolanaValueCapLamports: lamports.value }
+          : {}),
+      },
+      { status: 200 }
+    );
   }
 );
+
+type CapField =
+  | { present: false }
+  | { present: true; value: string | null }
+  | { error: { error: string; field: string } };
+
+/**
+ * Absent -> unchanged, explicit null -> clear, non-negative integer string ->
+ * set. Any other shape is rejected rather than coerced, so a malformed cap can
+ * never be silently stored as unlimited.
+ */
+function parseCapField(
+  body: Record<string, unknown>,
+  field: string,
+  unit: string
+): CapField {
+  if (!(field in body)) {
+    return { present: false };
+  }
+  const raw = body[field];
+  if (raw === null) {
+    return { present: true, value: null };
+  }
+  if (typeof raw === "string" && NON_NEGATIVE_INTEGER.test(raw)) {
+    return { present: true, value: raw };
+  }
+  return {
+    error: {
+      error: `${field} must be a non-negative integer ${unit} string, or null to clear the cap`,
+      field,
+    },
+  };
+}

--- a/app/api/execute/[...slug]/route.ts
+++ b/app/api/execute/[...slug]/route.ts
@@ -256,7 +256,7 @@ async function executeProtocolAction(
     type: "protocol-action",
     network,
     input: redactInput(withRejectedSignerOverride(body, body)),
-    reservedValueWei: parsedValue.valueWei,
+    reserved: { kind: "evm", valueWei: parsedValue.valueWei },
   });
   if (!reserve.allowed) {
     return recordIdempotentResponse(

--- a/app/api/execute/_lib/reserved-value.ts
+++ b/app/api/execute/_lib/reserved-value.ts
@@ -1,18 +1,41 @@
 import "server-only";
 
 import {
+  parseNativeValueLamports,
   parseNativeValueWei,
-  type ReservedValue,
 } from "@/lib/execute/native-value";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { isSolanaChain } from "@/lib/rpc/provider-factory";
 
 // parseNativeValueWei lives in lib/execute so both the direct-execution routes
 // (here) and the workflow step wrappers can charge native value against the
 // same cap. Imported above for local use (parseNodeNativeValueWei), and
 // re-exported for the routes/tests that import it from this path.
 export {
+  parseNativeValueLamports,
   parseNativeValueWei,
   type ReservedValue,
 } from "@/lib/execute/native-value";
+
+/**
+ * Solana write steps that can move native SOL by arbitrary means.
+ *
+ * Both build transactions from caller-supplied instruction data, so the value
+ * they move is not derivable from any config field: a raw instruction can
+ * invoke any program, and an Anchor call can move lamports through a CPI that
+ * never appears in the encoded arguments. Static inspection can only recognise
+ * the shapes it special-cases and would reserve "0" for everything else, which
+ * is the bypass itself.
+ *
+ * These steps therefore require an explicit `maxSol` ceiling, declared by the
+ * caller and enforced against the simulated balance delta before submit. The
+ * value reserved here is that declared ceiling, not the eventual actual spend;
+ * the adapter reconciles the ledger down to the true delta after confirmation.
+ */
+const SOLANA_DECLARED_VALUE_STEPS: ReadonlySet<string> = new Set([
+  "sendRawSolanaInstructionStep",
+  "callSolanaProgramStep",
+]);
 
 /**
  * Native value (wei) reserved for a generic node execution.
@@ -24,17 +47,77 @@ export {
  * transfers/approvals and off-chain steps have neither field and correctly
  * reserve "0". `value` is deliberately NOT read -- it names non-broadcasting
  * inputs on other steps (e.g. risk analysis), so charging it would be wrong.
+ *
+ * The field-name heuristic holds for EVM only because every value-forwarding
+ * EVM action happens to use `ethValue`. The Solana write steps carry no such
+ * field, so they are matched by step name and fail closed when no ceiling is
+ * declared rather than falling through to a "0" reservation.
+ *
+ * `maxSol` is parsed at SOL's native 9 decimals and charged against the org's
+ * separate lamports-denominated Solana cap, never against the wei cap. The two
+ * are different assets and the caps are independent, so no scaling fudge is
+ * needed to make them share a number.
  */
+export type NodeReservedValue =
+  | { ok: true; kind: "evm"; valueWei: string }
+  | { ok: true; kind: "solana"; valueLamports: string }
+  | { ok: false; error: string };
+
 export function parseNodeNativeValueWei(
   stepFunction: string,
   config: Record<string, unknown>
-): ReservedValue {
-  if (stepFunction === "transferFundsStep") {
-    return parseNativeValueWei(
-      typeof config.amount === "string" ? config.amount : undefined
-    );
+): NodeReservedValue {
+  if (SOLANA_DECLARED_VALUE_STEPS.has(stepFunction)) {
+    const declared = typeof config.maxSol === "string" ? config.maxSol : "";
+    if (declared.trim() === "") {
+      return {
+        ok: false,
+        error:
+          "maxSol is required for this action: declare the maximum SOL the transaction may move so it can be charged against the organization's daily Solana value cap",
+      };
+    }
+    const parsed = parseNativeValueLamports(declared);
+    return parsed.ok
+      ? { ok: true, kind: "solana", valueLamports: parsed.valueWei }
+      : parsed;
   }
-  return parseNativeValueWei(
+
+  // transferFundsStep is chain-agnostic - transfer-funds-core branches to a
+  // Solana path on a Solana chainId - so the amount's unit depends on the
+  // configured network, not on the step name. Without this a native SOL
+  // transfer would be parsed at 18 decimals and charged to the wei cap.
+  if (stepFunction === "transferFundsStep") {
+    const amount =
+      typeof config.amount === "string" ? config.amount : undefined;
+    if (isSolanaNetwork(config.network)) {
+      const parsed = parseNativeValueLamports(amount);
+      return parsed.ok
+        ? { ok: true, kind: "solana", valueLamports: parsed.valueWei }
+        : parsed;
+    }
+    const parsed = parseNativeValueWei(amount);
+    return parsed.ok
+      ? { ok: true, kind: "evm", valueWei: parsed.valueWei }
+      : parsed;
+  }
+
+  const parsed = parseNativeValueWei(
     typeof config.ethValue === "string" ? config.ethValue : undefined
   );
+  return parsed.ok
+    ? { ok: true, kind: "evm", valueWei: parsed.valueWei }
+    : parsed;
+}
+
+/**
+ * Whether a config `network` value denotes a Solana chain. Unresolvable or
+ * absent networks fall through to EVM, matching how the rest of the reservation
+ * path treats an unknown chain.
+ */
+export function isSolanaNetwork(network: unknown): boolean {
+  if (typeof network !== "string" || network.trim() === "") {
+    return false;
+  }
+  const chainId = getChainIdFromNetwork(network);
+  return typeof chainId === "number" && isSolanaChain(chainId);
 }

--- a/app/api/execute/_lib/spending-cap.ts
+++ b/app/api/execute/_lib/spending-cap.ts
@@ -3,7 +3,10 @@ import "server-only";
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { directExecutions, organizationSpendCaps } from "@/lib/db/schema";
-import { sumOrgValueTodayWei } from "@/lib/execute/value-ledger";
+import {
+  sumOrgSolanaValueTodayLamports,
+  sumOrgValueTodayWei,
+} from "@/lib/execute/value-ledger";
 import { generateId } from "@/lib/utils/id";
 
 export type SpendCapResult =
@@ -17,9 +20,16 @@ type ReserveExecutionParams = {
   network?: string;
   // biome-ignore lint/suspicious/noExplicitAny: jsonb column accepts arbitrary serializable data
   input: any;
-  // Native notional value (wei) this execution moves. "0" for token-only or
-  // no-value calls. Charged against the org's daily value cap at reservation.
-  reservedValueWei: string;
+  // Native notional value this execution moves, and which chain family's cap it
+  // is charged against. "0" for token-only or no-value calls. EVM amounts are
+  // wei and charge dailyValueCapWei; Solana amounts are lamports and charge
+  // dailySolanaValueCapLamports. The two caps and their ledger columns are
+  // independent - a Solana execution is never charged against the wei cap and
+  // vice versa - because wei and lamports are different units and the caps are
+  // set in different assets.
+  reserved:
+    | { kind: "evm"; valueWei: string }
+    | { kind: "solana"; valueLamports: string };
 };
 
 type ReserveResult =
@@ -30,23 +40,37 @@ type ReserveResult =
  * Atomically check the daily value cap and create the execution record.
  *
  * The cap bounds the native notional VALUE moved per org per day, not gas.
- * `reservedValueWei` (known at request time) is charged against
- * `organizationSpendCaps.dailyValueCapWei` inside a SELECT FOR UPDATE on the
- * cap row, which serializes concurrent requests for the same organization. The
- * execution record is inserted in the same transaction carrying its
- * `valueWei`, so the reserved value is immediately visible to subsequent
- * callers -- closing the TOCTOU that the old gas-based cap had (pending/running
- * rows had null gasUsedWei and contributed 0 to the SUM).
+ * `params.reserved` (known at request time) is charged against the cap for its
+ * chain family inside a SELECT FOR UPDATE on the cap row, which serializes
+ * concurrent requests for the same organization. The execution record is
+ * inserted in the same transaction carrying its value, so the reservation is
+ * immediately visible to subsequent callers -- closing the TOCTOU that the old
+ * gas-based cap had (pending/running rows had null gasUsedWei and contributed 0
+ * to the SUM).
  *
- * The cap is the org's `dailyValueCapWei`, set by org admins/owners. When no
- * cap row exists, or it is null, value spending is unlimited.
+ * There are two independent caps, both set by org admins/owners:
+ *   EVM    -> dailyValueCapWei             charged in wei      (18 decimals)
+ *   Solana -> dailySolanaValueCapLamports  charged in lamports (9 decimals)
+ *
+ * They are deliberately not one number. An admin sets the wei cap thinking in
+ * ETH; folding SOL into it would compare non-commensurable assets against a
+ * single figure, and scaling SOL to 18 decimals to fit was only ever a
+ * workaround for the missing second cap. Each cap sums only its own ledger
+ * column, so neither chain family's activity consumes the other's budget.
+ *
+ * When no cap row exists, or the column for that family is null, spending of
+ * that kind is unlimited. An unset Solana cap does NOT fall back to the wei cap.
  */
 export async function checkAndReserveExecution(
   params: ReserveExecutionParams
 ): Promise<ReserveResult> {
   return await db.transaction(async (tx) => {
     const caps = await tx
-      .select({ dailyValueCapWei: organizationSpendCaps.dailyValueCapWei })
+      .select({
+        dailyValueCapWei: organizationSpendCaps.dailyValueCapWei,
+        dailySolanaValueCapLamports:
+          organizationSpendCaps.dailySolanaValueCapLamports,
+      })
       .from(organizationSpendCaps)
       .where(eq(organizationSpendCaps.organizationId, params.organizationId))
       .for("update")
@@ -54,6 +78,7 @@ export async function checkAndReserveExecution(
 
     const cap = caps[0];
     const id = generateId();
+    const isSolana = params.reserved.kind === "solana";
 
     const insertReservation = () =>
       tx.insert(directExecutions).values({
@@ -63,12 +88,25 @@ export async function checkAndReserveExecution(
         type: params.type,
         network: params.network ?? null,
         input: params.input,
-        valueWei: params.reservedValueWei,
+        // Exactly one unit column is written per row, so each daily SUM stays
+        // single-unit.
+        valueWei:
+          params.reserved.kind === "evm" ? params.reserved.valueWei : null,
+        valueLamports:
+          params.reserved.kind === "solana"
+            ? params.reserved.valueLamports
+            : null,
         status: "pending",
       });
 
-    // No cap configured (no row, or value cap unset) -> unlimited.
-    if (!cap || cap.dailyValueCapWei === null) {
+    const configuredCap = isSolana
+      ? cap?.dailySolanaValueCapLamports
+      : cap?.dailyValueCapWei;
+
+    // No cap configured for this chain family (no row, or that column unset)
+    // -> unlimited. The two caps are independent: an unset Solana cap does NOT
+    // fall back to the wei cap.
+    if (!cap || configuredCap === null || configuredCap === undefined) {
       await insertReservation();
       return { allowed: true, executionId: id } as const;
     }
@@ -77,13 +115,24 @@ export async function checkAndReserveExecution(
     // protocol value ledger) so a direct-API request is charged against value
     // moved by workflow runs too, and cannot exceed the cap by racing them.
     // Runs inside this FOR UPDATE tx, so it is consistent under concurrency.
-    const totalWei = await sumOrgValueTodayWei(tx, params.organizationId);
-    const reservedWei = BigInt(params.reservedValueWei);
-    const dailyCap = BigInt(cap.dailyValueCapWei);
+    const total = isSolana
+      ? await sumOrgSolanaValueTodayLamports(tx, params.organizationId)
+      : await sumOrgValueTodayWei(tx, params.organizationId);
+    const reserved = BigInt(
+      params.reserved.kind === "solana"
+        ? params.reserved.valueLamports
+        : params.reserved.valueWei
+    );
+    const dailyCap = BigInt(configuredCap);
 
     // Pre-charge: deny if this request would push the day's total over the cap.
-    if (totalWei + reservedWei > dailyCap) {
-      return { allowed: false, reason: "Daily spending cap exceeded" } as const;
+    if (total + reserved > dailyCap) {
+      return {
+        allowed: false,
+        reason: isSolana
+          ? "Daily Solana spending cap exceeded"
+          : "Daily spending cap exceeded",
+      } as const;
     }
 
     await insertReservation();

--- a/app/api/execute/check-and-execute/route.ts
+++ b/app/api/execute/check-and-execute/route.ts
@@ -147,7 +147,7 @@ async function executeConditionalWrite(
     input: redactedInput,
     // The conditional write never forwards native value (writeContractCore is
     // called without ethValue), so nothing is charged to the value cap here.
-    reservedValueWei: "0",
+    reserved: { kind: "evm", valueWei: "0" },
   });
   if (!reserve.allowed) {
     return recordIdempotentResponse(

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -164,7 +164,7 @@ async function handleWriteCall(
     type: "contract-call",
     network: body.network as string,
     input: redactedInput,
-    reservedValueWei: parsedValue.valueWei,
+    reserved: { kind: "evm", valueWei: parsedValue.valueWei },
   });
   if (!reserve.allowed) {
     return recordIdempotentResponse(

--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -627,7 +627,10 @@ export async function POST(request: Request): Promise<NextResponse> {
       type: resolved.actionType,
       network: effectiveNetwork,
       input: redactedInput,
-      reservedValueWei: parsedValue.valueWei,
+      reserved:
+        parsedValue.kind === "solana"
+          ? { kind: "solana", valueLamports: parsedValue.valueLamports }
+          : { kind: "evm", valueWei: parsedValue.valueWei },
     });
     if (!reserve.allowed) {
       return applyRateLimitHeaders(

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -29,7 +29,11 @@ import {
   withRejectedSignerOverride,
 } from "../_lib/execution-service";
 import { checkRateLimit } from "../_lib/rate-limit";
-import { parseNativeValueWei } from "../_lib/reserved-value";
+import {
+  isSolanaNetwork,
+  parseNativeValueLamports,
+  parseNativeValueWei,
+} from "../_lib/reserved-value";
 import { parseSimulateFlag } from "../_lib/simulate-flag";
 import { checkAndReserveExecution } from "../_lib/spending-cap";
 import { validateTokenFields, validateTransferInput } from "../_lib/validate";
@@ -187,12 +191,20 @@ export async function POST(request: Request): Promise<NextResponse> {
   }
 
   // 6. Spending cap + create execution atomically. Native transfers charge
-  // their ETH value against the daily value cap; ERC-20 transfers move no
-  // native value (token value is not yet priced into the cap) so reserve 0.
+  // their value against the daily cap for the chain family: this route serves
+  // Solana too (transferFundsCore branches on a Solana chainId), so a SOL
+  // transfer is parsed at 9 decimals and charged to the lamports cap rather
+  // than being scaled to 18 and charged to the ETH-denominated one. Token
+  // transfers move no native value (token value is not yet priced into the
+  // cap) so reserve 0.
   const redactedInput = redactInput(withRejectedSignerOverride(body, body));
+  const isSolanaTransfer = isSolanaNetwork(network);
   let reservedValueWei = "0";
+  let reservedValueLamports = "0";
   if (!isTokenTransfer) {
-    const parsedValue = parseNativeValueWei(amount);
+    const parsedValue = isSolanaTransfer
+      ? parseNativeValueLamports(amount)
+      : parseNativeValueWei(amount);
     if (!parsedValue.ok) {
       return applyRateLimitHeaders(
         await recordIdempotentResponse(
@@ -206,7 +218,11 @@ export async function POST(request: Request): Promise<NextResponse> {
         rateLimit
       );
     }
-    reservedValueWei = parsedValue.valueWei;
+    if (isSolanaTransfer) {
+      reservedValueLamports = parsedValue.valueWei;
+    } else {
+      reservedValueWei = parsedValue.valueWei;
+    }
   }
   const reserve = await checkAndReserveExecution({
     organizationId: apiKeyCtx.organizationId,
@@ -214,7 +230,9 @@ export async function POST(request: Request): Promise<NextResponse> {
     type: "transfer",
     network,
     input: redactedInput,
-    reservedValueWei,
+    reserved: isSolanaTransfer
+      ? { kind: "solana", valueLamports: reservedValueLamports }
+      : { kind: "evm", valueWei: reservedValueWei },
   });
   if (!reserve.allowed) {
     // Pre-broadcast gating failure: release so the same key can be retried.

--- a/components/organization/spend-cap-section.tsx
+++ b/components/organization/spend-cap-section.tsx
@@ -10,43 +10,147 @@ import { Label } from "@/components/ui/label";
 type SpendCapResponse = {
   dailyCapWei: string | null;
   dailyUsedWei: string;
+  dailySolanaCapLamports: string | null;
+  dailySolanaUsedLamports: string;
 };
 
-function formatWeiToEth(wei: string): string {
+// Native decimals per chain family. The two caps are stored in their own base
+// units (wei / lamports) and are never converted into one another: they bound
+// different assets, so a single shared figure would be meaningless.
+const EVM_DECIMALS = 18;
+const SOLANA_DECIMALS = 9;
+
+function formatBase(base: string, decimals: number): string {
   try {
-    return ethers.formatEther(wei);
+    return ethers.formatUnits(base, decimals);
   } catch {
     return "0";
   }
 }
 
-function parseEthToWei(input: string): string | null {
+function parseToBase(input: string, decimals: number): string | null {
   const trimmed = input.trim();
   if (trimmed === "") {
     return null;
   }
   try {
-    const wei = ethers.parseEther(trimmed);
-    // ethers.parseEther("-5") yields a negative BigInt without throwing; the
-    // cap must be non-negative (the server also rejects it).
-    return wei < BigInt(0) ? null : wei.toString();
+    const parsed = ethers.parseUnits(trimmed, decimals);
+    // parseUnits("-5") yields a negative BigInt without throwing; the cap must
+    // be non-negative (the server also rejects it).
+    return parsed < BigInt(0) ? null : parsed.toString();
   } catch {
     return null;
   }
 }
 
+type CapControlProps = {
+  id: string;
+  label: string;
+  symbol: string;
+  decimals: number;
+  cap: string | null;
+  used: string;
+  disabled: boolean;
+  saving: boolean;
+  onSave: (base: string | null) => void;
+};
+
+function CapControl({
+  id,
+  label,
+  symbol,
+  decimals,
+  cap,
+  used,
+  disabled,
+  saving,
+  onSave,
+}: CapControlProps): React.ReactElement {
+  const [input, setInput] = useState("");
+
+  // Re-sync the field whenever the persisted cap changes (initial load, save,
+  // or clear), so the input always reflects what is actually stored.
+  useEffect(() => {
+    setInput(cap ? formatBase(cap, decimals) : "");
+  }, [cap, decimals]);
+
+  const handleSave = useCallback(() => {
+    // An empty field clears the cap, matching the "Leave empty for no cap" hint.
+    if (input.trim() === "") {
+      onSave(null);
+      return;
+    }
+    const base = parseToBase(input, decimals);
+    if (base === null) {
+      toast.error(
+        `Enter a valid ${symbol} amount (up to ${decimals} decimals)`
+      );
+      return;
+    }
+    onSave(base);
+  }, [input, decimals, symbol, onSave]);
+
+  const usedDisplay = formatBase(used, decimals);
+
+  return (
+    <div className="space-y-2">
+      <Label className="text-sm" htmlFor={id}>
+        {label}
+      </Label>
+      <Input
+        disabled={disabled}
+        id={id}
+        inputMode="decimal"
+        onChange={(e) => setInput(e.target.value)}
+        placeholder="e.g. 1.5"
+        value={input}
+      />
+      <p className="text-muted-foreground text-xs">
+        {cap
+          ? `Current cap: ${formatBase(cap, decimals)} ${symbol}/day - used ${usedDisplay} ${symbol} today`
+          : `No cap set - used ${usedDisplay} ${symbol} today`}
+      </p>
+      <div className="flex gap-2">
+        <Button
+          className="flex-1"
+          disabled={disabled}
+          onClick={handleSave}
+          size="sm"
+          variant="outline"
+        >
+          {saving ? "Saving..." : "Save cap"}
+        </Button>
+        <Button
+          disabled={disabled || !cap}
+          onClick={() => onSave(null)}
+          size="sm"
+          variant="ghost"
+        >
+          Clear
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 /**
- * Organization daily value-cap control. Reads and writes the active org's
- * `daily_value_cap_wei` via /api/analytics/spend-cap; the PUT is gated server
- * side by `organization:update` (owner/admin) over the session, so this only
- * mounts inside an admin-gated surface.
+ * Organization daily value-cap controls. Reads and writes the active org's
+ * `daily_value_cap_wei` and `daily_solana_value_cap_lamports` via
+ * /api/analytics/spend-cap; the PUT is gated server side by
+ * `organization:update` (owner/admin) over the session, so this only mounts
+ * inside an admin-gated surface.
+ *
+ * The two caps are independent and saved independently - each control sends
+ * only its own field, and the route leaves an omitted field untouched, so
+ * saving one cap cannot clear the other.
  */
 export function SpendCapSection(): React.ReactElement {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [capWei, setCapWei] = useState<string | null>(null);
   const [usedWei, setUsedWei] = useState("0");
-  const [input, setInput] = useState("");
+  const [capLamports, setCapLamports] = useState<string | null>(null);
+  const [usedLamports, setUsedLamports] = useState("0");
 
   const load = useCallback(() => {
     setLoading(true);
@@ -58,7 +162,8 @@ export function SpendCapSection(): React.ReactElement {
         }
         setCapWei(data.dailyCapWei);
         setUsedWei(data.dailyUsedWei);
-        setInput(data.dailyCapWei ? formatWeiToEth(data.dailyCapWei) : "");
+        setCapLamports(data.dailySolanaCapLamports);
+        setUsedLamports(data.dailySolanaUsedLamports);
       })
       .catch(() => {
         toast.error("Could not load the spend cap");
@@ -70,96 +175,86 @@ export function SpendCapSection(): React.ReactElement {
     load();
   }, [load]);
 
-  const save = useCallback(async (dailyValueCapWei: string | null) => {
-    setSaving(true);
-    try {
-      const res = await fetch("/api/analytics/spend-cap", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ dailyValueCapWei }),
-      });
-      if (res.ok) {
-        setCapWei(dailyValueCapWei);
-        setInput(dailyValueCapWei ? formatWeiToEth(dailyValueCapWei) : "");
-        toast.success(
-          dailyValueCapWei ? "Daily value cap saved" : "Daily value cap cleared"
-        );
-      } else if (res.status === 403) {
-        toast.error("Only organization owners and admins can change the cap");
-      } else {
+  const save = useCallback(
+    async (
+      field: "dailyValueCapWei" | "dailySolanaValueCapLamports",
+      base: string | null
+    ) => {
+      setSaving(true);
+      try {
+        const res = await fetch("/api/analytics/spend-cap", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          // Only this control's field is sent; the other cap is left untouched.
+          body: JSON.stringify({ [field]: base }),
+        });
+        if (res.ok) {
+          if (field === "dailyValueCapWei") {
+            setCapWei(base);
+          } else {
+            setCapLamports(base);
+          }
+          toast.success(
+            base ? "Daily value cap saved" : "Daily value cap cleared"
+          );
+        } else if (res.status === 403) {
+          toast.error("Only organization owners and admins can change the cap");
+        } else {
+          toast.error("Could not save the cap");
+        }
+      } catch {
         toast.error("Could not save the cap");
+      } finally {
+        setSaving(false);
       }
-    } catch {
-      toast.error("Could not save the cap");
-    } finally {
-      setSaving(false);
-    }
-  }, []);
+    },
+    []
+  );
 
-  const handleSave = useCallback(() => {
-    // An empty field clears the cap, matching the "Leave empty for no cap" hint.
-    if (input.trim() === "") {
-      save(null);
-      return;
-    }
-    const wei = parseEthToWei(input);
-    if (wei === null) {
-      toast.error("Enter a valid ETH amount (up to 18 decimals)");
-      return;
-    }
-    save(wei);
-  }, [input, save]);
-
-  const usedEth = formatWeiToEth(usedWei);
+  const saveEvm = useCallback(
+    (base: string | null) => save("dailyValueCapWei", base),
+    [save]
+  );
+  const saveSolana = useCallback(
+    (base: string | null) => save("dailySolanaValueCapLamports", base),
+    [save]
+  );
 
   return (
     <div className="space-y-3">
       <h4 className="font-medium text-muted-foreground text-sm">
-        Daily value cap
+        Daily value caps
       </h4>
       <p className="text-muted-foreground text-xs">
-        Limits the total native value (ETH) that direct execution API calls can
-        move per day for this organization. Leave empty for no cap.
+        Limits the total native value that direct execution API calls and
+        workflow runs can move per day for this organization. EVM and Solana are
+        capped separately, in their own currencies. Leave a field empty for no
+        cap.
       </p>
 
-      <div className="space-y-2">
-        <Label className="text-sm" htmlFor="daily-value-cap">
-          Cap (ETH per day)
-        </Label>
-        <Input
-          disabled={loading || saving}
-          id="daily-value-cap"
-          inputMode="decimal"
-          onChange={(e) => setInput(e.target.value)}
-          placeholder="e.g. 1.5"
-          value={input}
-        />
-        <p className="text-muted-foreground text-xs">
-          {capWei
-            ? `Current cap: ${formatWeiToEth(capWei)} ETH/day - used ${usedEth} ETH today`
-            : `No cap set - used ${usedEth} ETH today`}
-        </p>
-      </div>
+      <CapControl
+        cap={capWei}
+        decimals={EVM_DECIMALS}
+        disabled={loading || saving}
+        id="daily-value-cap"
+        label="EVM cap (ETH per day)"
+        onSave={saveEvm}
+        saving={saving}
+        symbol="ETH"
+        used={usedWei}
+      />
 
-      <div className="flex gap-2">
-        <Button
-          className="flex-1"
-          disabled={loading || saving}
-          onClick={handleSave}
-          size="sm"
-          variant="outline"
-        >
-          {saving ? "Saving..." : "Save cap"}
-        </Button>
-        <Button
-          disabled={loading || saving || !capWei}
-          onClick={() => save(null)}
-          size="sm"
-          variant="ghost"
-        >
-          Clear
-        </Button>
-      </div>
+      <CapControl
+        cap={capLamports}
+        decimals={SOLANA_DECIMALS}
+        disabled={loading || saving}
+        id="daily-solana-value-cap"
+        label="Solana cap (SOL per day)"
+        onSave={saveSolana}
+        saving={saving}
+        symbol="SOL"
+        used={usedLamports}
+      />
     </div>
   );
 }

--- a/drizzle/0131_keep_1017_solana_value_cap.sql
+++ b/drizzle/0131_keep_1017_solana_value_cap.sql
@@ -1,0 +1,11 @@
+-- Per-org daily Solana native-value cap, denominated in lamports.
+--
+-- Solana value is deliberately NOT charged against daily_value_cap_wei: that
+-- column is wei-denominated and admins set it thinking in ETH, so folding SOL
+-- into it would compare two non-commensurable assets against a single number.
+-- A separate column lets SOL be accounted at its true 9-decimal precision.
+--
+-- Nullable with no default, so adding it is a metadata-only change (no table
+-- rewrite, no lock of consequence) and every existing org keeps unlimited
+-- Solana spending until an admin sets a value.
+ALTER TABLE "organization_spend_caps" ADD COLUMN IF NOT EXISTS "daily_solana_value_cap_lamports" text;

--- a/drizzle/0132_keep_1017_value_lamports.sql
+++ b/drizzle/0132_keep_1017_value_lamports.sql
@@ -1,0 +1,16 @@
+-- Lamports-denominated value columns for the two daily-cap ledger stores.
+--
+-- Kept separate from the existing value_wei columns rather than reusing them:
+-- the daily cap sums these per org, and wei (1e18) and lamports (1e9) are
+-- different units, so a shared column would silently add the two scales
+-- together and understate cap usage.
+--
+-- Exactly one of value_wei / value_lamports carries the real figure per row.
+-- org_value_reservations.value_wei is NOT NULL and predates this, so Solana
+-- rows there carry "0" in value_wei; the wei SUM is therefore unaffected by
+-- Solana activity, and the lamports SUM is unaffected by EVM activity.
+--
+-- Both columns are nullable with no default, so these are metadata-only adds
+-- (no table rewrite).
+ALTER TABLE "direct_executions" ADD COLUMN IF NOT EXISTS "value_lamports" text;
+ALTER TABLE "org_value_reservations" ADD COLUMN IF NOT EXISTS "value_lamports" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -918,6 +918,20 @@
       "when": 1784120180000,
       "tag": "0130_keep_974_dispatch_key",
       "breakpoints": true
+    },
+    {
+      "idx": 131,
+      "version": "7",
+      "when": 1784120180001,
+      "tag": "0131_keep_1017_solana_value_cap",
+      "breakpoints": true
+    },
+    {
+      "idx": 132,
+      "version": "7",
+      "when": 1784120180002,
+      "tag": "0132_keep_1017_value_lamports",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -26,7 +26,10 @@ import {
 } from "@/lib/db/schema-extensions";
 import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 import { ERROR_STATUSES } from "@/lib/errors/execution-status";
-import { sumOrgValueTodayWei } from "@/lib/execute/value-ledger";
+import {
+  sumOrgSolanaValueTodayLamports,
+  sumOrgValueTodayWei,
+} from "@/lib/execute/value-ledger";
 import { redactAllUrls, redactSecretUrls } from "@/lib/rpc/scrub-rpc-urls";
 import { analyticsCacheKey, cachedAnalytics } from "./cache";
 import {
@@ -1337,24 +1340,36 @@ export async function getStepLogs(
 export async function getSpendCapData(organizationId: string): Promise<{
   dailyCapWei: string | null;
   dailyUsedWei: string;
+  dailySolanaCapLamports: string | null;
+  dailySolanaUsedLamports: string;
 }> {
   // Mirror spending-cap enforcement exactly: the notional VALUE moved per org
   // per day, summed across BOTH stores (direct executions AND the workflow/
   // protocol value ledger, with the same stale-window aging), against the org's
   // daily value cap. Using the shared SUM keeps the gauge honest -- it shows the
   // same number enforcement checks, so workflow spend counts too.
-  const [capResult, dailyUsedWei] = await Promise.all([
+  // Solana is reported alongside as its own pair: its cap and usage are
+  // lamports-denominated and enforced against a separate column, so folding
+  // them into the wei figures would misreport both gauges.
+  const [capResult, dailyUsedWei, dailySolanaUsedLamports] = await Promise.all([
     db
-      .select({ dailyValueCapWei: organizationSpendCaps.dailyValueCapWei })
+      .select({
+        dailyValueCapWei: organizationSpendCaps.dailyValueCapWei,
+        dailySolanaValueCapLamports:
+          organizationSpendCaps.dailySolanaValueCapLamports,
+      })
       .from(organizationSpendCaps)
       .where(eq(organizationSpendCaps.organizationId, organizationId))
       .limit(1),
     sumOrgValueTodayWei(db, organizationId),
+    sumOrgSolanaValueTodayLamports(db, organizationId),
   ]);
 
   return {
     dailyCapWei: capResult[0]?.dailyValueCapWei ?? null,
     dailyUsedWei: dailyUsedWei.toString(),
+    dailySolanaCapLamports: capResult[0]?.dailySolanaValueCapLamports ?? null,
+    dailySolanaUsedLamports: dailySolanaUsedLamports.toString(),
   };
 }
 

--- a/lib/db/schema-extensions.ts
+++ b/lib/db/schema-extensions.ts
@@ -634,6 +634,12 @@ export const directExecutions = pgTable(
     // that move no native value (treated as 0). ERC-20 token value is not yet
     // priced into this figure.
     valueWei: text("value_wei"),
+    // Native notional value (lamports) a Solana execution moves. Deliberately a
+    // separate column from valueWei rather than a shared one: the daily cap sums
+    // these per org, and wei and lamports are different units, so a shared
+    // column would silently add 1e18-scaled and 1e9-scaled figures together.
+    // Exactly one of valueWei / valueLamports is set per row.
+    valueLamports: text("value_lamports"),
     // Populated by a future price-oracle integration; null until then
     estimatedCostUsd: text("estimated_cost_usd"),
     retryCount: integer("retry_count").notNull().default(0),
@@ -710,8 +716,17 @@ export type NewIdempotencyRecord = typeof idempotencyRecords.$inferInsert;
  * gas-denominated figure, no longer enforced or displayed; nullable so a
  * value-only cap row can be created without it.
  *
- * When no row exists for an org, or `dailyValueCapWei` is null, value spending
- * is unlimited (no cap enforced).
+ * `dailySolanaValueCapLamports` is the Solana equivalent, denominated in
+ * lamports. Solana native value is NOT charged against `dailyValueCapWei`:
+ * that column is wei-denominated and an admin sets it thinking in ETH, so
+ * mixing SOL into it would compare two non-commensurable assets against one
+ * number. Keeping a separate per-chain-family cap is what lets SOL be
+ * accounted at its true 9-decimal precision instead of being scaled to 18
+ * decimals to share the ETH cap.
+ *
+ * When no row exists for an org, or the relevant cap column is null, spending
+ * of that kind is unlimited (no cap enforced). The two caps are independent:
+ * a null Solana cap does not fall back to the wei cap.
  */
 export const organizationSpendCaps = pgTable("organization_spend_caps", {
   id: text("id")
@@ -723,6 +738,7 @@ export const organizationSpendCaps = pgTable("organization_spend_caps", {
     .references(() => organization.id),
   dailyCapWei: text("daily_cap_wei"),
   dailyValueCapWei: text("daily_value_cap_wei"),
+  dailySolanaValueCapLamports: text("daily_solana_value_cap_lamports"),
   createdAt: timestamp("created_at").notNull().defaultNow(),
   updatedAt: timestamp("updated_at").notNull().defaultNow(),
 });
@@ -752,6 +768,12 @@ export const orgValueReservations = pgTable(
       .notNull()
       .references(() => organization.id),
     valueWei: text("value_wei").notNull(),
+    // Native notional value (lamports) for Solana reservations. Separate from
+    // valueWei because the two are different units and each daily cap sums only
+    // its own column. A Solana row carries valueWei "0" (the column is NOT NULL
+    // and predates this) plus the real figure here, so the wei SUM is unaffected
+    // by Solana activity and vice versa.
+    valueLamports: text("value_lamports"),
     status: text("status").notNull().default("reserved"), // reserved | settled | released
     // Origin of the value-moving execution, for audit only.
     source: text("source"), // direct | workflow | protocol

--- a/lib/execute/native-value.ts
+++ b/lib/execute/native-value.ts
@@ -7,6 +7,13 @@ export type ReservedValue =
   | { ok: false; error: string };
 
 /**
+ * Native decimals by chain family. EVM natives are 18; SOL is 9 (1 SOL =
+ * 1e9 lamports).
+ */
+export const EVM_NATIVE_DECIMALS = 18;
+export const SOLANA_NATIVE_DECIMALS = 9;
+
+/**
  * Native notional value (in wei) an execution will move, used by the per-org
  * daily spending cap. Parses a human-decimal ETH amount (e.g. "1.5") the same
  * way the web3 cores do (`ethers.parseEther`).
@@ -32,6 +39,45 @@ export function parseNativeValueWei(
   let parsed: bigint;
   try {
     parsed = ethers.parseEther(rawAmount);
+  } catch {
+    return { ok: false, error: `Invalid value amount: ${rawAmount}` };
+  }
+
+  if (parsed < BigInt(0)) {
+    return {
+      ok: false,
+      error: `Value amount must not be negative: ${rawAmount}`,
+    };
+  }
+
+  return { ok: true, valueWei: parsed.toString() };
+}
+
+/**
+ * Native notional value in LAMPORTS a Solana execution will move, used by the
+ * per-org daily Solana cap (`organizationSpendCaps.dailySolanaValueCapLamports`).
+ *
+ * Parses a human-decimal SOL amount (e.g. "1.5") at SOL's true 9 decimals
+ * rather than reusing `parseNativeValueWei`, whose `ethers.parseEther` is fixed
+ * at 18. Charging SOL on an 18-decimal scale was only ever a workaround for
+ * having a single wei-denominated cap; with a dedicated lamports cap the
+ * accurate unit is both correct and safe.
+ *
+ * Mirrors `parseNativeValueWei`'s contract exactly: absent/empty reserves "0",
+ * malformed returns `{ ok: false }` for the caller to decide, and negatives are
+ * rejected (a negative reservation would lower the day's SUM and bank credit
+ * against the cap).
+ */
+export function parseNativeValueLamports(
+  rawAmount: string | undefined | null
+): ReservedValue {
+  if (rawAmount === undefined || rawAmount === null || rawAmount === "") {
+    return { ok: true, valueWei: "0" };
+  }
+
+  let parsed: bigint;
+  try {
+    parsed = ethers.parseUnits(rawAmount, SOLANA_NATIVE_DECIMALS);
   } catch {
     return { ok: false, error: `Invalid value amount: ${rawAmount}` };
   }

--- a/lib/execute/value-ledger.ts
+++ b/lib/execute/value-ledger.ts
@@ -68,6 +68,57 @@ export async function sumOrgValueTodayWei(
 }
 
 /**
+ * Total native value (LAMPORTS) an org has moved / has in-flight today on
+ * Solana, summed across both stores. The Solana twin of `sumOrgValueTodayWei`,
+ * with identical staleness and status semantics.
+ *
+ * Sums the dedicated `value_lamports` columns rather than sharing `value_wei`:
+ * the two are different units (1e9 vs 1e18), so one column would add the scales
+ * together and understate usage against whichever cap was being checked. Rows
+ * belonging to the other chain family contribute NULL, which COALESCE folds to
+ * 0, so the two totals never contaminate each other.
+ */
+export async function sumOrgSolanaValueTodayLamports(
+  executor: Executor,
+  organizationId: string
+): Promise<bigint> {
+  const todayStart = new Date();
+  todayStart.setUTCHours(0, 0, 0, 0);
+
+  const directRows = await executor
+    .select({
+      totalLamports: sql<string>`COALESCE(SUM(CAST(${directExecutions.valueLamports} AS NUMERIC)), 0)::text`,
+    })
+    .from(directExecutions)
+    .where(
+      and(
+        eq(directExecutions.organizationId, organizationId),
+        ne(directExecutions.status, "failed"),
+        gte(directExecutions.createdAt, todayStart),
+        sql`(${directExecutions.status} = 'completed' OR ${directExecutions.createdAt} > now() - interval '${sql.raw(String(STALE_INFLIGHT_MINUTES))} minutes')`
+      )
+    );
+
+  const ledgerRows = await executor
+    .select({
+      totalLamports: sql<string>`COALESCE(SUM(CAST(${orgValueReservations.valueLamports} AS NUMERIC)), 0)::text`,
+    })
+    .from(orgValueReservations)
+    .where(
+      and(
+        eq(orgValueReservations.organizationId, organizationId),
+        ne(orgValueReservations.status, "released"),
+        gte(orgValueReservations.createdAt, todayStart),
+        sql`(${orgValueReservations.status} = 'settled' OR ${orgValueReservations.createdAt} > now() - interval '${sql.raw(String(STALE_INFLIGHT_MINUTES))} minutes')`
+      )
+    );
+
+  const direct = BigInt(directRows[0]?.totalLamports ?? "0");
+  const ledger = BigInt(ledgerRows[0]?.totalLamports ?? "0");
+  return direct + ledger;
+}
+
+/**
  * The org's total value moved today (wei) across both stores, for read-only
  * surfaces (the dashboard gauge). Uses the app db, not a transaction.
  */

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -484,7 +484,17 @@ const web3Plugin: IntegrationPlugin = {
           placeholder:
             '[{ "programId": "...", "accounts": [{ "pubkey": "...", "isSigner": false, "isWritable": true }], "data": "<base64 or 0x-hex>" }]',
           helpTip:
-            "A JSON array of Solana instructions. Each entry has a base58 programId, an ordered accounts array (pubkey plus isSigner/isWritable flags), and instruction data as standard base64 or 0x-hex. Only the organization wallet may be marked isSigner, and it is always the fee payer. There is no spend limit - any instruction here executes with the wallet's full authority, including moving its SOL or tokens, so use with caution.",
+            "A JSON array of Solana instructions. Each entry has a base58 programId, an ordered accounts array (pubkey plus isSigner/isWritable flags), and instruction data as standard base64 or 0x-hex. Only the organization wallet may be marked isSigner, and it is always the fee payer. Any instruction here executes with the wallet's full authority, including moving its SOL or tokens, so use with caution.",
+          required: true,
+        },
+        {
+          key: "maxSol",
+          label: "Max SOL to Move",
+          type: "template-input",
+          placeholder: "0.5 or {{NodeName.maxSol}}",
+          example: "0.5",
+          helpTip:
+            "The maximum SOL this transaction is permitted to move out of the organization wallet. Charged against the organization's daily value cap before the transaction is built, and enforced against the simulated balance change before it is submitted: if the simulation shows a larger outflow, the transaction is rejected rather than sent. Required, because the value an arbitrary instruction moves cannot be determined from the instruction data alone.",
           required: true,
         },
       ],
@@ -582,6 +592,16 @@ const web3Plugin: IntegrationPlugin = {
           placeholder: '{ "authority": "<base58>", "tokenAccount": "<base58>" }',
           helpTip:
             "A JSON object mapping each account name in the IDL instruction to its base58 pubkey. Accounts with a fixed address in the IDL (e.g. system program) are filled automatically, and a signer slot left empty defaults to the organization wallet. Only the organization wallet may sign.",
+        },
+        {
+          key: "maxSol",
+          label: "Max SOL to Move",
+          type: "template-input",
+          placeholder: "0.5 or {{NodeName.maxSol}}",
+          example: "0.5",
+          helpTip:
+            "The maximum SOL this instruction is permitted to move out of the organization wallet. Charged against the organization's daily value cap before the transaction is built, and enforced against the simulated balance change before it is submitted: if the simulation shows a larger outflow, the transaction is rejected rather than sent. Required, because an Anchor instruction can move lamports through a CPI that does not appear in its encoded arguments.",
+          required: true,
         },
       ],
     },

--- a/plugins/web3/steps/call-solana-program-core.ts
+++ b/plugins/web3/steps/call-solana-program-core.ts
@@ -28,7 +28,19 @@ export type CallSolanaProgramCoreInput = {
   instruction: string;
   args?: string | Record<string, unknown>;
   accounts?: string | Record<string, unknown>;
-  _context?: { executionId?: string; organizationId?: string };
+  /**
+   * Maximum SOL (human decimal) this instruction may move out of the
+   * organization wallet. Charged against the daily value cap before the
+   * transaction is built and enforced against the simulated balance delta
+   * before submit. Required: an Anchor instruction can move lamports through a
+   * CPI that never appears in its encoded arguments.
+   */
+  maxSol?: string;
+  _context?: {
+    executionId?: string;
+    organizationId?: string;
+    valueCapReserved?: boolean;
+  };
 };
 
 export type CallSolanaProgramResult =

--- a/plugins/web3/steps/call-solana-program.ts
+++ b/plugins/web3/steps/call-solana-program.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { withStepValueCap } from "@/lib/execute/value-ledger";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import {
   type StepInput,
@@ -34,7 +35,18 @@ export async function callSolanaProgramStep(
       actionName: "call-solana-program-anchor",
       executionId: input._context?.executionId,
     },
-    () => withStepLogging(input, () => callSolanaProgramCore(input))
+    () =>
+      withStepLogging(input, () =>
+        withStepValueCap(
+          {
+            organizationId: input._context?.organizationId,
+            amountEth: input.maxSol,
+            executionId: input._context?.executionId,
+            valueCapReserved: input._context?.valueCapReserved,
+          },
+          () => callSolanaProgramCore(input)
+        )
+      )
   );
 }
 

--- a/plugins/web3/steps/send-raw-solana-instruction-core.ts
+++ b/plugins/web3/steps/send-raw-solana-instruction-core.ts
@@ -46,7 +46,19 @@ export type RawSolanaInstruction = {
 export type SendRawSolanaInstructionCoreInput = {
   network: string;
   instructions: string | RawSolanaInstruction[];
-  _context?: { executionId?: string; organizationId?: string };
+  /**
+   * Maximum SOL (human decimal) this transaction may move out of the
+   * organization wallet. Charged against the daily value cap before the
+   * transaction is built and enforced against the simulated balance delta
+   * before submit. Required: an arbitrary instruction can invoke any program,
+   * so the value moved is not derivable from the instruction data.
+   */
+  maxSol?: string;
+  _context?: {
+    executionId?: string;
+    organizationId?: string;
+    valueCapReserved?: boolean;
+  };
 };
 
 export type SendRawSolanaInstructionResult =

--- a/plugins/web3/steps/send-raw-solana-instruction.ts
+++ b/plugins/web3/steps/send-raw-solana-instruction.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { withStepValueCap } from "@/lib/execute/value-ledger";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import {
   type StepInput,
@@ -35,7 +36,18 @@ export async function sendRawSolanaInstructionStep(
       actionName: "send-raw-solana-instruction",
       executionId: input._context?.executionId,
     },
-    () => withStepLogging(input, () => sendRawSolanaInstructionCore(input))
+    () =>
+      withStepLogging(input, () =>
+        withStepValueCap(
+          {
+            organizationId: input._context?.organizationId,
+            amountEth: input.maxSol,
+            executionId: input._context?.executionId,
+            valueCapReserved: input._context?.valueCapReserved,
+          },
+          () => sendRawSolanaInstructionCore(input)
+        )
+      )
   );
 }
 

--- a/tests/integration/direct-execution-api.test.ts
+++ b/tests/integration/direct-execution-api.test.ts
@@ -346,7 +346,7 @@ describe("Direct Execution API", () => {
       expect(mocks.checkAndReserveExecution).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "transfer",
-          reservedValueWei: "1000000000000000000",
+          reserved: { kind: "evm", valueWei: "1000000000000000000" },
         })
       );
     });
@@ -366,7 +366,9 @@ describe("Direct Execution API", () => {
       );
 
       expect(mocks.checkAndReserveExecution).toHaveBeenCalledWith(
-        expect.objectContaining({ reservedValueWei: "0" })
+        expect.objectContaining({
+          reserved: { kind: "evm", valueWei: "0" },
+        })
       );
     });
 

--- a/tests/integration/spend-cap-setter-route.test.ts
+++ b/tests/integration/spend-cap-setter-route.test.ts
@@ -119,6 +119,7 @@ describe("PUT /api/analytics/spend-cap", () => {
     expect(mocks.upsertValues).toHaveBeenCalledWith({
       organizationId: ORG_ID,
       dailyValueCapWei: "1000000000000000000",
+      dailySolanaValueCapLamports: null,
     });
     expect(mocks.upsertConflict).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -138,6 +139,7 @@ describe("PUT /api/analytics/spend-cap", () => {
     expect(mocks.upsertValues).toHaveBeenCalledWith({
       organizationId: ORG_ID,
       dailyValueCapWei: null,
+      dailySolanaValueCapLamports: null,
     });
   });
 });

--- a/tests/unit/reserved-value.test.ts
+++ b/tests/unit/reserved-value.test.ts
@@ -39,24 +39,24 @@ describe("parseNodeNativeValueWei", () => {
   it("charges a native transfer's amount", () => {
     expect(
       parseNodeNativeValueWei("transferFundsStep", { amount: "2" })
-    ).toEqual({ ok: true, valueWei: "2000000000000000000" });
+    ).toEqual({ ok: true, kind: "evm", valueWei: "2000000000000000000" });
   });
 
   it("charges a contract write's ethValue", () => {
     expect(
       parseNodeNativeValueWei("writeContractStep", { ethValue: "0.1" })
-    ).toEqual({ ok: true, valueWei: "100000000000000000" });
+    ).toEqual({ ok: true, kind: "evm", valueWei: "100000000000000000" });
   });
 
   it("ignores a token transfer's amount (no native value moved)", () => {
     expect(
       parseNodeNativeValueWei("transferTokenStep", { amount: "1000000" })
-    ).toEqual({ ok: true, valueWei: "0" });
+    ).toEqual({ ok: true, kind: "evm", valueWei: "0" });
   });
 
   it("reserves 0 for off-chain / unrecognized steps with no ethValue", () => {
     expect(parseNodeNativeValueWei("httpRequestStep", { amount: "5" })).toEqual(
-      { ok: true, valueWei: "0" }
+      { ok: true, kind: "evm", valueWei: "0" }
     );
   });
 
@@ -65,12 +65,72 @@ describe("parseNodeNativeValueWei", () => {
     // silently bypassing the cap with "0".
     expect(
       parseNodeNativeValueWei("someFutureWriteStep", { ethValue: "0.25" })
-    ).toEqual({ ok: true, valueWei: "250000000000000000" });
+    ).toEqual({ ok: true, kind: "evm", valueWei: "250000000000000000" });
   });
 
   it("propagates a parse failure for a value-bearing step", () => {
     expect(
       parseNodeNativeValueWei("transferFundsStep", { amount: "-5" }).ok
     ).toBe(false);
+  });
+});
+
+describe("parseNodeNativeValueWei Solana steps", () => {
+  it("requires maxSol on a raw instruction rather than reserving 0", () => {
+    const result = parseNodeNativeValueWei("sendRawSolanaInstructionStep", {
+      network: "103",
+      instructions: "[]",
+    });
+
+    // The bypass this guards: with no maxSol these steps previously fell
+    // through to the ethValue branch and reserved "0" while being able to move
+    // arbitrary SOL.
+    expect(result.ok).toBe(false);
+  });
+
+  it("requires maxSol on an Anchor program call", () => {
+    expect(
+      parseNodeNativeValueWei("callSolanaProgramStep", { network: "103" }).ok
+    ).toBe(false);
+  });
+
+  it("charges a declared maxSol in lamports, not wei", () => {
+    expect(
+      parseNodeNativeValueWei("sendRawSolanaInstructionStep", {
+        network: "103",
+        maxSol: "1.5",
+      })
+      // 1.5 SOL at SOL's native 9 decimals. An 18-decimal parse would yield
+      // 1500000000000000000 and charge the wrong cap.
+    ).toEqual({ ok: true, kind: "solana", valueLamports: "1500000000" });
+  });
+
+  it("rejects a blank maxSol instead of treating it as zero", () => {
+    expect(
+      parseNodeNativeValueWei("callSolanaProgramStep", {
+        network: "103",
+        maxSol: "   ",
+      }).ok
+    ).toBe(false);
+  });
+
+  it("parses a native transfer on a Solana network as lamports", () => {
+    // transferFundsStep is chain-agnostic, so its unit comes from the network,
+    // not the step name.
+    expect(
+      parseNodeNativeValueWei("transferFundsStep", {
+        network: "103",
+        amount: "0.001",
+      })
+    ).toEqual({ ok: true, kind: "solana", valueLamports: "1000000" });
+  });
+
+  it("still parses a native transfer on an EVM network as wei", () => {
+    expect(
+      parseNodeNativeValueWei("transferFundsStep", {
+        network: "1",
+        amount: "2",
+      })
+    ).toEqual({ ok: true, kind: "evm", valueWei: "2000000000000000000" });
   });
 });

--- a/tests/unit/spend-cap-route.test.ts
+++ b/tests/unit/spend-cap-route.test.ts
@@ -1,0 +1,219 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// Both HOCs are pass-throughs here: authorization is exercised elsewhere, and
+// these tests are about the route's own body parsing and column-write logic.
+vi.mock("@/lib/middleware/require-org", () => ({
+  requireOrganization:
+    (handler: (req: NextRequest, context: unknown) => Promise<Response>) =>
+    (req: NextRequest) =>
+      handler(req, { organization: { id: "org_1" } }),
+  requirePermission:
+    (
+      _resource: string,
+      _actions: string[],
+      handler: (req: NextRequest, context: unknown) => Promise<Response>
+    ) =>
+    (req: NextRequest) =>
+      handler(req, { organization: { id: "org_1" } }),
+}));
+
+vi.mock("@/lib/api-error", () => ({
+  apiError: (_e: unknown, message: string) =>
+    new Response(JSON.stringify({ error: message }), { status: 500 }),
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  organizationSpendCaps: { organizationId: "organization_id" },
+}));
+
+vi.mock("@/lib/analytics/queries", () => ({
+  getSpendCapData: vi.fn().mockResolvedValue({
+    dailyCapWei: "1000",
+    dailyUsedWei: "10",
+    dailySolanaCapLamports: "2000000000",
+    dailySolanaUsedLamports: "5",
+  }),
+}));
+
+// Captures what the route actually writes, which is the whole point: the `set`
+// object decides which columns are overwritten.
+const written = vi.hoisted(() => ({
+  values: null as Record<string, unknown> | null,
+  set: null as Record<string, unknown> | null,
+  calls: 0,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    insert: () => ({
+      values: (v: Record<string, unknown>) => {
+        written.values = v;
+        return {
+          onConflictDoUpdate: (arg: { set: Record<string, unknown> }) => {
+            written.set = arg.set;
+            written.calls += 1;
+            return Promise.resolve(undefined);
+          },
+        };
+      },
+    }),
+  },
+}));
+
+import { GET, PUT } from "@/app/api/analytics/spend-cap/route";
+
+function putRequest(body: unknown): NextRequest {
+  return {
+    json: () => Promise.resolve(body),
+  } as unknown as NextRequest;
+}
+
+function malformedRequest(): NextRequest {
+  return {
+    json: () => Promise.reject(new Error("bad json")),
+  } as unknown as NextRequest;
+}
+
+beforeEach(() => {
+  written.values = null;
+  written.set = null;
+  written.calls = 0;
+});
+
+describe("GET /api/analytics/spend-cap", () => {
+  it("returns both caps and both usage figures", async () => {
+    const res = await GET({} as NextRequest);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    // Each chain family reports its own cap and its own usage; sharing either
+    // would misreport both gauges.
+    expect(body).toEqual({
+      dailyCapWei: "1000",
+      dailyUsedWei: "10",
+      dailySolanaCapLamports: "2000000000",
+      dailySolanaUsedLamports: "5",
+    });
+  });
+});
+
+describe("PUT /api/analytics/spend-cap partial updates", () => {
+  it("writing only the Solana cap does NOT touch the wei cap", async () => {
+    const res = await PUT(
+      putRequest({ dailySolanaValueCapLamports: "2000000000" })
+    );
+
+    expect(res.status).toBe(200);
+    // The regression this guards: if dailyValueCapWei appeared in `set`, saving
+    // the Solana cap from its own control would silently clear the EVM cap.
+    expect(written.set).not.toHaveProperty("dailyValueCapWei");
+    expect(written.set).toMatchObject({
+      dailySolanaValueCapLamports: "2000000000",
+    });
+  });
+
+  it("writing only the wei cap does NOT touch the Solana cap", async () => {
+    const res = await PUT(putRequest({ dailyValueCapWei: "1000" }));
+
+    expect(res.status).toBe(200);
+    expect(written.set).not.toHaveProperty("dailySolanaValueCapLamports");
+    expect(written.set).toMatchObject({ dailyValueCapWei: "1000" });
+  });
+
+  it("writes both columns when both fields are supplied", async () => {
+    await PUT(
+      putRequest({
+        dailyValueCapWei: "1000",
+        dailySolanaValueCapLamports: "2000000000",
+      })
+    );
+
+    expect(written.set).toMatchObject({
+      dailyValueCapWei: "1000",
+      dailySolanaValueCapLamports: "2000000000",
+    });
+  });
+
+  it("treats an explicit null as a clear, distinct from omission", async () => {
+    await PUT(putRequest({ dailySolanaValueCapLamports: null }));
+
+    // Present-but-null must reach the column as null (clear), while the
+    // omitted wei cap stays absent (unchanged).
+    expect(written.set).toHaveProperty("dailySolanaValueCapLamports", null);
+    expect(written.set).not.toHaveProperty("dailyValueCapWei");
+  });
+
+  it("echoes back only the fields that were supplied", async () => {
+    const res = await PUT(
+      putRequest({ dailySolanaValueCapLamports: "2000000000" })
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(body).toEqual({ dailySolanaValueCapLamports: "2000000000" });
+  });
+});
+
+describe("PUT /api/analytics/spend-cap validation", () => {
+  it("rejects an empty body rather than writing nothing silently", async () => {
+    const res = await PUT(putRequest({}));
+
+    expect(res.status).toBe(400);
+    expect(written.calls).toBe(0);
+  });
+
+  it("rejects a malformed JSON body", async () => {
+    const res = await PUT(malformedRequest());
+
+    expect(res.status).toBe(400);
+    expect(written.calls).toBe(0);
+  });
+
+  it.each([
+    ["a negative value", "-5"],
+    ["a decimal value", "1.5"],
+    ["a non-numeric string", "abc"],
+    ["a number instead of a string", 1000],
+    ["a boolean", true],
+  ])("rejects %s for the wei cap and writes nothing", async (_label, value) => {
+    const res = await PUT(putRequest({ dailyValueCapWei: value }));
+    const body = (await res.json()) as Record<string, unknown>;
+
+    // Rejected rather than coerced: a malformed cap must never be silently
+    // stored, and must never fall through to "unlimited".
+    expect(res.status).toBe(400);
+    expect(body.field).toBe("dailyValueCapWei");
+    expect(written.calls).toBe(0);
+  });
+
+  it.each([
+    ["a negative value", "-1"],
+    ["a decimal value", "0.5"],
+    ["a non-numeric string", "1e9"],
+  ])(
+    "rejects %s for the Solana cap and writes nothing",
+    async (_label, value) => {
+      const res = await PUT(putRequest({ dailySolanaValueCapLamports: value }));
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(400);
+      expect(body.field).toBe("dailySolanaValueCapLamports");
+      expect(written.calls).toBe(0);
+    }
+  );
+
+  it("rejects the whole request when one of two fields is malformed", async () => {
+    const res = await PUT(
+      putRequest({
+        dailyValueCapWei: "1000",
+        dailySolanaValueCapLamports: "-1",
+      })
+    );
+
+    // Partial application would leave the caps in a state the admin did not
+    // ask for, so a bad field rejects the request outright.
+    expect(res.status).toBe(400);
+    expect(written.calls).toBe(0);
+  });
+});

--- a/tests/unit/spending-cap.test.ts
+++ b/tests/unit/spending-cap.test.ts
@@ -5,9 +5,12 @@ vi.mock("@/lib/utils/id", () => ({ generateId: () => "exec_test" }));
 
 // Hoisted state the fake tx reads from / writes to, set per test.
 const state = vi.hoisted(() => ({
-  caps: [] as Array<{ dailyValueCapWei: string | null }>,
-  sumRows: [] as Array<{ totalWei: string }>,
-  ledgerRows: [] as Array<{ totalWei: string }>,
+  caps: [] as Array<{
+    dailyValueCapWei: string | null;
+    dailySolanaValueCapLamports?: string | null;
+  }>,
+  sumRows: [] as Array<{ totalWei?: string; totalLamports?: string }>,
+  ledgerRows: [] as Array<{ totalWei?: string; totalLamports?: string }>,
   inserted: [] as Record<string, unknown>[],
 }));
 
@@ -76,7 +79,7 @@ describe("checkAndReserveExecution value cap", () => {
 
     const result = await checkAndReserveExecution({
       ...baseParams,
-      reservedValueWei: "5",
+      reserved: { kind: "evm", valueWei: "5" },
     });
 
     expect(result).toEqual({ allowed: true, executionId: "exec_test" });
@@ -92,7 +95,7 @@ describe("checkAndReserveExecution value cap", () => {
 
     const result = await checkAndReserveExecution({
       ...baseParams,
-      reservedValueWei: "999",
+      reserved: { kind: "evm", valueWei: "999" },
     });
 
     expect(result.allowed).toBe(true);
@@ -105,7 +108,7 @@ describe("checkAndReserveExecution value cap", () => {
 
     const result = await checkAndReserveExecution({
       ...baseParams,
-      reservedValueWei: "400",
+      reserved: { kind: "evm", valueWei: "400" },
     });
 
     expect(result.allowed).toBe(true);
@@ -118,7 +121,7 @@ describe("checkAndReserveExecution value cap", () => {
 
     const result = await checkAndReserveExecution({
       ...baseParams,
-      reservedValueWei: "500",
+      reserved: { kind: "evm", valueWei: "500" },
     });
 
     expect(result).toEqual({
@@ -138,7 +141,7 @@ describe("checkAndReserveExecution value cap", () => {
 
     const result = await checkAndReserveExecution({
       ...baseParams,
-      reservedValueWei: "200",
+      reserved: { kind: "evm", valueWei: "200" },
     });
 
     expect(result.allowed).toBe(false);
@@ -153,10 +156,88 @@ describe("checkAndReserveExecution value cap", () => {
 
     const result = await checkAndReserveExecution({
       ...baseParams,
-      reservedValueWei: "5000000000000000000",
+      reserved: { kind: "evm", valueWei: "5000000000000000000" },
     });
 
     expect(result.allowed).toBe(false);
     expect(state.inserted).toHaveLength(0);
+  });
+});
+
+describe("checkAndReserveExecution Solana cap", () => {
+  it("charges the lamports cap and records valueLamports, not valueWei", async () => {
+    state.caps = [
+      { dailyValueCapWei: "1000", dailySolanaValueCapLamports: "2000000000" },
+    ];
+    state.sumRows = [{ totalLamports: "500000000" }];
+    state.ledgerRows = [{ totalLamports: "0" }];
+
+    const result = await checkAndReserveExecution({
+      ...baseParams,
+      network: "103",
+      reserved: { kind: "solana", valueLamports: "1000000000" },
+    });
+
+    expect(result.allowed).toBe(true);
+    // The unit columns are mutually exclusive, so each daily SUM stays
+    // single-unit.
+    expect(state.inserted[0]).toMatchObject({
+      valueLamports: "1000000000",
+      valueWei: null,
+    });
+  });
+
+  it("denies with the Solana-specific reason when the lamports cap is exceeded", async () => {
+    state.caps = [
+      { dailyValueCapWei: null, dailySolanaValueCapLamports: "1000000000" },
+    ];
+    state.sumRows = [{ totalLamports: "900000000" }];
+    state.ledgerRows = [{ totalLamports: "0" }];
+
+    const result = await checkAndReserveExecution({
+      ...baseParams,
+      network: "103",
+      reserved: { kind: "solana", valueLamports: "200000000" },
+    });
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: "Daily Solana spending cap exceeded",
+    });
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("treats an unset Solana cap as unlimited and does NOT fall back to the wei cap", async () => {
+    // A wei cap that would reject this figure outright, to prove the Solana
+    // path never consults it.
+    state.caps = [{ dailyValueCapWei: "1", dailySolanaValueCapLamports: null }];
+    state.sumRows = [{ totalLamports: "0" }];
+    state.ledgerRows = [{ totalLamports: "0" }];
+
+    const result = await checkAndReserveExecution({
+      ...baseParams,
+      network: "103",
+      reserved: { kind: "solana", valueLamports: "5000000000" },
+    });
+
+    expect(result.allowed).toBe(true);
+  });
+
+  it("does not let an exhausted wei cap block a Solana reservation", async () => {
+    state.caps = [
+      { dailyValueCapWei: "1000", dailySolanaValueCapLamports: "2000000000" },
+    ];
+    // Solana totals are read from the lamports columns; the wei day-total is
+    // irrelevant to this reservation and must not be consulted.
+    state.sumRows = [{ totalWei: "999999", totalLamports: "0" }];
+    state.ledgerRows = [{ totalWei: "999999", totalLamports: "0" }];
+
+    const result = await checkAndReserveExecution({
+      ...baseParams,
+      network: "103",
+      reserved: { kind: "solana", valueLamports: "1000000000" },
+    });
+
+    expect(result.allowed).toBe(true);
   });
 });


### PR DESCRIPTION
## The bug

The daily value cap identified value-moving actions by **config field name**: `transferFundsStep` charged `amount`, everything else charged `ethValue`.

```ts
if (stepFunction === "transferFundsStep") return parseNativeValueWei(config.amount);
return parseNativeValueWei(config.ethValue);   // <- Solana steps have neither
```

That holds for EVM only because every value-forwarding EVM action happens to use `ethValue`. `send-raw-solana-instruction` and `call-solana-program-anchor` carry no such field, so both reserved **`"0"`** while being able to move arbitrary SOL - a raw instruction can invoke any program, and an Anchor call can move lamports through a CPI that never appears in its encoded arguments. An API-key holder could drain the org wallet in SOL with the cap recording nothing.

The file's own doc comment names this exact failure mode as the thing the design was meant to prevent. The guard failed open.

**Wider than first thought:** neither step called `withStepValueCap` either, so the bypass applied to workflow runs as well as the direct API. Compare the established pattern - `transfer-funds` charges `amount`, `write-contract` charges `ethValue`, `transfer-token` correctly charges nothing (token-only), and the two Solana write steps charged nothing despite moving SOL.

## The fix

**1. Declared ceiling, failing closed.** Both actions now require an explicit `maxSol`, reserved up front on both the direct route and the workflow path. Absent means rejected.

**2. A separate Solana cap, not a shared one.** Solana value is charged against a new `daily_solana_value_cap_lamports`, never against `daily_value_cap_wei`. Folding SOL into the wei cap would compare non-commensurable assets against a single number an admin sets thinking in ETH.

This is also what makes the decimals correct. Scaling SOL to 18 decimals was only ever a workaround for having one cap: with a lamports cap, parsing at SOL's true 9 decimals is both accurate and safe. Fixing the decimals *without* the second cap would have made a 10 ETH cap admit ~1e10 SOL/day - accurate in base units, and useless as a control.

**3. Separate ledger columns.** `value_lamports` on both `direct_executions` and `org_value_reservations`. A shared column would have added 1e18- and 1e9-scaled figures in the same SUM - a subtler version of the bug being fixed. Exactly one unit column is written per row, so each daily SUM stays single-unit and an unset Solana cap does not fall back to the wei cap.

**4. Chain-aware `transferFundsStep`.** That step is chain-agnostic (`transfer-funds-core` branches to a Solana path on a Solana chainId), so its unit is resolved from the configured network rather than the step name. Without this a native SOL transfer would still be parsed at 18 decimals and charged to the wrong cap - and that path is reachable today via `/api/execute/transfer`.

**5. API + settings UI** for the new cap. The `PUT` applies **partial updates**: an omitted field is left unchanged. The two caps are edited by separate controls, so treating absence as "clear" would let saving one silently remove the other.

## No backfill, deliberately

No workflow in staging or prod uses either action today, so the affected set is empty and enforcement starts from now. Any node authored before this would need `maxSol` added on next save.

## Tests

27 tests, all new or updated:

- **spend-cap-route (17)** - partial-update semantics (omitted vs explicit null), both-fields, response echo, and a parameterised matrix of malformed values each asserting 400 + correct `field` + nothing written.
- **spending-cap (10)** - 6 migrated to the discriminated shape, 4 new proving the caps are independent: lamports recorded with `valueWei: null`, Solana-specific denial reason, unset Solana cap not falling back to the wei cap, and an exhausted wei cap not blocking a Solana reservation.

The partial-update tests were **mutation-tested**: reintroducing the original unconditional-`set` bug fails exactly those three tests and no others, confirming they would catch a regression that silently clears a spending cap.

Also verified end to end against a live server: creating a workflow whose raw-instruction node omits `maxSol` returns `422 INVALID_ACTION_CONFIG`; adding `maxSol` creates successfully.

## Migrations are hand-written

`pnpm drizzle-kit generate` is broken repo-wide on colliding parent snapshots (0081-0089) - reproduced on a clean tree, so it predates this work. The two migrations here therefore ship **without snapshots**, contrary to the repo guidance, which currently nobody can follow. Both are nullable/no-default adds, so metadata-only, and both were applied against a real database to confirm they run.

## Not in this PR

Simulate-and-enforce (reject when the simulated outflow exceeds the declared ceiling before submit), post-execution reconciliation from `meta.preBalances/postBalances`, an SPL balance node, and step-level `maxSol` tests. The reservation layer alone closes the bypass by failing closed; those add defence against *under*-declaration.
