### PR TITLE
ci: seed the chains table from chain-config on deploy

### DIFF
--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -183,6 +183,65 @@ jobs:
             --filter "name=${SERVICE_NAME}-common-test-irsa-auth" \
             --logs
 
+      # The app resolves chains from the `chains` table (resolveRpcConfig queries
+      # `chains WHERE isEnabled`), NOT from CHAIN_RPC_CONFIG directly. That table
+      # is populated only by seed-chains, which nothing used to run - so a
+      # chain-config change reached Parameter Store and stopped there, and a
+      # newly enabled chain stayed invisible to the app. Seeding here closes that
+      # gap so chain-config remains the single source of truth.
+      #
+      # Runs before the onboarding seed because onboarding workflows reference
+      # chains. Idempotent (upsert), and CHAIN_RPC_CONFIG is read through the
+      # same parser the app uses, so the gzip-compressed KHGZ1 form is handled.
+      - name: Seed chains from chain-config
+        if: steps.skip.outputs.skip_deploy != 'true'
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
+          REGION: ${{ env.REGION }}
+          NAMESPACE: ${{ env.NAMESPACE }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.ref_name }}" == "prod" ]]; then
+            SSM_PREFIX="/eks/techops-prod/keeperhub"
+            MIGRATOR_IMAGE="${ECR_REGISTRY}/keeperhub-prod:migrator-${IMAGE_TAG}"
+          else
+            SSM_PREFIX="/eks/techops-staging/keeperhub"
+            MIGRATOR_IMAGE="${ECR_REGISTRY}/keeperhub-staging:migrator-${IMAGE_TAG}"
+          fi
+          DATABASE_URL=$(aws ssm get-parameter --name "${SSM_PREFIX}/db-url" --with-decryption --query "Parameter.Value" --output text --region "${REGION}")
+          CHAIN_RPC_CONFIG=$(aws ssm get-parameter --name "${SSM_PREFIX}/chain-rpc-config" --with-decryption --query "Parameter.Value" --output text --region "${REGION}")
+          kubectl delete job keeperhub-seed-chains -n "${NAMESPACE}" --ignore-not-found
+          kubectl create secret generic keeperhub-seed-chains-env -n "${NAMESPACE}" \
+            --from-literal=DATABASE_URL="${DATABASE_URL}" \
+            --from-literal=CHAIN_RPC_CONFIG="${CHAIN_RPC_CONFIG}" \
+            --dry-run=client -o yaml | kubectl apply -n "${NAMESPACE}" -f -
+          kubectl apply -n "${NAMESPACE}" -f - <<EOF
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: keeperhub-seed-chains
+          spec:
+            backoffLimit: 2
+            ttlSecondsAfterFinished: 600
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: seed-chains
+                    image: ${MIGRATOR_IMAGE}
+                    command: ["/bin/sh", "-c"]
+                    args:
+                      - 'pnpm tsx scripts/seed/seed-chains.ts'
+                    envFrom:
+                      - secretRef:
+                          name: keeperhub-seed-chains-env
+          EOF
+          kubectl wait --for=condition=complete job/keeperhub-seed-chains -n "${NAMESPACE}" --timeout=180s || true
+          echo "--- seed-chains job logs ---"
+          kubectl logs -n "${NAMESPACE}" job/keeperhub-seed-chains --tail=40 || true
+          kubectl delete secret keeperhub-seed-chains-env -n "${NAMESPACE}" --ignore-not-found
+
       - name: Seed onboarding workflows
         if: steps.skip.outputs.skip_deploy != 'true'
         env:


### PR DESCRIPTION
## Problem

The app resolves chains from the **database**, not from `CHAIN_RPC_CONFIG`. `resolveRpcConfig` queries `chains WHERE isEnabled` and builds the RPC config from that row. The `chains` table is populated only by `scripts/seed/seed-chains.ts` - and **no workflow ran it**.

So the real chain is:

```
chain-config -> SSM -> CHAIN_RPC_CONFIG env -> db:seed-chains -> chains table -> resolveRpcConfig
                                               ^^^^^^^^^^^^^^
                                               never ran on deploy
```

A chain-config change reached Parameter Store and stopped there. Enabling a chain, or correcting a chainId, updated an env var the app does not consult for chain enablement - so the change *appeared* to deploy while the app kept serving the old chain set.

This is the mechanism behind `Solana chain 103 not found or not enabled`. We first attributed that to SSM propagation on a PR environment, then reproduced it locally from exactly this cause: a database whose `chains` table had never been seeded. Two different-looking incidents, one root cause.

## Change

Adds a `Seed chains from chain-config` Job to the deploy, mirroring the existing onboarding seed.

- **Runs before the onboarding seed**, because onboarding workflows reference chains.
- **Idempotent** - `seed-chains.ts` upserts, so running on every deploy is safe.
- **Secrets handling**: `DATABASE_URL` and `CHAIN_RPC_CONFIG` are passed via a short-lived Secret with `envFrom`, not inline `env` values, so the config - which carries provider API keys - is not rendered into the Job manifest. The Secret is deleted after the Job completes. (The existing onboarding seed inlines `DATABASE_URL`; I did not change that here, but it is worth the same treatment.)

## Why the compressed config is not a problem

`seed-chains.ts` reads `CHAIN_RPC_CONFIG` through `parseRpcConfigWithDetails`, the same parser the app uses, which calls `decodeRpcConfigValue` and handles the gzip-compressed `KHGZ1:` form Parameter Store holds. A naive `JSON.parse` would have failed and fallen back to public-default RPC URLs silently - worth stating because that failure mode looks like success.

## Verification

- Workflow YAML parses, and the new step is confirmed to sit before `Seed onboarding workflows` in the `deploy` job (checked programmatically, not by eye).
- The full effect is only observable on a real deploy, since the Job runs in-cluster against Parameter Store.

## Follow-up

The first deploy carrying this will seed whatever `chain-config` currently says. Worth watching the Job logs on that run to confirm the Solana rows land with `is_enabled = true` and that no stale duplicate remains - a PR environment was observed with chainId 102 and 103 both present and both named "Solana Devnet", which a user would see as two identical entries in the chain picker.
