### PR TITLE
fix: disable chains that are no longer in chain-config

### DIFF
--- a/scripts/seed/seed-chains.ts
+++ b/scripts/seed/seed-chains.ts
@@ -10,7 +10,7 @@
  */
 
 import "dotenv/config";
-import { eq } from "drizzle-orm";
+import { and, eq, notInArray } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { getDatabaseUrl } from "../../lib/db/connection-utils";
@@ -840,6 +840,46 @@ async function seedChains() {
 
     await db.insert(chains).values(chain);
     console.log(`  + ${chain.name} (${chain.chainId}) inserted`);
+  }
+
+  // Disable any chain row whose chainId is no longer produced by this seed.
+  //
+  // The upsert above is keyed on chainId, so changing a chain's id leaves the
+  // old row behind, still enabled. That is not hypothetical: moving Solana
+  // devnet from 102 to 103 inserted 103 and left 102 in place, so an
+  // environment ended up serving two enabled rows both named "Solana Devnet" -
+  // one of them an id the app rejects as not a Solana chain.
+  //
+  // Disable rather than delete: chains are referenced by workflows, executions
+  // and supported tokens, so removing a row would orphan live data. A disabled
+  // row is invisible to resolveRpcConfig (it filters on isEnabled) which is the
+  // behaviour we want, and stays available for historical lookups.
+  const seededChainIds = DEFAULT_CHAINS.map((c) => c.chainId);
+
+  // Guard: only prune when CHAIN_RPC_CONFIG actually parsed. Without it the
+  // chainIds above fall back to hardcoded defaults, so a config that failed to
+  // load would disable every chain whose id is set from config - turning a
+  // recoverable parse failure into an outage.
+  if (Object.keys(rpcConfig).length === 0) {
+    console.warn(
+      "  ! Skipping stale-chain prune: CHAIN_RPC_CONFIG did not parse, so seeded chainIds may be defaults rather than the configured values"
+    );
+  } else {
+    const stale = await db
+      .update(chains)
+      .set({ isEnabled: false, updatedAt: new Date() })
+      .where(
+        and(notInArray(chains.chainId, seededChainIds), eq(chains.isEnabled, true))
+      )
+      .returning({ chainId: chains.chainId, name: chains.name });
+
+    if (stale.length === 0) {
+      console.log("  = No stale chains to disable");
+    } else {
+      for (const c of stale) {
+        console.log(`  - ${c.name} (${c.chainId}) disabled - no longer in config`);
+      }
+    }
   }
 
   // Build EXPLORER_CONFIGS dynamically using resolved chainIds from DEFAULT_CHAINS


### PR DESCRIPTION
## Problem

`seed-chains.ts` upserts keyed on `chainId` and never removed anything, so changing a chain's id orphaned the old row **while leaving it enabled**.

This is not hypothetical. Moving Solana devnet from 102 to 103 inserted 103 and left 102 in place:

```
101 | Solana        | enabled
102 | Solana Devnet | enabled   <- orphaned by the id change
103 | Solana Devnet | enabled
```

A user sees **two identical "Solana Devnet" entries** in the chain picker, and one of them carries an id every Solana action rejects as not a Solana network - with nothing in the UI to tell them apart.

## Change

After seeding, any enabled chain whose id is not among the seeded ids is disabled.

**Disable, not delete.** Chains are referenced by workflows, executions and supported tokens, so deleting would orphan live data. Disabling is sufficient because `resolveRpcConfig` filters on `isEnabled`, and it keeps the row available for historical lookups.

**Guarded on the config having parsed.** If `CHAIN_RPC_CONFIG` fails to load, the seeded chainIds fall back to hardcoded defaults - so pruning against them would disable every chain whose id comes from config, turning a recoverable parse failure into an outage. In that case the seeder warns and skips the prune.

## Verification

Reproduced the incident against a real database rather than reasoning about it.

Seeded a stale 102 row alongside 101 and 103, all enabled, then ran the patched seeder:

```
~ Solana (101) updated
~ Solana Devnet (103) updated
- Solana Devnet (102) disabled - no longer in config
```

Exactly one row pruned. No EVM chain affected (21 enabled / 2 disabled afterwards - 102 by the prune, and 101 by the upsert because the local config has Solana mainnet disabled, which is the upsert correctly writing config through).

A second run reported `= No stale chains to disable`, confirming idempotency.

The guard was also exercised unintentionally and worked: an earlier run with an unparseable `CHAIN_RPC_CONFIG` printed the skip warning and left every row alone, instead of disabling chains based on default ids.

`type-check` clean, lint clean on the changed file.

## Rollout note

The first deploy carrying this will disable any stale rows in that environment. Worth watching the `db-migration` initContainer logs on the first staging run to confirm it names only the rows you expect - the log lists every chain it disables.
