### PR TITLE
fix(metrics): count only billable executions in per-org plan usage gauges

### DIFF
--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -388,29 +388,33 @@ const billingTrialsByOutcome = getOrCreateGauge(
 // Per-org execution counts (rolling 30-day window). Keyed only on
 // org_slug so the series identity stays stable when an org changes plan.
 // Join with keeperhub_org_info for plan/billing_status context.
+// Counts billable executions only (same predicate as the billing guard), so
+// billing-blocked phantom rows and x402 pay-per-call runs are excluded.
 const orgExecutions30d = getOrCreateGauge(
   dbRegistry,
   "keeperhub_org_executions_30d",
-  "Workflow executions per org in the last 30 days",
+  "Billable workflow executions per org in the last 30 days",
   ["org_slug"]
 );
 
 // Per-org execution counts (current calendar month, used for plan limit
-// pressure).
+// pressure). Billable-only, matching what the billing guard counts.
 const orgExecutionsMonth = getOrCreateGauge(
   dbRegistry,
   "keeperhub_org_executions_month",
-  "Workflow executions per org since start of the current calendar month",
+  "Billable workflow executions per org since start of the current calendar month",
   ["org_slug"]
 );
 
-// Plan usage ratio: current-month executions / monthly limit. 0 when the
-// plan is unlimited (enterprise) or when there is no usage. Drives the
-// "approaching plan limit" alert and the dashboard heatmap.
+// Plan usage ratio: current-month billable executions / monthly limit. 0 when
+// the plan is unlimited (enterprise) or when there is no usage. Drives the
+// "approaching plan limit" alert and the dashboard heatmap. Billable-only, so
+// an over-limit org whose triggers keep getting blocked stays at ~1.0 instead
+// of climbing without bound.
 const orgPlanUsageRatio = getOrCreateGauge(
   dbRegistry,
   "keeperhub_org_plan_usage_ratio",
-  "Current-month executions divided by the org's plan monthly limit (0 = no pressure or unlimited)",
+  "Current-month billable executions divided by the org's plan monthly limit (0 = no pressure or unlimited)",
   ["org_slug"]
 );
 

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -1312,6 +1312,11 @@ export async function getBillingStatsFromDb(): Promise<BillingStats> {
     // in JS to keep the SQL straightforward. Anonymous workflows (no
     // organization) are excluded — they're already covered by ANONYMOUS_ORG_SLUG
     // in the per-org error gauge.
+    // Only billable rows count: this matches the billing guard's
+    // countMonthlyExecutions predicate, so the plan-usage ratio reflects quota
+    // actually consumed. Excludes billing-blocked phantom rows (never ran) and
+    // x402 pay-per-call runs (paid per call, no quota consumed) — without the
+    // filter a capped free org's blocked triggers inflate the ratio far past 1.
     const execByOrgResult = await db
       .select({
         orgSlug: organization.slug,
@@ -1327,7 +1332,10 @@ export async function getBillingStatsFromDb(): Promise<BillingStats> {
         organizationSubscriptions,
         eq(organizationSubscriptions.organizationId, organization.id)
       )
-      .where(sql`${workflowExecutions.startedAt} >= NOW() - INTERVAL '30 days'`)
+      .where(
+        sql`${workflowExecutions.startedAt} >= NOW() - INTERVAL '30 days'
+            AND ${workflowExecutions.billable} = TRUE`
+      )
       .groupBy(
         organization.slug,
         organizationSubscriptions.plan,


### PR DESCRIPTION
## Problem

The admin plan-utilization panel showed free orgs far above their quota (up to 18.8x the monthly limit). The billing guard itself works correctly: over-limit orgs get no real runs. But every blocked trigger leaves a non-billable error row, and the per-org execution query behind `keeperhub_org_executions_30d`, `keeperhub_org_executions_month` and `keeperhub_org_plan_usage_ratio` counted every `workflow_executions` row regardless of the `billable` flag. A capped free org with a frequent trigger accumulates tens of thousands of blocked rows per month, inflating the usage ratio without bound.

## Fix

Filter both count windows to `billable = TRUE` - the same predicate the billing guard's `countMonthlyExecutions` uses - so the panel and the guard agree on what consumes quota. This also excludes x402 pay-per-call runs, which are paid per call and consume no plan quota. Gauge help strings and comments updated to match.

No dashboard or alert changes needed: the git-synced dashboards consume these gauges as-is and pick up corrected values automatically.

## Validation

- Lint, type-check, unit and integration suites green locally.
- Query semantics verified against a local Postgres: seeded 2 billable + 1 billing-blocked + 1 x402 execution rows in one org inside a rolled-back transaction; the filtered query counts exactly 2 in both windows.
- There is no real-db test seam for `lib/metrics/db-metrics.ts` (its tests mock the db), so no automated test accompanies the query change.