### PR TITLE
fix: decode CHAIN_RPC_CONFIG when selecting the tier1 fork upstream

### DIFF
--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -451,15 +451,49 @@ jobs:
           # -> Alchemy, Arbitrum -> arb1.arbitrum.io), verified to serve the
           # storage/account reads fabrication needs; the primary is the
           # techops load balancer used for reads.
+          # chain-config stores the value gzip-compressed and base64-encoded
+          # behind a KHGZ1 prefix (see update-ssm-parameter.yml). jq cannot read
+          # that, and `// empty` swallows the failure, so a compressed secret
+          # silently degraded the fork to the public default - which is what
+          # made this job flaky. Decode first when the prefix is present.
           if [ -n "$CHAIN_RPC_CONFIG" ] && [ -n "$CFG_KEY" ]; then
-            ARCHIVE_FROM_CONFIG=$(echo "$CHAIN_RPC_CONFIG" | jq -r --arg k "$CFG_KEY" \
-              '.[$k].fallbackRpcUrl // empty')
+            case "$CHAIN_RPC_CONFIG" in
+              KHGZ1:*)
+                DECODED_CFG=$(printf '%s' "${CHAIN_RPC_CONFIG#KHGZ1:}" | base64 -d 2>/dev/null | gunzip 2>/dev/null) || DECODED_CFG=""
+                if [ -z "$DECODED_CFG" ]; then
+                  echo "::warning::CHAIN_RPC_CONFIG carries the KHGZ1 prefix but failed to decode; falling back to the public upstream"
+                fi
+                ;;
+              *) DECODED_CFG="$CHAIN_RPC_CONFIG" ;;
+            esac
+            if [ -n "$DECODED_CFG" ]; then
+              # Prefer the archive-grade fallback, but accept the primary so a
+              # config without a fallback still beats the public default.
+              ARCHIVE_FROM_CONFIG=$(printf '%s' "$DECODED_CFG" | jq -r --arg k "$CFG_KEY" \
+                '.[$k].fallbackRpcUrl // .[$k].primaryRpcUrl // empty' 2>/dev/null) || ARCHIVE_FROM_CONFIG=""
+              if [ -z "$ARCHIVE_FROM_CONFIG" ]; then
+                echo "::warning::CHAIN_RPC_CONFIG parsed but has no RPC URL for ${CFG_KEY}; falling back to the public upstream"
+              fi
+            fi
+          elif [ -z "$CHAIN_RPC_CONFIG" ]; then
+            echo "::warning::CHAIN_RPC_CONFIG is empty for this job; the fork will use the public upstream"
           fi
           case "${{ matrix.chain_id }}" in
             8453) UPSTREAM="${ANVIL_FORK_BASE_URL:-${ARCHIVE_FROM_CONFIG:-${{ matrix.default_upstream }}}}" ;;
             42161) UPSTREAM="${ANVIL_FORK_ARBITRUM_URL:-${ARCHIVE_FROM_CONFIG:-${{ matrix.default_upstream }}}}" ;;
             *) echo "unknown chain ${{ matrix.chain_id }}"; exit 1 ;;
           esac
+          # Log which source won, host only - these URLs carry provider API
+          # keys. Without this the job gives no way to tell a credentialed
+          # upstream from the flaky public fallback.
+          if [ -n "$ANVIL_FORK_BASE_URL" ] || [ -n "$ANVIL_FORK_ARBITRUM_URL" ]; then
+            UPSTREAM_SOURCE="ANVIL_FORK_*_URL secret"
+          elif [ -n "$ARCHIVE_FROM_CONFIG" ]; then
+            UPSTREAM_SOURCE="CHAIN_RPC_CONFIG"
+          else
+            UPSTREAM_SOURCE="public default (matrix.default_upstream)"
+          fi
+          echo "fork upstream source: ${UPSTREAM_SOURCE} (host: $(printf '%s' "$UPSTREAM" | sed -E 's#^[a-z]+://([^/]+).*#\1#'))"
           # Pin a few blocks behind head so a node behind a load-balanced
           # public upstream already has the block (bash arithmetic parses the
           # 0x head). See scripts/protocol-local.sh start_fork.


### PR DESCRIPTION
## The answer to "can the protocol sims use CHAIN_RPC_CONFIG?" is: they already try, and always fail

The fork step intends to prefer a credentialed archive upstream, treating the public endpoint as a last resort:

```bash
ARCHIVE_FROM_CONFIG=$(echo "$CHAIN_RPC_CONFIG" | jq -r --arg k "$CFG_KEY" '.[$k].fallbackRpcUrl // empty')
UPSTREAM="${ANVIL_FORK_BASE_URL:-${ARCHIVE_FROM_CONFIG:-${{ matrix.default_upstream }}}}"
```

But chain-config stores that value **gzip-compressed and base64-encoded behind a `KHGZ1:` prefix** (`update-ssm-parameter.yml`):

```bash
COMPRESSED_VALUE="KHGZ1:$(printf '%s' "$MINIFIED_VALUE" | gzip -9 | base64 -w0)"
```

`jq` cannot parse that. `// empty` swallows the failure. `UPSTREAM` falls through to `https://base-rpc.publicnode.com`.

Reproduced directly - piping a `KHGZ1:` payload into the original expression yields empty, which resolves to the public default.

## Why this matters more than it looks

This is the flake that has been blocking deploys all day.

`ci-pipeline.yml` gates `deploy` on `e2e-tests` with `if: !failure()`, so a tier1 failure **skips the whole staging deploy**. On 2026-07-23 that happened at 08:00, 09:03 and 10:42, plus one on 07-22 - four of nine staging deploys skipped, each time because of an unrelated EVM fork simulation.

The failures also masquerade as protocol bugs. A degraded upstream makes anvil unable to serve state, so every protocol fails at once with `missing revert data / CALL_EXCEPTION`. The 10:42 run was **71 failed, 0 passed** - an environment failure, not a logic regression.

## Change

- **Decode `KHGZ1:`** before `jq`. Plain JSON is unchanged.
- **Accept `primaryRpcUrl`** when `fallbackRpcUrl` is absent, so a config without a fallback still beats the public default.
- **Warn on every degradation path** (empty secret, undecodable payload, no URL for that chain) instead of silently falling back.
- **Log which source won** - secret, `CHAIN_RPC_CONFIG`, or public default - **host only**, since these URLs carry provider API keys.

That last point is why this survived so long: nothing in the job output revealed which upstream was in use. The job name renders `matrix.default_upstream` regardless of what was actually selected, which actively misleads.

## Verification

Exercised the extraction against every input shape:

| Input | Result |
|---|---|
| `KHGZ1:` compressed | resolves to the drpc URL |
| compressed, no `fallbackRpcUrl` | falls back to `primaryRpcUrl` |
| plain JSON | unchanged from today |
| empty secret | public default, with a warning |
| corrupt `KHGZ1:` | public default, with a warning |
| **old code + compressed** | **empty -> public default (the bug)** |

Workflow YAML parses.

## What this does not fix

The fork will now use a credentialed upstream, which should remove the dominant flake - but one fork simulation blocking every deploy is still fragile. Worth a retry on the tier1 step, or making it report-only for the `deploy` gate while staying blocking on PRs. Noted on the ticket.

Also: if the `CHAIN_RPC_CONFIG` repo secret happens to hold **plain** JSON rather than the compressed form, this change is a no-op for the flake and the real cause is elsewhere - the new log line will say so on the first run, which is the point.
