### PR TITLE
fix(deploy): repair workflow-runner egress to executor metrics ingest

### DIFF
--- a/deploy/keeperhub-stack/prod/networkpolicy.yaml
+++ b/deploy/keeperhub-stack/prod/networkpolicy.yaml
@@ -38,7 +38,7 @@ spec:
               kubernetes.io/metadata.name: keeperhub
           podSelector:
             matchLabels:
-              app.kubernetes.io/instance: keeperhub-executor
+              app.kubernetes.io/serviceName: keeperhub-executor-common
       ports:
         - protocol: TCP
           port: 3080

--- a/deploy/keeperhub-stack/staging/networkpolicy.yaml
+++ b/deploy/keeperhub-stack/staging/networkpolicy.yaml
@@ -38,7 +38,7 @@ spec:
               kubernetes.io/metadata.name: keeperhub
           podSelector:
             matchLabels:
-              app.kubernetes.io/instance: keeperhub-executor
+              app.kubernetes.io/serviceName: keeperhub-executor-common
       ports:
         - protocol: TCP
           port: 3080


### PR DESCRIPTION
## What

Change the workflow-runner NetworkPolicy egress rule for the executor metrics ingest port (3080) to select executor pods by `app.kubernetes.io/serviceName: keeperhub-executor-common` instead of `app.kubernetes.io/instance: keeperhub-executor`, in both environment files.

## Why

Since the deploys were consolidated into the keeperhub-stack umbrella release, executor pods no longer carry `app.kubernetes.io/instance: keeperhub-executor` (the instance label is now the umbrella release name). The egress rule therefore matched no pods, and every runner-to-executor metrics POST was dropped and timed out (`[ShipMetrics] Error shipping deltas: TimeoutError` in runner logs, ~26k/day in production). All counter deltas shipped from ephemeral runner pods - the workflow terminal counters and the RPC counters - were silently lost, so per-org success-rate SLIs read empty for schedule/block/event-driven executions.

The `serviceName` label is stable across both environments and uniquely identifies the executor pods (the app pods share the same instance and name labels, so those would over-match). Verified against live pod labels in both clusters.

## Expected effect

After deploy, runner logs show `[ShipMetrics] Shipped N counter deltas` and the workflow terminal counters and RPC counters resume incrementing on the executor scrape job. Both series will show a step increase - that is measurement recovery, not a traffic change.