### PR TITLE
fix: guard getChainIdFromNetwork against missing network

### DIFF
--- a/lib/errors/__tests__/classify.test.ts
+++ b/lib/errors/__tests__/classify.test.ts
@@ -186,14 +186,14 @@ describe("classifyExecutionError", () => {
       expect(r.errorType).toBe("user");
     });
 
-    it.each([
-      "URL is required",
-      "HTTP request failed: URL is required",
-    ])("keeps %s as validation + user (config fault, not transport)", (input) => {
-      const r = classifyExecutionError(input);
-      expect(r.errorCategory).toBe(ErrorCategory.VALIDATION);
-      expect(r.errorType).toBe("user");
-    });
+    it.each(["URL is required", "HTTP request failed: URL is required"])(
+      "keeps %s as validation + user (config fault, not transport)",
+      (input) => {
+        const r = classifyExecutionError(input);
+        expect(r.errorCategory).toBe(ErrorCategory.VALIDATION);
+        expect(r.errorType).toBe("user");
+      }
+    );
 
     it.each([
       "Failed to send webhook: fetch failed: getaddrinfo EAI_AGAIN events.pagerduty.com",
@@ -388,7 +388,9 @@ describe("applyErrorClassHint", () => {
     expect(applyErrorClassHint(coded, "system")).toEqual(coded);
 
     const uncoded = applyErrorClassHint(
-      classifyExecutionError("HTTP request failed: fetch failed: read ECONNRESET"),
+      classifyExecutionError(
+        "HTTP request failed: fetch failed: read ECONNRESET"
+      ),
       "system"
     );
     expect(uncoded.errorType).toBe("system");

--- a/lib/errors/classify.ts
+++ b/lib/errors/classify.ts
@@ -5,7 +5,7 @@ import {
 import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 import { ErrorCategory } from "@/lib/logging";
 
-export { ExecutionErrorType };
+export { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 
 /**
  * Classification of a workflow execution failure into:

--- a/lib/errors/classify.ts
+++ b/lib/errors/classify.ts
@@ -151,20 +151,6 @@ const RULES: readonly Rule[] = [
     errorType: ExecutionErrorType.USER,
     code: null,
   },
-  // Unanchored so step-wrapped forms (`Failed to check balance: Network is
-  // required`) stay a user config fault.
-  {
-    pattern: /Network is required/i,
-    errorCategory: ErrorCategory.VALIDATION,
-    errorType: ExecutionErrorType.USER,
-    code: null,
-  },
-  {
-    pattern: /Unsupported network:/i,
-    errorCategory: ErrorCategory.VALIDATION,
-    errorType: ExecutionErrorType.USER,
-    code: null,
-  },
   {
     pattern: /^For Each:\s*arraySource is required/i,
     errorCategory: ErrorCategory.CONFIGURATION,
@@ -238,6 +224,23 @@ const RULES: readonly Rule[] = [
     errorCategory: ErrorCategory.NETWORK_RPC,
     errorType: ExecutionErrorType.SYSTEM,
     code: "N-0001",
+  },
+  // User-config: missing or unrecognized network input. Unanchored so
+  // step-wrapped forms (`Failed to check balance: Network is required`) still
+  // match. Must come AFTER the RPC failover rules above: provider response
+  // bodies embedded in exhaustion messages can themselves contain phrases like
+  // `Unsupported network:`, and those must stay system/N-0001.
+  {
+    pattern: /Network is required/i,
+    errorCategory: ErrorCategory.VALIDATION,
+    errorType: ExecutionErrorType.USER,
+    code: null,
+  },
+  {
+    pattern: /Unsupported network:/i,
+    errorCategory: ErrorCategory.VALIDATION,
+    errorType: ExecutionErrorType.USER,
+    code: null,
   },
   // User-config: webhook hostname does not resolve -- the configured URL points
   // at a host that does not exist. Must come before the generic webhook rule.

--- a/lib/errors/classify.ts
+++ b/lib/errors/classify.ts
@@ -151,6 +151,20 @@ const RULES: readonly Rule[] = [
     errorType: ExecutionErrorType.USER,
     code: null,
   },
+  // Unanchored so step-wrapped forms (`Failed to check balance: Network is
+  // required`) stay a user config fault.
+  {
+    pattern: /Network is required/i,
+    errorCategory: ErrorCategory.VALIDATION,
+    errorType: ExecutionErrorType.USER,
+    code: null,
+  },
+  {
+    pattern: /Unsupported network:/i,
+    errorCategory: ErrorCategory.VALIDATION,
+    errorType: ExecutionErrorType.USER,
+    code: null,
+  },
   {
     pattern: /^For Each:\s*arraySource is required/i,
     errorCategory: ErrorCategory.CONFIGURATION,

--- a/lib/rpc/network-utils.ts
+++ b/lib/rpc/network-utils.ts
@@ -13,6 +13,12 @@ import { SUPPORTED_CHAIN_IDS } from "./types";
  * - Legacy network names (e.g., "mainnet", "sepolia", "base")
  */
 export function getChainIdFromNetwork(network: string | number): number {
+  // Runtime guard: untyped step configs can pass a missing value despite the
+  // signature, which would otherwise die on .toLowerCase() with a TypeError.
+  if (network === undefined || network === null || network === "") {
+    throw new Error("Network is required");
+  }
+
   // If already a number, return as-is
   if (typeof network === "number") {
     return network;

--- a/tests/unit/classify-execution-error.test.ts
+++ b/tests/unit/classify-execution-error.test.ts
@@ -17,6 +17,32 @@ describe("classifyExecutionError", () => {
     });
   });
 
+  it("classifies a missing network as a user validation error, including step-wrapped forms", () => {
+    const bare = classifyExecutionError("Network is required");
+    expect(bare).toEqual({
+      errorCategory: ErrorCategory.VALIDATION,
+      errorType: "user",
+      code: null,
+    });
+
+    const wrapped = classifyExecutionError(
+      "Failed to check balance: Network is required"
+    );
+    expect(wrapped.errorType).toBe("user");
+    expect(wrapped.errorCategory).toBe(ErrorCategory.VALIDATION);
+  });
+
+  it("classifies an unsupported network name as a user validation error", () => {
+    const result = classifyExecutionError(
+      "Unsupported network: polygon. Supported: mainnet, sepolia or numeric chain IDs"
+    );
+    expect(result).toEqual({
+      errorCategory: ErrorCategory.VALIDATION,
+      errorType: "user",
+      code: null,
+    });
+  });
+
   it("defaults unmatched messages to system so real engine faults still page", () => {
     const result = classifyExecutionError("some unexpected internal failure");
     expect(result.errorType).toBe("system");

--- a/tests/unit/classify-execution-error.test.ts
+++ b/tests/unit/classify-execution-error.test.ts
@@ -43,6 +43,17 @@ describe("classifyExecutionError", () => {
     });
   });
 
+  it("keeps RPC failover exhaustion as system even when the provider response mentions an unsupported network", () => {
+    const result = classifyExecutionError(
+      'Event query failed: RPC failed on both endpoints. Primary: server response 400 Bad Request ({ "message": "Unsupported network: eth" }). Fallback: timeout'
+    );
+    expect(result).toEqual({
+      errorCategory: ErrorCategory.NETWORK_RPC,
+      errorType: "system",
+      code: "N-0001",
+    });
+  });
+
   it("defaults unmatched messages to system so real engine faults still page", () => {
     const result = classifyExecutionError("some unexpected internal failure");
     expect(result.errorType).toBe("system");

--- a/tests/unit/network-utils.test.ts
+++ b/tests/unit/network-utils.test.ts
@@ -57,6 +57,30 @@ describe("getChainIdFromNetwork", () => {
     });
   });
 
+  describe("with missing network values", () => {
+    it("should throw a validation error for undefined", () => {
+      expect(() =>
+        getChainIdFromNetwork(undefined as unknown as string)
+      ).toThrow("Network is required");
+    });
+
+    it("should throw a validation error for null", () => {
+      expect(() => getChainIdFromNetwork(null as unknown as string)).toThrow(
+        "Network is required"
+      );
+    });
+
+    it("should throw a validation error for empty string", () => {
+      expect(() => getChainIdFromNetwork("")).toThrow("Network is required");
+    });
+
+    it("should not throw a TypeError for missing values", () => {
+      expect(() =>
+        getChainIdFromNetwork(undefined as unknown as string)
+      ).not.toThrow(TypeError);
+    });
+  });
+
   describe("with numeric chain IDs", () => {
     it("should return the same chain ID for numbers", () => {
       expect(getChainIdFromNetwork(1)).toBe(1);


### PR DESCRIPTION
## Problem

getChainIdFromNetwork dereferences its argument with .toLowerCase() before any validation. When a step config supplies an undefined or null network (possible because many callers feed it untyped config values), the user sees a cryptic TypeError instead of a validation error, and unwrapped call paths report it as an internal system error.

## Changes

- Guard at the top of getChainIdFromNetwork: undefined, null, or empty-string network now throws "Network is required" before anything dereferences the value. The signature stays string | number; the guard is a runtime defense against untyped config paths.
- Two new USER/VALIDATION rules in lib/errors/classify.ts so unwrapped callers stop defaulting these to WORKFLOW_ENGINE/system:
  - "Network is required" (unanchored, so step-wrapped forms like "Failed to check balance: Network is required" still match, same rationale as the existing "URL is required" rule)
  - "Unsupported network:" (the function's existing bad-name failure, which had the same mislabeling problem)
- Lead-in commit fixes two pre-existing lint errors on staging in lib/errors (ultracite format drift in classify.test.ts, noExportedImports on the ExecutionErrorType re-export) that block the pre-commit lint hook.

## Tests

- tests/unit/network-utils.test.ts: undefined, null, and empty string each throw "Network is required"; explicit assertion that undefined no longer raises a TypeError.
- tests/unit/classify-execution-error.test.ts: bare and step-wrapped "Network is required" plus "Unsupported network: ..." all classify as VALIDATION / user / code null.

This makes the error legible; the underlying missing-network propagation is tracked separately in the sibling ticket.