### PR TITLE
fix: flush unsaved editor state before manual workflow run

### DIFF
--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -51,10 +51,12 @@ import { integrationsAtom } from "@/lib/integrations-store";
 import type { IntegrationType } from "@/lib/types/integration";
 import { cn } from "@/lib/utils";
 import { evaluateShowWhen, type ShowWhen } from "@/lib/workflow/editor/show-when";
+import { ensureSavedBeforeRun } from "@/lib/workflow/run-preflight";
 import {
   addNodeAtom,
   canRedoAtom,
   canUndoAtom,
+  cancelPendingAutosave,
   clearWorkflowAtom,
   currentExecutionIdAtom,
   currentWorkflowIdAtom,
@@ -77,6 +79,7 @@ import {
   isWorkflowEnabled,
   isWorkflowOwnerAtom,
   nodesAtom,
+  previewVersionAtom,
   propertiesPanelActiveTabAtom,
   redoAtom,
   runsRefreshTriggerAtom,
@@ -551,6 +554,7 @@ type WorkflowHandlerParams = {
   isExecuting: boolean;
   setIsExecuting: (value: boolean) => void;
   setIsSaving: (value: boolean) => void;
+  hasUnsavedChanges: boolean;
   setHasUnsavedChanges: (value: boolean) => void;
   setActiveTab: (value: string) => void;
   setNodes: (nodes: WorkflowNode[]) => void;
@@ -570,6 +574,7 @@ function useWorkflowHandlers({
   isExecuting,
   setIsExecuting,
   setIsSaving,
+  hasUnsavedChanges,
   setHasUnsavedChanges,
   setActiveTab,
   setNodes,
@@ -583,6 +588,7 @@ function useWorkflowHandlers({
   const { open: openOverlay } = useOverlay();
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const setRunsRefreshTrigger = useSetAtom(runsRefreshTriggerAtom);
+  const previewVersion = useAtomValue(previewVersionAtom);
 
   // Cleanup polling interval on unmount
   useEffect(
@@ -594,26 +600,45 @@ function useWorkflowHandlers({
     []
   );
 
-  const handleSave = async () => {
+  const saveWorkflow = async (): Promise<boolean> => {
     if (!currentWorkflowId) {
-      return;
+      return false;
     }
 
     setIsSaving(true);
     try {
       await api.workflow.update(currentWorkflowId, { nodes, edges });
       setHasUnsavedChanges(false);
+      cancelPendingAutosave();
+      return true;
     } catch (error) {
       console.error("Failed to save workflow:", error);
       toast.error("Failed to save workflow. Please try again.");
+      return false;
     } finally {
       setIsSaving(false);
     }
   };
 
+  const handleSave = async () => {
+    await saveWorkflow();
+  };
+
   const executeWorkflow = async () => {
     if (!currentWorkflowId) {
       toast.error("Please save the workflow before executing");
+      return;
+    }
+
+    // The server executes the stored definition, not the canvas state, so
+    // edits still waiting on the debounced autosave must be flushed first.
+    // saveWorkflow already toasts on failure, so a failed flush aborts quietly.
+    const saved = await ensureSavedBeforeRun({
+      hasUnsavedChanges,
+      isPreviewingVersion: previewVersion !== null,
+      save: saveWorkflow,
+    });
+    if (!saved) {
       return;
     }
 
@@ -914,6 +939,7 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
     isExecuting,
     setIsExecuting,
     setIsSaving,
+    hasUnsavedChanges,
     setHasUnsavedChanges,
     clearWorkflow,
     workflowVisibility,
@@ -960,6 +986,7 @@ function useWorkflowActions(state: ReturnType<typeof useWorkflowState>) {
       isExecuting,
       setIsExecuting,
       setIsSaving,
+      hasUnsavedChanges,
       setHasUnsavedChanges,
       setActiveTab,
       setNodes,

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -606,10 +606,13 @@ function useWorkflowHandlers({
     }
 
     setIsSaving(true);
+    // Cancel before the await, not after: an edit made while this save is in
+    // flight schedules a new autosave that must survive; only the schedule
+    // this save supersedes should be dropped.
+    cancelPendingAutosave();
     try {
       await api.workflow.update(currentWorkflowId, { nodes, edges });
       setHasUnsavedChanges(false);
-      cancelPendingAutosave();
       return true;
     } catch (error) {
       console.error("Failed to save workflow:", error);

--- a/lib/workflow/run-preflight.ts
+++ b/lib/workflow/run-preflight.ts
@@ -1,0 +1,22 @@
+/**
+ * Persist unsaved editor state before a manual run.
+ *
+ * The execute endpoint runs the stored workflow definition, while config
+ * edits sit in a debounced autosave. Running without flushing executes a
+ * stale definition - freshly entered node config (e.g. network/address)
+ * silently never reaches the steps. Version previews are excluded: the
+ * canvas then shows a historical snapshot that must not overwrite the draft.
+ *
+ * Returns true when it is safe to execute, false when the save failed and
+ * the run must be aborted.
+ */
+export async function ensureSavedBeforeRun(params: {
+  hasUnsavedChanges: boolean;
+  isPreviewingVersion: boolean;
+  save: () => Promise<boolean>;
+}): Promise<boolean> {
+  if (!params.hasUnsavedChanges || params.isPreviewingVersion) {
+    return true;
+  }
+  return await params.save();
+}

--- a/lib/workflow/store.ts
+++ b/lib/workflow/store.ts
@@ -208,6 +208,18 @@ export const lastExecutionLogsAtom = atom<LastExecutionLogsState>({
 let autosaveTimeoutId: NodeJS.Timeout | null = null;
 const AUTOSAVE_DELAY = 2500; // debounce so rapid edits don't each save/version
 
+/**
+ * Cancel a scheduled (debounced) autosave. Called after an out-of-band save
+ * (manual Save, pre-run flush) so the already-scheduled debounced write does
+ * not fire redundantly after a fresher save has landed.
+ */
+export function cancelPendingAutosave(): void {
+  if (autosaveTimeoutId) {
+    clearTimeout(autosaveTimeoutId);
+    autosaveTimeoutId = null;
+  }
+}
+
 // Autosave atom that handles saving workflow state
 export const autosaveAtom = atom(
   null,
@@ -250,7 +262,9 @@ export const autosaveAtom = atom(
     };
 
     if (options?.immediate) {
-      // Save immediately (for add/delete/connect operations)
+      // Save immediately (for add/delete/connect operations); drop any
+      // pending debounced save so it doesn't re-fire with an older snapshot
+      cancelPendingAutosave();
       await saveFunc();
     } else {
       // Debounce for typing operations

--- a/tests/unit/run-preflight.test.ts
+++ b/tests/unit/run-preflight.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ensureSavedBeforeRun } from "@/lib/workflow/run-preflight";
+
+describe("ensureSavedBeforeRun", () => {
+  it("allows the run without saving when there are no unsaved changes", async () => {
+    const save = vi.fn().mockResolvedValue(true);
+
+    const result = await ensureSavedBeforeRun({
+      hasUnsavedChanges: false,
+      isPreviewingVersion: false,
+      save,
+    });
+
+    expect(result).toBe(true);
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("never saves while previewing a historical version", async () => {
+    const save = vi.fn().mockResolvedValue(true);
+
+    const result = await ensureSavedBeforeRun({
+      hasUnsavedChanges: true,
+      isPreviewingVersion: true,
+      save,
+    });
+
+    expect(result).toBe(true);
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("saves before allowing the run when there are unsaved changes", async () => {
+    const save = vi.fn().mockResolvedValue(true);
+
+    const result = await ensureSavedBeforeRun({
+      hasUnsavedChanges: true,
+      isPreviewingVersion: false,
+      save,
+    });
+
+    expect(result).toBe(true);
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts the run when the save fails", async () => {
+    const save = vi.fn().mockResolvedValue(false);
+
+    const result = await ensureSavedBeforeRun({
+      hasUnsavedChanges: true,
+      isPreviewingVersion: false,
+      save,
+    });
+
+    expect(result).toBe(false);
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/workflow-store-autosave.test.ts
+++ b/tests/unit/workflow-store-autosave.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import { createStore } from "jotai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api-client", () => ({
+  api: {
+    workflow: {
+      update: vi.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: {
+    VALIDATION: "validation",
+    WORKFLOW_ENGINE: "workflow_engine",
+    UNKNOWN: "unknown",
+  },
+  logSystemError: vi.fn(),
+  logUserError: vi.fn(),
+}));
+
+vi.mock("@/lib/workflow/editor/auto-layout", () => ({
+  computeAutoLayout: vi.fn((nodes: unknown) => nodes),
+}));
+
+vi.mock("@/lib/workflow/editor/template-helpers", () => ({
+  buildExecutionLogsMap: vi.fn(() => ({})),
+}));
+
+import { api } from "@/lib/api-client";
+import {
+  autosaveAtom,
+  cancelPendingAutosave,
+  currentWorkflowIdAtom,
+  hasUnsavedChangesAtom,
+} from "@/lib/workflow/store";
+
+const updateMock = vi.mocked(api.workflow.update);
+
+// The saveFunc inside autosaveAtom holds isSaving for 800ms after the API
+// call resolves; advance past it so awaiting the save promise settles.
+const SAVE_COOLDOWN_MS = 800;
+
+describe("workflow store autosave", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    updateMock.mockClear();
+  });
+
+  afterEach(() => {
+    cancelPendingAutosave();
+    vi.useRealTimers();
+  });
+
+  function storeWithWorkflow() {
+    const store = createStore();
+    store.set(currentWorkflowIdAtom, "wf-1");
+    return store;
+  }
+
+  it("fires a debounced save after the delay", async () => {
+    const store = storeWithWorkflow();
+
+    await store.set(autosaveAtom);
+    expect(updateMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(2500 + SAVE_COOLDOWN_MS);
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancelPendingAutosave drops a scheduled save", async () => {
+    const store = storeWithWorkflow();
+
+    await store.set(autosaveAtom);
+    cancelPendingAutosave();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("an immediate save clears the pending debounced save", async () => {
+    const store = storeWithWorkflow();
+
+    await store.set(autosaveAtom);
+
+    const immediate = store.set(autosaveAtom, { immediate: true });
+    await vi.advanceTimersByTimeAsync(SAVE_COOLDOWN_MS);
+    await immediate;
+    expect(updateMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the unsaved-changes flag on a successful save", async () => {
+    const store = storeWithWorkflow();
+    store.set(hasUnsavedChangesAtom, true);
+
+    const immediate = store.set(autosaveAtom, { immediate: true });
+    await vi.advanceTimersByTimeAsync(SAVE_COOLDOWN_MS);
+    await immediate;
+
+    expect(store.get(hasUnsavedChangesAtom)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

A manually-run workflow can execute with node config missing (e.g. check-balance receiving an undefined network/address), failing with a cryptic "Cannot read properties of undefined (reading 'toLowerCase')" while the config looks complete in the editor.

Root cause: the execute endpoint runs the stored workflow definition, but config edits sit in a 2.5s debounced autosave. Clicking Run inside that window executes the stale stored nodes; the autosave then lands moments later, so the stored config looks correct when investigated after the fact.

## Fix

- The Run flow now flushes unsaved editor state before executing: with unsaved changes, the workflow is saved first, and a failed save aborts the run (with the existing error toast) instead of executing a stale definition.
- Version previews are excluded from the flush so a historical snapshot can never overwrite the draft.
- A successful save (manual Save or pre-run flush) now cancels any pending debounced autosave so it cannot re-fire with an older snapshot; the autosave atom's immediate path does the same.

The gate lives in `lib/workflow/run-preflight.ts` as a pure helper so it is unit-testable (this repo has no testing-library for rendering hooks).

## Testing

- `tests/unit/run-preflight.test.ts`: no unsaved changes -> run without saving; previewing -> never saves; unsaved -> saves before running; failed save -> run aborted.
- `tests/unit/workflow-store-autosave.test.ts`: debounced save fires after the delay; cancelPendingAutosave drops a scheduled save; immediate save clears the pending debounce; successful save clears the unsaved-changes flag.

Runs from outside the editor (schedules, webhooks, MCP, CLI) have no unsaved client state and are unaffected.
