### PR TITLE
release: to prod

### DIFF
--- a/.github/actions/start-app/action.yml
+++ b/.github/actions/start-app/action.yml
@@ -55,6 +55,10 @@ inputs:
     description: 'TURNKEY_ORGANIZATION_ID for the Turnkey-managed org wallet path'
     required: false
     default: ''
+  solana_wallet_provisioning_enabled:
+    description: 'SOLANA_WALLET_PROVISIONING_ENABLED - when "true", Turnkey sub-orgs are created with a Solana account alongside the EVM one. Unset leaves wallets EVM-only, so any suite touching a Solana address must set it.'
+    required: false
+    default: ''
   ai_prompt_enabled:
     description: 'NEXT_PUBLIC_AI_PROMPT_ENABLED - gates /api/ai/generate (e2e api-key-auth suite). Scoped per-job so AI UI is not surfaced elsewhere.'
     required: false
@@ -138,6 +142,7 @@ runs:
         TURNKEY_API_PUBLIC_KEY: ${{ inputs.turnkey_api_public_key }}
         TURNKEY_API_PRIVATE_KEY: ${{ inputs.turnkey_api_private_key }}
         TURNKEY_ORGANIZATION_ID: ${{ inputs.turnkey_organization_id }}
+        SOLANA_WALLET_PROVISIONING_ENABLED: ${{ inputs.solana_wallet_provisioning_enabled }}
         ALLOW_TEST_ENDPOINTS: ${{ inputs.allow_test_endpoints }}
         LOAD_TEST_BYPASS_TOKEN: ${{ inputs.load_test_bypass_token }}
         SAFE_FETCH_SHADOW: ${{ inputs.safe_fetch_shadow }}
@@ -158,6 +163,7 @@ runs:
           "CI=true" \
           "TEST_API_KEY=${TEST_API_KEY}" \
           "WORKFLOW_TARGET_WORLD=@workflow/world-postgres" \
+          "SOLANA_WALLET_PROVISIONING_ENABLED=${SOLANA_WALLET_PROVISIONING_ENABLED}" \
           > /tmp/keeperhub-app.env
 
         # Jobs that execute workflow step bundles (e.g. the credential-bundle
@@ -278,6 +284,7 @@ runs:
         TURNKEY_API_PUBLIC_KEY: ${{ inputs.turnkey_api_public_key }}
         TURNKEY_API_PRIVATE_KEY: ${{ inputs.turnkey_api_private_key }}
         TURNKEY_ORGANIZATION_ID: ${{ inputs.turnkey_organization_id }}
+        SOLANA_WALLET_PROVISIONING_ENABLED: ${{ inputs.solana_wallet_provisioning_enabled }}
         SANDBOX_BACKEND: remote
         SANDBOX_URL: http://localhost:8787
         # Present so the production captcha guard (lib/auth.ts) lets the server

--- a/.github/workflows/deploy-events.yaml
+++ b/.github/workflows/deploy-events.yaml
@@ -9,6 +9,7 @@ on:
     paths:
       - "keeperhub-events/**"
       - "deploy/event-tracker/**"
+      - "deploy/solana-tracker/**"
       - ".github/workflows/deploy-events.yaml"
   workflow_dispatch:
 
@@ -33,6 +34,7 @@ jobs:
       NAMESPACE: keeperhub
       TRACKER_ECR_NAME: keeperhub-event-${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
       TRACKER_HELM_FILE: deploy/event-tracker/${{ github.ref_name == 'prod' && 'prod' || 'staging' }}/values.yaml
+      SOLANA_HELM_FILE: deploy/solana-tracker/${{ github.ref_name == 'prod' && 'prod' || 'staging' }}/values.yaml
       EVENTS_SERVICE_ACCOUNT_ROLE_ARN: ${{ vars.TO_EVENTS_ROLE_ARN }}
 
     steps:
@@ -79,14 +81,16 @@ jobs:
         if: steps.skip.outputs.skip_build == 'true'
         run: |
           IMAGE_TAG="${{ steps.vars.outputs.sha_short }}"
-          if ! aws ecr describe-images \
-            --repository-name "$TRACKER_ECR_NAME" \
-            --image-ids "imageTag=event-${IMAGE_TAG}" \
-            --region "${{ env.REGION }}" >/dev/null 2>&1; then
-            echo "::error::Cannot skip build: event-${IMAGE_TAG} not found in ${TRACKER_ECR_NAME}. Remove [skip build] or push a build first."
-            exit 1
-          fi
-          echo "event-${IMAGE_TAG} exists in ${TRACKER_ECR_NAME}"
+          for prefix in event solana; do
+            if ! aws ecr describe-images \
+              --repository-name "$TRACKER_ECR_NAME" \
+              --image-ids "imageTag=${prefix}-${IMAGE_TAG}" \
+              --region "${{ env.REGION }}" >/dev/null 2>&1; then
+              echo "::error::Cannot skip build: ${prefix}-${IMAGE_TAG} not found in ${TRACKER_ECR_NAME}. Remove [skip build] or push a build first."
+              exit 1
+            fi
+            echo "${prefix}-${IMAGE_TAG} exists in ${TRACKER_ECR_NAME}"
+          done
 
       - name: Build and push event tracker image
         if: steps.skip.outputs.skip_build != 'true'
@@ -101,7 +105,7 @@ jobs:
           targets: events
           push: true
 
-      - name: Replace variables in Helm values file
+      - name: Replace variables in Helm values files
         if: steps.skip.outputs.skip_deploy != 'true'
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -113,6 +117,11 @@ jobs:
           sed -i "s|\${IMAGE_TAG}|${IMAGE_TAG}|g" "$TRACKER_HELM_FILE"
           sed -i "s|\${AWS_ACCOUNT_ID}|${AWS_ACCOUNT_ID}|g" "$TRACKER_HELM_FILE"
           sed -i "s|\${EVENTS_SERVICE_ACCOUNT_ROLE_ARN}|${EVENTS_SERVICE_ACCOUNT_ROLE_ARN}|g" "$TRACKER_HELM_FILE"
+          # solana-tracker reuses the events service account (create: false), so
+          # it has no role-arn placeholder - only image/registry/account.
+          sed -i "s|\${ECR_REGISTRY}|${ECR_REGISTRY}|g" "$SOLANA_HELM_FILE"
+          sed -i "s|\${IMAGE_TAG}|${IMAGE_TAG}|g" "$SOLANA_HELM_FILE"
+          sed -i "s|\${AWS_ACCOUNT_ID}|${AWS_ACCOUNT_ID}|g" "$SOLANA_HELM_FILE"
 
       - name: Configure kubectl
         if: steps.skip.outputs.skip_deploy != 'true'
@@ -141,5 +150,23 @@ jobs:
           # would silently render blank if the role-arn variable were unset and
           # the pod would fall back to the node role. Rendered output is
           # otherwise identical to 0.2.1 apart from an opt-in helm test hook.
+          version: 0.5.0
+          atomic: true
+
+      # Separate Helm release from event-tracker: same chart, its own values
+      # (solana image tag, port 3001, HTTP health probes) and its own image in
+      # the shared events ECR. Reuses the keeperhub-events service account, so
+      # no role-arn is required here.
+      - name: Deploy solana-tracker
+        if: steps.skip.outputs.skip_deploy != 'true'
+        uses: bitovi/github-actions-deploy-eks-helm@v1.2.12
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          config-files: ${{ env.SOLANA_HELM_FILE }}
+          chart-path: techops-services/common
+          namespace: ${{ env.NAMESPACE }}
+          timeout: 5m0s
+          name: keeperhub-solana
+          chart-repository: https://techops-services.github.io/helm-charts
           version: 0.5.0
           atomic: true

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -451,15 +451,49 @@ jobs:
           # -> Alchemy, Arbitrum -> arb1.arbitrum.io), verified to serve the
           # storage/account reads fabrication needs; the primary is the
           # techops load balancer used for reads.
+          # chain-config stores the value gzip-compressed and base64-encoded
+          # behind a KHGZ1 prefix (see update-ssm-parameter.yml). jq cannot read
+          # that, and `// empty` swallows the failure, so a compressed secret
+          # silently degraded the fork to the public default - which is what
+          # made this job flaky. Decode first when the prefix is present.
           if [ -n "$CHAIN_RPC_CONFIG" ] && [ -n "$CFG_KEY" ]; then
-            ARCHIVE_FROM_CONFIG=$(echo "$CHAIN_RPC_CONFIG" | jq -r --arg k "$CFG_KEY" \
-              '.[$k].fallbackRpcUrl // empty')
+            case "$CHAIN_RPC_CONFIG" in
+              KHGZ1:*)
+                DECODED_CFG=$(printf '%s' "${CHAIN_RPC_CONFIG#KHGZ1:}" | base64 -d 2>/dev/null | gunzip 2>/dev/null) || DECODED_CFG=""
+                if [ -z "$DECODED_CFG" ]; then
+                  echo "::warning::CHAIN_RPC_CONFIG carries the KHGZ1 prefix but failed to decode; falling back to the public upstream"
+                fi
+                ;;
+              *) DECODED_CFG="$CHAIN_RPC_CONFIG" ;;
+            esac
+            if [ -n "$DECODED_CFG" ]; then
+              # Prefer the archive-grade fallback, but accept the primary so a
+              # config without a fallback still beats the public default.
+              ARCHIVE_FROM_CONFIG=$(printf '%s' "$DECODED_CFG" | jq -r --arg k "$CFG_KEY" \
+                '.[$k].fallbackRpcUrl // .[$k].primaryRpcUrl // empty' 2>/dev/null) || ARCHIVE_FROM_CONFIG=""
+              if [ -z "$ARCHIVE_FROM_CONFIG" ]; then
+                echo "::warning::CHAIN_RPC_CONFIG parsed but has no RPC URL for ${CFG_KEY}; falling back to the public upstream"
+              fi
+            fi
+          elif [ -z "$CHAIN_RPC_CONFIG" ]; then
+            echo "::warning::CHAIN_RPC_CONFIG is empty for this job; the fork will use the public upstream"
           fi
           case "${{ matrix.chain_id }}" in
             8453) UPSTREAM="${ANVIL_FORK_BASE_URL:-${ARCHIVE_FROM_CONFIG:-${{ matrix.default_upstream }}}}" ;;
             42161) UPSTREAM="${ANVIL_FORK_ARBITRUM_URL:-${ARCHIVE_FROM_CONFIG:-${{ matrix.default_upstream }}}}" ;;
             *) echo "unknown chain ${{ matrix.chain_id }}"; exit 1 ;;
           esac
+          # Log which source won, host only - these URLs carry provider API
+          # keys. Without this the job gives no way to tell a credentialed
+          # upstream from the flaky public fallback.
+          if [ -n "$ANVIL_FORK_BASE_URL" ] || [ -n "$ANVIL_FORK_ARBITRUM_URL" ]; then
+            UPSTREAM_SOURCE="ANVIL_FORK_*_URL secret"
+          elif [ -n "$ARCHIVE_FROM_CONFIG" ]; then
+            UPSTREAM_SOURCE="CHAIN_RPC_CONFIG"
+          else
+            UPSTREAM_SOURCE="public default (matrix.default_upstream)"
+          fi
+          echo "fork upstream source: ${UPSTREAM_SOURCE} (host: $(printf '%s' "$UPSTREAM" | sed -E 's#^[a-z]+://([^/]+).*#\1#'))"
           # Pin a few blocks behind head so a node behind a load-balanced
           # public upstream already has the block (bash arithmetic parses the
           # 0x head). See scripts/protocol-local.sh start_fork.

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -644,6 +644,7 @@ jobs:
           turnkey_api_public_key: ${{ secrets.TURNKEY_API_PUBLIC_KEY }}
           turnkey_api_private_key: ${{ secrets.TURNKEY_API_PRIVATE_KEY }}
           turnkey_organization_id: ${{ secrets.TURNKEY_ORGANIZATION_ID }}
+          solana_wallet_provisioning_enabled: "true"
           # NEXT_PUBLIC_AI_PROMPT_ENABLED is baked into the build-app
           # artifact, so only the runtime AI provider env is set here.
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -931,6 +932,7 @@ jobs:
           turnkey_api_public_key: ${{ secrets.TURNKEY_API_PUBLIC_KEY }}
           turnkey_api_private_key: ${{ secrets.TURNKEY_API_PRIVATE_KEY }}
           turnkey_organization_id: ${{ secrets.TURNKEY_ORGANIZATION_ID }}
+          solana_wallet_provisioning_enabled: "true"
           # Shadow-mode SSRF so the app's setup workflows can reach the
           # localhost anvil mainnet fork (chain 1 -> :8548).
           safe_fetch_shadow: "true"
@@ -1239,6 +1241,7 @@ jobs:
           turnkey_api_public_key: ${{ secrets.TURNKEY_API_PUBLIC_KEY }}
           turnkey_api_private_key: ${{ secrets.TURNKEY_API_PRIVATE_KEY }}
           turnkey_organization_id: ${{ secrets.TURNKEY_ORGANIZATION_ID }}
+          solana_wallet_provisioning_enabled: "true"
           load_test_bypass_token: ${{ secrets.LOAD_TEST_BYPASS_TOKEN }}
           # Enable testEndpointsEnabled() so the strict-signin/start credential
           # rate-limit bypass honors playwright's X-Test-API-Key header (the

--- a/app/api/analytics/spend-cap/route.ts
+++ b/app/api/analytics/spend-cap/route.ts
@@ -31,12 +31,20 @@ export const GET = requireOrganization(
 );
 
 /**
- * Set or clear the organization's daily value cap (native wei).
+ * Set or clear the organization's daily value caps.
+ *
+ * Two independent caps, each optional in the body:
+ *   dailyValueCapWei             EVM, wei      (18 decimals)
+ *   dailySolanaValueCapLamports  Solana, lamports (9 decimals)
+ *
+ * An omitted field is left unchanged; an explicit null clears that cap
+ * (unlimited). Partial updates matter here: the two caps are edited by separate
+ * controls, so treating an absent field as "clear" would let saving one cap
+ * silently remove the other.
  *
  * Gated by `organization:update` (admin/owner) over the session. A leaked `kh_`
  * API key or MCP OAuth token authenticates a different layer and never satisfies
  * the org session context, so a compromised key cannot raise its own ceiling.
- * A null `dailyValueCapWei` clears the cap (unlimited).
  */
 export const PUT = requirePermission(
   "organization",
@@ -50,42 +58,106 @@ export const PUT = requirePermission(
       );
     }
 
-    let body: { dailyValueCapWei?: unknown };
+    let body: {
+      dailyValueCapWei?: unknown;
+      dailySolanaValueCapLamports?: unknown;
+    };
     try {
-      body = (await req.json()) as { dailyValueCapWei?: unknown };
+      body = (await req.json()) as typeof body;
     } catch {
       return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
     }
 
-    const raw = body.dailyValueCapWei;
-    let dailyValueCapWei: string | null;
-    if (raw === null) {
-      dailyValueCapWei = null;
-    } else if (typeof raw === "string" && NON_NEGATIVE_INTEGER.test(raw)) {
-      dailyValueCapWei = raw;
-    } else {
+    const wei = parseCapField(body, "dailyValueCapWei", "wei");
+    if ("error" in wei) {
+      return NextResponse.json(wei.error, { status: 400 });
+    }
+    const lamports = parseCapField(
+      body,
+      "dailySolanaValueCapLamports",
+      "lamports"
+    );
+    if ("error" in lamports) {
+      return NextResponse.json(lamports.error, { status: 400 });
+    }
+
+    if (!(wei.present || lamports.present)) {
       return NextResponse.json(
         {
           error:
-            "dailyValueCapWei must be a non-negative integer wei string, or null to clear the cap",
-          field: "dailyValueCapWei",
+            "Provide dailyValueCapWei and/or dailySolanaValueCapLamports (null clears a cap)",
         },
         { status: 400 }
       );
     }
 
+    // Only columns explicitly present in the body are written, so updating one
+    // cap never clears the other.
+    const set: Record<string, unknown> = { updatedAt: new Date() };
+    if (wei.present) {
+      set.dailyValueCapWei = wei.value;
+    }
+    if (lamports.present) {
+      set.dailySolanaValueCapLamports = lamports.value;
+    }
+
     try {
       await db
         .insert(organizationSpendCaps)
-        .values({ organizationId, dailyValueCapWei })
+        .values({
+          organizationId,
+          dailyValueCapWei: wei.present ? wei.value : null,
+          dailySolanaValueCapLamports: lamports.present ? lamports.value : null,
+        })
         .onConflictDoUpdate({
           target: organizationSpendCaps.organizationId,
-          set: { dailyValueCapWei, updatedAt: new Date() },
+          set,
         });
     } catch (error: unknown) {
       return apiError(error, "Failed to update spend cap");
     }
 
-    return NextResponse.json({ dailyValueCapWei }, { status: 200 });
+    return NextResponse.json(
+      {
+        ...(wei.present ? { dailyValueCapWei: wei.value } : {}),
+        ...(lamports.present
+          ? { dailySolanaValueCapLamports: lamports.value }
+          : {}),
+      },
+      { status: 200 }
+    );
   }
 );
+
+type CapField =
+  | { present: false }
+  | { present: true; value: string | null }
+  | { error: { error: string; field: string } };
+
+/**
+ * Absent -> unchanged, explicit null -> clear, non-negative integer string ->
+ * set. Any other shape is rejected rather than coerced, so a malformed cap can
+ * never be silently stored as unlimited.
+ */
+function parseCapField(
+  body: Record<string, unknown>,
+  field: string,
+  unit: string
+): CapField {
+  if (!(field in body)) {
+    return { present: false };
+  }
+  const raw = body[field];
+  if (raw === null) {
+    return { present: true, value: null };
+  }
+  if (typeof raw === "string" && NON_NEGATIVE_INTEGER.test(raw)) {
+    return { present: true, value: raw };
+  }
+  return {
+    error: {
+      error: `${field} must be a non-negative integer ${unit} string, or null to clear the cap`,
+      field,
+    },
+  };
+}

--- a/app/api/execute/[...slug]/route.ts
+++ b/app/api/execute/[...slug]/route.ts
@@ -256,7 +256,7 @@ async function executeProtocolAction(
     type: "protocol-action",
     network,
     input: redactInput(withRejectedSignerOverride(body, body)),
-    reservedValueWei: parsedValue.valueWei,
+    reserved: { kind: "evm", valueWei: parsedValue.valueWei },
   });
   if (!reserve.allowed) {
     return recordIdempotentResponse(

--- a/app/api/execute/_lib/reserved-value.ts
+++ b/app/api/execute/_lib/reserved-value.ts
@@ -1,18 +1,41 @@
 import "server-only";
 
 import {
+  parseNativeValueLamports,
   parseNativeValueWei,
-  type ReservedValue,
 } from "@/lib/execute/native-value";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { isSolanaChain } from "@/lib/rpc/provider-factory";
 
 // parseNativeValueWei lives in lib/execute so both the direct-execution routes
 // (here) and the workflow step wrappers can charge native value against the
 // same cap. Imported above for local use (parseNodeNativeValueWei), and
 // re-exported for the routes/tests that import it from this path.
 export {
+  parseNativeValueLamports,
   parseNativeValueWei,
   type ReservedValue,
 } from "@/lib/execute/native-value";
+
+/**
+ * Solana write steps that can move native SOL by arbitrary means.
+ *
+ * Both build transactions from caller-supplied instruction data, so the value
+ * they move is not derivable from any config field: a raw instruction can
+ * invoke any program, and an Anchor call can move lamports through a CPI that
+ * never appears in the encoded arguments. Static inspection can only recognise
+ * the shapes it special-cases and would reserve "0" for everything else, which
+ * is the bypass itself.
+ *
+ * These steps therefore require an explicit `maxSol` ceiling, declared by the
+ * caller and enforced against the simulated balance delta before submit. The
+ * value reserved here is that declared ceiling, not the eventual actual spend;
+ * the adapter reconciles the ledger down to the true delta after confirmation.
+ */
+const SOLANA_DECLARED_VALUE_STEPS: ReadonlySet<string> = new Set([
+  "sendRawSolanaInstructionStep",
+  "callSolanaProgramStep",
+]);
 
 /**
  * Native value (wei) reserved for a generic node execution.
@@ -24,17 +47,77 @@ export {
  * transfers/approvals and off-chain steps have neither field and correctly
  * reserve "0". `value` is deliberately NOT read -- it names non-broadcasting
  * inputs on other steps (e.g. risk analysis), so charging it would be wrong.
+ *
+ * The field-name heuristic holds for EVM only because every value-forwarding
+ * EVM action happens to use `ethValue`. The Solana write steps carry no such
+ * field, so they are matched by step name and fail closed when no ceiling is
+ * declared rather than falling through to a "0" reservation.
+ *
+ * `maxSol` is parsed at SOL's native 9 decimals and charged against the org's
+ * separate lamports-denominated Solana cap, never against the wei cap. The two
+ * are different assets and the caps are independent, so no scaling fudge is
+ * needed to make them share a number.
  */
+export type NodeReservedValue =
+  | { ok: true; kind: "evm"; valueWei: string }
+  | { ok: true; kind: "solana"; valueLamports: string }
+  | { ok: false; error: string };
+
 export function parseNodeNativeValueWei(
   stepFunction: string,
   config: Record<string, unknown>
-): ReservedValue {
-  if (stepFunction === "transferFundsStep") {
-    return parseNativeValueWei(
-      typeof config.amount === "string" ? config.amount : undefined
-    );
+): NodeReservedValue {
+  if (SOLANA_DECLARED_VALUE_STEPS.has(stepFunction)) {
+    const declared = typeof config.maxSol === "string" ? config.maxSol : "";
+    if (declared.trim() === "") {
+      return {
+        ok: false,
+        error:
+          "maxSol is required for this action: declare the maximum SOL the transaction may move so it can be charged against the organization's daily Solana value cap",
+      };
+    }
+    const parsed = parseNativeValueLamports(declared);
+    return parsed.ok
+      ? { ok: true, kind: "solana", valueLamports: parsed.valueWei }
+      : parsed;
   }
-  return parseNativeValueWei(
+
+  // transferFundsStep is chain-agnostic - transfer-funds-core branches to a
+  // Solana path on a Solana chainId - so the amount's unit depends on the
+  // configured network, not on the step name. Without this a native SOL
+  // transfer would be parsed at 18 decimals and charged to the wei cap.
+  if (stepFunction === "transferFundsStep") {
+    const amount =
+      typeof config.amount === "string" ? config.amount : undefined;
+    if (isSolanaNetwork(config.network)) {
+      const parsed = parseNativeValueLamports(amount);
+      return parsed.ok
+        ? { ok: true, kind: "solana", valueLamports: parsed.valueWei }
+        : parsed;
+    }
+    const parsed = parseNativeValueWei(amount);
+    return parsed.ok
+      ? { ok: true, kind: "evm", valueWei: parsed.valueWei }
+      : parsed;
+  }
+
+  const parsed = parseNativeValueWei(
     typeof config.ethValue === "string" ? config.ethValue : undefined
   );
+  return parsed.ok
+    ? { ok: true, kind: "evm", valueWei: parsed.valueWei }
+    : parsed;
+}
+
+/**
+ * Whether a config `network` value denotes a Solana chain. Unresolvable or
+ * absent networks fall through to EVM, matching how the rest of the reservation
+ * path treats an unknown chain.
+ */
+export function isSolanaNetwork(network: unknown): boolean {
+  if (typeof network !== "string" || network.trim() === "") {
+    return false;
+  }
+  const chainId = getChainIdFromNetwork(network);
+  return typeof chainId === "number" && isSolanaChain(chainId);
 }

--- a/app/api/execute/_lib/spending-cap.ts
+++ b/app/api/execute/_lib/spending-cap.ts
@@ -3,7 +3,10 @@ import "server-only";
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { directExecutions, organizationSpendCaps } from "@/lib/db/schema";
-import { sumOrgValueTodayWei } from "@/lib/execute/value-ledger";
+import {
+  sumOrgSolanaValueTodayLamports,
+  sumOrgValueTodayWei,
+} from "@/lib/execute/value-ledger";
 import { generateId } from "@/lib/utils/id";
 
 export type SpendCapResult =
@@ -17,9 +20,16 @@ type ReserveExecutionParams = {
   network?: string;
   // biome-ignore lint/suspicious/noExplicitAny: jsonb column accepts arbitrary serializable data
   input: any;
-  // Native notional value (wei) this execution moves. "0" for token-only or
-  // no-value calls. Charged against the org's daily value cap at reservation.
-  reservedValueWei: string;
+  // Native notional value this execution moves, and which chain family's cap it
+  // is charged against. "0" for token-only or no-value calls. EVM amounts are
+  // wei and charge dailyValueCapWei; Solana amounts are lamports and charge
+  // dailySolanaValueCapLamports. The two caps and their ledger columns are
+  // independent - a Solana execution is never charged against the wei cap and
+  // vice versa - because wei and lamports are different units and the caps are
+  // set in different assets.
+  reserved:
+    | { kind: "evm"; valueWei: string }
+    | { kind: "solana"; valueLamports: string };
 };
 
 type ReserveResult =
@@ -30,23 +40,37 @@ type ReserveResult =
  * Atomically check the daily value cap and create the execution record.
  *
  * The cap bounds the native notional VALUE moved per org per day, not gas.
- * `reservedValueWei` (known at request time) is charged against
- * `organizationSpendCaps.dailyValueCapWei` inside a SELECT FOR UPDATE on the
- * cap row, which serializes concurrent requests for the same organization. The
- * execution record is inserted in the same transaction carrying its
- * `valueWei`, so the reserved value is immediately visible to subsequent
- * callers -- closing the TOCTOU that the old gas-based cap had (pending/running
- * rows had null gasUsedWei and contributed 0 to the SUM).
+ * `params.reserved` (known at request time) is charged against the cap for its
+ * chain family inside a SELECT FOR UPDATE on the cap row, which serializes
+ * concurrent requests for the same organization. The execution record is
+ * inserted in the same transaction carrying its value, so the reservation is
+ * immediately visible to subsequent callers -- closing the TOCTOU that the old
+ * gas-based cap had (pending/running rows had null gasUsedWei and contributed 0
+ * to the SUM).
  *
- * The cap is the org's `dailyValueCapWei`, set by org admins/owners. When no
- * cap row exists, or it is null, value spending is unlimited.
+ * There are two independent caps, both set by org admins/owners:
+ *   EVM    -> dailyValueCapWei             charged in wei      (18 decimals)
+ *   Solana -> dailySolanaValueCapLamports  charged in lamports (9 decimals)
+ *
+ * They are deliberately not one number. An admin sets the wei cap thinking in
+ * ETH; folding SOL into it would compare non-commensurable assets against a
+ * single figure, and scaling SOL to 18 decimals to fit was only ever a
+ * workaround for the missing second cap. Each cap sums only its own ledger
+ * column, so neither chain family's activity consumes the other's budget.
+ *
+ * When no cap row exists, or the column for that family is null, spending of
+ * that kind is unlimited. An unset Solana cap does NOT fall back to the wei cap.
  */
 export async function checkAndReserveExecution(
   params: ReserveExecutionParams
 ): Promise<ReserveResult> {
   return await db.transaction(async (tx) => {
     const caps = await tx
-      .select({ dailyValueCapWei: organizationSpendCaps.dailyValueCapWei })
+      .select({
+        dailyValueCapWei: organizationSpendCaps.dailyValueCapWei,
+        dailySolanaValueCapLamports:
+          organizationSpendCaps.dailySolanaValueCapLamports,
+      })
       .from(organizationSpendCaps)
       .where(eq(organizationSpendCaps.organizationId, params.organizationId))
       .for("update")
@@ -54,6 +78,7 @@ export async function checkAndReserveExecution(
 
     const cap = caps[0];
     const id = generateId();
+    const isSolana = params.reserved.kind === "solana";
 
     const insertReservation = () =>
       tx.insert(directExecutions).values({
@@ -63,12 +88,25 @@ export async function checkAndReserveExecution(
         type: params.type,
         network: params.network ?? null,
         input: params.input,
-        valueWei: params.reservedValueWei,
+        // Exactly one unit column is written per row, so each daily SUM stays
+        // single-unit.
+        valueWei:
+          params.reserved.kind === "evm" ? params.reserved.valueWei : null,
+        valueLamports:
+          params.reserved.kind === "solana"
+            ? params.reserved.valueLamports
+            : null,
         status: "pending",
       });
 
-    // No cap configured (no row, or value cap unset) -> unlimited.
-    if (!cap || cap.dailyValueCapWei === null) {
+    const configuredCap = isSolana
+      ? cap?.dailySolanaValueCapLamports
+      : cap?.dailyValueCapWei;
+
+    // No cap configured for this chain family (no row, or that column unset)
+    // -> unlimited. The two caps are independent: an unset Solana cap does NOT
+    // fall back to the wei cap.
+    if (!cap || configuredCap === null || configuredCap === undefined) {
       await insertReservation();
       return { allowed: true, executionId: id } as const;
     }
@@ -77,13 +115,24 @@ export async function checkAndReserveExecution(
     // protocol value ledger) so a direct-API request is charged against value
     // moved by workflow runs too, and cannot exceed the cap by racing them.
     // Runs inside this FOR UPDATE tx, so it is consistent under concurrency.
-    const totalWei = await sumOrgValueTodayWei(tx, params.organizationId);
-    const reservedWei = BigInt(params.reservedValueWei);
-    const dailyCap = BigInt(cap.dailyValueCapWei);
+    const total = isSolana
+      ? await sumOrgSolanaValueTodayLamports(tx, params.organizationId)
+      : await sumOrgValueTodayWei(tx, params.organizationId);
+    const reserved = BigInt(
+      params.reserved.kind === "solana"
+        ? params.reserved.valueLamports
+        : params.reserved.valueWei
+    );
+    const dailyCap = BigInt(configuredCap);
 
     // Pre-charge: deny if this request would push the day's total over the cap.
-    if (totalWei + reservedWei > dailyCap) {
-      return { allowed: false, reason: "Daily spending cap exceeded" } as const;
+    if (total + reserved > dailyCap) {
+      return {
+        allowed: false,
+        reason: isSolana
+          ? "Daily Solana spending cap exceeded"
+          : "Daily spending cap exceeded",
+      } as const;
     }
 
     await insertReservation();

--- a/app/api/execute/check-and-execute/route.ts
+++ b/app/api/execute/check-and-execute/route.ts
@@ -147,7 +147,7 @@ async function executeConditionalWrite(
     input: redactedInput,
     // The conditional write never forwards native value (writeContractCore is
     // called without ethValue), so nothing is charged to the value cap here.
-    reservedValueWei: "0",
+    reserved: { kind: "evm", valueWei: "0" },
   });
   if (!reserve.allowed) {
     return recordIdempotentResponse(

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -164,7 +164,7 @@ async function handleWriteCall(
     type: "contract-call",
     network: body.network as string,
     input: redactedInput,
-    reservedValueWei: parsedValue.valueWei,
+    reserved: { kind: "evm", valueWei: parsedValue.valueWei },
   });
   if (!reserve.allowed) {
     return recordIdempotentResponse(

--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -627,7 +627,10 @@ export async function POST(request: Request): Promise<NextResponse> {
       type: resolved.actionType,
       network: effectiveNetwork,
       input: redactedInput,
-      reservedValueWei: parsedValue.valueWei,
+      reserved:
+        parsedValue.kind === "solana"
+          ? { kind: "solana", valueLamports: parsedValue.valueLamports }
+          : { kind: "evm", valueWei: parsedValue.valueWei },
     });
     if (!reserve.allowed) {
       return applyRateLimitHeaders(

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -29,7 +29,11 @@ import {
   withRejectedSignerOverride,
 } from "../_lib/execution-service";
 import { checkRateLimit } from "../_lib/rate-limit";
-import { parseNativeValueWei } from "../_lib/reserved-value";
+import {
+  isSolanaNetwork,
+  parseNativeValueLamports,
+  parseNativeValueWei,
+} from "../_lib/reserved-value";
 import { parseSimulateFlag } from "../_lib/simulate-flag";
 import { checkAndReserveExecution } from "../_lib/spending-cap";
 import { validateTokenFields, validateTransferInput } from "../_lib/validate";
@@ -187,12 +191,20 @@ export async function POST(request: Request): Promise<NextResponse> {
   }
 
   // 6. Spending cap + create execution atomically. Native transfers charge
-  // their ETH value against the daily value cap; ERC-20 transfers move no
-  // native value (token value is not yet priced into the cap) so reserve 0.
+  // their value against the daily cap for the chain family: this route serves
+  // Solana too (transferFundsCore branches on a Solana chainId), so a SOL
+  // transfer is parsed at 9 decimals and charged to the lamports cap rather
+  // than being scaled to 18 and charged to the ETH-denominated one. Token
+  // transfers move no native value (token value is not yet priced into the
+  // cap) so reserve 0.
   const redactedInput = redactInput(withRejectedSignerOverride(body, body));
+  const isSolanaTransfer = isSolanaNetwork(network);
   let reservedValueWei = "0";
+  let reservedValueLamports = "0";
   if (!isTokenTransfer) {
-    const parsedValue = parseNativeValueWei(amount);
+    const parsedValue = isSolanaTransfer
+      ? parseNativeValueLamports(amount)
+      : parseNativeValueWei(amount);
     if (!parsedValue.ok) {
       return applyRateLimitHeaders(
         await recordIdempotentResponse(
@@ -206,7 +218,11 @@ export async function POST(request: Request): Promise<NextResponse> {
         rateLimit
       );
     }
-    reservedValueWei = parsedValue.valueWei;
+    if (isSolanaTransfer) {
+      reservedValueLamports = parsedValue.valueWei;
+    } else {
+      reservedValueWei = parsedValue.valueWei;
+    }
   }
   const reserve = await checkAndReserveExecution({
     organizationId: apiKeyCtx.organizationId,
@@ -214,7 +230,9 @@ export async function POST(request: Request): Promise<NextResponse> {
     type: "transfer",
     network,
     input: redactedInput,
-    reservedValueWei,
+    reserved: isSolanaTransfer
+      ? { kind: "solana", valueLamports: reservedValueLamports }
+      : { kind: "evm", valueWei: reservedValueWei },
   });
   if (!reserve.allowed) {
     // Pre-broadcast gating failure: release so the same key can be retried.

--- a/components/organization/spend-cap-section.tsx
+++ b/components/organization/spend-cap-section.tsx
@@ -10,43 +10,147 @@ import { Label } from "@/components/ui/label";
 type SpendCapResponse = {
   dailyCapWei: string | null;
   dailyUsedWei: string;
+  dailySolanaCapLamports: string | null;
+  dailySolanaUsedLamports: string;
 };
 
-function formatWeiToEth(wei: string): string {
+// Native decimals per chain family. The two caps are stored in their own base
+// units (wei / lamports) and are never converted into one another: they bound
+// different assets, so a single shared figure would be meaningless.
+const EVM_DECIMALS = 18;
+const SOLANA_DECIMALS = 9;
+
+function formatBase(base: string, decimals: number): string {
   try {
-    return ethers.formatEther(wei);
+    return ethers.formatUnits(base, decimals);
   } catch {
     return "0";
   }
 }
 
-function parseEthToWei(input: string): string | null {
+function parseToBase(input: string, decimals: number): string | null {
   const trimmed = input.trim();
   if (trimmed === "") {
     return null;
   }
   try {
-    const wei = ethers.parseEther(trimmed);
-    // ethers.parseEther("-5") yields a negative BigInt without throwing; the
-    // cap must be non-negative (the server also rejects it).
-    return wei < BigInt(0) ? null : wei.toString();
+    const parsed = ethers.parseUnits(trimmed, decimals);
+    // parseUnits("-5") yields a negative BigInt without throwing; the cap must
+    // be non-negative (the server also rejects it).
+    return parsed < BigInt(0) ? null : parsed.toString();
   } catch {
     return null;
   }
 }
 
+type CapControlProps = {
+  id: string;
+  label: string;
+  symbol: string;
+  decimals: number;
+  cap: string | null;
+  used: string;
+  disabled: boolean;
+  saving: boolean;
+  onSave: (base: string | null) => void;
+};
+
+function CapControl({
+  id,
+  label,
+  symbol,
+  decimals,
+  cap,
+  used,
+  disabled,
+  saving,
+  onSave,
+}: CapControlProps): React.ReactElement {
+  const [input, setInput] = useState("");
+
+  // Re-sync the field whenever the persisted cap changes (initial load, save,
+  // or clear), so the input always reflects what is actually stored.
+  useEffect(() => {
+    setInput(cap ? formatBase(cap, decimals) : "");
+  }, [cap, decimals]);
+
+  const handleSave = useCallback(() => {
+    // An empty field clears the cap, matching the "Leave empty for no cap" hint.
+    if (input.trim() === "") {
+      onSave(null);
+      return;
+    }
+    const base = parseToBase(input, decimals);
+    if (base === null) {
+      toast.error(
+        `Enter a valid ${symbol} amount (up to ${decimals} decimals)`
+      );
+      return;
+    }
+    onSave(base);
+  }, [input, decimals, symbol, onSave]);
+
+  const usedDisplay = formatBase(used, decimals);
+
+  return (
+    <div className="space-y-2">
+      <Label className="text-sm" htmlFor={id}>
+        {label}
+      </Label>
+      <Input
+        disabled={disabled}
+        id={id}
+        inputMode="decimal"
+        onChange={(e) => setInput(e.target.value)}
+        placeholder="e.g. 1.5"
+        value={input}
+      />
+      <p className="text-muted-foreground text-xs">
+        {cap
+          ? `Current cap: ${formatBase(cap, decimals)} ${symbol}/day - used ${usedDisplay} ${symbol} today`
+          : `No cap set - used ${usedDisplay} ${symbol} today`}
+      </p>
+      <div className="flex gap-2">
+        <Button
+          className="flex-1"
+          disabled={disabled}
+          onClick={handleSave}
+          size="sm"
+          variant="outline"
+        >
+          {saving ? "Saving..." : "Save cap"}
+        </Button>
+        <Button
+          disabled={disabled || !cap}
+          onClick={() => onSave(null)}
+          size="sm"
+          variant="ghost"
+        >
+          Clear
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 /**
- * Organization daily value-cap control. Reads and writes the active org's
- * `daily_value_cap_wei` via /api/analytics/spend-cap; the PUT is gated server
- * side by `organization:update` (owner/admin) over the session, so this only
- * mounts inside an admin-gated surface.
+ * Organization daily value-cap controls. Reads and writes the active org's
+ * `daily_value_cap_wei` and `daily_solana_value_cap_lamports` via
+ * /api/analytics/spend-cap; the PUT is gated server side by
+ * `organization:update` (owner/admin) over the session, so this only mounts
+ * inside an admin-gated surface.
+ *
+ * The two caps are independent and saved independently - each control sends
+ * only its own field, and the route leaves an omitted field untouched, so
+ * saving one cap cannot clear the other.
  */
 export function SpendCapSection(): React.ReactElement {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [capWei, setCapWei] = useState<string | null>(null);
   const [usedWei, setUsedWei] = useState("0");
-  const [input, setInput] = useState("");
+  const [capLamports, setCapLamports] = useState<string | null>(null);
+  const [usedLamports, setUsedLamports] = useState("0");
 
   const load = useCallback(() => {
     setLoading(true);
@@ -58,7 +162,8 @@ export function SpendCapSection(): React.ReactElement {
         }
         setCapWei(data.dailyCapWei);
         setUsedWei(data.dailyUsedWei);
-        setInput(data.dailyCapWei ? formatWeiToEth(data.dailyCapWei) : "");
+        setCapLamports(data.dailySolanaCapLamports);
+        setUsedLamports(data.dailySolanaUsedLamports);
       })
       .catch(() => {
         toast.error("Could not load the spend cap");
@@ -70,96 +175,86 @@ export function SpendCapSection(): React.ReactElement {
     load();
   }, [load]);
 
-  const save = useCallback(async (dailyValueCapWei: string | null) => {
-    setSaving(true);
-    try {
-      const res = await fetch("/api/analytics/spend-cap", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ dailyValueCapWei }),
-      });
-      if (res.ok) {
-        setCapWei(dailyValueCapWei);
-        setInput(dailyValueCapWei ? formatWeiToEth(dailyValueCapWei) : "");
-        toast.success(
-          dailyValueCapWei ? "Daily value cap saved" : "Daily value cap cleared"
-        );
-      } else if (res.status === 403) {
-        toast.error("Only organization owners and admins can change the cap");
-      } else {
+  const save = useCallback(
+    async (
+      field: "dailyValueCapWei" | "dailySolanaValueCapLamports",
+      base: string | null
+    ) => {
+      setSaving(true);
+      try {
+        const res = await fetch("/api/analytics/spend-cap", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          // Only this control's field is sent; the other cap is left untouched.
+          body: JSON.stringify({ [field]: base }),
+        });
+        if (res.ok) {
+          if (field === "dailyValueCapWei") {
+            setCapWei(base);
+          } else {
+            setCapLamports(base);
+          }
+          toast.success(
+            base ? "Daily value cap saved" : "Daily value cap cleared"
+          );
+        } else if (res.status === 403) {
+          toast.error("Only organization owners and admins can change the cap");
+        } else {
+          toast.error("Could not save the cap");
+        }
+      } catch {
         toast.error("Could not save the cap");
+      } finally {
+        setSaving(false);
       }
-    } catch {
-      toast.error("Could not save the cap");
-    } finally {
-      setSaving(false);
-    }
-  }, []);
+    },
+    []
+  );
 
-  const handleSave = useCallback(() => {
-    // An empty field clears the cap, matching the "Leave empty for no cap" hint.
-    if (input.trim() === "") {
-      save(null);
-      return;
-    }
-    const wei = parseEthToWei(input);
-    if (wei === null) {
-      toast.error("Enter a valid ETH amount (up to 18 decimals)");
-      return;
-    }
-    save(wei);
-  }, [input, save]);
-
-  const usedEth = formatWeiToEth(usedWei);
+  const saveEvm = useCallback(
+    (base: string | null) => save("dailyValueCapWei", base),
+    [save]
+  );
+  const saveSolana = useCallback(
+    (base: string | null) => save("dailySolanaValueCapLamports", base),
+    [save]
+  );
 
   return (
     <div className="space-y-3">
       <h4 className="font-medium text-muted-foreground text-sm">
-        Daily value cap
+        Daily value caps
       </h4>
       <p className="text-muted-foreground text-xs">
-        Limits the total native value (ETH) that direct execution API calls can
-        move per day for this organization. Leave empty for no cap.
+        Limits the total native value that direct execution API calls and
+        workflow runs can move per day for this organization. EVM and Solana are
+        capped separately, in their own currencies. Leave a field empty for no
+        cap.
       </p>
 
-      <div className="space-y-2">
-        <Label className="text-sm" htmlFor="daily-value-cap">
-          Cap (ETH per day)
-        </Label>
-        <Input
-          disabled={loading || saving}
-          id="daily-value-cap"
-          inputMode="decimal"
-          onChange={(e) => setInput(e.target.value)}
-          placeholder="e.g. 1.5"
-          value={input}
-        />
-        <p className="text-muted-foreground text-xs">
-          {capWei
-            ? `Current cap: ${formatWeiToEth(capWei)} ETH/day - used ${usedEth} ETH today`
-            : `No cap set - used ${usedEth} ETH today`}
-        </p>
-      </div>
+      <CapControl
+        cap={capWei}
+        decimals={EVM_DECIMALS}
+        disabled={loading || saving}
+        id="daily-value-cap"
+        label="EVM cap (ETH per day)"
+        onSave={saveEvm}
+        saving={saving}
+        symbol="ETH"
+        used={usedWei}
+      />
 
-      <div className="flex gap-2">
-        <Button
-          className="flex-1"
-          disabled={loading || saving}
-          onClick={handleSave}
-          size="sm"
-          variant="outline"
-        >
-          {saving ? "Saving..." : "Save cap"}
-        </Button>
-        <Button
-          disabled={loading || saving || !capWei}
-          onClick={() => save(null)}
-          size="sm"
-          variant="ghost"
-        >
-          Clear
-        </Button>
-      </div>
+      <CapControl
+        cap={capLamports}
+        decimals={SOLANA_DECIMALS}
+        disabled={loading || saving}
+        id="daily-solana-value-cap"
+        label="Solana cap (SOL per day)"
+        onSave={saveSolana}
+        saving={saving}
+        symbol="SOL"
+        used={usedLamports}
+      />
     </div>
   );
 }

--- a/components/workflow/config/trigger-config.tsx
+++ b/components/workflow/config/trigger-config.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Box, Boxes, Clock, Copy, Play, Webhook } from "lucide-react";
-import Image from "next/image";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -17,11 +16,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { TimezoneSelect } from "@/components/ui/timezone-select";
-import { buildEventAbiFragment } from "@/lib/protocol-registry";
-import type {
-  ProtocolDefinition,
-  ProtocolEvent,
-} from "@/lib/protocol-registry";
 import { parseIntervalSeconds } from "@/lib/cron-utils";
 import type { ActionConfigField } from "@/plugins/registry";
 import { ActionConfigRenderer } from "./action-config-renderer";
@@ -292,8 +286,6 @@ export function TriggerConfig({
   );
 }
 
-const CUSTOM_PROTOCOL_VALUE = "__custom__";
-
 type EventTriggerFieldsProps = {
   config: Record<string, unknown>;
   disabled: boolean;
@@ -305,20 +297,7 @@ function EventTriggerFields({
   disabled,
   onUpdateConfig,
 }: EventTriggerFieldsProps): React.ReactElement {
-  const [protocols, setProtocols] = useState<ProtocolDefinition[]>([]);
-
   const [chainTypes, setChainTypes] = useState<Record<string, string>>({});
-
-  useEffect(() => {
-    fetch("/api/protocols")
-      .then((res) => res.json())
-      .then((data: ProtocolDefinition[]) => {
-        setProtocols(data.filter((p) => p.events && p.events.length > 0));
-      })
-      .catch(() => {
-        // Silently ignore -- custom mode still works
-      });
-  }, []);
 
   useEffect(() => {
     fetch("/api/chains")
@@ -337,125 +316,6 @@ function EventTriggerFields({
 
   const selectedNetwork = (config.network as string) || "";
   const isSolanaNetwork = chainTypes[selectedNetwork] === "solana";
-
-  const selectedProtocolSlug =
-    (config._eventProtocolSlug as string) || CUSTOM_PROTOCOL_VALUE;
-  const selectedProtocol = protocols.find(
-    (p) => p.slug === selectedProtocolSlug
-  );
-
-  function handleProtocolChange(slug: string): void {
-    if (slug === CUSTOM_PROTOCOL_VALUE) {
-      onUpdateConfig("_eventProtocolSlug", "");
-      onUpdateConfig("_eventSlug", "");
-      onUpdateConfig("_eventProtocolIconPath", "");
-      onUpdateConfig("contractABI", "");
-      onUpdateConfig("eventName", "");
-      return;
-    }
-
-    const protocol = protocols.find((p) => p.slug === slug);
-    if (!protocol) {
-      return;
-    }
-
-    onUpdateConfig("_eventProtocolSlug", slug);
-    onUpdateConfig("_eventProtocolIconPath", protocol.icon ?? "");
-    onUpdateConfig("_eventSlug", "");
-    onUpdateConfig("contractABI", "");
-    onUpdateConfig("eventName", "");
-  }
-
-  function handleEventChange(eventSlug: string): void {
-    if (!selectedProtocol?.events) {
-      return;
-    }
-    const event = selectedProtocol.events.find((e) => e.slug === eventSlug);
-    if (!event) {
-      return;
-    }
-
-    onUpdateConfig("_eventSlug", event.slug);
-    onUpdateConfig("eventName", event.eventName);
-    onUpdateConfig("contractABI", buildEventAbiFragment(event));
-  }
-
-  if (selectedProtocol) {
-    const contract = selectedProtocol.contracts[
-      selectedProtocol.events?.[0]?.contract ?? ""
-    ];
-
-    const protocolFields: ActionConfigField[] = [
-      {
-        key: "network",
-        label: "Network",
-        type: "chain-select",
-        chainTypeFilter: "evm",
-        placeholder: "Select network",
-        required: true,
-      },
-    ];
-
-    if (contract?.userSpecifiedAddress) {
-      protocolFields.push({
-        key: "contractAddress",
-        label: `${contract.label} Address`,
-        type: "template-input",
-        placeholder: "0x...",
-        required: true,
-      });
-    }
-
-    return (
-      <>
-        <ProtocolSelector
-          config={config}
-          disabled={disabled}
-          onChange={handleProtocolChange}
-          protocols={protocols}
-        />
-        <ActionConfigRenderer
-          config={config}
-          disabled={disabled}
-          fields={protocolFields}
-          onUpdateConfig={onUpdateConfig}
-        />
-        <div className="space-y-2">
-          <Label className="ml-1">
-            Event <span className="text-red-500">*</span>
-          </Label>
-          <Select
-            disabled={disabled}
-            onValueChange={handleEventChange}
-            value={(config._eventSlug as string) || ""}
-          >
-            <SelectTrigger className="w-full">
-              <SelectValue placeholder="Select an event" />
-            </SelectTrigger>
-            <SelectContent>
-              {selectedProtocol.events?.map((event) => (
-                <SelectItem key={event.slug} value={event.slug}>
-                  <div className="flex flex-col">
-                    <span>{event.label}</span>
-                    <span className="text-muted-foreground text-xs">
-                      {event.eventName}(
-                      {event.inputs
-                        .map(
-                          (inp) =>
-                            `${inp.type}${inp.indexed ? " indexed" : ""} ${inp.name}`
-                        )
-                        .join(", ")}
-                      )
-                    </span>
-                  </div>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      </>
-    );
-  }
 
   const networkField: ActionConfigField[] = [
     {
@@ -500,14 +360,6 @@ function EventTriggerFields({
 
   return (
     <>
-      {protocols.length > 0 && !isSolanaNetwork && (
-        <ProtocolSelector
-          config={config}
-          disabled={disabled}
-          onChange={handleProtocolChange}
-          protocols={protocols}
-        />
-      )}
       <ActionConfigRenderer
         config={config}
         disabled={disabled}
@@ -631,52 +483,5 @@ function SolanaEventFields({
         </p>
       </div>
     </>
-  );
-}
-
-function ProtocolSelector({
-  protocols,
-  config,
-  disabled,
-  onChange,
-}: {
-  protocols: ProtocolDefinition[];
-  config: Record<string, unknown>;
-  disabled: boolean;
-  onChange: (slug: string) => void;
-}): React.ReactElement {
-  const value =
-    (config._eventProtocolSlug as string) || CUSTOM_PROTOCOL_VALUE;
-
-  return (
-    <div className="space-y-2">
-      <Label className="ml-1">Protocol</Label>
-      <Select disabled={disabled} onValueChange={onChange} value={value}>
-        <SelectTrigger className="w-full">
-          <SelectValue placeholder="Select protocol" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value={CUSTOM_PROTOCOL_VALUE}>
-            Custom (paste ABI)
-          </SelectItem>
-          {protocols.map((protocol) => (
-            <SelectItem key={protocol.slug} value={protocol.slug}>
-              <div className="flex items-center gap-2">
-                {protocol.icon && (
-                  <Image
-                    alt={protocol.name}
-                    className="rounded"
-                    height={16}
-                    src={protocol.icon}
-                    width={16}
-                  />
-                )}
-                {protocol.name}
-              </div>
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
   );
 }

--- a/deploy/keeperhub-stack/prod/networkpolicy.yaml
+++ b/deploy/keeperhub-stack/prod/networkpolicy.yaml
@@ -38,7 +38,7 @@ spec:
               kubernetes.io/metadata.name: keeperhub
           podSelector:
             matchLabels:
-              app.kubernetes.io/instance: keeperhub-executor
+              app.kubernetes.io/serviceName: keeperhub-executor-common
       ports:
         - protocol: TCP
           port: 3080

--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -29,6 +29,12 @@ app:
       type: parameterStore
       name: chain-rpc-config
       parameter_name: /eks/techops-prod/keeperhub/chain-rpc-config
+    # KEEP-988: gate Solana wallet provisioning at signup (Turnkey provisions an
+    # ed25519 Solana account alongside the EVM EOA). Off in prod until the prod
+    # Solana rollout; flip to "true" in a PR when ready.
+    SOLANA_WALLET_PROVISIONING_ENABLED:
+      type: kv
+      value: "false"
     TURNKEY_API_PUBLIC_KEY:
       type: parameterStore
       name: turnkey-api-public-key

--- a/deploy/keeperhub-stack/staging/networkpolicy.yaml
+++ b/deploy/keeperhub-stack/staging/networkpolicy.yaml
@@ -38,7 +38,7 @@ spec:
               kubernetes.io/metadata.name: keeperhub
           podSelector:
             matchLabels:
-              app.kubernetes.io/instance: keeperhub-executor
+              app.kubernetes.io/serviceName: keeperhub-executor-common
       ports:
         - protocol: TCP
           port: 3080

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -29,6 +29,12 @@ app:
       type: parameterStore
       name: chain-rpc-config
       parameter_name: /eks/techops-staging/keeperhub/chain-rpc-config
+    # KEEP-988: gate Solana wallet provisioning at signup (Turnkey provisions an
+    # ed25519 Solana account alongside the EVM EOA). Enabled in staging; prod
+    # stays off until the prod Solana rollout (flip to "true" in a PR then).
+    SOLANA_WALLET_PROVISIONING_ENABLED:
+      type: kv
+      value: "true"
     TURNKEY_API_PUBLIC_KEY:
       type: parameterStore
       name: turnkey-api-public-key

--- a/deploy/pr-environment/values.template.yaml
+++ b/deploy/pr-environment/values.template.yaml
@@ -16,6 +16,11 @@ shared_env: &shared_env
     type: parameterStore
     name: chain-rpc-config
     parameter_name: /eks/techops-staging/keeperhub/chain-rpc-config
+  # KEEP-988: PR environments exercise the Solana rollout end to end, so
+  # provision EVM + Solana wallets at signup (mirrors staging).
+  SOLANA_WALLET_PROVISIONING_ENABLED:
+    type: kv
+    value: "true"
 
 replicaCount: 1
 

--- a/deploy/solana-tracker/prod/values.yaml
+++ b/deploy/solana-tracker/prod/values.yaml
@@ -1,0 +1,101 @@
+# Solana ingestion service (event + block triggers). Single-process reconciler:
+# 2+ replicas would subscribe to every chain WSS twice and dispatch duplicate
+# SQS messages, so this must stay 1.
+#
+# Reuses the event-tracker's service account (keeperhub-events-prod) + IRSA
+# role, Redis, and workflow queue - Solana ingestion has the same access needs
+# as the EVM event tracker, so no new AWS resources are required. Runs healthy
+# but idle until a Solana chain (101/103) with primary RPC + WSS is configured
+# in chain-config; the mapper skips chains without WSS and starts no ingestors.
+replicaCount: 1
+
+service:
+  enabled: true
+  name: keeperhub-solana-prod
+  port: 3001
+  type: ClusterIP
+  containerPort: 3001
+  tls:
+    enabled: false
+
+ingress:
+  enabled: false
+
+image:
+  repository: ${ECR_REGISTRY}/keeperhub-event-prod
+  tag: solana-${IMAGE_TAG}
+  pullPolicy: Always
+
+deployment:
+  enabled: true
+
+# Reuse the event-tracker service account + IRSA role (created by the
+# keeperhub-event release). create: false so this release only references it -
+# no new IAM role is provisioned for Solana.
+serviceAccount:
+  create: false
+  name: keeperhub-events-prod
+
+podAnnotations:
+  reloader.stakater.com/auto: "true"
+
+resources:
+  limits:
+    memory: 1Gi
+  requests:
+    cpu: 50m
+    memory: 256Mi
+
+env:
+  NODE_ENV:
+    type: kv
+    value: "production"
+  LOG_LEVEL:
+    type: kv
+    value: "info"
+  HEALTH_PORT:
+    type: kv
+    value: "3001"
+  KEEPERHUB_API_URL:
+    type: kv
+    value: "http://keeperhub-common:3000"
+  INTERNAL_SERVICE_HMAC_SECRET:
+    type: parameterStore
+    name: internal-service-hmac-secret
+    parameter_name: /eks/techops-prod/keeperhub/internal-service-hmac-secret
+  REDIS_HOST:
+    type: parameterStore
+    name: redis-host
+    parameter_name: /eks/techops-prod/keeperhub-events/redis-host
+  REDIS_PORT:
+    type: parameterStore
+    name: redis-port
+    parameter_name: /eks/techops-prod/keeperhub-events/redis-port
+  REDIS_PASSWORD:
+    type: parameterStore
+    name: redis-password
+    parameter_name: /eks/techops-prod/keeperhub-events/redis-password
+  SQS_QUEUE_URL:
+    type: kv
+    value: "https://sqs.us-east-2.amazonaws.com/${AWS_ACCOUNT_ID}/keeperhub-workflow-queue-prod"
+  AWS_REGION:
+    type: kv
+    value: "us-east-2"
+
+externalSecrets:
+  clusterSecretStoreName: techops-prod
+
+# solana-tracker serves an HTTP health server on HEALTH_PORT (unlike
+# event-tracker, which has no server and uses a pgrep exec probe).
+livenessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  httpGet:
+    path: /healthz
+    port: 3001
+readinessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  httpGet:
+    path: /healthz
+    port: 3001

--- a/deploy/solana-tracker/staging/values.yaml
+++ b/deploy/solana-tracker/staging/values.yaml
@@ -1,0 +1,101 @@
+# Solana ingestion service (event + block triggers). Single-process reconciler:
+# 2+ replicas would subscribe to every chain WSS twice and dispatch duplicate
+# SQS messages, so this must stay 1.
+#
+# Reuses the event-tracker's service account (keeperhub-events-staging) + IRSA
+# role, Redis, and workflow queue - Solana ingestion has the same access needs
+# as the EVM event tracker, so no new AWS resources are required. Runs healthy
+# but idle until a Solana chain (101/103) with primary RPC + WSS is configured
+# in chain-config; the mapper skips chains without WSS and starts no ingestors.
+replicaCount: 1
+
+service:
+  enabled: true
+  name: keeperhub-solana-staging
+  port: 3001
+  type: ClusterIP
+  containerPort: 3001
+  tls:
+    enabled: false
+
+ingress:
+  enabled: false
+
+image:
+  repository: ${ECR_REGISTRY}/keeperhub-event-staging
+  tag: solana-${IMAGE_TAG}
+  pullPolicy: Always
+
+deployment:
+  enabled: true
+
+# Reuse the event-tracker service account + IRSA role (created by the
+# keeperhub-event release). create: false so this release only references it -
+# no new IAM role is provisioned for Solana.
+serviceAccount:
+  create: false
+  name: keeperhub-events-staging
+
+podAnnotations:
+  reloader.stakater.com/auto: "true"
+
+resources:
+  limits:
+    memory: 512Mi
+  requests:
+    cpu: 50m
+    memory: 128Mi
+
+env:
+  NODE_ENV:
+    type: kv
+    value: "staging"
+  LOG_LEVEL:
+    type: kv
+    value: "info"
+  HEALTH_PORT:
+    type: kv
+    value: "3001"
+  KEEPERHUB_API_URL:
+    type: kv
+    value: "http://keeperhub-common:3000"
+  INTERNAL_SERVICE_HMAC_SECRET:
+    type: parameterStore
+    name: internal-service-hmac-secret
+    parameter_name: /eks/techops-staging/keeperhub/internal-service-hmac-secret
+  REDIS_HOST:
+    type: parameterStore
+    name: redis-host
+    parameter_name: /eks/techops-staging/keeperhub-events/redis-host
+  REDIS_PORT:
+    type: parameterStore
+    name: redis-port
+    parameter_name: /eks/techops-staging/keeperhub-events/redis-port
+  REDIS_PASSWORD:
+    type: parameterStore
+    name: redis-password
+    parameter_name: /eks/techops-staging/keeperhub-events/redis-password
+  SQS_QUEUE_URL:
+    type: kv
+    value: "https://sqs.us-east-1.amazonaws.com/${AWS_ACCOUNT_ID}/keeperhub-workflow-queue-staging"
+  AWS_REGION:
+    type: kv
+    value: "us-east-1"
+
+externalSecrets:
+  clusterSecretStoreName: techops-staging
+
+# solana-tracker serves an HTTP health server on HEALTH_PORT (unlike
+# event-tracker, which has no server and uses a pgrep exec probe).
+livenessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  httpGet:
+    path: /healthz
+    port: 3001
+readinessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  httpGet:
+    path: /healthz
+    port: 3001

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -34,7 +34,7 @@ group "default" {
 }
 
 group "events" {
-  targets = ["event-tracker"]
+  targets = ["event-tracker", "solana-tracker"]
 }
 
 group "scheduler" {
@@ -57,7 +57,7 @@ group "pipeline" {
 }
 
 group "all" {
-  targets = ["app", "migrator", "workflow-runner", "event-tracker", "schedule-dispatcher", "block-dispatcher", "executor", "sandbox", "metrics-collector"]
+  targets = ["app", "migrator", "workflow-runner", "event-tracker", "solana-tracker", "schedule-dispatcher", "block-dispatcher", "executor", "sandbox", "metrics-collector"]
 }
 
 target "app" {
@@ -165,6 +165,22 @@ target "event-tracker" {
   ])
   cache-from = ["type=registry,ref=${ECR_REGISTRY}/${EVENTS_ECR_TRACKER_REPO}:cache"]
   cache-to   = ["type=registry,ref=${ECR_REGISTRY}/${EVENTS_ECR_TRACKER_REPO}:cache,mode=max"]
+  attest     = []
+}
+
+# Solana ingestion (event + block triggers). Shares the events ECR repo, so all
+# tags/cache are "solana-" prefixed to avoid colliding with the event-tracker
+# images. Final Dockerfile stage is "runtime", so no explicit target is needed.
+target "solana-tracker" {
+  context    = "./keeperhub-events"
+  dockerfile = "solana-tracker/Dockerfile"
+  tags = compact([
+    "${ECR_REGISTRY}/${EVENTS_ECR_TRACKER_REPO}:solana-${IMAGE_TAG}",
+    "${ECR_REGISTRY}/${EVENTS_ECR_TRACKER_REPO}:solana-latest",
+    ENVIRONMENT_TAG != "" ? "${ECR_REGISTRY}/${EVENTS_ECR_TRACKER_REPO}:solana-${ENVIRONMENT_TAG}" : "",
+  ])
+  cache-from = ["type=registry,ref=${ECR_REGISTRY}/${EVENTS_ECR_TRACKER_REPO}:cache-solana"]
+  cache-to   = ["type=registry,ref=${ECR_REGISTRY}/${EVENTS_ECR_TRACKER_REPO}:cache-solana,mode=max"]
   attest     = []
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -489,6 +489,41 @@ services:
       - minikube
 
   # ===========================================================================
+  # Solana Tracker (keeperhub-events/solana-tracker)
+  # Unified Solana ingestion for event + block triggers; routes to the same SQS
+  # queue as event-tracker. Serves an HTTP health server on HEALTH_PORT.
+  # ===========================================================================
+  solana-tracker:
+    build:
+      context: ./keeperhub-events
+      dockerfile: solana-tracker/Dockerfile
+    container_name: keeperhub-solana-tracker
+    restart: unless-stopped
+    environment:
+      HEALTH_PORT: "3001"
+      LOG_LEVEL: info
+      KEEPERHUB_API_URL: http://keeperhub:3000
+      INTERNAL_SERVICE_HMAC_SECRET: ${INTERNAL_SERVICE_HMAC_SECRET:-bG9jYWwtZGV2LWludGVybmFsLXNlcnZpY2UtaG1hYzA=}
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      SQS_QUEUE_URL: http://localstack:4566/000000000000/keeperhub-workflow-queue
+      AWS_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_ENDPOINT_URL: http://localstack:4566
+      NODE_ENV: development
+    depends_on:
+      redis:
+        condition: service_started
+      localstack:
+        condition: service_healthy
+      app-dev:
+        condition: service_started
+    profiles:
+      - dev
+      - minikube
+
+  # ===========================================================================
   # Block Dispatcher (keeperhub-scheduler)
   # Monitors blockchain blocks and routes matching workflows to SQS
   # ===========================================================================

--- a/drizzle/0131_keep_1017_solana_value_cap.sql
+++ b/drizzle/0131_keep_1017_solana_value_cap.sql
@@ -1,0 +1,11 @@
+-- Per-org daily Solana native-value cap, denominated in lamports.
+--
+-- Solana value is deliberately NOT charged against daily_value_cap_wei: that
+-- column is wei-denominated and admins set it thinking in ETH, so folding SOL
+-- into it would compare two non-commensurable assets against a single number.
+-- A separate column lets SOL be accounted at its true 9-decimal precision.
+--
+-- Nullable with no default, so adding it is a metadata-only change (no table
+-- rewrite, no lock of consequence) and every existing org keeps unlimited
+-- Solana spending until an admin sets a value.
+ALTER TABLE "organization_spend_caps" ADD COLUMN IF NOT EXISTS "daily_solana_value_cap_lamports" text;

--- a/drizzle/0132_keep_1017_value_lamports.sql
+++ b/drizzle/0132_keep_1017_value_lamports.sql
@@ -1,0 +1,16 @@
+-- Lamports-denominated value columns for the two daily-cap ledger stores.
+--
+-- Kept separate from the existing value_wei columns rather than reusing them:
+-- the daily cap sums these per org, and wei (1e18) and lamports (1e9) are
+-- different units, so a shared column would silently add the two scales
+-- together and understate cap usage.
+--
+-- Exactly one of value_wei / value_lamports carries the real figure per row.
+-- org_value_reservations.value_wei is NOT NULL and predates this, so Solana
+-- rows there carry "0" in value_wei; the wei SUM is therefore unaffected by
+-- Solana activity, and the lamports SUM is unaffected by EVM activity.
+--
+-- Both columns are nullable with no default, so these are metadata-only adds
+-- (no table rewrite).
+ALTER TABLE "direct_executions" ADD COLUMN IF NOT EXISTS "value_lamports" text;
+ALTER TABLE "org_value_reservations" ADD COLUMN IF NOT EXISTS "value_lamports" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -918,6 +918,20 @@
       "when": 1784120180000,
       "tag": "0130_keep_974_dispatch_key",
       "breakpoints": true
+    },
+    {
+      "idx": 131,
+      "version": "7",
+      "when": 1784120180001,
+      "tag": "0131_keep_1017_solana_value_cap",
+      "breakpoints": true
+    },
+    {
+      "idx": 132,
+      "version": "7",
+      "when": 1784120180002,
+      "tag": "0132_keep_1017_value_lamports",
+      "breakpoints": true
     }
   ]
 }

--- a/keeperhub-events/solana-tracker/package.json
+++ b/keeperhub-events/solana-tracker/package.json
@@ -16,6 +16,7 @@
     "test:unit": "vitest run tests/unit",
     "test:integration": "vitest run tests/integration",
     "e2e:injected": "tsx tests/e2e/injected.ts",
+    "e2e:injected-block": "tsx tests/e2e/injected-block.ts",
     "e2e:devnet": "tsx tests/e2e/devnet.ts"
   },
   "dependencies": {

--- a/keeperhub-events/solana-tracker/tests/e2e/injected-block.ts
+++ b/keeperhub-events/solana-tracker/tests/e2e/injected-block.ts
@@ -1,0 +1,100 @@
+import { SQS_QUEUE_URL } from "../../lib/config/environment";
+import { createPhantomExecution } from "../../lib/phantom";
+import { sqs } from "../../lib/sqs-client";
+import { logger } from "../../lib/utils/logger";
+import { enqueueWorkflowBlockTrigger } from "../../lib/workflow-sqs";
+import { fetchSolanaTriggers } from "../../src/discovery";
+import { buildRegistrations } from "../../src/mapper";
+import { matchBlocks } from "../../src/match/block-matcher";
+import type { NormalizedBlock } from "../../src/match/types";
+import { executionStatus, poll } from "./lib";
+
+/**
+ * Injected-block E2E for the Block trigger (deterministic). Mirrors injected.ts
+ * but drives the block path: discovery -> registration -> matchBlocks -> phantom
+ * -> SQS -> executor, injecting a synthetic block whose height divides the
+ * trigger's interval instead of polling a live chain. Proves the block
+ * trigger's SQS -> executor -> execution leg with no devnet dependency.
+ * Requires a live local stack (app-dev, localstack, redis, executor, Postgres).
+ */
+const WORKFLOW = process.env.E2E_WORKFLOW_ID ?? "dev_wf_block_on";
+const CHAIN_ID = Number(process.env.E2E_CHAIN_ID ?? "103");
+
+async function main(): Promise<void> {
+  const data = await fetchSolanaTriggers();
+  if (!data) {
+    throw new Error("discovery returned no data (is app-dev up + HMAC set?)");
+  }
+  const reg = buildRegistrations(data).find((r) => r.chainId === CHAIN_ID);
+  if (!reg) {
+    throw new Error(`no chain ${CHAIN_ID} registration from discovery`);
+  }
+  const trigger = reg.blockTriggers.find((t) => t.workflowId === WORKFLOW);
+  if (!trigger) {
+    throw new Error(
+      `${WORKFLOW} not found among chain ${CHAIN_ID} block triggers`,
+    );
+  }
+
+  // A synthetic block whose height is divisible by the trigger interval, so the
+  // real matcher fires. Block matching is height-based, so no transactions are
+  // needed.
+  const height = trigger.blockInterval * 1000;
+  const block: NormalizedBlock = {
+    slot: height + 1,
+    blockHeight: height,
+    blockhash: "e2e-injected-block",
+    blockTime: Math.floor(Date.now() / 1000),
+    parentSlot: height,
+    transactions: [],
+  };
+
+  const fire = matchBlocks(block, reg.blockTriggers).find(
+    (f) => f.workflowId === WORKFLOW,
+  );
+  if (!fire) {
+    throw new Error("matcher produced no fire for the injected block");
+  }
+
+  const executionId = await createPhantomExecution(
+    fire.workflowId,
+    fire.userId,
+    "block",
+    "scheduler",
+  );
+  if (!executionId) {
+    throw new Error("createPhantomExecution failed (check app-dev + HMAC)");
+  }
+  await enqueueWorkflowBlockTrigger(sqs, SQS_QUEUE_URL, {
+    executionId,
+    workflowId: fire.workflowId,
+    userId: fire.userId,
+    triggerData: fire.payload,
+  });
+  logger.log(
+    `[e2e-injected-block] enqueued execution ${executionId}; waiting for the executor...`,
+  );
+
+  const advanced = await poll(
+    () => executionStatus(executionId) !== "phantom",
+    45_000,
+  );
+  const finalStatus = executionStatus(executionId);
+  if (!advanced) {
+    logger.error(
+      `[e2e-injected-block] FAIL: execution ${executionId} stayed "phantom" - the executor did not consume the SQS message`,
+    );
+    process.exit(1);
+  }
+  logger.log(
+    `[e2e-injected-block] PASS: injected block -> matcher -> phantom -> SQS -> executor (final status=${finalStatus})`,
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  logger.error(
+    `[e2e-injected-block] error: ${err instanceof Error ? err.message : String(err)}`,
+  );
+  process.exit(1);
+});

--- a/keeperhub-executor/in-process.ts
+++ b/keeperhub-executor/in-process.ts
@@ -4,6 +4,7 @@ import { buildExecutorInput } from "../lib/workflow/executor/build-executor-inpu
 import { executeWorkflow } from "../lib/workflow/executor/executor.workflow";
 import type { WorkflowEdge, WorkflowNode } from "../lib/workflow/store";
 import { loadWorkflowForExecution } from "../lib/workflow/load-for-execution";
+import type { ApiExecuteTriggerType } from "./api-execute";
 import type { DbSchema } from "./lib/db-helpers";
 import {
   applyExecutionResult,
@@ -21,10 +22,12 @@ export async function executeInProcess(params: {
   workflowId: string;
   executionId: string;
   input: Record<string, unknown>;
+  triggerType: ApiExecuteTriggerType;
   scheduleId?: string;
   db: PostgresJsDatabase<DbSchema>;
 }): Promise<void> {
-  const { workflowId, executionId, input, scheduleId, db } = params;
+  const { workflowId, executionId, input, triggerType, scheduleId, db } =
+    params;
   const startTime = Date.now();
 
   console.log("[Executor:InProcess] Starting workflow execution");
@@ -38,8 +41,14 @@ export async function executeInProcess(params: {
     // workflow could have been disabled, soft-deleted, deactivated, or its
     // owning org deactivated between dispatch and execution. Cancel rather than
     // run. The org owns the workflow, so org deactivation is the owner gate.
+    //
+    // Manual runs are the exception: the editor "Run" button must work on
+    // not-yet-enabled drafts, so manual triggers pass requireEnabled: false to
+    // match the interactive execute route. That only bypasses the "disabled"
+    // reason - deleted/deactivated/org-deactivated still block - so it stays
+    // safe. Automated triggers (schedule/event/block/webhook) keep the guard.
     const loaded = await loadWorkflowForExecution(workflowId, {
-      requireEnabled: true,
+      requireEnabled: triggerType !== "manual",
     });
     if (loaded.status === "not_found") {
       throw new Error(`Workflow not found: ${workflowId}`);

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -237,6 +237,7 @@ async function dispatchExecution(params: {
         workflowId,
         executionId,
         input,
+        triggerType,
         scheduleId,
         db,
       });
@@ -288,13 +289,19 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
   );
 
   // Load the workflow and evaluate its lifecycle state in one round-trip.
-  // A soft-deleted, disabled, or deactivated workflow - or one whose owning
-  // org is deactivated - must never execute, even if a stale schedule or
-  // queued message still references it. The block_executions DB trigger is the
+  // A soft-deleted or deactivated workflow - or one whose owning org is
+  // deactivated - must never execute, even if a stale schedule or queued
+  // message still references it. The block_executions DB trigger is the
   // INSERT-time backstop; this skips the work before it gets that far. The org
   // owns the workflow, so org deactivation is the owner gate.
+  //
+  // Manual runs are the exception: the editor "Run" button must work on
+  // not-yet-enabled drafts, so manual triggers pass requireEnabled: false to
+  // match the interactive execute route. That only bypasses the "disabled"
+  // reason - deleted/deactivated/org-deactivated still block - so it stays safe.
+  // Automated triggers (schedule/event/block/webhook) keep the enabled gate.
   const loaded = await loadWorkflowForExecution(workflowId, {
-    requireEnabled: true,
+    requireEnabled: triggerType !== "manual",
   });
   if (loaded.status === "not_found") {
     console.error(`[Executor] Workflow not found: ${workflowId}`);

--- a/keeperhub-executor/k8s-job.ts
+++ b/keeperhub-executor/k8s-job.ts
@@ -113,6 +113,7 @@ export async function createWorkflowJob(params: {
     { name: "WORKFLOW_ID", value: workflowId },
     { name: "EXECUTION_ID", value: executionId },
     { name: "WORKFLOW_INPUT", value: JSON.stringify(input) },
+    { name: "TRIGGER_TYPE", value: triggerType },
     // With readOnlyRootFilesystem the only writable path is the /tmp emptyDir
     // below. tsx/esbuild and any plugin temp writes resolve through TMPDIR, so
     // point it there to keep the runner working under the hardened context.

--- a/keeperhub-executor/workflow-runner.ts
+++ b/keeperhub-executor/workflow-runner.ts
@@ -36,6 +36,7 @@ import { executeWorkflow } from "../lib/workflow/executor/executor.workflow";
 import { SHUTDOWN_TIMEOUT_MS } from "../lib/workflow/executor/runner-constants";
 import type { WorkflowEdge, WorkflowNode } from "../lib/workflow/store";
 import { loadWorkflowForExecution } from "../lib/workflow/load-for-execution";
+import type { ApiExecuteTriggerType } from "./api-execute";
 import {
   applyExecutionResult,
   initializeExecutionProgress,
@@ -49,6 +50,7 @@ function validateEnv(): {
   workflowId: string;
   executionId: string;
   input: Record<string, unknown>;
+  triggerType?: ApiExecuteTriggerType;
   scheduleId?: string;
 } {
   const workflowId = process.env.WORKFLOW_ID;
@@ -83,6 +85,7 @@ function validateEnv(): {
     workflowId,
     executionId,
     input,
+    triggerType: process.env.TRIGGER_TYPE as ApiExecuteTriggerType | undefined,
     scheduleId: process.env.SCHEDULE_ID,
   };
 }
@@ -156,7 +159,8 @@ process.on("SIGINT", () => handleGracefulShutdown("SIGINT"));
 
 async function main(): Promise<void> {
   const startTime = Date.now();
-  const { workflowId, executionId, input, scheduleId } = validateEnv();
+  const { workflowId, executionId, input, triggerType, scheduleId } =
+    validateEnv();
 
   currentExecutionId = executionId;
   currentScheduleId = scheduleId ?? null;
@@ -178,8 +182,14 @@ async function main(): Promise<void> {
     // workflow could have been disabled, soft-deleted, deactivated, or its
     // owning org deactivated between dispatch and pod startup. Cancel rather
     // than run. The org owns the workflow, so org deactivation is the owner gate.
+    //
+    // Manual runs are the exception: the editor "Run" button must work on
+    // not-yet-enabled drafts, so manual triggers pass requireEnabled: false to
+    // match the interactive execute route. That only bypasses the "disabled"
+    // reason - deleted/deactivated/org-deactivated still block - so it stays
+    // safe. Automated triggers (schedule/event/block/webhook) keep the guard.
     const loaded = await loadWorkflowForExecution(workflowId, {
-      requireEnabled: true,
+      requireEnabled: triggerType !== "manual",
     });
     if (loaded.status === "not_found") {
       throw new Error(`Workflow not found: ${workflowId}`);

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -26,7 +26,10 @@ import {
 } from "@/lib/db/schema-extensions";
 import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 import { ERROR_STATUSES } from "@/lib/errors/execution-status";
-import { sumOrgValueTodayWei } from "@/lib/execute/value-ledger";
+import {
+  sumOrgSolanaValueTodayLamports,
+  sumOrgValueTodayWei,
+} from "@/lib/execute/value-ledger";
 import { redactAllUrls, redactSecretUrls } from "@/lib/rpc/scrub-rpc-urls";
 import { analyticsCacheKey, cachedAnalytics } from "./cache";
 import {
@@ -1337,24 +1340,36 @@ export async function getStepLogs(
 export async function getSpendCapData(organizationId: string): Promise<{
   dailyCapWei: string | null;
   dailyUsedWei: string;
+  dailySolanaCapLamports: string | null;
+  dailySolanaUsedLamports: string;
 }> {
   // Mirror spending-cap enforcement exactly: the notional VALUE moved per org
   // per day, summed across BOTH stores (direct executions AND the workflow/
   // protocol value ledger, with the same stale-window aging), against the org's
   // daily value cap. Using the shared SUM keeps the gauge honest -- it shows the
   // same number enforcement checks, so workflow spend counts too.
-  const [capResult, dailyUsedWei] = await Promise.all([
+  // Solana is reported alongside as its own pair: its cap and usage are
+  // lamports-denominated and enforced against a separate column, so folding
+  // them into the wei figures would misreport both gauges.
+  const [capResult, dailyUsedWei, dailySolanaUsedLamports] = await Promise.all([
     db
-      .select({ dailyValueCapWei: organizationSpendCaps.dailyValueCapWei })
+      .select({
+        dailyValueCapWei: organizationSpendCaps.dailyValueCapWei,
+        dailySolanaValueCapLamports:
+          organizationSpendCaps.dailySolanaValueCapLamports,
+      })
       .from(organizationSpendCaps)
       .where(eq(organizationSpendCaps.organizationId, organizationId))
       .limit(1),
     sumOrgValueTodayWei(db, organizationId),
+    sumOrgSolanaValueTodayLamports(db, organizationId),
   ]);
 
   return {
     dailyCapWei: capResult[0]?.dailyValueCapWei ?? null,
     dailyUsedWei: dailyUsedWei.toString(),
+    dailySolanaCapLamports: capResult[0]?.dailySolanaValueCapLamports ?? null,
+    dailySolanaUsedLamports: dailySolanaUsedLamports.toString(),
   };
 }
 

--- a/lib/db/schema-extensions.ts
+++ b/lib/db/schema-extensions.ts
@@ -634,6 +634,12 @@ export const directExecutions = pgTable(
     // that move no native value (treated as 0). ERC-20 token value is not yet
     // priced into this figure.
     valueWei: text("value_wei"),
+    // Native notional value (lamports) a Solana execution moves. Deliberately a
+    // separate column from valueWei rather than a shared one: the daily cap sums
+    // these per org, and wei and lamports are different units, so a shared
+    // column would silently add 1e18-scaled and 1e9-scaled figures together.
+    // Exactly one of valueWei / valueLamports is set per row.
+    valueLamports: text("value_lamports"),
     // Populated by a future price-oracle integration; null until then
     estimatedCostUsd: text("estimated_cost_usd"),
     retryCount: integer("retry_count").notNull().default(0),
@@ -710,8 +716,17 @@ export type NewIdempotencyRecord = typeof idempotencyRecords.$inferInsert;
  * gas-denominated figure, no longer enforced or displayed; nullable so a
  * value-only cap row can be created without it.
  *
- * When no row exists for an org, or `dailyValueCapWei` is null, value spending
- * is unlimited (no cap enforced).
+ * `dailySolanaValueCapLamports` is the Solana equivalent, denominated in
+ * lamports. Solana native value is NOT charged against `dailyValueCapWei`:
+ * that column is wei-denominated and an admin sets it thinking in ETH, so
+ * mixing SOL into it would compare two non-commensurable assets against one
+ * number. Keeping a separate per-chain-family cap is what lets SOL be
+ * accounted at its true 9-decimal precision instead of being scaled to 18
+ * decimals to share the ETH cap.
+ *
+ * When no row exists for an org, or the relevant cap column is null, spending
+ * of that kind is unlimited (no cap enforced). The two caps are independent:
+ * a null Solana cap does not fall back to the wei cap.
  */
 export const organizationSpendCaps = pgTable("organization_spend_caps", {
   id: text("id")
@@ -723,6 +738,7 @@ export const organizationSpendCaps = pgTable("organization_spend_caps", {
     .references(() => organization.id),
   dailyCapWei: text("daily_cap_wei"),
   dailyValueCapWei: text("daily_value_cap_wei"),
+  dailySolanaValueCapLamports: text("daily_solana_value_cap_lamports"),
   createdAt: timestamp("created_at").notNull().defaultNow(),
   updatedAt: timestamp("updated_at").notNull().defaultNow(),
 });
@@ -752,6 +768,12 @@ export const orgValueReservations = pgTable(
       .notNull()
       .references(() => organization.id),
     valueWei: text("value_wei").notNull(),
+    // Native notional value (lamports) for Solana reservations. Separate from
+    // valueWei because the two are different units and each daily cap sums only
+    // its own column. A Solana row carries valueWei "0" (the column is NOT NULL
+    // and predates this) plus the real figure here, so the wei SUM is unaffected
+    // by Solana activity and vice versa.
+    valueLamports: text("value_lamports"),
     status: text("status").notNull().default("reserved"), // reserved | settled | released
     // Origin of the value-moving execution, for audit only.
     source: text("source"), // direct | workflow | protocol

--- a/lib/execute/native-value.ts
+++ b/lib/execute/native-value.ts
@@ -7,6 +7,13 @@ export type ReservedValue =
   | { ok: false; error: string };
 
 /**
+ * Native decimals by chain family. EVM natives are 18; SOL is 9 (1 SOL =
+ * 1e9 lamports).
+ */
+export const EVM_NATIVE_DECIMALS = 18;
+export const SOLANA_NATIVE_DECIMALS = 9;
+
+/**
  * Native notional value (in wei) an execution will move, used by the per-org
  * daily spending cap. Parses a human-decimal ETH amount (e.g. "1.5") the same
  * way the web3 cores do (`ethers.parseEther`).
@@ -32,6 +39,45 @@ export function parseNativeValueWei(
   let parsed: bigint;
   try {
     parsed = ethers.parseEther(rawAmount);
+  } catch {
+    return { ok: false, error: `Invalid value amount: ${rawAmount}` };
+  }
+
+  if (parsed < BigInt(0)) {
+    return {
+      ok: false,
+      error: `Value amount must not be negative: ${rawAmount}`,
+    };
+  }
+
+  return { ok: true, valueWei: parsed.toString() };
+}
+
+/**
+ * Native notional value in LAMPORTS a Solana execution will move, used by the
+ * per-org daily Solana cap (`organizationSpendCaps.dailySolanaValueCapLamports`).
+ *
+ * Parses a human-decimal SOL amount (e.g. "1.5") at SOL's true 9 decimals
+ * rather than reusing `parseNativeValueWei`, whose `ethers.parseEther` is fixed
+ * at 18. Charging SOL on an 18-decimal scale was only ever a workaround for
+ * having a single wei-denominated cap; with a dedicated lamports cap the
+ * accurate unit is both correct and safe.
+ *
+ * Mirrors `parseNativeValueWei`'s contract exactly: absent/empty reserves "0",
+ * malformed returns `{ ok: false }` for the caller to decide, and negatives are
+ * rejected (a negative reservation would lower the day's SUM and bank credit
+ * against the cap).
+ */
+export function parseNativeValueLamports(
+  rawAmount: string | undefined | null
+): ReservedValue {
+  if (rawAmount === undefined || rawAmount === null || rawAmount === "") {
+    return { ok: true, valueWei: "0" };
+  }
+
+  let parsed: bigint;
+  try {
+    parsed = ethers.parseUnits(rawAmount, SOLANA_NATIVE_DECIMALS);
   } catch {
     return { ok: false, error: `Invalid value amount: ${rawAmount}` };
   }

--- a/lib/execute/value-ledger.ts
+++ b/lib/execute/value-ledger.ts
@@ -68,6 +68,57 @@ export async function sumOrgValueTodayWei(
 }
 
 /**
+ * Total native value (LAMPORTS) an org has moved / has in-flight today on
+ * Solana, summed across both stores. The Solana twin of `sumOrgValueTodayWei`,
+ * with identical staleness and status semantics.
+ *
+ * Sums the dedicated `value_lamports` columns rather than sharing `value_wei`:
+ * the two are different units (1e9 vs 1e18), so one column would add the scales
+ * together and understate usage against whichever cap was being checked. Rows
+ * belonging to the other chain family contribute NULL, which COALESCE folds to
+ * 0, so the two totals never contaminate each other.
+ */
+export async function sumOrgSolanaValueTodayLamports(
+  executor: Executor,
+  organizationId: string
+): Promise<bigint> {
+  const todayStart = new Date();
+  todayStart.setUTCHours(0, 0, 0, 0);
+
+  const directRows = await executor
+    .select({
+      totalLamports: sql<string>`COALESCE(SUM(CAST(${directExecutions.valueLamports} AS NUMERIC)), 0)::text`,
+    })
+    .from(directExecutions)
+    .where(
+      and(
+        eq(directExecutions.organizationId, organizationId),
+        ne(directExecutions.status, "failed"),
+        gte(directExecutions.createdAt, todayStart),
+        sql`(${directExecutions.status} = 'completed' OR ${directExecutions.createdAt} > now() - interval '${sql.raw(String(STALE_INFLIGHT_MINUTES))} minutes')`
+      )
+    );
+
+  const ledgerRows = await executor
+    .select({
+      totalLamports: sql<string>`COALESCE(SUM(CAST(${orgValueReservations.valueLamports} AS NUMERIC)), 0)::text`,
+    })
+    .from(orgValueReservations)
+    .where(
+      and(
+        eq(orgValueReservations.organizationId, organizationId),
+        ne(orgValueReservations.status, "released"),
+        gte(orgValueReservations.createdAt, todayStart),
+        sql`(${orgValueReservations.status} = 'settled' OR ${orgValueReservations.createdAt} > now() - interval '${sql.raw(String(STALE_INFLIGHT_MINUTES))} minutes')`
+      )
+    );
+
+  const direct = BigInt(directRows[0]?.totalLamports ?? "0");
+  const ledger = BigInt(ledgerRows[0]?.totalLamports ?? "0");
+  return direct + ledger;
+}
+
+/**
  * The org's total value moved today (wei) across both stores, for read-only
  * surfaces (the dashboard gauge). Uses the app db, not a transaction.
  */

--- a/lib/mcp/workflow-schema-constants.ts
+++ b/lib/mcp/workflow-schema-constants.ts
@@ -219,10 +219,22 @@ export const TRIGGERS = {
     },
     optionalFields: {},
     outputFields: {
-      blockNumber: "number - The block height",
-      blockHash: "string - Hash of the block",
-      blockTimestamp: "number - Unix timestamp of the block",
-      parentHash: "string - Hash of the parent block",
+      // EVM chains
+      blockNumber: "number - EVM: the block number",
+      blockHash: "string - EVM: hash of the block",
+      blockTimestamp: "number - EVM: Unix timestamp of the block",
+      parentHash: "string - EVM: hash of the parent block",
+      // Solana chains (fields emitted by the solana-tracker block payload;
+      // keep in sync with buildBlockPayload in
+      // keeperhub-events/solana-tracker/src/payload/block-payload.ts)
+      chainType: 'string - Solana: "solana"; absent on EVM block triggers',
+      slot: "number - Solana: the slot the block was produced in",
+      blockHeight:
+        "number - Solana: the block height (null for skipped/empty slots)",
+      blockhash:
+        "string - Solana: the block hash (note: lower-case, distinct from EVM blockHash)",
+      blockTime: "number - Solana: Unix timestamp of the block (may be null)",
+      parentSlot: "number - Solana: the parent slot",
       triggeredAt:
         "string - ISO timestamp when the block was detected (available on all trigger types)",
     },

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -388,29 +388,33 @@ const billingTrialsByOutcome = getOrCreateGauge(
 // Per-org execution counts (rolling 30-day window). Keyed only on
 // org_slug so the series identity stays stable when an org changes plan.
 // Join with keeperhub_org_info for plan/billing_status context.
+// Counts billable executions only (same predicate as the billing guard), so
+// billing-blocked phantom rows and x402 pay-per-call runs are excluded.
 const orgExecutions30d = getOrCreateGauge(
   dbRegistry,
   "keeperhub_org_executions_30d",
-  "Workflow executions per org in the last 30 days",
+  "Billable workflow executions per org in the last 30 days",
   ["org_slug"]
 );
 
 // Per-org execution counts (current calendar month, used for plan limit
-// pressure).
+// pressure). Billable-only, matching what the billing guard counts.
 const orgExecutionsMonth = getOrCreateGauge(
   dbRegistry,
   "keeperhub_org_executions_month",
-  "Workflow executions per org since start of the current calendar month",
+  "Billable workflow executions per org since start of the current calendar month",
   ["org_slug"]
 );
 
-// Plan usage ratio: current-month executions / monthly limit. 0 when the
-// plan is unlimited (enterprise) or when there is no usage. Drives the
-// "approaching plan limit" alert and the dashboard heatmap.
+// Plan usage ratio: current-month billable executions / monthly limit. 0 when
+// the plan is unlimited (enterprise) or when there is no usage. Drives the
+// "approaching plan limit" alert and the dashboard heatmap. Billable-only, so
+// an over-limit org whose triggers keep getting blocked stays at ~1.0 instead
+// of climbing without bound.
 const orgPlanUsageRatio = getOrCreateGauge(
   dbRegistry,
   "keeperhub_org_plan_usage_ratio",
-  "Current-month executions divided by the org's plan monthly limit (0 = no pressure or unlimited)",
+  "Current-month billable executions divided by the org's plan monthly limit (0 = no pressure or unlimited)",
   ["org_slug"]
 );
 

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -1312,6 +1312,11 @@ export async function getBillingStatsFromDb(): Promise<BillingStats> {
     // in JS to keep the SQL straightforward. Anonymous workflows (no
     // organization) are excluded — they're already covered by ANONYMOUS_ORG_SLUG
     // in the per-org error gauge.
+    // Only billable rows count: this matches the billing guard's
+    // countMonthlyExecutions predicate, so the plan-usage ratio reflects quota
+    // actually consumed. Excludes billing-blocked phantom rows (never ran) and
+    // x402 pay-per-call runs (paid per call, no quota consumed) — without the
+    // filter a capped free org's blocked triggers inflate the ratio far past 1.
     const execByOrgResult = await db
       .select({
         orgSlug: organization.slug,
@@ -1327,7 +1332,10 @@ export async function getBillingStatsFromDb(): Promise<BillingStats> {
         organizationSubscriptions,
         eq(organizationSubscriptions.organizationId, organization.id)
       )
-      .where(sql`${workflowExecutions.startedAt} >= NOW() - INTERVAL '30 days'`)
+      .where(
+        sql`${workflowExecutions.startedAt} >= NOW() - INTERVAL '30 days'
+            AND ${workflowExecutions.billable} = TRUE`
+      )
       .groupBy(
         organization.slug,
         organizationSubscriptions.plan,

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -484,7 +484,17 @@ const web3Plugin: IntegrationPlugin = {
           placeholder:
             '[{ "programId": "...", "accounts": [{ "pubkey": "...", "isSigner": false, "isWritable": true }], "data": "<base64 or 0x-hex>" }]',
           helpTip:
-            "A JSON array of Solana instructions. Each entry has a base58 programId, an ordered accounts array (pubkey plus isSigner/isWritable flags), and instruction data as standard base64 or 0x-hex. Only the organization wallet may be marked isSigner, and it is always the fee payer. There is no spend limit - any instruction here executes with the wallet's full authority, including moving its SOL or tokens, so use with caution.",
+            "A JSON array of Solana instructions. Each entry has a base58 programId, an ordered accounts array (pubkey plus isSigner/isWritable flags), and instruction data as standard base64 or 0x-hex. Only the organization wallet may be marked isSigner, and it is always the fee payer. Any instruction here executes with the wallet's full authority, including moving its SOL or tokens, so use with caution.",
+          required: true,
+        },
+        {
+          key: "maxSol",
+          label: "Max SOL to Move",
+          type: "template-input",
+          placeholder: "0.5 or {{NodeName.maxSol}}",
+          example: "0.5",
+          helpTip:
+            "The maximum SOL this transaction is permitted to move out of the organization wallet. Charged against the organization's daily value cap before the transaction is built, and enforced against the simulated balance change before it is submitted: if the simulation shows a larger outflow, the transaction is rejected rather than sent. Required, because the value an arbitrary instruction moves cannot be determined from the instruction data alone.",
           required: true,
         },
       ],
@@ -582,6 +592,16 @@ const web3Plugin: IntegrationPlugin = {
           placeholder: '{ "authority": "<base58>", "tokenAccount": "<base58>" }',
           helpTip:
             "A JSON object mapping each account name in the IDL instruction to its base58 pubkey. Accounts with a fixed address in the IDL (e.g. system program) are filled automatically, and a signer slot left empty defaults to the organization wallet. Only the organization wallet may sign.",
+        },
+        {
+          key: "maxSol",
+          label: "Max SOL to Move",
+          type: "template-input",
+          placeholder: "0.5 or {{NodeName.maxSol}}",
+          example: "0.5",
+          helpTip:
+            "The maximum SOL this instruction is permitted to move out of the organization wallet. Charged against the organization's daily value cap before the transaction is built, and enforced against the simulated balance change before it is submitted: if the simulation shows a larger outflow, the transaction is rejected rather than sent. Required, because an Anchor instruction can move lamports through a CPI that does not appear in its encoded arguments.",
+          required: true,
         },
       ],
     },

--- a/plugins/web3/steps/call-solana-program-core.ts
+++ b/plugins/web3/steps/call-solana-program-core.ts
@@ -28,7 +28,19 @@ export type CallSolanaProgramCoreInput = {
   instruction: string;
   args?: string | Record<string, unknown>;
   accounts?: string | Record<string, unknown>;
-  _context?: { executionId?: string; organizationId?: string };
+  /**
+   * Maximum SOL (human decimal) this instruction may move out of the
+   * organization wallet. Charged against the daily value cap before the
+   * transaction is built and enforced against the simulated balance delta
+   * before submit. Required: an Anchor instruction can move lamports through a
+   * CPI that never appears in its encoded arguments.
+   */
+  maxSol?: string;
+  _context?: {
+    executionId?: string;
+    organizationId?: string;
+    valueCapReserved?: boolean;
+  };
 };
 
 export type CallSolanaProgramResult =

--- a/plugins/web3/steps/call-solana-program.ts
+++ b/plugins/web3/steps/call-solana-program.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { withStepValueCap } from "@/lib/execute/value-ledger";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import {
   type StepInput,
@@ -34,7 +35,18 @@ export async function callSolanaProgramStep(
       actionName: "call-solana-program-anchor",
       executionId: input._context?.executionId,
     },
-    () => withStepLogging(input, () => callSolanaProgramCore(input))
+    () =>
+      withStepLogging(input, () =>
+        withStepValueCap(
+          {
+            organizationId: input._context?.organizationId,
+            amountEth: input.maxSol,
+            executionId: input._context?.executionId,
+            valueCapReserved: input._context?.valueCapReserved,
+          },
+          () => callSolanaProgramCore(input)
+        )
+      )
   );
 }
 

--- a/plugins/web3/steps/send-raw-solana-instruction-core.ts
+++ b/plugins/web3/steps/send-raw-solana-instruction-core.ts
@@ -46,7 +46,19 @@ export type RawSolanaInstruction = {
 export type SendRawSolanaInstructionCoreInput = {
   network: string;
   instructions: string | RawSolanaInstruction[];
-  _context?: { executionId?: string; organizationId?: string };
+  /**
+   * Maximum SOL (human decimal) this transaction may move out of the
+   * organization wallet. Charged against the daily value cap before the
+   * transaction is built and enforced against the simulated balance delta
+   * before submit. Required: an arbitrary instruction can invoke any program,
+   * so the value moved is not derivable from the instruction data.
+   */
+  maxSol?: string;
+  _context?: {
+    executionId?: string;
+    organizationId?: string;
+    valueCapReserved?: boolean;
+  };
 };
 
 export type SendRawSolanaInstructionResult =

--- a/plugins/web3/steps/send-raw-solana-instruction.ts
+++ b/plugins/web3/steps/send-raw-solana-instruction.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { withStepValueCap } from "@/lib/execute/value-ledger";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import {
   type StepInput,
@@ -35,7 +36,18 @@ export async function sendRawSolanaInstructionStep(
       actionName: "send-raw-solana-instruction",
       executionId: input._context?.executionId,
     },
-    () => withStepLogging(input, () => sendRawSolanaInstructionCore(input))
+    () =>
+      withStepLogging(input, () =>
+        withStepValueCap(
+          {
+            organizationId: input._context?.organizationId,
+            amountEth: input.maxSol,
+            executionId: input._context?.executionId,
+            valueCapReserved: input._context?.valueCapReserved,
+          },
+          () => sendRawSolanaInstructionCore(input)
+        )
+      )
   );
 }
 

--- a/scripts/seed/seed-chains.ts
+++ b/scripts/seed/seed-chains.ts
@@ -10,7 +10,7 @@
  */
 
 import "dotenv/config";
-import { eq } from "drizzle-orm";
+import { and, eq, notInArray } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { getDatabaseUrl } from "../../lib/db/connection-utils";
@@ -840,6 +840,46 @@ async function seedChains() {
 
     await db.insert(chains).values(chain);
     console.log(`  + ${chain.name} (${chain.chainId}) inserted`);
+  }
+
+  // Disable any chain row whose chainId is no longer produced by this seed.
+  //
+  // The upsert above is keyed on chainId, so changing a chain's id leaves the
+  // old row behind, still enabled. That is not hypothetical: moving Solana
+  // devnet from 102 to 103 inserted 103 and left 102 in place, so an
+  // environment ended up serving two enabled rows both named "Solana Devnet" -
+  // one of them an id the app rejects as not a Solana chain.
+  //
+  // Disable rather than delete: chains are referenced by workflows, executions
+  // and supported tokens, so removing a row would orphan live data. A disabled
+  // row is invisible to resolveRpcConfig (it filters on isEnabled) which is the
+  // behaviour we want, and stays available for historical lookups.
+  const seededChainIds = DEFAULT_CHAINS.map((c) => c.chainId);
+
+  // Guard: only prune when CHAIN_RPC_CONFIG actually parsed. Without it the
+  // chainIds above fall back to hardcoded defaults, so a config that failed to
+  // load would disable every chain whose id is set from config - turning a
+  // recoverable parse failure into an outage.
+  if (Object.keys(rpcConfig).length === 0) {
+    console.warn(
+      "  ! Skipping stale-chain prune: CHAIN_RPC_CONFIG did not parse, so seeded chainIds may be defaults rather than the configured values"
+    );
+  } else {
+    const stale = await db
+      .update(chains)
+      .set({ isEnabled: false, updatedAt: new Date() })
+      .where(
+        and(notInArray(chains.chainId, seededChainIds), eq(chains.isEnabled, true))
+      )
+      .returning({ chainId: chains.chainId, name: chains.name });
+
+    if (stale.length === 0) {
+      console.log("  = No stale chains to disable");
+    } else {
+      for (const c of stale) {
+        console.log(`  - ${c.name} (${c.chainId}) disabled - no longer in config`);
+      }
+    }
   }
 
   // Build EXPLORER_CONFIGS dynamically using resolved chainIds from DEFAULT_CHAINS

--- a/tests/integration/direct-execution-api.test.ts
+++ b/tests/integration/direct-execution-api.test.ts
@@ -346,7 +346,7 @@ describe("Direct Execution API", () => {
       expect(mocks.checkAndReserveExecution).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "transfer",
-          reservedValueWei: "1000000000000000000",
+          reserved: { kind: "evm", valueWei: "1000000000000000000" },
         })
       );
     });
@@ -366,7 +366,9 @@ describe("Direct Execution API", () => {
       );
 
       expect(mocks.checkAndReserveExecution).toHaveBeenCalledWith(
-        expect.objectContaining({ reservedValueWei: "0" })
+        expect.objectContaining({
+          reserved: { kind: "evm", valueWei: "0" },
+        })
       );
     });
 

--- a/tests/integration/spend-cap-setter-route.test.ts
+++ b/tests/integration/spend-cap-setter-route.test.ts
@@ -119,6 +119,7 @@ describe("PUT /api/analytics/spend-cap", () => {
     expect(mocks.upsertValues).toHaveBeenCalledWith({
       organizationId: ORG_ID,
       dailyValueCapWei: "1000000000000000000",
+      dailySolanaValueCapLamports: null,
     });
     expect(mocks.upsertConflict).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -138,6 +139,7 @@ describe("PUT /api/analytics/spend-cap", () => {
     expect(mocks.upsertValues).toHaveBeenCalledWith({
       organizationId: ORG_ID,
       dailyValueCapWei: null,
+      dailySolanaValueCapLamports: null,
     });
   });
 });

--- a/tests/unit/block-trigger-output-schema.test.ts
+++ b/tests/unit/block-trigger-output-schema.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { TRIGGERS } from "@/lib/mcp/workflow-schema-constants";
+
+// The Solana block trigger's triggerData is produced by buildBlockPayload in
+// keeperhub-events/solana-tracker/src/payload/block-payload.ts. Those field
+// names must be documented in the Block trigger's outputFields so template
+// autocomplete ({{@trigger:...}}) and AI-generated Solana block workflows
+// reference fields that actually exist. This guards against the two drifting.
+const SOLANA_BLOCK_PAYLOAD_KEYS = [
+  "chainType",
+  "slot",
+  "blockHeight",
+  "blockhash",
+  "blockTime",
+  "parentSlot",
+] as const;
+
+const EVM_BLOCK_KEYS = [
+  "blockNumber",
+  "blockHash",
+  "blockTimestamp",
+  "parentHash",
+] as const;
+
+describe("Block trigger outputFields", () => {
+  const fields = TRIGGERS.Block.outputFields as Record<string, string>;
+
+  it("documents every Solana block payload field", () => {
+    for (const key of SOLANA_BLOCK_PAYLOAD_KEYS) {
+      expect(fields).toHaveProperty(key);
+    }
+  });
+
+  it("retains the EVM block fields (additive, not replaced)", () => {
+    for (const key of EVM_BLOCK_KEYS) {
+      expect(fields).toHaveProperty(key);
+    }
+  });
+
+  it("keeps triggeredAt (present on all trigger types)", () => {
+    expect(fields).toHaveProperty("triggeredAt");
+  });
+});

--- a/tests/unit/reserved-value.test.ts
+++ b/tests/unit/reserved-value.test.ts
@@ -39,24 +39,24 @@ describe("parseNodeNativeValueWei", () => {
   it("charges a native transfer's amount", () => {
     expect(
       parseNodeNativeValueWei("transferFundsStep", { amount: "2" })
-    ).toEqual({ ok: true, valueWei: "2000000000000000000" });
+    ).toEqual({ ok: true, kind: "evm", valueWei: "2000000000000000000" });
   });
 
   it("charges a contract write's ethValue", () => {
     expect(
       parseNodeNativeValueWei("writeContractStep", { ethValue: "0.1" })
-    ).toEqual({ ok: true, valueWei: "100000000000000000" });
+    ).toEqual({ ok: true, kind: "evm", valueWei: "100000000000000000" });
   });
 
   it("ignores a token transfer's amount (no native value moved)", () => {
     expect(
       parseNodeNativeValueWei("transferTokenStep", { amount: "1000000" })
-    ).toEqual({ ok: true, valueWei: "0" });
+    ).toEqual({ ok: true, kind: "evm", valueWei: "0" });
   });
 
   it("reserves 0 for off-chain / unrecognized steps with no ethValue", () => {
     expect(parseNodeNativeValueWei("httpRequestStep", { amount: "5" })).toEqual(
-      { ok: true, valueWei: "0" }
+      { ok: true, kind: "evm", valueWei: "0" }
     );
   });
 
@@ -65,12 +65,72 @@ describe("parseNodeNativeValueWei", () => {
     // silently bypassing the cap with "0".
     expect(
       parseNodeNativeValueWei("someFutureWriteStep", { ethValue: "0.25" })
-    ).toEqual({ ok: true, valueWei: "250000000000000000" });
+    ).toEqual({ ok: true, kind: "evm", valueWei: "250000000000000000" });
   });
 
   it("propagates a parse failure for a value-bearing step", () => {
     expect(
       parseNodeNativeValueWei("transferFundsStep", { amount: "-5" }).ok
     ).toBe(false);
+  });
+});
+
+describe("parseNodeNativeValueWei Solana steps", () => {
+  it("requires maxSol on a raw instruction rather than reserving 0", () => {
+    const result = parseNodeNativeValueWei("sendRawSolanaInstructionStep", {
+      network: "103",
+      instructions: "[]",
+    });
+
+    // The bypass this guards: with no maxSol these steps previously fell
+    // through to the ethValue branch and reserved "0" while being able to move
+    // arbitrary SOL.
+    expect(result.ok).toBe(false);
+  });
+
+  it("requires maxSol on an Anchor program call", () => {
+    expect(
+      parseNodeNativeValueWei("callSolanaProgramStep", { network: "103" }).ok
+    ).toBe(false);
+  });
+
+  it("charges a declared maxSol in lamports, not wei", () => {
+    expect(
+      parseNodeNativeValueWei("sendRawSolanaInstructionStep", {
+        network: "103",
+        maxSol: "1.5",
+      })
+      // 1.5 SOL at SOL's native 9 decimals. An 18-decimal parse would yield
+      // 1500000000000000000 and charge the wrong cap.
+    ).toEqual({ ok: true, kind: "solana", valueLamports: "1500000000" });
+  });
+
+  it("rejects a blank maxSol instead of treating it as zero", () => {
+    expect(
+      parseNodeNativeValueWei("callSolanaProgramStep", {
+        network: "103",
+        maxSol: "   ",
+      }).ok
+    ).toBe(false);
+  });
+
+  it("parses a native transfer on a Solana network as lamports", () => {
+    // transferFundsStep is chain-agnostic, so its unit comes from the network,
+    // not the step name.
+    expect(
+      parseNodeNativeValueWei("transferFundsStep", {
+        network: "103",
+        amount: "0.001",
+      })
+    ).toEqual({ ok: true, kind: "solana", valueLamports: "1000000" });
+  });
+
+  it("still parses a native transfer on an EVM network as wei", () => {
+    expect(
+      parseNodeNativeValueWei("transferFundsStep", {
+        network: "1",
+        amount: "2",
+      })
+    ).toEqual({ ok: true, kind: "evm", valueWei: "2000000000000000000" });
   });
 });

--- a/tests/unit/spend-cap-route.test.ts
+++ b/tests/unit/spend-cap-route.test.ts
@@ -1,0 +1,219 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// Both HOCs are pass-throughs here: authorization is exercised elsewhere, and
+// these tests are about the route's own body parsing and column-write logic.
+vi.mock("@/lib/middleware/require-org", () => ({
+  requireOrganization:
+    (handler: (req: NextRequest, context: unknown) => Promise<Response>) =>
+    (req: NextRequest) =>
+      handler(req, { organization: { id: "org_1" } }),
+  requirePermission:
+    (
+      _resource: string,
+      _actions: string[],
+      handler: (req: NextRequest, context: unknown) => Promise<Response>
+    ) =>
+    (req: NextRequest) =>
+      handler(req, { organization: { id: "org_1" } }),
+}));
+
+vi.mock("@/lib/api-error", () => ({
+  apiError: (_e: unknown, message: string) =>
+    new Response(JSON.stringify({ error: message }), { status: 500 }),
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  organizationSpendCaps: { organizationId: "organization_id" },
+}));
+
+vi.mock("@/lib/analytics/queries", () => ({
+  getSpendCapData: vi.fn().mockResolvedValue({
+    dailyCapWei: "1000",
+    dailyUsedWei: "10",
+    dailySolanaCapLamports: "2000000000",
+    dailySolanaUsedLamports: "5",
+  }),
+}));
+
+// Captures what the route actually writes, which is the whole point: the `set`
+// object decides which columns are overwritten.
+const written = vi.hoisted(() => ({
+  values: null as Record<string, unknown> | null,
+  set: null as Record<string, unknown> | null,
+  calls: 0,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    insert: () => ({
+      values: (v: Record<string, unknown>) => {
+        written.values = v;
+        return {
+          onConflictDoUpdate: (arg: { set: Record<string, unknown> }) => {
+            written.set = arg.set;
+            written.calls += 1;
+            return Promise.resolve(undefined);
+          },
+        };
+      },
+    }),
+  },
+}));
+
+import { GET, PUT } from "@/app/api/analytics/spend-cap/route";
+
+function putRequest(body: unknown): NextRequest {
+  return {
+    json: () => Promise.resolve(body),
+  } as unknown as NextRequest;
+}
+
+function malformedRequest(): NextRequest {
+  return {
+    json: () => Promise.reject(new Error("bad json")),
+  } as unknown as NextRequest;
+}
+
+beforeEach(() => {
+  written.values = null;
+  written.set = null;
+  written.calls = 0;
+});
+
+describe("GET /api/analytics/spend-cap", () => {
+  it("returns both caps and both usage figures", async () => {
+    const res = await GET({} as NextRequest);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    // Each chain family reports its own cap and its own usage; sharing either
+    // would misreport both gauges.
+    expect(body).toEqual({
+      dailyCapWei: "1000",
+      dailyUsedWei: "10",
+      dailySolanaCapLamports: "2000000000",
+      dailySolanaUsedLamports: "5",
+    });
+  });
+});
+
+describe("PUT /api/analytics/spend-cap partial updates", () => {
+  it("writing only the Solana cap does NOT touch the wei cap", async () => {
+    const res = await PUT(
+      putRequest({ dailySolanaValueCapLamports: "2000000000" })
+    );
+
+    expect(res.status).toBe(200);
+    // The regression this guards: if dailyValueCapWei appeared in `set`, saving
+    // the Solana cap from its own control would silently clear the EVM cap.
+    expect(written.set).not.toHaveProperty("dailyValueCapWei");
+    expect(written.set).toMatchObject({
+      dailySolanaValueCapLamports: "2000000000",
+    });
+  });
+
+  it("writing only the wei cap does NOT touch the Solana cap", async () => {
+    const res = await PUT(putRequest({ dailyValueCapWei: "1000" }));
+
+    expect(res.status).toBe(200);
+    expect(written.set).not.toHaveProperty("dailySolanaValueCapLamports");
+    expect(written.set).toMatchObject({ dailyValueCapWei: "1000" });
+  });
+
+  it("writes both columns when both fields are supplied", async () => {
+    await PUT(
+      putRequest({
+        dailyValueCapWei: "1000",
+        dailySolanaValueCapLamports: "2000000000",
+      })
+    );
+
+    expect(written.set).toMatchObject({
+      dailyValueCapWei: "1000",
+      dailySolanaValueCapLamports: "2000000000",
+    });
+  });
+
+  it("treats an explicit null as a clear, distinct from omission", async () => {
+    await PUT(putRequest({ dailySolanaValueCapLamports: null }));
+
+    // Present-but-null must reach the column as null (clear), while the
+    // omitted wei cap stays absent (unchanged).
+    expect(written.set).toHaveProperty("dailySolanaValueCapLamports", null);
+    expect(written.set).not.toHaveProperty("dailyValueCapWei");
+  });
+
+  it("echoes back only the fields that were supplied", async () => {
+    const res = await PUT(
+      putRequest({ dailySolanaValueCapLamports: "2000000000" })
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(body).toEqual({ dailySolanaValueCapLamports: "2000000000" });
+  });
+});
+
+describe("PUT /api/analytics/spend-cap validation", () => {
+  it("rejects an empty body rather than writing nothing silently", async () => {
+    const res = await PUT(putRequest({}));
+
+    expect(res.status).toBe(400);
+    expect(written.calls).toBe(0);
+  });
+
+  it("rejects a malformed JSON body", async () => {
+    const res = await PUT(malformedRequest());
+
+    expect(res.status).toBe(400);
+    expect(written.calls).toBe(0);
+  });
+
+  it.each([
+    ["a negative value", "-5"],
+    ["a decimal value", "1.5"],
+    ["a non-numeric string", "abc"],
+    ["a number instead of a string", 1000],
+    ["a boolean", true],
+  ])("rejects %s for the wei cap and writes nothing", async (_label, value) => {
+    const res = await PUT(putRequest({ dailyValueCapWei: value }));
+    const body = (await res.json()) as Record<string, unknown>;
+
+    // Rejected rather than coerced: a malformed cap must never be silently
+    // stored, and must never fall through to "unlimited".
+    expect(res.status).toBe(400);
+    expect(body.field).toBe("dailyValueCapWei");
+    expect(written.calls).toBe(0);
+  });
+
+  it.each([
+    ["a negative value", "-1"],
+    ["a decimal value", "0.5"],
+    ["a non-numeric string", "1e9"],
+  ])(
+    "rejects %s for the Solana cap and writes nothing",
+    async (_label, value) => {
+      const res = await PUT(putRequest({ dailySolanaValueCapLamports: value }));
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(400);
+      expect(body.field).toBe("dailySolanaValueCapLamports");
+      expect(written.calls).toBe(0);
+    }
+  );
+
+  it("rejects the whole request when one of two fields is malformed", async () => {
+    const res = await PUT(
+      putRequest({
+        dailyValueCapWei: "1000",
+        dailySolanaValueCapLamports: "-1",
+      })
+    );
+
+    // Partial application would leave the caps in a state the admin did not
+    // ask for, so a bad field rejects the request outright.
+    expect(res.status).toBe(400);
+    expect(written.calls).toBe(0);
+  });
+});

--- a/tests/unit/spending-cap.test.ts
+++ b/tests/unit/spending-cap.test.ts
@@ -5,9 +5,12 @@ vi.mock("@/lib/utils/id", () => ({ generateId: () => "exec_test" }));
 
 // Hoisted state the fake tx reads from / writes to, set per test.
 const state = vi.hoisted(() => ({
-  caps: [] as Array<{ dailyValueCapWei: string | null }>,
-  sumRows: [] as Array<{ totalWei: string }>,
-  ledgerRows: [] as Array<{ totalWei: string }>,
+  caps: [] as Array<{
+    dailyValueCapWei: string | null;
+    dailySolanaValueCapLamports?: string | null;
+  }>,
+  sumRows: [] as Array<{ totalWei?: string; totalLamports?: string }>,
+  ledgerRows: [] as Array<{ totalWei?: string; totalLamports?: string }>,
   inserted: [] as Record<string, unknown>[],
 }));
 
@@ -76,7 +79,7 @@ describe("checkAndReserveExecution value cap", () => {
 
     const result = await checkAndReserveExecution({
       ...baseParams,
-      reservedValueWei: "5",
+      reserved: { kind: "evm", valueWei: "5" },
     });
 
     expect(result).toEqual({ allowed: true, executionId: "exec_test" });
@@ -92,7 +95,7 @@ describe("checkAndReserveExecution value cap", () => {
 
     const result = await checkAndReserveExecution({
       ...baseParams,
-      reservedValueWei: "999",
+      reserved: { kind: "evm", valueWei: "999" },
     });
 
     expect(result.allowed).toBe(true);
@@ -105,7 +108,7 @@ describe("checkAndReserveExecution value cap", () => {
 
     const result = await checkAndReserveExecution({
       ...baseParams,
-      reservedValueWei: "400",
+      reserved: { kind: "evm", valueWei: "400" },
     });
 
     expect(result.allowed).toBe(true);
@@ -118,7 +121,7 @@ describe("checkAndReserveExecution value cap", () => {
 
     const result = await checkAndReserveExecution({
       ...baseParams,
-      reservedValueWei: "500",
+      reserved: { kind: "evm", valueWei: "500" },
     });
 
     expect(result).toEqual({
@@ -138,7 +141,7 @@ describe("checkAndReserveExecution value cap", () => {
 
     const result = await checkAndReserveExecution({
       ...baseParams,
-      reservedValueWei: "200",
+      reserved: { kind: "evm", valueWei: "200" },
     });
 
     expect(result.allowed).toBe(false);
@@ -153,10 +156,88 @@ describe("checkAndReserveExecution value cap", () => {
 
     const result = await checkAndReserveExecution({
       ...baseParams,
-      reservedValueWei: "5000000000000000000",
+      reserved: { kind: "evm", valueWei: "5000000000000000000" },
     });
 
     expect(result.allowed).toBe(false);
     expect(state.inserted).toHaveLength(0);
+  });
+});
+
+describe("checkAndReserveExecution Solana cap", () => {
+  it("charges the lamports cap and records valueLamports, not valueWei", async () => {
+    state.caps = [
+      { dailyValueCapWei: "1000", dailySolanaValueCapLamports: "2000000000" },
+    ];
+    state.sumRows = [{ totalLamports: "500000000" }];
+    state.ledgerRows = [{ totalLamports: "0" }];
+
+    const result = await checkAndReserveExecution({
+      ...baseParams,
+      network: "103",
+      reserved: { kind: "solana", valueLamports: "1000000000" },
+    });
+
+    expect(result.allowed).toBe(true);
+    // The unit columns are mutually exclusive, so each daily SUM stays
+    // single-unit.
+    expect(state.inserted[0]).toMatchObject({
+      valueLamports: "1000000000",
+      valueWei: null,
+    });
+  });
+
+  it("denies with the Solana-specific reason when the lamports cap is exceeded", async () => {
+    state.caps = [
+      { dailyValueCapWei: null, dailySolanaValueCapLamports: "1000000000" },
+    ];
+    state.sumRows = [{ totalLamports: "900000000" }];
+    state.ledgerRows = [{ totalLamports: "0" }];
+
+    const result = await checkAndReserveExecution({
+      ...baseParams,
+      network: "103",
+      reserved: { kind: "solana", valueLamports: "200000000" },
+    });
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: "Daily Solana spending cap exceeded",
+    });
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("treats an unset Solana cap as unlimited and does NOT fall back to the wei cap", async () => {
+    // A wei cap that would reject this figure outright, to prove the Solana
+    // path never consults it.
+    state.caps = [{ dailyValueCapWei: "1", dailySolanaValueCapLamports: null }];
+    state.sumRows = [{ totalLamports: "0" }];
+    state.ledgerRows = [{ totalLamports: "0" }];
+
+    const result = await checkAndReserveExecution({
+      ...baseParams,
+      network: "103",
+      reserved: { kind: "solana", valueLamports: "5000000000" },
+    });
+
+    expect(result.allowed).toBe(true);
+  });
+
+  it("does not let an exhausted wei cap block a Solana reservation", async () => {
+    state.caps = [
+      { dailyValueCapWei: "1000", dailySolanaValueCapLamports: "2000000000" },
+    ];
+    // Solana totals are read from the lamports columns; the wei day-total is
+    // irrelevant to this reservation and must not be consulted.
+    state.sumRows = [{ totalWei: "999999", totalLamports: "0" }];
+    state.ledgerRows = [{ totalWei: "999999", totalLamports: "0" }];
+
+    const result = await checkAndReserveExecution({
+      ...baseParams,
+      network: "103",
+      reserved: { kind: "solana", valueLamports: "1000000000" },
+    });
+
+    expect(result.allowed).toBe(true);
   });
 });


### PR DESCRIPTION
Promotes the current `staging` to `prod`. Bundles the work merged since the last release; multiple authors, as expected.

## Included (by merged PR)

- #1813 - repair the workflow-runner NetworkPolicy egress so runner pods can reach the executor metrics-ingest endpoint again. The selector had gone stale at the umbrella-chart cutover, so all runner-shipped counter deltas (workflow terminal counters + RPC counters) were being dropped. Verified live on staging: the executor scrape job's success counter went from 0 to real volume; prod still reads 0 until this deploys.
- #1811 - count only billable executions in the per-org plan-usage gauges.
- #1812 - decode CHAIN_RPC_CONFIG when picking the tier1 fork upstream.
- #1810 - disable chains that are no longer present in chain-config.
- #1807 / #1799 - Solana: close a spending-cap bypass and add a Solana native-value daily cap; add the Solana Block trigger (schema output fields + injected-block E2E harness) and wire solana-tracker into the events build/deploy pipeline.
- #1806 / #1804 / #1803 - provision Solana wallets in ephemeral e2e and PR environments; enable Solana wallet provisioning in staging + prod Helm.
- #1805 - remove the protocol picker from the Event trigger.
- #1802 - run disabled workflows on a manual trigger.

## Database migrations

Two new migrations, both metadata-only `ADD COLUMN IF NOT EXISTS` (nullable, no default, no table rewrite, no lock of consequence):

- `0131_..._solana_value_cap.sql` - `organization_spend_caps.daily_solana_value_cap_lamports`
- `0132_..._value_lamports.sql` - `direct_executions.value_lamports`, `org_value_reservations.value_lamports`

Neither carries the `@requires-db-prep` directive, so no `db-prepped-prod` label is required and they run as normal transactional migrations on deploy.

## Post-deploy verification

- Confirm the runner->executor metrics shipping recovers in prod: `keeperhub_workflow_executions_finished_total{job="keeperhub-executor-common", status="success"}` should go from ~0 to real volume, and the managed-client SLI panels should populate.
