### PR TITLE
ci: fork-cache tier 2 protocol coverage, unblock e2e from build tail

### DIFF
--- a/.github/actions/start-sandbox/action.yml
+++ b/.github/actions/start-sandbox/action.yml
@@ -16,10 +16,33 @@ inputs:
     description: Full ECR ref of a prebuilt sandbox image to pull. Empty builds locally.
     required: false
     default: ""
+  aws_role_arn:
+    description: IAM role to assume for the ECR pull. Only used when image_ref is set.
+    required: false
+    default: ""
+  aws_region:
+    description: AWS region for the ECR login. Only used when image_ref is set.
+    required: false
+    default: ""
 
 runs:
   using: composite
   steps:
+    # Authenticate to ECR ourselves rather than relying on a prior start-app
+    # step - the playwright job starts the sandbox before the app, so an
+    # ordering assumption would silently fall back to a local build there.
+    # Skipped when image_ref is empty (PRs), which build locally anyway.
+    - name: Configure AWS credentials for sandbox pull
+      if: inputs.image_ref != '' && inputs.aws_role_arn != ''
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ inputs.aws_role_arn }}
+        aws-region: ${{ inputs.aws_region }}
+
+    - name: Login to AWS ECR for sandbox pull
+      if: inputs.image_ref != '' && inputs.aws_role_arn != ''
+      uses: aws-actions/amazon-ecr-login@v2
+
     - name: Provide sandbox image (pull prebuilt, else build)
       shell: bash
       env:

--- a/.github/actions/start-sandbox/action.yml
+++ b/.github/actions/start-sandbox/action.yml
@@ -1,6 +1,9 @@
 # Builds and starts the code-execution sandbox container for e2e jobs that
 # exercise the remote sandbox backend (SANDBOX_BACKEND=remote). Mirrors the
 # build+run+health pattern used by pr-checks.yml:test-unit-sandbox-remote.
+# On staging pushes the image is prebuilt by build-images.yml and passed via
+# image_ref, so this pulls instead of rebuilding (~72s/job); PRs (no prebuilt
+# image) and any pull failure fall back to the local build.
 name: Start Sandbox
 description: Build and start the code-execution sandbox container for e2e tests
 
@@ -9,13 +12,28 @@ inputs:
     description: Host port to publish the sandbox on (reach it at http://localhost:<port>)
     required: false
     default: "8787"
+  image_ref:
+    description: Full ECR ref of a prebuilt sandbox image to pull. Empty builds locally.
+    required: false
+    default: ""
 
 runs:
   using: composite
   steps:
-    - name: Build sandbox image
+    - name: Provide sandbox image (pull prebuilt, else build)
       shell: bash
-      run: docker build -f sandbox/Dockerfile -t keeperhub-sandbox:ci .
+      env:
+        IMAGE_REF: ${{ inputs.image_ref }}
+      run: |
+        if [ -n "$IMAGE_REF" ] && docker pull "$IMAGE_REF"; then
+          echo "using prebuilt sandbox image $IMAGE_REF"
+          docker tag "$IMAGE_REF" keeperhub-sandbox:ci
+        else
+          if [ -n "$IMAGE_REF" ]; then
+            echo "pull of $IMAGE_REF failed; building sandbox locally"
+          fi
+          docker build -f sandbox/Dockerfile -t keeperhub-sandbox:ci .
+        fi
 
     - name: Start sandbox container
       shell: bash

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -10,6 +10,9 @@ on:
       image_tag:
         description: "Short SHA used as image tag"
         value: ${{ jobs.build.outputs.image_tag }}
+      sandbox_image:
+        description: "Full ECR ref of the prebuilt sandbox image for e2e to pull"
+        value: ${{ jobs.build.outputs.sandbox_image }}
       ecr_registry:
         description: "ECR registry URL"
         value: ${{ jobs.build.outputs.ecr_registry }}
@@ -19,6 +22,12 @@ on:
       ecr_region:
         description: "AWS region for ECR"
         value: ${{ jobs.build.outputs.ecr_region }}
+      skip_build:
+        description: "true when [skip build] was in the commit message"
+        value: ${{ jobs.build.outputs.skip_build }}
+      images_exist:
+        description: "true when every pipeline image already exists in ECR for this SHA"
+        value: ${{ jobs.build.outputs.images_exist }}
 
 permissions:
   contents: read
@@ -30,9 +39,14 @@ jobs:
     environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
     outputs:
       image_tag: ${{ steps.vars.outputs.sha_short }}
+      sandbox_image: ${{ steps.vars.outputs.sandbox_image }}
       ecr_registry: ${{ steps.login-ecr.outputs.registry }}
       ecr_repo: ${{ steps.vars.outputs.ecr_repo }}
       ecr_region: ${{ steps.vars.outputs.ecr_region }}
+      # Surfaced so the sibling sentry-upload job (ci-pipeline.yml) can reuse the
+      # same skip/rerun guard the build steps use without re-querying ECR.
+      skip_build: ${{ steps.skip.outputs.skip_build }}
+      images_exist: ${{ steps.check-image.outputs.exists }}
     env:
       REGION: ${{ vars.TO_REGION }}
       AWS_ECR_NAME: ${{ vars.TO_ECR_NAME }}
@@ -41,6 +55,11 @@ jobs:
       EXECUTOR_ECR_NAME: keeperhub-executor-${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
       SCHEDULER_ECR_NAME: keeperhub-scheduler-${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
       COLLECTOR_ECR_NAME: keeperhub-metrics-collector-${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
+      # Baked alongside the pipeline on push so the e2e jobs pull a prebuilt
+      # image instead of each rebuilding the sandbox locally (~72s/job). Same
+      # convention deploy-sandbox.yaml uses; the sandbox target has its own
+      # Dockerfile and cache scope, so it does not share the app builder stage.
+      SANDBOX_ECR_NAME: keeperhub-sandbox-${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
       ENVIRONMENT_TAG: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
       # INCLUDE_TEST_ENDPOINTS is derived from ENVIRONMENT_TAG in the
       # "Derive build flags" step below (KEEP-237).
@@ -95,6 +114,7 @@ jobs:
             echo "sha_short=${SHA}"
             echo "ecr_repo=${AWS_ECR_NAME}"
             echo "ecr_region=${REGION}"
+            echo "sandbox_image=${{ steps.login-ecr.outputs.registry }}/${SANDBOX_ECR_NAME}:sandbox-${SHA}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Check if images already exist
@@ -110,7 +130,8 @@ jobs:
             "${{ env.EXECUTOR_ECR_NAME }}:executor" \
             "${{ env.SCHEDULER_ECR_NAME }}:schedule" \
             "${{ env.SCHEDULER_ECR_NAME }}:block" \
-            "${{ env.COLLECTOR_ECR_NAME }}:collector"; do
+            "${{ env.COLLECTOR_ECR_NAME }}:collector" \
+            "${{ env.SANDBOX_ECR_NAME }}:sandbox"; do
             repo="${pair%%:*}"; prefix="${pair##*:}"
             if aws ecr describe-images \
               --repository-name "${repo}" \
@@ -186,6 +207,7 @@ jobs:
           EXECUTOR_ECR_REPO: ${{ env.EXECUTOR_ECR_NAME }}
           SCHEDULER_ECR_REPO: ${{ env.SCHEDULER_ECR_NAME }}
           METRICS_COLLECTOR_ECR_REPO: ${{ env.COLLECTOR_ECR_NAME }}
+          SANDBOX_ECR_REPO: ${{ env.SANDBOX_ECR_NAME }}
           IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
           NEXT_PUBLIC_AUTH_PROVIDERS: ${{ env.NEXT_PUBLIC_AUTH_PROVIDERS }}
           NEXT_PUBLIC_GITHUB_CLIENT_ID: ${{ env.NEXT_PUBLIC_GITHUB_CLIENT_ID }}
@@ -202,27 +224,17 @@ jobs:
           SENTRY_RELEASE: ${{ steps.vars.outputs.sha_short }}
         with:
           files: docker-bake.hcl
-          targets: pipeline
+          # sandbox baked in the same session so it pushes under the app-compile
+          # shadow instead of adding a serial ~72s to every e2e job. It has its
+          # own Dockerfile/context and cache scope, so it builds independently
+          # of the shared app builder stage.
+          targets: |
+            pipeline
+            sandbox
           push: true
 
-      - name: Upload Sentry source maps
-        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
-        uses: docker/bake-action@v7
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPO: ${{ env.AWS_ECR_NAME }}
-          NEXT_PUBLIC_AUTH_PROVIDERS: ${{ env.NEXT_PUBLIC_AUTH_PROVIDERS }}
-          NEXT_PUBLIC_GITHUB_CLIENT_ID: ${{ env.NEXT_PUBLIC_GITHUB_CLIENT_ID }}
-          NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ env.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
-          NEXT_PUBLIC_BILLING_ENABLED: ${{ env.NEXT_PUBLIC_BILLING_ENABLED }}
-          NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED: ${{ env.NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED }}
-          NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ env.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
-          NEXT_PUBLIC_SENTRY_DSN: ${{ env.NEXT_PUBLIC_SENTRY_DSN }}
-          INCLUDE_TEST_ENDPOINTS: ${{ env.INCLUDE_TEST_ENDPOINTS }}
-          SENTRY_ORG: ${{ env.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ env.SENTRY_PROJECT }}
-          SENTRY_AUTH_TOKEN: ${{ env.SENTRY_AUTH_TOKEN }}
-          SENTRY_RELEASE: ${{ steps.vars.outputs.sha_short }}
-        with:
-          files: docker-bake.hcl
-          targets: sentry-upload
+      # Sentry source-map upload moved out to its own sentry-upload.yml job,
+      # fanned out from build-images in ci-pipeline.yml so it runs parallel to
+      # e2e instead of extending this job's critical path. It consumes the
+      # :cache-app scope this pipeline bake just pushed, so it stays ordered
+      # after build via `needs: [build-images]`.

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -8,6 +8,16 @@ on:
     types: [labeled, synchronize]
   workflow_dispatch: {}
 
+# Cancel a PR's in-flight run when it is superseded by a newer push to the same
+# PR - saves runner queue time on rapid iteration. Scoped to pull_request only:
+# push (staging/prod) and workflow_dispatch each get a unique per-run group via
+# github.run_id, so deploys are never cancelled and always run to completion.
+# Deliberately NOT cancel-on-failure - a run must be able to surface multiple
+# test failures at once.
+concurrency:
+  group: ci-pipeline-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: write
   pull-requests: write
@@ -39,9 +49,26 @@ jobs:
       # Pass build outputs only on staging; '' must be the `||` fallthrough since
       # an empty string is falsy (`cond && '' || x` would always yield x).
       image_tag: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.image_tag || '') || '' }}
+      # Prebuilt sandbox ref, staging only (same fallthrough rule as image_tag);
+      # empty on PRs/prod makes the e2e jobs build the sandbox locally.
+      sandbox_image: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.sandbox_image || '') || '' }}
       ecr_registry: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.ecr_registry || '') || '' }}
       ecr_repo: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.ecr_repo || '') || '' }}
       ecr_region: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.ecr_region || '') || '' }}
+    secrets: inherit
+
+  # Sentry source-map upload, fanned out from build-images alongside e2e so it
+  # no longer extends the build critical path. Runs on staging/prod pushes only
+  # (PRs never build images), and only when the build actually baked - a
+  # [skip build] or all-images-exist rerun skips it, mirroring the guard the
+  # old in-build step used. Deploy does not depend on it, so a source-map
+  # failure surfaces as a red run without blocking the deploy.
+  sentry-upload:
+    needs: [build-images]
+    if: ${{ github.event_name != 'pull_request' && !failure() && !cancelled() && needs.build-images.outputs.skip_build != 'true' && needs.build-images.outputs.images_exist != 'true' }}
+    uses: ./.github/workflows/sentry-upload.yml
+    with:
+      image_tag: ${{ needs.build-images.outputs.image_tag }}
     secrets: inherit
 
   # Deploy runs after build-images and e2e-tests.

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -741,6 +741,8 @@ jobs:
         uses: ./.github/actions/start-sandbox
         with:
           image_ref: ${{ inputs.sandbox_image }}
+          aws_role_arn: ${{ vars.AWS_ROLE_ARN }}
+          aws_region: ${{ inputs.ecr_region }}
 
       - name: Run E2E Vitest tests
         run: pnpm test:e2e:vitest
@@ -1122,6 +1124,8 @@ jobs:
         uses: ./.github/actions/start-sandbox
         with:
           image_ref: ${{ inputs.sandbox_image }}
+          aws_role_arn: ${{ vars.AWS_ROLE_ARN }}
+          aws_region: ${{ inputs.ecr_region }}
 
       - name: Run protocol-coverage tests
         run: |
@@ -1355,6 +1359,8 @@ jobs:
         uses: ./.github/actions/start-sandbox
         with:
           image_ref: ${{ inputs.sandbox_image }}
+          aws_role_arn: ${{ vars.AWS_ROLE_ARN }}
+          aws_region: ${{ inputs.ecr_region }}
 
       - name: Start application
         uses: ./.github/actions/start-app

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -29,6 +29,11 @@ on:
         type: string
         required: false
         default: ""
+      sandbox_image:
+        description: "Full ECR ref of the prebuilt sandbox image. When provided, start-sandbox pulls it instead of building locally."
+        type: string
+        required: false
+        default: ""
       ecr_registry:
         description: "ECR registry URL"
         type: string
@@ -734,6 +739,8 @@ jobs:
 
       - name: Start code-execution sandbox
         uses: ./.github/actions/start-sandbox
+        with:
+          image_ref: ${{ inputs.sandbox_image }}
 
       - name: Run E2E Vitest tests
         run: pnpm test:e2e:vitest
@@ -980,15 +987,101 @@ jobs:
           # instead of rebuilding.
           prebuilt: "true"
 
+      # The cache is produced by protocol-nightly.yml, a different workflow,
+      # and actions/download-artifact cannot fetch across workflows without a
+      # concrete run id - list and download through gh api with github.token
+      # instead. Consumption requires ANVIL_FORK_MAINNET_URL: the cache serves
+      # warmed state locally, but cold reads at a day-old pin need an archive
+      # upstream. Every failure mode (no secret, no fresh staging artifact, API
+      # error, corrupt zip/tar, bad name) exits 0 with empty outputs so the
+      # fork-start step falls back to the live fork. Same mechanism as
+      # tier1-simulations - see that job for the annotated reference.
+      - name: Download latest fork RPC cache
+        id: fork-cache
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ANVIL_FORK_MAINNET_URL: ${{ secrets.ANVIL_FORK_MAINNET_URL }}
+        run: |
+          if [ -z "$ANVIL_FORK_MAINNET_URL" ]; then
+            echo "ANVIL_FORK_MAINNET_URL not set; cold reads at a stale pin need an archive upstream - will start a live fork"
+            exit 0
+          fi
+          # Freshness gates: only a non-expired artifact from the last
+          # 36 hours whose producing run was on staging (a nightly on
+          # the default branch, not a fork-cache job from a topic
+          # branch experiment).
+          cutoff=$(date -u -d '36 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+          artifact_id=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=fork-cache-mainnet&per_page=10" \
+            --jq "[.artifacts[] | select(.expired == false and .workflow_run.head_branch == \"staging\" and .created_at > \"${cutoff}\")] | sort_by(.created_at) | last | .id // empty" \
+            2>/dev/null) || artifact_id=""
+          if [ -z "$artifact_id" ]; then
+            echo "no fresh fork-cache-mainnet artifact from staging; will start a live fork"
+            exit 0
+          fi
+          if ! gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" > fork-cache.zip; then
+            echo "artifact ${artifact_id} download failed; will start a live fork"
+            exit 0
+          fi
+          if ! unzip -o fork-cache.zip -d fork-cache-artifact; then
+            echo "artifact ${artifact_id} unzip failed; will start a live fork"
+            exit 0
+          fi
+          tarball=$(find fork-cache-artifact -maxdepth 1 -name 'fork-cache-mainnet-*.tgz' | head -n 1)
+          block=""
+          if [ -n "$tarball" ]; then
+            block=$(basename "$tarball" .tgz | grep -oE '[0-9]+$') || true
+          fi
+          if [ -z "$tarball" ] || [ -z "$block" ]; then
+            echo "artifact has no fork-cache-mainnet-<block>.tgz; will start a live fork"
+            exit 0
+          fi
+          mkdir -p fork-cache
+          if ! tar -xzf "$tarball" -C fork-cache; then
+            echo "cache tar extraction failed; will start a live fork"
+            rm -rf fork-cache
+            exit 0
+          fi
+          if [ ! -f "fork-cache/rpc/mainnet/${block}/storage.json" ]; then
+            echo "cache tar lacks rpc/mainnet/${block}/storage.json; will start a live fork"
+            rm -rf fork-cache
+            exit 0
+          fi
+          # anvil runs as uid 1000 (foundry) in the container; the
+          # runner user extracting the tar is a different uid.
+          chmod -R a+rX fork-cache
+          echo "using fork cache at pinned block ${block}"
+          echo "dir=fork-cache" >> "$GITHUB_OUTPUT"
+          echo "block=$block" >> "$GITHUB_OUTPUT"
+
       - name: Start anvil Ethereum mainnet fork
-        # ANVIL_FORK_MAINNET_URL feeds the compose fork-url (falls back to
-        # publicnode when the secret is unset), matching tier1-simulations.
+        # With a fresh cache the fork is pinned to the cache block and serves
+        # warmed state locally; without one it falls back to the live-head
+        # compose fork feeding ANVIL_FORK_MAINNET_URL (publicnode when unset),
+        # matching tier1-simulations.
         env:
           ANVIL_FORK_MAINNET_URL: ${{ secrets.ANVIL_FORK_MAINNET_URL }}
         run: |
-          docker network create keeperhub-network 2>/dev/null || true
-          docker compose --profile test up -d --wait test-anvil-fork-mainnet || \
-            docker compose --profile test up -d test-anvil-fork-mainnet
+          CACHE_DIR="${{ steps.fork-cache.outputs.dir }}"
+          if [ -n "$CACHE_DIR" ]; then
+            # Cache-loaded fork: mount the nightly RPC fetch cache at foundry's
+            # cache path and re-pin to the block its values were fetched at, so
+            # setup writes run against warmed state with zero upstream requests
+            # (this is what unblocks morpho's long setup chain). Cold state
+            # lazy-fetches from the archive upstream at the pin, which the
+            # download step guaranteed is configured. The app reaches this fork
+            # over --network host at localhost:8548, same as the compose path.
+            docker run -d --name keeperhub-test-anvil-fork-mainnet -p 8548:8545 \
+              -v "$PWD/$CACHE_DIR:/home/foundry/.foundry/cache" \
+              --entrypoint anvil ghcr.io/foundry-rs/foundry:latest \
+              --host 0.0.0.0 \
+              --fork-url "$ANVIL_FORK_MAINNET_URL" \
+              --fork-block-number "${{ steps.fork-cache.outputs.block }}" \
+              --chain-id 1 --block-time 1
+          else
+            docker network create keeperhub-network 2>/dev/null || true
+            docker compose --profile test up -d --wait test-anvil-fork-mainnet || \
+              docker compose --profile test up -d test-anvil-fork-mainnet
+          fi
           # Health-poll up to ~60s. Chain ID 0x1 confirms we are on the
           # mainnet fork (not another anvil on the same port).
           retries=0
@@ -1027,6 +1120,8 @@ jobs:
 
       - name: Start code-execution sandbox
         uses: ./.github/actions/start-sandbox
+        with:
+          image_ref: ${{ inputs.sandbox_image }}
 
       - name: Run protocol-coverage tests
         run: |
@@ -1258,6 +1353,8 @@ jobs:
       # vitest job, which already runs a sandbox for its execution suites.
       - name: Start code-execution sandbox
         uses: ./.github/actions/start-sandbox
+        with:
+          image_ref: ${{ inputs.sandbox_image }}
 
       - name: Start application
         uses: ./.github/actions/start-app

--- a/.github/workflows/sentry-upload.yml
+++ b/.github/workflows/sentry-upload.yml
@@ -1,0 +1,89 @@
+# Type: reusable | Called by ci-pipeline.yml
+# Uploads Sentry source maps for the app build. Split out of build-images.yml
+# so it runs parallel to e2e-tests instead of extending the build critical
+# path. The sentry-upload bake target is a pure consumer of the :cache-app
+# registry scope (no cache-to), so this must run AFTER the pipeline bake has
+# pushed that scope - the caller enforces that via `needs: [build-images]`.
+# The NEXT_PUBLIC_* / INCLUDE_TEST_ENDPOINTS args below must match the build
+# job's app target exactly, or BuildKit forks the builder stage and rebuilds
+# from scratch.
+name: Sentry Upload
+
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        description: "Short SHA used as the Sentry release (from build-images)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  sentry-upload:
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
+    env:
+      REGION: ${{ vars.TO_REGION }}
+      AWS_ECR_NAME: ${{ vars.TO_ECR_NAME }}
+      ENVIRONMENT_TAG: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
+      # INCLUDE_TEST_ENDPOINTS is derived from ENVIRONMENT_TAG in the
+      # "Derive build flags" step below, exactly as build-images.yml does.
+      NEXT_PUBLIC_AUTH_PROVIDERS: ${{ vars.NEXT_PUBLIC_AUTH_PROVIDERS }}
+      NEXT_PUBLIC_GITHUB_CLIENT_ID: ${{ vars.NEXT_PUBLIC_GITHUB_CLIENT_ID }}
+      NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
+      NEXT_PUBLIC_BILLING_ENABLED: ${{ vars.NEXT_PUBLIC_BILLING_ENABLED }}
+      NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED: ${{ vars.NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED }}
+      NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ vars.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
+      NEXT_PUBLIC_SENTRY_DSN: ${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
+      SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Derive build flags
+        run: |
+          if [[ "$ENVIRONMENT_TAG" != "prod" ]]; then
+            echo "INCLUDE_TEST_ENDPOINTS=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ env.REGION }}
+
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Upload Sentry source maps
+        uses: docker/bake-action@v7
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPO: ${{ env.AWS_ECR_NAME }}
+          NEXT_PUBLIC_AUTH_PROVIDERS: ${{ env.NEXT_PUBLIC_AUTH_PROVIDERS }}
+          NEXT_PUBLIC_GITHUB_CLIENT_ID: ${{ env.NEXT_PUBLIC_GITHUB_CLIENT_ID }}
+          NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ env.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
+          NEXT_PUBLIC_BILLING_ENABLED: ${{ env.NEXT_PUBLIC_BILLING_ENABLED }}
+          NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED: ${{ env.NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED }}
+          NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ env.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
+          NEXT_PUBLIC_SENTRY_DSN: ${{ env.NEXT_PUBLIC_SENTRY_DSN }}
+          INCLUDE_TEST_ENDPOINTS: ${{ env.INCLUDE_TEST_ENDPOINTS }}
+          SENTRY_ORG: ${{ env.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ env.SENTRY_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ env.SENTRY_AUTH_TOKEN }}
+          SENTRY_RELEASE: ${{ inputs.image_tag }}
+        with:
+          files: docker-bake.hcl
+          targets: sentry-upload

--- a/tests/e2e/vitest/protocol-coverage/morpho/ethereum/coverage.test.ts
+++ b/tests/e2e/vitest/protocol-coverage/morpho/ethereum/coverage.test.ts
@@ -16,22 +16,19 @@ import { cleanupAll, createSharedCtx, runSetup } from "../../_shared/setup";
 
 const PROTOCOL = "morpho";
 const CHAIN_ID = "1";
-const _SKIP_INFRA_TESTS =
+const SKIP_INFRA_TESTS =
   !(process.env.DATABASE_URL && process.env.ANVIL_FORK_MAINNET_URL) ||
   process.env.SKIP_INFRA_TESTS === "true";
 
-// Hard-skipped: morpho has the registry's longest setup write chain (two
-// token provisions, three approvals, vault interactions), and on the CI
-// fork the archive upstream's cold-fetch latency under 16 concurrent
-// suite setups pushes single approves past 3.5 minutes - the setup
-// workflow cannot finish inside any sane budget (measured twice on
-// first activation, 2026-07-07). Every morpho action retains full Tier 1
-// fork-simulation coverage including writes and oracles; Tier 2's shared
-// execution path is proven by the sibling suites.
-// Unlock: mount the nightly fork RPC cache into this job's mainnet fork
-// (as tier1 does) so setup writes run against warmed state, then
-// re-enable.
-describe.skip(`${PROTOCOL} (Ethereum)`, () => {
+// morpho has the registry's longest setup write chain (two token
+// provisions, three approvals, vault interactions). On a cold fork the
+// archive upstream's fetch latency under concurrent suite setups pushed
+// single approves past 3.5 minutes, so this suite was hard-skipped on
+// first activation (2026-07-07). The protocol-coverage job now mounts the
+// nightly fork RPC cache and pins the fork to the cache block, so setup
+// writes run against warmed state and finish inside budget - re-enabled on
+// the same infra gate as the sibling suites.
+describe.skipIf(SKIP_INFRA_TESTS)(`${PROTOCOL} (Ethereum)`, () => {
   const ctx = createSharedCtx();
 
   beforeAll(async () => {


### PR DESCRIPTION
## What

Cuts the staging push-to-deploy wall-clock (~47m baseline) by removing cold-fork cost from the protocol gate and freeing e2e/deploy from work that need not block them.

### Fork-cache + pinned fork for `protocol-coverage-ephemeral`
Ports the `tier1-simulations` mechanism as-is: a `Download latest fork RPC cache` step (cross-workflow `gh api` discovery of `fork-cache-mainnet`, three freshness gates - not expired, produced on staging, under 36h - every failure path exiting 0 so a missing cache falls back to the live fork), then a raw `docker run` anvil fork with the cache mounted at `/home/foundry/.foundry/cache` plus `--fork-block-number`. Compose remains the no-cache fallback. The fork health probe and chain-1 DB patch are unchanged. The app reaches the fork over `--network host` at `localhost:8548`, same as the compose path.

Re-enables the **morpho** suite, previously hard-skipped pending exactly this warming - now gated on the same `SKIP_INFRA_TESTS` infra check as its sibling suites.

### Sentry off the build critical path
Moves `Upload Sentry source maps` out of `build-images` into a new reusable `sentry-upload.yml`, fanned out from `build-images` in the orchestrator so it runs parallel to `e2e` instead of extending the build tail. `skip_build` / `images_exist` are promoted to `build-images` outputs so the split job reuses the same guard. It stays ordered after the pipeline bake (`needs: [build-images]`) because the `sentry-upload` target is a pure `:cache-app` consumer; validated via `bake --print` that its builder args match the `app` target, so it reuses the cached builder layer rather than cold-rebuilding.

### Concurrency for superseded PR runs
Adds `cancel-in-progress` on `ci-pipeline`, scoped to `pull_request` only. Push and `workflow_dispatch` get a unique per-run group via `run_id`, so staging/prod deploys always run to completion. Deliberately not cancel-on-failure.

### Bake sandbox on push
The sandbox is now baked in the main push bake (under the app-compile shadow) and pushed to ECR; `start-sandbox` pulls it, falling back to a local `docker build` on PRs or any pull failure, removing the ~72s per-e2e-job sandbox rebuild.

## Follow-up in this PR
Shard rebalance is intentionally deferred to a follow-up commit on this branch: it must rebalance by the **measured** per-suite profile from a cache-active run, which only exists once this lands in CI. Re-enabling morpho also shifts shard 4's load.

## Behavior note
A Sentry source-map failure now surfaces as a red run without blocking `deploy` (it is no longer a `deploy` dependency). Previously an in-build Sentry failure blocked the whole pipeline.

## Validation
Local: `actionlint` clean on all changed workflows; `docker buildx bake --print` confirms sandbox resolves and app/sentry-upload builder args match; `biome check` and `tsc --noEmit` green. End-to-end wall-clock and floor-count verification happen on the first staging-shaped CI run.