### PR TITLE
fix: unblock fork-cache nightly and make the protocol gate fail-safe

### DIFF
--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -1168,6 +1168,14 @@ jobs:
           # chronicle, superfluid) run for real. When unset those suites
           # skip cleanly and the floor above drops accordingly.
           ANVIL_FORK_MAINNET_URL: ${{ secrets.ANVIL_FORK_MAINNET_URL }}
+          # Non-empty only when the fork-cache download produced a warmed,
+          # pinned cache (set = its `dir` output). morpho gates on this in
+          # addition to ANVIL_FORK_MAINNET_URL: its setup write chain is the
+          # longest in the registry and only fits the shard budget against
+          # warmed state, so on a cache miss (live cold fork) it self-skips
+          # instead of blowing the shard timeout. The other chain-1 suites
+          # run fine cold and stay gated on ANVIL_FORK_MAINNET_URL alone.
+          PROTOCOL_FORK_CACHED: ${{ steps.fork-cache.outputs.dir != '' && '1' || '' }}
           # PR-gate/nightly split: PR-triggered runs shrink each phase to
           # its first runnable action (run-fixture.ts) and the floor
           # derivation above switches to the representatives floor with
@@ -1242,11 +1250,16 @@ jobs:
   # Merge the sharded protocol-coverage results and enforce the sweep-wide
   # guards: the executed-test floor (suites self-skip when infra gates are
   # absent, so a green shard can mean "ran nothing") and suite completeness
-  # (a suite left out of every shard's list would silently vanish). Runs only
-  # when all shards succeed; a shard's own test failures fail the run
-  # directly via that shard's non-zero vitest exit.
+  # (a suite left out of every shard's list would silently vanish).
+  #
+  # Runs whenever e2e is meant to run, even if a shard FAILED or was cancelled
+  # (e.g. hit its timeout) - a cancelled shard uploads no/partial results, so
+  # completeness sees its suites missing and fails here. This is the deploy
+  # gate: without it, a timed-out shard is "cancelled" not "failed", which
+  # slips past deploy's !failure() guard and lets the sweep ship uncovered.
   protocol-coverage-floor:
     needs: [should-run, protocol-coverage-ephemeral]
+    if: ${{ !cancelled() && needs.should-run.outputs.run-e2e == 'true' }}
     runs-on: ubuntu-latest
     environment: staging
     timeout-minutes: 10

--- a/.github/workflows/protocol-nightly.yml
+++ b/.github/workflows/protocol-nightly.yml
@@ -18,6 +18,11 @@ permissions:
   # only downgrade caller permissions): the tier1 job lists/downloads
   # the nightly fork-cache artifact.
   actions: read
+  # Required: e2e-tests-ephemeral.yml declares id-token: write for AWS OIDC
+  # (configure-aws-credentials in build-app/start-app). A called workflow
+  # requesting a permission the caller lacks fails the whole run at startup,
+  # which is why this nightly never once ran since the reusable call was added.
+  id-token: write
 
 jobs:
   e2e-full:

--- a/tests/e2e/vitest/protocol-coverage/morpho/ethereum/coverage.test.ts
+++ b/tests/e2e/vitest/protocol-coverage/morpho/ethereum/coverage.test.ts
@@ -16,18 +16,23 @@ import { cleanupAll, createSharedCtx, runSetup } from "../../_shared/setup";
 
 const PROTOCOL = "morpho";
 const CHAIN_ID = "1";
-const SKIP_INFRA_TESTS =
-  !(process.env.DATABASE_URL && process.env.ANVIL_FORK_MAINNET_URL) ||
-  process.env.SKIP_INFRA_TESTS === "true";
-
 // morpho has the registry's longest setup write chain (two token
 // provisions, three approvals, vault interactions). On a cold fork the
 // archive upstream's fetch latency under concurrent suite setups pushed
-// single approves past 3.5 minutes, so this suite was hard-skipped on
-// first activation (2026-07-07). The protocol-coverage job now mounts the
-// nightly fork RPC cache and pins the fork to the cache block, so setup
-// writes run against warmed state and finish inside budget - re-enabled on
-// the same infra gate as the sibling suites.
+// single approves past 3.5 minutes, blowing the shard timeout, so this
+// suite additionally requires a warmed, pinned fork cache (PROTOCOL_FORK_CACHED,
+// set by the CI fork-cache download step only when a fresh nightly cache is
+// mounted). On a cache miss it self-skips like before instead of timing out;
+// with the cache its setup writes run against warmed state and finish in
+// budget. The sibling chain-1 suites run fine cold and gate on
+// ANVIL_FORK_MAINNET_URL alone.
+const SKIP_INFRA_TESTS =
+  !(
+    process.env.DATABASE_URL &&
+    process.env.ANVIL_FORK_MAINNET_URL &&
+    process.env.PROTOCOL_FORK_CACHED
+  ) || process.env.SKIP_INFRA_TESTS === "true";
+
 describe.skipIf(SKIP_INFRA_TESTS)(`${PROTOCOL} (Ethereum)`, () => {
   const ctx = createSharedCtx();
 


### PR DESCRIPTION
Follow-up to the fork-cache work. The first staging run surfaced that the fork cache producer was already broken, so item 1 fell back to a cold live fork and the re-enabled morpho suite timed out shard 4, which then slipped past the deploy gate.

## Three fixes

### 1. protocol-nightly never ran (no cache ever produced)
`protocol-nightly.yml` has failed with `startup_failure` on every run since the reusable `e2e-tests-ephemeral` call was added - zero `fork-cache-mainnet` artifacts exist. Cause: `e2e-tests-ephemeral.yml` declares `id-token: write` (AWS OIDC in build-app/start-app), and a called reusable workflow requesting a permission the caller lacks fails the entire run at startup. `ci-pipeline` works only because it grants `id-token: write`. Fix: grant `id-token: write` on the nightly. This is also why tier1's KEEP-943 cache optimization has silently not been working.

### 2. morpho ran on a cold fork and timed out shard 4
morpho was gated on `ANVIL_FORK_MAINNET_URL` alone, so on a cache miss it ran against the cold live fork; a single approve took 3.3 min and the shard blew its 25-min timeout. Now gated on a new `PROTOCOL_FORK_CACHED` signal (set only when the fork-cache download mounts a fresh cache), so it self-skips without a warm cache and auto-activates once the nightly produces one. Sibling chain-1 suites run fine cold and are unchanged.

### 3. a timed-out shard slipped past the deploy gate
A shard hitting `timeout-minutes` is reported as *cancelled*, not *failed*, so it passed deploy's `!failure()` guard while `protocol-coverage-floor` silently skipped - the sweep could ship uncovered. The floor now runs whenever e2e is meant to run, even after a failed/cancelled shard. A cancelled shard uploads no results, so its suites show missing in the completeness check and the floor fails - turning the timeout into a real `e2e-tests` failure that blocks deploy through the existing gate.

## Sequencing after merge
1. Merge to staging.
2. Dispatch protocol-nightly to produce the first `fork-cache-mainnet` artifact.
3. Next staging push: tier1 and the protocol job consume the cache; morpho activates and we learn whether shard 4 fits budget cache-backed.
4. Then the shard rebalance (item 2) can use real measured per-suite times.

## Validation
actionlint clean on both workflows; biome + `tsc --noEmit` clean on the morpho change. End-to-end proof comes from the nightly dispatch + next staging run.