### PR TITLE
docs(mcp): add args.memoText to the Transfer trigger output schema

### DIFF
--- a/lib/mcp/workflow-schema-constants.ts
+++ b/lib/mcp/workflow-schema-constants.ts
@@ -259,6 +259,8 @@ export const TRIGGERS = {
       "args.to": "string - Recipient address (the watched deposit address)",
       "args.value": "string - Amount transferred, in the token's smallest unit",
       "args.memo": "string - The bytes32 memo attached to the transfer",
+      "args.memoText":
+        "string - The memo decoded to text (e.g. INV-1042), or empty for a non-text memo",
       transactionHash: "string - Hash of the payment transaction",
       blockNumber: "number - Block height the payment landed in",
       address: "string - The TIP-20 token contract that emitted the event",


### PR DESCRIPTION
The Transfer trigger decodes the on-chain bytes32 memo to UTF-8 text and exposes it as `args.memoText` alongside the raw `args.memo`. The field is already resolved at runtime and listed in the workflow editor's trigger output fields, but the MCP workflow schema (`lib/mcp/workflow-schema-constants.ts`) only advertised `args.memo`.

As a result, MCP-generated workflows had no way to discover the decoded-text field and would fall back to the raw bytes32 hex. This adds `args.memoText` to the trigger's documented output so agents can reference the human-readable memo.

No behavior change: the field already resolves at runtime; this only makes it discoverable through the MCP schema.