### PR TITLE
feat: add MCP tools for projects and tags

### DIFF
--- a/app/api/tags/route.ts
+++ b/app/api/tags/route.ts
@@ -9,6 +9,7 @@ import {
   resolveOrganizationId,
 } from "@/lib/middleware/auth-helpers";
 import { requireScope } from "@/lib/middleware/require-scope";
+import { COLOR_PALETTE } from "@/lib/palette";
 import { buildAuditMetadata, recordAuditEvent } from "@/lib/security/audit-log";
 import { loadCreators } from "@/lib/security/creator-lookup";
 
@@ -102,15 +103,19 @@ export async function POST(request: Request): Promise<NextResponse> {
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
     }
 
-    if (!body.color) {
-      return NextResponse.json({ error: "Color is required" }, { status: 400 });
-    }
+    const existingCount = await db
+      .select({ value: count() })
+      .from(tags)
+      .where(eq(tags.organizationId, organizationId));
+
+    const colorIndex = (existingCount[0]?.value ?? 0) % COLOR_PALETTE.length;
+    const color = body.color || COLOR_PALETTE[colorIndex];
 
     const [newTag] = await db
       .insert(tags)
       .values({
         name,
-        color: body.color,
+        color,
         organizationId,
         userId: creatorUserId,
       })

--- a/lib/mcp/oauth-scopes.ts
+++ b/lib/mcp/oauth-scopes.ts
@@ -53,12 +53,16 @@ const READ_TOOLS = new Set<string>([
   "validate_workflow",
   "prepare_test_pin_data",
   "get_workflow_listing",
+  "list_projects",
+  "list_tags",
 ]);
 
 const WRITE_TOOLS = new Set<string>([
   ...READ_TOOLS,
   "create_workflow",
   "update_workflow",
+  "create_project",
+  "create_tag",
   "delete_workflow",
   "execute_workflow",
   "deploy_template",

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -465,6 +465,119 @@ export function registerTools(
   );
 
   // =========================================================================
+  // Projects & Tags (workflow organization)
+  // =========================================================================
+
+  server.tool(
+    "list_projects",
+    "List all projects for the authenticated organization, each with its workflow count. Use a project's id as projectId when creating, updating, or filtering workflows.",
+    {},
+    { title: "List Projects", readOnlyHint: true, destructiveHint: false },
+    withScopeCheck("list_projects", scope, (_args) =>
+      withToolLogging("list_projects", undefined, async () => {
+        const data = await callApi(
+          internalApiBaseUrl,
+          authHeader,
+          "/api/projects",
+          "GET"
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+        };
+      })
+    )
+  );
+
+  server.tool(
+    "create_project",
+    "Create a project to group workflows. Returns the new project including its id, which you can pass as projectId to create_workflow or update_workflow to assign workflows to it.",
+    {
+      name: z.string().describe("Project name"),
+      description: z
+        .string()
+        .optional()
+        .describe("Optional project description"),
+      color: z
+        .string()
+        .optional()
+        .describe(
+          "Optional hex color (e.g. #4A90D9). Auto-assigned from the palette when omitted."
+        ),
+    },
+    { title: "Create Project", readOnlyHint: false, destructiveHint: false },
+    withScopeCheck("create_project", scope, (args) =>
+      withToolLogging("create_project", undefined, async () => {
+        const data = await callApi(
+          internalApiBaseUrl,
+          authHeader,
+          "/api/projects",
+          "POST",
+          {
+            name: args.name,
+            description: args.description,
+            color: args.color,
+          }
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+        };
+      })
+    )
+  );
+
+  server.tool(
+    "list_tags",
+    "List all tags for the authenticated organization, each with its workflow count. Use a tag's id as tagId when creating, updating, or filtering workflows.",
+    {},
+    { title: "List Tags", readOnlyHint: true, destructiveHint: false },
+    withScopeCheck("list_tags", scope, (_args) =>
+      withToolLogging("list_tags", undefined, async () => {
+        const data = await callApi(
+          internalApiBaseUrl,
+          authHeader,
+          "/api/tags",
+          "GET"
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+        };
+      })
+    )
+  );
+
+  server.tool(
+    "create_tag",
+    "Create a tag to label workflows. Returns the new tag including its id, which you can pass as tagId to create_workflow or update_workflow to label workflows.",
+    {
+      name: z.string().describe("Tag name"),
+      color: z
+        .string()
+        .optional()
+        .describe(
+          "Optional hex color (e.g. #4A90D9). Auto-assigned from the palette when omitted."
+        ),
+    },
+    { title: "Create Tag", readOnlyHint: false, destructiveHint: false },
+    withScopeCheck("create_tag", scope, (args) =>
+      withToolLogging("create_tag", undefined, async () => {
+        const data = await callApi(
+          internalApiBaseUrl,
+          authHeader,
+          "/api/tags",
+          "POST",
+          {
+            name: args.name,
+            color: args.color,
+          }
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+        };
+      })
+    )
+  );
+
+  // =========================================================================
   // Execution
   // =========================================================================
 
@@ -862,6 +975,13 @@ export function registerTools(
           "- get_workflow: Fetch a single workflow by ID",
           "- update_workflow: Modify name, nodes, edges, project, or tag",
           "- delete_workflow: Permanently delete a workflow",
+          "",
+          "PROJECTS & TAGS",
+          "Projects group workflows; tags label them. Both are org-scoped.",
+          "- list_projects / list_tags: Discover existing IDs to link to",
+          "- create_project / create_tag: Create one, then use the returned id",
+          "- Link: pass projectId/tagId to create_workflow or update_workflow",
+          "- Unlink: call update_workflow with projectId=null or tagId=null",
           "",
           "INTEGRATIONS",
           "- list_integrations: See all configured credentials (Discord, Sendgrid, wallets)",

--- a/tests/unit/mcp-scope-required.test.ts
+++ b/tests/unit/mcp-scope-required.test.ts
@@ -25,6 +25,8 @@ describe("getRequiredScopeForTool (KEEP-483)", () => {
     "list_action_schemas",
     "search_plugins",
     "list_integrations",
+    "list_projects",
+    "list_tags",
   ])("returns mcp:read for read tool %s", (toolName) => {
     expect(getRequiredScopeForTool(toolName)).toBe(SCOPE_MCP_READ);
   });
@@ -41,6 +43,8 @@ describe("getRequiredScopeForTool (KEEP-483)", () => {
     "call_workflow",
     "list_workflow",
     "unlist_workflow",
+    "create_project",
+    "create_tag",
   ])("returns mcp:write for write tool %s", (toolName) => {
     expect(getRequiredScopeForTool(toolName)).toBe(SCOPE_MCP_WRITE);
   });

--- a/tests/unit/oauth-scopes.test.ts
+++ b/tests/unit/oauth-scopes.test.ts
@@ -38,6 +38,25 @@ describe("oauth-scopes — read-only consent (only the Read box ticked)", () => 
   });
 });
 
+describe("oauth-scopes — project & tag tools", () => {
+  it("mcp:read allows listing projects and tags", () => {
+    expect(isToolAllowed("list_projects", "mcp:read")).toBe(true);
+    expect(isToolAllowed("list_tags", "mcp:read")).toBe(true);
+  });
+
+  it("mcp:read denies creating projects and tags", () => {
+    expect(isToolAllowed("create_project", "mcp:read")).toBe(false);
+    expect(isToolAllowed("create_tag", "mcp:read")).toBe(false);
+  });
+
+  it("mcp:write allows creating projects and tags", () => {
+    expect(isToolAllowed("create_project", "mcp:write")).toBe(true);
+    expect(isToolAllowed("create_tag", "mcp:write")).toBe(true);
+    expect(isToolAllowed("list_projects", "mcp:write")).toBe(true);
+    expect(isToolAllowed("list_tags", "mcp:write")).toBe(true);
+  });
+});
+
 describe("oauth-scopes — scopeSatisfies (A-03)", () => {
   it("undefined granted scope passes every level (non-OAuth full access)", () => {
     expect(scopeSatisfies(undefined, "mcp:read")).toBe(true);


### PR DESCRIPTION
## Problem

The KeeperHub MCP server accepted `projectId`/`tagId` as filter and assignment params on the workflow tools, but exposed no tools to create projects or tags, nor to list existing ones. An MCP client could therefore never obtain a project/tag id to link a workflow to, so projects and tags were effectively unreachable over MCP. Creating a workflow inside a project, or tagging one, was impossible from an MCP client even though the underlying HTTP API supported it.

## Change

- Add four MCP tools: `list_projects`, `create_project`, `list_tags`, `create_tag`, each proxying the existing `/api/projects` and `/api/tags` endpoints.
- Wire the new tools into the scope sets: `list_projects`/`list_tags` require `mcp:read`, `create_project`/`create_tag` require `mcp:write`.
- Document the project/tag lifecycle in `tools_documentation`, including linking (pass `projectId`/`tagId` to `create_workflow`/`update_workflow`) and unlinking (`update_workflow` with `projectId`/`tagId` set to `null`), which already worked.
- Mirror the projects route's palette color auto-assignment in the tags `POST` route so `create_tag` can omit `color`, matching how project creation behaves.

Linking and unlinking themselves were already functional through `create_workflow`/`update_workflow`; the missing piece was the ability to create and discover the projects/tags to reference.

## Tests

- Extended `oauth-scopes.test.ts` and `mcp-scope-required.test.ts` to cover the new tools' read/write scope requirements.