### PR TITLE
fix: fail protocol shard on timeout and scope morpho to the direct-sign path

### DIFF
--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -1143,8 +1143,22 @@ jobs:
           for suite in $SUITE_DIRS; do
             SUITES="$SUITES tests/e2e/vitest/protocol-coverage/$suite/coverage.test.ts"
           done
-          pnpm vitest run $SUITES \
-            --reporter=default --reporter=json --outputFile="protocol-results-${SHARD}.json"
+          # Bound the sweep just under the job's timeout-minutes (25) with a
+          # shell timeout so a hung shard exits NON-ZERO (a failure) rather than
+          # being cancelled by timeout-minutes. A timeout-minutes cancellation
+          # is reported as "cancelled", which slips past deploy's !failure()
+          # guard; a real failure blocks deploy. The 2-minute headroom lets the
+          # failure/dump/upload steps still run before the job cap.
+          set +e
+          timeout --signal=SIGTERM --kill-after=30s 23m \
+            pnpm vitest run $SUITES \
+              --reporter=default --reporter=json --outputFile="protocol-results-${SHARD}.json"
+          code=$?
+          set -e
+          if [ "$code" -eq 124 ] || [ "$code" -eq 137 ]; then
+            echo "::error::protocol-coverage shard ${SHARD} exceeded 23m and was killed; failing the shard so a hung protocol gate blocks deploy instead of being silently cancelled at the job timeout."
+          fi
+          exit "$code"
         env:
           SHARD: ${{ matrix.shard }}
           SUITE_DIRS: ${{ matrix.suites }}
@@ -1176,6 +1190,20 @@ jobs:
           # instead of blowing the shard timeout. The other chain-1 suites
           # run fine cold and stay gated on ANVIL_FORK_MAINNET_URL alone.
           PROTOCOL_FORK_CACHED: ${{ steps.fork-cache.outputs.dir != '' && '1' || '' }}
+          # Non-empty only on the direct-signing path (bare-metal app, i.e.
+          # image_tag empty: build-app builds with
+          # NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED=false, so fork writes sign
+          # directly and mine fast). The staging-push docker path runs the
+          # production image with gas sponsorship on, routing writes through
+          # Turnkey sponsorship - measured ~10x slower and flaky on a fork
+          # (aave-v3 18s -> 256s, lido 14s -> 204s, pre-flight-simulation
+          # failures). morpho's setup write chain is the longest in the
+          # registry and only fits the shard budget on the direct-sign path, so
+          # it also gates on this: it runs in the nightly full sweep and
+          # self-skips on the docker staging push until that path is moved to
+          # direct signing. Tracked separately; the other suites tolerate the
+          # slow path today.
+          PROTOCOL_DIRECT_SIGN: ${{ inputs.image_tag == '' && '1' || '' }}
           # PR-gate/nightly split: PR-triggered runs shrink each phase to
           # its first runnable action (run-fixture.ts) and the floor
           # derivation above switches to the representatives floor with

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -1158,6 +1158,14 @@ jobs:
           if [ "$code" -eq 124 ] || [ "$code" -eq 137 ]; then
             echo "::error::protocol-coverage shard ${SHARD} exceeded 23m and was killed; failing the shard so a hung protocol gate blocks deploy instead of being silently cancelled at the job timeout."
           fi
+          # A kill can leave no results JSON (reporter flushes on completion) or
+          # a truncated one. Leave a parseable empty result so the floor job
+          # fails cleanly on "shard suites missing" rather than crashing on a
+          # JSON parse error. The shard still exits non-zero below, so deploy is
+          # blocked either way.
+          if [ "$code" -ne 0 ] && { [ ! -s "protocol-results-${SHARD}.json" ] || ! jq empty "protocol-results-${SHARD}.json" >/dev/null 2>&1; }; then
+            echo '{"testResults":[]}' > "protocol-results-${SHARD}.json"
+          fi
           exit "$code"
         env:
           SHARD: ${{ matrix.shard }}

--- a/tests/e2e/vitest/protocol-coverage/morpho/ethereum/coverage.test.ts
+++ b/tests/e2e/vitest/protocol-coverage/morpho/ethereum/coverage.test.ts
@@ -17,20 +17,21 @@ import { cleanupAll, createSharedCtx, runSetup } from "../../_shared/setup";
 const PROTOCOL = "morpho";
 const CHAIN_ID = "1";
 // morpho has the registry's longest setup write chain (two token
-// provisions, three approvals, vault interactions). On a cold fork the
-// archive upstream's fetch latency under concurrent suite setups pushed
-// single approves past 3.5 minutes, blowing the shard timeout, so this
-// suite additionally requires a warmed, pinned fork cache (PROTOCOL_FORK_CACHED,
-// set by the CI fork-cache download step only when a fresh nightly cache is
-// mounted). On a cache miss it self-skips like before instead of timing out;
-// with the cache its setup writes run against warmed state and finish in
-// budget. The sibling chain-1 suites run fine cold and gate on
-// ANVIL_FORK_MAINNET_URL alone.
+// provisions, three approvals, vault interactions), so it only fits the
+// shard budget on the fast path: a warmed, pinned fork cache
+// (PROTOCOL_FORK_CACHED, so reads are served locally) AND the direct-signing
+// app path (PROTOCOL_DIRECT_SIGN, so writes mine fast instead of going
+// through slow/flaky Turnkey gas sponsorship). Both hold in the nightly
+// full sweep, where it runs; on the staging-push docker path writes are
+// sponsored (~10x slower) so it self-skips there rather than blowing the
+// shard timeout. The sibling chain-1 suites tolerate the slow path and gate
+// on ANVIL_FORK_MAINNET_URL alone.
 const SKIP_INFRA_TESTS =
   !(
     process.env.DATABASE_URL &&
     process.env.ANVIL_FORK_MAINNET_URL &&
-    process.env.PROTOCOL_FORK_CACHED
+    process.env.PROTOCOL_FORK_CACHED &&
+    process.env.PROTOCOL_DIRECT_SIGN
   ) || process.env.SKIP_INFRA_TESTS === "true";
 
 describe.skipIf(SKIP_INFRA_TESTS)(`${PROTOCOL} (Ethereum)`, () => {


### PR DESCRIPTION
Two follow-ups from the first cache-backed staging runs of the fork-cache work.

## 1. A timed-out protocol shard no longer slips past the deploy gate
A shard that hits `timeout-minutes` is reported as *cancelled*, not *failed*, so it passes `deploy`'s `!failure()` guard - and the floor-completeness gate doesn't catch it because the cancelled shard still uploads a results file with all suites present. Confirmed live: a shard timed out, floor passed, deploy proceeded.

Fix: bound the sweep with a shell `timeout` (`23m`) just under the job's `timeout-minutes: 25`, so a hang exits non-zero (a real failure) with headroom for the dump/upload steps. A failure blocks deploy through the existing gate.

## 2. morpho scoped to the direct-sign path
Even fork-cache-backed, protocol writes on the staging-push docker image go through Turnkey gas sponsorship (the prod image bakes `NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED=true`), which is ~10x slower and flaky on a fork than the bare-metal direct-sign path:

| Suite | bare-metal (direct-sign) | docker (sponsored) |
| -- | -- | -- |
| aave-v3 | 18s | 256s |
| lido | 14s | 204s |
| morpho | 93s (pass) | 342s + failed write |

The cache warms reads; the docker-path shard-4 tail is dominated by these slow writes. morpho's long write chain only fits the shard budget on the direct-sign path, so it now also gates on `PROTOCOL_DIRECT_SIGN` (`inputs.image_tag == ''`): it runs in the nightly full sweep and self-skips on the docker staging push, keeping shard 4 green there.

The underlying docker-path sponsorship issue is tracked in KEEP-1037 (assigned to Jacob) - the real fix is direct signing on the docker path, after which morpho's direct-sign gate can be dropped and the KEEP-990 shard rebalance can use representative numbers.

## Validation
actionlint clean; `bash -n` on the timeout block; biome + `tsc --noEmit` clean. The gate behavior and morpho scoping validate on the next staging push.