### PR TITLE
feat(billing): show per-period execution usage in billing history

### DIFF
--- a/app/api/billing/invoices/route.ts
+++ b/app/api/billing/invoices/route.ts
@@ -1,5 +1,11 @@
 import { NextResponse } from "next/server";
+import { getExecutionsUsedForPeriods } from "@/lib/billing/execution-usage";
 import { isBillingEnabled } from "@/lib/billing/feature-flag";
+import {
+  getPlanLimits,
+  parsePlanName,
+  parseTierKey,
+} from "@/lib/billing/plans";
 import { getOrgSubscription } from "@/lib/billing/plans-server";
 import { getBillingProvider } from "@/lib/billing/providers";
 import { requireOrgOwner } from "@/lib/billing/require-org-owner";
@@ -34,7 +40,27 @@ export async function GET(request: Request): Promise<NextResponse> {
       startingAfter,
     });
 
-    return NextResponse.json(result);
+    // Annotate each invoice with the executions used during its own billing
+    // period, so usage reconciles with the period the customer was billed on.
+    const limits = getPlanLimits(
+      parsePlanName(sub.plan),
+      parseTierKey(sub.tier),
+      sub.planOverrides
+    );
+    const usage = await getExecutionsUsedForPeriods(
+      activeOrgId,
+      result.invoices.map((invoice) => ({
+        periodStart: invoice.periodStart,
+        periodEnd: invoice.periodEnd,
+      }))
+    );
+    const invoices = result.invoices.map((invoice, index) => ({
+      ...invoice,
+      executionsUsed: usage[index] ?? 0,
+      executionLimit: limits.maxExecutionsPerMonth,
+    }));
+
+    return NextResponse.json({ invoices, hasMore: result.hasMore });
   } catch (error) {
     logSystemError(
       ErrorCategory.EXTERNAL_SERVICE,

--- a/components/billing/billing-history.tsx
+++ b/components/billing/billing-history.tsx
@@ -13,6 +13,11 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { BILLING_API } from "@/lib/billing/constants";
 import type { InvoiceItem } from "@/lib/billing/provider";
 
@@ -28,6 +33,8 @@ type InvoiceResponse = {
     periodEnd: string;
     invoiceUrl: string | null;
     pdfUrl: string | null;
+    executionsUsed: number;
+    executionLimit: number;
   }>;
   hasMore: boolean;
 };
@@ -69,6 +76,22 @@ function formatPeriod(start: string, end: string): string {
     year: "numeric",
   });
   return `${startDate} - ${endDate}`;
+}
+
+const compactNumber = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+function formatUsageCompact(used: number, limit: number): string {
+  const usedLabel = compactNumber.format(used);
+  const limitLabel = limit === -1 ? "∞" : compactNumber.format(limit);
+  return `${usedLabel} / ${limitLabel}`;
+}
+
+function formatUsageExact(used: number, limit: number): string {
+  const limitLabel = limit === -1 ? "Unlimited" : limit.toLocaleString();
+  return `${used.toLocaleString()} / ${limitLabel} executions`;
 }
 
 const PAGE_SIZE = 10;
@@ -144,6 +167,7 @@ export function BillingHistory(): React.ReactElement {
               <Skeleton className="h-4 w-32" />
               <Skeleton className="h-4 w-16" />
               <Skeleton className="h-4 w-28" />
+              <Skeleton className="h-4 w-20" />
               <Skeleton className="h-4 w-12" />
               <Skeleton className="h-4 w-16" />
             </div>
@@ -153,6 +177,7 @@ export function BillingHistory(): React.ReactElement {
                 <Skeleton className="h-4 w-32" />
                 <Skeleton className="h-4 w-16" />
                 <Skeleton className="h-4 w-28" />
+                <Skeleton className="h-4 w-20" />
                 <Skeleton className="h-4 w-12 rounded-full" />
                 <Skeleton className="h-4 w-16" />
               </div>
@@ -191,6 +216,7 @@ export function BillingHistory(): React.ReactElement {
               <TableHead>Description</TableHead>
               <TableHead>Amount</TableHead>
               <TableHead>Period</TableHead>
+              <TableHead>Usage</TableHead>
               <TableHead>Status</TableHead>
               <TableHead>Invoice</TableHead>
             </TableRow>
@@ -201,12 +227,39 @@ export function BillingHistory(): React.ReactElement {
                 <TableCell className="whitespace-nowrap">
                   {formatDate(invoice.date)}
                 </TableCell>
-                <TableCell>{invoice.description}</TableCell>
+                <TableCell>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="block max-w-[240px] truncate text-left">
+                        {invoice.description}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>{invoice.description}</TooltipContent>
+                  </Tooltip>
+                </TableCell>
                 <TableCell className="whitespace-nowrap">
                   {formatAmount(invoice.amount, invoice.currency)}
                 </TableCell>
                 <TableCell className="whitespace-nowrap">
                   {formatPeriod(invoice.periodStart, invoice.periodEnd)}
+                </TableCell>
+                <TableCell className="whitespace-nowrap">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="cursor-help tabular-nums">
+                        {formatUsageCompact(
+                          invoice.executionsUsed,
+                          invoice.executionLimit
+                        )}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {formatUsageExact(
+                        invoice.executionsUsed,
+                        invoice.executionLimit
+                      )}
+                    </TooltipContent>
+                  </Tooltip>
                 </TableCell>
                 <TableCell>
                   <Badge variant={STATUS_VARIANT[invoice.status]}>

--- a/lib/billing/execution-usage.ts
+++ b/lib/billing/execution-usage.ts
@@ -1,0 +1,48 @@
+import "server-only";
+
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+
+export type PeriodWindow = {
+  periodStart: Date;
+  periodEnd: Date;
+};
+
+/**
+ * Billable executions (billable workflow executions + direct API/MCP executions)
+ * counted within each invoice's own billing period, returned aligned to the
+ * input order. A closed period's count is fixed -- it reflects exactly what that
+ * invoice was billed on, including any over-limit executions (e.g. 26k against a
+ * 25k plan, whose excess is billed as overage on the following invoice). Bounded
+ * to the periods passed in (the visible invoices page).
+ */
+export function getExecutionsUsedForPeriods(
+  organizationId: string,
+  windows: PeriodWindow[]
+): Promise<number[]> {
+  return Promise.all(
+    windows.map(async ({ periodStart, periodEnd }) => {
+      const result = await db.execute<{ count: number }>(
+        sql`SELECT
+              (
+                SELECT COUNT(*)::int
+                  FROM workflow_executions we
+                  JOIN workflows w ON we.workflow_id = w.id
+                 WHERE w.organization_id = ${organizationId}
+                   AND we.started_at >= ${periodStart.toISOString()}
+                   AND we.started_at <  ${periodEnd.toISOString()}
+                   AND we.billable = TRUE
+              )
+              +
+              (
+                SELECT COUNT(*)::int
+                  FROM direct_executions de
+                 WHERE de.organization_id = ${organizationId}
+                   AND de.created_at >= ${periodStart.toISOString()}
+                   AND de.created_at <  ${periodEnd.toISOString()}
+              ) AS count`
+      );
+      return result[0]?.count ?? 0;
+    })
+  );
+}

--- a/tests/integration/billing-invoices-route.test.ts
+++ b/tests/integration/billing-invoices-route.test.ts
@@ -32,6 +32,14 @@ vi.mock("@/lib/billing/providers", () => ({
   }),
 }));
 
+const mockDbExecute = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    execute: (...args: unknown[]) => mockDbExecute(...args),
+  },
+}));
+
 import { GET } from "@/app/api/billing/invoices/route";
 
 function makeRequest(query = ""): Request {
@@ -55,21 +63,33 @@ beforeEach(() => {
 });
 
 describe("GET /api/billing/invoices", () => {
-  it("returns invoices for org owner", async () => {
+  it("returns invoices annotated with per-period usage for org owner", async () => {
     mockSession();
     mockGetOrgSubscription.mockResolvedValue({
       providerCustomerId: "cus_1",
+      plan: "pro",
+      tier: "25k",
     });
     mockListInvoices.mockResolvedValue({
-      invoices: [{ id: "inv_1" }],
+      invoices: [
+        {
+          id: "inv_1",
+          periodStart: new Date("2026-06-13T00:00:00Z"),
+          periodEnd: new Date("2026-07-13T00:00:00Z"),
+        },
+      ],
       hasMore: false,
     });
+    // Usage count for the invoice's period.
+    mockDbExecute.mockResolvedValue([{ count: 22_140 }]);
 
     const response = await GET(makeRequest());
     const json = await response.json();
 
     expect(response.status).toBe(200);
     expect(json.invoices).toHaveLength(1);
+    expect(json.invoices[0].executionsUsed).toBe(22_140);
+    expect(json.invoices[0].executionLimit).toBe(25_000);
   });
 
   it("returns 401 without auth", async () => {


### PR DESCRIPTION
## Summary

Adds a per-period execution usage column to the Billing History table so customers and support can see how many executions each billing period used, without querying the database directly.

- Each invoice row shows executions used / plan limit for that invoice's exact billing period, counted from billable workflow executions plus direct (API/MCP) executions.
- A closed period is fixed: it reflects exactly what that invoice was billed on, including over-limit periods (for example 26k against a 25k plan, whose excess bills as overage on the following invoice).
- The current period accumulates and reconciles with the "Monthly executions" meter.
- Long invoice descriptions truncate with a tooltip for the full text.

## Changes

- `lib/billing/execution-usage.ts`: counts billable executions within each invoice period, bounded to the visible invoices page.
- `app/api/billing/invoices/route.ts`: annotates each invoice with executionsUsed and executionLimit.
- `components/billing/billing-history.tsx`: Usage column (compact, exact on hover) and truncated description.
- `tests/integration/billing-invoices-route.test.ts`: asserts the usage annotation.

No changes to enforcement, the executor, or how overage is billed.
