### PR TITLE
fix(billing): soft-delete executions so history purges keep the usage count

### DIFF
--- a/app/api/workflows/[workflowId]/executions/route.ts
+++ b/app/api/workflows/[workflowId]/executions/route.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
@@ -58,9 +58,12 @@ export async function GET(
       );
     }
 
-    // Fetch executions
+    // Fetch executions, excluding runs whose history was purged.
     const executions = await db.query.workflowExecutions.findMany({
-      where: eq(workflowExecutions.workflowId, workflowId),
+      where: and(
+        eq(workflowExecutions.workflowId, workflowId),
+        isNull(workflowExecutions.deletedAt)
+      ),
       orderBy: [desc(workflowExecutions.startedAt)],
       limit: 50,
     });
@@ -190,27 +193,33 @@ export async function DELETE(
       );
     }
 
-    // Get all execution IDs for this workflow
+    // Only the runs not already purged; keeps deletedCount accurate on re-runs.
     const executions = await db.query.workflowExecutions.findMany({
-      where: eq(workflowExecutions.workflowId, workflowId),
+      where: and(
+        eq(workflowExecutions.workflowId, workflowId),
+        isNull(workflowExecutions.deletedAt)
+      ),
       columns: { id: true },
     });
 
     const executionIds = executions.map((e) => e.id);
 
-    // Delete logs first (if there are any executions)
     if (executionIds.length > 0) {
       const { workflowExecutionLogs } = await import("@/lib/db/schema");
-      const { inArray } = await import("drizzle-orm");
 
+      // Per-step logs are the bulky payloads and are not billing-relevant, so
+      // hard-delete them to reclaim storage.
       await db
         .delete(workflowExecutionLogs)
         .where(inArray(workflowExecutionLogs.executionId, executionIds));
 
-      // Then delete the executions
+      // Soft-delete the runs themselves: usage counters count every row, so the
+      // billing total cannot be reset by purging history. Listings filter
+      // deleted_at IS NULL.
       await db
-        .delete(workflowExecutions)
-        .where(eq(workflowExecutions.workflowId, workflowId));
+        .update(workflowExecutions)
+        .set({ deletedAt: new Date() })
+        .where(inArray(workflowExecutions.id, executionIds));
     }
 
     return NextResponse.json({

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -914,10 +914,12 @@ export async function DELETE(
 
     // KEEP-440: soft-delete the workflow row instead of hard-deleting it. The
     // surviving row keeps its listedSlug bound in idx_workflows_listed_slug, so
-    // the slug can never be re-claimed by another workflow. Execution history
-    // is still hard-deleted on force (only the workflow row must persist), and
-    // schedules are removed explicitly -- the ON DELETE CASCADE that used to
-    // clean them up no longer fires now that the row is not actually deleted.
+    // the slug can never be re-claimed by another workflow. On force, the bulky
+    // per-step logs are hard-deleted to reclaim storage but the execution runs
+    // are soft-deleted (deleted_at) so usage counters, which count every row,
+    // stay accurate; schedules are removed explicitly -- the ON DELETE CASCADE
+    // that used to clean them up no longer fires now that the row is not
+    // actually deleted.
     const softDelete = softDeleteValues();
 
     if (hasExecutions && force) {
@@ -938,7 +940,8 @@ export async function DELETE(
             .where(inArray(workflowExecutionLogs.executionId, executionIds));
 
           await tx
-            .delete(workflowExecutions)
+            .update(workflowExecutions)
+            .set({ deletedAt: new Date() })
             .where(eq(workflowExecutions.workflowId, workflowId));
         }
 

--- a/drizzle/0134_keep_1035_workflow_executions_soft_delete.sql
+++ b/drizzle/0134_keep_1035_workflow_executions_soft_delete.sql
@@ -1,0 +1,8 @@
+-- Soft-delete marker for workflow execution history. Purging a workflow's runs
+-- sets deleted_at instead of hard-deleting the row, so billing usage counters
+-- (which count all rows regardless of deleted_at) stay independent of history
+-- purges. User-facing execution listings filter deleted_at IS NULL.
+-- Nullable with no default, so this is a metadata-only ADD COLUMN: no table
+-- rewrite and no long lock even on a large table (no @requires-db-prep needed).
+-- Idempotent: safe to re-run.
+ALTER TABLE "workflow_executions" ADD COLUMN IF NOT EXISTS "deleted_at" TIMESTAMP;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -939,6 +939,13 @@
       "when": 1784239042000,
       "tag": "0133_tempo_held_payments",
       "breakpoints": true
+    },
+    {
+      "idx": 134,
+      "version": "7",
+      "when": 1784325442000,
+      "tag": "0134_keep_1035_workflow_executions_soft_delete",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -737,6 +737,13 @@ export const workflowExecutions = pgTable(
      * never collide.
      */
     dispatchKey: text("dispatch_key"),
+    /**
+     * Soft-delete marker for execution history. Purging a workflow's runs sets
+     * this instead of hard-deleting the row; billing usage counters count all
+     * rows regardless of deleted_at, while user-facing execution listings
+     * filter deleted_at IS NULL.
+     */
+    deletedAt: timestamp("deleted_at"),
   },
   (table) => [
     index("idx_workflow_executions_status").on(table.status),

--- a/tests/unit/executions-route-soft-delete.test.ts
+++ b/tests/unit/executions-route-soft-delete.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const findFirstMock = vi.fn();
+const findManyMock = vi.fn();
+const deleteWhereMock = vi.fn();
+const deleteMock = vi.fn(() => ({ where: deleteWhereMock }));
+const updateWhereMock = vi.fn();
+const updateSetMock = vi.fn(() => ({ where: updateWhereMock }));
+const updateMock = vi.fn(() => ({ set: updateSetMock }));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      workflows: { findFirst: findFirstMock },
+      workflowExecutions: { findMany: findManyMock },
+    },
+    delete: deleteMock,
+    update: updateMock,
+  },
+}));
+
+vi.mock("@/lib/middleware/auth-helpers", () => ({
+  getDualAuthContext: vi.fn().mockResolvedValue({
+    userId: "user_1",
+    organizationId: "org_1",
+    authMethod: "session",
+    scope: undefined,
+    apiKeyId: null,
+  }),
+}));
+
+vi.mock("@/lib/middleware/require-scope", () => ({
+  requireScope: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("@/lib/workflow/access", () => ({
+  getWorkflowAccess: vi
+    .fn()
+    .mockResolvedValue({ hasFullAccess: true, isDeleted: false }),
+}));
+
+import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  deleteWhereMock.mockResolvedValue(undefined);
+  updateWhereMock.mockResolvedValue(undefined);
+});
+
+// Purging execution history must not reduce the billable count, so runs are
+// soft-deleted (deleted_at) rather than hard-deleted; only the bulky per-step
+// logs are hard-deleted to reclaim storage.
+describe("executions DELETE route soft-deletes runs", () => {
+  it("soft-deletes the runs and hard-deletes only their logs", async () => {
+    findFirstMock.mockResolvedValueOnce({
+      id: "wf_1",
+      userId: "user_1",
+      organizationId: "org_1",
+    });
+    findManyMock.mockResolvedValueOnce([{ id: "exec_1" }, { id: "exec_2" }]);
+
+    const { DELETE } = await import(
+      "@/app/api/workflows/[workflowId]/executions/route"
+    );
+    const response = await DELETE(
+      new Request("http://test/executions", { method: "DELETE" }),
+      { params: Promise.resolve({ workflowId: "wf_1" }) }
+    );
+    const body = (await response.json()) as { deletedCount: number };
+
+    expect(response.status).toBe(200);
+    expect(body.deletedCount).toBe(2);
+
+    // Runs are soft-deleted (deleted_at stamped), never hard-deleted.
+    expect(updateMock).toHaveBeenCalledWith(workflowExecutions);
+    expect(updateSetMock).toHaveBeenCalledWith(
+      expect.objectContaining({ deletedAt: expect.any(Date) })
+    );
+    expect(deleteMock).not.toHaveBeenCalledWith(workflowExecutions);
+
+    // Only the per-step logs are hard-deleted.
+    expect(deleteMock).toHaveBeenCalledWith(workflowExecutionLogs);
+  });
+
+  it("does not touch executions when there are none", async () => {
+    findFirstMock.mockResolvedValueOnce({
+      id: "wf_1",
+      userId: "user_1",
+      organizationId: "org_1",
+    });
+    findManyMock.mockResolvedValueOnce([]);
+
+    const { DELETE } = await import(
+      "@/app/api/workflows/[workflowId]/executions/route"
+    );
+    const response = await DELETE(
+      new Request("http://test/executions", { method: "DELETE" }),
+      { params: Promise.resolve({ workflowId: "wf_1" }) }
+    );
+    const body = (await response.json()) as { deletedCount: number };
+
+    expect(body.deletedCount).toBe(0);
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Monthly usage is counted from `workflow_executions`, but the force-delete and delete-executions routes hard-deleted those rows. Purging a workflow's execution history therefore reset the org's usage count, so an org could stay under its plan limit by repeatedly deleting workflows it had already run.

Execution runs are now soft-deleted (`deleted_at`) instead of hard-deleted, so the billing counters, which count every row, stay accurate. The bulky per-step logs are still hard-deleted, so purging still reclaims storage. Purged runs are hidden from the per-workflow execution list; analytics and the periodic digest keep counting them as raw activity (unchanged).

## Changes

- `lib/db/schema.ts` + `drizzle/0134_...`: add `deleted_at` to `workflow_executions` (metadata-only `ADD COLUMN`, no table rewrite or lock).
- `app/api/workflows/[workflowId]/route.ts`: force-delete soft-deletes the runs, still hard-deletes their logs.
- `app/api/workflows/[workflowId]/executions/route.ts`: DELETE soft-deletes the runs; GET filters `deleted_at IS NULL`.
- `tests/unit/executions-route-soft-delete.test.ts`: regression test asserting the runs are soft-deleted and only the logs are hard-deleted.

The billing counters intentionally do not filter `deleted_at`, so soft-deleted runs still count.
