### PR TITLE
fix(workflow): remove selected-run highlight ring from runs panel

### DIFF
--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -1276,7 +1276,6 @@ export function WorkflowRuns({
     <div data-ready={String(isReady)} data-testid="workflow-runs" className="space-y-3">
       {executions.map((execution, index) => {
         const isExpanded = expandedRuns.has(execution.id);
-        const isSelected = selectedExecutionId === execution.id;
         const executionLogs = (logs[execution.id] || []).sort((a, b) => {
           // Sort by startedAt to ensure first to last order
           return (
@@ -1294,11 +1293,7 @@ export function WorkflowRuns({
 
         return (
           <div
-            className={cn(
-              "overflow-hidden rounded-lg border bg-card transition-all",
-              isSelected &&
-                "ring-2 ring-primary ring-offset-2 ring-offset-background"
-            )}
+            className="overflow-hidden rounded-lg border bg-card transition-all"
             key={execution.id}
           >
             <div className="flex w-full items-center gap-3 p-4">


### PR DESCRIPTION
Removes the ring/outline drawn around the selected run card in the workflow Runs panel. The `ring-2 ring-primary ring-offset-2 ring-offset-background` treatment produced a visible outline (with an offset gap) around the active run.

Each run card keeps its normal border, so cards remain visually delineated; they just no longer get the extra highlight ring when selected. Also drops the now-unused `isSelected` variable.