### PR TITLE
fix(deploy): raise solana-tracker cpu request to 150m

### DIFF
--- a/deploy/solana-tracker/prod/values.yaml
+++ b/deploy/solana-tracker/prod/values.yaml
@@ -43,7 +43,7 @@ resources:
   limits:
     memory: 1Gi
   requests:
-    cpu: 50m
+    cpu: 150m
     memory: 256Mi
 
 env:

--- a/deploy/solana-tracker/staging/values.yaml
+++ b/deploy/solana-tracker/staging/values.yaml
@@ -43,7 +43,7 @@ resources:
   limits:
     memory: 512Mi
   requests:
-    cpu: 50m
+    cpu: 150m
     memory: 128Mi
 
 env:


### PR DESCRIPTION
The keeperhub-solana-common staging deployment was firing recurring "High CPU Usage" alerts (e.g. Incident #33235) because its CPU request of 50m was sized for the service's pre-launch idle state. Since PR #1799 enabled real Solana chain ingestion on 2026-07-23, the container has run at a sustained 70-180m (p95 113m, p99 171m, max 182m over 32h of Prometheus data), which sat above the alert's 2x-request threshold of 100m for much of normal operation. This change raises the CPU request in deploy/solana-tracker/staging/values.yaml to 150m so the alert threshold (300m) sits comfortably above observed load.

Preemptively increasing CPU for prod as well.