### PR TITLE
chore: enable Solana wallet provisioning in prod

### DIFF
--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -30,11 +30,11 @@ app:
       name: chain-rpc-config
       parameter_name: /eks/techops-prod/keeperhub/chain-rpc-config
     # KEEP-988: gate Solana wallet provisioning at signup (Turnkey provisions an
-    # ed25519 Solana account alongside the EVM EOA). Off in prod until the prod
-    # Solana rollout; flip to "true" in a PR when ready.
+    # ed25519 Solana account alongside the EVM EOA). Enabled for the prod Solana
+    # rollout; existing wallets were backfilled via scripts/backfill-solana-address.ts.
     SOLANA_WALLET_PROVISIONING_ENABLED:
       type: kv
-      value: "false"
+      value: "true"
     TURNKEY_API_PUBLIC_KEY:
       type: parameterStore
       name: turnkey-api-public-key


### PR DESCRIPTION
Flips SOLANA_WALLET_PROVISIONING_ENABLED to true in the prod Helm values so the To Prod release (#1828) carries it.

Context:
- Wallet backfill is complete in both environments: prod 373 applied / 0 failed (405/405 active wallets covered), staging 20 applied / 0 failed (21/21 covered).
- New signups will provision EVM + Solana wallets once this deploys with the release.
- Prod chain enablement (chain-config production.json isEnabled) remains a separate, deliberate step.

No staging behavior change: this touches only deploy/keeperhub-stack/prod/values.yaml.