### PR TITLE
fix(execute): return a typed insufficient_balance from the simulator

### DIFF
--- a/docs/api/direct-execution.md
+++ b/docs/api/direct-execution.md
@@ -302,7 +302,38 @@ When the chain would have rejected the transaction, the endpoint returns HTTP 40
 }
 ```
 
-Revert decoding tries (in order): the contract's own ABI custom errors, common OpenZeppelin / standard errors, then the standard `Error(string)` revert (which is surfaced as `Error(<message>)`). If none match, the raw RPC error message is surfaced.
+Revert decoding tries (in order): the contract's own ABI custom errors, common OpenZeppelin / standard errors, then the standard `Error(string)` revert (which is surfaced as `Error(<message>)`). If none match, the failure is either attributed to a funding shortfall (see below) or the raw RPC error message is surfaced.
+
+### Response — underfunded sender
+
+A node asked to estimate gas for a transfer the sender cannot pay for rejects it without revert data, and the resulting `CALL_EXCEPTION` names neither the balance nor the address. When the simulator can confirm that is what happened, the failure carries a machine-readable `code` and the numbers a caller needs to fix it:
+
+```json
+{
+  "success": false,
+  "status": "simulated",
+  "from": "0x...orgWallet",
+  "to": "0x...recipient",
+  "value": "1000000000000000000",
+  "wouldRevert": true,
+  "revertReason": "Insufficient ETH balance. Have: 0.25, Need: 1.0. Fund 0x...orgWallet with at least 0.75 ETH on this chain and retry.",
+  "error": "Insufficient ETH balance. Have: 0.25, Need: 1.0. Fund 0x...orgWallet with at least 0.75 ETH on this chain and retry.",
+  "code": "insufficient_balance",
+  "balanceWei": "250000000000000000",
+  "requiredWei": "1000000000000000000",
+  "shortfallWei": "750000000000000000",
+  "nativeSymbol": "ETH",
+  "originalError": "missing revert data (action=\"estimateGas\", ...)"
+}
+```
+
+- `code`: `"insufficient_balance"` — branch on this rather than string-matching `revertReason`. Absent when the simulator could not attribute the failure to anything more specific than "the call reverted"
+- `balanceWei` / `requiredWei` / `shortfallWei`: the sender's native balance, the native value the call would move, and the difference, all in wei
+- `nativeSymbol`: the chain's native currency symbol (`ETH`, `BNB`, `POL`); falls back to `native` if the chain is not seeded
+- `originalError`: the node's own message, kept verbatim. Attribution only ever adds — nothing the chain said is discarded
+- `undecodedRevertData`: present only when the node did return revert data that no ABI on the decode path matched. The first four bytes are the custom-error selector, which you can look up in a selector database. When this field is set, funding the wallet may not be enough on its own — the contract is also rejecting the call
+
+The comparison is against the transfer value only; gas is not included (the gas estimate is what failed, so there is no number to add). A wallet funded with exactly the transfer amount therefore still fails, with the node's own `insufficient funds for gas * price + value` message and no `code`.
 
 ### Token-transfer specifics
 

--- a/lib/execute/native-balance.ts
+++ b/lib/execute/native-balance.ts
@@ -1,0 +1,87 @@
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import { ethers } from "ethers";
+import { db } from "@/lib/db";
+import { chains } from "@/lib/db/schema";
+
+/**
+ * Native-balance helpers shared by the broadcast preflight
+ * (transfer-funds-core) and the read-only simulator (lib/execute/simulate).
+ *
+ * Both paths answer the same question — "does the funding address hold
+ * enough native currency for this transfer?" — and both have to phrase the
+ * answer for a caller who cannot see the chain. Keeping the wording in one
+ * place stops the dry run and the broadcast from drifting apart.
+ */
+
+/** Machine-readable `code` for a native-currency shortfall. */
+export const INSUFFICIENT_BALANCE_CODE = "insufficient_balance";
+
+export type InsufficientBalanceCode = typeof INSUFFICIENT_BALANCE_CODE;
+
+/**
+ * The chain's native symbol ("ETH", "BNB", "POL"), read from the seeded
+ * `chains` table.
+ *
+ * Falls back to the chain-agnostic "native" when the chain is unknown or the
+ * lookup fails: this only ever runs on an error path, so a database blip must
+ * degrade the message rather than replace the real failure with its own.
+ */
+export async function getNativeSymbol(chainId: number): Promise<string> {
+  try {
+    const chainRow = await db
+      .select({ symbol: chains.symbol })
+      .from(chains)
+      .where(eq(chains.chainId, chainId))
+      .limit(1);
+    return chainRow[0]?.symbol ?? "native";
+  } catch {
+    return "native";
+  }
+}
+
+export type NativeShortfall = {
+  code: InsufficientBalanceCode;
+  /** Funding address' native balance, in wei. */
+  balanceWei: string;
+  /** Native value the transfer would move, in wei. */
+  requiredWei: string;
+  /** requiredWei - balanceWei, in wei. Always > 0. */
+  shortfallWei: string;
+  nativeSymbol: string;
+  /** Human-readable message; safe to surface to an API caller verbatim. */
+  message: string;
+};
+
+/**
+ * Describe a native-balance shortfall.
+ *
+ * `holder` is optional so the broadcast preflight keeps its existing wording
+ * byte-for-byte. When supplied (the simulator does), the message also names
+ * the address to fund and how much it is short — the two things a headless
+ * caller needs and cannot look up from an error string.
+ */
+export function describeNativeShortfall(input: {
+  symbol: string;
+  balance: bigint;
+  required: bigint;
+  holder?: string;
+}): NativeShortfall {
+  const shortfall = input.required - input.balance;
+  const have = ethers.formatEther(input.balance);
+  const need = ethers.formatEther(input.required);
+  const base = `Insufficient ${input.symbol} balance. Have: ${have}, Need: ${need}`;
+  const message = input.holder
+    ? `${base}. Fund ${input.holder} with at least ${ethers.formatEther(shortfall)} ${input.symbol} on this chain and retry.`
+    : base;
+
+  return {
+    code: INSUFFICIENT_BALANCE_CODE,
+    balanceWei: input.balance.toString(),
+    requiredWei: input.required.toString(),
+    shortfallWei: shortfall.toString(),
+    nativeSymbol: input.symbol,
+    message,
+  };
+}

--- a/lib/execute/native-balance.ts
+++ b/lib/execute/native-balance.ts
@@ -13,12 +13,14 @@ import { chains } from "@/lib/db/schema";
  * enough native currency for this transfer?" — and both have to phrase the
  * answer for a caller who cannot see the chain. Keeping the wording in one
  * place stops the dry run and the broadcast from drifting apart.
+ *
+ * Scope: the question is about the transfer value only. Neither caller adds
+ * gas to the requirement, so a wallet holding exactly `value` still cannot
+ * pay `value + gas * price` and is not reported as short by either path.
  */
 
 /** Machine-readable `code` for a native-currency shortfall. */
 export const INSUFFICIENT_BALANCE_CODE = "insufficient_balance";
-
-export type InsufficientBalanceCode = typeof INSUFFICIENT_BALANCE_CODE;
 
 /**
  * The chain's native symbol ("ETH", "BNB", "POL"), read from the seeded
@@ -42,7 +44,7 @@ export async function getNativeSymbol(chainId: number): Promise<string> {
 }
 
 export type NativeShortfall = {
-  code: InsufficientBalanceCode;
+  code: typeof INSUFFICIENT_BALANCE_CODE;
   /** Funding address' native balance, in wei. */
   balanceWei: string;
   /** Native value the transfer would move, in wei. */

--- a/lib/execute/simulate.ts
+++ b/lib/execute/simulate.ts
@@ -6,13 +6,16 @@ import { type AbiItem, findAbiFunction } from "@/lib/abi/utils";
 import {
   describeNativeShortfall,
   getNativeSymbol,
-  type InsufficientBalanceCode,
+  type INSUFFICIENT_BALANCE_CODE,
 } from "@/lib/execute/native-balance";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { getErrorMessage } from "@/lib/utils";
-import { decodeRevertReason } from "@/lib/web3/decode-revert-error";
+import {
+  decodeRevertReason,
+  extractRevertData,
+} from "@/lib/web3/decode-revert-error";
 import { getOrganizationWalletAddress } from "@/lib/web3/wallet-helpers";
 import { parseTokenAddress } from "@/plugins/web3/steps/transfer-token-core";
 
@@ -32,7 +35,10 @@ import { parseTokenAddress } from "@/plugins/web3/steps/transfer-token-core";
  * When the preflight fails because the funding address cannot cover the
  * native value, the failure carries `code: "insufficient_balance"` with the
  * balance, the requirement and the shortfall — the same answer the broadcast
- * preflight gives — rather than the node's revert-data-less CALL_EXCEPTION.
+ * preflight gives — instead of the node's revert-data-less CALL_EXCEPTION.
+ * Attribution only ever adds: the node's own message stays in
+ * `originalError`, and revert data that failed to decode stays in
+ * `undecodedRevertData`, so no failure is less informative than before.
  *
  * Known limitation: `from` is resolved via getOrganizationWalletAddress
  * (the org's EOA / smart account address). Orgs that route writes
@@ -70,6 +76,15 @@ export type SimulateSuccess = {
   wouldRevert: false;
 };
 
+/**
+ * Machine-readable causes the simulator can attribute a failure to.
+ *
+ * Named for the concept rather than its single current member: adding a
+ * second code widens this union instead of replacing a one-literal alias,
+ * so an exhaustive `switch` on the client keeps compiling.
+ */
+export type SimulateFailureCode = typeof INSUFFICIENT_BALANCE_CODE;
+
 export type SimulateFailure = {
   success: false;
   status: "simulated";
@@ -84,7 +99,7 @@ export type SimulateFailure = {
    * failure to something more specific than "the call reverted". Clients
    * should branch on this rather than string-matching `revertReason`.
    */
-  code?: InsufficientBalanceCode;
+  code?: SimulateFailureCode;
   /** Set with `code: "insufficient_balance"`: `from`'s native balance, in wei. */
   balanceWei?: string;
   /** Set with `code: "insufficient_balance"`: native value needed, in wei. */
@@ -93,6 +108,20 @@ export type SimulateFailure = {
   shortfallWei?: string;
   /** Set with `code: "insufficient_balance"`: e.g. "ETH". */
   nativeSymbol?: string;
+  /**
+   * The node's own error message, kept verbatim whenever the simulator put
+   * an attribution in `revertReason` instead. Attribution augments, never
+   * discards: `revertReason` carries the actionable claim, this carries
+   * what the chain actually said.
+   */
+  originalError?: string;
+  /**
+   * Revert data the node did return but which neither the supplied ABI, the
+   * common-error list, nor `Error(string)` could decode. Look its first four
+   * bytes up in a selector database to identify the custom error. Absent
+   * when the node returned no revert data at all.
+   */
+  undecodedRevertData?: string;
 };
 
 export type SimulateResult = SimulateSuccess | SimulateFailure;
@@ -188,6 +217,12 @@ function failure(
  * be read), so a real revert reason is never masked by a guess. The balance
  * is read for the same `from` the simulation used, inheriting the Safe
  * routing limitation documented at the top of this file.
+ *
+ * The comparison is `balance >= value` and deliberately ignores gas: the
+ * estimate is what just failed, so there is no gas number to add. A wallet
+ * holding exactly `value` therefore still fails on `value + gas * price`,
+ * and this returns null for it — nodes answer that case with a readable
+ * "insufficient funds for gas * price + value" of their own.
  */
 async function nativeShortfallFailure(input: {
   rpc: RpcProviderManager;
@@ -195,6 +230,10 @@ async function nativeShortfallFailure(input: {
   from: string;
   to: string;
   value: bigint;
+  /** The node's own message, carried through so attribution discards nothing. */
+  originalError: string;
+  /** Revert data the node returned that nothing could decode, if any. */
+  undecodedRevertData?: string;
 }): Promise<SimulateFailure | null> {
   // A zero-value call can never be short, so skip the extra round trip.
   if (input.value <= BigInt(0)) {
@@ -215,19 +254,81 @@ async function nativeShortfallFailure(input: {
       required: input.value,
       holder: input.from,
     });
+    // The wallet is genuinely short, but a contract that also returned revert
+    // data may be rejecting the call for an unrelated reason. Say both.
+    const message = input.undecodedRevertData
+      ? `${shortfall.message} The call also returned revert data no ABI here decodes (selector ${revertSelector(input.undecodedRevertData)}), so funding alone may not make it succeed.`
+      : shortfall.message;
     return {
-      ...failure(input.from, input.to, input.value, shortfall.message),
+      ...failure(input.from, input.to, input.value, message),
       code: shortfall.code,
       balanceWei: shortfall.balanceWei,
       requiredWei: shortfall.requiredWei,
       shortfallWei: shortfall.shortfallWei,
       nativeSymbol: shortfall.nativeSymbol,
+      originalError: input.originalError,
+      undecodedRevertData: input.undecodedRevertData,
     };
   } catch {
     // Attribution is best-effort: it runs inside an error path, so it must
     // fall back to the original failure rather than raise one of its own.
     return null;
   }
+}
+
+/** First four bytes of revert data: the selector an integrator can look up. */
+function revertSelector(data: string): string {
+  return ethers.dataLength(data) >= 4 ? ethers.dataSlice(data, 0, 4) : data;
+}
+
+/**
+ * Turn a failed preflight into a SimulateFailure, shared by every path that
+ * calls estimateGas.
+ *
+ * Order of preference: a decoded revert reason is the most specific answer,
+ * so it wins outright. Otherwise the failure may be a funding shortfall —
+ * attribute it, but never at the cost of what the node said. `decodeRevert-
+ * Reason` returns undefined both when there was no revert data and when
+ * there was revert data nothing could decode; the second case keeps its raw
+ * bytes in `undecodedRevertData` and its selector in the message, and both
+ * cases keep the node's message in `originalError`.
+ */
+async function failureFromPreflightError(input: {
+  rpc: RpcProviderManager;
+  chainId: number;
+  from: string;
+  to: string;
+  value: bigint;
+  err: unknown;
+  /** The call's ABI, when there is one. Native sends have none. */
+  iface?: ethers.Interface;
+}): Promise<SimulateFailure> {
+  const reason = decodeRevertReason(input.err, input.iface);
+  if (reason) {
+    return failure(input.from, input.to, input.value, reason);
+  }
+
+  const originalError = getErrorMessage(input.err);
+  const revertData = extractRevertData(input.err);
+  const shortfall = await nativeShortfallFailure({
+    rpc: input.rpc,
+    chainId: input.chainId,
+    from: input.from,
+    to: input.to,
+    value: input.value,
+    originalError,
+    undecodedRevertData:
+      revertData && revertData !== "0x" ? revertData : undefined,
+  });
+  return (
+    shortfall ??
+    failure(
+      input.from,
+      input.to,
+      input.value,
+      `Simulation reverted: ${originalError}`
+    )
+  );
 }
 
 async function getRpcManagerForChain(
@@ -338,24 +439,15 @@ export async function simulateContractCall(
       "preflight"
     );
   } catch (err) {
-    // A decoded revert is the most specific answer available, so it wins.
-    // Only when the node returned no revert data is an empty wallet a
-    // plausible explanation worth spending an extra RPC read on.
-    const reason = decodeRevertReason(err, iface);
-    if (reason) {
-      return failure(from, to, value, reason);
-    }
-    const shortfall = await nativeShortfallFailure({
+    return await failureFromPreflightError({
       rpc,
       chainId,
       from,
       to,
       value,
+      err,
+      iface,
     });
-    return (
-      shortfall ??
-      failure(from, to, value, `Simulation reverted: ${getErrorMessage(err)}`)
-    );
   }
 
   let simulatedReturnValue: unknown = null;
@@ -411,17 +503,17 @@ export async function simulateNativeTransfer(
       "preflight"
     );
   } catch (err) {
-    const shortfall = await nativeShortfallFailure({
+    // No ABI to pass: a native send has none. decodeRevertReason still
+    // tries the common-error list and Error(string), so a reverting
+    // contract recipient gets its reason decoded here too.
+    return await failureFromPreflightError({
       rpc,
       chainId,
       from,
       to,
       value,
+      err,
     });
-    return (
-      shortfall ??
-      failure(from, to, value, `Simulation reverted: ${getErrorMessage(err)}`)
-    );
   }
 
   return {

--- a/lib/execute/simulate.ts
+++ b/lib/execute/simulate.ts
@@ -3,6 +3,11 @@ import "server-only";
 import { ethers } from "ethers";
 import { coerceArgsForAbi, reshapeArgsForAbi } from "@/lib/abi/struct-args";
 import { type AbiItem, findAbiFunction } from "@/lib/abi/utils";
+import {
+  describeNativeShortfall,
+  getNativeSymbol,
+  type InsufficientBalanceCode,
+} from "@/lib/execute/native-balance";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
@@ -23,6 +28,11 @@ import { parseTokenAddress } from "@/plugins/web3/steps/transfer-token-core";
  * Every chain call is routed through rpcManager.executeWithFailover so
  * a primary-RPC blip falls over to the chain's configured fallback,
  * matching the behaviour of read paths in the broadcast cores.
+ *
+ * When the preflight fails because the funding address cannot cover the
+ * native value, the failure carries `code: "insufficient_balance"` with the
+ * balance, the requirement and the shortfall — the same answer the broadcast
+ * preflight gives — rather than the node's revert-data-less CALL_EXCEPTION.
  *
  * Known limitation: `from` is resolved via getOrganizationWalletAddress
  * (the org's EOA / smart account address). Orgs that route writes
@@ -69,6 +79,20 @@ export type SimulateFailure = {
   wouldRevert: true;
   revertReason: string;
   error: string;
+  /**
+   * Machine-readable cause, set only when the simulator could attribute the
+   * failure to something more specific than "the call reverted". Clients
+   * should branch on this rather than string-matching `revertReason`.
+   */
+  code?: InsufficientBalanceCode;
+  /** Set with `code: "insufficient_balance"`: `from`'s native balance, in wei. */
+  balanceWei?: string;
+  /** Set with `code: "insufficient_balance"`: native value needed, in wei. */
+  requiredWei?: string;
+  /** Set with `code: "insufficient_balance"`: how much is missing, in wei. */
+  shortfallWei?: string;
+  /** Set with `code: "insufficient_balance"`: e.g. "ETH". */
+  nativeSymbol?: string;
 };
 
 export type SimulateResult = SimulateSuccess | SimulateFailure;
@@ -146,6 +170,64 @@ function failure(
     revertReason: message,
     error: message,
   };
+}
+
+/**
+ * Attribute a failed preflight to a funding wallet that cannot cover the
+ * transfer value.
+ *
+ * `eth_estimateGas` from an address holding less than `value` is rejected by
+ * the node without revert data, which ethers surfaces as a bare
+ * `missing revert data (action="estimateGas", ..., code=CALL_EXCEPTION)`.
+ * That string names neither the balance nor the address, so a headless caller
+ * — the exact case a dry run exists for — has nothing to act on. Read the
+ * balance once, on the failure path only, and report the same shortfall the
+ * broadcast preflight in transfer-funds-core already reports.
+ *
+ * Returns null whenever the balance does not explain the failure (or cannot
+ * be read), so a real revert reason is never masked by a guess. The balance
+ * is read for the same `from` the simulation used, inheriting the Safe
+ * routing limitation documented at the top of this file.
+ */
+async function nativeShortfallFailure(input: {
+  rpc: RpcProviderManager;
+  chainId: number;
+  from: string;
+  to: string;
+  value: bigint;
+}): Promise<SimulateFailure | null> {
+  // A zero-value call can never be short, so skip the extra round trip.
+  if (input.value <= BigInt(0)) {
+    return null;
+  }
+
+  try {
+    const balance = await input.rpc.executeWithFailover(
+      (p) => p.getBalance(input.from),
+      "preflight"
+    );
+    if (balance >= input.value) {
+      return null;
+    }
+    const shortfall = describeNativeShortfall({
+      symbol: await getNativeSymbol(input.chainId),
+      balance,
+      required: input.value,
+      holder: input.from,
+    });
+    return {
+      ...failure(input.from, input.to, input.value, shortfall.message),
+      code: shortfall.code,
+      balanceWei: shortfall.balanceWei,
+      requiredWei: shortfall.requiredWei,
+      shortfallWei: shortfall.shortfallWei,
+      nativeSymbol: shortfall.nativeSymbol,
+    };
+  } catch {
+    // Attribution is best-effort: it runs inside an error path, so it must
+    // fall back to the original failure rather than raise one of its own.
+    return null;
+  }
 }
 
 async function getRpcManagerForChain(
@@ -242,7 +324,7 @@ export async function simulateContractCall(
     );
   }
 
-  const { rpc } = await getRpcManagerForChain(input.network);
+  const { rpc, chainId } = await getRpcManagerForChain(input.network);
   const tx: ethers.TransactionRequest = { from, to, data: encodedData, value };
 
   let gasEstimate: bigint;
@@ -256,10 +338,24 @@ export async function simulateContractCall(
       "preflight"
     );
   } catch (err) {
-    const reason =
-      decodeRevertReason(err, iface) ??
-      `Simulation reverted: ${getErrorMessage(err)}`;
-    return failure(from, to, value, reason);
+    // A decoded revert is the most specific answer available, so it wins.
+    // Only when the node returned no revert data is an empty wallet a
+    // plausible explanation worth spending an extra RPC read on.
+    const reason = decodeRevertReason(err, iface);
+    if (reason) {
+      return failure(from, to, value, reason);
+    }
+    const shortfall = await nativeShortfallFailure({
+      rpc,
+      chainId,
+      from,
+      to,
+      value,
+    });
+    return (
+      shortfall ??
+      failure(from, to, value, `Simulation reverted: ${getErrorMessage(err)}`)
+    );
   }
 
   let simulatedReturnValue: unknown = null;
@@ -300,7 +396,7 @@ export async function simulateNativeTransfer(
   }
   const value = valueOrError;
 
-  const { rpc } = await getRpcManagerForChain(input.network);
+  const { rpc, chainId } = await getRpcManagerForChain(input.network);
   const tx: ethers.TransactionRequest = { from, to, value };
 
   // Run estimateGas + provider.call together so a contract recipient
@@ -315,11 +411,16 @@ export async function simulateNativeTransfer(
       "preflight"
     );
   } catch (err) {
-    return failure(
+    const shortfall = await nativeShortfallFailure({
+      rpc,
+      chainId,
       from,
       to,
       value,
-      `Simulation reverted: ${getErrorMessage(err)}`
+    });
+    return (
+      shortfall ??
+      failure(from, to, value, `Simulation reverted: ${getErrorMessage(err)}`)
     );
   }
 

--- a/lib/web3/decode-revert-error.ts
+++ b/lib/web3/decode-revert-error.ts
@@ -131,7 +131,17 @@ export function formatContractError(
   return `${label}: ${message}`;
 }
 
-function extractRevertData(error: unknown): string | undefined {
+/**
+ * Pull the raw revert data out of an ethers.js error, wherever the provider
+ * nested it. Returns undefined when the node returned none at all.
+ *
+ * Exported so callers can tell apart the two cases `decodeRevertReason`
+ * collapses into `undefined`: "the node returned no revert data" (a rejected
+ * estimate, an underfunded sender) versus "revert data came back but no
+ * known ABI decodes it" (an unlisted custom error). The follow-up action
+ * differs, so the two must not be treated as the same answer.
+ */
+export function extractRevertData(error: unknown): string | undefined {
   if (!error || typeof error !== "object") {
     return;
   }

--- a/plugins/web3/steps/transfer-funds-core.ts
+++ b/plugins/web3/steps/transfer-funds-core.ts
@@ -10,7 +10,11 @@ import "server-only";
 import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { db } from "@/lib/db";
-import { chains, explorerConfigs, workflowExecutions } from "@/lib/db/schema";
+import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
+import {
+  describeNativeShortfall,
+  getNativeSymbol,
+} from "@/lib/execute/native-balance";
 import { getTransactionUrl } from "@/lib/explorer";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import {
@@ -328,21 +332,19 @@ export async function transferFundsCore(
       "preflight"
     );
     if (nativeBalance < amountInWei) {
-      const balanceFormatted = ethers.formatEther(nativeBalance);
-      const requestedFormatted = ethers.formatEther(amountInWei);
-      // Look up the chain's native symbol so the error reads "Insufficient
-      // ETH balance" / "Insufficient BNB balance" instead of the chain-
-      // agnostic "native". Looked up lazily because this branch only fires
-      // on the slow / unhappy path.
-      const chainRow = await db
-        .select({ symbol: chains.symbol })
-        .from(chains)
-        .where(eq(chains.chainId, chainId))
-        .limit(1);
-      const nativeSymbol = chainRow[0]?.symbol ?? "native";
+      // Wording (and the chain's native symbol, so the error reads
+      // "Insufficient ETH balance" rather than the chain-agnostic "native")
+      // comes from lib/execute/native-balance, shared with the dry-run
+      // simulator so the two paths cannot drift. Looked up lazily because
+      // this branch only fires on the slow / unhappy path.
+      const shortfall = describeNativeShortfall({
+        symbol: await getNativeSymbol(chainId),
+        balance: nativeBalance,
+        required: amountInWei,
+      });
       return {
         success: false,
-        error: `Insufficient ${nativeSymbol} balance. Have: ${balanceFormatted}, Need: ${requestedFormatted}`,
+        error: shortfall.message,
       };
     }
 

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -146,7 +146,7 @@
       "path": "/api/execute/{executionId}/status",
       "route_file": "app/api/execute/[executionId]/status/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 338
+      "line": 369
     },
     {
       "method": "GET",

--- a/tests/integration/execute-simulate-route.test.ts
+++ b/tests/integration/execute-simulate-route.test.ts
@@ -344,6 +344,53 @@ describe("/api/execute/transfer simulate", () => {
     expect(transferFundsCore).not.toHaveBeenCalled();
   });
 
+  it("carries the insufficient_balance fields across the HTTP boundary", async () => {
+    resetSpies();
+    // The route spreads the simulate result into NextResponse.json, so the
+    // machine-readable attribution fields have to survive serialisation —
+    // that is the whole point of a headless caller branching on `code`.
+    const undecodable = `0x1234abcd${"00".repeat(32)}`;
+    simulateNativeTransferMock.mockResolvedValueOnce({
+      success: false,
+      status: "simulated",
+      from: FROM_ADDRESS,
+      to: "0xcc0000000000000000000000000000000000cc00",
+      value: "100000000000000000",
+      wouldRevert: true,
+      revertReason: "Insufficient ETH balance. Have: 0.0, Need: 0.1.",
+      error: "Insufficient ETH balance. Have: 0.0, Need: 0.1.",
+      code: "insufficient_balance",
+      balanceWei: "0",
+      requiredWei: "100000000000000000",
+      shortfallWei: "100000000000000000",
+      nativeSymbol: "ETH",
+      originalError: "execution reverted (unknown custom error)",
+      undecodedRevertData: undecodable,
+    });
+
+    const res = await transferPOST(
+      jsonRequest("/api/execute/transfer", {
+        recipientAddress: "0xcc0000000000000000000000000000000000cc00",
+        amount: "0.1",
+        chainId: 1,
+        simulate: true,
+      })
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("insufficient_balance");
+    expect(body.balanceWei).toBe("0");
+    expect(body.requiredWei).toBe("100000000000000000");
+    expect(body.shortfallWei).toBe("100000000000000000");
+    expect(body.nativeSymbol).toBe("ETH");
+    expect(body.originalError).toBe(
+      "execution reverted (unknown custom error)"
+    );
+    expect(body.undecodedRevertData).toBe(undecodable);
+    expect(transferFundsCore).not.toHaveBeenCalled();
+  });
+
   it("simulate=true routes a token transfer to simulateTokenTransfer", async () => {
     resetSpies();
     simulateTokenTransferMock.mockResolvedValueOnce(HAPPY_SIMULATE);

--- a/tests/unit/execute-simulate.test.ts
+++ b/tests/unit/execute-simulate.test.ts
@@ -7,6 +7,9 @@
  *
  *   - happy path: gas + decoded return value come back serialised
  *   - revert path: provider throws -> decoded reason in revertReason
+ *   - empty-wallet path: a revert-data-less estimateGas failure is
+ *     attributed to the funding address with code "insufficient_balance",
+ *     and is NOT claimed when the balance covers the value or cannot be read
  *   - input-validation paths short-circuit before any RPC call
  *   - simulateTokenTransfer resolves the token address via
  *     parseTokenAddress (same helper the broadcast path uses) and
@@ -53,6 +56,24 @@ vi.mock("@/plugins/web3/steps/transfer-token-core", () => ({
 vi.mock("@/lib/logging", () => ({
   logSystemError: vi.fn(),
   ErrorCategory: { DATABASE: "database" },
+}));
+
+// getNativeSymbol reads the chain's symbol from the seeded `chains` table.
+// Only the insufficient-balance path touches it, and only for wording.
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve([{ symbol: "ETH" }]),
+        }),
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  chains: { chainId: "chain_id", symbol: "symbol" },
 }));
 
 // Import after mocks so the simulate module binds to the stubbed deps.
@@ -151,6 +172,32 @@ describe("simulateContractCall", () => {
     if (!result.success) {
       expect(result.revertReason).toContain("Insufficient balance");
       expect(result.error).toBe(result.revertReason);
+    }
+  });
+
+  it("attributes an undecodable failure on a value-bearing call to an empty wallet", async () => {
+    resetSpies();
+    // No revert data to decode, and the wallet cannot cover the 1 ETH value.
+    executeWithFailover.mockRejectedValueOnce(
+      new Error('missing revert data (action="estimateGas")')
+    );
+    executeWithFailover.mockResolvedValueOnce(ethers.parseEther("0.25"));
+
+    const result = await simulateContractCall({
+      organizationId: "org_test",
+      network: "1",
+      contractAddress: CONTRACT_ADDRESS,
+      abi: WRITE_ABI,
+      functionName: "setValue",
+      functionArgs: JSON.stringify(["1"]),
+      value: "1.0",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("insufficient_balance");
+      expect(result.shortfallWei).toBe(ethers.parseEther("0.75").toString());
+      expect(result.revertReason).toContain("Have: 0.25, Need: 1.0");
     }
   });
 
@@ -296,6 +343,9 @@ describe("simulateNativeTransfer", () => {
     executeWithFailover.mockRejectedValueOnce(
       new Error("insufficient funds for gas * price + value")
     );
+    // Balance covers the value, so the node's own message is the truthful
+    // answer and must not be replaced by a shortfall claim.
+    executeWithFailover.mockResolvedValueOnce(ethers.parseEther("10"));
 
     const result = await simulateNativeTransfer({
       organizationId: "org_test",
@@ -307,7 +357,84 @@ describe("simulateNativeTransfer", () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.revertReason).toContain("insufficient funds");
+      expect(result.code).toBeUndefined();
     }
+  });
+
+  it("attributes a revert-data-less estimateGas failure to an empty wallet", async () => {
+    resetSpies();
+    // What Base (and most nodes) return when `from` cannot cover the value:
+    // an error with no revert data, which ethers surfaces as a bare
+    // CALL_EXCEPTION naming neither the balance nor the address.
+    executeWithFailover.mockRejectedValueOnce(
+      new Error(
+        'missing revert data (action="estimateGas", data=null, reason=null, code=CALL_EXCEPTION, version=6.16.0)'
+      )
+    );
+    executeWithFailover.mockResolvedValueOnce(BigInt(0));
+
+    const result = await simulateNativeTransfer({
+      organizationId: "org_test",
+      network: "1",
+      recipientAddress: RECIPIENT_ADDRESS,
+      amount: "0.001",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.wouldRevert).toBe(true);
+    if (!result.success) {
+      expect(result.code).toBe("insufficient_balance");
+      expect(result.balanceWei).toBe("0");
+      expect(result.requiredWei).toBe(ethers.parseEther("0.001").toString());
+      expect(result.shortfallWei).toBe(ethers.parseEther("0.001").toString());
+      expect(result.nativeSymbol).toBe("ETH");
+      // The message has to carry the two facts the caller cannot look up:
+      // which address to fund, and by how much.
+      expect(result.revertReason).toContain(FROM_ADDRESS);
+      expect(result.revertReason).toContain("Have: 0.0, Need: 0.001");
+      expect(result.revertReason).toContain("at least 0.001 ETH");
+      expect(result.error).toBe(result.revertReason);
+    }
+    // One estimateGas/call round trip, then exactly one balance read.
+    expect(executeWithFailover).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the original error when the balance read itself fails", async () => {
+    resetSpies();
+    executeWithFailover.mockRejectedValueOnce(new Error("node exploded"));
+    executeWithFailover.mockRejectedValueOnce(new Error("balance read failed"));
+
+    const result = await simulateNativeTransfer({
+      organizationId: "org_test",
+      network: "1",
+      recipientAddress: RECIPIENT_ADDRESS,
+      amount: "0.001",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.revertReason).toContain("node exploded");
+      expect(result.code).toBeUndefined();
+    }
+  });
+
+  it("does not read the balance for a zero-value transfer", async () => {
+    resetSpies();
+    executeWithFailover.mockRejectedValueOnce(new Error("node exploded"));
+
+    const result = await simulateNativeTransfer({
+      organizationId: "org_test",
+      network: "1",
+      recipientAddress: RECIPIENT_ADDRESS,
+      amount: "0",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBeUndefined();
+    }
+    // A zero-value call cannot be short of funds: no extra round trip.
+    expect(executeWithFailover).toHaveBeenCalledTimes(1);
   });
 
   it("rejects a malformed amount before touching the network", async () => {

--- a/tests/unit/execute-simulate.test.ts
+++ b/tests/unit/execute-simulate.test.ts
@@ -31,6 +31,7 @@ const RECIPIENT_ADDRESS = "0xcc0000000000000000000000000000000000cc00";
 const rpcSpies = vi.hoisted(() => ({
   executeWithFailover: vi.fn(),
   parseTokenAddress: vi.fn(),
+  chainsLookup: vi.fn(() => Promise.resolve([{ symbol: "ETH" }])),
 }));
 
 vi.mock("@/lib/web3/wallet-helpers", () => ({
@@ -60,18 +61,25 @@ vi.mock("@/lib/logging", () => ({
 
 // getNativeSymbol reads the chain's symbol from the seeded `chains` table.
 // Only the insufficient-balance path touches it, and only for wording.
+// Routed through a spy so a test can make the lookup reject and pin the
+// documented degradation ("native") instead of a thrown error.
 vi.mock("@/lib/db", () => ({
   db: {
     select: () => ({
       from: () => ({
         where: () => ({
-          limit: () => Promise.resolve([{ symbol: "ETH" }]),
+          limit: () => rpcSpies.chainsLookup(),
         }),
       }),
     }),
   },
 }));
 
+// Coupling note: this stub exports only `chains`, which is every table the
+// module graph under test currently reads (wallet-helpers and
+// transfer-token-core are themselves mocked above, so the real schema never
+// loads). If native-balance.ts ever reads a second table, Vitest fails this
+// file with "No X export is defined on the mock" — add the table here.
 vi.mock("@/lib/db/schema", () => ({
   chains: { chainId: "chain_id", symbol: "symbol" },
 }));
@@ -198,6 +206,78 @@ describe("simulateContractCall", () => {
       expect(result.code).toBe("insufficient_balance");
       expect(result.shortfallWei).toBe(ethers.parseEther("0.75").toString());
       expect(result.revertReason).toContain("Have: 0.25, Need: 1.0");
+      // Attribution adds, it does not replace: the node's own message
+      // survives even when the shortfall claim takes over revertReason.
+      expect(result.originalError).toContain("missing revert data");
+      // The node returned no revert data here, so there is none to keep.
+      expect(result.undecodedRevertData).toBeUndefined();
+    }
+  });
+
+  it("keeps undecodable revert data alongside the shortfall claim", async () => {
+    resetSpies();
+    // Revert data the decode path cannot touch: the selector is not in the
+    // supplied ABI, not in the common-errors list, and not Error(string).
+    // The wallet is short too, so both facts are true at once.
+    const undecodable = `0x1234abcd${"00".repeat(32)}`;
+    executeWithFailover.mockRejectedValueOnce({
+      data: undecodable,
+      message: "execution reverted (unknown custom error)",
+    });
+    executeWithFailover.mockResolvedValueOnce(ethers.parseEther("0.25"));
+
+    const result = await simulateContractCall({
+      organizationId: "org_test",
+      network: "1",
+      contractAddress: CONTRACT_ADDRESS,
+      abi: WRITE_ABI,
+      functionName: "setValue",
+      functionArgs: JSON.stringify(["1"]),
+      value: "1.0",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // The shortfall is real, so it is still reported...
+      expect(result.code).toBe("insufficient_balance");
+      expect(result.shortfallWei).toBe(ethers.parseEther("0.75").toString());
+      // ...but the harder half to rediscover is kept: raw data for a
+      // selector lookup, the selector named in the message, the node's
+      // wording verbatim, and a warning that funding may not be the fix.
+      expect(result.undecodedRevertData).toBe(undecodable);
+      expect(result.revertReason).toContain("0x1234abcd");
+      expect(result.revertReason).toContain("funding alone may not");
+      expect(result.originalError).toBe(
+        "execution reverted (unknown custom error)"
+      );
+    }
+  });
+
+  it("reports a chain-agnostic symbol when the chains lookup fails", async () => {
+    resetSpies();
+    rpcSpies.chainsLookup.mockRejectedValueOnce(new Error("db unavailable"));
+    executeWithFailover.mockRejectedValueOnce(
+      new Error('missing revert data (action="estimateGas")')
+    );
+    executeWithFailover.mockResolvedValueOnce(BigInt(0));
+
+    const result = await simulateContractCall({
+      organizationId: "org_test",
+      network: "1",
+      contractAddress: CONTRACT_ADDRESS,
+      abi: WRITE_ABI,
+      functionName: "setValue",
+      functionArgs: JSON.stringify(["1"]),
+      value: "1.0",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // A DB blip degrades the wording; it must not replace the real
+      // failure with a database error of its own.
+      expect(result.code).toBe("insufficient_balance");
+      expect(result.nativeSymbol).toBe("native");
+      expect(result.revertReason).toContain("Insufficient native balance");
     }
   });
 
@@ -394,9 +474,65 @@ describe("simulateNativeTransfer", () => {
       expect(result.revertReason).toContain("Have: 0.0, Need: 0.001");
       expect(result.revertReason).toContain("at least 0.001 ETH");
       expect(result.error).toBe(result.revertReason);
+      // The node's message is kept even though the shortfall claim is the
+      // one surfaced in revertReason.
+      expect(result.originalError).toContain("missing revert data");
     }
     // One estimateGas/call round trip, then exactly one balance read.
     expect(executeWithFailover).toHaveBeenCalledTimes(2);
+  });
+
+  it("decodes a reverting contract recipient without a supplied ABI", async () => {
+    resetSpies();
+    // A native send can hit a contract that reverts with Error(string).
+    // There is no ABI on this path, but the standard selector still decodes.
+    const encodedReason = ethers.AbiCoder.defaultAbiCoder().encode(
+      ["string"],
+      ["recipient rejects ETH"]
+    );
+    executeWithFailover.mockRejectedValueOnce({
+      data: `0x08c379a0${encodedReason.slice(2)}`,
+    });
+
+    const result = await simulateNativeTransfer({
+      organizationId: "org_test",
+      network: "1",
+      recipientAddress: RECIPIENT_ADDRESS,
+      amount: "0.001",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.revertReason).toContain("recipient rejects ETH");
+      expect(result.code).toBeUndefined();
+    }
+    // A decoded reason is the specific answer: no balance read is spent.
+    expect(executeWithFailover).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a native send's undecodable revert data when the wallet is short", async () => {
+    resetSpies();
+    const undecodable = `0x9abcdef0${"11".repeat(32)}`;
+    executeWithFailover.mockRejectedValueOnce({
+      data: undecodable,
+      message: "execution reverted",
+    });
+    executeWithFailover.mockResolvedValueOnce(BigInt(0));
+
+    const result = await simulateNativeTransfer({
+      organizationId: "org_test",
+      network: "1",
+      recipientAddress: RECIPIENT_ADDRESS,
+      amount: "0.001",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("insufficient_balance");
+      expect(result.undecodedRevertData).toBe(undecodable);
+      expect(result.revertReason).toContain("0x9abcdef0");
+      expect(result.originalError).toBe("execution reverted");
+    }
   });
 
   it("keeps the original error when the balance read itself fails", async () => {


### PR DESCRIPTION
## What

`POST /api/execute/transfer` with `simulate: true`, from an organization wallet
that cannot cover the value, now returns:

```json
{
  "success": false,
  "wouldRevert": true,
  "code": "insufficient_balance",
  "revertReason": "Insufficient ETH balance. Have: 0.0, Need: 0.001. Fund 0x746bCd53b8627B4e207d88a64311b968a5F4D3C8 with at least 0.001 ETH on this chain and retry.",
  "balanceWei": "0",
  "requiredWei": "1000000000000000",
  "shortfallWei": "1000000000000000",
  "nativeSymbol": "ETH"
}
```

instead of:

```
Simulation reverted: missing revert data (action="estimateGas", data=null, reason=null, ..., code=CALL_EXCEPTION, version=6.16.0)
```

## Why

A brand-new organization wallet holds nothing, so the first non-zero transfer a
new integrator attempts is also the first thing that fails — inside the one call
that exists so a headless caller never has to read a raw node error. Nodes reject
`eth_estimateGas` from an underfunded `from` without revert data, and ethers
surfaces that as a bare `CALL_EXCEPTION`. It names neither the balance nor the
address, and at that moment "which wallet?" is a genuine question: the wallet to
fund is not the wallet you signed in with.

The broadcast path already answers this. `transfer-funds-core` reads the funding
balance before signing and returns `Insufficient ETH balance. Have: …, Need: …`.
The dry run, whose job is to give that answer before anything is signed, did not
— though the module docstring claims it catches insufficient balance.

## How

- `lib/execute/native-balance.ts` (new): `getNativeSymbol(chainId)`, moved out of
  `transfer-funds-core`, and `describeNativeShortfall(...)`. One place owns the
  wording so the dry run and the broadcast preflight cannot drift. `holder` is
  optional and the broadcast path passes none, so its message is unchanged
  byte-for-byte; it can adopt the fuller sentence in a follow-up if you want it.
- `lib/execute/simulate.ts`: attribute the failure on the failure path only.
  Order is decoded revert → balance shortfall → original error, so a real revert
  reason is never replaced by a guess. Zero-value calls skip the read (they
  cannot be short); if the balance read itself fails the original error stands;
  and the whole attribution is wrapped so it cannot raise from inside an error
  path. Cost is one `eth_getBalance` on a preflight that has already failed, and
  nothing on the success path.
- The balance is read for the same `from` the simulation uses, so it inherits
  the Safe-routing limitation already documented at the top of the file.
- `getNativeSymbol` changed one failure semantic on the broadcast path: the
  `chains` lookup used to be unwrapped in `transfer-funds-core`, so a DB failure
  propagated; it is now `try/catch` to `"native"`. The wording is unchanged
  byte-for-byte, the failure behaviour is not. The lookup only runs on an
  already-failed path and only decides a currency label, so degrading beats
  replacing the real error with a database one — but it is a change, and it is
  now covered by a test.

## Update after review

`decodeRevertReason` returns `undefined` both when the node returned no revert
data and when revert data came back that nothing on the decode path matched.
The first version treated the two the same, so a call to a contract reverting
with an unlisted custom error, from a wallet that was also short, returned only
the balance claim and dropped the selector.

Attribution now only ever adds:

- `originalError` keeps the node's message verbatim on every attributed failure.
- `undecodedRevertData` keeps revert data that failed to decode, and the message
  names its selector and says funding alone may not be the fix.
- `extractRevertData` is exported from `decode-revert-error.ts`, so the two
  `undefined` cases are distinguishable at the call site rather than guessed at.
- `simulateNativeTransfer` now goes through the same shared helper as
  `simulateContractCall`, so a reverting contract recipient gets `Error(string)`
  and the common-error list tried against it instead of never decoded.
- `SimulateFailureCode` replaces the single-literal `InsufficientBalanceCode`
  alias, so a second code widens a union instead of breaking an exhaustive
  `switch` on the client.
- `docs/api/direct-execution.md` documents the underfunded response shape field
  by field, including that the comparison excludes gas. `specs/api-coverage.json`
  carries the one line-number shift that follows from the added section.

## Verified

- `vitest run tests/unit/execute-simulate.test.ts` — 23 pass, 4 new: undecodable
  revert data plus a short wallet keeps both facts; the same case on a native
  send; a reverting contract recipient decoded without a supplied ABI; the
  `chains`-lookup catch branch degrades to `native`. Checking out the pre-review
  `simulate.ts` under the new tests turns exactly 5 red and leaves 18 green.
- `vitest run tests/integration/execute-simulate-route.test.ts` — 10 pass, 1 new:
  every attribution field survives `NextResponse.json` on the transfer route
  with HTTP 400.
- `vitest run tests/unit/decode-revert-error.test.ts` — 26 pass, unchanged by the
  new export. The transfer cores still pass: `transfer-token-core`,
  `check-and-execute-routing`, `execute-simulate-flag`, `turnkey-revert` — 25.
- `tsc --noEmit` over the touched files and their route consumers: no new errors
  (one pre-existing `lib/rpc/providers/solana.ts` fetch-type error reproduces
  identically on the unmodified tree). `biome check` clean on all five files.
- End to end against Base mainnet with a freshly generated empty address:
  `estimateGas` comes back `CALL_EXCEPTION` with `data=null`, and
  `simulateNativeTransfer` produces the payload at the top of this description.
  That JSON is real output, not a hand-written example.
- CI has still not run: this is a fork PR and the repo requires maintainer
  approval before workflows start on one. All three of my open PRs show zero
  checks while #1847 (a branch on this repo) shows 40. I cannot start them from
  here — "Approve and run workflows" on the Checks tab is yours to click, and I
  would rather you did than take the numbers above on faith.

---


