### PR TITLE
fix: claim device user code before approving it

### DIFF
--- a/app/device/page.tsx
+++ b/app/device/page.tsx
@@ -3,6 +3,7 @@
 import { useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
 import { AuthDialog } from "@/components/auth/dialog";
+import { claimAndApproveDevice } from "@/lib/device-authorization-client";
 import { isAnonymousUser } from "@/lib/is-anonymous";
 
 function SuccessState(): React.JSX.Element {
@@ -115,26 +116,14 @@ function DevicePageContent(): React.JSX.Element {
 
   const handleConfirm = async (): Promise<void> => {
     setStatus("loading");
-    const response = await fetch("/api/auth/device/approve", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      credentials: "include",
-      body: JSON.stringify({ userCode }),
-    });
+    const result = await claimAndApproveDevice(userCode);
 
-    if (response.ok) {
+    if (result.ok) {
       setStatus("success");
       return;
     }
 
-    const data = (await response.json().catch(() => ({}))) as {
-      error?: string;
-      error_description?: string;
-      message?: string;
-    };
-    setErrorMessage(
-      data.error_description ?? data.message ?? "Verification failed."
-    );
+    setErrorMessage(result.message);
     setStatus("error");
   };
 

--- a/lib/device-authorization-client.ts
+++ b/lib/device-authorization-client.ts
@@ -1,0 +1,74 @@
+/**
+ * Client-side device authorization flow for the CLI login (`kh auth login`).
+ *
+ * Better Auth's device-authorization plugin splits browser approval into two
+ * calls that must happen in order:
+ *
+ *   1. `GET /api/auth/device?user_code=...` binds the pending device code to
+ *      the signed-in session (sets `deviceCode.userId`).
+ *   2. `POST /api/auth/device/approve` verifies that binding - it rejects any
+ *      record whose `userId` is unset, and rejects a record claimed by a
+ *      different user.
+ *
+ * Approving without claiming first therefore always fails, regardless of the
+ * code's validity.
+ */
+
+const DEVICE_CLAIM_PATH = "/api/auth/device";
+const DEVICE_APPROVE_PATH = "/api/auth/device/approve";
+const FALLBACK_ERROR_MESSAGE = "Verification failed.";
+
+export type DeviceAuthorizationResult =
+  | { ok: true }
+  | { ok: false; message: string };
+
+type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+type ErrorBody = {
+  error?: string;
+  error_description?: string;
+  message?: string;
+};
+
+async function readErrorMessage(response: Response): Promise<string> {
+  const data = (await response.json().catch(() => ({}))) as ErrorBody;
+  return data.error_description ?? data.message ?? FALLBACK_ERROR_MESSAGE;
+}
+
+/**
+ * Claims the user code for the current session, then approves it.
+ *
+ * A failed claim short-circuits: the claim endpoint reports the specific
+ * cause (unknown code, expired code), whereas approve would only report the
+ * generic "has not been claimed" message and hide it.
+ *
+ * `fetchImpl` is wrapped rather than defaulted to bare `fetch` because
+ * browsers require `fetch` to be invoked with `window` as its receiver -
+ * passing the unbound reference around throws "Illegal invocation".
+ */
+export async function claimAndApproveDevice(
+  userCode: string,
+  fetchImpl: FetchLike = (input, init) => fetch(input, init)
+): Promise<DeviceAuthorizationResult> {
+  const claimResponse = await fetchImpl(
+    `${DEVICE_CLAIM_PATH}?user_code=${encodeURIComponent(userCode)}`,
+    { credentials: "include" }
+  );
+
+  if (!claimResponse.ok) {
+    return { ok: false, message: await readErrorMessage(claimResponse) };
+  }
+
+  const approveResponse = await fetchImpl(DEVICE_APPROVE_PATH, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ userCode }),
+  });
+
+  if (!approveResponse.ok) {
+    return { ok: false, message: await readErrorMessage(approveResponse) };
+  }
+
+  return { ok: true };
+}

--- a/tests/unit/device-authorization-client.test.ts
+++ b/tests/unit/device-authorization-client.test.ts
@@ -1,0 +1,172 @@
+// Regression guard: the /device page used to approve a user code without first
+// claiming it, so `POST /api/auth/device/approve` always rejected with
+// DEVICE_CODE_NOT_CLAIMED and `kh auth login` could never complete. The
+// ordering assertions below pin the claim GET before the approve POST.
+
+import { describe, expect, it } from "vitest";
+
+import { claimAndApproveDevice } from "@/lib/device-authorization-client";
+
+const USER_CODE = "ABCD-1234";
+const CLAIM_URL = `/api/auth/device?user_code=${encodeURIComponent(USER_CODE)}`;
+const APPROVE_URL = "/api/auth/device/approve";
+
+type RecordedCall = { input: string; init?: RequestInit };
+
+/**
+ * Builds a fetch double that replays `responses` in call order and records
+ * every request, so tests can assert on the sequence rather than just the
+ * fact that a call happened.
+ */
+function createFetchSpy(responses: Response[]): {
+  fetchImpl: (input: string, init?: RequestInit) => Promise<Response>;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  let index = 0;
+
+  return {
+    calls,
+    fetchImpl: (input: string, init?: RequestInit) => {
+      calls.push({ input, init });
+      const response = responses[index];
+      index += 1;
+      if (!response) {
+        throw new Error(`Unexpected fetch call to ${input}`);
+      }
+      return Promise.resolve(response);
+    },
+  };
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function okClaim(): Response {
+  return jsonResponse({ user_code: USER_CODE, status: "pending" }, 200);
+}
+
+describe("claimAndApproveDevice", () => {
+  it("claims the user code before approving it", async () => {
+    const { fetchImpl, calls } = createFetchSpy([
+      okClaim(),
+      jsonResponse({ success: true }, 200),
+    ]);
+
+    const result = await claimAndApproveDevice(USER_CODE, fetchImpl);
+
+    expect(result).toEqual({ ok: true });
+    expect(calls.map((call) => call.input)).toEqual([CLAIM_URL, APPROVE_URL]);
+  });
+
+  it("sends the claim as a credentialed GET carrying the user code", async () => {
+    const { fetchImpl, calls } = createFetchSpy([
+      okClaim(),
+      jsonResponse({ success: true }, 200),
+    ]);
+
+    await claimAndApproveDevice(USER_CODE, fetchImpl);
+
+    const claimCall = calls[0];
+    expect(claimCall.input).toBe(CLAIM_URL);
+    expect(claimCall.init?.credentials).toBe("include");
+    // The claim binds the code to the session cookie, so it must not be a POST
+    // and must not carry a body - better-auth reads `user_code` from the query.
+    expect(claimCall.init?.method).toBeUndefined();
+    expect(claimCall.init?.body).toBeUndefined();
+  });
+
+  it("sends the approval as a credentialed POST with the user code body", async () => {
+    const { fetchImpl, calls } = createFetchSpy([
+      okClaim(),
+      jsonResponse({ success: true }, 200),
+    ]);
+
+    await claimAndApproveDevice(USER_CODE, fetchImpl);
+
+    const approveCall = calls[1];
+    expect(approveCall.input).toBe(APPROVE_URL);
+    expect(approveCall.init?.method).toBe("POST");
+    expect(approveCall.init?.credentials).toBe("include");
+    expect(approveCall.init?.body).toBe(
+      JSON.stringify({ userCode: USER_CODE })
+    );
+  });
+
+  it("percent-encodes a user code containing URL-significant characters", async () => {
+    const { fetchImpl, calls } = createFetchSpy([
+      okClaim(),
+      jsonResponse({ success: true }, 200),
+    ]);
+
+    await claimAndApproveDevice("A B&C=D", fetchImpl);
+
+    expect(calls[0].input).toBe("/api/auth/device?user_code=A%20B%26C%3DD");
+  });
+
+  it("does not approve when the claim fails, and surfaces the claim error", async () => {
+    const { fetchImpl, calls } = createFetchSpy([
+      jsonResponse(
+        {
+          error: "expired_token",
+          error_description: "User code has expired",
+        },
+        400
+      ),
+    ]);
+
+    const result = await claimAndApproveDevice(USER_CODE, fetchImpl);
+
+    expect(result).toEqual({ ok: false, message: "User code has expired" });
+    // Short-circuiting matters: approve would mask the real cause behind the
+    // generic "has not been claimed" message.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].input).toBe(CLAIM_URL);
+  });
+
+  it("surfaces the approve error when the claim succeeds but approval is rejected", async () => {
+    const { fetchImpl } = createFetchSpy([
+      okClaim(),
+      jsonResponse(
+        {
+          error: "access_denied",
+          error_description:
+            "You are not authorized to approve this device authorization",
+        },
+        403
+      ),
+    ]);
+
+    const result = await claimAndApproveDevice(USER_CODE, fetchImpl);
+
+    expect(result).toEqual({
+      ok: false,
+      message: "You are not authorized to approve this device authorization",
+    });
+  });
+
+  it("falls back to `message` when the error body has no error_description", async () => {
+    const { fetchImpl } = createFetchSpy([
+      okClaim(),
+      jsonResponse({ message: "Something went wrong" }, 500),
+    ]);
+
+    const result = await claimAndApproveDevice(USER_CODE, fetchImpl);
+
+    expect(result).toEqual({ ok: false, message: "Something went wrong" });
+  });
+
+  it("falls back to a generic message when the error body is not JSON", async () => {
+    const { fetchImpl } = createFetchSpy([
+      new Response("<html>502 Bad Gateway</html>", { status: 502 }),
+    ]);
+
+    const result = await claimAndApproveDevice(USER_CODE, fetchImpl);
+
+    expect(result).toEqual({ ok: false, message: "Verification failed." });
+  });
+});


### PR DESCRIPTION
## Summary

`kh auth login` could never complete. The device authorization page approved the user code
without first claiming it, so `POST /api/auth/device/approve` always rejected with:

```
Device code has not been claimed by a verifying session; call `GET /device` with the
`user_code` while signed in before approving or denying
```

Better Auth's device-authorization plugin splits browser approval into two ordered calls:
`GET /api/auth/device?user_code=...` binds the pending device code to the signed-in session
(sets `deviceCode.userId`), and `POST /api/auth/device/approve` then verifies that binding.
The page only ever made the second call, so the flow could not succeed for any code.

This is not a regression - the claim call is absent from every commit the page has ever had.

## Changes

- `lib/device-authorization-client.ts` (new): `claimAndApproveDevice()` performs the claim GET,
  then the approve POST.
- `app/device/page.tsx`: `handleConfirm` delegates to the helper.
- `tests/unit/device-authorization-client.test.ts` (new): 8 tests pinning the call ordering and
  the request shape of each call.

The claim runs in `handleConfirm` rather than in the session `useEffect` because the session is
usually established after mount via the sign-in dialog, so an effect-based claim would fire
pre-auth and silently no-op.

A failed claim short-circuits instead of falling through to approve. The claim endpoint reports
the specific cause (unknown code, expired code); approve would only report the generic
"has not been claimed" message and hide it. So an expired code now surfaces
"User code has expired" rather than a misleading message about claiming.

## Verification

Route contract checked against the installed better-auth (1.6.25), not just the declared range:

- The claim endpoint is `/device` (`GET`, `user_code` query param), not `/device/verify`.
- The claim is conditional and idempotent - it sets `userId` only when a session exists, `userId`
  is unset, and status is `pending`, so it cannot steal a code already claimed by another user.
- `approve` rejects `deviceCodeRecord.userId !== session.user.id` with `FORBIDDEN`, so the claim
  genuinely binds the code to the approving session.
- `verification_uri_complete` is built as `<baseURL>/device?user_code=<code>`, matching the query
  param the page reads.
- The default user code generator emits a dashless code, so the server's `replace(/-/g, "")`
  normalization is a no-op and no format mismatch exists between storage and lookup.
- The `/device/token` poll the CLI uses requires `status === "approved"` and a non-null `userId`,
  both of which this flow now produces, and returns `access_token` as the CLI expects.
- The custom auth route wrapper's guards are path-scoped (`/sign-in/email-otp`, the OAuth callback
  regex) and there is no root middleware, so nothing intercepts the device routes.

Test quality was checked by reverting the fix: 7 of the 8 tests fail against the pre-fix code,
including the ordering assertion.

`pnpm type-check` passes clean. `pnpm check` is clean on all three files (the repo has 6
pre-existing lint errors on unrelated files, left untouched).

## Test Plan

- [x] Unit tests pass (8/8), and fail against the pre-fix code
- [x] Type-check clean
- [ ] `kh auth login` completes end to end against staging
- [ ] `kh auth login` completes end to end against production
