### PR TITLE
docs: comment workflow save validation limits and wallet indirection

### DIFF
--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -518,6 +518,24 @@ export async function PATCH(
     const updateData = buildUpdateData(body);
 
     if (Array.isArray(updateData.nodes)) {
+      // What these two gates do NOT do: prove the workflow will run.
+      //
+      // validateWorkflowIntegrations is an AUTHORIZATION check, not an
+      // existence check - filterUnauthorizedIntegrationIds deliberately treats
+      // ids with no matching row as authorized so stale references to deleted
+      // integrations stay savable. A syntactically valid but wholly fictional
+      // integrationId therefore passes and is persisted verbatim.
+      //
+      // Config values outside integrationId get less than that: `network` and
+      // `actionType` are not checked against the chain registry or the action
+      // catalogue on this path at all. Everything in data.config is stored as
+      // opaque JSONB.
+      //
+      // So a 200 here means "you were allowed to save this", never "this
+      // works". Misconfigured nodes surface only at execution time. Callers
+      // driving the API directly (kh, MCP) should not read a successful
+      // create or update as evidence that a workflow is functional.
+      //
       // Validate the exact shape that will be persisted. The sanitizer moves
       // misplaced root fields into data.config, including integrationId.
       // Org principal: the workflow may only reference its owning org's

--- a/app/api/workflows/create/route.ts
+++ b/app/api/workflows/create/route.ts
@@ -153,6 +153,15 @@ export async function POST(request: Request) {
     nodes = sanitized.nodes;
     edges = sanitized.edges;
 
+    // A 201 from this endpoint does not mean the workflow will run. The gate
+    // below is an AUTHORIZATION check on integrationId, not an existence
+    // check: filterUnauthorizedIntegrationIds treats ids with no matching row
+    // as authorized so stale references stay savable, so a fictional
+    // integrationId is accepted and persisted verbatim. `network` and
+    // `actionType` are not validated against the chain registry or action
+    // catalogue here at all. See the fuller note on the PATCH handler in
+    // app/api/workflows/[workflowId]/route.ts.
+    //
     // Validate the exact shape that will be persisted. The sanitizer moves
     // misplaced root fields into data.config, including integrationId.
     // Org principal: the new workflow is org-owned, so it may only reference

--- a/lib/db/schema-extensions.ts
+++ b/lib/db/schema-extensions.ts
@@ -41,6 +41,17 @@ import { generateId } from "@/lib/utils/id";
  *
  * NOTE: userId tracks who created the wallet, but the wallet belongs to the organization.
  * Only organization admins and owners can create/manage wallets.
+ *
+ * This row is where the signing key actually lives. Workflow node configs do
+ * not reference it directly - they carry an `integrationId` pointing at the
+ * org's single `web3` row in `integrations` (lib/db/schema.ts), which holds no
+ * key and exists mainly so the builder has something to show. Resolving a
+ * signer means going integration -> org -> this table.
+ *
+ * One row covers both chain families: `walletAddress` is the EVM address and
+ * `solanaAddress` the Solana one, derived from the same Turnkey sub-org. That
+ * is why a single integrationId is valid for EVM and Solana actions alike; the
+ * chain comes from the node's own `network` config, not from the integration.
  */
 export const organizationWallets = pgTable(
   "organization_wallets",

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -541,6 +541,22 @@ export const integrations = pgTable(
     // here so any future web3 write hits the same guard. Closes the race
     // in ensureWalletIntegration where two concurrent /api/integrations
     // GETs could both pass the existence check and both insert.
+    //
+    // "Cosmetic" is load-bearing, and the indirection it implies is the part
+    // that reads like a bug until you know it: this row holds no key. A web3
+    // action node references `integrations.id`, but the signing material sits
+    // in the org's `organizationWallets` row (lib/db/schema-extensions.ts),
+    // which carries both `wallet_address` (EVM) and `solana_address` against
+    // one set of Turnkey identifiers.
+    //
+    // Because the org has exactly one web3 integration and one active wallet,
+    // a single integrationId legitimately serves EVM and Solana actions across
+    // every chain. Seeing the same integrationId on an Ethereum transfer and a
+    // Solana balance check is correct, not copy-paste: the chain is selected by
+    // the node's own `network` config, never by the integration.
+    //
+    // Corollary for anyone hunting a "wrong wallet" bug: changing integrationId
+    // cannot change which address signs. Look at organizationWallets instead.
     uniqueIndex("idx_integrations_org_web3")
       .on(table.organizationId)
       .where(


### PR DESCRIPTION
## What

Comments only. No behaviour change, no logic touched.

## Why

Two things about workflow saves were misread during recent Solana work, both costing real debugging time.

### A successful save is not evidence the workflow runs

A falsification test against production updated a node with `integrationId: "zzzzINVALIDzzz00000000"`. The API accepted and persisted it. That looks like there is no validation at all, but the actual mechanism is narrower and worth stating where the gates live:

`validateWorkflowIntegrations` is an **authorization** check, not an existence check. `filterUnauthorizedIntegrationIds` deliberately treats ids with no matching row as authorized so stale references to deleted integrations stay savable - there is a unit test named for exactly this. A syntactically valid but wholly fictional id passes and is stored verbatim.

Config values other than `integrationId` get less than that: `network` and `actionType` are not checked against the chain registry or the action catalogue on either path. So a 2xx means "you were allowed to save this", never "this works"; misconfiguration surfaces only at execution time. Callers driving the API directly (the CLI, MCP) should not read a successful create or update as a health signal.

Comments added at both the create handler and the PATCH handler, where someone reading the gate would form the wrong impression.

### integrationId does not identify a wallet

The relationship is chain-agnostic and non-obvious. The `web3` row in `integrations` holds no key - the existing "cosmetic KeeperHub-wallet entry" comment was what eventually resolved the confusion. The signer lives in `organizationWallets`, whose single row carries both `wallet_address` and `solana_address` against one Turnkey sub-org.

So one `integrationId` legitimately serves EVM and Solana actions across every chain, and seeing the same id on an Ethereum transfer and a Solana balance check is correct rather than copy-paste. The chain comes from each node's own `network` config. Extended the existing comment to spell out the indirection, with a matching note on `organizationWallets` and a corollary for anyone hunting a wrong-wallet bug: changing `integrationId` cannot change which address signs.

## Follow-up

Server-side node-config validation is the real fix for the first item and deserves its own ticket. This PR only makes the current contract legible.

## Test plan

`pnpm type-check` clean. `pnpm check` reports 6 errors, all confirmed pre-existing on `staging` - stashing the schema change reproduces the export-sort error on the unmodified file, and the other 5 are in files this PR does not touch.