### PR TITLE
fix: issue an organization API key for CLI device login

### DIFF
--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -11,11 +11,13 @@ import {
   buildPendingOauthMfaSetCookie,
   encodePendingOauthMfaCookie,
 } from "@/lib/oauth-mfa-cookie";
+import { issueCliDeviceApiKey } from "@/lib/organization-api-key";
 import {
   buildPendingSignupSetCookie,
   encodePendingSignupCookie,
 } from "@/lib/pending-signup-cookie";
 import { sanitizeNextPath } from "@/lib/sanitize-next-path";
+import { buildAuditMetadata } from "@/lib/security/audit-log";
 
 const handlers = toNextJsHandler(auth);
 
@@ -305,6 +307,108 @@ async function interceptOauthCallback(
 }
 
 /**
+ * Swap the device grant's session token for an organization API key.
+ *
+ * Better Auth's device plugin answers /device/token with a raw session token.
+ * That credential is useless to the CLI: it sends `Authorization: Bearer` on
+ * every request, api-key-auth requires a `kh_` prefix, and session tokens only
+ * authenticate as cookies. Widening bearer auth to accept session tokens is
+ * deliberately closed off - the bearer() plugin was removed to keep the MFA and
+ * IP step-up gates, which key off the session cookie, intact.
+ *
+ * So the grant returns the credential shape the API already accepts. The
+ * session Better Auth minted is left alone; it simply goes unused.
+ *
+ * The plaintext key is returned exactly once, here. Nothing can re-issue it,
+ * which is why the CLI must persist what it receives rather than re-running the
+ * flow and minting a fresh key on every login.
+ */
+async function issueApiKeyForDeviceGrant(
+  req: Request,
+  res: Response
+): Promise<Response> {
+  const url = new URL(req.url);
+  if (!(url.pathname.endsWith("/device/token") && res.ok)) {
+    return res;
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await res.clone().json()) as Record<string, unknown>;
+  } catch {
+    return res;
+  }
+  const accessToken = body.access_token;
+  if (typeof accessToken !== "string") {
+    return res;
+  }
+
+  try {
+    // The session row carries both the approving user and the org the
+    // session.create.after hook resolved for them.
+    const [sessionRow] = await db
+      .select({
+        userId: sessions.userId,
+        activeOrganizationId: sessions.activeOrganizationId,
+      })
+      .from(sessions)
+      .where(eq(sessions.token, hashSessionToken(accessToken)))
+      .limit(1);
+
+    if (!sessionRow?.activeOrganizationId) {
+      // Without an org there is no key to mint. Fail the grant rather than
+      // hand back a session token that authenticates nothing.
+      logSystemError(
+        ErrorCategory.AUTH,
+        "[Device] No active organization for device grant; cannot issue API key",
+        new Error("device_grant_no_active_org"),
+        { endpoint: "/api/auth/device/token" }
+      );
+      return NextResponse.json(
+        {
+          error: "server_error",
+          error_description:
+            "No active organization for this account; cannot complete device login.",
+        },
+        { status: HttpStatus.INTERNAL_SERVER_ERROR }
+      );
+    }
+
+    const [user] = await db
+      .select({ email: users.email })
+      .from(users)
+      .where(eq(users.id, sessionRow.userId))
+      .limit(1);
+
+    const apiKey = await issueCliDeviceApiKey({
+      userId: sessionRow.userId,
+      userEmail: user?.email ?? null,
+      organizationId: sessionRow.activeOrganizationId,
+      auditMetadata: buildAuditMetadata(req),
+    });
+
+    return NextResponse.json(
+      { ...body, access_token: apiKey, token_type: "Bearer" },
+      { status: res.status, headers: { "Cache-Control": "no-store" } }
+    );
+  } catch (error) {
+    logSystemError(
+      ErrorCategory.AUTH,
+      "[Device] Failed to issue API key for device grant",
+      error,
+      { endpoint: "/api/auth/device/token" }
+    );
+    return NextResponse.json(
+      {
+        error: "server_error",
+        error_description: "Could not issue an API key for this device login.",
+      },
+      { status: HttpStatus.INTERNAL_SERVER_ERROR }
+    );
+  }
+}
+
+/**
  * Block Better Auth's standalone /sign-in/email-otp endpoint for any
  * user whose two_factor_enabled flag is true. That endpoint mints a
  * session immediately on email-OTP verification, completely bypassing
@@ -365,7 +469,10 @@ export async function POST(req: Request) {
     if (blocked) {
       return blocked;
     }
-    return normalizeRateLimitRetryAfter(await handlers.POST(req));
+    const res = await handlers.POST(req);
+    return normalizeRateLimitRetryAfter(
+      await issueApiKeyForDeviceGrant(req, res)
+    );
   } catch (error) {
     logSystemError(ErrorCategory.AUTH, "[Auth POST] Handler error:", error, {
       endpoint: "/api/auth",

--- a/app/api/keys/route.ts
+++ b/app/api/keys/route.ts
@@ -1,4 +1,3 @@
-import { createHash, randomBytes } from "node:crypto";
 import { and, count, eq, inArray, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
@@ -10,18 +9,15 @@ import { STEP_UP_ACTIONS } from "@/lib/mfa/step-up-policy";
 import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
 import { authorizeAction } from "@/lib/middleware/authorize-action";
 import { getOrgContext } from "@/lib/middleware/org-context";
+import { generateOrganizationApiKey } from "@/lib/organization-api-key";
 import { buildPage, parsePageRequest } from "@/lib/pagination";
 import { notifyApiKeyChange } from "@/lib/security/api-key-notification";
 import { buildAuditMetadata, recordAuditEvent } from "@/lib/security/audit-log";
 
-// Generate a secure API key with KeeperHub prefix
-function generateApiKey(): { key: string; hash: string; prefix: string } {
-  const randomPart = randomBytes(24).toString("base64url");
-  const key = `kh_${randomPart}`;
-  const hash = createHash("sha256").update(key).digest("hex");
-  const prefix = key.slice(0, 8); // "kh_" + first 5 chars
-  return { key, hash, prefix };
-}
+// Key generation lives in lib/organization-api-key.ts so the device-login
+// path mints byte-identical credentials; api-key-auth validates the shared
+// `kh_` prefix and SHA-256 hash, which a second implementation could drift from.
+const generateApiKey = generateOrganizationApiKey;
 
 // GET - List all API keys for the current organization
 export async function GET(request: Request) {

--- a/lib/cli-version.ts
+++ b/lib/cli-version.ts
@@ -1,0 +1,35 @@
+/**
+ * The oldest `kh` CLI release this deployment considers supported.
+ *
+ * Every CLI request carries `KH-CLI-Version`, and the CLI compares its own
+ * version against the `KH-Minimum-CLI-Version` response header on every
+ * response (internal/http/version.go). Older builds print a warning to stderr;
+ * nothing is blocked, so raising this floor degrades gracefully.
+ *
+ * The floor is 0.11.1 because 0.11.0 is the last release whose device login
+ * could not work: it stores whatever `/device/token` returns, and before the
+ * API-key swap that was a Better Auth session token, which no server auth path
+ * accepts from a CLI. Any release carrying the fix sorts above 0.11.1, so the
+ * warning reaches exactly the users who need to upgrade.
+ *
+ * Override per environment with KH_MINIMUM_CLI_VERSION to raise the floor
+ * without a code change.
+ */
+export const MINIMUM_CLI_VERSION =
+  process.env.KH_MINIMUM_CLI_VERSION ?? "0.11.1";
+
+export const MINIMUM_CLI_VERSION_HEADER = "KH-Minimum-CLI-Version";
+
+/**
+ * The next.config `headers()` rule that advertises the floor on API routes,
+ * kept here so it can be asserted directly - next.config's default export is
+ * wrapped by withSentryConfig/withWorkflow and does not expose a callable
+ * headers() to import.
+ */
+export const CLI_VERSION_HEADER_RULE: {
+  source: string;
+  headers: Array<{ key: string; value: string }>;
+} = {
+  source: "/api/:path*",
+  headers: [{ key: MINIMUM_CLI_VERSION_HEADER, value: MINIMUM_CLI_VERSION }],
+};

--- a/lib/organization-api-key.ts
+++ b/lib/organization-api-key.ts
@@ -1,0 +1,95 @@
+import { createHash, randomBytes } from "node:crypto";
+import { db } from "@/lib/db";
+import { organizationApiKeys } from "@/lib/db/schema";
+import { notifyApiKeyChange } from "@/lib/security/api-key-notification";
+import { recordAuditEvent } from "@/lib/security/audit-log";
+
+/**
+ * The label given to keys minted by the CLI device-authorization flow, so they
+ * are distinguishable from keys a user created by hand in the dashboard.
+ */
+export const CLI_DEVICE_KEY_NAME = "kh CLI";
+
+/**
+ * Mint an organization API key.
+ *
+ * The plaintext key is returned to the caller and never stored - only its
+ * SHA-256 hash goes to the database, which is why a key can be shown exactly
+ * once and why an existing key can never be re-issued.
+ */
+export function generateOrganizationApiKey(): {
+  key: string;
+  hash: string;
+  prefix: string;
+} {
+  const randomPart = randomBytes(24).toString("base64url");
+  const key = `kh_${randomPart}`;
+  const hash = createHash("sha256").update(key).digest("hex");
+  const prefix = key.slice(0, 8); // "kh_" + first 5 chars
+  return { key, hash, prefix };
+}
+
+/**
+ * Issue an API key for a CLI device login and record it the same way a
+ * dashboard-created key is recorded.
+ *
+ * The device flow's own credential is a Better Auth session token, which no
+ * server auth path accepts from a CLI: `lib/api-key-auth.ts` requires a `kh_`
+ * prefix, and session tokens are only usable as cookies. Rather than widen
+ * bearer auth to cover session tokens - deliberately closed off in the
+ * `bearer()` plugin removal to keep the MFA and IP step-up gates intact - the
+ * device grant hands back the credential shape the API already accepts.
+ *
+ * Emits the same notification and audit event as the dashboard path: this
+ * creates a real org credential and must be as visible and revocable as any
+ * other.
+ */
+export async function issueCliDeviceApiKey(params: {
+  userId: string;
+  userEmail: string | null;
+  organizationId: string;
+  auditMetadata?: Record<string, unknown>;
+}): Promise<string> {
+  const { key, hash, prefix } = generateOrganizationApiKey();
+
+  const [newKey] = await db
+    .insert(organizationApiKeys)
+    .values({
+      organizationId: params.organizationId,
+      name: CLI_DEVICE_KEY_NAME,
+      keyHash: hash,
+      keyPrefix: prefix,
+      createdBy: params.userId,
+      expiresAt: null,
+      scope: null,
+    })
+    .returning({
+      id: organizationApiKeys.id,
+      name: organizationApiKeys.name,
+      keyPrefix: organizationApiKeys.keyPrefix,
+      createdAt: organizationApiKeys.createdAt,
+    });
+
+  notifyApiKeyChange({
+    userId: params.userId,
+    loginEmail: params.userEmail ?? "",
+    action: "created",
+    tokenName: newKey.name,
+    keyPrefix: newKey.keyPrefix,
+    when: newKey.createdAt,
+  });
+  await recordAuditEvent({
+    actor: {
+      userId: params.userId,
+      organizationId: params.organizationId,
+      authMethod: "session",
+    },
+    action: "org_api_key.created",
+    resourceType: "org_api_key",
+    resourceId: newKey.id,
+    after: { name: newKey.name, keyPrefix: newKey.keyPrefix },
+    metadata: params.auditMetadata,
+  });
+
+  return key;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import { withSentryConfig } from "@sentry/nextjs";
 import type { NextConfig } from "next";
 import { withWorkflow } from "workflow/next";
+import { CLI_VERSION_HEADER_RULE } from "./lib/cli-version";
 
 const nextConfig = {
   output: "standalone",
@@ -293,6 +294,12 @@ const nextConfig = {
           },
         ],
       },
+      // The kh CLI already checks this header on every response and warns when
+      // its own build is older (internal/http/version.go). The client half
+      // shipped long ago; nothing was ever sending the header, so the check was
+      // inert. Updates are manual (`kh update`) with no prompt, so this warning
+      // is the only signal an out-of-date CLI ever gets.
+      CLI_VERSION_HEADER_RULE,
     ];
   },
   async redirects() {

--- a/tests/integration/device-token-api-key.test.ts
+++ b/tests/integration/device-token-api-key.test.ts
@@ -1,0 +1,231 @@
+// Better Auth's device plugin answers /device/token with a session token, which
+// the CLI cannot use: it sends Authorization: Bearer, api-key-auth demands a
+// kh_ prefix, and session tokens only authenticate as cookies. Widening bearer
+// auth is closed off on purpose (the bearer() plugin was removed to keep the MFA
+// and IP step-up gates intact), so the grant returns an org API key instead.
+// These tests pin that swap, and pin that it never leaks a session token.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const {
+  mockHandlerPost,
+  mockHandlerGet,
+  mockIssueCliDeviceApiKey,
+  mockHashSessionToken,
+  sessionRows,
+  userRows,
+  selectCalls,
+} = vi.hoisted(() => ({
+  mockHandlerPost: vi.fn(),
+  mockHandlerGet: vi.fn(),
+  mockIssueCliDeviceApiKey: vi.fn(),
+  mockHashSessionToken: vi.fn((token: string) => `hashed:${token}`),
+  sessionRows: [] as Array<{
+    userId: string;
+    activeOrganizationId: string | null;
+  }>,
+  userRows: [] as Array<{ email: string | null }>,
+  selectCalls: [] as unknown[],
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: (column: unknown, value: unknown) => ({ column, value }),
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: { api: { getSession: vi.fn() } } }));
+
+vi.mock("better-auth/next-js", () => ({
+  toNextJsHandler: () => ({ GET: mockHandlerGet, POST: mockHandlerPost }),
+}));
+
+vi.mock("@/lib/auth-session-token-hash", () => ({
+  hashSessionToken: mockHashSessionToken,
+}));
+
+vi.mock("@/lib/organization-api-key", () => ({
+  issueCliDeviceApiKey: mockIssueCliDeviceApiKey,
+}));
+
+// Two sequential selects run: the session row, then the user row.
+let selectIndex = 0;
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn((where: unknown) => ({
+          limit: vi.fn(() => {
+            selectCalls.push(where);
+            const rows = selectIndex === 0 ? sessionRows : userRows;
+            selectIndex += 1;
+            return Promise.resolve(rows);
+          }),
+        })),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve(undefined)) })),
+    })),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  sessions: {
+    token: "sessions.token",
+    userId: "sessions.userId",
+    activeOrganizationId: "sessions.activeOrganizationId",
+  },
+  users: { id: "users.id", email: "users.email" },
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { AUTH: "AUTH" },
+  logSystemError: vi.fn(),
+  logSystemWarn: vi.fn(),
+}));
+
+vi.mock("@/lib/security/audit-log", () => ({
+  buildAuditMetadata: vi.fn(() => ({ ip: "203.0.113.1" })),
+  recordAuditEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/oauth-mfa-cookie", () => ({
+  buildPendingOauthMfaSetCookie: vi.fn(),
+  encodePendingOauthMfaCookie: vi.fn(),
+}));
+
+vi.mock("@/lib/pending-signup-cookie", () => ({
+  buildPendingSignupSetCookie: vi.fn(),
+  encodePendingSignupCookie: vi.fn(),
+}));
+
+vi.mock("@/lib/sanitize-next-path", () => ({ sanitizeNextPath: vi.fn() }));
+
+const { POST } = await import("@/app/api/auth/[...all]/route");
+
+const TOKEN_URL = "https://app.example.com/api/auth/device/token";
+
+function postRequest(url: string): Request {
+  return new Request(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ grant_type: "device_code" }),
+  });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  selectIndex = 0;
+  selectCalls.length = 0;
+  sessionRows.length = 0;
+  userRows.length = 0;
+  mockHandlerPost.mockReset();
+  mockIssueCliDeviceApiKey.mockReset();
+  mockIssueCliDeviceApiKey.mockResolvedValue("kh_generated_key");
+  mockHandlerPost.mockResolvedValue(jsonResponse({ success: true }));
+});
+
+describe("device token - API key issuance", () => {
+  it("returns an org API key instead of the session token", async () => {
+    sessionRows.push({ userId: "user-1", activeOrganizationId: "org-1" });
+    userRows.push({ email: "dev@example.com" });
+    mockHandlerPost.mockResolvedValue(
+      jsonResponse({
+        access_token: "raw-session-token",
+        token_type: "Bearer",
+        scope: "",
+      })
+    );
+
+    const res = await POST(postRequest(TOKEN_URL));
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(body.access_token).toBe("kh_generated_key");
+    // The session token must never reach the CLI - it is the credential the
+    // whole defect is about.
+    expect(JSON.stringify(body)).not.toContain("raw-session-token");
+    // Unrelated fields from the grant response survive the swap.
+    expect(body.scope).toBe("");
+    expect(body.token_type).toBe("Bearer");
+  });
+
+  it("mints the key against the approving user and their active org", async () => {
+    sessionRows.push({ userId: "user-1", activeOrganizationId: "org-1" });
+    userRows.push({ email: "dev@example.com" });
+    mockHandlerPost.mockResolvedValue(
+      jsonResponse({ access_token: "raw-session-token" })
+    );
+
+    await POST(postRequest(TOKEN_URL));
+
+    expect(mockIssueCliDeviceApiKey).toHaveBeenCalledWith({
+      userId: "user-1",
+      userEmail: "dev@example.com",
+      organizationId: "org-1",
+      auditMetadata: { ip: "203.0.113.1" },
+    });
+    // The session is found by hashed token, since that is how sessions are stored.
+    expect(mockHashSessionToken).toHaveBeenCalledWith("raw-session-token");
+  });
+
+  it("fails the grant when the account has no active organization", async () => {
+    sessionRows.push({ userId: "user-1", activeOrganizationId: null });
+    mockHandlerPost.mockResolvedValue(
+      jsonResponse({ access_token: "raw-session-token" })
+    );
+
+    const res = await POST(postRequest(TOKEN_URL));
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(500);
+    expect(mockIssueCliDeviceApiKey).not.toHaveBeenCalled();
+    // Better to fail loudly than hand back a token that authenticates nothing.
+    expect(JSON.stringify(body)).not.toContain("raw-session-token");
+  });
+
+  it("fails the grant when key issuance throws, leaking no session token", async () => {
+    sessionRows.push({ userId: "user-1", activeOrganizationId: "org-1" });
+    userRows.push({ email: "dev@example.com" });
+    mockIssueCliDeviceApiKey.mockRejectedValue(new Error("insert failed"));
+    mockHandlerPost.mockResolvedValue(
+      jsonResponse({ access_token: "raw-session-token" })
+    );
+
+    const res = await POST(postRequest(TOKEN_URL));
+
+    expect(res.status).toBe(500);
+    expect(JSON.stringify(await res.json())).not.toContain("raw-session-token");
+  });
+
+  it("passes a pending poll through untouched", async () => {
+    mockHandlerPost.mockResolvedValue(
+      jsonResponse({ error: "authorization_pending" }, 400)
+    );
+
+    const res = await POST(postRequest(TOKEN_URL));
+
+    expect(res.status).toBe(400);
+    expect(mockIssueCliDeviceApiKey).not.toHaveBeenCalled();
+    expect((await res.json()).error).toBe("authorization_pending");
+  });
+
+  it("leaves other auth endpoints untouched", async () => {
+    mockHandlerPost.mockResolvedValue(
+      jsonResponse({ access_token: "some-other-token" })
+    );
+
+    const res = await POST(
+      postRequest("https://app.example.com/api/auth/sign-in/email")
+    );
+
+    expect(mockIssueCliDeviceApiKey).not.toHaveBeenCalled();
+    expect((await res.json()).access_token).toBe("some-other-token");
+  });
+});

--- a/tests/unit/cli-minimum-version-header.test.ts
+++ b/tests/unit/cli-minimum-version-header.test.ts
@@ -1,0 +1,48 @@
+// The kh CLI compares its own build against KH-Minimum-CLI-Version on every
+// response and warns when it is older (internal/http/version.go). That client
+// check shipped long ago but nothing ever sent the header, so it was inert.
+// Since `kh update` is manual and unprompted, this warning is the only signal
+// an out-of-date CLI gets - these tests pin the contract it depends on.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  CLI_VERSION_HEADER_RULE,
+  MINIMUM_CLI_VERSION,
+  MINIMUM_CLI_VERSION_HEADER,
+} from "@/lib/cli-version";
+
+describe("minimum CLI version header", () => {
+  it("uses the exact header name the CLI reads", () => {
+    // internal/http/version.go does resp.Header.Get("KH-Minimum-CLI-Version"),
+    // so any drift in this string silently disables the warning.
+    expect(MINIMUM_CLI_VERSION_HEADER).toBe("KH-Minimum-CLI-Version");
+  });
+
+  it("floors above the last release with a broken device login", () => {
+    // 0.11.0 is the last release whose device login could not work, so the
+    // floor has to sort above it for those users to be warned.
+    expect(MINIMUM_CLI_VERSION).toBe("0.11.1");
+  });
+
+  it("advertises the floor on API routes, where the CLI talks", () => {
+    expect(CLI_VERSION_HEADER_RULE.source).toBe("/api/:path*");
+    expect(CLI_VERSION_HEADER_RULE.headers).toContainEqual({
+      key: MINIMUM_CLI_VERSION_HEADER,
+      value: MINIMUM_CLI_VERSION,
+    });
+  });
+
+  it("is wired into next.config's headers()", async () => {
+    // next.config's default export is wrapped by withSentryConfig/withWorkflow
+    // and exposes no callable headers(), so assert on the source text: the rule
+    // must actually be referenced, not merely defined.
+    const { readFile } = await import("node:fs/promises");
+    const source = await readFile(
+      new URL("../../next.config.ts", import.meta.url),
+      "utf8"
+    );
+    expect(source).toContain("CLI_VERSION_HEADER_RULE");
+    expect(source).toContain('from "./lib/cli-version"');
+  });
+});


### PR DESCRIPTION
## Summary

`kh auth login` completed and stored a token, but the token authenticated
nothing - every subsequent `kh` command failed with `token is invalid or
expired`.

Better Auth's device plugin answers `/device/token` with a **session token**. A
session token is only usable as a cookie, and no path the CLI uses accepts one:

- The CLI sends every request as `Authorization: Bearer <token>`
  (`internal/http/client.go:79`) and never sends cookies.
- `lib/api-key-auth.ts:75` rejects any bearer value not starting with `kh_`.
- `/api/auth/get-session` ignores the header entirely - the `bearer()` plugin is
  not registered.
- The MCP path (`lib/mcp/oauth-auth.ts:131`) requires a signed OAuth JWT.

The credential the flow issued and the credentials the server accepts were
disjoint sets.

## Why not just enable `bearer()`

That was the first approach and it was abandoned. Commit `24b55cb12`
(*"remove unused better-auth bearer plugin to close MFA and IP gate bypass"*)
removed it deliberately, and `tests/unit/auth-plugins.test.ts` pins it as absent.
Of the three gates that commit names, re-enabling bearer would have left the **IP
step-up gate** unaddressed - `lib/security/login-risk.ts`, `user_trusted_ips` and
`/verify-ip` all assume the cookie flow, and a CLI session resolving from an
arbitrary IP walks around them.

That commit also names the right answer: *"kh_ API keys, OAuth JWTs, and wfb_
webhook tokens each have independent auth paths."* Non-browser clients are meant
to hold `kh_` keys. This PR leaves the pin untouched and green.

One premise of that removal has changed and deserves a look from whoever owns
F-021: *"Nothing in the app sends a session token as a bearer credential."* That
held partly because device login was broken; it no longer does.

## Changes

- `lib/organization-api-key.ts` (new) - shared key generation plus
  `issueCliDeviceApiKey()`, emitting the same notification and audit event as a
  dashboard-created key. This is a real org credential and must be as visible and
  revocable as any other.
- `app/api/auth/[...all]/route.ts` - `/device/token` swaps the session token for
  the API key. The session Better Auth minted is left unused; the response is
  rebuilt, so no session cookie leaks.
- `app/api/keys/route.ts` - now uses the shared generator instead of a private
  copy, so the two paths cannot drift on key format (`api-key-auth` validates the
  shared `kh_` prefix and SHA-256 hash).
- `lib/cli-version.ts` + `next.config.ts` - send `KH-Minimum-CLI-Version` on
  `/api/*`. The CLI has read this header on every response since
  `internal/http/version.go` shipped, but nothing ever sent it, so the check was
  inert. `kh update` is manual with no prompt, so this warning is the only signal
  an out-of-date CLI gets - and this fix needs a CLI release to reach anyone. The
  floor is 0.11.1 because 0.11.0 is the last release whose device login could not
  work; any release carrying the fix sorts above it. Warning only, nothing is
  blocked.

The org is the approving session's `activeOrganizationId`. With no org the grant
fails loudly rather than handing back a token that authenticates nothing.

## Decisions worth reviewing

1. **No auto-revoke of prior CLI keys** - revoking would log the user out on every
   other machine. Sprawl is bounded by the CLI-side login skip instead.
2. **No expiry on the key**, matching the dashboard default, though this is a
   long-lived org credential issued from a single browser confirm.
3. **No org picker** - a multi-org user gets their active org.
4. **The session Better Auth mints is orphaned.** Nobody receives it, but the row
   lives until expiry. Deleting it would be tidier.

## Test plan

- [x] 6 tests on the token swap, including that a session token never reaches the
      CLI on any path (success, no-org, and issuance-failure)
- [x] 47 existing API-key tests still pass after the shared-generator refactor
- [x] 4 tests on the version header
- [x] `auth-plugins.test.ts` (the F-021 pin) still green
- [x] `pnpm type-check` clean
- [ ] End-to-end `kh auth login` against staging, with the paired CLI build
- [ ] Confirm the audit event and notification land as expected

## Not verified

No live run of the new flow yet, and the token-swap tests were not checked
against pre-fix code the way a negative control would.

Requires the paired CLI change (KeeperHub/cli) and a CLI release to reach users.
