### PR TITLE
fix: add the two_factor lockout columns Better Auth writes

### DIFF
--- a/drizzle/0136_keep_1054_two_factor_lockout_columns.sql
+++ b/drizzle/0136_keep_1054_two_factor_lockout_columns.sql
@@ -1,0 +1,19 @@
+-- Better Auth's two-factor plugin owns an account-lockout feature that is
+-- enabled by default (resolveAccountLockoutConfig reads
+-- `enabled: lockout?.enabled ?? true`, and lib/auth.ts passes no accountLockout
+-- option). It reads and writes exactly two fields on this table:
+-- failedVerificationCount and lockedUntil.
+--
+-- Neither column existed, so resetTwoFactorFailures - which runs on every
+-- SUCCESSFUL verification - had both fields stripped by the drizzle adapter and
+-- emitted `UPDATE two_factor SET  WHERE ...`, which Postgres rejects. A correct
+-- TOTP code therefore 500'd after validating. The same gap made the lockout
+-- inert: assertTwoFactorNotLocked gates on locked_until, which read as
+-- undefined, so the cap on consecutive failed verifications never applied.
+--
+-- two_factor holds one row per enrolled user and is small; adding a column with
+-- a constant default is metadata-only on PG11+, so no table rewrite and no long
+-- lock (no @requires-db-prep needed).
+-- Idempotent: safe to re-run.
+ALTER TABLE "two_factor" ADD COLUMN IF NOT EXISTS "failed_verification_count" INTEGER DEFAULT 0 NOT NULL;
+ALTER TABLE "two_factor" ADD COLUMN IF NOT EXISTS "locked_until" TIMESTAMP;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -953,6 +953,13 @@
       "when": 1785116800000,
       "tag": "0135_keep_1039_billable_execution_count_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 136,
+      "version": "7",
+      "when": 1785211866351,
+      "tag": "0136_keep_1054_two_factor_lockout_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -244,6 +244,26 @@ export const twoFactor = pgTable(
     // Defaults to true so rows enrolled through our own routes are treated
     // as verified and the plugin skips the write entirely.
     verified: boolean("verified").notNull().default(true),
+    // The same contract as `verified` above, for the plugin's account-lockout
+    // feature. It is enabled by default - resolveAccountLockoutConfig reads
+    // `enabled: lockout?.enabled ?? true` and we pass no accountLockout option -
+    // so resetTwoFactorFailures runs on every successful verification and
+    // updates exactly these two fields. Without the columns the adapter strips
+    // both, leaving an empty SET that Postgres rejects, so a correct TOTP code
+    // 500s after validating.
+    //
+    // They also have to exist for the control to do anything:
+    // assertTwoFactorNotLocked gates on `lockedUntil`, which reads as undefined
+    // when the column is absent, so the cap on consecutive failed verifications
+    // (NIST SP 800-63B 5.2.2) silently never applies.
+    //
+    // Property names must match Better Auth's field names exactly -
+    // failedVerificationCount and lockedUntil - because the drizzle adapter
+    // maps by property, not column.
+    failedVerificationCount: integer("failed_verification_count")
+      .notNull()
+      .default(0),
+    lockedUntil: timestamp("locked_until"),
   },
   (table) => [index("idx_two_factor_user_id").on(table.userId)]
 );
@@ -846,12 +866,6 @@ export {
   type WalletApprovalRequest,
   walletApprovalRequests,
 } from "./schema-agentic-wallets";
-export {
-  type NewTempoHeldPayment,
-  type TempoHeldPayment,
-  tempoHeldPayments,
-  tempoHeldPaymentStatus,
-} from "./schema-tempo-payments";
 // KeeperHub: Organization Wallets, Organization API Keys, and Organization Tokens (imported from KeeperHub schema extensions)
 // Note: Using relative path instead of @/ alias for drizzle-kit compatibility
 export {
@@ -950,6 +964,12 @@ export {
   type WorkflowPayment,
   workflowPayments,
 } from "./schema-payments";
+export {
+  type NewTempoHeldPayment,
+  type TempoHeldPayment,
+  tempoHeldPaymentStatus,
+  tempoHeldPayments,
+} from "./schema-tempo-payments";
 
 // Better Auth: Device Authorization table (for CLI device flow)
 export const deviceCode = pgTable("device_code", {

--- a/tests/unit/two-factor-schema-contract.test.ts
+++ b/tests/unit/two-factor-schema-contract.test.ts
@@ -1,0 +1,71 @@
+// Better Auth's two-factor plugin writes to the twoFactor model by *field name*,
+// and the drizzle adapter maps those names to our table's properties. A field the
+// plugin writes but our table lacks is silently stripped, and when that leaves
+// nothing to write the adapter emits `UPDATE two_factor SET  WHERE ...`, which
+// Postgres rejects outright.
+//
+// That is not hypothetical. It happened twice: first with `verified`, then with
+// the account-lockout fields (`failedVerificationCount`, `lockedUntil`), where a
+// correct TOTP code 500'd after validating because resetTwoFactorFailures runs on
+// every successful verification.
+//
+// So rather than listing the fields we happen to know about, this test reads them
+// from the plugin itself. A Better Auth upgrade that adds a field to this model
+// fails here instead of in production.
+
+import { describe, expect, it, vi } from "vitest";
+
+// lib/db/schema pulls in no Redis, but keep the stub in line with the other
+// auth-adjacent unit tests so the module graph resolves without a live Redis.
+vi.mock("ioredis", () => ({ Redis: class {} }));
+
+import { twoFactor as twoFactorPlugin } from "better-auth/plugins";
+
+import { twoFactor as twoFactorTable } from "@/lib/db/schema";
+
+/** Field names Better Auth declares on the twoFactor model. */
+function pluginFieldNames(): string[] {
+  const plugin = twoFactorPlugin();
+  const fields = (
+    plugin.schema as
+      | { twoFactor?: { fields?: Record<string, unknown> } }
+      | undefined
+  )?.twoFactor?.fields;
+  return Object.keys(fields ?? {});
+}
+
+/** Property names on our drizzle table (what the adapter maps onto). */
+function tablePropertyNames(): string[] {
+  return Object.keys(twoFactorTable);
+}
+
+describe("two_factor schema contract with Better Auth", () => {
+  it("declares every field the plugin writes", () => {
+    const missing = pluginFieldNames().filter(
+      (field) => !tablePropertyNames().includes(field)
+    );
+
+    expect(
+      missing,
+      `lib/db/schema.ts twoFactor is missing ${missing.join(", ")}. The adapter ` +
+        "strips unknown fields, so an update touching only these emits an empty " +
+        "SET and Postgres rejects it. Add the columns and a migration."
+    ).toEqual([]);
+  });
+
+  it("still covers the account-lockout fields specifically", () => {
+    // These two are what broke sign-in, and they are what makes
+    // assertTwoFactorNotLocked able to enforce anything at all - it gates on
+    // lockedUntil, which reads as undefined when the column is absent.
+    const properties = tablePropertyNames();
+    expect(properties).toContain("failedVerificationCount");
+    expect(properties).toContain("lockedUntil");
+  });
+
+  it("uses the plugin's field names verbatim, since the adapter maps by property", () => {
+    // A column named differently (failed_count, locked_at, ...) would compile and
+    // migrate cleanly while still being invisible to the plugin.
+    expect(pluginFieldNames()).toContain("failedVerificationCount");
+    expect(pluginFieldNames()).toContain("lockedUntil");
+  });
+});


### PR DESCRIPTION
## Summary

A user who enters a **correct** TOTP code can be refused sign-in with a 500. The
code validates, then the request dies writing invalid SQL:

```
[strict-signin] verifyTOTP chain failed after TOTP validation
Failed query: update "two_factor" set  where "two_factor"."id" = $1 ...
cause: PostgresError: syntax error at or near "where"
```

Note `set` with nothing after it.

## Root cause

Better Auth's two-factor plugin owns an account-lockout feature that writes two
fields on the `twoFactor` model - `failedVerificationCount` and `lockedUntil` -
and **it is enabled by default**: `resolveAccountLockoutConfig` resolves
`enabled: lockout?.enabled ?? true`, and `lib/auth.ts` passes no `accountLockout`
option.

Neither column existed on `two_factor`. `resetTwoFactorFailures` runs on every
**successful** verification and updates exactly those two fields, so the drizzle
adapter stripped both and emitted an empty `SET`. Deterministic, not a race: any
request reaching that path fails.

This is upgrade drift - the plugin gained the fields, our schema never followed.

## Second problem: the lockout has never run

`assertTwoFactorNotLocked` gates on `twoFactor.lockedUntil`, which reads as
undefined when the column is absent. So the cap on consecutive failed 2FA
verifications - which the plugin cites NIST SP 800-63B 5.2.2 for - has never been
enforced, while the configuration reads as enabled. Adding the columns fixes the
500 and activates the control.

## Not a regression from the release

The failing code is byte-identical on `prod` and `staging` (absent from the
`prod..staging` diff), so this is live in production today. It surfaced as the
sole failure in `e2e-playwright-ephemeral` on the prod release PR #1845 - 1
failed, 123 passed - where it blocks the staging deploy and therefore the
release.

## The test reads the contract from the plugin

This is the **second** time this exact failure has hit this table; the existing
comment on `verified` documents the first. Listing the fields we currently know
about would just set up a third.

So `tests/unit/two-factor-schema-contract.test.ts` reads the field names from
`twoFactorPlugin().schema.twoFactor.fields` and diffs them against our table. Any
future Better Auth upgrade that adds a field to this model fails there instead of
in production.

Negative control: against the pre-fix schema it fails with
`missing failedVerificationCount, lockedUntil`.

## Note for reviewers: hand-written migration

`pnpm drizzle-kit generate` **cannot run on this branch**:

```
Error: [drizzle/meta/0081_snapshot.json ... 0089_snapshot.json] are pointing to a
parent snapshot: drizzle/meta/0081_snapshot.json/snapshot.json which is a collision.
```

That reproduces with this change stashed, so it is pre-existing on `staging` and
worth its own ticket - nobody can generate migrations right now.

The migration and journal entry are therefore hand-written. Verified by applying
**all 137 migrations to an empty database** and checking the resulting column
types, rather than trusting the SQL by eye. No snapshot accompanies this
migration, since generate cannot produce one.

`two_factor` holds one row per enrolled user, and adding a column with a constant
default is metadata-only on PG11+, so no `@requires-db-prep`.

## Test plan

- [x] Contract test passes, and fails against the pre-fix schema
- [x] All 137 migrations apply to an empty DB; `failed_verification_count integer
      not null default 0` and `locked_until timestamp` present
- [x] `pnpm type-check` clean, lint clean on changed files
- [x] `auth-plugins` and `totp-enroll-route` suites still pass
- [ ] `e2e-playwright-ephemeral` passes - this PR should unblock it
