### PR TITLE
fix(idempotency): mark replayed responses so a cached failure is visible

### DIFF
--- a/lib/idempotency.ts
+++ b/lib/idempotency.ts
@@ -338,7 +338,26 @@ export async function beginIdempotentFromRequest(args: {
   });
 }
 
-export type IdempotencyEarlyResponse = { status: number; body: unknown };
+export type IdempotencyEarlyResponse = {
+  status: number;
+  body: unknown;
+  replayed?: boolean;
+};
+
+// Marks a replayed body so the caller can tell a cached prior outcome apart
+// from a fresh one. A replayed failure is otherwise indistinguishable from a
+// live failure: it carries the original contract-shaped error and nothing else,
+// so a retry loop reads "still reverting" when in fact no transaction was sent.
+// The flag rides in the body rather than a header because the common consumer
+// is an agent reading a tool result, where response headers are not surfaced.
+// Only plain objects are annotated -- arrays and primitives are returned
+// untouched so a stored response shape is never corrupted.
+function annotateReplay(body: unknown): unknown {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return body;
+  }
+  return { ...(body as Record<string, unknown>), idempotentReplay: true };
+}
 
 // Maps a non-proceed outcome to the response the caller should return as-is.
 // Returns null for `proceed` (the caller does the work, then calls finalize).
@@ -347,7 +366,11 @@ export function idempotencyEarlyResponse(
 ): IdempotencyEarlyResponse | null {
   switch (outcome.kind) {
     case "replay":
-      return { status: outcome.responseStatus, body: outcome.responseBody };
+      return {
+        status: outcome.responseStatus,
+        body: annotateReplay(outcome.responseBody),
+        replayed: true,
+      };
     case "conflict":
       return {
         status: 409,

--- a/tests/unit/idempotency.test.ts
+++ b/tests/unit/idempotency.test.ts
@@ -159,14 +159,60 @@ describe("idempotencyEarlyResponse", () => {
     expect(idempotencyEarlyResponse(proceedFns())).toBeNull();
   });
 
-  it("maps replay to the stored status and body", () => {
+  it("maps replay to the stored status and body, marked as a replay", () => {
     expect(
       idempotencyEarlyResponse({
         kind: "replay",
         responseStatus: 202,
         responseBody: { executionId: "e1" },
       })
-    ).toEqual({ status: 202, body: { executionId: "e1" } });
+    ).toEqual({
+      status: 202,
+      body: { executionId: "e1", idempotentReplay: true },
+      replayed: true,
+    });
+  });
+
+  // A replayed failure is the case that actually misleads a caller: without the
+  // marker it is indistinguishable from a fresh revert, so a retry loop keeps
+  // reading "still failing" while no transaction is being sent at all.
+  it("marks a replayed failure so it is distinguishable from a fresh one", () => {
+    const early = idempotencyEarlyResponse({
+      kind: "replay",
+      responseStatus: 200,
+      responseBody: {
+        success: false,
+        error: "Contract call failed: Error(LK: not yet due)",
+      },
+    });
+    const body = early?.body as Record<string, unknown>;
+    expect(early?.replayed).toBe(true);
+    expect(body.idempotentReplay).toBe(true);
+    // The original payload is preserved untouched alongside the marker.
+    expect(body.error).toBe("Contract call failed: Error(LK: not yet due)");
+    expect(body.success).toBe(false);
+  });
+
+  it("leaves non-object replay bodies untouched", () => {
+    for (const stored of [null, "raw text", 42, [1, 2, 3]]) {
+      const early = idempotencyEarlyResponse({
+        kind: "replay",
+        responseStatus: 200,
+        responseBody: stored,
+      });
+      expect(early?.body).toEqual(stored);
+      expect(early?.replayed).toBe(true);
+    }
+  });
+
+  it("does not mark a fresh conflict or in_progress response as a replay", () => {
+    expect(
+      idempotencyEarlyResponse({ kind: "conflict", originalResourceId: "e1" })
+        ?.replayed
+    ).toBeUndefined();
+    expect(
+      idempotencyEarlyResponse({ kind: "in_progress" })?.replayed
+    ).toBeUndefined();
   });
 
   it("maps conflict to 409 with the original execution id", () => {


### PR DESCRIPTION
## The problem

Reusing an `idempotency_key` after a failure replays the cached failure forever, so a retry can never recover. Reading `lib/idempotency.ts`, that replay is **deliberate and correct**: a `failed` record means the call reached the broadcast path, so re-running it could double-spend. Changing that would trade a visible annoyance for an invisible fund-loss risk. I have not touched it.

What is genuinely wrong is that the replay is **silent**. `idempotencyEarlyResponse` returns the stored body verbatim, so a replayed failure is byte-identical to a fresh one:

```
{ "success": false, "error": "Contract call failed: Error(LK: not yet due)" }
```

The reporter put it exactly right — *"it is invisible. The response carries a plausible, contract-shaped error message rather than any hint that it is cached."* Their retry loop read "still reverting" three times while no transaction was being sent at all, against a contract that was verifiably due.

## The change

Make the replay observable, without altering when a replay happens:

- object bodies are annotated with `idempotentReplay: true`
- `IdempotencyEarlyResponse` gains `replayed?: boolean`

The marker rides in the **body rather than a header** on purpose: the common consumer here is an agent reading an MCP tool result, and response headers are not surfaced through that path. A header alone would not fix the reported problem.

Arrays and primitives are passed through untouched so a stored response shape is never corrupted, and the original payload is always preserved alongside the marker.

All eight routes calling `idempotencyEarlyResponse` inherit this with no call-site changes, since they already do `NextResponse.json(early.body, { status: early.status })`.

## Why this is the right shape of fix

A caller can now tell the two cases apart and act correctly:

- `idempotentReplay: true` → this is a cached prior outcome; if chain state has since changed, retry under a **new key** rather than backing off
- no marker → this is a live result

That turns a silent dead end into a self-describing one, and it keeps the double-spend guarantee intact.

## Tests

`tests/unit/idempotency.test.ts` — 25 passing, including four new cases:

- a replayed failure is marked and its original payload preserved
- non-object bodies (`null`, string, number, array) pass through untouched
- `conflict` / `in_progress` are not mislabelled as replays
- the existing replay mapping test updated for the new shape

```
✓ tests/unit/idempotency.test.ts (25 tests) 18ms
Test Files  1 passed (1)
     Tests  25 passed (25)
```

## Follow-up worth considering (not in this PR)

The docs could state plainly that `idempotency_key` identifies **one attempt**, not one logical action retried across changing chain state — a retry after a precondition flips needs a fresh key. That framing is what the reporter was missing, and it is a docs change rather than a code one.