### PR TITLE
fix: accept multi-chain listings on either payment rail

### DIFF
--- a/lib/agentic-wallet/workflow-binding.ts
+++ b/lib/agentic-wallet/workflow-binding.ts
@@ -60,6 +60,15 @@
  * not platform-enforced. Tighten at the listing API if that ever becomes
  * a policy concern.
  *
+ * An explicit multi-chain tag ("multi-chain", "any", "cross-chain", ...) is
+ * treated like a data-chain listing: the workflow declares no single payment-
+ * chain preference, so both Base x402 and Tempo MPP are accepted. This is the
+ * supported way for a listing to say "payable on either rail" -- previously
+ * the only ways to express it were a null chain or a data-chain id, and a
+ * natural value like "multi-chain" fell through to the defensive-mismatch
+ * branch and 403'd every payment on both rails. Unrecognised tags still stay
+ * defensive so a typo never silently widens access.
+ *
  * Lookup chain mirrors lib/x402/payment-gate.ts:resolveCreatorWallet.
  */
 import { and, eq } from "drizzle-orm";
@@ -121,9 +130,27 @@ export const KNOWN_DATA_CHAIN_IDS = new Set<string>([
   "9745", // Plasma Mainnet
 ]);
 
+/**
+ * Explicit "payable on either rail" tags. A listing carrying one of these
+ * declares no single payment-chain preference, so the binding accepts both
+ * Base x402 and Tempo MPP -- the same acceptance as a data-chain id or a null
+ * chain. Matched case-insensitively after trim (see classifyChainTag).
+ */
+export const MULTI_CHAIN_TAGS = new Set<string>([
+  "multi-chain",
+  "multichain",
+  "multi_chain",
+  "multi",
+  "cross-chain",
+  "crosschain",
+  "any",
+  "all",
+]);
+
 type ChainClassification =
   | { readonly kind: "payment"; readonly chain: BindingChain }
   | { readonly kind: "data" }
+  | { readonly kind: "multi" }
   | { readonly kind: "unrecognised" };
 
 /**
@@ -133,6 +160,8 @@ type ChainClassification =
  * - "data": a recognised data-chain id (Ethereum, OP, Polygon, Arbitrum); the
  *   listing's chain identifies where the contracts live, not which chain
  *   payment must arrive on. Either Base or Tempo payment is accepted.
+ * - "multi": an explicit multi-chain tag (see MULTI_CHAIN_TAGS). The listing
+ *   opts into either payment rail; accepted like a data-chain listing.
  * - "unrecognised": a non-empty value we can't parse. Treated as defensive
  *   mismatch by the binding so a typo or future tag never silently widens
  *   access.
@@ -160,6 +189,9 @@ function classifyChainTag(
   }
   if (KNOWN_DATA_CHAIN_IDS.has(v)) {
     return { kind: "data" };
+  }
+  if (MULTI_CHAIN_TAGS.has(v)) {
+    return { kind: "multi" };
   }
   return { kind: "unrecognised" };
 }
@@ -225,6 +257,7 @@ export async function verifyWorkflowBinding(
   // defence). Data-chain listings (Ethereum, Arbitrum, Polygon, BNB, Avalanche, 0G, Plasma) only
   // describe where the workflow READS contracts from — they have no inherent
   // payment-chain preference, so either Base x402 or Tempo MPP is accepted.
+  // Explicit multi-chain tags opt into the same either-rail acceptance.
   // Unrecognised tags stay defensive (mismatch) so a typo never widens access.
   // A null wf.chain remains permissive for legacy listings that pre-date the
   // workflows.chain column.
@@ -232,6 +265,7 @@ export async function verifyWorkflowBinding(
     const wfClass = classifyChainTag(wf.chain);
     const matched =
       wfClass.kind === "data" ||
+      wfClass.kind === "multi" ||
       (wfClass.kind === "payment" && wfClass.chain === chain);
     if (!matched) {
       return {

--- a/tests/unit/agentic-wallet-workflow-binding.test.ts
+++ b/tests/unit/agentic-wallet-workflow-binding.test.ts
@@ -59,9 +59,8 @@ vi.mock("@/lib/db/schema", () => ({
   organizationWallets: { _table: "organization_wallets" },
 }));
 
-const { verifyWorkflowBinding, KNOWN_DATA_CHAIN_IDS } = await import(
-  "@/lib/agentic-wallet/workflow-binding"
-);
+const { verifyWorkflowBinding, KNOWN_DATA_CHAIN_IDS, MULTI_CHAIN_TAGS } =
+  await import("@/lib/agentic-wallet/workflow-binding");
 
 const SLUG = "test-slug";
 const CREATOR = "0xCreATor000000000000000000000000000000001";
@@ -412,6 +411,75 @@ describe("verifyWorkflowBinding", () => {
         ok: false,
         status: 403,
         code: "WORKFLOW_NOT_PAYABLE",
+      });
+    });
+  });
+
+  // Explicit multi-chain tags ("multi-chain", "any", ...) declare no single
+  // payment-chain preference, so both Base x402 and Tempo MPP are accepted --
+  // the same acceptance as a data-chain id. Before this, a listing tagged
+  // "multi-chain" fell through to the defensive-mismatch branch and 403'd
+  // every payment on both rails.
+  describe("multi-chain listings", () => {
+    it("accepts Base payment for a multi-chain listing", async () => {
+      queueWorkflow({ chain: "multi-chain" });
+      queueWallet({});
+      const r = await verifyWorkflowBinding(SLUG, "base", CREATOR, "50000");
+      expect(r.ok).toBe(true);
+    });
+
+    it("accepts Tempo payment for a multi-chain listing", async () => {
+      queueWorkflow({ chain: "multi-chain" });
+      queueWallet({});
+      const r = await verifyWorkflowBinding(SLUG, "tempo", "", "0");
+      expect(r.ok).toBe(true);
+    });
+
+    it("accepts either payment chain for every multi-chain tag", async () => {
+      for (const tag of MULTI_CHAIN_TAGS) {
+        queueWorkflow({ chain: tag });
+        queueWallet({});
+        const rBase = await verifyWorkflowBinding(
+          SLUG,
+          "base",
+          CREATOR,
+          "50000"
+        );
+        expect(rBase.ok).toBe(true);
+
+        queueWorkflow({ chain: tag });
+        queueWallet({});
+        const rTempo = await verifyWorkflowBinding(SLUG, "tempo", "", "0");
+        expect(rTempo.ok).toBe(true);
+      }
+    });
+
+    it("normalises case + whitespace on a multi-chain tag", async () => {
+      queueWorkflow({ chain: " Multi-Chain " });
+      queueWallet({});
+      const r = await verifyWorkflowBinding(SLUG, "base", CREATOR, "50000");
+      expect(r.ok).toBe(true);
+    });
+
+    it("still enforces payTo equality on the Base path for a multi-chain listing", async () => {
+      queueWorkflow({ chain: "multi-chain" });
+      queueWallet({});
+      const r = await verifyWorkflowBinding(SLUG, "base", ATTACKER, "50000");
+      expect(r).toMatchObject({
+        ok: false,
+        status: 403,
+        code: "PAYTO_MISMATCH",
+      });
+    });
+
+    it("still enforces amount equality on the Base path for a multi-chain listing", async () => {
+      queueWorkflow({ chain: "multi-chain" });
+      queueWallet({});
+      const r = await verifyWorkflowBinding(SLUG, "base", CREATOR, "100000");
+      expect(r).toMatchObject({
+        ok: false,
+        status: 403,
+        code: "AMOUNT_MISMATCH",
       });
     });
   });


### PR DESCRIPTION
## Summary

A listed workflow whose `chain` tag is an explicit multi-chain value (for
example `multi-chain`) returned `403 CHAIN_MISMATCH` for every payment on both
the Base x402 and Tempo MPP rails. The wallet was behaving correctly; the
rejection came from the server-side binding in `verifyWorkflowBinding`.

## Root cause

`classifyChainTag` recognises only payment-chain slugs/ids (`base`/`tempo`),
whitelisted data-chain ids, and `null`. Any other non-null value is classified
`unrecognised` and rejected defensively. `multi-chain` is a natural way for a
creator to say "payable on either rail", but it was not in the vocabulary, so
it fell into the defensive branch and blocked both rails.

## Fix

Add an explicit `MULTI_CHAIN_TAGS` set classified as a new `multi` kind that is
accepted on either rail, the same acceptance already granted to data-chain ids
and `null`. The defensive reject for genuinely unrecognised tags and the
Base-path payTo/amount equality checks are unchanged, so no payment-redirection
surface is widened.

## Tests

Extends the binding unit suite with a `multi-chain listings` group: both rails
accepted for every tag, case/whitespace normalisation, and confirmation that
Base-path payTo/amount equality still rejects. 41 tests pass; `pnpm type-check`
and `biome check` are clean.
