### PR TITLE
fix: persist workflow sidebar flyout and gate truncation tooltips

### DIFF
--- a/components/navigation-sidebar.tsx
+++ b/components/navigation-sidebar.tsx
@@ -29,6 +29,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { TruncatedTooltip } from "@/components/ui/truncated-tooltip";
 import { useIsMobile } from "@/hooks/use-mobile";
 import type { Project, SavedWorkflow, Tag } from "@/lib/api-client";
 import { api } from "@/lib/api-client";
@@ -116,14 +117,13 @@ function WorkflowItem({
       onClick={() => router.push(`/workflows/${workflow.id}`)}
       type="button"
     >
-      <span
+      <TruncatedTooltip
         className={cn(
-          "truncate",
           (isDeactivated || showDisabled) && "text-muted-foreground"
         )}
-      >
-        {workflow.name}
-      </span>
+        side="right"
+        text={workflow.name}
+      />
       {isDeactivated && (
         <span className="ml-2 shrink-0 text-muted-foreground text-xs">
           Deactivated
@@ -231,7 +231,7 @@ function ProjectsPanel({
                 backgroundColor: project.color ?? "var(--color-text-muted)",
               }}
             />
-            <span className="truncate">{project.name}</span>
+            <TruncatedTooltip side="right" text={project.name} />
             <span className="ml-auto flex items-center gap-1 text-muted-foreground text-xs">
               {projectWorkflows.length}
               <ChevronRight className="size-3.5" />
@@ -338,7 +338,7 @@ function TagsPanel({
                 className="inline-block size-2 shrink-0 rounded-full"
                 style={{ backgroundColor: tag.color }}
               />
-              <span className="truncate">{tag.name}</span>
+              <TruncatedTooltip side="right" text={tag.name} />
               <span className="ml-auto normal-case tracking-normal">
                 {tag.workflowCount}
               </span>
@@ -897,11 +897,11 @@ export function NavigationSidebar(): React.ReactNode {
       return;
     }
     if (item.id === "address-book") {
-      navState.closeAll();
       openOverlay(AddressBookOverlay);
       return;
     }
-    navState.closeAll();
+    // Keep the workflows flyout open when moving between pages so the picker
+    // stays available instead of collapsing on every navigation.
     if (item.href) {
       router.push(item.href);
     }

--- a/components/organization/org-switcher.tsx
+++ b/components/organization/org-switcher.tsx
@@ -16,11 +16,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { TruncatedTooltip } from "@/components/ui/truncated-tooltip";
 import { useSession } from "@/lib/auth-client";
 import {
   useOrganization,
@@ -168,14 +164,11 @@ export function OrgSwitcher() {
                         organization.id === org.id ? "opacity-100" : "opacity-0"
                       }`}
                     />
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="min-w-0 flex-1 truncate text-left">
-                          {org.name}
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent side="right">{org.name}</TooltipContent>
-                    </Tooltip>
+                    <TruncatedTooltip
+                      className="min-w-0 flex-1 text-left"
+                      side="right"
+                      text={org.name}
+                    />
                   </CommandItem>
                 ))}
               </CommandGroup>

--- a/components/overlays/address-book-overlay.tsx
+++ b/components/overlays/address-book-overlay.tsx
@@ -10,13 +10,6 @@ import { useOverlay } from "@/components/overlays/overlay-provider";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import {
   Table,
@@ -149,53 +142,22 @@ export function AddAddressOverlay({
 
 type AddressBookSearchAndControlsProps = {
   searchQuery: string;
-  itemsPerPage: number;
-  shouldRenderItemsPerPageSelector: boolean;
   onSearchChange: (value: string) => void;
-  onItemsPerPageChange: (value: number) => void;
 };
 
 function AddressBookSearchAndControls({
   searchQuery,
-  itemsPerPage,
-  shouldRenderItemsPerPageSelector = true,
   onSearchChange,
-  onItemsPerPageChange,
 }: AddressBookSearchAndControlsProps) {
   return (
-    <div className="flex items-center justify-between gap-4">
-      <div className="relative max-w-xs flex-1">
-        <Search className="-translate-y-1/2 absolute top-1/2 left-3 h-4 w-4 text-muted-foreground" />
-        <Input
-          className="pl-9"
-          onChange={(e) => onSearchChange(e.target.value)}
-          placeholder="Search by name..."
-          value={searchQuery}
-        />
-      </div>
-      {shouldRenderItemsPerPageSelector && (
-        <div className="flex items-center gap-2">
-          <Label className="text-muted-foreground text-sm" htmlFor="page-size">
-            Items per page:
-          </Label>
-          <Select
-            onValueChange={(value) =>
-              onItemsPerPageChange(Number.parseInt(value, 10))
-            }
-            value={itemsPerPage.toString()}
-          >
-            <SelectTrigger className="w-20" id="page-size">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="5">5</SelectItem>
-              <SelectItem value="10">10</SelectItem>
-              <SelectItem value="20">20</SelectItem>
-              <SelectItem value="25">25</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-      )}
+    <div className="relative max-w-xs">
+      <Search className="-translate-y-1/2 absolute top-1/2 left-3 h-4 w-4 text-muted-foreground" />
+      <Input
+        className="pl-9"
+        onChange={(e) => onSearchChange(e.target.value)}
+        placeholder="Search by name..."
+        value={searchQuery}
+      />
     </div>
   );
 }
@@ -353,7 +315,6 @@ export function AddressBookOverlay({ overlayId }: AddressBookOverlayProps) {
     paginatedItems: paginatedEntries,
     currentPage,
     itemsPerPage,
-    setItemsPerPage,
     goToNextPage,
     goToPreviousPage,
     goToPage,
@@ -364,10 +325,8 @@ export function AddressBookOverlay({ overlayId }: AddressBookOverlayProps) {
     totalItems,
     pageNumbers,
   } = usePagination<AddressBookEntry>(filteredEntries, {
-    defaultItemsPerPage: 5,
+    defaultItemsPerPage: 25,
   });
-
-  const shouldRenderItemsPerPageSelector = filteredEntries.length > 5; // default items per page is 5;
 
   const loadEntries = useCallback(async () => {
     if (isTemporalAccount) {
@@ -486,13 +445,8 @@ export function AddressBookOverlay({ overlayId }: AddressBookOverlayProps) {
         {!(loading || isTemporalAccount) && entries.length > 0 && (
           <>
             <AddressBookSearchAndControls
-              itemsPerPage={itemsPerPage}
-              onItemsPerPageChange={setItemsPerPage}
               onSearchChange={setSearchQuery}
               searchQuery={searchQuery}
-              shouldRenderItemsPerPageSelector={
-                shouldRenderItemsPerPageSelector
-              }
             />
 
             {filteredEntries.length === 0 ? (

--- a/components/ui/truncated-tooltip.tsx
+++ b/components/ui/truncated-tooltip.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import type * as React from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+type TruncatedTooltipProps = {
+  /** Text to display (truncated) and show in full inside the tooltip. */
+  text: string;
+  /** Classes applied to the truncating span (the `truncate` class is added). */
+  className?: string;
+  side?: React.ComponentProps<typeof TooltipContent>["side"];
+  tooltipClassName?: string;
+};
+
+/**
+ * Single-line text that only reveals a tooltip with its full value when the
+ * content is actually clipped. When the text fits, no tooltip is shown so
+ * hovering a fully-visible label does nothing.
+ */
+export function TruncatedTooltip({
+  text,
+  className,
+  side = "top",
+  tooltipClassName,
+}: TruncatedTooltipProps): React.ReactNode {
+  const spanRef = useRef<HTMLSpanElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  const measure = useCallback(() => {
+    const el = spanRef.current;
+    if (el) {
+      setIsTruncated(el.scrollWidth > el.clientWidth);
+    }
+  }, []);
+
+  useLayoutEffect(() => {
+    measure();
+    const el = spanRef.current;
+    if (!el || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [measure]);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className={cn("truncate", className)} ref={spanRef}>
+          {text}
+        </span>
+      </TooltipTrigger>
+      {isTruncated && (
+        <TooltipContent className={tooltipClassName} side={side}>
+          {text}
+        </TooltipContent>
+      )}
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
## Summary

Three UI fixes.

### Workflows sidebar stays open across navigation
The flyout picker collapsed on every navigation because `handleNavClick` called `closeAll()` for each non-workflow nav item. Removed those calls so the picker stays open when moving between Hub, Analytics, Earnings, Held Payments and Activity. The persisted state already existed; the component was force-closing it.

### Tooltips only appear when text is clipped
Added `components/ui/truncated-tooltip.tsx`, which measures `scrollWidth > clientWidth` and only renders a tooltip when the label is actually truncated. Applied it to:
- Organization switcher dropdown items (previously always showed a tooltip, even for names that fit)
- Workflow, project and tag names in the sidebar flyouts

### Address book pagination
Removed the "Items per page" selector and set the default page size to 25. There is no URL query param backing this control; the only duplicated source of truth was the page-size number, which is now a single value.

## Verification
- `pnpm type-check` passes
- `pnpm check` clean on the changed files
- `tests/unit/use-persisted-nav-state.test.ts` passes