### PR TITLE
feat(workflow-builder): surface validator issues in run preflight

### DIFF
--- a/components/overlays/workflow-issues-overlay.tsx
+++ b/components/overlays/workflow-issues-overlay.tsx
@@ -113,37 +113,7 @@ export function WorkflowIssuesOverlay({
     onRunAnyway();
   };
 
-  const renderValidationIssue = (
-    issue: WorkflowValidationIssue,
-    index: number
-  ) => {
-    const nodeId = issue.nodeId;
 
-    return (
-      <div
-        className="flex items-center gap-3 py-1"
-        key={`${issue.code}-${issue.parameterPath}-${index}`}
-      >
-        <div className="min-w-0 flex-1">
-          <p className="text-sm">{issue.message}</p>
-          <p className="break-all font-mono text-muted-foreground text-xs">
-            {issue.parameterPath}
-          </p>
-        </div>
-
-        {nodeId && (
-          <Button
-            className="shrink-0"
-            onClick={() => handleGoToStep(nodeId, issue.fieldKey)}
-            size="sm"
-            variant="outline"
-          >
-            Fix
-          </Button>
-        )}
-      </div>
-    );
-  };
 
   return (
     <Overlay

--- a/components/overlays/workflow-issues-overlay.tsx
+++ b/components/overlays/workflow-issues-overlay.tsx
@@ -113,6 +113,38 @@ export function WorkflowIssuesOverlay({
     onRunAnyway();
   };
 
+  const renderValidationIssue = (
+    issue: WorkflowValidationIssue,
+    index: number
+  ) => {
+    const nodeId = issue.nodeId;
+
+    return (
+      <div
+        className="flex items-center gap-3 py-1"
+        key={`${issue.code}-${issue.parameterPath}-${index}`}
+      >
+        <div className="min-w-0 flex-1">
+          <p className="text-sm">{issue.message}</p>
+          <p className="break-all font-mono text-muted-foreground text-xs">
+            {issue.parameterPath}
+          </p>
+        </div>
+
+        {nodeId && (
+          <Button
+            className="shrink-0"
+            onClick={() => handleGoToStep(nodeId, issue.fieldKey)}
+            size="sm"
+            variant="outline"
+          >
+            Fix
+          </Button>
+        )}
+      </div>
+    );
+  };
+
   return (
     <Overlay
       actions={[
@@ -149,31 +181,34 @@ export function WorkflowIssuesOverlay({
             <h4 className="font-medium text-destructive text-xs uppercase tracking-wide">
               Blocking Errors
             </h4>
-            {validationErrors.map((issue, index) => (
-              <div
-                className="flex items-center gap-3 py-1"
-                key={`${issue.code}-${issue.parameterPath}-${index}`}
-              >
-                <div className="min-w-0 flex-1">
-                  <p className="text-sm">{issue.message}</p>
-                  <p className="break-all font-mono text-muted-foreground text-xs">
-                    {issue.parameterPath}
-                  </p>
+            {validationErrors.map((issue, index) => {
+              const nodeId = issue.nodeId;
+
+              return (
+                <div
+                  className="flex items-center gap-3 py-1"
+                  key={`${issue.code}-${issue.parameterPath}-${index}`}
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm">{issue.message}</p>
+                    <p className="break-all font-mono text-muted-foreground text-xs">
+                      {issue.parameterPath}
+                    </p>
+                  </div>
+
+                  {nodeId && (
+                    <Button
+                      className="shrink-0"
+                      onClick={() => handleGoToStep(nodeId, issue.fieldKey)}
+                      size="sm"
+                      variant="outline"
+                    >
+                      Fix
+                    </Button>
+                  )}
                 </div>
-                {issue.nodeId && (
-                  <Button
-                    className="shrink-0"
-                    onClick={() =>
-                      handleGoToStep(issue.nodeId!, issue.fieldKey)
-                    }
-                    size="sm"
-                    variant="outline"
-                  >
-                    Fix
-                  </Button>
-                )}
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
 
@@ -183,31 +218,34 @@ export function WorkflowIssuesOverlay({
             <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
               Warnings
             </h4>
-            {validationWarnings.map((issue, index) => (
-              <div
-                className="flex items-center gap-3 py-1"
-                key={`${issue.code}-${issue.parameterPath}-${index}`}
-              >
-                <div className="min-w-0 flex-1">
-                  <p className="text-sm">{issue.message}</p>
-                  <p className="break-all font-mono text-muted-foreground text-xs">
-                    {issue.parameterPath}
-                  </p>
+            {validationWarnings.map((issue, index) => {
+              const nodeId = issue.nodeId;
+
+              return (
+                <div
+                  className="flex items-center gap-3 py-1"
+                  key={`${issue.code}-${issue.parameterPath}-${index}`}
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm">{issue.message}</p>
+                    <p className="break-all font-mono text-muted-foreground text-xs">
+                      {issue.parameterPath}
+                    </p>
+                  </div>
+
+                  {nodeId && (
+                    <Button
+                      className="shrink-0"
+                      onClick={() => handleGoToStep(nodeId, issue.fieldKey)}
+                      size="sm"
+                      variant="outline"
+                    >
+                      Fix
+                    </Button>
+                  )}
                 </div>
-                {issue.nodeId && (
-                  <Button
-                    className="shrink-0"
-                    onClick={() =>
-                      handleGoToStep(issue.nodeId!, issue.fieldKey)
-                    }
-                    size="sm"
-                    variant="outline"
-                  >
-                    Fix
-                  </Button>
-                )}
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
 

--- a/components/overlays/workflow-issues-overlay.tsx
+++ b/components/overlays/workflow-issues-overlay.tsx
@@ -7,6 +7,7 @@ import { IntegrationIcon } from "@/components/ui/integration-icon";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { integrationsVersionAtom } from "@/lib/integrations-store";
 import type { IntegrationType } from "@/lib/types/integration";
+import type { WorkflowValidationIssue } from "@/lib/workflow/editor/run-validation";
 import { ConfigureConnectionOverlay } from "./add-connection-overlay";
 import { ConfigurationOverlay } from "./configuration-overlay";
 import { Overlay } from "./overlay";
@@ -42,12 +43,14 @@ type WorkflowIssues = {
   brokenReferences: BrokenReference[];
   missingRequiredFields: MissingRequiredField[];
   missingIntegrations: MissingIntegration[];
+  validationErrors?: WorkflowValidationIssue[];
+  validationWarnings?: WorkflowValidationIssue[];
 };
 
 type WorkflowIssuesOverlayProps = OverlayComponentProps<{
   issues: WorkflowIssues;
   onGoToStep: (nodeId: string, fieldKey?: string) => void;
-  onRunAnyway: () => void;
+  onRunAnyway?: () => void;
   actionLabel?: string;
 }>;
 
@@ -62,13 +65,22 @@ export function WorkflowIssuesOverlay({
   const setIntegrationsVersion = useSetAtom(integrationsVersionAtom);
   const isMobile = useIsMobile();
 
-  const { brokenReferences, missingRequiredFields, missingIntegrations } =
-    issues;
+  const {
+    brokenReferences,
+    missingRequiredFields,
+    missingIntegrations,
+    validationErrors = [],
+    validationWarnings = [],
+  } = issues;
+
+  const hasBlockingIssues = validationErrors.length > 0;
 
   const totalIssues =
     brokenReferences.length +
     missingRequiredFields.length +
-    missingIntegrations.length;
+    missingIntegrations.length +
+    validationErrors.length +
+    validationWarnings.length;
 
   const handleGoToStep = (nodeId: string, fieldKey?: string) => {
     // Select the node and set tab (this is handled by onGoToStep)
@@ -93,6 +105,10 @@ export function WorkflowIssuesOverlay({
   };
 
   const handleRunAnyway = () => {
+    if (!onRunAnyway || hasBlockingIssues) {
+      return;
+    }
+
     closeAll();
     onRunAnyway();
   };
@@ -100,8 +116,19 @@ export function WorkflowIssuesOverlay({
   return (
     <Overlay
       actions={[
-        { label: actionLabel, variant: "outline", onClick: handleRunAnyway },
-        { label: "Cancel", onClick: closeAll },
+        ...(hasBlockingIssues || !onRunAnyway
+          ? []
+          : [
+              {
+                label: actionLabel,
+                variant: "outline" as const,
+                onClick: handleRunAnyway,
+              },
+            ]),
+        {
+          label: hasBlockingIssues ? "Close" : "Cancel",
+          onClick: closeAll,
+        },
       ]}
       overlayId={overlayId}
       title={`Workflow Issues (${totalIssues})`}
@@ -109,11 +136,81 @@ export function WorkflowIssuesOverlay({
       <div className="flex items-center gap-2 text-orange-500">
         <AlertTriangle className="size-5" />
         <p className="text-muted-foreground text-sm">
-          This workflow has issues that may cause it to fail.
+          {hasBlockingIssues
+            ? "Fix the blocking errors before running this workflow."
+            : "This workflow has issues that may cause it to fail."}
         </p>
       </div>
 
       <div className="mt-4 space-y-4">
+        {/* Server Validation Errors */}
+        {validationErrors.length > 0 && (
+          <div className="space-y-2">
+            <h4 className="font-medium text-destructive text-xs uppercase tracking-wide">
+              Blocking Errors
+            </h4>
+            {validationErrors.map((issue, index) => (
+              <div
+                className="flex items-center gap-3 py-1"
+                key={`${issue.code}-${issue.parameterPath}-${index}`}
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm">{issue.message}</p>
+                  <p className="break-all font-mono text-muted-foreground text-xs">
+                    {issue.parameterPath}
+                  </p>
+                </div>
+                {issue.nodeId && (
+                  <Button
+                    className="shrink-0"
+                    onClick={() =>
+                      handleGoToStep(issue.nodeId!, issue.fieldKey)
+                    }
+                    size="sm"
+                    variant="outline"
+                  >
+                    Fix
+                  </Button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Server Validation Warnings */}
+        {validationWarnings.length > 0 && (
+          <div className="space-y-2">
+            <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+              Warnings
+            </h4>
+            {validationWarnings.map((issue, index) => (
+              <div
+                className="flex items-center gap-3 py-1"
+                key={`${issue.code}-${issue.parameterPath}-${index}`}
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm">{issue.message}</p>
+                  <p className="break-all font-mono text-muted-foreground text-xs">
+                    {issue.parameterPath}
+                  </p>
+                </div>
+                {issue.nodeId && (
+                  <Button
+                    className="shrink-0"
+                    onClick={() =>
+                      handleGoToStep(issue.nodeId!, issue.fieldKey)
+                    }
+                    size="sm"
+                    variant="outline"
+                  >
+                    Fix
+                  </Button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
         {/* Missing Connections Section */}
         {missingIntegrations.length > 0 && (
           <div className="space-y-1">

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -51,6 +51,10 @@ import { integrationsAtom } from "@/lib/integrations-store";
 import type { IntegrationType } from "@/lib/types/integration";
 import { cn } from "@/lib/utils";
 import { evaluateShowWhen, type ShowWhen } from "@/lib/workflow/editor/show-when";
+import {
+  mapWorkflowValidationIssues,
+  type WorkflowValidationResult,
+} from "@/lib/workflow/editor/run-validation";
 import { ensureSavedBeforeRun } from "@/lib/workflow/run-preflight";
 import {
   addNodeAtom,
@@ -627,21 +631,8 @@ function useWorkflowHandlers({
     await saveWorkflow();
   };
 
-  const executeWorkflow = async () => {
+  const startWorkflowExecution = async () => {
     if (!currentWorkflowId) {
-      toast.error("Please save the workflow before executing");
-      return;
-    }
-
-    // The server executes the stored definition, not the canvas state, so
-    // edits still waiting on the debounced autosave must be flushed first.
-    // saveWorkflow already toasts on failure, so a failed flush aborts quietly.
-    const saved = await ensureSavedBeforeRun({
-      hasUnsavedChanges,
-      isPreviewingVersion: previewVersion !== null,
-      save: saveWorkflow,
-    });
-    if (!saved) {
       return;
     }
 
@@ -665,6 +656,82 @@ function useWorkflowHandlers({
       onExecutionStarted: () => setRunsRefreshTrigger((c) => c + 1),
     });
     // Don't set executing to false here - let polling handle it
+  };
+
+  const executeWorkflow = async () => {
+    if (!currentWorkflowId) {
+      toast.error("Please save the workflow before executing");
+      return;
+    }
+
+    // The server executes the stored definition, not the canvas state, so
+    // edits still waiting on the debounced autosave must be flushed first.
+    // saveWorkflow already toasts on failure, so a failed flush aborts quietly.
+    const saved = await ensureSavedBeforeRun({
+      hasUnsavedChanges,
+      isPreviewingVersion: previewVersion !== null,
+      save: saveWorkflow,
+    });
+    if (!saved) {
+      return;
+    }
+
+    let response: Response;
+
+    try {
+      response = await fetch(
+        `/api/workflows/${currentWorkflowId}/validate`
+      );
+    } catch {
+      toast.error("Could not validate the workflow before running it");
+      return;
+    }
+
+    if (!response.ok) {
+      toast.error("Could not validate the workflow before running it");
+      return;
+    }
+
+    const payload = (await response.json()) as {
+      result?: WorkflowValidationResult;
+    };
+
+    if (!payload.result) {
+      toast.error("Workflow validation returned an unexpected response");
+      return;
+    }
+
+    const validationErrors = mapWorkflowValidationIssues(
+      payload.result.errors,
+      nodes
+    );
+    const validationWarnings = mapWorkflowValidationIssues(
+      payload.result.warnings,
+      nodes
+    );
+
+    if (
+      validationErrors.length > 0 ||
+      validationWarnings.length > 0
+    ) {
+      openOverlay(WorkflowIssuesOverlay, {
+        issues: {
+          brokenReferences: [],
+          missingRequiredFields: [],
+          missingIntegrations: [],
+          validationErrors,
+          validationWarnings,
+        },
+        onGoToStep: handleGoToStep,
+        onRunAnyway:
+          validationErrors.length === 0
+            ? startWorkflowExecution
+            : undefined,
+      });
+      return;
+    }
+
+    await startWorkflowExecution();
   };
 
   const handleCancel = async (): Promise<void> => {

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -51,10 +51,7 @@ import { integrationsAtom } from "@/lib/integrations-store";
 import type { IntegrationType } from "@/lib/types/integration";
 import { cn } from "@/lib/utils";
 import { evaluateShowWhen, type ShowWhen } from "@/lib/workflow/editor/show-when";
-import {
-  mapWorkflowValidationIssues,
-  type WorkflowValidationResult,
-} from "@/lib/workflow/editor/run-validation";
+import { runWorkflowValidationPreflight } from "@/lib/workflow/editor/run-validation";
 import { ensureSavedBeforeRun } from "@/lib/workflow/run-preflight";
 import {
   addNodeAtom,
@@ -676,62 +673,29 @@ function useWorkflowHandlers({
       return;
     }
 
-    let response: Response;
-
-    try {
-      response = await fetch(
-        `/api/workflows/${currentWorkflowId}/validate`
-      );
-    } catch {
-      toast.error("Could not validate the workflow before running it");
-      return;
-    }
-
-    if (!response.ok) {
-      toast.error("Could not validate the workflow before running it");
-      return;
-    }
-
-    const payload = (await response.json()) as {
-      result?: WorkflowValidationResult;
-    };
-
-    if (!payload.result) {
-      toast.error("Workflow validation returned an unexpected response");
-      return;
-    }
-
-    const validationErrors = mapWorkflowValidationIssues(
-      payload.result.errors,
-      nodes
-    );
-    const validationWarnings = mapWorkflowValidationIssues(
-      payload.result.warnings,
-      nodes
-    );
-
-    if (
-      validationErrors.length > 0 ||
-      validationWarnings.length > 0
-    ) {
-      openOverlay(WorkflowIssuesOverlay, {
-        issues: {
-          brokenReferences: [],
-          missingRequiredFields: [],
-          missingIntegrations: [],
-          validationErrors,
-          validationWarnings,
-        },
-        onGoToStep: handleGoToStep,
-        onRunAnyway:
-          validationErrors.length === 0
-            ? startWorkflowExecution
-            : undefined,
-      });
-      return;
-    }
-
-    await startWorkflowExecution();
+    await runWorkflowValidationPreflight({
+      workflowId: currentWorkflowId,
+      nodes,
+      onOpenIssues: ({
+        validationErrors,
+        validationWarnings,
+        onRunAnyway,
+      }) => {
+        openOverlay(WorkflowIssuesOverlay, {
+          issues: {
+            brokenReferences: [],
+            missingRequiredFields: [],
+            missingIntegrations: [],
+            validationErrors,
+            validationWarnings,
+          },
+          onGoToStep: handleGoToStep,
+          onRunAnyway,
+        });
+      },
+      onStartWorkflowExecution: startWorkflowExecution,
+      onError: (message) => toast.error(message),
+    });
   };
 
   const handleCancel = async (): Promise<void> => {

--- a/lib/workflow/editor/run-validation.ts
+++ b/lib/workflow/editor/run-validation.ts
@@ -1,0 +1,54 @@
+export type WorkflowValidationIssue = {
+  code: string;
+  message: string;
+  parameterPath: string;
+  nodeId?: string;
+  fieldKey?: string;
+};
+
+export type WorkflowValidationResult = {
+  valid: boolean;
+  nodeCount: number;
+  errors?: WorkflowValidationIssue[];
+  warnings?: WorkflowValidationIssue[];
+};
+
+type NodeLike = {
+  id?: unknown;
+};
+
+const NODE_PARAMETER_PATH =
+  /^nodes\[(\d+)\](?:\.data)?(?:\.config(?:\.([^.[\]]+))?)?/;
+
+/**
+ * Adds editor navigation targets to server-side validation issues when their
+ * parameter paths identify a specific workflow node.
+ */
+export function mapWorkflowValidationIssues(
+  issues: WorkflowValidationIssue[] | undefined,
+  nodes: NodeLike[]
+): WorkflowValidationIssue[] {
+  if (!issues) {
+    return [];
+  }
+
+  return issues.map((issue) => {
+    const match = NODE_PARAMETER_PATH.exec(issue.parameterPath);
+    if (!match) {
+      return issue;
+    }
+
+    const nodeIndex = Number(match[1]);
+    const node = nodes[nodeIndex];
+
+    if (!node || typeof node.id !== "string") {
+      return issue;
+    }
+
+    return {
+      ...issue,
+      nodeId: node.id,
+      fieldKey: match[2],
+    };
+  });
+}

--- a/lib/workflow/editor/run-validation.ts
+++ b/lib/workflow/editor/run-validation.ts
@@ -13,20 +13,37 @@ export type WorkflowValidationResult = {
   warnings?: WorkflowValidationIssue[];
 };
 
-type NodeLike = {
+export type WorkflowValidationNode = {
   id?: unknown;
+};
+
+export type WorkflowValidationOverlayIssues = {
+  validationErrors: WorkflowValidationIssue[];
+  validationWarnings: WorkflowValidationIssue[];
+  onRunAnyway?: () => void | Promise<void>;
+};
+
+type WorkflowValidationFetcher = (url: string) => Promise<Response>;
+
+type RunWorkflowValidationPreflightParams = {
+  workflowId: string;
+  nodes: WorkflowValidationNode[];
+  fetcher?: WorkflowValidationFetcher;
+  onOpenIssues: (issues: WorkflowValidationOverlayIssues) => void;
+  onStartWorkflowExecution: () => void | Promise<void>;
+  onError: (message: string) => void;
 };
 
 const NODE_PARAMETER_PATH =
   /^nodes\[(\d+)\](?:\.data)?(?:\.config(?:\.([^.[\]]+))?)?/;
 
 /**
- * Adds editor navigation targets to server-side validation issues when their
+ * Adds editor navigation targets to server validation issues when their
  * parameter paths identify a specific workflow node.
  */
 export function mapWorkflowValidationIssues(
   issues: WorkflowValidationIssue[] | undefined,
-  nodes: NodeLike[]
+  nodes: WorkflowValidationNode[]
 ): WorkflowValidationIssue[] {
   if (!issues) {
     return [];
@@ -51,4 +68,61 @@ export function mapWorkflowValidationIssues(
       fieldKey: match[2],
     };
   });
+}
+
+/**
+ * Runs server validation and decides whether execution is blocked, can be
+ * overridden, or should start immediately.
+ */
+export async function runWorkflowValidationPreflight({
+  workflowId,
+  nodes,
+  fetcher = fetch,
+  onOpenIssues,
+  onStartWorkflowExecution,
+  onError,
+}: RunWorkflowValidationPreflightParams): Promise<void> {
+  let response: Response;
+
+  try {
+    response = await fetcher(`/api/workflows/${workflowId}/validate`);
+  } catch {
+    onError("Could not validate the workflow before running it");
+    return;
+  }
+
+  if (!response.ok) {
+    onError("Could not validate the workflow before running it");
+    return;
+  }
+
+  const payload = (await response.json().catch(() => null)) as {
+    result?: WorkflowValidationResult;
+  } | null;
+
+  if (!payload?.result) {
+    onError("Workflow validation returned an unexpected response");
+    return;
+  }
+
+  const validationErrors = mapWorkflowValidationIssues(
+    payload.result.errors,
+    nodes
+  );
+  const validationWarnings = mapWorkflowValidationIssues(
+    payload.result.warnings,
+    nodes
+  );
+
+  if (validationErrors.length > 0 || validationWarnings.length > 0) {
+    onOpenIssues({
+      validationErrors,
+      validationWarnings,
+      onRunAnyway:
+        validationErrors.length === 0 ? onStartWorkflowExecution : undefined,
+    });
+    return;
+  }
+
+  await onStartWorkflowExecution();
 }

--- a/tests/unit/workflow-run-validation.test.ts
+++ b/tests/unit/workflow-run-validation.test.ts
@@ -1,10 +1,26 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   mapWorkflowValidationIssues,
+  runWorkflowValidationPreflight,
   type WorkflowValidationIssue,
+  type WorkflowValidationOverlayIssues,
 } from "@/lib/workflow/editor/run-validation";
 
 const nodes = [{ id: "trigger-1" }, { id: "action-1" }];
+
+function createJsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+function createInvalidJsonResponse(): Response {
+  return {
+    ok: true,
+    json: vi.fn().mockRejectedValue(new SyntaxError("Invalid JSON")),
+  } as unknown as Response;
+}
 
 describe("mapWorkflowValidationIssues", () => {
   it("maps a node config path to its editor node and field", () => {
@@ -52,5 +68,182 @@ describe("mapWorkflowValidationIssues", () => {
 
   it("returns an empty array when the API omits the issues key", () => {
     expect(mapWorkflowValidationIssues(undefined, nodes)).toEqual([]);
+  });
+});
+
+describe("runWorkflowValidationPreflight", () => {
+  it("blocks execution and removes Run Anyway when errors are returned", async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      createJsonResponse({
+        result: {
+          valid: false,
+          nodeCount: 2,
+          errors: [
+            {
+              code: "invalid-address",
+              message: '"0x1234" is not a valid EVM address',
+              parameterPath: "nodes[1].config.contractAddress",
+            },
+          ],
+        },
+      })
+    );
+
+    const onOpenIssues = vi.fn();
+    const onStartWorkflowExecution = vi.fn();
+    const onError = vi.fn();
+
+    await runWorkflowValidationPreflight({
+      workflowId: "workflow-1",
+      nodes,
+      fetcher,
+      onOpenIssues,
+      onStartWorkflowExecution,
+      onError,
+    });
+
+    expect(fetcher).toHaveBeenCalledWith("/api/workflows/workflow-1/validate");
+
+    expect(onOpenIssues).toHaveBeenCalledWith({
+      validationErrors: [
+        expect.objectContaining({
+          code: "invalid-address",
+          nodeId: "action-1",
+          fieldKey: "contractAddress",
+        }),
+      ],
+      validationWarnings: [],
+      onRunAnyway: undefined,
+    });
+
+    expect(onStartWorkflowExecution).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("offers Run Anyway when only warnings are returned", async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      createJsonResponse({
+        result: {
+          valid: true,
+          nodeCount: 2,
+          warnings: [
+            {
+              code: "allowance-warning",
+              message: "Allowance may be insufficient",
+              parameterPath: "nodes[1].config.amount",
+            },
+          ],
+        },
+      })
+    );
+
+    const onOpenIssues = vi.fn();
+    const onStartWorkflowExecution = vi.fn();
+    const onError = vi.fn();
+
+    await runWorkflowValidationPreflight({
+      workflowId: "workflow-1",
+      nodes,
+      fetcher,
+      onOpenIssues,
+      onStartWorkflowExecution,
+      onError,
+    });
+
+    expect(onOpenIssues).toHaveBeenCalledTimes(1);
+    expect(onStartWorkflowExecution).not.toHaveBeenCalled();
+
+    const overlayIssues = onOpenIssues.mock
+      .calls[0]?.[0] as WorkflowValidationOverlayIssues;
+
+    expect(overlayIssues.validationErrors).toEqual([]);
+    expect(overlayIssues.validationWarnings).toEqual([
+      expect.objectContaining({
+        code: "allowance-warning",
+        nodeId: "action-1",
+        fieldKey: "amount",
+      }),
+    ]);
+    expect(overlayIssues.onRunAnyway).toEqual(expect.any(Function));
+
+    await overlayIssues.onRunAnyway?.();
+
+    expect(onStartWorkflowExecution).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("starts execution immediately when validation is clean", async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      createJsonResponse({
+        result: {
+          valid: true,
+          nodeCount: 2,
+        },
+      })
+    );
+
+    const onOpenIssues = vi.fn();
+    const onStartWorkflowExecution = vi.fn();
+    const onError = vi.fn();
+
+    await runWorkflowValidationPreflight({
+      workflowId: "workflow-1",
+      nodes,
+      fetcher,
+      onOpenIssues,
+      onStartWorkflowExecution,
+      onError,
+    });
+
+    expect(onOpenIssues).not.toHaveBeenCalled();
+    expect(onStartWorkflowExecution).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("reports an unexpected response when the body is not JSON", async () => {
+    const fetcher = vi.fn().mockResolvedValue(createInvalidJsonResponse());
+    const onOpenIssues = vi.fn();
+    const onStartWorkflowExecution = vi.fn();
+    const onError = vi.fn();
+
+    await runWorkflowValidationPreflight({
+      workflowId: "workflow-1",
+      nodes,
+      fetcher,
+      onOpenIssues,
+      onStartWorkflowExecution,
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledWith(
+      "Workflow validation returned an unexpected response"
+    );
+    expect(onOpenIssues).not.toHaveBeenCalled();
+    expect(onStartWorkflowExecution).not.toHaveBeenCalled();
+  });
+
+  it("reports a validation failure when the endpoint is not successful", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue(createJsonResponse({ error: "Failed" }, false));
+
+    const onOpenIssues = vi.fn();
+    const onStartWorkflowExecution = vi.fn();
+    const onError = vi.fn();
+
+    await runWorkflowValidationPreflight({
+      workflowId: "workflow-1",
+      nodes,
+      fetcher,
+      onOpenIssues,
+      onStartWorkflowExecution,
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledWith(
+      "Could not validate the workflow before running it"
+    );
+    expect(onOpenIssues).not.toHaveBeenCalled();
+    expect(onStartWorkflowExecution).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/workflow-run-validation.test.ts
+++ b/tests/unit/workflow-run-validation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  mapWorkflowValidationIssues,
+  type WorkflowValidationIssue,
+} from "@/lib/workflow/editor/run-validation";
+
+const nodes = [{ id: "trigger-1" }, { id: "action-1" }];
+
+describe("mapWorkflowValidationIssues", () => {
+  it("maps a node config path to its editor node and field", () => {
+    const issues: WorkflowValidationIssue[] = [
+      {
+        code: "invalid-token-address",
+        message: "Invalid contract address",
+        parameterPath: "nodes[1].config.contractAddress",
+      },
+    ];
+
+    expect(mapWorkflowValidationIssues(issues, nodes)).toEqual([
+      {
+        ...issues[0],
+        nodeId: "action-1",
+        fieldKey: "contractAddress",
+      },
+    ]);
+  });
+
+  it("maps nested config paths to the top-level editor field", () => {
+    const issues: WorkflowValidationIssue[] = [
+      {
+        code: "invalid-token-address",
+        message: "Invalid custom token address",
+        parameterPath: "nodes[1].config.tokenConfig.customToken.address",
+      },
+    ];
+
+    expect(mapWorkflowValidationIssues(issues, nodes)[0]).toMatchObject({
+      nodeId: "action-1",
+      fieldKey: "tokenConfig",
+    });
+  });
+
+  it("leaves workflow-level issues without navigation targets", () => {
+    const issue: WorkflowValidationIssue = {
+      code: "empty-nodes-array",
+      message: "Workflow has no nodes",
+      parameterPath: "nodes",
+    };
+
+    expect(mapWorkflowValidationIssues([issue], nodes)).toEqual([issue]);
+  });
+
+  it("returns an empty array when the API omits the issues key", () => {
+    expect(mapWorkflowValidationIssues(undefined, nodes)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces results from the existing workflow validator in the run preflight.

- Flushes pending workflow changes before validation
- Blocks execution when validation errors are found
- Displays validation messages and parameter paths
- Adds a **Fix** action that navigates to the affected node and field
- Keeps warnings non-blocking with **Run Anyway**
- Preserves the existing local preflight checks

## Testing

- Added unit coverage for mapping validator paths to editor fields
- Verified that an invalid contract address is blocked before execution
- Verified that a valid workflow passes preflight and starts a run

## Screenshot

<img width="1314" height="827" alt="Screenshot 2026-07-29 at 23 31 19" src="https://github.com/user-attachments/assets/49d4e8d3-c6d5-4e81-a2ef-6987f1cdef8e" />
