### PR TITLE
feat(mcp): expose the simulate dry-run flag on the execute tools

### DIFF
--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -232,6 +232,18 @@ const IDEMPOTENCY_KEY_ARG = z
     "Optional Idempotency-Key (e.g. an agent-side transaction id). Retrying with the same key and arguments returns the original result instead of executing again, within a 24h window. Reusing a key with different arguments returns a 409 conflict."
   );
 
+// Optional dry-run flag shared by the direct-execution tools. Forwarded to the
+// REST layer as `simulate`, which runs the call against current chain state
+// without signing or broadcasting. Must be a real boolean: parseSimulateFlag
+// in app/api/execute/_lib/simulate-flag.ts rejects strings and numbers rather
+// than risk coercing a mistyped "false" into a live broadcast.
+const SIMULATE_ARG = z
+  .boolean()
+  .optional()
+  .describe(
+    "When true, dry-run the call instead of broadcasting it: returns the gas the network would charge and the decoded revert reason if it would fail. Nothing is signed and no transaction is sent. Must be a boolean (true/false), not a string. Defaults to false."
+  );
+
 async function callApi(
   internalApiBaseUrl: string,
   authHeader: string,
@@ -1031,6 +1043,7 @@ export function registerTools(
         .describe(
           "ERC20 token contract address. Omit for native token transfers."
         ),
+      simulate: SIMULATE_ARG,
       idempotency_key: IDEMPOTENCY_KEY_ARG,
     },
     { title: "Transfer Funds", readOnlyHint: false, destructiveHint: true },
@@ -1046,6 +1059,7 @@ export function registerTools(
             recipientAddress: args.to_address,
             amount: args.amount,
             tokenAddress: args.token_address,
+            simulate: args.simulate,
           },
           args.idempotency_key
         );
@@ -1093,6 +1107,7 @@ export function registerTools(
         .describe(
           "Explicit maxPriorityFeePerGas in gwei (e.g., '2'). Bypasses the chain's default min/max priority-fee clamp. Use when the network's mempool requires a tip above the configured floor."
         ),
+      simulate: SIMULATE_ARG,
       idempotency_key: IDEMPOTENCY_KEY_ARG,
     },
     { title: "Contract Call", readOnlyHint: false, destructiveHint: false },
@@ -1112,6 +1127,7 @@ export function registerTools(
             value: args.value,
             gasLimitMultiplier: args.gas_limit_multiplier,
             priorityFeeGwei: args.priority_fee_gwei,
+            simulate: args.simulate,
           },
           args.idempotency_key
         );
@@ -1164,6 +1180,7 @@ export function registerTools(
           .optional()
           .describe("Gas limit multiplier for the action"),
       }),
+      simulate: SIMULATE_ARG,
       idempotency_key: IDEMPOTENCY_KEY_ARG,
     },
     { title: "Check and Execute", readOnlyHint: false, destructiveHint: true },
@@ -1188,6 +1205,7 @@ export function registerTools(
               abi: args.action.abi,
               gasLimitMultiplier: args.action.gas_limit_multiplier,
             },
+            simulate: args.simulate,
           },
           args.idempotency_key
         );

--- a/tests/unit/mcp-execute-simulate.test.ts
+++ b/tests/unit/mcp-execute-simulate.test.ts
@@ -1,0 +1,246 @@
+/**
+ * The direct-execution REST routes accept a `simulate` dry-run flag (parsed by
+ * app/api/execute/_lib/simulate-flag.ts), but the MCP tools never exposed it,
+ * so an agent driving KeeperHub over MCP had no way to check a call before
+ * broadcasting it.
+ *
+ * `simulate` is deliberately typed as a real boolean rather than the string
+ * encoding the other scalars use: parseSimulateFlag rejects strings and numbers
+ * outright so a mistyped "false" can never fall through to a live broadcast.
+ *
+ * Coverage mirrors mcp-execute-field-naming.test.ts:
+ *   - Handler level: the flag is in each schema and reaches the route body,
+ *     and is omitted (not sent as null) when the caller leaves it out.
+ *   - SDK level: a real Client <-> McpServer pair over an in-memory transport,
+ *     so the MCP SDK's own Zod validation accepts a boolean and rejects the
+ *     string form before the handler runs.
+ */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import { registerTools } from "@/lib/mcp/tools";
+
+type RegisteredTool = {
+  name: string;
+  schema: Record<string, unknown>;
+  handler: (...args: unknown[]) => unknown;
+};
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+const VALIDATION_ERROR_PATTERN = /required|Invalid arguments|validation/i;
+
+const EXECUTE_TOOLS = [
+  "execute_transfer",
+  "execute_contract_call",
+  "execute_check_and_execute",
+] as const;
+
+let fetchMock: FetchMock;
+
+function jsonOkResponse(body: Record<string, unknown>): unknown {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: { get: () => "application/json" },
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(""),
+  };
+}
+
+function lastBody(): Record<string, unknown> {
+  const call = fetchMock.mock.calls.at(-1);
+  if (!call) {
+    throw new Error("fetch was not called");
+  }
+  const init = call[1] as { body: string };
+  return JSON.parse(init.body) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn(() =>
+    Promise.resolve(jsonOkResponse({ simulated: true, gasEstimate: "21000" }))
+  );
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Handler level
+// ---------------------------------------------------------------------------
+
+function makeMockServer(): {
+  server: McpServer;
+  registeredTools: RegisteredTool[];
+} {
+  const registeredTools: RegisteredTool[] = [];
+  const server = {
+    tool: vi.fn(
+      (
+        name: string,
+        _description: string,
+        schema: Record<string, unknown>,
+        _annotations: unknown,
+        handler: (...args: unknown[]) => unknown
+      ) => {
+        registeredTools.push({ name, schema, handler });
+      }
+    ),
+  } as unknown as McpServer;
+  return { server, registeredTools };
+}
+
+function getTool(name: string): RegisteredTool {
+  const { server, registeredTools } = makeMockServer();
+  registerTools(server, "http://internal", "Bearer test", SCOPE_MCP_WRITE);
+  const tool = registeredTools.find((t) => t.name === name);
+  if (!tool) {
+    throw new Error(`tool ${name} not registered`);
+  }
+  return tool;
+}
+
+const MINIMAL_ARGS: Record<string, Record<string, unknown>> = {
+  execute_transfer: {
+    chain_id: "8453",
+    to_address: "0xabc",
+    amount: "0.1",
+  },
+  execute_contract_call: {
+    contract_address: "0xc",
+    chain_id: "11155111",
+    function_name: "foo",
+  },
+  execute_check_and_execute: {
+    contract_address: "0xc",
+    chain_id: "42161",
+    function_name: "baz",
+    condition: { operator: "gt", value: "1000" },
+    action: { contract_address: "0xa", function_name: "bar" },
+  },
+};
+
+describe("MCP execute tools expose the simulate dry-run flag", () => {
+  it.each(EXECUTE_TOOLS)("%s schema declares simulate", (name) => {
+    expect(Object.keys(getTool(name).schema)).toContain("simulate");
+  });
+
+  it.each(EXECUTE_TOOLS)(
+    "%s forwards simulate: true to the route body",
+    async (name) => {
+      await getTool(name).handler({ ...MINIMAL_ARGS[name], simulate: true });
+      expect(lastBody().simulate).toBe(true);
+    }
+  );
+
+  it.each(EXECUTE_TOOLS)(
+    "%s forwards simulate: false explicitly when the caller opts out",
+    async (name) => {
+      await getTool(name).handler({ ...MINIMAL_ARGS[name], simulate: false });
+      expect(lastBody().simulate).toBe(false);
+    }
+  );
+
+  it.each(EXECUTE_TOOLS)(
+    "%s omits simulate when the caller leaves it out, so the route default applies",
+    async (name) => {
+      await getTool(name).handler({ ...MINIMAL_ARGS[name] });
+      expect(lastBody().simulate).toBeUndefined();
+    }
+  );
+
+  it("execute_check_and_execute keeps simulate at the top level, not inside action", async () => {
+    await getTool("execute_check_and_execute").handler({
+      ...MINIMAL_ARGS.execute_check_and_execute,
+      simulate: true,
+    });
+    const body = lastBody();
+    expect(body.simulate).toBe(true);
+    expect(body.action).not.toHaveProperty("simulate");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SDK level - real Client <-> McpServer over an in-memory transport, so the
+// MCP SDK's Zod validation runs the full tools/call path.
+// ---------------------------------------------------------------------------
+
+type ConnectedClient = { client: Client; close: () => Promise<void> };
+
+async function connectedClient(): Promise<ConnectedClient> {
+  const server = new McpServer({ name: "simulate-test", version: "0.0.0" });
+  registerTools(server, "http://internal", "Bearer test", SCOPE_MCP_WRITE);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client({
+    name: "simulate-test-client",
+    version: "0.0.0",
+  });
+
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+
+  return {
+    client,
+    close: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+type ToolCallResult = {
+  isError?: boolean;
+  content?: Array<{ type: string; text?: string }>;
+};
+
+describe("MCP execute tools simulate flag - SDK level", () => {
+  it("accepts a boolean simulate through SDK validation", async () => {
+    const { client, close } = await connectedClient();
+    try {
+      const result = (await client.callTool({
+        name: "execute_contract_call",
+        arguments: {
+          ...MINIMAL_ARGS.execute_contract_call,
+          simulate: true,
+        },
+      })) as ToolCallResult;
+
+      expect(result.isError).toBeFalsy();
+      expect(lastBody().simulate).toBe(true);
+    } finally {
+      await close();
+    }
+  });
+
+  it("rejects the string form before the handler runs, so no request is sent", async () => {
+    const { client, close } = await connectedClient();
+    try {
+      const result = (await client.callTool({
+        name: "execute_contract_call",
+        // parseSimulateFlag would 400 on this anyway; failing at the schema
+        // keeps the round trip off the wire entirely.
+        arguments: {
+          ...MINIMAL_ARGS.execute_contract_call,
+          simulate: "true",
+        },
+      })) as ToolCallResult;
+
+      expect(result.isError).toBe(true);
+      expect(result.content?.[0]?.text ?? "").toMatch(VALIDATION_ERROR_PATTERN);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      await close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The direct-execution routes already support a `simulate` dry-run: `parseSimulateFlag` in `app/api/execute/_lib/simulate-flag.ts` is read by `/api/execute/transfer`, `/contract-call` and `/check-and-execute`, and `lib/execute/simulate.ts` runs the call against current chain state to return the gas the network would charge plus the decoded revert reason, without signing or broadcasting.

The MCP tools never forwarded it. `grep -n simulate lib/mcp/tools.ts` returned nothing before this change, so an agent driving KeeperHub over MCP had no way to check a call before sending it -- the only way to find out whether a contract call would revert was to broadcast it. That is the one capability an autonomous caller most wants before spending gas, and it was already implemented one layer down.

This forwards the existing flag. No route, executor or simulator behaviour changes.

## Changes

- Add a shared `SIMULATE_ARG` next to `IDEMPOTENCY_KEY_ARG` and attach it to `execute_transfer`, `execute_contract_call` and `execute_check_and_execute`.
- Forward `simulate` into each route body. Omitting it sends nothing, so the existing broadcast default is preserved.
- On `execute_check_and_execute` the flag sits at the top level rather than inside `action`, matching the route contract.

## Why boolean and not string

The other scalars on these tools are strings, so a string would have been the consistent-looking choice. `parseSimulateFlag` deliberately rejects strings and numbers instead of coercing them, on the grounds that an execute endpoint should not silently fall through to spending real funds because a caller typed `"false"`. Declaring the arg as `z.boolean()` puts that same rule in the tool schema, so a bad value is rejected by schema validation before the request leaves the MCP server rather than coming back as a 400 from the route.

## Tests

`tests/unit/mcp-execute-simulate.test.ts`, mirroring the two-layer structure of the existing `mcp-execute-field-naming.test.ts`:

- Handler level: the flag is present in all three schemas, `true` and `false` both reach the route body, omitting it leaves `simulate` undefined so the route default applies, and on check-and-execute it does not leak into `action`.
- SDK level: a real `Client` and `McpServer` over an in-memory transport, so the MCP SDK's own Zod validation runs. A boolean is accepted; the string `"true"` is rejected before the handler runs and no request is made.

15 tests, and `mcp-execute-field-naming.test.ts` still passes.

## Verification

- `npx vitest run tests/unit/mcp-execute-simulate.test.ts tests/unit/mcp-execute-field-naming.test.ts` -- 22 passed.
- `npx ultracite check lib/mcp/tools.ts tests/unit/mcp-execute-simulate.test.ts` -- clean.
- `npx tsc --noEmit` -- introduces no new errors. Four pre-existing errors remain on `staging` for `@/lib/step-registry` and `@/lib/credential-map`, both generated by `pnpm discover-plugins`; they are present with this branch stashed and are untouched by this change.

Docs were left alone: `docs/ai-tools/mcp-server.md` documents the tool list rather than per-tool parameters, so there is no parameter table to keep in sync. Happy to add a dry-run note there, or to `docs/api/direct-execution.md`, if you would like it documented for callers.
