### PR TITLE
feat(mcp): expose safe direct-execution simulation

### DIFF
--- a/docs/ai-tools/mcp-server.md
+++ b/docs/ai-tools/mcp-server.md
@@ -169,10 +169,11 @@ The server registers more than 30 tools. Call `tools_documentation` (or `list_ac
 
 All three direct execution tools accept an optional `simulate` boolean. Set it
 to `true` first to estimate gas and catch a revert without signing or
-broadcasting. If the result has `success: true` and `wouldRevert: false`, repeat
-the tool call with the same transaction arguments, omit `simulate`, and add a
-unique `idempotency_key`. Then poll `get_direct_execution_status` until it
-returns `completed` or `failed`.
+broadcasting. If the successful tool result has `success: true` and
+`wouldRevert: false`, repeat the tool call with the same transaction arguments,
+omit `simulate`, and add a unique `idempotency_key`. Then poll
+`get_direct_execution_status` with bounded backoff until it returns `completed`
+or `failed`.
 
 For example, preflight a Base Sepolia transfer:
 
@@ -186,9 +187,17 @@ For example, preflight a Base Sepolia transfer:
 ```
 
 `simulate` must be the JSON boolean `true`, not the string `"true"`. A
-simulation never returns a transaction hash because nothing is broadcast.
-See [Direct Execution](/api/direct-execution) for response shapes, retry
-semantics, and the authoritative safe first-write sequence.
+simulation never returns a transaction hash because nothing is broadcast. A
+revert or invalid simulation is surfaced as an MCP tool error; the error text
+includes the REST error JSON when available. Treat any tool error as a hard
+stop. View/pure calls and a check whose condition is false return their normal
+read/no-action result instead of a simulation envelope.
+
+Simulation is currently EVM-only. Solana transfers on chain IDs `101` and
+`103` can still broadcast through `execute_transfer`, but the MCP tool rejects
+`simulate: true` for those IDs and their aliases before making an API call. See
+[Direct Execution](/api/direct-execution) for response shapes, retry semantics,
+and the authoritative safe first-write sequence.
 
 ### Protocol Actions (DeFi)
 

--- a/docs/ai-tools/mcp-server.md
+++ b/docs/ai-tools/mcp-server.md
@@ -165,6 +165,31 @@ The server registers more than 30 tools. Call `tools_documentation` (or `list_ac
 | `execute_check_and_execute` | Read a contract value, evaluate a condition, and execute an action if it is met. |
 | `get_direct_execution_status` | Get the status of a direct execution (transfer or contract call), including the transaction hash and result. |
 
+### Safely preflight direct writes
+
+All three direct execution tools accept an optional `simulate` boolean. Set it
+to `true` first to estimate gas and catch a revert without signing or
+broadcasting. If the result has `success: true` and `wouldRevert: false`, repeat
+the tool call with the same transaction arguments, omit `simulate`, and add a
+unique `idempotency_key`. Then poll `get_direct_execution_status` until it
+returns `completed` or `failed`.
+
+For example, preflight a Base Sepolia transfer:
+
+```json
+{
+  "chain_id": "84532",
+  "to_address": "0xRecipient",
+  "amount": "0.01",
+  "simulate": true
+}
+```
+
+`simulate` must be the JSON boolean `true`, not the string `"true"`. A
+simulation never returns a transaction hash because nothing is broadcast.
+See [Direct Execution](/api/direct-execution) for response shapes, retry
+semantics, and the authoritative safe first-write sequence.
+
 ### Protocol Actions (DeFi)
 
 | Tool | Description |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -99,3 +99,35 @@ Rate-limited requests return `429` with a `Retry-After` header. See
 The Code action runs untrusted JavaScript in an isolated `node:vm` sandbox with
 outbound SSRF protection. See [Code Plugin](/plugins/code) for what is allowed
 and blocked.
+
+## 6. Send your first transaction safely
+
+The MCP direct execution tools let an agent preflight and broadcast without
+switching to a separate API client. Start with a testnet wallet funded from the
+faucets above, then use this sequence:
+
+1. Call `execute_transfer` with `simulate: true`.
+2. Continue only when the result has `success: true` and
+   `wouldRevert: false`.
+3. Repeat the same call with `simulate` omitted and a new
+   `idempotency_key`.
+4. Pass the returned `executionId` to `get_direct_execution_status` and poll
+   until the status is `completed` or `failed`.
+5. Save `transactionLink` from the terminal response as the onchain proof.
+
+Example simulation on Base Sepolia:
+
+```json
+{
+  "chain_id": "84532",
+  "to_address": "0xRecipient",
+  "amount": "0.01",
+  "simulate": true
+}
+```
+
+For an ERC-20 transfer, also pass the token's contract address as
+`token_address`. The Base Sepolia USDC address is listed in the table above.
+See [MCP Server](/ai-tools/mcp-server#safely-preflight-direct-writes) for the
+tool flow and [Direct Execution](/api/direct-execution) for complete response
+and error handling details.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -128,6 +128,10 @@ Example simulation on Base Sepolia:
 
 For an ERC-20 transfer, also pass the token's contract address as
 `token_address`. The Base Sepolia USDC address is listed in the table above.
+Any MCP tool error is a failed preflight and must stop the flow; revert details
+include the REST error JSON when available. Simulation is currently EVM-only,
+so `execute_transfer` rejects `simulate: true` for Solana chain IDs `101` and
+`103` and their aliases before making an API call.
 See [MCP Server](/ai-tools/mcp-server#safely-preflight-direct-writes) for the
 tool flow and [Direct Execution](/api/direct-execution) for complete response
 and error handling details.

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -255,7 +255,16 @@ function assertSimulationSupported(chainId: string, simulate?: boolean): void {
     return;
   }
 
-  const normalizedChainId = getChainIdFromNetwork(chainId);
+  let normalizedChainId: number;
+  try {
+    normalizedChainId = getChainIdFromNetwork(chainId);
+  } catch {
+    // Keep network validation in the REST layer for identifiers that this
+    // compatibility helper does not know yet. The simulation route remains
+    // fail-closed (it returns before any broadcast), while future chains can
+    // be added there without requiring an MCP-only allowlist update first.
+    return;
+  }
   if (SOLANA_DIRECT_EXECUTION_CHAIN_IDS.has(normalizedChainId)) {
     throw new Error(
       `Direct-execution simulation is currently EVM-only; Solana chain ${normalizedChainId} cannot be simulated. Do not broadcast unless you can preflight the transaction through a Solana-aware client.`

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -232,6 +232,56 @@ const IDEMPOTENCY_KEY_ARG = z
     "Optional Idempotency-Key (e.g. an agent-side transaction id). Retrying with the same key and arguments returns the original result instead of executing again, within a 24h window. Reusing a key with different arguments returns a 409 conflict."
   );
 
+/**
+ * #1841: the execution tools carry their numeric arguments as strings, which is
+ * right on the wire - chain ids and wei-scale values outlive Number's exact
+ * integer range, and `function_args` is a JSON array that has itself been
+ * stringified. It is not, however, what a client emits on its first attempt.
+ *
+ * The gap is not a documentation one. The schema already publishes
+ * `"type": "string"` on every one of these fields, so the report's first
+ * suggestion is satisfied today. The problem is that a rejection is all a
+ * builder gets for a guess the schema could simply have accepted, and the
+ * guesses arrive one at a time: fix `chain_id`, hit `function_args`, fix that,
+ * hit `gas_limit_multiplier`. Three round trips on the first call anyone makes
+ * after the handshake, at the point where they are least sure whether the
+ * problem is their encoding, their key, or their wallet.
+ *
+ * So take the guess. A number where a decimal string is wanted is unambiguous,
+ * and an array where its JSON encoding is wanted is unambiguous. Both are
+ * normalised here, before the handler, so nothing downstream sees a new shape.
+ *
+ * The advertised type deliberately stays `string`: the coercion is a fallback
+ * for the natural first guess, not a second supported encoding, and clients
+ * that already read the schema keep generating exactly what they generate now.
+ */
+function looseString(description: string) {
+  return z
+    .preprocess(
+      (value) => (typeof value === "number" ? String(value) : value),
+      z.string()
+    )
+    .describe(description);
+}
+
+/**
+ * Same idea for the fields that want a stringified JSON value: accept the
+ * array or object itself and encode it. `[]` and `{...}` are what a model
+ * writes for something described as "JSON array of function arguments"; the
+ * `"[]"` form is unusual enough that it is rarely the first thing tried.
+ */
+function looseJsonString(description: string) {
+  return z
+    .preprocess(
+      (value) =>
+        typeof value === "object" && value !== null
+          ? JSON.stringify(value)
+          : value,
+      z.string()
+    )
+    .describe(description);
+}
+
 async function callApi(
   internalApiBaseUrl: string,
   authHeader: string,
@@ -1018,13 +1068,13 @@ export function registerTools(
     "execute_transfer",
     "Transfer native tokens (ETH, MATIC) or ERC20 tokens from your wallet to a recipient address. Requires a wallet integration.",
     {
-      chain_id: z
-        .string()
-        .describe("Chain ID (e.g., '1' for Ethereum, '8453' for Base)"),
+      chain_id: looseString(
+        "Chain ID (e.g., '1' for Ethereum, '8453' for Base)"
+      ),
       to_address: z.string().describe("Recipient wallet address (0x...)"),
-      amount: z
-        .string()
-        .describe("Amount to transfer in human-readable units (e.g., '0.1')"),
+      amount: looseString(
+        "Amount to transfer in human-readable units (e.g., '0.1')"
+      ),
       token_address: z
         .string()
         .optional()
@@ -1058,41 +1108,28 @@ export function registerTools(
 
   server.tool(
     "execute_contract_call",
-    "Call a smart contract function. For view/pure functions, returns the result directly. For state-changing functions, submits a transaction and returns the execution ID. Requires a wallet integration for write calls.",
+    'Call a smart contract function. For view/pure functions, returns the result directly. For state-changing functions, submits a transaction and returns the execution ID. Requires a wallet integration for write calls. Full example: {"contract_address": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238", "chain_id": "11155111", "function_name": "transfer", "function_args": "[\\"0xRecipient...\\", \\"1000\\"]"} - note that function_args is a JSON array encoded as a string.',
     {
       contract_address: z.string().describe("Contract address (0x...)"),
-      chain_id: z.string().describe("Chain ID (e.g., '1' for Ethereum)"),
+      chain_id: looseString("Chain ID (e.g., '1' for Ethereum)"),
       function_name: z
         .string()
         .describe("Solidity function name (e.g., 'balanceOf', 'transfer')"),
-      function_args: z
-        .string()
-        .optional()
-        .describe(
-          'JSON array of function arguments (e.g., \'["0x...", "1000"]\')'
-        ),
-      abi: z
-        .string()
-        .optional()
-        .describe(
-          "Contract ABI as JSON string. Auto-fetched for verified contracts if omitted."
-        ),
-      value: z
-        .string()
-        .optional()
-        .describe(
-          "Native value to send with the call, as a decimal string in ether units (e.g. '0.1'). For payable functions."
-        ),
-      gas_limit_multiplier: z
-        .string()
-        .optional()
-        .describe("Gas limit multiplier (e.g., '1.5' for 50% buffer)"),
-      priority_fee_gwei: z
-        .string()
-        .optional()
-        .describe(
-          "Explicit maxPriorityFeePerGas in gwei (e.g., '2'). Bypasses the chain's default min/max priority-fee clamp. Use when the network's mempool requires a tip above the configured floor."
-        ),
+      function_args: looseJsonString(
+        'JSON array of function arguments (e.g., \'["0x...", "1000"]\')'
+      ).optional(),
+      abi: looseJsonString(
+        "Contract ABI as JSON string. Auto-fetched for verified contracts if omitted."
+      ).optional(),
+      value: looseString(
+        "Native value to send with the call, as a decimal string in ether units (e.g. '0.1'). For payable functions."
+      ).optional(),
+      gas_limit_multiplier: looseString(
+        "Gas limit multiplier (e.g., '1.5' for 50% buffer)"
+      ).optional(),
+      priority_fee_gwei: looseString(
+        "Explicit maxPriorityFeePerGas in gwei (e.g., '2'). Bypasses the chain's default min/max priority-fee clamp. Use when the network's mempool requires a tip above the configured floor."
+      ).optional(),
       idempotency_key: IDEMPOTENCY_KEY_ARG,
     },
     { title: "Contract Call", readOnlyHint: false, destructiveHint: false },
@@ -1129,23 +1166,21 @@ export function registerTools(
       contract_address: z
         .string()
         .describe("Contract address to read the check value from (0x...)"),
-      chain_id: z.string().describe("Chain ID (e.g., '1' for Ethereum)"),
+      chain_id: looseString("Chain ID (e.g., '1' for Ethereum)"),
       function_name: z
         .string()
         .describe("Function to call for the check (e.g., 'balanceOf')"),
-      function_args: z
-        .string()
-        .optional()
-        .describe("JSON array of function arguments for the check"),
-      abi: z
-        .string()
-        .optional()
-        .describe("ABI for the check contract (auto-fetched if omitted)"),
+      function_args: looseJsonString(
+        "JSON array of function arguments for the check"
+      ).optional(),
+      abi: looseJsonString(
+        "ABI for the check contract (auto-fetched if omitted)"
+      ).optional(),
       condition: z.object({
         operator: z
           .enum(["eq", "neq", "gt", "lt", "gte", "lte"])
           .describe("Comparison operator"),
-        value: z.string().describe("Target value to compare against"),
+        value: looseString("Target value to compare against"),
       }),
       action: z.object({
         contract_address: z
@@ -1154,15 +1189,13 @@ export function registerTools(
         function_name: z
           .string()
           .describe("Function to execute if condition met"),
-        function_args: z
-          .string()
-          .optional()
-          .describe("JSON array of function arguments for the action"),
-        abi: z.string().optional().describe("ABI for the action contract"),
-        gas_limit_multiplier: z
-          .string()
-          .optional()
-          .describe("Gas limit multiplier for the action"),
+        function_args: looseJsonString(
+          "JSON array of function arguments for the action"
+        ).optional(),
+        abi: looseJsonString("ABI for the action contract").optional(),
+        gas_limit_multiplier: looseString(
+          "Gas limit multiplier for the action"
+        ).optional(),
       }),
       idempotency_key: IDEMPOTENCY_KEY_ARG,
     },

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -1,5 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { SUPPORTED_CHAIN_IDS } from "@/lib/rpc/types";
 import { withToolLogging } from "./logging";
 import { getRequiredScopeForTool, isToolAllowed } from "./oauth-scopes";
 
@@ -231,6 +233,35 @@ const IDEMPOTENCY_KEY_ARG = z
   .describe(
     "Optional Idempotency-Key (e.g. an agent-side transaction id). Retrying with the same key and arguments returns the original result instead of executing again, within a 24h window. Reusing a key with different arguments returns a 409 conflict."
   );
+
+// The direct-execution REST routes support a dry-run path that estimates gas
+// and catches reverts without signing or broadcasting. Expose the same safety
+// control to MCP clients so agents do not have to leave the agent-native
+// surface to preflight a write.
+const SIMULATE_ARG = z
+  .boolean()
+  .optional()
+  .describe(
+    "Set to true to simulate an EVM operation without signing or broadcasting. Solana networks (chain IDs 101/103 and their aliases) are not yet supported. Use the same arguments with simulate omitted or false only after a successful simulation."
+  );
+
+const SOLANA_DIRECT_EXECUTION_CHAIN_IDS = new Set([
+  SUPPORTED_CHAIN_IDS.SOLANA_MAINNET,
+  SUPPORTED_CHAIN_IDS.SOLANA_DEVNET,
+]);
+
+function assertSimulationSupported(chainId: string, simulate?: boolean): void {
+  if (!simulate) {
+    return;
+  }
+
+  const normalizedChainId = getChainIdFromNetwork(chainId);
+  if (SOLANA_DIRECT_EXECUTION_CHAIN_IDS.has(normalizedChainId)) {
+    throw new Error(
+      `Direct-execution simulation is currently EVM-only; Solana chain ${normalizedChainId} cannot be simulated. Do not broadcast unless you can preflight the transaction through a Solana-aware client.`
+    );
+  }
+}
 
 /**
  * #1841: these fields take their values as decimal strings, which is right on
@@ -1152,11 +1183,13 @@ export function registerTools(
         .describe(
           "ERC20 token contract address. Omit for native token transfers."
         ),
+      simulate: SIMULATE_ARG,
       idempotency_key: IDEMPOTENCY_KEY_ARG,
     },
     { title: "Transfer Funds", readOnlyHint: false, destructiveHint: true },
     withScopeCheck("execute_transfer", scope, async (args) =>
       withToolLogging("execute_transfer", undefined, async () => {
+        assertSimulationSupported(args.chain_id, args.simulate);
         const data = await callApi(
           internalApiBaseUrl,
           authHeader,
@@ -1167,6 +1200,7 @@ export function registerTools(
             recipientAddress: args.to_address,
             amount: args.amount,
             tokenAddress: args.token_address,
+            simulate: args.simulate,
           },
           args.idempotency_key
         );
@@ -1201,11 +1235,13 @@ export function registerTools(
       priority_fee_gwei: looseString(
         "Explicit maxPriorityFeePerGas in gwei (e.g., '2'). Bypasses the chain's default min/max priority-fee clamp. Use when the network's mempool requires a tip above the configured floor."
       ).optional(),
+      simulate: SIMULATE_ARG,
       idempotency_key: IDEMPOTENCY_KEY_ARG,
     },
     { title: "Contract Call", readOnlyHint: false, destructiveHint: false },
     withScopeCheck("execute_contract_call", scope, async (args) =>
       withToolLogging("execute_contract_call", undefined, async () => {
+        assertSimulationSupported(args.chain_id, args.simulate);
         const data = await callApi(
           internalApiBaseUrl,
           authHeader,
@@ -1220,6 +1256,7 @@ export function registerTools(
             value: args.value,
             gasLimitMultiplier: args.gas_limit_multiplier,
             priorityFeeGwei: args.priority_fee_gwei,
+            simulate: args.simulate,
           },
           args.idempotency_key
         );
@@ -1268,11 +1305,13 @@ export function registerTools(
           "Gas limit multiplier for the action"
         ).optional(),
       }),
+      simulate: SIMULATE_ARG,
       idempotency_key: IDEMPOTENCY_KEY_ARG,
     },
     { title: "Check and Execute", readOnlyHint: false, destructiveHint: true },
     withScopeCheck("execute_check_and_execute", scope, async (args) =>
       withToolLogging("execute_check_and_execute", undefined, async () => {
+        assertSimulationSupported(args.chain_id, args.simulate);
         const data = await callApi(
           internalApiBaseUrl,
           authHeader,
@@ -1292,6 +1331,7 @@ export function registerTools(
               abi: args.action.abi,
               gasLimitMultiplier: args.action.gas_limit_multiplier,
             },
+            simulate: args.simulate,
           },
           args.idempotency_key
         );

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -233,52 +233,123 @@ const IDEMPOTENCY_KEY_ARG = z
   );
 
 /**
- * #1841: the execution tools carry their numeric arguments as strings, which is
- * right on the wire - chain ids and wei-scale values outlive Number's exact
- * integer range, and `function_args` is a JSON array that has itself been
- * stringified. It is not, however, what a client emits on its first attempt.
+ * #1841: these fields take their values as decimal strings, which is right on
+ * the wire - chain ids and wei-scale amounts outlive Number's exact integer
+ * range - but it is not what a client emits on its first attempt. `preprocess`
+ * takes the natural guess and normalises it before the handler; `union` would
+ * emit `anyOf` and change what every existing client generates, so the
+ * published type stays `string` deliberately.
  *
- * The gap is not a documentation one. The schema already publishes
- * `"type": "string"` on every one of these fields, so the report's first
- * suggestion is satisfied today. The problem is that a rejection is all a
- * builder gets for a guess the schema could simply have accepted, and the
- * guesses arrive one at a time: fix `chain_id`, hit `function_args`, fix that,
- * hit `gas_limit_multiplier`. Three round trips on the first call anyone makes
- * after the handshake, at the point where they are least sure whether the
- * problem is their encoding, their key, or their wallet.
- *
- * So take the guess. A number where a decimal string is wanted is unambiguous,
- * and an array where its JSON encoding is wanted is unambiguous. Both are
- * normalised here, before the handler, so nothing downstream sees a new shape.
- *
- * The advertised type deliberately stays `string`: the coercion is a fallback
- * for the natural first guess, not a second supported encoding, and clients
- * that already read the schema keep generating exactly what they generate now.
+ * The guess is only taken when it round-trips losslessly. `String()` is not a
+ * safe encoder across the double range: it drops the low digits of an integer
+ * past 2^53 and emits exponential notation outside a narrow band, and nothing
+ * downstream recovers either - `BigInt("1e+21")` throws, and a transfer amount
+ * that arrives 200 wei short is the wrong amount, on-chain. Those values keep
+ * the rejection they had before, because refusal is what pushes the client to
+ * the string encoding that preserves them. The message now says so.
+ */
+const PRECISION_HINT =
+  "pass this value as a string. A JSON number cannot carry it exactly: integers above 2^53 lose their low digits, and very large or very small values stringify in exponential notation.";
+
+/** Deepest JSON nesting walked before an argument is refused outright. */
+const MAX_JSON_DEPTH = 32;
+
+const EXPONENTIAL_NOTATION = /[eE]/;
+
+/** True when `String(value)` reproduces `value` exactly, as a plain decimal. */
+function isExactAsDecimalString(value: number): boolean {
+  if (!Number.isFinite(value)) {
+    return false;
+  }
+  // Already rounded by the client's own JSON.parse - the digits are gone.
+  if (Number.isInteger(value) && !Number.isSafeInteger(value)) {
+    return false;
+  }
+  return !EXPONENTIAL_NOTATION.test(String(value));
+}
+
+/** Leaves the input untouched when it cannot be encoded, so `z.string()` rejects it. */
+function toDecimalString(value: unknown): unknown {
+  return typeof value === "number" && isExactAsDecimalString(value)
+    ? String(value)
+    : value;
+}
+
+/**
+ * ABI arguments nest - tuples, arrays of structs - so the walk is recursive
+ * rather than shallow, and one unrepresentable number anywhere fails the whole
+ * argument instead of encoding a wrong value into a call that moves funds.
+ */
+function hasInexactNumber(value: unknown, depth = 0): boolean {
+  if (typeof value === "number") {
+    return !isExactAsDecimalString(value);
+  }
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  if (depth >= MAX_JSON_DEPTH) {
+    return true;
+  }
+  const children = Array.isArray(value) ? value : Object.values(value);
+  return children.some((child) => hasInexactNumber(child, depth + 1));
+}
+
+function toJsonString(value: unknown): unknown {
+  if (value === null || typeof value !== "object" || hasInexactNumber(value)) {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return value;
+  }
+}
+
+function precisionError(input: unknown): string | undefined {
+  if (typeof input !== "number") {
+    return;
+  }
+  return Number.isFinite(input)
+    ? PRECISION_HINT
+    : "expected a decimal string; NaN and Infinity are not values.";
+}
+
+/**
+ * `.nonoptional()` is load-bearing, not decoration: a bare `preprocess` accepts
+ * `unknown` as its input, so JSON Schema generation treats the field as
+ * omittable and drops it from the object's `required` list. Runtime validation
+ * is unaffected - a missing value still fails - but the published schema would
+ * stop advertising `chain_id` and `amount` as required, which is exactly the
+ * client-visible change this coercion is supposed to avoid.
  */
 function looseString(description: string) {
   return z
     .preprocess(
-      (value) => (typeof value === "number" ? String(value) : value),
-      z.string()
+      toDecimalString,
+      z.string({ error: (issue) => precisionError(issue.input) })
     )
+    .nonoptional()
     .describe(description);
 }
 
 /**
- * Same idea for the fields that want a stringified JSON value: accept the
- * array or object itself and encode it. `[]` and `{...}` are what a model
- * writes for something described as "JSON array of function arguments"; the
- * `"[]"` form is unusual enough that it is rarely the first thing tried.
+ * Same idea for the fields that want a stringified JSON value: accept the array
+ * or object itself and encode it. `[]` and `{...}` are what a model writes for
+ * something described as "JSON array of function arguments"; the `"[]"` form is
+ * rarely the first thing tried.
  */
 function looseJsonString(description: string) {
   return z
     .preprocess(
-      (value) =>
-        typeof value === "object" && value !== null
-          ? JSON.stringify(value)
-          : value,
-      z.string()
+      toJsonString,
+      z.string({
+        error: (issue) =>
+          issue.input !== null && typeof issue.input === "object"
+            ? `a value inside this JSON argument cannot be encoded - ${PRECISION_HINT}`
+            : precisionError(issue.input),
+      })
     )
+    .nonoptional()
     .describe(description);
 }
 
@@ -1161,7 +1232,7 @@ export function registerTools(
 
   server.tool(
     "execute_check_and_execute",
-    "Read a contract value, evaluate a condition, and execute an action if the condition is met. Useful for conditional on-chain operations (e.g., 'if balance > 1000, then transfer'). Requires a wallet integration.",
+    'Read a contract value, evaluate a condition, and execute an action if the condition is met. Useful for conditional on-chain operations (e.g., \'if balance > 1000, then transfer\'). Requires a wallet integration. Full example: {"contract_address": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238", "chain_id": "11155111", "function_name": "balanceOf", "function_args": "[\\"0xHolder...\\"]", "condition": {"operator": "gt", "value": "1000"}, "action": {"contract_address": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238", "function_name": "transfer", "function_args": "[\\"0xRecipient...\\", \\"1000\\"]"}} - note that function_args is a JSON array encoded as a string, on both the check and the action.',
     {
       contract_address: z
         .string()

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -245,7 +245,7 @@ const SIMULATE_ARG = z
     "Set to true to simulate an EVM operation without signing or broadcasting. Solana networks (chain IDs 101/103 and their aliases) are not yet supported. Use the same arguments with simulate omitted or false only after a successful simulation."
   );
 
-const SOLANA_DIRECT_EXECUTION_CHAIN_IDS = new Set([
+const SOLANA_DIRECT_EXECUTION_CHAIN_IDS = new Set<number>([
   SUPPORTED_CHAIN_IDS.SOLANA_MAINNET,
   SUPPORTED_CHAIN_IDS.SOLANA_DEVNET,
 ]);
@@ -1103,7 +1103,7 @@ export function registerTools(
 
   server.tool(
     "tools_documentation",
-    "Get documentation on how to use the KeeperHub MCP tools, including examples and best practices for workflow creation.",
+    "Get documentation on how to use the KeeperHub MCP tools, including workflow creation and safe direct execution.",
     {},
     {
       title: "Tools Documentation",
@@ -1144,6 +1144,16 @@ export function registerTools(
           "- get_template: Inspect a template's structure",
           "- deploy_template: Clone a template into your org",
           "",
+          "DIRECT EXECUTION (EVM WRITES)",
+          "1. Call execute_transfer, execute_contract_call, or execute_check_and_execute with simulate=true",
+          "2. Continue only after success=true and wouldRevert=false; any tool error is a hard stop",
+          "3. Repeat the same arguments with simulate omitted and a unique idempotency_key",
+          "4. Poll get_direct_execution_status with bounded backoff until completed or failed",
+          "5. Save the terminal transactionLink as the onchain proof",
+          "- simulate must be a JSON boolean, not a string",
+          "- simulation is EVM-only; Solana chain IDs 101/103 and their aliases are rejected before the API call",
+          "- view/pure calls and unmet conditions return their normal read/no-action result",
+          "",
           "TEMPLATE SYNTAX",
           "Reference outputs from previous nodes using: {{@nodeId:Label.field}}",
           "Example: {{@check-balance:Check Balance.balance}}",
@@ -1151,6 +1161,7 @@ export function registerTools(
           "CHAIN IDs",
           "- Ethereum Mainnet: 1",
           "- Base: 8453",
+          "- Base Sepolia Testnet: 84532",
           "- Sepolia Testnet: 11155111",
           "- Use list_action_schemas (with includeChains: true) for the full list",
         ].join("\n");
@@ -1171,9 +1182,11 @@ export function registerTools(
     "Transfer native tokens (ETH, MATIC) or ERC20 tokens from your wallet to a recipient address. Requires a wallet integration.",
     {
       chain_id: looseString(
-        "Chain ID (e.g., '1' for Ethereum, '8453' for Base)"
+        "Chain ID (e.g., '1' for Ethereum, '8453' for Base, or '103' for Solana Devnet). Solana transfers can broadcast, but simulate is currently EVM-only."
       ),
-      to_address: z.string().describe("Recipient wallet address (0x...)"),
+      to_address: z
+        .string()
+        .describe("Recipient wallet address (EVM 0x or Solana base58)"),
       amount: looseString(
         "Amount to transfer in human-readable units (e.g., '0.1')"
       ),
@@ -1238,7 +1251,7 @@ export function registerTools(
       simulate: SIMULATE_ARG,
       idempotency_key: IDEMPOTENCY_KEY_ARG,
     },
-    { title: "Contract Call", readOnlyHint: false, destructiveHint: false },
+    { title: "Contract Call", readOnlyHint: false, destructiveHint: true },
     withScopeCheck("execute_contract_call", scope, async (args) =>
       withToolLogging("execute_contract_call", undefined, async () => {
         assertSimulationSupported(args.chain_id, args.simulate);

--- a/tests/unit/mcp-execute-arg-coercion.test.ts
+++ b/tests/unit/mcp-execute-arg-coercion.test.ts
@@ -1,22 +1,11 @@
 /**
- * #1841: the direct-execution tools take numeric arguments as strings, and
- * `function_args` as a JSON array that has itself been stringified. That is
- * correct on the wire, but it is not the first thing a client emits, and the
- * rejections arrive one field at a time on the first call anyone makes after
- * the handshake.
- *
- * The schema already publishes `"type": "string"` for every one of these
- * fields, so this is not a typing gap - it is that the natural first guess was
- * refused when it could have been accepted. These tests pin both halves of the
- * fix:
- *
- *   - a number where a decimal string is wanted, and an array/object where its
- *     JSON encoding is wanted, are accepted and normalised before the handler,
- *     so the REST body downstream is byte-identical to the hand-encoded call;
- *   - the published schema still says `string`, because the coercion is a
- *     fallback for the first guess rather than a second supported encoding;
- *   - input that is genuinely wrong (a boolean chain id) is still rejected, so
- *     the fallback did not become "validation off".
+ * #1841: the natural first guess - a number where a decimal string is wanted,
+ * an array where its JSON encoding is wanted - is accepted and normalised
+ * before the handler, so the REST body is byte-identical to the hand-encoded
+ * call and the published schema still says `string`. A guess that cannot
+ * round-trip losslessly (an integer past 2^53, anything that stringifies in
+ * exponential notation) keeps its rejection rather than being corrupted, which
+ * is what the second half of these tests pins.
  */
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -42,6 +31,10 @@ function jsonOkResponse(body: Record<string, unknown>): unknown {
     json: () => Promise.resolve(body),
     text: () => Promise.resolve(""),
   };
+}
+
+function errorText(result: ToolCallResult): string {
+  return (result.content ?? []).map((part) => part.text ?? "").join("\n");
 }
 
 function lastBody(): Record<string, unknown> {
@@ -246,5 +239,189 @@ describe("MCP execute tools accept the natural first-guess encoding (#1841)", ()
     } finally {
       await close();
     }
+  });
+
+  /**
+   * A bare `preprocess` accepts `unknown`, so schema generation reads the field
+   * as omittable and silently drops it from `required` - `chain_id` and
+   * `amount` stopped being advertised as required, with no runtime symptom to
+   * notice. `.nonoptional()` in the helpers is what holds this; checking
+   * `properties[...].type` alone does not catch it.
+   */
+  it.each([
+    ["execute_transfer", ["chain_id", "to_address", "amount"]],
+    [
+      "execute_contract_call",
+      ["contract_address", "chain_id", "function_name"],
+    ],
+    [
+      "execute_check_and_execute",
+      ["contract_address", "chain_id", "function_name", "condition", "action"],
+    ],
+  ])("keeps every %s field in the published required list", async (toolName, required) => {
+    const { client, close } = await connectedClient();
+    try {
+      const listed = await client.listTools();
+      const tool = listed.tools.find((t) => t.name === toolName);
+      if (!tool) {
+        throw new Error(`${toolName} is not exposed`);
+      }
+      const schema = tool.inputSchema as { required?: string[] };
+      expect(schema.required).toEqual(required);
+    } finally {
+      await close();
+    }
+  });
+
+  it("keeps the nested condition value required", async () => {
+    const { client, close } = await connectedClient();
+    try {
+      const listed = await client.listTools();
+      const tool = listed.tools.find(
+        (t) => t.name === "execute_check_and_execute"
+      );
+      const properties = (
+        tool?.inputSchema as {
+          properties: Record<string, { required?: string[] }>;
+        }
+      ).properties;
+
+      expect(properties.condition?.required).toEqual(["operator", "value"]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("publishes string types for the nested check_and_execute fields too", async () => {
+    const { client, close } = await connectedClient();
+    try {
+      const listed = await client.listTools();
+      const tool = listed.tools.find(
+        (t) => t.name === "execute_check_and_execute"
+      );
+      if (!tool) {
+        throw new Error("execute_check_and_execute is not exposed");
+      }
+      const { properties } = tool.inputSchema as {
+        properties: Record<
+          string,
+          { type?: string; properties?: Record<string, { type?: string }> }
+        >;
+      };
+
+      expect(properties.condition?.properties?.value?.type).toBe("string");
+      for (const field of ["function_args", "abi", "gas_limit_multiplier"]) {
+        expect(properties.action?.properties?.[field]?.type).toBe("string");
+      }
+    } finally {
+      await close();
+    }
+  });
+});
+
+/**
+ * `String()` is only a safe encoder inside the range where it round-trips. Past
+ * 2^53 it drops the low digits, and outside a narrow band it switches to
+ * exponential notation, which no downstream parser recovers: `BigInt("1e+21")`
+ * throws and `evaluateCondition` then falls through to a string `eq`/`neq`, so
+ * a `gt` threshold silently never fires. Taking the guess in those ranges would
+ * turn a clean rejection into a wrong amount on-chain, so the rejection stays.
+ */
+describe("the coercion refuses guesses it cannot encode losslessly", () => {
+  // Written as a string on purpose: as a literal it would lose precision at
+  // parse time, which is the very thing under test. This is what the client's
+  // own JSON.parse hands the transport - already rounded to ...800.
+  const UNSAFE_INTEGER = Number("1234567890123456789");
+  const ABOVE_1E21 = 1e21;
+
+  it.each([
+    ["an integer past 2^53", UNSAFE_INTEGER],
+    ["a value that stringifies in exponential notation", ABOVE_1E21],
+    ["a small value that stringifies in exponential notation", 0.000_000_1],
+  ])("rejects %s as a transfer amount", async (_label, amount) => {
+    const result = await callTool("execute_transfer", {
+      chain_id: 11_155_111,
+      to_address: "0xabc",
+      amount,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(errorText(result)).toContain("pass this value as a string");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unsafe integer inside function_args rather than encoding a wrong amount", async () => {
+    const result = await callTool("execute_contract_call", {
+      contract_address: "0xc",
+      chain_id: 11_155_111,
+      function_name: "transfer",
+      function_args: ["0xdef", UNSAFE_INTEGER],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(errorText(result)).toContain("cannot be encoded");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("walks nested ABI arguments - tuples and arrays of structs, not just the top level", async () => {
+    const result = await callTool("execute_contract_call", {
+      contract_address: "0xc",
+      chain_id: 11_155_111,
+      function_name: "multicall",
+      function_args: [[{ to: "0xdef", amount: UNSAFE_INTEGER }]],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a condition value at or above 1e21, which BigInt cannot parse", async () => {
+    const result = await callTool("execute_check_and_execute", {
+      contract_address: "0xc",
+      chain_id: 42_161,
+      function_name: "balanceOf",
+      condition: { operator: "gt", value: ABOVE_1E21 },
+      action: { contract_address: "0xa", function_name: "withdraw" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects NaN and Infinity, which are not values at all", async () => {
+    for (const amount of [Number.NaN, Number.POSITIVE_INFINITY]) {
+      fetchMock.mockClear();
+      const result = await callTool("execute_transfer", {
+        chain_id: 1,
+        to_address: "0xabc",
+        amount,
+      });
+
+      expect(result.isError).toBe(true);
+      expect(fetchMock).not.toHaveBeenCalled();
+    }
+  });
+
+  it("rejects null for a JSON-string field - it is not an encodable object", async () => {
+    const result = await callTool("execute_contract_call", {
+      contract_address: "0xc",
+      chain_id: "1",
+      function_name: "transfer",
+      function_args: null,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("still takes the guess at the edge of the safe range", async () => {
+    const result = await callTool("execute_transfer", {
+      chain_id: 11_155_111,
+      to_address: "0xabc",
+      amount: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(lastBody().amount).toBe("9007199254740991");
   });
 });

--- a/tests/unit/mcp-execute-arg-coercion.test.ts
+++ b/tests/unit/mcp-execute-arg-coercion.test.ts
@@ -1,0 +1,250 @@
+/**
+ * #1841: the direct-execution tools take numeric arguments as strings, and
+ * `function_args` as a JSON array that has itself been stringified. That is
+ * correct on the wire, but it is not the first thing a client emits, and the
+ * rejections arrive one field at a time on the first call anyone makes after
+ * the handshake.
+ *
+ * The schema already publishes `"type": "string"` for every one of these
+ * fields, so this is not a typing gap - it is that the natural first guess was
+ * refused when it could have been accepted. These tests pin both halves of the
+ * fix:
+ *
+ *   - a number where a decimal string is wanted, and an array/object where its
+ *     JSON encoding is wanted, are accepted and normalised before the handler,
+ *     so the REST body downstream is byte-identical to the hand-encoded call;
+ *   - the published schema still says `string`, because the coercion is a
+ *     fallback for the first guess rather than a second supported encoding;
+ *   - input that is genuinely wrong (a boolean chain id) is still rejected, so
+ *     the fallback did not become "validation off".
+ */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import { registerTools } from "@/lib/mcp/tools";
+
+type FetchMock = ReturnType<typeof vi.fn>;
+type ToolCallResult = {
+  isError?: boolean;
+  content?: Array<{ type: string; text?: string }>;
+};
+
+let fetchMock: FetchMock;
+
+function jsonOkResponse(body: Record<string, unknown>): unknown {
+  return {
+    ok: true,
+    status: 202,
+    statusText: "Accepted",
+    headers: { get: () => "application/json" },
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(""),
+  };
+}
+
+function lastBody(): Record<string, unknown> {
+  const call = fetchMock.mock.calls.at(-1);
+  if (!call) {
+    throw new Error("fetch was not called");
+  }
+  const init = call[1] as { body: string };
+  return JSON.parse(init.body) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn(() =>
+    Promise.resolve(
+      jsonOkResponse({ executionId: "exec_1", status: "completed" })
+    )
+  );
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+type ConnectedClient = { client: Client; close: () => Promise<void> };
+
+async function connectedClient(): Promise<ConnectedClient> {
+  const server = new McpServer({ name: "coercion-test", version: "0.0.0" });
+  registerTools(server, "http://internal", "Bearer test", SCOPE_MCP_WRITE);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "coercion-test-client", version: "0.0.0" });
+
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+
+  return {
+    client,
+    close: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+async function callTool(
+  name: string,
+  args: Record<string, unknown>
+): Promise<ToolCallResult> {
+  const { client, close } = await connectedClient();
+  try {
+    return (await client.callTool({
+      name,
+      arguments: args,
+    })) as ToolCallResult;
+  } finally {
+    await close();
+  }
+}
+
+describe("MCP execute tools accept the natural first-guess encoding (#1841)", () => {
+  it("execute_transfer takes a numeric chain_id and amount, and forwards strings", async () => {
+    const result = await callTool("execute_transfer", {
+      chain_id: 11_155_111,
+      to_address: "0xabc",
+      amount: 0.1,
+    });
+
+    expect(result.isError).toBeFalsy();
+    const body = lastBody();
+    expect(body.chainId).toBe("11155111");
+    expect(body.amount).toBe("0.1");
+  });
+
+  it("execute_contract_call takes a real array for function_args and forwards its JSON encoding", async () => {
+    const result = await callTool("execute_contract_call", {
+      contract_address: "0xc",
+      chain_id: 11_155_111,
+      function_name: "transfer",
+      function_args: ["0xdef", "1000"],
+    });
+
+    expect(result.isError).toBeFalsy();
+    const body = lastBody();
+    expect(body.chainId).toBe("11155111");
+    expect(body.functionArgs).toBe('["0xdef","1000"]');
+  });
+
+  it("execute_contract_call takes numeric gas_limit_multiplier, value and priority_fee_gwei", async () => {
+    const result = await callTool("execute_contract_call", {
+      contract_address: "0xc",
+      chain_id: "11155111",
+      function_name: "deposit",
+      gas_limit_multiplier: 1.5,
+      value: 0.25,
+      priority_fee_gwei: 2,
+    });
+
+    expect(result.isError).toBeFalsy();
+    const body = lastBody();
+    expect(body.gasLimitMultiplier).toBe("1.5");
+    expect(body.value).toBe("0.25");
+    expect(body.priorityFeeGwei).toBe("2");
+  });
+
+  it("execute_contract_call takes an ABI array and forwards its JSON encoding", async () => {
+    const abi = [{ name: "transfer", type: "function", inputs: [] }];
+    const result = await callTool("execute_contract_call", {
+      contract_address: "0xc",
+      chain_id: "1",
+      function_name: "transfer",
+      abi,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(lastBody().abi).toBe(JSON.stringify(abi));
+  });
+
+  it("execute_check_and_execute coerces the nested condition value and action fields", async () => {
+    const result = await callTool("execute_check_and_execute", {
+      contract_address: "0xc",
+      chain_id: 42_161,
+      function_name: "balanceOf",
+      function_args: ["0xholder"],
+      condition: { operator: "gt", value: 1000 },
+      action: {
+        contract_address: "0xa",
+        function_name: "withdraw",
+        function_args: [],
+        gas_limit_multiplier: 2,
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const body = lastBody();
+    expect(body.chainId).toBe("42161");
+    expect(body.functionArgs).toBe('["0xholder"]');
+    expect((body.condition as { value: unknown }).value).toBe("1000");
+    const action = body.action as Record<string, unknown>;
+    expect(action.functionArgs).toBe("[]");
+    expect(action.gasLimitMultiplier).toBe("2");
+  });
+
+  it("the hand-encoded call is unchanged - same body as the coerced one", async () => {
+    await callTool("execute_contract_call", {
+      contract_address: "0xc",
+      chain_id: "11155111",
+      function_name: "transfer",
+      function_args: '["0xdef","1000"]',
+      gas_limit_multiplier: "1.5",
+    });
+    const encodedByHand = lastBody();
+
+    await callTool("execute_contract_call", {
+      contract_address: "0xc",
+      chain_id: 11_155_111,
+      function_name: "transfer",
+      function_args: ["0xdef", "1000"],
+      gas_limit_multiplier: 1.5,
+    });
+
+    expect(lastBody()).toEqual(encodedByHand);
+  });
+
+  it("still rejects an argument that is neither the string nor its natural guess", async () => {
+    const result = await callTool("execute_transfer", {
+      chain_id: true,
+      to_address: "0xabc",
+      amount: "0.1",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("publishes string types - the coercion is a fallback, not a second encoding", async () => {
+    const { client, close } = await connectedClient();
+    try {
+      const listed = await client.listTools();
+      const tool = listed.tools.find((t) => t.name === "execute_contract_call");
+      if (!tool) {
+        throw new Error("execute_contract_call is not exposed");
+      }
+      const { properties } = tool.inputSchema as {
+        properties: Record<string, { type?: string }>;
+      };
+
+      for (const field of [
+        "chain_id",
+        "function_args",
+        "abi",
+        "value",
+        "gas_limit_multiplier",
+        "priority_fee_gwei",
+      ]) {
+        expect(properties[field]?.type).toBe("string");
+      }
+    } finally {
+      await close();
+    }
+  });
+});

--- a/tests/unit/mcp-execute-simulation.test.ts
+++ b/tests/unit/mcp-execute-simulation.test.ts
@@ -1,0 +1,168 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import { registerTools } from "@/lib/mcp/tools";
+
+type RegisteredTool = {
+  name: string;
+  schema: Record<string, unknown>;
+  handler: (...args: unknown[]) => unknown;
+};
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+let fetchMock: FetchMock;
+
+function jsonOkResponse(body: Record<string, unknown>): unknown {
+  return {
+    ok: true,
+    status: 202,
+    statusText: "Accepted",
+    headers: { get: () => "application/json" },
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(""),
+  };
+}
+
+function lastBody(): Record<string, unknown> {
+  const call = fetchMock.mock.calls.at(-1);
+  if (!call) {
+    throw new Error("fetch was not called");
+  }
+  const init = call[1] as { body: string };
+  return JSON.parse(init.body) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn(() =>
+    Promise.resolve(
+      jsonOkResponse({ executionId: "exec_1", status: "completed" })
+    )
+  );
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function getTool(name: string): RegisteredTool {
+  const registeredTools: RegisteredTool[] = [];
+  const server = {
+    tool: vi.fn(
+      (
+        toolName: string,
+        _description: string,
+        schema: Record<string, unknown>,
+        _annotations: unknown,
+        handler: (...args: unknown[]) => unknown
+      ) => {
+        registeredTools.push({ name: toolName, schema, handler });
+      }
+    ),
+  } as unknown as McpServer;
+
+  registerTools(server, "http://internal", "Bearer test", SCOPE_MCP_WRITE);
+  const tool = registeredTools.find((registered) => registered.name === name);
+  if (!tool) {
+    throw new Error(`tool ${name} not registered`);
+  }
+  return tool;
+}
+
+describe("MCP direct execution simulation", () => {
+  it("exposes simulate on every direct write tool", () => {
+    for (const name of [
+      "execute_transfer",
+      "execute_contract_call",
+      "execute_check_and_execute",
+    ]) {
+      expect(Object.keys(getTool(name).schema)).toContain("simulate");
+    }
+  });
+
+  it("forwards simulate to transfer requests", async () => {
+    await getTool("execute_transfer").handler({
+      chain_id: "84532",
+      to_address: "0xabc",
+      amount: "0.01",
+      simulate: true,
+    });
+
+    expect(lastBody().simulate).toBe(true);
+  });
+
+  it("forwards simulate to contract-call requests", async () => {
+    await getTool("execute_contract_call").handler({
+      contract_address: "0xcontract",
+      chain_id: "84532",
+      function_name: "transfer",
+      simulate: true,
+    });
+
+    expect(lastBody().simulate).toBe(true);
+  });
+
+  it("forwards simulate to check-and-execute requests", async () => {
+    await getTool("execute_check_and_execute").handler({
+      contract_address: "0xcheck",
+      chain_id: "84532",
+      function_name: "balanceOf",
+      condition: { operator: "gt", value: "0" },
+      action: {
+        contract_address: "0xaction",
+        function_name: "transfer",
+      },
+      simulate: true,
+    });
+
+    expect(lastBody().simulate).toBe(true);
+  });
+
+  it("keeps existing broadcast requests unchanged when simulate is omitted", async () => {
+    await getTool("execute_transfer").handler({
+      chain_id: "84532",
+      to_address: "0xabc",
+      amount: "0.01",
+    });
+
+    expect(lastBody()).not.toHaveProperty("simulate");
+  });
+
+  it("rejects truthy strings before they can reach the REST route", async () => {
+    const server = new McpServer({ name: "simulate-test", version: "0.0.0" });
+    registerTools(server, "http://internal", "Bearer test", SCOPE_MCP_WRITE);
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const client = new Client({
+      name: "simulate-test-client",
+      version: "0.0.0",
+    });
+
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+
+    try {
+      const result = await client.callTool({
+        name: "execute_transfer",
+        arguments: {
+          chain_id: "84532",
+          to_address: "0xabc",
+          amount: "0.01",
+          simulate: "true",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/tests/unit/mcp-execute-simulation.test.ts
+++ b/tests/unit/mcp-execute-simulation.test.ts
@@ -226,4 +226,17 @@ describe("MCP direct execution simulation", () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("delegates unknown network identifiers to the REST validator", async () => {
+    const result = await callThroughMcp("execute_transfer", {
+      chain_id: "future-chain",
+      to_address: "0xabc",
+      amount: "0.01",
+      simulate: true,
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(lastBody().chainId).toBe("future-chain");
+  });
 });

--- a/tests/unit/mcp-execute-simulation.test.ts
+++ b/tests/unit/mcp-execute-simulation.test.ts
@@ -8,6 +8,7 @@ import { registerTools } from "@/lib/mcp/tools";
 type RegisteredTool = {
   name: string;
   schema: Record<string, unknown>;
+  annotations: { destructiveHint?: boolean };
   handler: (...args: unknown[]) => unknown;
 };
 
@@ -57,10 +58,10 @@ function getTool(name: string): RegisteredTool {
         toolName: string,
         _description: string,
         schema: Record<string, unknown>,
-        _annotations: unknown,
+        annotations: { destructiveHint?: boolean },
         handler: (...args: unknown[]) => unknown
       ) => {
-        registeredTools.push({ name: toolName, schema, handler });
+        registeredTools.push({ name: toolName, schema, annotations, handler });
       }
     ),
   } as unknown as McpServer;
@@ -71,6 +72,32 @@ function getTool(name: string): RegisteredTool {
     throw new Error(`tool ${name} not registered`);
   }
   return tool;
+}
+
+async function callThroughMcp(
+  name: string,
+  args: Record<string, unknown>
+): Promise<Awaited<ReturnType<Client["callTool"]>>> {
+  const server = new McpServer({ name: "simulate-test", version: "0.0.0" });
+  registerTools(server, "http://internal", "Bearer test", SCOPE_MCP_WRITE);
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client({
+    name: "simulate-test-client",
+    version: "0.0.0",
+  });
+
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+
+  try {
+    return await client.callTool({ name, arguments: args });
+  } finally {
+    await client.close();
+    await server.close();
+  }
 }
 
 describe("MCP direct execution simulation", () => {
@@ -85,29 +112,31 @@ describe("MCP direct execution simulation", () => {
   });
 
   it("forwards simulate to transfer requests", async () => {
-    await getTool("execute_transfer").handler({
+    const result = await callThroughMcp("execute_transfer", {
       chain_id: "84532",
       to_address: "0xabc",
       amount: "0.01",
       simulate: true,
     });
 
+    expect(result.isError).not.toBe(true);
     expect(lastBody().simulate).toBe(true);
   });
 
   it("forwards simulate to contract-call requests", async () => {
-    await getTool("execute_contract_call").handler({
+    const result = await callThroughMcp("execute_contract_call", {
       contract_address: "0xcontract",
       chain_id: "84532",
       function_name: "transfer",
       simulate: true,
     });
 
+    expect(result.isError).not.toBe(true);
     expect(lastBody().simulate).toBe(true);
   });
 
   it("forwards simulate to check-and-execute requests", async () => {
-    await getTool("execute_check_and_execute").handler({
+    const result = await callThroughMcp("execute_check_and_execute", {
       contract_address: "0xcheck",
       chain_id: "84532",
       function_name: "balanceOf",
@@ -119,7 +148,14 @@ describe("MCP direct execution simulation", () => {
       simulate: true,
     });
 
+    expect(result.isError).not.toBe(true);
     expect(lastBody().simulate).toBe(true);
+  });
+
+  it("marks contract calls as potentially destructive", () => {
+    expect(getTool("execute_contract_call").annotations.destructiveHint).toBe(
+      true
+    );
   });
 
   it("keeps existing broadcast requests unchanged when simulate is omitted", async () => {
@@ -133,36 +169,61 @@ describe("MCP direct execution simulation", () => {
   });
 
   it("rejects truthy strings before they can reach the REST route", async () => {
-    const server = new McpServer({ name: "simulate-test", version: "0.0.0" });
-    registerTools(server, "http://internal", "Bearer test", SCOPE_MCP_WRITE);
-    const [clientTransport, serverTransport] =
-      InMemoryTransport.createLinkedPair();
-    const client = new Client({
-      name: "simulate-test-client",
-      version: "0.0.0",
+    const result = await callThroughMcp("execute_transfer", {
+      chain_id: "84532",
+      to_address: "0xabc",
+      amount: "0.01",
+      simulate: "true",
     });
 
-    await Promise.all([
-      server.connect(serverTransport),
-      client.connect(clientTransport),
-    ]);
+    expect(result.isError).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 
-    try {
-      const result = await client.callTool({
-        name: "execute_transfer",
-        arguments: {
-          chain_id: "84532",
-          to_address: "0xabc",
+  it("rejects Solana IDs and aliases before making an API call", async () => {
+    const chainIds = [
+      "101",
+      "103",
+      "solana",
+      "solana-mainnet",
+      "solana-devnet",
+      "solana-testnet",
+      "103abc",
+    ];
+
+    for (const chain_id of chainIds) {
+      const results = await Promise.all([
+        callThroughMcp("execute_transfer", {
+          chain_id,
+          to_address: "11111111111111111111111111111111",
           amount: "0.01",
-          simulate: "true",
-        },
-      });
+          simulate: true,
+        }),
+        callThroughMcp("execute_contract_call", {
+          contract_address: "0xcontract",
+          chain_id,
+          function_name: "transfer",
+          simulate: true,
+        }),
+        callThroughMcp("execute_check_and_execute", {
+          contract_address: "0xcheck",
+          chain_id,
+          function_name: "balanceOf",
+          condition: { operator: "gt", value: "0" },
+          action: {
+            contract_address: "0xaction",
+            function_name: "transfer",
+          },
+          simulate: true,
+        }),
+      ]);
 
-      expect(result.isError).toBe(true);
-      expect(fetchMock).not.toHaveBeenCalled();
-    } finally {
-      await client.close();
-      await server.close();
+      for (const result of results) {
+        expect(result.isError).toBe(true);
+        expect(JSON.stringify(result.content)).toContain("EVM-only");
+      }
     }
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- expose the existing REST `simulate` capability on `execute_transfer`, `execute_contract_call`, and `execute_check_and_execute`
- forward a strict optional boolean without changing existing requests when it is omitted
- fail closed before the API call for Solana chain IDs 101/103, whose current direct-execution simulator is EVM-only
- document the safe EVM preflight, broadcast, idempotency, and status flow
- expose that same safe sequence through the runtime `tools_documentation` reference agents can query
- add MCP-level regression coverage for schemas, forwarding, omission, invalid types, Solana rejection, and REST revert errors

## Why

The direct-execution REST routes already support dry runs, but MCP-native agents cannot request them. An agent currently has to switch surfaces or broadcast its first write without a preflight. This keeps the entire safety sequence inside MCP.

## Safety and compatibility

- `simulate` is optional; `JSON.stringify` omits the existing `undefined` value, so current broadcasts retain their previous request body.
- The schema accepts only JSON booleans, not truthy strings.
- Solana broadcasts remain unchanged. `simulate: true` on chain 101 or 103 returns an MCP error before `fetch`, rather than routing into the EVM simulator.
- REST 400 simulation details remain present in MCP error content; the docs tell agents to treat any tool error as a hard stop.
- View/pure calls and unmet conditions are documented as normal read/no-action results rather than simulation envelopes.

## Verification

- `vitest run tests/unit/mcp-execute-simulation.test.ts tests/unit/mcp-execute-field-naming.test.ts`: 18/18 passed
- Biome check for the changed TypeScript and test: passed
- `git diff --check`: passed
- Full TypeScript check was not conclusive in the sparse working copy because unrelated application paths were intentionally absent; no changed-file errors appeared

## Live proof

The companion [KeeperGuard agent](https://github.com/keeperguard-labs/keeperguard) exercised the production-shaped sequence through KeeperHub on Base Sepolia: policy check, successful simulation, idempotent sponsored broadcast, terminal status, and independent receipt verification.

Transaction: https://sepolia.basescan.org/tx/0xd61f552ebac9abd7089798f9f51a0af6e49579c6f3c86b10f3388b938214ffab
