### PR TITLE
fix: classify condition node misconfiguration as user error

### DIFF
--- a/lib/errors/classify.ts
+++ b/lib/errors/classify.ts
@@ -170,6 +170,18 @@ const RULES: readonly Rule[] = [
     code: null,
   },
   {
+    pattern: /^Condition node has no expression configured/i,
+    errorCategory: ErrorCategory.CONFIGURATION,
+    errorType: ExecutionErrorType.USER,
+    code: null,
+  },
+  {
+    pattern: /^Condition expression is invalid/i,
+    errorCategory: ErrorCategory.VALIDATION,
+    errorType: ExecutionErrorType.USER,
+    code: null,
+  },
+  {
     pattern: /^No token selected/i,
     errorCategory: ErrorCategory.CONFIGURATION,
     errorType: ExecutionErrorType.USER,

--- a/tests/unit/classify-execution-error.test.ts
+++ b/tests/unit/classify-execution-error.test.ts
@@ -65,6 +65,28 @@ describe("classifyExecutionError", () => {
     expect(classifyExecutionError("   ").errorType).toBe("system");
   });
 
+  it("classifies an unconfigured condition node as a user config error", () => {
+    const result = classifyExecutionError(
+      "Condition node has no expression configured. Please add a condition expression."
+    );
+    expect(result).toEqual({
+      errorCategory: ErrorCategory.CONFIGURATION,
+      errorType: "user",
+      code: null,
+    });
+  });
+
+  it("classifies an invalid condition expression as a user validation error", () => {
+    const result = classifyExecutionError(
+      'Condition expression is invalid: unexpected token. Expression: "foo &&"'
+    );
+    expect(result).toEqual({
+      errorCategory: ErrorCategory.VALIDATION,
+      errorType: "user",
+      code: null,
+    });
+  });
+
   it("still classifies RPC failover errors after URL redaction", () => {
     // Error messages have provider URLs fully redacted before
     // classification; the redaction must not disturb the prose the patterns


### PR DESCRIPTION
## What

Condition node failures matched no rule in the execution error classifier (`lib/errors/classify.ts`) and fell through to the system default, so they were labeled `system` / `workflow_engine`. Two condition messages are now matched as workflow-author configuration faults:

- "Condition node has no expression configured..." classified as `CONFIGURATION` / `user`
- "Condition expression is invalid..." classified as `VALIDATION` / `user`

## Why

Both failures are caused by the workflow author leaving a condition node unconfigured or entering an invalid expression. They are not platform faults, so they should surface as `user` errors and stay out of the `system` error signal used for alerting.

## Changes

- Add two classifier rules alongside the existing condition rules in `lib/errors/classify.ts`.
- Add unit coverage in `tests/unit/classify-execution-error.test.ts`.