### PR TITLE
docs: document KH_MINIMUM_CLI_VERSION override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ BETTER_AUTH_URL=http://localhost:3000
 # OpenAI API key for workflow orchestration
 export OPENAI_API_KEY=""
 
+# Oldest `kh` CLI release this deployment considers supported. Advertised to
+# every CLI response via the KH-Minimum-CLI-Version header (lib/cli-version.ts);
+# older builds print an upgrade warning. Defaults to 0.11.1 if unset.
+KH_MINIMUM_CLI_VERSION=""
+
 # KeeperHub: Feedback Service
 NEXT_PUBLIC_FEEDBACK_API_URL="http://localhost:3002/api/feedback"
 NEXT_PUBLIC_FEEDBACK_API_KEY=""


### PR DESCRIPTION
## Summary

`KH_MINIMUM_CLI_VERSION` has controlled the `KH-Minimum-CLI-Version` response
header since #1839, but was never documented in `.env.example`, so there was
no discoverable way for an operator to learn the override exists or what it
does.

Found while closing out the remaining scope of a CLI-side ticket that makes
`kh doctor` actually compare against this header instead of only printing the
local version: KeeperHub/cli#84

## Test plan

- [x] Doc-only change, no code paths affected