### PR TITLE
feat(welcome): add pay-per-execution onboarding step

### DIFF
--- a/app/welcome/pay-per-execution/page.tsx
+++ b/app/welcome/pay-per-execution/page.tsx
@@ -1,0 +1,7 @@
+import { PayPerExecutionStep } from "@/components/welcome/steps/pay-per-execution-step";
+import { requireOnboardingSession } from "@/lib/onboarding-session";
+
+export default async function PayPerExecutionPage(): Promise<React.ReactElement> {
+  await requireOnboardingSession();
+  return <PayPerExecutionStep />;
+}

--- a/components/welcome/previews.tsx
+++ b/components/welcome/previews.tsx
@@ -1251,9 +1251,13 @@ function DecorativeNodeCard({
 export function PayPerExecutionPreview({
   enabled,
   priceLabel,
+  dailyCap,
+  periodCap,
 }: {
   enabled: boolean;
   priceLabel: string;
+  dailyCap: string;
+  periodCap: string;
 }): React.ReactElement {
   const reducedMotion = useReducedMotion() ?? false;
   const { phase, runIndex, outcome } = useWorkflowRunLoop(reducedMotion);
@@ -1319,6 +1323,17 @@ export function PayPerExecutionPreview({
                   ) : null}
                 </Fragment>
               ))}
+            </div>
+
+            <div className="mt-5 flex items-center justify-center gap-3 border-border/60 border-t pt-4 text-xs">
+              <span className="text-muted-foreground">Default caps</span>
+              <span className="font-medium text-foreground tabular-nums">
+                {dailyCap} / day
+              </span>
+              <span className="text-muted-foreground">&middot;</span>
+              <span className="font-medium text-foreground tabular-nums">
+                {periodCap} / month
+              </span>
             </div>
           </PreviewFrame>
 

--- a/components/welcome/previews.tsx
+++ b/components/welcome/previews.tsx
@@ -2,18 +2,24 @@
 
 import {
   Activity,
+  ArrowLeftRight,
   ArrowUp,
   AudioLines,
+  Banknote,
   BarChart3,
   Bookmark,
   Boxes,
   Check,
   ChevronDown,
+  Clock,
+  Coins,
   Copy,
   DollarSign,
+  FileCode,
   Globe,
   History,
   Info,
+  LineChart,
   Loader2,
   Mic,
   Plus,
@@ -21,8 +27,9 @@ import {
   Sparkles,
   Users,
   Workflow,
+  Zap,
 } from "lucide-react";
-import { motion } from "motion/react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import {
   type ComponentType,
   Fragment,
@@ -863,6 +870,466 @@ export function ConnectAgentPreview({
             )}
           </div>
         </motion.div>
+      </div>
+    </div>
+  );
+}
+
+// Step 3 preview (pay-per-execution): a large auto-executing 3-node workflow
+// graph (Onchain Event -> Health Factor -> Supply to Aave) set on a dotted
+// canvas with dimmed decorative nodes scattered around it. Every run starts
+// with an upfront payment/cap check (shown as a chip at the top of the
+// card); only a paid run lights the nodes left to right with a pulse
+// traveling each connector, while a blocked run stays idle and resets.
+type GraphPhase =
+  | "gate"
+  | "trigger"
+  | "toCondition"
+  | "condition"
+  | "toAction"
+  | "action"
+  | "hold";
+
+type RunOutcome = "paid" | "blocked";
+
+const PAID_PHASE_ORDER: GraphPhase[] = [
+  "gate",
+  "trigger",
+  "toCondition",
+  "condition",
+  "toAction",
+  "action",
+  "hold",
+];
+
+const BLOCKED_PHASE_ORDER: GraphPhase[] = ["gate", "hold"];
+
+const GRAPH_PHASE_DURATION_MS: Record<GraphPhase, number> = {
+  gate: 900,
+  trigger: 700,
+  toCondition: 500,
+  condition: 700,
+  toAction: 500,
+  action: 700,
+  hold: 900,
+};
+
+// The blocked run's "hold" dwells longer than the paid run's so the rejection
+// message has time to read even though its run is otherwise much shorter.
+const HOLD_DURATION_MS: Record<RunOutcome, number> = {
+  paid: 900,
+  blocked: 1600,
+};
+
+const REDUCED_MOTION_MULTIPLIER = 1.8;
+const BLOCKED_EVERY_N_RUNS = 4;
+
+type NodeStatus = "idle" | "active" | "done";
+
+type GraphNodeMeta = {
+  id: string;
+  title: string;
+  kind: string;
+  icon: ComponentType<{ className?: string }>;
+  accentClass: string;
+};
+
+const GRAPH_NODES: GraphNodeMeta[] = [
+  {
+    id: "trigger",
+    title: "Onchain Event",
+    kind: "Trigger",
+    icon: Boxes,
+    accentClass: "text-emerald-400",
+  },
+  {
+    id: "condition",
+    title: "Health Factor",
+    kind: "Condition",
+    icon: Activity,
+    accentClass: "text-amber-400",
+  },
+  {
+    id: "action",
+    title: "Supply to Aave",
+    kind: "Action",
+    icon: Banknote,
+    accentClass: "text-blue-400",
+  },
+];
+
+// Static, low-opacity node cards scattered around the main card to fill out
+// the panel like a real, sprawling workflow canvas. Purely decorative.
+type DecorativeNodeMeta = {
+  id: string;
+  title: string;
+  icon: ComponentType<{ className?: string }>;
+  style: React.CSSProperties;
+};
+
+const DECORATIVE_NODES: DecorativeNodeMeta[] = [
+  {
+    id: "schedule",
+    title: "Schedule",
+    icon: Clock,
+    style: { top: "10%", left: "6%" },
+  },
+  {
+    id: "read-contract",
+    title: "Read Contract",
+    icon: FileCode,
+    style: { top: "16%", right: "8%" },
+  },
+  {
+    id: "uniswap-swap",
+    title: "Uniswap Swap",
+    icon: ArrowLeftRight,
+    style: { bottom: "14%", left: "11%" },
+  },
+  {
+    id: "transfer-erc20",
+    title: "Transfer ERC20",
+    icon: Coins,
+    style: { bottom: "10%", right: "13%" },
+  },
+  {
+    id: "price-feed",
+    title: "Price Feed",
+    icon: LineChart,
+    style: { top: "46%", right: "3%" },
+  },
+];
+
+function outcomeForRun(run: number): RunOutcome {
+  return (run + 1) % BLOCKED_EVERY_N_RUNS === 0 ? "blocked" : "paid";
+}
+
+function scaledDuration(
+  phase: GraphPhase,
+  reducedMotion: boolean,
+  outcome: RunOutcome = "paid"
+): number {
+  const base =
+    phase === "hold"
+      ? HOLD_DURATION_MS[outcome]
+      : GRAPH_PHASE_DURATION_MS[phase];
+  return base * (reducedMotion ? REDUCED_MOTION_MULTIPLIER : 1);
+}
+
+// Drives the loop on a self-scheduling timeout chain (not React state), so
+// the effect only depends on the reduced-motion flag and never re-fires on
+// every phase change. Each run resolves its payment outcome first ("gate")
+// and only walks the paid phase sequence when the charge succeeds; a
+// blocked run skips straight to a longer "hold" before resetting.
+function useWorkflowRunLoop(reducedMotion: boolean): {
+  phase: GraphPhase;
+  runIndex: number;
+  outcome: RunOutcome;
+} {
+  const [phase, setPhase] = useState<GraphPhase>("gate");
+  const [runIndex, setRunIndex] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout>;
+    let run = 0;
+    let outcome = outcomeForRun(run);
+    let phaseOrder =
+      outcome === "blocked" ? BLOCKED_PHASE_ORDER : PAID_PHASE_ORDER;
+    let phaseIndex = 0;
+
+    const scheduleNext = (): void => {
+      const current = phaseOrder[phaseIndex];
+      timeoutId = setTimeout(
+        () => {
+          if (cancelled) {
+            return;
+          }
+          phaseIndex += 1;
+          if (phaseIndex >= phaseOrder.length) {
+            run += 1;
+            outcome = outcomeForRun(run);
+            phaseOrder =
+              outcome === "blocked" ? BLOCKED_PHASE_ORDER : PAID_PHASE_ORDER;
+            phaseIndex = 0;
+            setRunIndex(run);
+          }
+          setPhase(phaseOrder[phaseIndex]);
+          scheduleNext();
+        },
+        scaledDuration(current, reducedMotion, outcome)
+      );
+    };
+
+    scheduleNext();
+    return (): void => {
+      cancelled = true;
+      clearTimeout(timeoutId);
+    };
+  }, [reducedMotion]);
+
+  return { phase, runIndex, outcome: outcomeForRun(runIndex) };
+}
+
+// Node statuses only ever leave "idle" on a paid run: a blocked run resolves
+// at the gate and never reaches the execution phases, so the graph stays
+// dimmed to make the upfront rejection visible.
+function triggerNodeStatus(phase: GraphPhase, outcome: RunOutcome): NodeStatus {
+  if (outcome === "blocked" || phase === "gate") {
+    return "idle";
+  }
+  return phase === "trigger" ? "active" : "done";
+}
+
+function conditionNodeStatus(
+  phase: GraphPhase,
+  outcome: RunOutcome
+): NodeStatus {
+  if (
+    outcome === "blocked" ||
+    phase === "gate" ||
+    phase === "trigger" ||
+    phase === "toCondition"
+  ) {
+    return "idle";
+  }
+  return phase === "condition" ? "active" : "done";
+}
+
+function actionNodeStatus(phase: GraphPhase, outcome: RunOutcome): NodeStatus {
+  if (outcome === "blocked") {
+    return "idle";
+  }
+  if (phase === "action") {
+    return "active";
+  }
+  return phase === "hold" ? "done" : "idle";
+}
+
+/** Atom: a workflow node card that lights up as the run reaches it. */
+function GraphNodeCard({
+  node,
+  status,
+}: {
+  node: GraphNodeMeta;
+  status: NodeStatus;
+}): React.ReactElement {
+  const Icon = node.icon;
+  return (
+    <motion.div
+      animate={{ scale: status === "active" ? 1.05 : 1 }}
+      className={cn(
+        "flex w-40 flex-none flex-col items-center gap-2 rounded-2xl border bg-background/60 px-4 py-5 text-center",
+        status === "idle" && "border-border",
+        status === "active" &&
+          "border-keeperhub-green/60 shadow-keeperhub-green/20 shadow-lg ring-2 ring-keeperhub-green/60",
+        status === "done" && "border-keeperhub-green/30 bg-keeperhub-green/5"
+      )}
+      transition={{ duration: 0.3, ease: "easeOut" }}
+    >
+      <Icon
+        className={cn(
+          "size-7",
+          status === "idle" ? "text-muted-foreground" : node.accentClass
+        )}
+      />
+      <p className="font-semibold text-foreground text-sm">{node.title}</p>
+      <p className="text-muted-foreground text-xs uppercase tracking-wide">
+        {node.kind}
+      </p>
+    </motion.div>
+  );
+}
+
+/** Atom: a dashed connector between two nodes, with a pulse dot on activation. */
+function GraphConnector({
+  active,
+  durationMs,
+}: {
+  active: boolean;
+  durationMs: number;
+}): React.ReactElement {
+  return (
+    <div className="relative h-px w-10 flex-none self-center">
+      <div
+        className={cn(
+          "absolute inset-0 border-t border-dashed transition-colors duration-300",
+          active ? "border-keeperhub-green/50" : "border-border"
+        )}
+      />
+      <AnimatePresence>
+        {active ? (
+          <motion.span
+            animate={{ left: "100%", opacity: [0, 1, 1, 0] }}
+            className="-translate-y-1/2 absolute top-1/2 size-1.5 rounded-full bg-keeperhub-green shadow-keeperhub-green/60 shadow-md"
+            exit={{ opacity: 0 }}
+            initial={{ left: "0%", opacity: 0 }}
+            key="pulse"
+            transition={{ duration: durationMs / 1000, ease: "easeInOut" }}
+          />
+        ) : null}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+/** Atom: the upfront paid/blocked gate chip shown at the top of the card. */
+function GateChip({
+  outcome,
+  priceLabel,
+}: {
+  outcome: RunOutcome;
+  priceLabel: string;
+}): React.ReactElement {
+  return (
+    <motion.div
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -4 }}
+      initial={{ opacity: 0, y: -4 }}
+      transition={{ duration: 0.25, ease: "easeOut" }}
+    >
+      {outcome === "blocked" ? (
+        <Badge
+          className="gap-1 whitespace-nowrap border-destructive/30 bg-destructive/10 text-destructive"
+          variant="outline"
+        >
+          Blocked &middot; daily cap reached
+        </Badge>
+      ) : (
+        <Badge
+          className="gap-1 whitespace-nowrap border-keeperhub-green/30 bg-keeperhub-green/10 text-keeperhub-green"
+          variant="outline"
+        >
+          <Zap className="size-3" />
+          Paid {priceLabel} USDC
+        </Badge>
+      )}
+    </motion.div>
+  );
+}
+
+const DOT_GRID_STYLE: React.CSSProperties = {
+  backgroundImage:
+    "radial-gradient(circle, currentColor 1px, transparent 1.2px)",
+  backgroundSize: "24px 24px",
+  maskImage:
+    "radial-gradient(ellipse 60% 70% at center, black 40%, transparent 100%)",
+  WebkitMaskImage:
+    "radial-gradient(ellipse 60% 70% at center, black 40%, transparent 100%)",
+};
+
+/** Atom: full-bleed dot-grid canvas backdrop, faded to transparent at the edges. */
+function DotGridBackground(): React.ReactElement {
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 text-muted-foreground/25"
+      style={DOT_GRID_STYLE}
+    />
+  );
+}
+
+/** Atom: a dimmed, static node card that fills out the surrounding canvas. */
+function DecorativeNodeCard({
+  node,
+}: {
+  node: DecorativeNodeMeta;
+}): React.ReactElement {
+  const Icon = node.icon;
+  return (
+    <div
+      aria-hidden="true"
+      className="absolute flex w-28 flex-col items-center gap-1.5 rounded-xl border border-border/50 bg-card/40 px-3 py-3 text-center opacity-40"
+      style={node.style}
+    >
+      <Icon className="size-4 text-muted-foreground" />
+      <p className="text-muted-foreground text-xs">{node.title}</p>
+    </div>
+  );
+}
+
+export function PayPerExecutionPreview({
+  enabled,
+  priceLabel,
+}: {
+  enabled: boolean;
+  priceLabel: string;
+}): React.ReactElement {
+  const reducedMotion = useReducedMotion() ?? false;
+  const { phase, runIndex, outcome } = useWorkflowRunLoop(reducedMotion);
+
+  const statuses: NodeStatus[] = [
+    triggerNodeStatus(phase, outcome),
+    conditionNodeStatus(phase, outcome),
+    actionNodeStatus(phase, outcome),
+  ];
+
+  return (
+    <div className="absolute inset-0 overflow-hidden">
+      <DotGridBackground />
+      {DECORATIVE_NODES.map((node) => (
+        <DecorativeNodeCard key={node.id} node={node} />
+      ))}
+
+      <div className="absolute inset-0 flex items-center justify-center p-10">
+        <div className="flex w-full flex-col items-center gap-4">
+          <PreviewFrame className="w-full max-w-2xl bg-card p-6">
+            <div className="mb-5 flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <Workflow className="size-5 text-keeperhub-green" />
+                <h3 className="font-semibold text-lg">Aave collateral guard</h3>
+              </div>
+              <Badge
+                className={cn(
+                  "gap-1 border-keeperhub-green/30 text-keeperhub-green",
+                  enabled ? "bg-keeperhub-green/10" : "bg-muted"
+                )}
+                variant="outline"
+              >
+                {enabled ? "Live" : "Preview"}
+              </Badge>
+            </div>
+
+            <div className="mb-5 flex min-h-8 items-center justify-center">
+              <AnimatePresence mode="wait">
+                <GateChip
+                  key={runIndex}
+                  outcome={outcome}
+                  priceLabel={priceLabel}
+                />
+              </AnimatePresence>
+            </div>
+
+            <div className="flex items-center justify-center gap-1">
+              {GRAPH_NODES.map((node, index) => (
+                <Fragment key={node.id}>
+                  <GraphNodeCard node={node} status={statuses[index]} />
+                  {index < GRAPH_NODES.length - 1 ? (
+                    <GraphConnector
+                      active={
+                        index === 0
+                          ? phase === "toCondition"
+                          : phase === "toAction"
+                      }
+                      durationMs={scaledDuration(
+                        index === 0 ? "toCondition" : "toAction",
+                        reducedMotion
+                      )}
+                    />
+                  ) : null}
+                </Fragment>
+              ))}
+            </div>
+          </PreviewFrame>
+
+          <Badge
+            className="gap-1.5 border-keeperhub-green/30 bg-keeperhub-green/10 text-keeperhub-green"
+            variant="outline"
+          >
+            <Zap className="size-3" />
+            Powered by x402 &middot; gasless USDC on Base
+          </Badge>
+        </div>
       </div>
     </div>
   );

--- a/components/welcome/steps/connect-agent-step.tsx
+++ b/components/welcome/steps/connect-agent-step.tsx
@@ -32,7 +32,7 @@ import {
 import { api } from "@/lib/api-client";
 import { markOnboardingComplete } from "@/lib/welcome-status";
 
-const BACK_PATH = "/welcome/invite-members";
+const BACK_PATH = "/welcome/pay-per-execution";
 
 const TAB_ICONS: Record<string, ComponentType<{ className?: string }>> = {
   "claude-code": ClaudeCodeIcon,
@@ -199,7 +199,7 @@ export function ConnectAgentStep(): React.ReactElement {
       onBack={() => router.push(BACK_PATH)}
       onNext={finish}
       preview={<ConnectAgentPreview frameworkId={activeId} />}
-      stepIndex={2}
+      stepIndex={3}
       title="Connect your AI agent"
     >
       <div className="flex flex-col gap-6">

--- a/components/welcome/steps/connect-agent-step.tsx
+++ b/components/welcome/steps/connect-agent-step.tsx
@@ -30,6 +30,7 @@ import {
   getAgentFrameworks,
 } from "@/lib/agent-connect-commands";
 import { api } from "@/lib/api-client";
+import { BILLING_API } from "@/lib/billing/constants";
 import { markOnboardingComplete } from "@/lib/welcome-status";
 
 const BACK_PATH = "/welcome/pay-per-execution";
@@ -157,12 +158,46 @@ export function ConnectAgentStep(): React.ReactElement {
       ? `${process.env.NEXT_PUBLIC_APP_URL}/mcp`
       : ""
   );
+  const [paygEnabled, setPaygEnabled] = useState(false);
 
   useEffect(() => {
     if (!mcpUrl) {
       setMcpUrl(`${window.location.origin}/mcp`);
     }
   }, [mcpUrl]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadPayg = async (): Promise<void> => {
+      try {
+        const res = await fetch(BILLING_API.PAYG, { cache: "no-store" });
+        if (!res.ok) {
+          return;
+        }
+        const data = (await res.json()) as { enabled?: boolean };
+        if (!cancelled) {
+          setPaygEnabled(Boolean(data.enabled));
+        }
+      } catch {
+        // PAYG status is best-effort here; leave it disabled on failure.
+      }
+    };
+    loadPayg().catch(() => undefined);
+    return (): void => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Enabling pay-as-you-go on the previous step is provisional: going back undoes
+  // it (disable + clear caps) so the user makes a fresh choice.
+  const handleBack = async (): Promise<void> => {
+    if (paygEnabled) {
+      await fetch(BILLING_API.PAYG, { method: "DELETE" }).catch(
+        () => undefined
+      );
+    }
+    router.push(BACK_PATH);
+  };
 
   const frameworks = getAgentFrameworks(mcpUrl || "/mcp");
   const agents = frameworks.filter((f) => f.group === "mcp");
@@ -196,7 +231,7 @@ export function ConnectAgentStep(): React.ReactElement {
       contentClassName="max-w-none"
       description="Point your AI agent at KeeperHub over MCP, then drive workflows and wallets from your editor."
       nextLabel="Finish"
-      onBack={() => router.push(BACK_PATH)}
+      onBack={handleBack}
       onNext={finish}
       preview={<ConnectAgentPreview frameworkId={activeId} />}
       stepIndex={3}

--- a/components/welcome/steps/invite-members-step.tsx
+++ b/components/welcome/steps/invite-members-step.tsx
@@ -28,7 +28,7 @@ import {
 } from "@/lib/onboarding/invite-validation";
 import { cn } from "@/lib/utils";
 
-const NEXT_PATH = "/welcome/connect-agent";
+const NEXT_PATH = "/welcome/pay-per-execution";
 const BACK_PATH = "/welcome/create-org";
 
 type InviteRole = "member" | "admin";

--- a/components/welcome/steps/pay-per-execution-step.tsx
+++ b/components/welcome/steps/pay-per-execution-step.tsx
@@ -136,7 +136,6 @@ function FundingWalletCard({
 export function PayPerExecutionStep(): React.ReactElement {
   const router = useRouter();
   const [payg, setPayg] = useState<PaygStatus | null>(null);
-  const [paygAvailable, setPaygAvailable] = useState(true);
   const [walletAddress, setWalletAddress] = useState<string | null>(null);
   const [balances, setBalances] = useState<ChainBalance[]>([]);
   const [balanceLoading, setBalanceLoading] = useState(true);
@@ -148,9 +147,6 @@ export function PayPerExecutionStep(): React.ReactElement {
       try {
         const res = await fetch(BILLING_API.PAYG, { cache: "no-store" });
         if (!res.ok) {
-          if (!cancelled) {
-            setPaygAvailable(false);
-          }
           return;
         }
         const data = (await res.json()) as PaygStatus;
@@ -158,9 +154,7 @@ export function PayPerExecutionStep(): React.ReactElement {
           setPayg(data);
         }
       } catch {
-        if (!cancelled) {
-          setPaygAvailable(false);
-        }
+        // PAYG status is optional context on this step.
       }
     };
     loadPayg().catch(() => undefined);
@@ -252,19 +246,19 @@ export function PayPerExecutionStep(): React.ReactElement {
       .finally(() => setEnabling(false));
   };
 
-  const canEnable = paygAvailable && !(payg?.enabled ?? false);
-
   return (
     <WelcomeShell
       busy={enabling}
       description="Every organization gets 5,000 free executions a month. Turn on pay-as-you-go to keep workflows running past the free tier."
-      nextLabel={canEnable ? "Enable pay-as-you-go" : "Continue"}
+      nextLabel="Enable pay-as-you-go"
       onBack={() => router.push(BACK_PATH)}
-      onNext={canEnable ? handleEnableAndContinue : goNext}
+      onNext={handleEnableAndContinue}
       onSkip={goNext}
       preview={
         <PayPerExecutionPreview
+          dailyCap={`$${DEFAULT_DAILY_CAP_USDC}`}
           enabled={payg?.enabled ?? false}
+          periodCap={`$${DEFAULT_PERIOD_CAP_USDC}`}
           priceLabel={priceLabel}
         />
       }

--- a/components/welcome/steps/pay-per-execution-step.tsx
+++ b/components/welcome/steps/pay-per-execution-step.tsx
@@ -1,0 +1,345 @@
+"use client";
+
+import { Copy, ExternalLink, Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { PayPerExecutionPreview } from "@/components/welcome/previews";
+import { WelcomeShell } from "@/components/welcome/welcome-shell";
+import { toChecksumAddress } from "@/lib/address-utils";
+import { BILLING_API } from "@/lib/billing/constants";
+import { PAYG_DEFAULT_CHAIN_ID } from "@/lib/billing/payg/constants";
+
+const NEXT_PATH = "/welcome/connect-agent";
+const BACK_PATH = "/welcome/invite-members";
+const BASE_CHAIN_ID = 8453;
+
+type PaygStatus = {
+  enabled: boolean;
+  priceUsdc: string;
+  treasuryConfigured: boolean;
+  chainId: number;
+};
+
+type TokenBalance = { symbol: string; balance: string };
+
+type ChainBalance = {
+  chainId: number;
+  supportedTokens: TokenBalance[];
+  tokens: TokenBalance[];
+};
+
+type BalancesResponse = {
+  walletAddress: string;
+  balances: ChainBalance[];
+};
+
+function formatUsdc(amount: string | undefined): string {
+  const value = Number.parseFloat(amount ?? "0");
+  if (!Number.isFinite(value)) {
+    return "$0.00 USDC";
+  }
+  return `$${value.toFixed(2)} USDC`;
+}
+
+function findUsdcBalance(
+  balances: ChainBalance[],
+  chainId: number
+): string | undefined {
+  const chain = balances.find((b) => b.chainId === chainId);
+  if (!chain) {
+    return undefined;
+  }
+  const pool =
+    chain.supportedTokens.length > 0 ? chain.supportedTokens : chain.tokens;
+  return pool.find((t) => t.symbol.toUpperCase() === "USDC")?.balance;
+}
+
+/** Highlighted callout for the free-tier execution cap, the headline of this step. */
+function FreeCapCallout({
+  priceLabel,
+}: {
+  priceLabel: string;
+}): React.ReactElement {
+  return (
+    <div className="flex items-center gap-4 rounded-lg border border-keeperhub-green/20 bg-keeperhub-green/5 p-4">
+      <p className="font-semibold text-4xl text-keeperhub-green tabular-nums">
+        5,000
+      </p>
+      <div className="flex flex-col gap-0.5">
+        <p className="font-medium text-foreground text-sm">
+          Free executions included every month
+        </p>
+        <p className="text-muted-foreground text-xs">
+          Then {priceLabel} per execution in USDC, gasless.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/** Funding wallet card: prominent USDC balance plus the checksummed address. */
+function FundingWalletCard({
+  balanceLoading,
+  usdcBalance,
+  checksummedAddress,
+  explorerUrl,
+  onCopy,
+}: {
+  balanceLoading: boolean;
+  usdcBalance: string | undefined;
+  checksummedAddress: string | null;
+  explorerUrl: string | null;
+  onCopy: () => void;
+}): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-border bg-card p-3">
+      <p className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+        Funding wallet
+      </p>
+      <p className="font-semibold text-foreground text-xl">
+        {balanceLoading ? "Loading balance..." : formatUsdc(usdcBalance)}
+      </p>
+      {checksummedAddress ? (
+        <div className="flex items-center gap-1.5 text-muted-foreground text-xs">
+          <code className="break-all font-mono">{checksummedAddress}</code>
+          <button
+            aria-label="Copy funding address"
+            className="hover:text-foreground"
+            onClick={onCopy}
+            type="button"
+          >
+            <Copy className="size-3" />
+          </button>
+          {explorerUrl ? (
+            <a
+              aria-label="View on Basescan"
+              className="hover:text-foreground"
+              href={explorerUrl}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <ExternalLink className="size-3" />
+            </a>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/** Enable button, "Enabled" badge, or a muted note, depending on payg status. */
+function EnableAction({
+  available,
+  status,
+  enabling,
+  onEnable,
+}: {
+  available: boolean;
+  status: PaygStatus | null;
+  enabling: boolean;
+  onEnable: () => void;
+}): React.ReactElement | null {
+  if (!available) {
+    return null;
+  }
+  if (status?.enabled) {
+    return (
+      <Badge
+        className="w-fit border-keeperhub-green/30 bg-keeperhub-green/10 text-keeperhub-green"
+        variant="outline"
+      >
+        Enabled
+      </Badge>
+    );
+  }
+  if (!status?.treasuryConfigured) {
+    return (
+      <p className="text-muted-foreground text-xs">Available in production.</p>
+    );
+  }
+  return (
+    <Button
+      className="w-fit"
+      disabled={enabling}
+      onClick={onEnable}
+      size="sm"
+      type="button"
+      variant="outline"
+    >
+      {enabling ? <Loader2 className="size-3.5 animate-spin" /> : null}
+      Enable pay-as-you-go
+    </Button>
+  );
+}
+
+/** Wizard step 3: introduce the free + pay-as-you-go plan and fund the wallet. */
+export function PayPerExecutionStep(): React.ReactElement {
+  const router = useRouter();
+  const [payg, setPayg] = useState<PaygStatus | null>(null);
+  const [paygAvailable, setPaygAvailable] = useState(true);
+  const [walletAddress, setWalletAddress] = useState<string | null>(null);
+  const [balances, setBalances] = useState<ChainBalance[]>([]);
+  const [balanceLoading, setBalanceLoading] = useState(true);
+  const [enabling, setEnabling] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadPayg = async (): Promise<void> => {
+      try {
+        const res = await fetch(BILLING_API.PAYG, { cache: "no-store" });
+        if (!res.ok) {
+          if (!cancelled) {
+            setPaygAvailable(false);
+          }
+          return;
+        }
+        const data = (await res.json()) as PaygStatus;
+        if (!cancelled) {
+          setPayg(data);
+        }
+      } catch {
+        if (!cancelled) {
+          setPaygAvailable(false);
+        }
+      }
+    };
+    loadPayg().catch(() => undefined);
+    return (): void => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadBalances = async (): Promise<void> => {
+      try {
+        const res = await fetch("/api/user/wallet/balances", {
+          cache: "no-store",
+        });
+        if (!res.ok) {
+          return;
+        }
+        const data = (await res.json()) as BalancesResponse;
+        if (!cancelled) {
+          setWalletAddress(data.walletAddress);
+          setBalances(data.balances);
+        }
+      } catch {
+        // Balance stays unknown; the funding block shows a loading fallback.
+      } finally {
+        if (!cancelled) {
+          setBalanceLoading(false);
+        }
+      }
+    };
+    loadBalances().catch(() => undefined);
+    return (): void => {
+      cancelled = true;
+    };
+  }, []);
+
+  const chainId = payg?.chainId ?? PAYG_DEFAULT_CHAIN_ID;
+  const usdcBalance = findUsdcBalance(balances, chainId);
+  const checksummedAddress = walletAddress
+    ? toChecksumAddress(walletAddress)
+    : null;
+  const priceLabel = payg?.priceUsdc
+    ? `$${Number.parseFloat(payg.priceUsdc).toFixed(2)}`
+    : "$0.01";
+  const explorerUrl =
+    checksummedAddress && chainId === BASE_CHAIN_ID
+      ? `https://basescan.org/address/${checksummedAddress}`
+      : null;
+
+  const handleCopy = (): void => {
+    if (!checksummedAddress) {
+      return;
+    }
+    navigator.clipboard
+      .writeText(checksummedAddress)
+      .then(() => toast.success("Address copied"))
+      .catch(() => undefined);
+  };
+
+  const handleEnable = (): void => {
+    setEnabling(true);
+    fetch(BILLING_API.PAYG, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          const data = (await res.json().catch(() => ({}))) as {
+            error?: string;
+          };
+          toast.error(data.error ?? "Could not enable pay-as-you-go");
+          return;
+        }
+        const data = (await res.json()) as PaygStatus;
+        setPayg(data);
+        toast.success("Pay-as-you-go enabled");
+      })
+      .catch((error: unknown) => {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Could not enable pay-as-you-go"
+        );
+      })
+      .finally(() => setEnabling(false));
+  };
+
+  return (
+    <WelcomeShell
+      description="Every organization gets 5,000 free executions a month. Turn on pay-as-you-go to keep workflows running past the free tier."
+      nextLabel="Continue"
+      onBack={() => router.push(BACK_PATH)}
+      onNext={() => router.push(NEXT_PATH)}
+      onSkip={() => router.push(NEXT_PATH)}
+      preview={
+        <PayPerExecutionPreview
+          enabled={payg?.enabled ?? false}
+          priceLabel={priceLabel}
+        />
+      }
+      stepIndex={2}
+      title="Pay per execution"
+    >
+      <div className="flex flex-col gap-5">
+        <FreeCapCallout priceLabel={priceLabel} />
+
+        <ul className="list-disc space-y-1 pl-4 text-muted-foreground text-sm">
+          <li>
+            Charges are gasless USDC pulled straight from your organization
+            wallet. No card required.
+          </li>
+          <li>Spending caps and top-ups are always available in Billing.</li>
+        </ul>
+
+        <FundingWalletCard
+          balanceLoading={balanceLoading}
+          checksummedAddress={checksummedAddress}
+          explorerUrl={explorerUrl}
+          onCopy={handleCopy}
+          usdcBalance={usdcBalance}
+        />
+
+        <EnableAction
+          available={paygAvailable}
+          enabling={enabling}
+          onEnable={handleEnable}
+          status={payg}
+        />
+
+        <p className="text-muted-foreground text-xs">
+          Optional now. You can enable pay-as-you-go, set spending caps, and top
+          up anytime in Billing.
+        </p>
+      </div>
+    </WelcomeShell>
+  );
+}

--- a/components/welcome/steps/pay-per-execution-step.tsx
+++ b/components/welcome/steps/pay-per-execution-step.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import { Copy, ExternalLink, Loader2 } from "lucide-react";
+import { Copy, ExternalLink } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { PayPerExecutionPreview } from "@/components/welcome/previews";
 import { WelcomeShell } from "@/components/welcome/welcome-shell";
 import { toChecksumAddress } from "@/lib/address-utils";
@@ -15,6 +13,10 @@ import { PAYG_DEFAULT_CHAIN_ID } from "@/lib/billing/payg/constants";
 const NEXT_PATH = "/welcome/connect-agent";
 const BACK_PATH = "/welcome/invite-members";
 const BASE_CHAIN_ID = 8453;
+// Default spending caps applied when a user enables pay-as-you-go here; both are
+// editable later in Billing.
+const DEFAULT_DAILY_CAP_USDC = "5";
+const DEFAULT_PERIOD_CAP_USDC = "50";
 
 type PaygStatus = {
   enabled: boolean;
@@ -130,51 +132,6 @@ function FundingWalletCard({
   );
 }
 
-/** Enable button, "Enabled" badge, or a muted note, depending on payg status. */
-function EnableAction({
-  available,
-  status,
-  enabling,
-  onEnable,
-}: {
-  available: boolean;
-  status: PaygStatus | null;
-  enabling: boolean;
-  onEnable: () => void;
-}): React.ReactElement | null {
-  if (!available) {
-    return null;
-  }
-  if (status?.enabled) {
-    return (
-      <Badge
-        className="w-fit border-keeperhub-green/30 bg-keeperhub-green/10 text-keeperhub-green"
-        variant="outline"
-      >
-        Enabled
-      </Badge>
-    );
-  }
-  if (!status?.treasuryConfigured) {
-    return (
-      <p className="text-muted-foreground text-xs">Available in production.</p>
-    );
-  }
-  return (
-    <Button
-      className="w-fit"
-      disabled={enabling}
-      onClick={onEnable}
-      size="sm"
-      type="button"
-      variant="outline"
-    >
-      {enabling ? <Loader2 className="size-3.5 animate-spin" /> : null}
-      Enable pay-as-you-go
-    </Button>
-  );
-}
-
 /** Wizard step 3: introduce the free + pay-as-you-go plan and fund the wallet. */
 export function PayPerExecutionStep(): React.ReactElement {
   const router = useRouter();
@@ -264,12 +221,19 @@ export function PayPerExecutionStep(): React.ReactElement {
       .catch(() => undefined);
   };
 
-  const handleEnable = (): void => {
+  const goNext = (): void => router.push(NEXT_PATH);
+
+  // Enable pay-as-you-go with default spending caps, then advance. On failure we
+  // stay on the step so the user can retry or skip.
+  const handleEnableAndContinue = (): void => {
     setEnabling(true);
     fetch(BILLING_API.PAYG, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({}),
+      body: JSON.stringify({
+        dailyCapUsdc: DEFAULT_DAILY_CAP_USDC,
+        periodCapUsdc: DEFAULT_PERIOD_CAP_USDC,
+      }),
     })
       .then(async (res) => {
         if (!res.ok) {
@@ -279,27 +243,25 @@ export function PayPerExecutionStep(): React.ReactElement {
           toast.error(data.error ?? "Could not enable pay-as-you-go");
           return;
         }
-        const data = (await res.json()) as PaygStatus;
-        setPayg(data);
         toast.success("Pay-as-you-go enabled");
+        goNext();
       })
-      .catch((error: unknown) => {
-        toast.error(
-          error instanceof Error
-            ? error.message
-            : "Could not enable pay-as-you-go"
-        );
+      .catch(() => {
+        toast.error("Could not enable pay-as-you-go");
       })
       .finally(() => setEnabling(false));
   };
 
+  const canEnable = paygAvailable && !(payg?.enabled ?? false);
+
   return (
     <WelcomeShell
+      busy={enabling}
       description="Every organization gets 5,000 free executions a month. Turn on pay-as-you-go to keep workflows running past the free tier."
-      nextLabel="Continue"
+      nextLabel={canEnable ? "Enable pay-as-you-go" : "Continue"}
       onBack={() => router.push(BACK_PATH)}
-      onNext={() => router.push(NEXT_PATH)}
-      onSkip={() => router.push(NEXT_PATH)}
+      onNext={canEnable ? handleEnableAndContinue : goNext}
+      onSkip={goNext}
       preview={
         <PayPerExecutionPreview
           enabled={payg?.enabled ?? false}
@@ -315,9 +277,12 @@ export function PayPerExecutionStep(): React.ReactElement {
         <ul className="list-disc space-y-1 pl-4 text-muted-foreground text-sm">
           <li>
             Charges are gasless USDC pulled straight from your organization
-            wallet. No card required.
+            wallet. No credit card required.
           </li>
-          <li>Spending caps and top-ups are always available in Billing.</li>
+          <li>
+            Enabling sets a $5 daily and $50 monthly spending cap. Change or
+            remove them anytime in Billing.
+          </li>
         </ul>
 
         <FundingWalletCard
@@ -328,16 +293,9 @@ export function PayPerExecutionStep(): React.ReactElement {
           usdcBalance={usdcBalance}
         />
 
-        <EnableAction
-          available={paygAvailable}
-          enabling={enabling}
-          onEnable={handleEnable}
-          status={payg}
-        />
-
         <p className="text-muted-foreground text-xs">
-          Optional now. You can enable pay-as-you-go, set spending caps, and top
-          up anytime in Billing.
+          Optional now. If you skip, you can enable pay-as-you-go anytime in
+          Billing.
         </p>
       </div>
     </WelcomeShell>

--- a/components/welcome/welcome-shell.tsx
+++ b/components/welcome/welcome-shell.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 export const WELCOME_STEPS = [
   { path: "/welcome/create-org", label: "Organization" },
   { path: "/welcome/invite-members", label: "Invite team" },
+  { path: "/welcome/pay-per-execution", label: "Funding" },
   { path: "/welcome/connect-agent", label: "Connect agent" },
 ] as const;
 


### PR DESCRIPTION
## Summary

Adds a new onboarding step that introduces the free execution tier and pay-as-you-go pricing, placed between "Invite members" and the "Connect agent" chat step.

## What changed

- New step at `/welcome/pay-per-execution`:
  - Highlights the 5,000 free executions per month cap as the headline, with the per-execution USDC price as the secondary line.
  - Surfaces the organization funding wallet balance and address (copy + explorer link) so owners can top up.
  - Lets owners optionally enable pay-as-you-go inline (no-op when the treasury is not configured, e.g. outside production).
- Right-side preview animates a 3-node workflow (Onchain Event, Health Factor, Supply to Aave) on a dotted canvas. Each run resolves the charge upfront for the whole execution via x402 (gasless USDC on Base): most runs show a paid state and the nodes execute; capped runs are blocked before execution.
- Rewired the wizard: `Invite members` now advances to this step, the step count is derived from the step list, and the `Connect agent` step is renumbered and points back here.

## Notes

- Presentational only. Reuses the existing `GET/POST /api/billing/payg` and `/api/user/wallet/balances` endpoints; no schema or API changes.
- Verified with `pnpm type-check`, `npx ultracite check`, and `node scripts/token-audit.js --quiet` (no new errors).