### PR TITLE
fix(tempo): confirm transactions by receipt poll to prevent false failures

### DIFF
--- a/lib/web3/chain-adapter/evm.ts
+++ b/lib/web3/chain-adapter/evm.ts
@@ -15,6 +15,22 @@ import type {
   TransactionReceipt,
 } from "./types";
 
+// Tempo (4217 mainnet, 42431 Moderato testnet) settles native 0x76
+// transactions whose RPC shape carries a null top level `value` and a `calls`
+// array. ethers v6 `tx.wait()` arms replacement scanning that reads full
+// transactions and blocks; its `formatTransactionResponse` throws BAD_DATA on
+// that null `value`, so a mined Tempo tx is reported as failed. A receipt has
+// no `value` or `calls` fields, so confirm by polling the receipt on Tempo.
+const TEMPO_CHAIN_IDS = new Set<number>([4217, 42_431]);
+const TEMPO_RECEIPT_TIMEOUT_MS = 60_000;
+const TEMPO_RECEIPT_POLL_INTERVAL_MS = 1500;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
 export class EvmChainAdapter implements ChainAdapter {
   readonly chainFamily = "evm";
   private readonly chainId: number;
@@ -295,6 +311,43 @@ export class EvmChainAdapter implements ChainAdapter {
     }
   }
 
+  // Confirm by polling the receipt directly by hash instead of ethers
+  // `tx.wait()`. Used on Tempo, where wait()'s replacement scan parses full
+  // 0x76 transactions and throws BAD_DATA on their null `value`, failing an
+  // already mined tx. Prefers the rpcManager (failover) and falls back to the
+  // response's own provider for legacy callers.
+  private async waitForReceiptByHash(
+    tx: ethers.TransactionResponse,
+    options: TransactionOptions
+  ): Promise<ethers.TransactionReceipt> {
+    const { rpcManager } = options;
+    const provider = tx.provider;
+    const fetchReceipt = (): Promise<ethers.TransactionReceipt | null> => {
+      if (rpcManager) {
+        return rpcManager.executeWithFailover(
+          (p) => p.getTransactionReceipt(tx.hash),
+          "read"
+        );
+      }
+      if (!provider) {
+        throw new Error("Transaction has no provider to poll for a receipt");
+      }
+      return provider.getTransactionReceipt(tx.hash);
+    };
+
+    const deadline = Date.now() + TEMPO_RECEIPT_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      const receipt = await fetchReceipt();
+      if (receipt) {
+        return receipt;
+      }
+      await delay(TEMPO_RECEIPT_POLL_INTERVAL_MS);
+    }
+    throw new Error(
+      `Timed out waiting for Tempo transaction receipt (${tx.hash})`
+    );
+  }
+
   private async confirmTransaction(
     tx: ethers.TransactionResponse,
     session: NonceSession,
@@ -310,7 +363,9 @@ export class EvmChainAdapter implements ChainAdapter {
       gasConfig.maxFeePerGas.toString()
     );
 
-    const receipt = await tx.wait();
+    const receipt = TEMPO_CHAIN_IDS.has(this.chainId)
+      ? await this.waitForReceiptByHash(tx, options)
+      : await tx.wait();
     if (!receipt) {
       throw new Error("Transaction sent but receipt not available");
     }

--- a/tests/unit/evm-chain-adapter-tempo-confirm.test.ts
+++ b/tests/unit/evm-chain-adapter-tempo-confirm.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/db", () => ({ db: {} }));
+vi.mock("@/lib/db/schema", () => ({ explorerConfigs: {} }));
+vi.mock("drizzle-orm", () => ({ eq: () => ({}) }));
+vi.mock("@/lib/explorer", () => ({
+  getAddressUrl: () => "",
+  getTransactionUrl: () => "",
+}));
+
+import { EvmChainAdapter } from "@/lib/web3/chain-adapter/evm";
+
+const FROM = "0x2c9F694183A4240B6431771F6c714a8106179dF5";
+const TO = "0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59";
+const TX_HASH = "0xf00d";
+const TEMPO_TESTNET = 42_431;
+const SEPOLIA = 11_155_111;
+
+function buildReceipt(): Record<string, unknown> {
+  return {
+    hash: TX_HASH,
+    status: 1,
+    gasUsed: BigInt(210_000),
+    gasPrice: BigInt(1_000_000_000),
+    blockNumber: 500,
+  };
+}
+
+function createGasStrategy(): unknown {
+  return {
+    getGasConfig: vi.fn().mockResolvedValue({
+      gasLimit: BigInt(100_000),
+      maxFeePerGas: BigInt(1_000_000_000),
+      maxPriorityFeePerGas: BigInt(1_000_000),
+    }),
+  };
+}
+
+function createNonceManager(): unknown {
+  return {
+    getNextNonce: vi.fn().mockReturnValue(7),
+    recordTransaction: vi.fn().mockResolvedValue(undefined),
+    confirmTransaction: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+// An ethers TransactionResponse.wait() that throws the exact ethers v6 error a
+// Tempo 0x76 tx triggers when wait() parses a full transaction or block.
+function badDataWait(): ReturnType<typeof vi.fn> {
+  return vi.fn().mockRejectedValue(
+    Object.assign(new Error("invalid BigNumberish value (value=null)"), {
+      code: "BAD_DATA",
+    })
+  );
+}
+
+type Harness = {
+  adapter: EvmChainAdapter;
+  signer: unknown;
+  wait: ReturnType<typeof vi.fn>;
+  getTransactionReceipt: ReturnType<typeof vi.fn>;
+};
+
+function createHarness(
+  chainId: number,
+  wait: ReturnType<typeof vi.fn>
+): Harness {
+  const getTransactionReceipt = vi.fn().mockResolvedValue(buildReceipt());
+  const provider = {
+    getNetwork: vi.fn().mockResolvedValue({ chainId: BigInt(chainId) }),
+    call: vi.fn().mockResolvedValue("0x"),
+    estimateGas: vi.fn().mockResolvedValue(BigInt(210_000)),
+    getTransactionReceipt,
+  };
+  const txResponse = { hash: TX_HASH, provider, wait };
+  const signer = {
+    getAddress: vi.fn().mockResolvedValue(FROM),
+    provider,
+    sendTransaction: vi.fn().mockResolvedValue(txResponse),
+  };
+  const adapter = new EvmChainAdapter(
+    chainId,
+    createGasStrategy() as ConstructorParameters<typeof EvmChainAdapter>[1],
+    createNonceManager() as ConstructorParameters<typeof EvmChainAdapter>[2]
+  );
+  return { adapter, signer, wait, getTransactionReceipt };
+}
+
+async function send(h: Harness): Promise<{ hash: string }> {
+  return await h.adapter.sendTransaction(
+    h.signer as unknown as Parameters<EvmChainAdapter["sendTransaction"]>[0],
+    { to: TO, value: BigInt(1) },
+    {} as Parameters<EvmChainAdapter["sendTransaction"]>[2],
+    { gasOverrides: {} }
+  );
+}
+
+describe("EvmChainAdapter Tempo confirmation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("confirms a Tempo tx via receipt poll even when tx.wait() throws BAD_DATA", async () => {
+    const h = createHarness(TEMPO_TESTNET, badDataWait());
+
+    const result = await send(h);
+
+    expect(result.hash).toBe(TX_HASH);
+    expect(h.getTransactionReceipt).toHaveBeenCalledWith(TX_HASH);
+    // The bug: relying on tx.wait() reports a mined Tempo tx as failed.
+    expect(h.wait).not.toHaveBeenCalled();
+  });
+
+  it("still uses tx.wait() on a chain other than Tempo", async () => {
+    const wait = vi.fn().mockResolvedValue(buildReceipt());
+    const h = createHarness(SEPOLIA, wait);
+
+    const result = await send(h);
+
+    expect(result.hash).toBe(TX_HASH);
+    expect(h.wait).toHaveBeenCalledTimes(1);
+    expect(h.getTransactionReceipt).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Summary:

Successful Tempo transactions are reported as failed, and a retry on that
false failure can double spend. This confirms Tempo transactions by polling
the receipt instead of ethers `tx.wait()`.

# Details:

Direct execution on Tempo (chains 4217 and 42431) runs through the generic
EVM adapter, which confirms with ethers v6 `tx.wait()`. wait() arms
replacement scanning that reads full transactions and blocks (`getTransaction`,
`getBlock(n, true)`), and its formatter throws `invalid BigNumberish value
(value=null)` (BAD_DATA) on Tempo 0x76 transactions, which carry a `calls`
array and a null top level `value`. So a transaction that broadcast and mined
is reported as failed, and a caller that retries can double spend.

On Tempo chains the adapter now confirms by polling `getTransactionReceipt(hash)`.
A receipt has no `value` or `calls` fields, so it parses cleanly. Every other
chain keeps using `tx.wait()`, and the status 0 revert check is unchanged. The
added unit test drives a Tempo send whose `tx.wait()` throws the exact BAD_DATA
error and asserts it still confirms through the receipt poll, plus a control
that a chain other than Tempo still uses `tx.wait()`.
