### PR TITLE
fix(tempo): floor memo transfer gas so estimates cover settlement

### DIFF
--- a/plugins/tempo/steps/tempo-tx-core.ts
+++ b/plugins/tempo/steps/tempo-tx-core.ts
@@ -29,7 +29,7 @@ import "server-only";
 
 import { ethers } from "ethers";
 import { TxEnvelopeTempo } from "ox/tempo";
-import { encodeFunctionData, type Hex } from "viem";
+import { encodeFunctionData, type Hex, toFunctionSelector } from "viem";
 import { Abis } from "viem/tempo";
 import { toChecksumAddress } from "@/lib/address-utils";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
@@ -223,12 +223,41 @@ export function normalizeMemo(memo?: string): Hex {
   }
 }
 
+const TRANSFER_WITH_MEMO_SELECTOR = toFunctionSelector(
+  "transferWithMemo(address,uint256,bytes32)"
+);
+
+/**
+ * Floor for a memo transfer's estimate. eth_estimateGas on Tempo reports the
+ * storage cost of the bytes32 memo write too low, so a memo transfer's estimate
+ * (~35k) can land far below its real settlement cost (~272k) and the node
+ * rejects the tx ("call gas cost exceeds the gas limit"). Raising the limit is
+ * free on Tempo (the fee is charged on gas used, not the limit), so flooring is
+ * safe and applies to each memo call.
+ */
+export const TEMPO_MEMO_MIN_GAS = BigInt(300_000);
+
+/** Raise a memo transfer's estimate to the memo floor; other calls unchanged. */
+export function applyTempoMemoGasFloor(
+  call: TempoCall,
+  estimatedGas: bigint
+): bigint {
+  const isMemoTransfer = call.data
+    .toLowerCase()
+    .startsWith(TRANSFER_WITH_MEMO_SELECTOR);
+  if (isMemoTransfer && estimatedGas < TEMPO_MEMO_MIN_GAS) {
+    return TEMPO_MEMO_MIN_GAS;
+  }
+  return estimatedGas;
+}
+
 /**
  * Estimate execution gas for the batch by summing per-call estimates. The
  * atomic 0x76 envelope is not directly estimable via eth_estimateGas, so each
  * call is estimated as a standalone call from the wallet; summing slightly
  * over-counts the shared intrinsic cost, which is safe (on Tempo the fee is
- * charged on gas used, not the limit). The AdaptiveGasStrategy multiplier then
+ * charged on gas used, not the limit). Memo transfers are floored because their
+ * estimate omits the memo storage cost. The AdaptiveGasStrategy multiplier then
  * adds the safety margin on top.
  */
 async function estimateTempoGas(
@@ -243,7 +272,7 @@ async function estimateTempoGas(
         provider.estimateGas({ from, to: call.to, data: call.data }),
       "preflight"
     );
-    total += gas;
+    total += applyTempoMemoGasFloor(call, gas);
   }
   return total;
 }

--- a/tests/unit/tempo-tx-core.test.ts
+++ b/tests/unit/tempo-tx-core.test.ts
@@ -25,10 +25,13 @@ vi.mock("@/lib/logging", () => ({
 }));
 
 import {
+  applyTempoMemoGasFloor,
+  buildSwapExactAmountInCall,
   buildTransferWithMemoCall,
   deriveTempoNonceKey,
   isTempoChain,
   normalizeMemo,
+  TEMPO_MEMO_MIN_GAS,
 } from "@/plugins/tempo/steps/tempo-tx-core";
 
 const ZERO_MEMO = `0x${"0".repeat(64)}`;
@@ -118,5 +121,39 @@ describe("buildTransferWithMemoCall", () => {
     const decoded = decodeFunctionData({ abi: Abis.tip20, data: call.data });
     expect(decoded.functionName).toBe("transferWithMemo");
     expect(decoded.args).toEqual([RECIPIENT, BigInt(1_500_000), memo]);
+  });
+});
+
+describe("applyTempoMemoGasFloor", () => {
+  const memoCall = buildTransferWithMemoCall(
+    USDC,
+    RECIPIENT,
+    BigInt(1_500_000),
+    normalizeMemo("benchmark")
+  );
+  // A memo transfer's real settlement cost observed on Tempo testnet.
+  const REAL_MEMO_GAS = BigInt(272_108);
+  // What eth_estimateGas returns for it, below even a plain transfer.
+  const UNDERESTIMATE = BigInt(35_770);
+
+  it("raises a memo transfer's underestimate to a floor that covers real cost", () => {
+    const floored = applyTempoMemoGasFloor(memoCall, UNDERESTIMATE);
+    expect(floored).toBe(TEMPO_MEMO_MIN_GAS);
+    expect(TEMPO_MEMO_MIN_GAS).toBeGreaterThan(REAL_MEMO_GAS);
+  });
+
+  it("keeps a memo estimate that already exceeds the floor", () => {
+    const high = TEMPO_MEMO_MIN_GAS + BigInt(50_000);
+    expect(applyTempoMemoGasFloor(memoCall, high)).toBe(high);
+  });
+
+  it("leaves a call that is not a memo transfer (DEX swap) untouched", () => {
+    const swapCall = buildSwapExactAmountInCall(
+      USDC,
+      RECIPIENT,
+      BigInt(1_000_000),
+      BigInt(990_000)
+    );
+    expect(applyTempoMemoGasFloor(swapCall, UNDERESTIMATE)).toBe(UNDERESTIMATE);
   });
 });


### PR DESCRIPTION
# Summary:

Memo transfers on Tempo are estimated far too low, so the node rejects them.
This floors the memo transfer gas so the limit covers real settlement.

# Details:

The `tempo/transfer-with-memo` action sums per call `eth_estimateGas`. On
Tempo, `eth_estimateGas` reports the storage cost of the bytes32 memo write
too low, so `transferWithMemo` estimates around 35k while its real settlement
cost is around 272k. With only the 1.5x chain multiplier the node rejects the
transfer with "call gas cost exceeds the gas limit".

Each memo transfer call is now floored to 300k before the multiplier, detected
by the `transferWithMemo` selector. Raising the limit is free on Tempo, since
the fee is charged on gas used and not on the limit, and the floor applies to
each memo call, so batch payouts scale and plain transfers and swaps keep their
accurate estimates. The added unit cases cover a memo call built by
`buildTransferWithMemoCall` with an underestimate being raised to the floor
(asserted above the observed real cost of 272,108), a memo estimate already
above the floor staying put, and a DEX swap call staying untouched.
