### PR TITLE
fix(tempo): reject native transfers with a clear TIP-20 message

### DIFF
--- a/plugins/web3/steps/transfer-funds-core.ts
+++ b/plugins/web3/steps/transfer-funds-core.ts
@@ -47,6 +47,10 @@ import {
   withNonceSession,
 } from "@/lib/web3/transaction-manager";
 
+// Tempo (4217 mainnet, 42431 testnet) has no native gas token: value moves via
+// TIP-20 transfers, so a native send has no valid form and reverts at preflight.
+const TEMPO_CHAIN_IDS = new Set([4217, 42_431]);
+
 export type TransferFundsCoreInput = {
   network: string;
   amount: string;
@@ -120,6 +124,16 @@ export async function transferFundsCore(
       gasLimitMultiplier,
       _context,
     });
+  }
+
+  // Tempo has no native token to move; fail with a clear message instead of the
+  // opaque CALL_EXCEPTION an empty data preflight would otherwise return.
+  if (TEMPO_CHAIN_IDS.has(chainId)) {
+    return {
+      success: false,
+      error:
+        "Tempo has no native token to transfer. Send a TIP-20 stablecoin instead by providing a token address.",
+    };
   }
 
   // Validate recipient address

--- a/tests/unit/transfer-funds-tempo-native.test.ts
+++ b/tests/unit/transfer-funds-tempo-native.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/web3/wallet-helpers", () => ({
+  initializeSolanaWallet: vi.fn(),
+  initializeWalletSigner: vi.fn(),
+  getOrganizationWalletAddress: vi.fn(),
+}));
+
+vi.mock("@/lib/web3/chain-adapter", () => ({ getChainAdapter: vi.fn() }));
+
+vi.mock("@/lib/web3/resolve-org-context", () => ({
+  resolveOrganizationContext: vi.fn(),
+}));
+
+import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
+import { transferFundsCore } from "@/plugins/web3/steps/transfer-funds-core";
+
+const RECIPIENT = "0x1111111111111111111111111111111111111111";
+
+async function nativeTransfer(
+  network: string
+): ReturnType<typeof transferFundsCore> {
+  return await transferFundsCore({
+    network,
+    amount: "1.0",
+    recipientAddress: RECIPIENT,
+    _context: { organizationId: "org-1" },
+  });
+}
+
+describe("transferFundsCore - Tempo native transfer guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // A chain other than Tempo that passes the guard fails here, giving us a
+    // distinct marker to prove the guard did not fire.
+    vi.mocked(resolveOrganizationContext).mockResolvedValue({
+      success: false,
+      error: "no org in test",
+    });
+  });
+
+  it("rejects a native transfer on Tempo testnet with a clear TIP-20 message", async () => {
+    const result = await nativeTransfer("42431");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Tempo has no native token");
+      expect(result.error).toContain("TIP-20");
+    }
+    // The guard returns before org resolution runs.
+    expect(resolveOrganizationContext).not.toHaveBeenCalled();
+  });
+
+  it("rejects a native transfer on Tempo mainnet too", async () => {
+    const result = await nativeTransfer("4217");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Tempo has no native token");
+    }
+  });
+
+  it("does not fire the guard on an EVM chain that is not Tempo", async () => {
+    const result = await nativeTransfer("8453");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).not.toContain("Tempo has no native token");
+      expect(result.error).toBe("no org in test");
+    }
+    expect(resolveOrganizationContext).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
# Summary:

A native transfer on Tempo fails with an opaque CALL_EXCEPTION. This returns a
clear message telling the caller to send a TIP-20 stablecoin instead.

# Details:

Tempo (chains 4217 and 42431) has no native gas token, since value moves
through TIP-20 transfers. A native transfer with no token therefore has no
valid onchain form and fails at the empty data preflight with an opaque
CALL_EXCEPTION that is surfaced to the caller verbatim.

The native transfer path now guards Tempo early and returns a clear message
directing the caller to send a TIP-20 stablecoin by providing a token address.
This is the clear message option rather than auto mapping a native transfer to
a TIP-20 transfer, because a native call carries no token and there is no
unambiguous default to map to. The added unit test covers native transfers on
Tempo mainnet and testnet returning the clear message before org resolution
runs, and a chain other than Tempo (Base) passing the guard and proceeding.
