### PR TITLE
fix(billing): accept PAYG spend caps typed with a leading or trailing dot

### DIFF
--- a/lib/billing/payg/usdc.ts
+++ b/lib/billing/payg/usdc.ts
@@ -3,12 +3,15 @@
 
 export const USDC_DECIMALS = 6;
 
-const DECIMAL_RE = /^\d+(\.\d+)?$/;
+// Non-negative decimal with an optional integer and/or fractional part, so the
+// common ways to type a USDC amount all parse: "5", "0.5", ".5", "5.", "5.50".
+// Rejects negatives, letters, and multiple dots.
+const DECIMAL_RE = /^(\d+\.?\d*|\.\d+)$/;
 
 /**
- * True if `value` is a well-formed non-negative USDC decimal (e.g. "0", "1.5").
- * Callers that must distinguish "0" (a valid zero) from garbage validate with
- * this before calling usdcDecimalToRaw, which returns 0n for both.
+ * True if `value` is a well-formed non-negative USDC decimal (e.g. "0", "1.5",
+ * ".5"). Callers that must distinguish "0" (a valid zero) from garbage validate
+ * with this before calling usdcDecimalToRaw, which returns 0n for both.
  */
 export function isValidUsdcDecimal(value: string): boolean {
   return DECIMAL_RE.test(value.trim());

--- a/tests/integration/payg-enable-route.test.ts
+++ b/tests/integration/payg-enable-route.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// Auth + gating: authenticated org owner on the free plan, PAYG available.
+vi.mock("@/lib/billing/feature-flag", () => ({
+  isBillingEnabled: () => true,
+}));
+vi.mock("@/lib/billing/require-org-owner", () => ({
+  requireOrgOwner: vi.fn(async () => ({
+    orgId: "org_1",
+    userId: "user_1",
+    email: "owner@example.com",
+  })),
+}));
+vi.mock("@/lib/billing/plans-server", () => ({
+  getOrgPlan: vi.fn(async () => "free"),
+}));
+vi.mock("@/lib/billing/payg/treasury", () => ({
+  getPaygTreasuryOrNull: () => "0x000000000000000000000000000000000000dEaD",
+}));
+vi.mock("@/lib/billing/payg/pricing", () => ({
+  getPaygExecutionPriceRaw: () => BigInt(10_000),
+}));
+
+// Capture what the route persists so we can assert the parsed raw amounts.
+const upsertPaygConfig = vi.fn(async (..._a: unknown[]) => undefined);
+vi.mock("@/lib/billing/payg/config-store", () => ({
+  upsertPaygConfig: (...a: unknown[]) => upsertPaygConfig(...a),
+  deletePaygConfig: vi.fn(async () => undefined),
+  getPaygConfig: vi.fn(async () => ({
+    id: "cfg_1",
+    organizationId: "org_1",
+    chainId: 8453,
+    dailyCapRaw: "0",
+    periodCapRaw: "0",
+    startedAt: new Date("2026-01-01T00:00:00Z"),
+  })),
+}));
+vi.mock("@/lib/billing/payg/usage", () => ({
+  getCurrentPaygUsage: vi.fn(async () => null),
+}));
+vi.mock("@/lib/middleware/auth-helpers", () => ({
+  resolveOrganizationId: vi.fn(async () => ({ organizationId: "org_1" })),
+}));
+vi.mock("@/lib/security/audit-log", () => ({
+  buildAuditMetadata: () => ({}),
+  recordAuditEvent: vi.fn(async () => undefined),
+}));
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { BILLING: "billing" },
+  logSystemError: vi.fn(),
+}));
+
+import { POST } from "@/app/api/billing/payg/route";
+
+function postCaps(body: unknown): Request {
+  return new Request("http://localhost:3000/api/billing/payg", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/billing/payg enable (spend caps)", () => {
+  it("accepts caps typed with a leading dot (.5) and persists the raw amounts", async () => {
+    const res = await POST(
+      postCaps({ dailyCapUsdc: ".5", periodCapUsdc: "1" })
+    );
+
+    expect(res.status).toBe(200);
+    expect(upsertPaygConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: "org_1",
+        dailyCapRaw: "500000",
+        periodCapRaw: "1000000",
+      })
+    );
+  });
+
+  it("treats an empty cap as no limit (raw 0) and still enables", async () => {
+    const res = await POST(postCaps({ dailyCapUsdc: "", periodCapUsdc: "" }));
+
+    expect(res.status).toBe(200);
+    expect(upsertPaygConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ dailyCapRaw: "0", periodCapRaw: "0" })
+    );
+  });
+
+  it("rejects a genuinely malformed cap with 400 and does not persist", async () => {
+    const res = await POST(
+      postCaps({ dailyCapUsdc: "abc", periodCapUsdc: "1" })
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Spending caps must be valid USDC amounts");
+    expect(upsertPaygConfig).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/billing-payg.test.ts
+++ b/tests/unit/billing-payg.test.ts
@@ -35,6 +35,13 @@ describe("USDC 6-decimal raw conversion", () => {
     expect(usdcDecimalToRaw("10")).toBe(BigInt(10_000_000));
   });
 
+  it("parses a cap typed with a leading or trailing dot", () => {
+    // The billing modal lets a user type ".5" or "5."; both are valid amounts.
+    expect(usdcDecimalToRaw(".5")).toBe(BigInt(500_000));
+    expect(usdcDecimalToRaw("0.5")).toBe(BigInt(500_000));
+    expect(usdcDecimalToRaw("5.")).toBe(BigInt(5_000_000));
+  });
+
   it("returns 0 for malformed input", () => {
     expect(usdcDecimalToRaw("")).toBe(BigInt(0));
     expect(usdcDecimalToRaw("abc")).toBe(BigInt(0));
@@ -46,8 +53,17 @@ describe("USDC 6-decimal raw conversion", () => {
 });
 
 describe("USDC decimal validation (spend caps)", () => {
-  it("accepts well-formed non-negative decimals", () => {
-    for (const value of ["0", "1", "1.5", "0.01", "1000.000000"]) {
+  it("accepts well-formed non-negative decimals, incl. a leading/trailing dot", () => {
+    for (const value of [
+      "0",
+      "1",
+      "1.5",
+      "0.01",
+      "1000.000000",
+      ".5",
+      "0.5",
+      "5.",
+    ]) {
       expect(isValidUsdcDecimal(value)).toBe(true);
     }
   });


### PR DESCRIPTION
The enable-pay-as-you-go modal rejected common decimal forms. The cap validator's regex required a leading digit, so typing `.5` (0.5) returned 400 "Spending caps must be valid USDC amounts". This shipped with the PAYG feature and is failing on staging.

## Fix
Widen the decimal regex to accept an optional integer and/or fractional part (`.5`, `5.`, `0.5`, `5.50`) while still rejecting negatives, letters, and multiple dots.

## Why it is safe (whole-flow checked)
The stored value shape is unchanged: `parseCap` always persists `usdcDecimalToRaw(x).toString()`, a clean integer string. So the guard-rail cap checks (`BigInt(dailyCapRaw / periodCapRaw)` in `autopayForExecution`) and every other `BigInt(capRaw / amountRaw)` call across `lib/`, `app/`, and `keeperhub-executor/` operate on clean integers and cannot throw on any input, including garbage (which normalizes to `0`).

Caps are parsed once at enable time (route `try/catch` returns 400, never 500). The execution and charge path never re-parses user input; it only reads the normalized integer from the DB, so a cap value cannot break the execution pipeline.

## Verification
- New `POST /api/billing/payg` enable test: `.5`/`1` accepted and persisted as raw (`500000`/`1000000`), empty maps to no-limit (`0`), garbage returns 400 without persisting.
- Unit cases for the new decimal forms and the raw conversion.
- Full unit suite green (20096 passed).