### PR TITLE
feat: surface sponsored/7702 execution details in direct-execution API

### DIFF
--- a/app/api/execute/[executionId]/status/route.ts
+++ b/app/api/execute/[executionId]/status/route.ts
@@ -79,6 +79,7 @@ export async function GET(
     type: execution.type,
     transactionHash: execution.transactionHash,
     transactionLink: (output?.transactionLink as string) ?? null,
+    sponsored: Boolean(output?.sponsored),
     result: output ?? null,
     error: execution.error,
     gasUsedWei: execution.gasUsedWei,

--- a/app/api/execute/_lib/types.ts
+++ b/app/api/execute/_lib/types.ts
@@ -3,6 +3,8 @@ export type ExecutionStatus = "pending" | "running" | "completed" | "failed";
 export type ExecuteResponse = {
   executionId: string;
   status: ExecutionStatus;
+  transactionHash?: string | null;
+  transactionLink?: string | null;
 };
 
 export type ExecutionStatusResponse = {
@@ -11,6 +13,7 @@ export type ExecutionStatusResponse = {
   type: string;
   transactionHash: string | null;
   transactionLink: string | null;
+  sponsored: boolean;
   result: unknown;
   error: string | null;
   gasUsedWei: string | null;

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -36,6 +36,7 @@ import {
 } from "../_lib/reserved-value";
 import { parseSimulateFlag } from "../_lib/simulate-flag";
 import { checkAndReserveExecution } from "../_lib/spending-cap";
+import type { ExecuteResponse } from "../_lib/types";
 import { validateTokenFields, validateTransferInput } from "../_lib/validate";
 import { requireWallet } from "../_lib/wallet-check";
 
@@ -291,13 +292,20 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   // 10. Return. A failed broadcast is finalized (not released) so a retry
   // replays the failure instead of re-sending the tx.
+  const responseBody: ExecuteResponse = {
+    executionId,
+    status: result.success ? "completed" : "failed",
+    ...(result.success
+      ? {
+          transactionHash: result.transactionHash,
+          transactionLink: result.transactionLink,
+        }
+      : {}),
+  };
   return applyRateLimitHeaders(
     await recordIdempotentResponse(
       idem,
-      NextResponse.json(
-        { executionId, status: result.success ? "completed" : "failed" },
-        { status: HttpStatus.ACCEPTED }
-      ),
+      NextResponse.json(responseBody, { status: HttpStatus.ACCEPTED }),
       result.success ? "success" : "failed"
     ),
     rateLimit

--- a/docs/api/direct-execution.md
+++ b/docs/api/direct-execution.md
@@ -69,6 +69,16 @@ curl -X POST https://app.keeperhub.com/api/execute/transfer \
 
 Workflow webhooks (`POST /api/workflows/{workflowId}/webhook`) accept the same header, scoped per workflow.
 
+## Sponsored Executions
+
+Writes may be gas-sponsored and broadcast through a relayer or smart-account
+(EIP-7702) path instead of your org's EOA wallet. A sponsored execution does
+not change your EOA's nonce or native balance, and it will not appear in a
+block explorer's `txlist` for that address — checks against the EOA will
+conclude nothing happened even though the transaction succeeded. Check the
+`sponsored` field on the status response and treat `transactionHash` /
+`transactionLink` as the authoritative proof, not EOA-level state.
+
 ## Transfer Funds
 
 ```http
@@ -107,11 +117,13 @@ Successful broadcast requests return HTTP `202 Accepted`:
 ```json
 {
   "executionId": "direct_123",
-  "status": "completed"
+  "status": "completed",
+  "transactionHash": "0x...",
+  "transactionLink": "https://etherscan.io/tx/0x..."
 }
 ```
 
-The execution runs synchronously. Status will be `completed` or `failed` when the request returns.
+The execution runs synchronously. Status will be `completed` or `failed` when the request returns. `transactionHash` and `transactionLink` are present only when `status` is `completed`.
 
 ## Call Smart Contract
 
@@ -349,6 +361,7 @@ Check the status of a direct execution.
   "type": "transfer",
   "transactionHash": "0x...",
   "transactionLink": "https://etherscan.io/tx/0x...",
+  "sponsored": false,
   "gasUsedWei": "21000000000000",
   "result": {...},
   "error": null,
@@ -363,6 +376,10 @@ Check the status of a direct execution.
 - `running`: Currently executing
 - `completed`: Successfully completed
 - `failed`: Execution failed
+
+`sponsored` is `true` when the write was gas-sponsored and broadcast through
+a relayer or smart-account path rather than your org's EOA wallet — see
+[Sponsored Executions](#sponsored-executions).
 
 When polling this endpoint, honour the `X-Poll-Interval-Hint` response header instead of polling on a fixed timer: it gives the recommended number of seconds to wait before the next poll. A value of `0` means the execution has reached a terminal state (`completed` or `failed`) and you can stop polling.
 

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -146,7 +146,7 @@
       "path": "/api/execute/{executionId}/status",
       "route_file": "app/api/execute/[executionId]/status/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 338
+      "line": 350
     },
     {
       "method": "GET",
@@ -342,21 +342,21 @@
       "path": "/api/execute/check-and-execute",
       "route_file": "app/api/execute/check-and-execute/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 175
+      "line": 187
     },
     {
       "method": "POST",
       "path": "/api/execute/contract-call",
       "route_file": "app/api/execute/contract-call/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 119
+      "line": 131
     },
     {
       "method": "POST",
       "path": "/api/execute/transfer",
       "route_file": "app/api/execute/transfer/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 75
+      "line": 85
     },
     {
       "method": "POST",

--- a/tests/integration/direct-execution-api.test.ts
+++ b/tests/integration/direct-execution-api.test.ts
@@ -300,6 +300,8 @@ describe("Direct Execution API", () => {
       const data = await response.json();
       expect(data.executionId).toBe("exec_1");
       expect(data.status).toBe("completed");
+      expect(data.transactionHash).toBe("0xabc");
+      expect(data.transactionLink).toBe("https://etherscan.io/tx/0xabc");
       expect(mocks.completeExecution).toHaveBeenCalledOnce();
       expect(mocks.transferFundsCore).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -330,6 +332,8 @@ describe("Direct Execution API", () => {
       expect(response.status).toBe(202);
       const data = await response.json();
       expect(data.status).toBe("completed");
+      expect(data.transactionHash).toBe("0xdef");
+      expect(data.transactionLink).toBe("https://etherscan.io/tx/0xdef");
       expect(mocks.transferTokenCore).toHaveBeenCalledOnce();
       expect(mocks.transferFundsCore).not.toHaveBeenCalled();
     });
@@ -413,6 +417,8 @@ describe("Direct Execution API", () => {
       expect(response.status).toBe(202);
       const data = await response.json();
       expect(data.status).toBe("failed");
+      expect(data.transactionHash).toBeUndefined();
+      expect(data.transactionLink).toBeUndefined();
       expect(mocks.failExecution).toHaveBeenCalledWith(
         "exec_1",
         "Insufficient funds"
@@ -877,8 +883,45 @@ describe("Direct Execution API", () => {
       expect(data.type).toBe("transfer");
       expect(data.transactionHash).toBe("0xabc");
       expect(data.transactionLink).toBe("https://etherscan.io/tx/0xabc");
+      expect(data.sponsored).toBe(false);
       expect(data.createdAt).toBe(now.toISOString());
       expect(data.completedAt).toBe(now.toISOString());
+    });
+
+    it("returns sponsored: true for a gas-sponsored execution", async () => {
+      setupPassingGuards();
+      const now = new Date();
+      mocks.statusDbResult = [
+        {
+          id: "exec_2",
+          organizationId: "org_test",
+          apiKeyId: "key_test",
+          type: "transfer",
+          network: "ethereum",
+          status: "completed",
+          transactionHash: "0xabc",
+          gasUsedWei: "441000000000000",
+          gasPriceWei: "500000221",
+          estimatedCostUsd: null,
+          retryCount: 0,
+          input: {},
+          output: {
+            transactionLink: "https://etherscan.io/tx/0xabc",
+            sponsored: true,
+          },
+          error: null,
+          createdAt: now,
+          completedAt: now,
+        },
+      ];
+
+      const response = await statusGET(getRequest("/exec_2/status"), {
+        params: Promise.resolve({ executionId: "exec_2" }),
+      });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.sponsored).toBe(true);
     });
 
     it("route exports GET only -- non-GET methods are intentionally 405 (Next.js auto-handler)", async () => {


### PR DESCRIPTION
## Summary
- Document that gas-sponsored and EIP-7702 smart-account executions are invisible to EOA-level nonce/balance/txlist checks (docs/api/direct-execution.md).
- Echo `transactionHash` and `transactionLink` on the `POST /api/execute/transfer` 202 response instead of only `executionId`/`status`.
- Add a `sponsored` field to the `GET /api/execute/{executionId}/status` response, derived from the execution's stored output.

Both API changes are additive only - no existing field removed or renamed.

## Test plan
- [x] `tsc --noEmit` - clean
- [x] `biome check` on changed files - clean
- [x] `vitest run tests/integration/direct-execution-api.test.ts` - 40/40 passing (new/updated assertions cover transactionHash/transactionLink on success and failure, and sponsored true/false)
- [x] `vitest run` on adjacent execute-route test suites - no regressions