### PR TITLE
fix: warp aerodrome vote to an epoch-relative timestamp

### DIFF
--- a/tests/e2e/vitest/protocol-simulation/_shared/simulate-events.ts
+++ b/tests/e2e/vitest/protocol-simulation/_shared/simulate-events.ts
@@ -538,6 +538,24 @@ const AERO_VOTER_IFACE = new Interface([
 const AERO_DEPOSIT_TOPIC = id(
   "Deposit(address,uint256,uint8,uint256,uint256,uint256)"
 );
+const AERO_WEEK = BigInt(7 * 24 * 3600);
+const AERO_HOUR = BigInt(3600);
+
+// Mirrors VelodromeTimeLibrary.epochStart: epochs run Thu 00:00 UTC to Thu
+// 00:00 UTC. Voter.onlyNewEpoch additionally reverts with DistributeWindow
+// during the first hour of a new epoch (Voter.sol:105) and NotWhitelistedNFT
+// past the last hour of the old one (Voter.sol:266), so a vote is only valid
+// strictly between those two bounds.
+function aeroEpochStart(timestamp: bigint): bigint {
+  return timestamp - (timestamp % AERO_WEEK);
+}
+
+function isInAeroVoteWindow(timestamp: bigint): boolean {
+  const start = aeroEpochStart(timestamp);
+  return (
+    timestamp > start + AERO_HOUR && timestamp < start + AERO_WEEK - AERO_HOUR
+  );
+}
 
 async function emitAerodrome(provider: JsonRpcProvider): Promise<Log[]> {
   const logs: Log[] = [];
@@ -608,9 +626,31 @@ async function emitAerodrome(provider: JsonRpcProvider): Promise<Log[]> {
   );
   const id1 = tokenIdFrom(lock1.logs);
 
-  // voter-voted: past the epoch distribute window, vote for the WETH/USDC pool.
-  await provider.send("evm_increaseTime", [2 * 24 * 3600]);
+  // voter-voted: warp to a fixed offset into the *next* epoch rather than a
+  // fixed +2d delta from "now" - the old delta drifted in and out of the
+  // epoch's voting window depending on when CI ran. Target epochStart(now) +
+  // WEEK + 12h, which is always a fresh epoch (comfortably clears the 1h
+  // DistributeWindow at its start) with an 11h margin either side.
+  const preVoteBlock = await provider.getBlock("latest");
+  if (!preVoteBlock) {
+    throw new Error("aerodrome fork: no latest block before vote warp");
+  }
+  const voteTarget =
+    aeroEpochStart(BigInt(preVoteBlock.timestamp)) +
+    AERO_WEEK +
+    AERO_HOUR * BigInt(12);
+  await provider.send("evm_increaseTime", [
+    Number(voteTarget - BigInt(preVoteBlock.timestamp)),
+  ]);
   await provider.send("evm_mine", []);
+  const votedBlock = await provider.getBlock("latest");
+  if (!votedBlock) {
+    throw new Error("aerodrome fork: no latest block after vote warp");
+  }
+  expect(
+    isInAeroVoteWindow(BigInt(votedBlock.timestamp)),
+    `aerodrome vote warp landed at ${votedBlock.timestamp}, outside the Aerodrome voting window`
+  ).toBe(true);
   await push(
     AERO_VOTER,
     AERO_VOTER_IFACE.encodeFunctionData("vote", [id1, [AERO_POOL], [ONE]])
@@ -630,14 +670,28 @@ async function emitAerodrome(provider: JsonRpcProvider): Promise<Log[]> {
   await push(AERO_ESCROW, AERO_VE_IFACE.encodeFunctionData("withdraw", [id2]));
 
   // distribute-reward: a fresh epoch, then distribute emissions to the voted
-  // gauge (permissionless; drives minter.updatePeriod).
+  // gauge (permissionless; drives minter.updatePeriod). Assert the epoch
+  // actually flips instead of assuming the fixed 7-day warp always crosses
+  // one (the same unchecked-assumption class of bug as the vote-window one).
   const gauge = (await new Contract(
     AERO_VOTER,
     AERO_VOTER_IFACE,
     provider
   ).gauges(AERO_POOL)) as string;
+  const preDistributeBlock = await provider.getBlock("latest");
+  if (!preDistributeBlock) {
+    throw new Error("aerodrome fork: no latest block before distribute warp");
+  }
   await provider.send("evm_increaseTime", [7 * 24 * 3600]);
   await provider.send("evm_mine", []);
+  const distributeBlock = await provider.getBlock("latest");
+  if (!distributeBlock) {
+    throw new Error("aerodrome fork: no latest block after distribute warp");
+  }
+  expect(
+    aeroEpochStart(BigInt(distributeBlock.timestamp)),
+    "distribute-reward warp did not cross an Aerodrome epoch boundary"
+  ).toBeGreaterThan(aeroEpochStart(BigInt(preDistributeBlock.timestamp)));
   await push(
     AERO_VOTER,
     AERO_VOTER_IFACE.encodeFunctionData("distribute", [[gauge]])

--- a/tests/e2e/vitest/protocol-simulation/_shared/simulate-events.ts
+++ b/tests/e2e/vitest/protocol-simulation/_shared/simulate-events.ts
@@ -542,10 +542,11 @@ const AERO_WEEK = BigInt(7 * 24 * 3600);
 const AERO_HOUR = BigInt(3600);
 
 // Mirrors VelodromeTimeLibrary.epochStart: epochs run Thu 00:00 UTC to Thu
-// 00:00 UTC. Voter.onlyNewEpoch additionally reverts with DistributeWindow
-// during the first hour of a new epoch (Voter.sol:105) and NotWhitelistedNFT
-// past the last hour of the old one (Voter.sol:266), so a vote is only valid
-// strictly between those two bounds.
+// 00:00 UTC. Voter.onlyNewEpoch reverts with DistributeWindow for
+// timestamp <= epochVoteStart (the first hour of a new epoch, Voter.sol:105)
+// and with NotWhitelistedNFT for timestamp > epochVoteEnd (the last hour of
+// the old one, Voter.sol:266), so a vote is only valid in the half-open
+// range (epochVoteStart, epochVoteEnd].
 function aeroEpochStart(timestamp: bigint): bigint {
   return timestamp - (timestamp % AERO_WEEK);
 }
@@ -553,7 +554,7 @@ function aeroEpochStart(timestamp: bigint): bigint {
 function isInAeroVoteWindow(timestamp: bigint): boolean {
   const start = aeroEpochStart(timestamp);
   return (
-    timestamp > start + AERO_HOUR && timestamp < start + AERO_WEEK - AERO_HOUR
+    timestamp > start + AERO_HOUR && timestamp <= start + AERO_WEEK - AERO_HOUR
   );
 }
 
@@ -629,8 +630,8 @@ async function emitAerodrome(provider: JsonRpcProvider): Promise<Log[]> {
   // voter-voted: warp to a fixed offset into the *next* epoch rather than a
   // fixed +2d delta from "now" - the old delta drifted in and out of the
   // epoch's voting window depending on when CI ran. Target epochStart(now) +
-  // WEEK + 12h, which is always a fresh epoch (comfortably clears the 1h
-  // DistributeWindow at its start) with an 11h margin either side.
+  // WEEK + 12h: always a fresh epoch, 11h clear of the opening
+  // DistributeWindow and far clear (~155h) of the closing epochVoteEnd cutoff.
   const preVoteBlock = await provider.getBlock("latest");
   if (!preVoteBlock) {
     throw new Error("aerodrome fork: no latest block before vote warp");


### PR DESCRIPTION
## Summary

The `voter-voted` step in the aerodrome Tier 1 event simulation warped a
fixed +2 days from "now" instead of an epoch-relative offset, so the vote
landed inside the Aerodrome Voter's 1-hour distribute window (or past
`epochVoteEnd`) depending on when CI happened to run, deterministically
failing `e2e-tests / tier1-simulations-l2 (base)` on `staging` for a
~2 hour window every week.

## Fix

- `voter-voted` now targets `epochStart(now) + WEEK + 12h`, always landing
  in a fresh epoch - 11h clear of the opening `DistributeWindow` and far
  clear (~155h) of the closing `epochVoteEnd` cutoff - and asserts the
  resulting timestamp is actually inside the window before calling `vote`.
- `distribute-reward` now asserts its warp actually crosses an epoch
  boundary instead of assuming a fixed 7-day delta always does.
- `isInAeroVoteWindow`'s upper bound is inclusive (`<= epochVoteEnd`),
  matching the contract's actual guard (`revert if timestamp > epochVoteEnd`).

## Test plan

- [x] `pnpm type-check` and `biome check` pass on the changed file.
- [x] Ran the aerodrome suite against a live Base fork (`scripts/protocol-local.sh sim base`) at the current wall-clock time - full suite green.
- [x] Reproduced both historically-failing CI windows by warping the fork's clock before running: `now` landing in `[epochStart+WEEK-1h, epochStart+WEEK)` (the old `NotWhitelistedNFT` case) and in `[epochStart, epochStart+1h)` (the old `DistributeWindow` case) - both pass with the fix.
- [x] Re-ran the full suite after the boundary-condition fix - still green.