### PR TITLE
fix: unblock the release - approve-token chainId and simulation harness read cache

### DIFF
--- a/plugins/web3/steps/approve-token-core.ts
+++ b/plugins/web3/steps/approve-token-core.ts
@@ -73,6 +73,9 @@ export type ApproveTokenResult =
   | {
       success: true;
       transactionHash: string;
+      // Chain the transaction was broadcast on, required for independent
+      // on-chain receipt verification at execution finalize time.
+      chainId: number;
       transactionLink: string;
       gasUsed: string;
       gasUsedUnits: string;
@@ -319,6 +322,7 @@ export async function approveTokenCore(
           success: true,
           sponsored: true,
           transactionHash: sponsoredResult.transactionHash,
+          chainId,
           transactionLink,
           gasUsed: sponsoredResult.gasUsed,
           gasUsedUnits: sponsoredResult.gasUsedUnits,
@@ -473,6 +477,7 @@ export async function approveTokenCore(
       return {
         success: true,
         transactionHash: receipt.hash,
+        chainId,
         transactionLink,
         gasUsed: gasCostWei,
         gasUsedUnits,

--- a/tests/e2e/vitest/protocol-simulation/_shared/simulate-events.ts
+++ b/tests/e2e/vitest/protocol-simulation/_shared/simulate-events.ts
@@ -724,6 +724,15 @@ export function runEventSimulation(opts: {
 
   const provider = new JsonRpcProvider(opts.rpcUrl, undefined, {
     staticNetwork: true,
+    // ethers shares the result of identical requests made within
+    // cacheTimeout ms (default 250). This harness mutates chain state
+    // between reads - a getBlock("latest") before a warp and one after it
+    // are an identical request, so the second read silently returns the
+    // pre-warp block and any before/after comparison compares a block to
+    // itself. Local anvil makes that round trip fast enough to always hit
+    // the cache. Disable it: a harness that mutates chain state must never
+    // read cached chain state.
+    cacheTimeout: -1,
   });
 
   let collected: Log[] = [];

--- a/tests/e2e/vitest/protocol-simulation/_shared/simulate.ts
+++ b/tests/e2e/vitest/protocol-simulation/_shared/simulate.ts
@@ -263,6 +263,10 @@ export function runSimulation(opts: {
   }
   const provider = new JsonRpcProvider(opts.rpcUrl, undefined, {
     staticNetwork: true,
+    // See simulate-events.ts: this harness mutates chain state between
+    // reads, so ethers' 250ms same-request cache can serve a pre-mutation
+    // block to a post-mutation read.
+    cacheTimeout: -1,
   });
 
   // Populated by the provision step below and read by the action tests

--- a/tests/unit/step-transaction-hash-chain-id.test.ts
+++ b/tests/unit/step-transaction-hash-chain-id.test.ts
@@ -1,0 +1,162 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const PLUGINS_DIR = join(process.cwd(), "plugins");
+const STEP_FILENAME = /\.ts$/;
+
+/**
+ * Execution finalize independently re-verifies every claimed transaction
+ * hash against the chain before a run may settle as success
+ * (reconcileTransactionHashes in lib/workflow/executor/logging.ts). That
+ * reconciliation is fail-closed: a hash it cannot attribute to a chain
+ * fails the whole batch, so a step that reports `transactionHash` without
+ * `chainId` turns its own successful run into a failed one.
+ *
+ * The tracker reads both fields off the step's success output by name
+ * (recordTransactionHashIfPresent), so the contract is a property of the
+ * step's result type and can be checked here rather than in the expensive
+ * protocol-coverage tier, where the only symptom is a setup workflow
+ * failing after every step reported success.
+ */
+
+/**
+ * Steps whose `transactionHash` is a Solana signature (base58), not an EVM
+ * hash. The tracker only records 0x-prefixed hashes, so these outputs never
+ * reach reconciliation and have no numeric chain to verify against. Adding
+ * an EVM-shaped step to this list would silently reopen the hole.
+ */
+const NON_EVM_HASH_STEPS = new Set([
+  "web3/steps/call-solana-program-core.ts",
+  "web3/steps/send-raw-solana-instruction-core.ts",
+  "web3/steps/transfer-spl-token-core.ts",
+]);
+
+function collectStepFiles(): string[] {
+  const found: string[] = [];
+  for (const plugin of readdirSync(PLUGINS_DIR, { withFileTypes: true })) {
+    if (!plugin.isDirectory()) {
+      continue;
+    }
+    const stepsDir = join(PLUGINS_DIR, plugin.name, "steps");
+    let entries: string[];
+    try {
+      entries = readdirSync(stepsDir);
+    } catch {
+      continue;
+    }
+    for (const name of entries) {
+      if (STEP_FILENAME.test(name)) {
+        found.push(join(stepsDir, name));
+      }
+    }
+  }
+  return found.sort();
+}
+
+function propertyNamed(
+  node: ts.TypeLiteralNode,
+  name: string
+): ts.PropertySignature | undefined {
+  for (const member of node.members) {
+    if (ts.isPropertySignature(member) && member.name.getText() === name) {
+      return member;
+    }
+  }
+  return undefined;
+}
+
+function isSuccessBranch(node: ts.TypeLiteralNode): boolean {
+  const success = propertyNamed(node, "success");
+  const type = success?.type;
+  return Boolean(
+    type &&
+      ts.isLiteralTypeNode(type) &&
+      type.literal.kind === ts.SyntaxKind.TrueKeyword
+  );
+}
+
+/**
+ * Every `{ success: true; ... }` object type in the file that also declares
+ * `transactionHash`. Nested types are visited too, but a type that does not
+ * carry the success discriminant (e.g. query-events' DecodedEvent, whose
+ * transactionHash belongs to a log entry rather than to the step output) is
+ * not a step result branch and is correctly skipped.
+ */
+function successBranchesWithHash(source: ts.SourceFile): ts.TypeLiteralNode[] {
+  const branches: ts.TypeLiteralNode[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isTypeLiteralNode(node) &&
+      isSuccessBranch(node) &&
+      propertyNamed(node, "transactionHash")
+    ) {
+      branches.push(node);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return branches;
+}
+
+function declaresNumericChainId(node: ts.TypeLiteralNode): boolean {
+  const chainId = propertyNamed(node, "chainId");
+  return chainId?.type?.kind === ts.SyntaxKind.NumberKeyword;
+}
+
+const stepFiles = collectStepFiles();
+
+const producers = stepFiles
+  .map((path) => {
+    const source = ts.createSourceFile(
+      path,
+      readFileSync(path, "utf8"),
+      ts.ScriptTarget.Latest,
+      /* setParentNodes */ true
+    );
+    return {
+      relative: path.replace(`${PLUGINS_DIR}/`, ""),
+      branches: successBranchesWithHash(source),
+    };
+  })
+  .filter((entry) => entry.branches.length > 0);
+
+describe("step results that report a transaction hash", () => {
+  it("finds step files to scan", () => {
+    expect(stepFiles.length).toBeGreaterThan(0);
+  });
+
+  it("finds the known EVM hash producers", () => {
+    const scanned = producers.map((p) => p.relative);
+    expect(scanned).toEqual(
+      expect.arrayContaining([
+        "web3/steps/approve-token-core.ts",
+        "web3/steps/write-contract-core.ts",
+        "web3/steps/transfer-funds-core.ts",
+        "web3/steps/transfer-token-core.ts",
+      ])
+    );
+  });
+
+  it("exempts only steps that are still present", () => {
+    const scanned = new Set(producers.map((p) => p.relative));
+    for (const exempt of NON_EVM_HASH_STEPS) {
+      expect(scanned.has(exempt)).toBe(true);
+    }
+  });
+
+  for (const { relative, branches } of producers) {
+    if (NON_EVM_HASH_STEPS.has(relative)) {
+      continue;
+    }
+    it(`declares a numeric chainId alongside it: ${relative}`, () => {
+      for (const branch of branches) {
+        expect(
+          declaresNumericChainId(branch),
+          `${relative} returns transactionHash without "chainId: number"; execution finalize cannot verify the receipt and fails the run`
+        ).toBe(true);
+      }
+    });
+  }
+});


### PR DESCRIPTION
Two independent regressions currently on `staging` are failing four CI jobs on the open staging -> prod release PR. Both were introduced by merges already on `staging`, and both reproduce deterministically (identical assertion values across runs 11 hours apart).

## 1. approve-token omits chainId, failing successful executions

Execution finalize independently re-verifies every claimed transaction hash on-chain before a run may settle as success, and is deliberately fail-closed: a hash it cannot attribute to a chain fails the whole batch. `approve-token` reported `transactionHash` without `chainId`, so **any workflow containing an approve step finalized as `error` even though every step succeeded on-chain** - the inverse of what that verification was built to do. This is a production behaviour bug, not just a test failure.

The synchronous-reconciliation change added `chainId` to the write-contract, transfer-funds, and transfer-token result types but not to approve-token.

Evidence: the pendle setup workflow is `trigger -> approve-1 -> approve-2 -> approve-3`, all reported success, and the execution still finalized as error. An approve step alone is sufficient to trigger it.

I audited every step that returns a `transactionHash`. `approve-token` was the only gap:

| Producer | Status |
|---|---|
| write-contract / transfer-funds / transfer-token | already carry `chainId` |
| protocol-write (aave-v3, superfluid, pendle, ...) | delegates to `writeContractCore`, inherits it |
| tempo batch-payout / dex-swap / transfer-with-memo | already carry `chainId` |
| Solana steps | never recorded (tracker only records `0x`-prefixed hashes) |
| get-transaction / query-events | not recorded (`hash`, and a nested log field, respectively) |
| **approve-token** | **missing** |

Fixed in both success paths (sponsored and direct); the Safe and Role branches fall through to the direct return.

**Guard against recurrence:** because reconciliation is fail-closed, any future step that forgets `chainId` becomes a production incident that only the expensive protocol-coverage tier catches. Added a unit test that parses plugin step result types and requires a numeric `chainId` on every success branch reporting `transactionHash`. Verified it fails on this exact bug before the fix and passes after. Solana steps are exempt via an explicit list, since their base58 signatures never reach reconciliation.

## 2. Simulation harness read its own pre-warp state

ethers shares the result of identical requests made within `cacheTimeout` (default 250ms), and `getBlock("latest")` routes through that cache. The harness mutates chain state between reads, so a `getBlock("latest")` before a warp and one after it are the same request - the second returns the pre-warp block. Against local anvil that round trip always lands inside the cache window.

That is why `distribute-reward warp did not cross an Aerodrome epoch boundary: expected 1786579200 to be greater than 1786579200` reports two identical values: advancing by exactly one week always advances `epochStart` by exactly one week, so equal values prove the two reads returned the same block rather than that the warp was too small.

The same pattern made the vote-window assertion compare against stale state, so it was passing vacuously.

Fix: disable the request cache on the simulation providers. A harness that mutates chain state must never read cached chain state. No upstream cost - the sim RPC is a local anvil fork.

## Verification

- `tsc --noEmit` clean
- biome clean on changed files
- `approve-token`, `verify-receipt`, `write-contract-core`, `check-allowance` and the new guard: 55 tests passing
- New guard verified in both directions (fails with the fix reverted, passes with it applied)
- The aerodrome and protocol-coverage jobs themselves need the CI rig; they are exercised by this PR's own run