### PR TITLE
docs: correct the execution endpoint paths in API authentication

### DIFF
--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -51,7 +51,11 @@ Session authentication is accepted everywhere. API keys (`kh_`) are accepted onl
 
 Endpoints whose semantics are organization-scoped accept `kh_` keys:
 
-- Workflow CRUD and execution: `/api/workflows`, `/api/executions`, `/api/execute`
+- Workflow CRUD: `/api/workflows`
+- Execution history and status: `/api/workflows/{workflowId}/executions`,
+  `/api/workflows/executions/{executionId}/status`
+- Direct execution: `/api/execute/transfer`, `/api/execute/contract-call`,
+  `/api/execute/check-and-execute`, `/api/execute/{executionId}/status`
 - Integrations: `/api/integrations`
 - Projects, tags, public tags, supported chains
 - Organization-scoped billing and analytics

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -51,11 +51,15 @@ Session authentication is accepted everywhere. API keys (`kh_`) are accepted onl
 
 Endpoints whose semantics are organization-scoped accept `kh_` keys:
 
-- Workflow CRUD: `/api/workflows`
-- Execution history and status: `/api/workflows/{workflowId}/executions`,
-  `/api/workflows/executions/{executionId}/status`
-- Direct execution: `/api/execute/transfer`, `/api/execute/contract-call`,
-  `/api/execute/check-and-execute`, `/api/execute/{executionId}/status`
+- Workflow CRUD and execution: `/api/workflows`, including
+  `POST /api/workflows/{workflowId}/execute` and execution history and status
+  (`GET /api/workflows/{workflowId}/executions` and
+  `GET /api/workflows/executions/{executionId}/{status,logs,wait}`).
+  A few sub-paths are session-only; see [Session-only](#session-only) below
+- Direct execution: everything under `/api/execute` - `/transfer`,
+  `/contract-call`, `/check-and-execute`, `/swap`, `/node`, protocol actions
+  (`/api/execute/{protocol}/{action}`), and
+  `GET /api/execute/{executionId}/status`
 - Integrations: `/api/integrations`
 - Projects, tags, public tags, supported chains
 - Organization-scoped billing and analytics
@@ -73,6 +77,7 @@ Endpoints that act on a user account, hold credential material, or sit on a huma
 - **Authentication primitives**: creating organization API keys (`POST /api/keys`), creating/listing/deleting personal webhook keys (`/api/api-keys/*`), AI Gateway OAuth flows
 - **Human-in-the-loop wallet approvals**: agentic-wallet linking and approve/reject endpoints
 - **Per-user state**: workflow drafts, workflow ratings, leaving an organization
+- **Organization-scoped but session-gated**: `POST /api/executions/{executionId}/cancel` and `POST /api/workflows/{workflowId}/go-live`. These two do not follow the rationale above - their semantics are organization-scoped, but the routes resolve auth from the session only. Treat them as current implementation limits rather than deliberate boundaries.
 
 If you have a use case for session-only behavior over an API key, open an issue describing it. The boundary is deliberate: it keeps a leaked API key from escalating into account control or wallet drainage.
 


### PR DESCRIPTION
/api/executions is listed under "Accepted on API keys" but returns 404, as do its sub-paths. Replaced with the routes that actually resolve.

Verified against the live API on 2026-08-03 with a kh_ key (read+write+admin):

  404  GET /api/executions
  404  GET /api/executions/{id}
  404  GET /api/executions/{id}/status
  200  GET /api/workflows/{workflowId}/executions
  200  GET /api/workflows/executions/{executionId}/status
  200  GET /api/execute/{executionId}/status

Also split out /api/execute, which 404s on its own while its sub-paths work.

Found while building an n8n community node against the REST API: https://github.com/iamrobertmoore/n8n-nodes-keeperhub