### PR TITLE
fix: tier new-account detection on evidence instead of paging on every match

### DIFF
--- a/app/api/cron/security-behavioral-scan/route.ts
+++ b/app/api/cron/security-behavioral-scan/route.ts
@@ -28,10 +28,38 @@
  * scheduler timing doesn't drop an event: the CronJob fires every 5
  * minutes but EXECUTION_LOOKBACK_MS is 10 minutes, so every execution is
  * read by two consecutive scans and a single late/skipped run still
- * leaves it covered. Idempotency comes from the downstream alert layer
- * (the `new_account_first_workflow` Loki rule evaluates a 10-minute
- * window and fires on >=1 occurrence, so the duplicate emissions collapse
- * to a single page), not from this endpoint.
+ * leaves it covered. The duplicate emissions do NOT collapse downstream,
+ * contrary to what this comment used to claim. The Loki module builds
+ * `sum by (pod) (count_over_time({...} |~ "<substring>" [1m]))` on a 60s
+ * evaluation interval, so the rule's effective counting window is 1
+ * minute regardless of the 600s `relative_time_range` (which only sets
+ * the instant query's time envelope, and which the alert annotation text
+ * misreports as the window). Two emissions 5 minutes apart therefore
+ * always fire, resolve, and fire again as separate PagerDuty incidents.
+ * Grouping by `pod` compounds it -- consecutive scans hit different
+ * replicas, so they are not even the same alert series -- but the 1m
+ * window alone guarantees the re-fire. Both are hardcoded in the module
+ * (`SkyEcosystem/loki-grafana-alert`) with no variable to override, so
+ * closing this needs a change there, not here. Sentry dedupes correctly
+ * via the executionId fingerprint below; PagerDuty does not.
+ *
+ * Tiering. Account age alone is not evidence of anything -- signing up
+ * and immediately running something is what the product's own onboarding
+ * tour instructs people to do, and on 60 days of prod it accounted for
+ * the large majority of matches. Every row is still scanned and still
+ * emitted, but only rows carrying evidence the actor actually produced
+ * are emitted under the paging event name:
+ *
+ *   - `behavioral.new_account_first_workflow`   (evidence present -> pages)
+ *   - `behavioral.new_account_routine_execution` (no evidence -> dashboard only)
+ *
+ * The Loki module matches a SUBSTRING of the log line, so the paging name
+ * is kept byte-identical to what the existing rule already matches and
+ * the routine name deliberately shares no prefix with it. That way the
+ * tiering takes effect from this change alone, with no coordinated
+ * terraform edit and no window where the rule matches a name nothing
+ * emits yet. Do not rename the flagged event without editing
+ * `error_message` in keeperhub-security-alerts.tf in the same change.
  */
 
 import { and, eq, gt, isNotNull } from "drizzle-orm";
@@ -44,14 +72,64 @@ export const dynamic = "force-dynamic";
 
 const NEW_ACCOUNT_WINDOW_MS = 15 * 60 * 1000;
 // Wider than the 5-minute CronJob interval so consecutive scans overlap and
-// scheduler jitter cannot drop an execution from coverage. Matched to the
-// 10-minute window of the downstream `new_account_first_workflow` Loki alert
-// (relative_time_range from=600 in keeperhub-security-alerts.tf) so the
-// resulting duplicate emissions dedupe to a single page.
+// scheduler jitter cannot drop an execution from coverage. The overlap is
+// for coverage only -- it does NOT dedupe downstream (see the note on the
+// alert's real 1-minute counting window above), so an execution re-emitted
+// by the next scan re-pages if it is in the evidence tier. Coverage is
+// worth that: narrowing this to the cron interval would silently drop an
+// execution whenever a scan is late or skipped.
 const EXECUTION_LOOKBACK_MS = 10 * 60 * 1000;
+
+// Backstop for the one shape the other evidence types cannot see: many
+// manual, session-driven, read-only executions, i.e. throughput abuse
+// rather than compromise. Set from the live distribution of first-15-minute
+// execution counts rather than picked: p50 is 1, p75 is 2, p95 is 6, and 6
+// is also the highest value observed since `trigger_source` began being
+// populated. It therefore fires on nothing the other predicates do not
+// already catch today, which is the intent -- it exists to cover a future
+// pattern, not to reclassify a current one.
+const NEW_ACCOUNT_BURST_THRESHOLD = 6;
+
+// Evidence the actor produced, as opposed to metadata they chose. Anything
+// derived from workflow content is deliberately absent: `workflow_type`
+// defaults to "read" and is only derived on the MCP listing path, so a
+// wallet-draining workflow built in the UI editor still reads as "read".
+type Evidence = "api_key" | "onchain_write" | "automated_trigger" | "burst";
+
+type EvidenceRow = {
+  triggerSource: string | null;
+  triggeredByUserApiKeyId: string | null;
+  triggeredByOrgApiKeyId: string | null;
+  transactionHashes: unknown[] | null;
+};
+
+function collectEvidence(row: EvidenceRow, burstCount: number): Evidence[] {
+  const evidence: Evidence[] = [];
+  if (
+    row.triggeredByUserApiKeyId !== null ||
+    row.triggeredByOrgApiKeyId !== null
+  ) {
+    evidence.push("api_key");
+  }
+  if ((row.transactionHashes?.length ?? 0) > 0) {
+    evidence.push("onchain_write");
+  }
+  // Explicitly NOT `!== "manual"`: trigger_source was introduced on
+  // 2026-06-02 and is NULL for every execution before it, so a loose
+  // comparison reads all of them as automated. Unknown is not evidence.
+  if (row.triggerSource !== null && row.triggerSource !== "manual") {
+    evidence.push("automated_trigger");
+  }
+  if (burstCount >= NEW_ACCOUNT_BURST_THRESHOLD) {
+    evidence.push("burst");
+  }
+  return evidence;
+}
 
 type BehavioralScanResponse = {
   newAccountFirstWorkflowEvents: number;
+  newAccountRoutineEvents: number;
+  executionPredatesAccountEvents: number;
   durationMs: number;
 };
 
@@ -73,6 +151,9 @@ async function scanNewAccountFirstWorkflow(
       executionId: workflowExecutions.id,
       triggerSource: workflowExecutions.triggerSource,
       triggeredByCountry: workflowExecutions.triggeredByCountry,
+      triggeredByUserApiKeyId: workflowExecutions.triggeredByUserApiKeyId,
+      triggeredByOrgApiKeyId: workflowExecutions.triggeredByOrgApiKeyId,
+      transactionHashes: workflowExecutions.transactionHashes,
       userCreatedAt: users.createdAt,
       executionStartedAt: workflowExecutions.startedAt,
     })
@@ -86,13 +167,82 @@ async function scanNewAccountFirstWorkflow(
       )
     );
 
+  // Burst is counted over the rows already in hand rather than by a second
+  // query: the scan window IS the burst window, so the set is identical.
+  const executionsByUser = new Map<string, number>();
   for (const row of rows) {
-    const ageSeconds = Math.max(
-      0,
-      Math.round(
-        (row.executionStartedAt.getTime() - row.userCreatedAt.getTime()) / 1000
-      )
+    if (row.userId !== null) {
+      executionsByUser.set(
+        row.userId,
+        (executionsByUser.get(row.userId) ?? 0) + 1
+      );
+    }
+  }
+
+  let flaggedEvents = 0;
+  let routineEvents = 0;
+  let predatesAccountEvents = 0;
+
+  for (const row of rows) {
+    const ageSeconds = Math.round(
+      (row.executionStartedAt.getTime() - row.userCreatedAt.getTime()) / 1000
     );
+
+    // A negative age means the execution predates the account row, which is
+    // the anonymous-to-registered conversion path re-attributing anonymous
+    // work to the new user id at signup. That is the reverse of what this
+    // detection is looking for, so it gets its own name instead of being
+    // clamped to 0 and silently reported as "ran instantly after signup".
+    if (ageSeconds < 0) {
+      predatesAccountEvents += 1;
+      logSecurityEvent(
+        "behavioral.execution_predates_account",
+        {
+          userId: row.userId,
+          workflowId: row.workflowId,
+          executionId: row.executionId,
+          triggerSource: row.triggerSource,
+          triggeredByCountry: row.triggeredByCountry,
+          ageSecondsSinceSignup: ageSeconds,
+        },
+        {
+          fingerprint: [
+            "security.behavioral.execution_predates_account",
+            row.executionId,
+          ],
+          tags: { security: "behavioral.execution_predates_account" },
+          user: { id: row.userId },
+          extra: {
+            workflowId: row.workflowId,
+            executionId: row.executionId,
+            ageSecondsSinceSignup: ageSeconds,
+          },
+        }
+      );
+      continue;
+    }
+
+    const evidence = collectEvidence(
+      row,
+      row.userId === null ? 0 : (executionsByUser.get(row.userId) ?? 0)
+    );
+    // An execution still running has no transaction_hashes yet, so it can be
+    // classified routine on the first pass. The overlapping windows give it a
+    // second read 5 minutes later, by which point anything of realistic
+    // duration has finished. Rows are never skipped for this -- dropping a
+    // row to wait for it to settle would lose coverage if it outlives the
+    // lookback, and losing coverage is the worse failure.
+    const eventName =
+      evidence.length > 0
+        ? "behavioral.new_account_first_workflow"
+        : "behavioral.new_account_routine_execution";
+
+    if (evidence.length > 0) {
+      flaggedEvents += 1;
+    } else {
+      routineEvents += 1;
+    }
+
     // Dual emit (Sentry + structured stdout) mirrors the pattern used by
     // the other detection signals in lib/security/* -- alert lands even if
     // one transport fails, and Sentry's UI gives triagers richer pivots
@@ -101,11 +251,14 @@ async function scanNewAccountFirstWorkflow(
     // The overlapping scan windows (10-minute lookback, 5-minute interval)
     // mean the same execution is re-emitted by two consecutive scans -- and
     // ~10x in PR envs where the job runs every minute. Fingerprint on the
-    // executionId so those duplicates collapse into a single Sentry issue
-    // (Loki already dedupes the page); the row's full detail still rides on
-    // each event's tags/extra for triage.
+    // executionId so those duplicates collapse into a single Sentry issue;
+    // the row's full detail still rides on each event's tags/extra.
+    //
+    // `evidence` rides on the event so the page says WHY it fired. Without
+    // it every page reads identically and the triager has to go to the DB
+    // to learn whether an API key was used or a transaction was written.
     logSecurityEvent(
-      "behavioral.new_account_first_workflow",
+      eventName,
       {
         userId: row.userId,
         workflowId: row.workflowId,
@@ -113,15 +266,14 @@ async function scanNewAccountFirstWorkflow(
         triggerSource: row.triggerSource,
         triggeredByCountry: row.triggeredByCountry,
         ageSecondsSinceSignup: ageSeconds,
+        evidence,
       },
       {
-        fingerprint: [
-          "security.behavioral.new_account_first_workflow",
-          row.executionId,
-        ],
+        fingerprint: [`security.${eventName}`, row.executionId],
         tags: {
-          security: "behavioral.new_account_first_workflow",
+          security: eventName,
           trigger_source: row.triggerSource ?? "unknown",
+          evidence: evidence.length > 0 ? evidence.join(",") : "none",
         },
         user: { id: row.userId },
         extra: {
@@ -129,13 +281,16 @@ async function scanNewAccountFirstWorkflow(
           executionId: row.executionId,
           triggeredByCountry: row.triggeredByCountry,
           ageSecondsSinceSignup: ageSeconds,
+          evidence,
         },
       }
     );
   }
 
   return {
-    newAccountFirstWorkflowEvents: rows.length,
+    newAccountFirstWorkflowEvents: flaggedEvents,
+    newAccountRoutineEvents: routineEvents,
+    executionPredatesAccountEvents: predatesAccountEvents,
     durationMs: Date.now() - startedAt,
   };
 }

--- a/tests/integration/security-behavioral-scan.test.ts
+++ b/tests/integration/security-behavioral-scan.test.ts
@@ -69,6 +69,9 @@ vi.mock("@/lib/db/schema", () => ({
     startedAt: "we.started_at",
     triggerSource: "we.trigger_source",
     triggeredByCountry: "we.triggered_by_country",
+    triggeredByUserApiKeyId: "we.triggered_by_user_api_key_id",
+    triggeredByOrgApiKeyId: "we.triggered_by_org_api_key_id",
+    transactionHashes: "we.transaction_hashes",
   },
 }));
 
@@ -131,6 +134,45 @@ describe("security-behavioral-scan auth", () => {
   });
 });
 
+type ScanRow = {
+  userId: string;
+  workflowId: string;
+  executionId: string;
+  triggerSource: string | null;
+  triggeredByCountry: string | null;
+  triggeredByUserApiKeyId: string | null;
+  triggeredByOrgApiKeyId: string | null;
+  transactionHashes: unknown[];
+  userCreatedAt: Date;
+  executionStartedAt: Date;
+};
+
+// Baseline row: a brand-new account manually running a workflow from a
+// browser session that touched nothing. This is the overwhelmingly common
+// real-world shape (the onboarding tour, a blank-canvas Run click), so it is
+// the default and each test opts INTO a piece of evidence.
+function makeRow(overrides: Partial<ScanRow> = {}): ScanRow {
+  return {
+    userId: "user_freshly_signed_up",
+    workflowId: "wf_1",
+    executionId: "exec_1",
+    triggerSource: "manual",
+    triggeredByCountry: "US",
+    triggeredByUserApiKeyId: null,
+    triggeredByOrgApiKeyId: null,
+    transactionHashes: [],
+    userCreatedAt: new Date("2026-05-26T10:00:00Z"),
+    executionStartedAt: new Date("2026-05-26T10:00:42Z"),
+    ...overrides,
+  };
+}
+
+function loggedEvents(): Record<string, unknown>[] {
+  return warnSpy.mock.calls.map(
+    (call) => JSON.parse(call[0] as string) as Record<string, unknown>
+  );
+}
+
 describe("security-behavioral-scan response shape", () => {
   function authedRequest(): Request {
     // Top-level beforeEach already sets mockAuthResult.authenticated = true.
@@ -142,26 +184,20 @@ describe("security-behavioral-scan response shape", () => {
     const res = await GET(authedRequest());
     const body = (await res.json()) as {
       newAccountFirstWorkflowEvents: number;
+      newAccountRoutineEvents: number;
+      executionPredatesAccountEvents: number;
       durationMs: number;
     };
     expect(body.newAccountFirstWorkflowEvents).toBe(0);
+    expect(body.newAccountRoutineEvents).toBe(0);
+    expect(body.executionPredatesAccountEvents).toBe(0);
     expect(body.durationMs).toBeGreaterThanOrEqual(0);
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it("emits one structured warn and one Sentry capture per matched row", async () => {
-    const userCreatedAt = new Date("2026-05-26T10:00:00Z");
-    const executionStartedAt = new Date("2026-05-26T10:00:42Z");
     mockSelectChain.mockResolvedValueOnce([
-      {
-        userId: "user_freshly_signed_up",
-        workflowId: "wf_1",
-        executionId: "exec_1",
-        triggerSource: "manual",
-        triggeredByCountry: "US",
-        userCreatedAt,
-        executionStartedAt,
-      },
+      makeRow({ triggeredByOrgApiKeyId: "orgkey_1" }),
     ]);
     const res = await GET(authedRequest());
     const body = (await res.json()) as {
@@ -170,8 +206,7 @@ describe("security-behavioral-scan response shape", () => {
     expect(body.newAccountFirstWorkflowEvents).toBe(1);
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    const logged = JSON.parse(warnSpy.mock.calls[0][0] as string);
-    expect(logged).toMatchObject({
+    expect(loggedEvents()[0]).toMatchObject({
       event: "security.behavioral.new_account_first_workflow",
       userId: "user_freshly_signed_up",
       workflowId: "wf_1",
@@ -179,6 +214,7 @@ describe("security-behavioral-scan response shape", () => {
       triggerSource: "manual",
       triggeredByCountry: "US",
       ageSecondsSinceSignup: 42,
+      evidence: ["api_key"],
     });
 
     // Dual-emit pattern: Sentry mirrors the stdout signal so triage gets
@@ -204,6 +240,7 @@ describe("security-behavioral-scan response shape", () => {
       tags: {
         security: "behavioral.new_account_first_workflow",
         trigger_source: "manual",
+        evidence: "api_key",
       },
       user: { id: "user_freshly_signed_up" },
       extra: {
@@ -211,6 +248,7 @@ describe("security-behavioral-scan response shape", () => {
         executionId: "exec_1",
         triggeredByCountry: "US",
         ageSecondsSinceSignup: 42,
+        evidence: ["api_key"],
       },
     });
   });
@@ -219,21 +257,156 @@ describe("security-behavioral-scan response shape", () => {
     mockCaptureMessage.mockImplementationOnce(() => {
       throw new Error("sentry down");
     });
-    mockSelectChain.mockResolvedValueOnce([
-      {
-        userId: "u_1",
-        workflowId: "wf_1",
-        executionId: "exec_1",
-        triggerSource: "manual",
-        triggeredByCountry: null,
-        userCreatedAt: new Date("2026-05-26T10:00:00Z"),
-        executionStartedAt: new Date("2026-05-26T10:00:30Z"),
-      },
-    ]);
+    mockSelectChain.mockResolvedValueOnce([makeRow()]);
     const res = await GET(authedRequest());
     expect(res.status).toBe(200);
     // Sentry threw but stdout still emitted -- the signal is durable.
     expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("security-behavioral-scan evidence tiering", () => {
+  function authedRequest(): Request {
+    return makeRequest({ "x-kh-caller": "test-key" });
+  }
+
+  // The paging name is what the Loki rule matches by substring. A rename
+  // here silently stops the page, so it is asserted literally rather than
+  // through a constant.
+  const FLAGGED = "security.behavioral.new_account_first_workflow";
+  const ROUTINE = "security.behavioral.new_account_routine_execution";
+
+  it("does not page a manual session-credential run that touched nothing", async () => {
+    mockSelectChain.mockResolvedValueOnce([makeRow()]);
+    const res = await GET(authedRequest());
+    const body = (await res.json()) as {
+      newAccountFirstWorkflowEvents: number;
+      newAccountRoutineEvents: number;
+    };
+
+    expect(body.newAccountFirstWorkflowEvents).toBe(0);
+    expect(body.newAccountRoutineEvents).toBe(1);
+    expect(loggedEvents()[0]).toMatchObject({
+      event: ROUTINE,
+      evidence: [],
+    });
+  });
+
+  it("keeps the routine event name disjoint from the paging name", () => {
+    // The Loki module matches a substring, so a routine name containing the
+    // flagged name would page on every routine event and undo the tiering.
+    expect(ROUTINE.includes(FLAGGED)).toBe(false);
+    expect(FLAGGED.includes(ROUTINE)).toBe(false);
+  });
+
+  it.each([
+    ["a user API key", { triggeredByUserApiKeyId: "userkey_1" }, "api_key"],
+    ["an org API key", { triggeredByOrgApiKeyId: "orgkey_1" }, "api_key"],
+    [
+      "an on-chain write",
+      { transactionHashes: [{ hash: "0xabc" }] },
+      "onchain_write",
+    ],
+    [
+      "a non-manual trigger",
+      { triggerSource: "schedule" },
+      "automated_trigger",
+    ],
+  ])("pages on %s", async (_label, overrides, expectedEvidence) => {
+    mockSelectChain.mockResolvedValueOnce([
+      makeRow(overrides as Partial<ScanRow>),
+    ]);
+    const res = await GET(authedRequest());
+    const body = (await res.json()) as {
+      newAccountFirstWorkflowEvents: number;
+      newAccountRoutineEvents: number;
+    };
+
+    expect(body.newAccountFirstWorkflowEvents).toBe(1);
+    expect(body.newAccountRoutineEvents).toBe(0);
+    expect(loggedEvents()[0]).toMatchObject({
+      event: FLAGGED,
+      evidence: [expectedEvidence],
+    });
+  });
+
+  it("treats a NULL trigger_source as unknown, not as automation", async () => {
+    // trigger_source landed on 2026-06-02 and is NULL for every execution
+    // before it. A `!== "manual"` comparison reads all of those as automated
+    // and floods the page. Unknown is not evidence.
+    mockSelectChain.mockResolvedValueOnce([makeRow({ triggerSource: null })]);
+    const res = await GET(authedRequest());
+    const body = (await res.json()) as {
+      newAccountFirstWorkflowEvents: number;
+      newAccountRoutineEvents: number;
+    };
+
+    expect(body.newAccountFirstWorkflowEvents).toBe(0);
+    expect(body.newAccountRoutineEvents).toBe(1);
+    expect(loggedEvents()[0]).toMatchObject({ event: ROUTINE, evidence: [] });
+  });
+
+  it("pages the whole burst once a single new user crosses the threshold", async () => {
+    // Six manual, credential-free, no-transaction runs by one account. No
+    // individual row carries evidence; the volume is the evidence.
+    const burst = Array.from({ length: 6 }, (_unused, index) =>
+      makeRow({ executionId: `exec_${index}` })
+    );
+    mockSelectChain.mockResolvedValueOnce(burst);
+    const res = await GET(authedRequest());
+    const body = (await res.json()) as {
+      newAccountFirstWorkflowEvents: number;
+      newAccountRoutineEvents: number;
+    };
+
+    expect(body.newAccountFirstWorkflowEvents).toBe(6);
+    expect(body.newAccountRoutineEvents).toBe(0);
+    for (const event of loggedEvents()) {
+      expect(event).toMatchObject({ event: FLAGGED, evidence: ["burst"] });
+    }
+  });
+
+  it("does not attribute burst across different users", async () => {
+    // Six rows, six accounts. Volume belongs to an account, not to the
+    // scan window, so nothing here should page.
+    const rows = Array.from({ length: 6 }, (_unused, index) =>
+      makeRow({ userId: `user_${index}`, executionId: `exec_${index}` })
+    );
+    mockSelectChain.mockResolvedValueOnce(rows);
+    const res = await GET(authedRequest());
+    const body = (await res.json()) as {
+      newAccountFirstWorkflowEvents: number;
+      newAccountRoutineEvents: number;
+    };
+
+    expect(body.newAccountFirstWorkflowEvents).toBe(0);
+    expect(body.newAccountRoutineEvents).toBe(6);
+  });
+
+  it("reports an execution that predates its account under its own name", async () => {
+    // Anonymous-to-registered conversion re-attributes anonymous work to the
+    // new user id, so the execution can legitimately precede users.created_at.
+    // Clamping that to 0 reported it as "ran instantly after signup".
+    mockSelectChain.mockResolvedValueOnce([
+      makeRow({
+        userCreatedAt: new Date("2026-05-26T10:00:00Z"),
+        executionStartedAt: new Date("2026-05-26T09:59:25Z"),
+      }),
+    ]);
+    const res = await GET(authedRequest());
+    const body = (await res.json()) as {
+      newAccountFirstWorkflowEvents: number;
+      newAccountRoutineEvents: number;
+      executionPredatesAccountEvents: number;
+    };
+
+    expect(body.executionPredatesAccountEvents).toBe(1);
+    expect(body.newAccountFirstWorkflowEvents).toBe(0);
+    expect(body.newAccountRoutineEvents).toBe(0);
+    expect(loggedEvents()[0]).toMatchObject({
+      event: "security.behavioral.execution_predates_account",
+      ageSecondsSinceSignup: -35,
+    });
   });
 });
 


### PR DESCRIPTION
## Problem

The `Keeperhub new account first workflow` detection matches on two predicates and pages P2 on any occurrence:

```
workflow_executions.started_at > now() - 10 minutes
AND users.created_at        > now() - 15 minutes
```

That is the whole rule. The `nodes` column is never selected, so the workflow content, the trigger type, the credential used and whether any step actually ran are all ignored. The alert name reads as *a suspicious workflow was run*; what it means is *a young account row sat next to an execution row*.

The premise was that speed proxies for intent. It does not: signing up and immediately running something is what the product's own onboarding tour instructs people to do.

## Evidence

60 days of prod, 34 events across 21 users:

| Pattern | Events | Users |
|---|---|---|
| Manual run, session credential, no transactions | 24 | 17 |
| On-chain transactions written | 4 | 2 |
| Triggered by an org API key | 1 | 1 |
| Non-manual trigger on an enabled workflow | 2 | 2 |
| Same user, 4+ executions in the window | 6 | 1 |

The three evidence-bearing cases (an org API key used 8 minutes after signup; an account with real transaction hashes running 6 executions in 12 minutes; two accounts enabling block-triggered automation within 9 minutes) each produced exactly one page, identical in shape to the 24 blank-canvas pages around them.

## Change

Every row is still scanned and still emitted. Detection coverage does not shrink by a single row. Only the paging threshold moves.

- **Flagged** (`behavioral.new_account_first_workflow`, unchanged name, still pages): the execution carried evidence the actor produced. API key, non-empty `transaction_hashes`, non-manual `trigger_source`, or 6+ executions by one account in the window.
- **Routine** (`behavioral.new_account_routine_execution`, new name, matched by no alert): everything else. Goes to a review row on the Platform Health dashboard.

Measured against the same 60 days: 10 flagged events / 5 users, and 24 routine / 17 users.

The firing event now carries an `evidence` array in the log line and Sentry tags, so a page states why it fired instead of requiring a DB lookup to find out.

### Why this is stricter, not more permissive

- No allow-list. Nothing keys off a workflow name, user, org or country, so there is nothing to type your way past. The onboarding tour stops paging because it is a manual read that wrote nothing, not because of what it is called.
- Every predicate is evidence the actor produced, not metadata they chose.
- `workflow_type` is deliberately unused. It is `.default("read")` and only derived on the MCP listing path, so a wallet-draining workflow built in the UI editor still reads as `"read"`. Skipping on it would silently stop looking at exactly the wrong things.

### Name coupling (load-bearing)

The Loki module matches a **substring** of the log line. The flagged name is kept byte-identical to what the existing rule already matches, and the routine name shares no prefix with it. The rule therefore narrows itself with no coordinated terraform change and no window where it matches a name nothing emits. Renaming either event requires changing `error_message` in `keeperhub-security-alerts.tf` in the same change. There is a test asserting the two names stay substring-disjoint.

## Two bugs fixed alongside

**`trigger_source` NULL handling.** The column landed on 2026-06-02 and is NULL for all 1.17M executions before it. `IS DISTINCT FROM 'manual'` reads every one of them as automated. The check is now explicitly `!== null && !== "manual"` — unknown is not evidence — with a regression test. This is not hypothetical: it produced a wrong baseline while the burst threshold was being set.

**Executions predating their account.** 5 of the 34 events start *before* `users.created_at`, by up to 39 seconds. That is the anonymous-to-registered conversion path re-attributing anonymous work at signup, the reverse of what this detection looks for. `Math.max(0, ...)` reported them as `ageSecondsSinceSignup: 0`, hiding it. They now emit under `behavioral.execution_predates_account`, which no alert matches.

## Burst threshold

6, from the live distribution rather than a guess. Since `trigger_source` began being populated, 20 users ran anything in their first 15 minutes: 14 once, 5 twice, 1 six times — and that one is already flagged via `onchain_write`. p95 all-time is also 6. It therefore catches nothing the other predicates do not already catch; it is a backstop for the throughput-abuse shape they are blind to.

## Known non-fix

The duplicate-page behaviour is **not** fixed here and cannot be from this repo. The alert module builds `sum by (pod) (count_over_time({...} |~"<substring>" [1m]))` on a 60s interval, so the effective window is 1 minute regardless of the 600s `relative_time_range` (which the rule's own annotation text misreports). Emissions 5 minutes apart always re-page. Both the window and the `pod` grouping are hardcoded in `SkyEcosystem/loki-grafana-alert` with no override, so closing it needs a change there. Severity drops sharply once routine events stop paging.

The stale comment claiming the overlapping scans dedupe downstream is corrected in the file.

## Testing

18 tests in `tests/integration/security-behavioral-scan.test.ts`: one per evidence type, the routine tier, the NULL-`trigger_source` regression, burst crossing the threshold, burst *not* attributed across different users, predates-account, and the substring-disjointness guard.

Local: `pnpm type-check` clean, `pnpm test:integration` 889 passed, `pnpm test:unit __tests__ keeperhub-metrics-collector` 20328 passed (both exactly what CI runs), `pnpm check:api-docs` no drift, lint clean on both changed files.

## Heads-up for reviewers

The `lint` job will fail on this PR through no fault of the branch. `pnpm check` runs repo-wide and has 4 pre-existing errors on `staging` in `tests/unit/mcp-execute-arg-coercion.test.ts` and `tests/unit/rpc-config.test.ts`, neither of which this branch touches (`git diff origin/staging --name-only` returns only the two files above). Best fixed in a separate PR.

The `build` job could not be run locally (ECR credentials), so it is unverified.

## Companion

Dashboard row for the routine tier plus the alert documentation are in a matching branch on `techops-services/infrastructure`. The two can merge independently: this one narrows the alert on its own, and the dashboard row is where the routine tier lands.