### PR TITLE
fix: remove the Owner option from the member role dropdown

### DIFF
--- a/components/organization/manage-orgs-modal.tsx
+++ b/components/organization/manage-orgs-modal.tsx
@@ -327,12 +327,10 @@ function MembersListContent({
                   <SelectTrigger className="h-8 w-[120px]">
                     <SelectValue />
                   </SelectTrigger>
+                  {/* One owner per org (DB-enforced), so becoming owner is a transfer, handled in the Leave Organization flow. */}
                   <SelectContent>
                     <SelectItem value={"member"}>Member</SelectItem>
                     <SelectItem value={"admin"}>Admin</SelectItem>
-                    {canChangeRole && (
-                      <SelectItem value={"owner"}>Owner</SelectItem>
-                    )}
                   </SelectContent>
                 </Select>
               )}

--- a/components/organization/members-list.tsx
+++ b/components/organization/members-list.tsx
@@ -141,10 +141,10 @@ export function MembersList({
                 <SelectTrigger className="w-[120px]">
                   <SelectValue />
                 </SelectTrigger>
+                {/* One owner per org (DB-enforced), so becoming owner is a transfer, handled in the Leave Organization flow. */}
                 <SelectContent>
                   <SelectItem value="member">Member</SelectItem>
                   <SelectItem value="admin">Admin</SelectItem>
-                  <SelectItem value="owner">Owner</SelectItem>
                 </SelectContent>
               </Select>
             </TableCell>


### PR DESCRIPTION
## Problem

The organization members UI offered "Owner" in the role dropdown, but selecting
it always failed. The request returned a 500 and the UI showed a generic
"Failed to update role" toast, with the dropdown reverting to its previous value
and no explanation of what went wrong.

## Root cause

An organization can have exactly one owner, enforced in the database by a
partial unique index on `member(organization_id) WHERE role = 'owner'`.

The role dropdown calls better-auth's `updateMemberRole`, which issues a plain
`UPDATE` with no ownership-transfer step. Promoting a second member to owner
therefore violates the index, and the constraint violation propagated as an
unhandled 500.

This affected every member regardless of how they authenticate. Running the same
flow against a wallet-authenticated member and an email-authenticated member in
one organization gives identical results: changing either to Admin succeeds,
changing either to Owner fails.

## Change

Remove the Owner option from the role dropdown so the UI no longer offers an
action that cannot succeed. Member and Admin are unchanged and continue to work
in both directions.

Ownership transfer remains available through the Leave Organization flow, which
already performs the demote-then-promote sequence in the order the index
requires.

The same option is also removed from `components/organization/members-list.tsx`.
That component is currently imported nowhere, but it carried the identical
dropdown and would reintroduce the defect if it were put back into use.
