### PR TITLE
fix: re-read the execution count at the free-tier limit

### DIFF
--- a/keeperhub-executor/billing-guard.ts
+++ b/keeperhub-executor/billing-guard.ts
@@ -1,7 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import {
-  countMonthlyExecutionsCached,
+  countMonthlyExecutionsForAdmission,
   decideExecutionLimit,
   effectiveExecutionLimit,
 } from "../lib/billing/execution-limit-core";
@@ -97,7 +97,10 @@ export async function checkExecutionLimitForExecutor(
     debtExecutions
   );
 
-  const used = await countMonthlyExecutionsCached(db, organizationId);
+  const used = await countMonthlyExecutionsForAdmission(db, organizationId, {
+    maxExecutionsPerMonth: limits.maxExecutionsPerMonth,
+    overageEnabled: planDef.overage.enabled,
+  });
 
   const outcome = decideExecutionLimit({
     maxExecutionsPerMonth: limits.maxExecutionsPerMonth,

--- a/lib/billing/execution-limit-core.ts
+++ b/lib/billing/execution-limit-core.ts
@@ -85,6 +85,13 @@ type CountCacheEntry = {
 
 const countCache = new Map<string, CountCacheEntry>();
 
+type CountRead = {
+  count: number;
+  // True when this read started a scan or joined one already in flight, i.e.
+  // no fresher value is obtainable right now.
+  fresh: boolean;
+};
+
 /**
  * countMonthlyExecutions behind a per-process TTL cache with in-flight dedup.
  *
@@ -97,39 +104,34 @@ const countCache = new Map<string, CountCacheEntry>();
  * i.e. under DB stress) they share the same promise instead of each starting
  * their own scan.
  *
- * Tradeoff: the guard may act on a count up to TTL stale, so an org crossing
- * its limit can overshoot by roughly TTL x its throughput, once, in the
- * window that straddles the crossing. The next refresh blocks it.
+ * ttlMs 0 keeps the in-flight sharing but never serves a completed value, which
+ * is how admission re-reads at the limit without letting concurrent callers
+ * stack scans. BILLING_COUNT_CACHE_TTL_MS=0 puts every read on that footing.
  *
  * For admission control only. The paths that turn a count into money - overage
  * billing (lib/billing/overage.ts) and the invoice usage figures
- * (lib/billing/execution-usage.ts) - must keep reading the exact committed
- * count for their own billing period, so they do not use this.
- *
- * Set BILLING_COUNT_CACHE_TTL_MS=0 to disable (recompute on every call).
+ * (lib/billing/execution-usage.ts) - read the exact committed count for their
+ * own billing period with their own query, and never come through here.
  */
-export function countMonthlyExecutionsCached<
-  TSchema extends Record<string, unknown>,
->(
+async function readCount<TSchema extends Record<string, unknown>>(
   db: PostgresJsDatabase<TSchema>,
   organizationId: string,
-  since: Date = startOfCurrentMonthUtc()
-): Promise<number> {
-  const ttl = getCountCacheTtlMs();
-  if (ttl <= 0) {
-    return countMonthlyExecutions(db, organizationId, since);
-  }
-
+  since: Date,
+  ttlMs: number
+): Promise<CountRead> {
   // Keyed on the window start as well as the org so a month rollover starts a
   // fresh count instead of serving the old month's total.
   const key = `${organizationId}|${since.toISOString()}`;
   const existing = countCache.get(key);
   if (existing) {
+    // An in-flight scan is shared even at ttl 0: it is already as fresh as a
+    // new scan, and sharing is what keeps concurrent admissions from stacking
+    // duplicate scans over one org.
     if (existing.completedAt === null) {
-      return existing.promise;
+      return { count: await existing.promise, fresh: true };
     }
-    if (performance.now() - existing.completedAt < ttl) {
-      return existing.promise;
+    if (ttlMs > 0 && performance.now() - existing.completedAt < ttlMs) {
+      return { count: await existing.promise, fresh: false };
     }
   }
 
@@ -155,7 +157,49 @@ export function countMonthlyExecutionsCached<
       // settle callback threw; nothing actionable here
     });
 
-  return promise;
+  return { count: await promise, fresh: true };
+}
+
+/**
+ * How far from the limit admission stops trusting a cached count. Sized above
+ * the largest burst one org has fitted into a single TTL window, so a burst
+ * cannot jump the band from underneath it.
+ */
+export const ADMISSION_RECOUNT_MARGIN = 500;
+
+/**
+ * The count to admit or refuse an execution on.
+ *
+ * Plans that bill overage keep the cache: going over there is charged, so a
+ * stale count costs nothing. Without overage an over-limit run is admitted for
+ * free, so near the limit the count is re-read instead.
+ *
+ * The band closes above the limit too. A pay-as-you-go org runs well past its
+ * included executions, and once it is clearly over, a stale count gives the
+ * same answer, so it returns to the cache rather than re-reading forever.
+ *
+ * Simultaneous in-flight admissions still share one count and can each be
+ * admitted at the boundary. That is the check-then-act window; closing it needs
+ * an atomic count-and-reserve, not a fresher read.
+ */
+export async function countMonthlyExecutionsForAdmission<
+  TSchema extends Record<string, unknown>,
+>(
+  db: PostgresJsDatabase<TSchema>,
+  organizationId: string,
+  plan: { maxExecutionsPerMonth: number; overageEnabled: boolean },
+  since: Date = startOfCurrentMonthUtc()
+): Promise<number> {
+  const read = await readCount(db, organizationId, since, getCountCacheTtlMs());
+  if (
+    read.fresh ||
+    plan.overageEnabled ||
+    plan.maxExecutionsPerMonth < 0 ||
+    Math.abs(read.count - plan.maxExecutionsPerMonth) > ADMISSION_RECOUNT_MARGIN
+  ) {
+    return read.count;
+  }
+  return (await readCount(db, organizationId, since, 0)).count;
 }
 
 /**

--- a/lib/billing/payg/charge.ts
+++ b/lib/billing/payg/charge.ts
@@ -1,8 +1,9 @@
 import "server-only";
 
-import { countMonthlyExecutionsCached } from "@/lib/billing/execution-limit-core";
+import { countMonthlyExecutionsForAdmission } from "@/lib/billing/execution-limit-core";
 import {
   getPlanLimits,
+  PLANS,
   parsePlanName,
   parseTierKey,
 } from "@/lib/billing/plans";
@@ -45,7 +46,14 @@ export async function chargePaygIfBillable(params: {
     parseTierKey(sub?.tier),
     sub?.planOverrides
   );
-  const used = await countMonthlyExecutionsCached(db, params.organizationId);
+  const used = await countMonthlyExecutionsForAdmission(
+    db,
+    params.organizationId,
+    {
+      maxExecutionsPerMonth: limits.maxExecutionsPerMonth,
+      overageEnabled: PLANS[plan].overage.enabled,
+    }
+  );
   if (used < limits.maxExecutionsPerMonth) {
     return { applicable: false };
   }

--- a/lib/billing/plans-server.ts
+++ b/lib/billing/plans-server.ts
@@ -5,7 +5,7 @@ import { db } from "@/lib/db";
 import { organizationSubscriptions } from "@/lib/db/schema";
 import { getActiveDebtExecutions } from "./execution-debt";
 import {
-  countMonthlyExecutionsCached,
+  countMonthlyExecutionsForAdmission,
   decideExecutionLimit,
   effectiveExecutionLimit,
 } from "./execution-limit-core";
@@ -251,8 +251,11 @@ export async function checkExecutionLimit(
     debtExecutions
   );
 
-  const used = await countMonthlyExecutionsCached(db, organizationId);
   const planDef = PLANS[plan];
+  const used = await countMonthlyExecutionsForAdmission(db, organizationId, {
+    maxExecutionsPerMonth: limits.maxExecutionsPerMonth,
+    overageEnabled: planDef.overage.enabled,
+  });
 
   const outcome = decideExecutionLimit({
     maxExecutionsPerMonth: limits.maxExecutionsPerMonth,

--- a/tests/unit/billing-execution-limit-core.test.ts
+++ b/tests/unit/billing-execution-limit-core.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetExecutionCountCacheForTest,
-  countMonthlyExecutionsCached,
+  countMonthlyExecutionsForAdmission,
 } from "@/lib/billing/execution-limit-core";
 
 type FakeDb = { execute: ReturnType<typeof vi.fn> };
@@ -10,10 +10,20 @@ function fakeDb(): FakeDb {
   return { execute: vi.fn() };
 }
 
-// The cached wrapper only touches db.execute; the cast keeps the fake minimal.
-function asDb(db: FakeDb): Parameters<typeof countMonthlyExecutionsCached>[0] {
-  return db as unknown as Parameters<typeof countMonthlyExecutionsCached>[0];
+// The reader only touches db.execute; the cast keeps the fake minimal.
+function asDb(
+  db: FakeDb
+): Parameters<typeof countMonthlyExecutionsForAdmission>[0] {
+  return db as unknown as Parameters<
+    typeof countMonthlyExecutionsForAdmission
+  >[0];
 }
+
+// A plan the org is nowhere near, so admission always takes the cached path.
+const FAR_FROM_LIMIT = {
+  maxExecutionsPerMonth: 1_000_000,
+  overageEnabled: false,
+};
 
 const SINCE = new Date("2026-07-01T00:00:00.000Z");
 
@@ -25,7 +35,7 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-describe("countMonthlyExecutionsCached", () => {
+describe("execution count cache", () => {
   it("shares a single in-flight query across concurrent callers", async () => {
     const db = fakeDb();
     let resolveQuery: (rows: { count: number }[]) => void = () => {
@@ -37,8 +47,18 @@ describe("countMonthlyExecutionsCached", () => {
       })
     );
 
-    const first = countMonthlyExecutionsCached(asDb(db), "org_1", SINCE);
-    const second = countMonthlyExecutionsCached(asDb(db), "org_1", SINCE);
+    const first = countMonthlyExecutionsForAdmission(
+      asDb(db),
+      "org_1",
+      FAR_FROM_LIMIT,
+      SINCE
+    );
+    const second = countMonthlyExecutionsForAdmission(
+      asDb(db),
+      "org_1",
+      FAR_FROM_LIMIT,
+      SINCE
+    );
     resolveQuery([{ count: 7 }]);
 
     expect(await first).toBe(7);
@@ -50,12 +70,22 @@ describe("countMonthlyExecutionsCached", () => {
     const db = fakeDb();
     db.execute.mockResolvedValue([{ count: 3 }]);
 
-    expect(await countMonthlyExecutionsCached(asDb(db), "org_1", SINCE)).toBe(
-      3
-    );
-    expect(await countMonthlyExecutionsCached(asDb(db), "org_1", SINCE)).toBe(
-      3
-    );
+    expect(
+      await countMonthlyExecutionsForAdmission(
+        asDb(db),
+        "org_1",
+        FAR_FROM_LIMIT,
+        SINCE
+      )
+    ).toBe(3);
+    expect(
+      await countMonthlyExecutionsForAdmission(
+        asDb(db),
+        "org_1",
+        FAR_FROM_LIMIT,
+        SINCE
+      )
+    ).toBe(3);
     expect(db.execute).toHaveBeenCalledTimes(1);
   });
 
@@ -66,13 +96,23 @@ describe("countMonthlyExecutionsCached", () => {
       .mockResolvedValueOnce([{ count: 3 }])
       .mockResolvedValueOnce([{ count: 4 }]);
 
-    expect(await countMonthlyExecutionsCached(asDb(db), "org_1", SINCE)).toBe(
-      3
-    );
+    expect(
+      await countMonthlyExecutionsForAdmission(
+        asDb(db),
+        "org_1",
+        FAR_FROM_LIMIT,
+        SINCE
+      )
+    ).toBe(3);
     await new Promise((resolve) => setTimeout(resolve, 10));
-    expect(await countMonthlyExecutionsCached(asDb(db), "org_1", SINCE)).toBe(
-      4
-    );
+    expect(
+      await countMonthlyExecutionsForAdmission(
+        asDb(db),
+        "org_1",
+        FAR_FROM_LIMIT,
+        SINCE
+      )
+    ).toBe(4);
     expect(db.execute).toHaveBeenCalledTimes(2);
   });
 
@@ -82,12 +122,22 @@ describe("countMonthlyExecutionsCached", () => {
       .mockResolvedValueOnce([{ count: 1 }])
       .mockResolvedValueOnce([{ count: 2 }]);
 
-    expect(await countMonthlyExecutionsCached(asDb(db), "org_1", SINCE)).toBe(
-      1
-    );
-    expect(await countMonthlyExecutionsCached(asDb(db), "org_2", SINCE)).toBe(
-      2
-    );
+    expect(
+      await countMonthlyExecutionsForAdmission(
+        asDb(db),
+        "org_1",
+        FAR_FROM_LIMIT,
+        SINCE
+      )
+    ).toBe(1);
+    expect(
+      await countMonthlyExecutionsForAdmission(
+        asDb(db),
+        "org_2",
+        FAR_FROM_LIMIT,
+        SINCE
+      )
+    ).toBe(2);
     expect(db.execute).toHaveBeenCalledTimes(2);
   });
 
@@ -97,12 +147,22 @@ describe("countMonthlyExecutionsCached", () => {
       .mockResolvedValueOnce([{ count: 500 }])
       .mockResolvedValueOnce([{ count: 0 }]);
 
-    expect(await countMonthlyExecutionsCached(asDb(db), "org_1", SINCE)).toBe(
-      500
-    );
+    expect(
+      await countMonthlyExecutionsForAdmission(
+        asDb(db),
+        "org_1",
+        FAR_FROM_LIMIT,
+        SINCE
+      )
+    ).toBe(500);
     const nextMonth = new Date("2026-08-01T00:00:00.000Z");
     expect(
-      await countMonthlyExecutionsCached(asDb(db), "org_1", nextMonth)
+      await countMonthlyExecutionsForAdmission(
+        asDb(db),
+        "org_1",
+        FAR_FROM_LIMIT,
+        nextMonth
+      )
     ).toBe(0);
     expect(db.execute).toHaveBeenCalledTimes(2);
   });
@@ -114,11 +174,21 @@ describe("countMonthlyExecutionsCached", () => {
       .mockResolvedValueOnce([{ count: 9 }]);
 
     await expect(
-      countMonthlyExecutionsCached(asDb(db), "org_1", SINCE)
+      countMonthlyExecutionsForAdmission(
+        asDb(db),
+        "org_1",
+        FAR_FROM_LIMIT,
+        SINCE
+      )
     ).rejects.toThrow("statement timeout");
-    expect(await countMonthlyExecutionsCached(asDb(db), "org_1", SINCE)).toBe(
-      9
-    );
+    expect(
+      await countMonthlyExecutionsForAdmission(
+        asDb(db),
+        "org_1",
+        FAR_FROM_LIMIT,
+        SINCE
+      )
+    ).toBe(9);
     expect(db.execute).toHaveBeenCalledTimes(2);
   });
 
@@ -129,12 +199,22 @@ describe("countMonthlyExecutionsCached", () => {
       .mockResolvedValueOnce([{ count: 1 }])
       .mockResolvedValueOnce([{ count: 2 }]);
 
-    expect(await countMonthlyExecutionsCached(asDb(db), "org_1", SINCE)).toBe(
-      1
-    );
-    expect(await countMonthlyExecutionsCached(asDb(db), "org_1", SINCE)).toBe(
-      2
-    );
+    expect(
+      await countMonthlyExecutionsForAdmission(
+        asDb(db),
+        "org_1",
+        FAR_FROM_LIMIT,
+        SINCE
+      )
+    ).toBe(1);
+    expect(
+      await countMonthlyExecutionsForAdmission(
+        asDb(db),
+        "org_1",
+        FAR_FROM_LIMIT,
+        SINCE
+      )
+    ).toBe(2);
     expect(db.execute).toHaveBeenCalledTimes(2);
   });
 
@@ -143,12 +223,131 @@ describe("countMonthlyExecutionsCached", () => {
     const db = fakeDb();
     db.execute.mockResolvedValue([{ count: 3 }]);
 
-    expect(await countMonthlyExecutionsCached(asDb(db), "org_1", SINCE)).toBe(
-      3
-    );
-    expect(await countMonthlyExecutionsCached(asDb(db), "org_1", SINCE)).toBe(
-      3
-    );
+    expect(
+      await countMonthlyExecutionsForAdmission(
+        asDb(db),
+        "org_1",
+        FAR_FROM_LIMIT,
+        SINCE
+      )
+    ).toBe(3);
+    expect(
+      await countMonthlyExecutionsForAdmission(
+        asDb(db),
+        "org_1",
+        FAR_FROM_LIMIT,
+        SINCE
+      )
+    ).toBe(3);
+    expect(db.execute).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("countMonthlyExecutionsForAdmission", () => {
+  const FREE = { maxExecutionsPerMonth: 5000, overageEnabled: false };
+  const PAID = { maxExecutionsPerMonth: 25_000, overageEnabled: true };
+
+  it("refuses a burst the stale count would have admitted", async () => {
+    const db = fakeDb();
+    db.execute
+      .mockResolvedValueOnce([{ count: 4999 }])
+      .mockResolvedValue([{ count: 5000 }]);
+
+    expect(
+      await countMonthlyExecutionsForAdmission(asDb(db), "org_1", FREE, SINCE)
+    ).toBe(4999);
+    // Second admission inside the same TTL window must not reuse 4999.
+    expect(
+      await countMonthlyExecutionsForAdmission(asDb(db), "org_1", FREE, SINCE)
+    ).toBe(5000);
+    expect(db.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not re-read a count it just fetched itself", async () => {
+    const db = fakeDb();
+    db.execute.mockResolvedValue([{ count: 5000 }]);
+
+    expect(
+      await countMonthlyExecutionsForAdmission(asDb(db), "org_1", FREE, SINCE)
+    ).toBe(5000);
+    expect(db.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the cache for an org far below its limit", async () => {
+    const db = fakeDb();
+    db.execute.mockResolvedValue([{ count: 100 }]);
+
+    expect(
+      await countMonthlyExecutionsForAdmission(
+        asDb(db),
+        "org_1",
+        FAR_FROM_LIMIT,
+        SINCE
+      )
+    ).toBe(100);
+    expect(
+      await countMonthlyExecutionsForAdmission(asDb(db), "org_1", FREE, SINCE)
+    ).toBe(100);
+    expect(db.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the cache for plans that bill overage", async () => {
+    const db = fakeDb();
+    db.execute.mockResolvedValue([{ count: 25_000 }]);
+
+    expect(
+      await countMonthlyExecutionsForAdmission(
+        asDb(db),
+        "org_1",
+        FAR_FROM_LIMIT,
+        SINCE
+      )
+    ).toBe(25_000);
+    expect(
+      await countMonthlyExecutionsForAdmission(asDb(db), "org_1", PAID, SINCE)
+    ).toBe(25_000);
+    expect(db.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns to the cache once an org is well past its limit", async () => {
+    const db = fakeDb();
+    db.execute.mockResolvedValue([{ count: 20_000 }]);
+
+    expect(
+      await countMonthlyExecutionsForAdmission(
+        asDb(db),
+        "org_1",
+        FAR_FROM_LIMIT,
+        SINCE
+      )
+    ).toBe(20_000);
+    expect(
+      await countMonthlyExecutionsForAdmission(asDb(db), "org_1", FREE, SINCE)
+    ).toBe(20_000);
+    expect(db.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the cache for unlimited plans", async () => {
+    const db = fakeDb();
+    db.execute.mockResolvedValue([{ count: 400_000 }]);
+    const unlimited = { maxExecutionsPerMonth: -1, overageEnabled: false };
+
+    expect(
+      await countMonthlyExecutionsForAdmission(
+        asDb(db),
+        "org_1",
+        FAR_FROM_LIMIT,
+        SINCE
+      )
+    ).toBe(400_000);
+    expect(
+      await countMonthlyExecutionsForAdmission(
+        asDb(db),
+        "org_1",
+        unlimited,
+        SINCE
+      )
+    ).toBe(400_000);
     expect(db.execute).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Problem

Admission reads the monthly execution count through a 30 second per-process TTL
cache. A burst of executions inside one cache window all read the same stale,
under-limit count, so free-tier runs past the included 5,000 were admitted.

Two gates share that count and both got it wrong:

- **Admission** decides block vs allow. With pay-as-you-go off it should have
  blocked, but the stale count kept the org under its limit, so the run went
  through for free.
- **The charge gate** decides charge vs free using the same `used < limit`
  comparison. With pay-as-you-go on, the run was correctly admitted, but the
  stale count classified it as still inside the free bucket, so it was never
  charged.

## Change

Admission re-reads the count when a stale one could admit an unbilled run: the
plan does not bill overage, and the cached count is within
`ADMISSION_RECOUNT_MARGIN` of the limit.

Everything else keeps the cache:

- Plans that bill overage, since exceeding the limit there is charged either way
  and a stale count costs nothing.
- Unlimited plans, which skip the count entirely.
- Orgs comfortably below their limit.

The band also closes above the limit, so a pay-as-you-go org running well past
its included executions returns to the cache instead of re-reading on every
execution.

The margin is sized above the largest burst measured inside a single TTL window,
so a burst cannot jump the band from underneath it.

## Cost

The cache exists to stop a slow count from stacking concurrent scans, so the
extra reads are kept narrow. They are confined to free-tier orgs at their limit,
whose count is permanently bounded by the limit itself and measures about 7 ms.
The expensive case, a plan with a much higher limit, is excluded by the overage
condition.

Billing and invoicing are unaffected. Overage and invoice usage run their own
exact count and never used this cache.

## Removed helper

`countMonthlyExecutionsCached` had no callers left once the three admission
points moved across. It is removed rather than left as an export that would
reintroduce this bug if it were used for admission. The cache tests now exercise
the same machinery through the admission entry point.

One behavior change worth noting: with `BILLING_COUNT_CACHE_TTL_MS=0` the old
path bypassed the cache entirely with no in-flight dedup, so concurrent callers
each started their own scan. They now share one in-flight scan, while sequential
callers still recompute.

## Not covered

Simultaneous in-flight admissions still share one count and can each pass at the
boundary. That is the documented check-then-act window; closing it needs an
atomic count-and-reserve rather than a fresher read.
