### PR TITLE
fix: keep pay-as-you-go charge history visible after disabling

### DIFF
--- a/app/api/billing/payg/route.ts
+++ b/app/api/billing/payg/route.ts
@@ -14,6 +14,7 @@ import {
   usdcDecimalToRaw,
   usdcRawToDecimal,
 } from "@/lib/billing/payg/usdc";
+import { PAYG_PLAN_NAME } from "@/lib/billing/plans";
 import { getOrgPlan } from "@/lib/billing/plans-server";
 import { requireOrgOwner } from "@/lib/billing/require-org-owner";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
@@ -149,7 +150,7 @@ export async function POST(request: Request): Promise<NextResponse> {
     // PAYG is a free-tier feature: it lets a free org keep running past its
     // included limit. Paid plans have their own executions/overage, so only
     // free-plan orgs may enable it.
-    if ((await getOrgPlan(orgId)) !== "free") {
+    if ((await getOrgPlan(orgId)) !== PAYG_PLAN_NAME) {
       return NextResponse.json(
         { error: "Pay-as-you-go is available on the free plan only" },
         { status: 409 }

--- a/components/billing/billing-status.tsx
+++ b/components/billing/billing-status.tsx
@@ -16,6 +16,7 @@ import {
 import { BILLING_ALERTS, BILLING_API } from "@/lib/billing/constants";
 import {
   type BillingInterval,
+  billsOverage,
   PLANS,
   type PlanName,
   parsePlanName,
@@ -839,7 +840,9 @@ function BillingStatusContent({
 
       <OverageChargesSection charges={overageCharges} />
 
-      {plan === "free" && <PaygSection />}
+      {/* Overage plans never had pay-as-you-go, so they have no charges to show.
+          The rest keep the section, which self-hides when there is nothing. */}
+      {!billsOverage(plan) && <PaygSection plan={plan} />}
     </CardContent>
   );
 }

--- a/components/billing/payg-section.tsx
+++ b/components/billing/payg-section.tsx
@@ -36,7 +36,11 @@ import {
 } from "@/components/ui/tooltip";
 import { toChecksumAddress } from "@/lib/address-utils";
 import { BILLING_API } from "@/lib/billing/constants";
-import { PLANS } from "@/lib/billing/plans";
+import {
+  PAYG_PLAN_NAME,
+  PLANS,
+  type PlanName,
+} from "@/lib/billing/plans";
 import { useDebounce } from "@/lib/hooks/use-debounce";
 import { useOrganization } from "@/lib/hooks/use-organization";
 import type { PageMeta } from "@/lib/pagination";
@@ -56,7 +60,7 @@ type PaygStatus = {
   } | null;
 };
 
-const FREE_LIMIT = PLANS.free.features.maxExecutionsPerMonth;
+const FREE_LIMIT = PLANS[PAYG_PLAN_NAME].features.maxExecutionsPerMonth;
 
 function formatUsdc(decimal: string): string {
   return `$${Number(decimal).toLocaleString(undefined, {
@@ -251,9 +255,16 @@ function PaygWalletFunding({
  * Pay-as-you-go controls for a free org, rendered inside the Current Plan card.
  * Caps show as read-only labels; enabling and editing them happen in a modal.
  */
-export function PaygSection(): React.ReactElement | null {
+export function PaygSection({
+  plan,
+}: {
+  plan: PlanName;
+}): React.ReactElement | null {
   const { organization } = useOrganization();
   const orgId = organization?.id;
+  // Only one plan can turn pay-as-you-go on. Others reach this component to
+  // read charges they settled while they were on it, and get history only.
+  const canUsePayg = plan === PAYG_PLAN_NAME;
 
   const [status, setStatus] = useState<PaygStatus | null>(null);
   const [loading, setLoading] = useState(true);
@@ -345,6 +356,12 @@ export function PaygSection(): React.ReactElement | null {
 
   if (!status) {
     return null;
+  }
+
+  // Nothing here is actionable off the pay-as-you-go plan, so show the settled
+  // charges alone. The table renders nothing when there are none.
+  if (!canUsePayg) {
+    return <PaygChargesTable key={orgId} paygEnabled={false} standalone />;
   }
 
   const priceConfigured = Number(status.priceUsdc) > 0;
@@ -451,7 +468,9 @@ export function PaygSection(): React.ReactElement | null {
         </div>
       )}
 
-      {status.enabled && <PaygChargesTable key={orgId} />}
+      {/* Not gated on status.enabled: disabling deletes the config row, but the
+          settled charges are real transactions and stay visible. */}
+      <PaygChargesTable key={orgId} paygEnabled={status.enabled} />
 
       <PaygCapsDialog
         enabling={!status.enabled}
@@ -622,7 +641,14 @@ function formatDateTime(iso: string): string {
  * Server-side paginated charge history. Re-mounted (via key) on org switch so
  * paging resets to the first page for the new org.
  */
-function PaygChargesTable(): React.ReactElement | null {
+function PaygChargesTable({
+  paygEnabled,
+  standalone = false,
+}: {
+  paygEnabled: boolean;
+  /** Render as its own block rather than a continuation of the section above. */
+  standalone?: boolean;
+}): React.ReactElement | null {
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebounce(search.trim(), 300);
@@ -676,7 +702,11 @@ function PaygChargesTable(): React.ReactElement | null {
 
   return (
     <>
-      <Separator />
+      {standalone ? (
+        <div className="border-border/40 border-t pt-4" />
+      ) : (
+        <Separator />
+      )}
       <div className="space-y-2">
         <button
           aria-expanded={open}
@@ -693,9 +723,15 @@ function PaygChargesTable(): React.ReactElement | null {
         </button>
         {open && (
           <>
-            <div className="flex justify-end">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              {!paygEnabled && (
+                <p className="text-muted-foreground text-xs">
+                  Pay-as-you-go is off. These are charges from when it was
+                  active.
+                </p>
+              )}
               <Input
-                className="h-8 w-full max-w-56"
+                className="ml-auto h-8 w-full max-w-56"
                 onChange={(e) => {
                   setSearch(e.target.value);
                   setPage(1);

--- a/lib/billing/plans.ts
+++ b/lib/billing/plans.ts
@@ -61,6 +61,9 @@ const VALID_TIER_KEYS: ReadonlySet<string> = new Set<TierKey>([
 // the tiers that value may select; anything else falls back to the default.
 // Every other plan and tier is pay-now.
 export const TRIAL_PLAN_NAME: PlanName = "pro";
+// Pay-as-you-go is offered on this plan only; every other plan either bills
+// overage past its included limit or is unlimited.
+export const PAYG_PLAN_NAME: PlanName = "free";
 export const DEFAULT_TRIAL_TIER_KEY: TierKey = "25k";
 export const TRIAL_ELIGIBLE_TIER_KEYS: readonly TierKey[] = [
   "25k",
@@ -189,6 +192,12 @@ export const PLANS: Record<PlanName, PlanDefinition> = {
     overage: { enabled: false, ratePerThousand: 0 },
   },
 } as const;
+
+// Whether the plan bills overage past its included limit. Overage and
+// pay-as-you-go are the two ways to run past the limit, and no plan has both.
+export function billsOverage(plan: PlanName): boolean {
+  return PLANS[plan].overage.enabled;
+}
 
 // Whether `value` is a Pro tier that may be configured as the trial tier.
 // Guards the TRIAL_TIER env against a plan/tier that does not exist.


### PR DESCRIPTION
## Problem

Disabling pay-as-you-go deletes the org's config row. That flipped
`status.enabled` to false, which hid the "Show recent charges" toggle and the
charges table along with it, so an org could no longer see charges it had
already been billed for. Those are settled on-chain transactions and the
payments rows are still there.

The section as a whole was also gated on the free plan, so the same history
disappeared on upgrade.

## Change

The charges table no longer depends on the enable state. It already self-hides
when the org has no charges, so the gate was redundant rather than load-bearing.

The section is now gated on the plan not billing overage, instead of on the free
plan by name. Overage and pay-as-you-go are the two ways to run past the included
limit and no plan has both, so this is the same condition expressed in terms of
what the plan actually does. Plans that cannot turn pay-as-you-go on get the
settled history alone, without the enable and cap controls.

Plan comparisons go through `PAYG_PLAN_NAME` and `billsOverage` rather than
string literals, including the server-side enable gate, so the client and server
cannot drift apart.

When pay-as-you-go is off, the expanded panel says the charges are historical.
The note sits on the search row so the collapsed state stays a single line.

## Notes

No backend change was needed. `GET /api/billing/payg/charges` only checks the
billing feature flag and org auth, and queries the payments rows directly with no
reference to the config row, so it already returned charges with pay-as-you-go
disabled.
