### PR TITLE
fix: correct the Claude Code setup commands in onboarding and docs

### DIFF
--- a/components/welcome/copy-block.tsx
+++ b/components/welcome/copy-block.tsx
@@ -36,8 +36,12 @@ export function CopyBlock({
           {caption}
         </div>
       ) : null}
-      <div className="relative">
-        <pre className="overflow-x-auto whitespace-pre px-4 py-4 pr-14 font-mono text-foreground text-xs leading-relaxed">
+      {/* The gutter is on the wrapper, not the pre: padding inside a scroll
+          container scrolls with the content, so a long command would pass under
+          the copy button instead of stopping short of it. The mask fades the
+          cut-off edge so a command that runs on does not look complete. */}
+      <div className="relative pr-16">
+        <pre className="overflow-x-auto whitespace-pre px-4 py-4 font-mono text-foreground text-xs leading-relaxed [mask-image:linear-gradient(to_right,black_calc(100%_-_1.5rem),transparent)]">
           {body}
         </pre>
         <Button

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -158,7 +158,7 @@ The KeeperHub [MCP server](/ai-tools/mcp-server) lets AI agents (Claude, custom 
 The fastest way is to connect directly to KeeperHub's hosted MCP server:
 
 ```bash
-claude mcp add --transport http keeperhub https://app.keeperhub.com/mcp
+claude mcp add --transport http --scope user keeperhub https://app.keeperhub.com/mcp
 ```
 
 Then run `/mcp` inside Claude Code and authorize via browser. No CLI or plugin installation needed.
@@ -168,7 +168,7 @@ Then run `/mcp` inside Claude Code and authorize via browser. No CLI or plugin i
 **Option A (remote, no install):**
 
 ```bash
-claude mcp add --transport http keeperhub https://app.keeperhub.com/mcp
+claude mcp add --transport http --scope user keeperhub https://app.keeperhub.com/mcp
 ```
 
 Run `/mcp` in Claude Code to authorize via browser.
@@ -178,10 +178,21 @@ Run `/mcp` in Claude Code to authorize via browser.
 ```bash
 /plugin marketplace add KeeperHub/claude-plugins
 /plugin install keeperhub@keeperhub-plugins
+```
+
+Restart Claude Code so the plugin's commands register, then sign in:
+
+```bash
 /keeperhub:login
 ```
 
-Restart Claude Code after setup. Verify with `/keeperhub:status`.
+Verify with `/keeperhub:status`.
+
+### Claude Code says "Login expired, please run /login". Is my KeeperHub session expired?
+
+That message is about your Claude account, and `/login` is a Claude Code command. Run `/login` inside Claude Code to sign back in.
+
+Your KeeperHub connection is separate. Check it with `/keeperhub:status`, and re-authorize it with `/mcp` (remote MCP) or `/keeperhub:login` (plugin).
 
 ### What's the difference between `kh_` and `wfb_` API keys?
 

--- a/docs/ai-tools/claude-code-plugin.md
+++ b/docs/ai-tools/claude-code-plugin.md
@@ -18,7 +18,7 @@ There are two ways to connect Claude Code to KeeperHub:
 Connect directly to KeeperHub's hosted MCP server. No CLI or plugin installation required.
 
 ```bash
-claude mcp add --transport http keeperhub https://app.keeperhub.com/mcp
+claude mcp add --transport http --scope user keeperhub https://app.keeperhub.com/mcp
 ```
 
 Then run `/mcp` inside Claude Code to authorize via browser. That's it.
@@ -40,16 +40,35 @@ See [CLI installation options](https://github.com/KeeperHub/cli#install) for oth
 ```bash
 /plugin marketplace add KeeperHub/claude-plugins
 /plugin install keeperhub@keeperhub-plugins
+```
+
+**3. Restart Claude Code**
+
+The plugin's commands are registered on restart. Run them before that and Claude
+Code reports them as unknown commands.
+
+**4. Sign in**
+
+```bash
 /keeperhub:login
 ```
 
-Restart Claude Code after setup for MCP tools to become available.
+Run `/keeperhub:status` to confirm the connection.
 
 ### Requirements
 
 - KeeperHub account at [app.keeperhub.com](https://app.keeperhub.com)
 - Option A: just a browser (for OAuth)
 - Option B: the `kh` CLI ([install instructions](https://github.com/KeeperHub/cli#install))
+
+### Which login is which
+
+Claude Code shows "Login expired, please run /login" about your Claude account,
+and `/login` is one of its own commands. Run `/login` inside Claude Code to sign
+back in.
+
+Your KeeperHub connection is separate. Check it with `/keeperhub:status` and
+re-authorize it with `/mcp` or `/keeperhub:login`.
 
 ## Commands
 

--- a/docs/ai-tools/mcp-server.md
+++ b/docs/ai-tools/mcp-server.md
@@ -14,7 +14,7 @@ The KeeperHub MCP server exposes tools over the Model Context Protocol, enabling
 Connect directly to KeeperHub's hosted MCP server. No local process or CLI installation needed.
 
 ```bash
-claude mcp add --transport http keeperhub https://app.keeperhub.com/mcp
+claude mcp add --transport http --scope user keeperhub https://app.keeperhub.com/mcp
 ```
 
 Then run `/mcp` inside Claude Code to complete the OAuth authorization via browser. KeeperHub will ask you to approve access, and the token is stored automatically.
@@ -22,7 +22,7 @@ Then run `/mcp` inside Claude Code to complete the OAuth authorization via brows
 For headless or CI environments where browser auth is not available, pass an API key:
 
 ```bash
-claude mcp add --transport http keeperhub https://app.keeperhub.com/mcp \
+claude mcp add --transport http --scope user keeperhub https://app.keeperhub.com/mcp \
   --header "Authorization: Bearer kh_your_key_here"
 ```
 
@@ -43,7 +43,7 @@ This matters because LLMs select tools from `tools/list` in a single decision st
 ### Install
 
 ```bash
-claude mcp add --transport http my-workflow https://app.keeperhub.com/mcp/w/<slug> \
+claude mcp add --transport http --scope user my-workflow https://app.keeperhub.com/mcp/w/<slug> \
   --header "Authorization: Bearer kh_your_key_here"
 ```
 
@@ -103,7 +103,7 @@ To work with a different org, re-authenticate:
 
 ```bash
 claude mcp remove keeperhub
-claude mcp add --transport http keeperhub https://app.keeperhub.com/mcp
+claude mcp add --transport http --scope user keeperhub https://app.keeperhub.com/mcp
 ```
 
 Complete the OAuth flow again -- the new active org will be captured.

--- a/docs/cli/quickstart.md
+++ b/docs/cli/quickstart.md
@@ -67,7 +67,7 @@ KeeperHub exposes its actions as tools to AI assistants via the [Model Context P
 
 **Recommended: remote HTTP endpoint (no local server required):**
 ```
-claude mcp add --transport http keeperhub https://app.keeperhub.com/mcp
+claude mcp add --transport http --scope user keeperhub https://app.keeperhub.com/mcp
 ```
 
 **Add to Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,14 +15,14 @@ section links to its full reference page.
 The hosted MCP server is the fastest way to drive KeeperHub from an AI agent.
 
 ```bash
-claude mcp add --transport http keeperhub https://app.keeperhub.com/mcp
+claude mcp add --transport http --scope user keeperhub https://app.keeperhub.com/mcp
 ```
 
 Run `/mcp` in Claude Code to complete OAuth in the browser. For headless or CI
 environments, pass an organization API key instead:
 
 ```bash
-claude mcp add --transport http keeperhub https://app.keeperhub.com/mcp \
+claude mcp add --transport http --scope user keeperhub https://app.keeperhub.com/mcp \
   --header "Authorization: Bearer kh_your_key_here"
 ```
 

--- a/lib/agent-connect-commands.ts
+++ b/lib/agent-connect-commands.ts
@@ -37,7 +37,7 @@ export function getAgentFrameworks(mcpUrl: string): AgentFramework[] {
       snippets: [
         {
           caption: "Add the server",
-          body: `claude mcp add --transport http keeperhub ${mcpUrl}`,
+          body: `claude mcp add --transport http --scope user keeperhub ${mcpUrl}`,
         },
       ],
       note: "Run /mcp in Claude Code and complete the browser sign-in when prompted.",
@@ -152,8 +152,13 @@ url = "${mcpUrl}"`,
         {
           caption: "Install the plugin",
           body: `/plugin marketplace add KeeperHub/claude-plugins
-/plugin install keeperhub@keeperhub-plugins
-/keeperhub:login`,
+/plugin install keeperhub@keeperhub-plugins`,
+        },
+        {
+          // The plugin's commands only register on restart, so /keeperhub:login
+          // is a separate snippet rather than a third line above.
+          caption: "Restart Claude Code, then sign in",
+          body: "/keeperhub:login",
         },
       ],
       note: "Run /keeperhub:status to verify the connection.",

--- a/tests/unit/agent-connect-commands.test.ts
+++ b/tests/unit/agent-connect-commands.test.ts
@@ -32,8 +32,13 @@ describe("getAgentFrameworks", () => {
   it("adds the Claude Code server over http with the MCP url", () => {
     const [claude] = getAgentFrameworks(MCP_URL);
     expect(claude.snippets[0].body).toBe(
-      `claude mcp add --transport http keeperhub ${MCP_URL}`
+      `claude mcp add --transport http --scope user keeperhub ${MCP_URL}`
     );
+  });
+
+  it("scopes the Claude Code server to the user, not the launch directory", () => {
+    const [claude] = getAgentFrameworks(MCP_URL);
+    expect(claude.snippets[0].body).toContain("--scope user");
   });
 
   it("interpolates the MCP url into the config-based frameworks", () => {
@@ -58,5 +63,16 @@ describe("getAgentFrameworks", () => {
     expect(byId.get("hermes")?.snippets[0].body).toContain(
       "hermes plugins install KeeperHub/hermes-plugin --enable"
     );
+  });
+
+  it("keeps the plugin sign-in out of the install snippet so a restart can sit between them", () => {
+    const plugin = new Map(
+      getAgentFrameworks(MCP_URL).map((f) => [f.id, f])
+    ).get("claude-plugin");
+    const [install, signIn] = plugin?.snippets ?? [];
+
+    expect(install.body).not.toContain("/keeperhub:login");
+    expect(signIn.body).toContain("/keeperhub:login");
+    expect(signIn.caption.toLowerCase()).toContain("restart");
   });
 });


### PR DESCRIPTION
Three onboarding fixes reported during hackathon setup, plus one UI fix the
first of them exposed.

## The MCP server was registering to the wrong directory

`claude mcp add` defaults to `local` scope, so the server registered only for the
directory Claude Code happened to be launched in and was gone once the developer
moved into their real project. It reads as a silent failure: the tools are simply
absent, with no error.

Every snippet now passes `--scope user`.

This was larger than reported. There are **11** `claude mcp add` invocations
across 7 files, not the 6 that were listed. The ones that were missed are the
API-key variants in `quickstart.md` and `mcp-server.md`, the per-workflow server
in `mcp-server.md`, and the second FAQ snippet. Fixing only the listed 6 would
have left the docs inconsistent, which is the exact failure the report was
trying to prevent.

## Plugin setup ran a plugin command before the plugin existed

`/plugin install` asks the user to reload before the plugin's commands register,
but `/keeperhub:login` was listed immediately after it with no reload between,
so on a fresh install it is not found yet.

The install and the sign-in are now separate steps with the restart between
them, in the onboarding UI and in the docs.

This also had a third occurrence that was not reported: the FAQ had the same
ordering, with the restart mentioned only after the login command.

## "Login expired, please run /login" did not say which login

The string is emitted by Claude Code about the Claude account, and `/login` is
one of its own commands. It is not ours to change, and a user went looking for
an expired KeeperHub session.

Added a short entry to the FAQ and the plugin doc saying which login it refers
to, and how to check the KeeperHub connection separately.

## Copy block truncated commands under the copy button

Not tracked by a ticket, included because the fix above is what makes it
visible.

The code block reserved space for the copy button with padding inside the
scrolling element. Padding there scrolls with the content rather than shrinking
the viewport, so any command wide enough ran underneath the button. Nothing was
wide enough by default until `--scope user` lengthened the command.

The gutter moved to the wrapper so the scroll viewport stops short of the
button, and the cut-off edge is masked to a fade so a command that runs on does
not look complete. The mask fades the text's own alpha rather than overlaying a
colour, so it needs no background match and works in both themes.

This is in the shared `CopyBlock`, so it applies to every agent tab, not just
Claude Code.

## Note

`docs-site/content` is a symlink to `docs/`, so the published site renders these
same files and there is no second copy to keep in sync.
