### PR TITLE
docs: explain what a sponsored transaction looks like on-chain

### DIFF
--- a/docs/wallet-management/_meta.ts
+++ b/docs/wallet-management/_meta.ts
@@ -2,5 +2,6 @@ export default {
   turnkey: "Turnkey Integration",
   safe: "Safe Smart Accounts",
   gas: "Gas Management",
+  "onchain-appearance": "Transactions On-Chain",
   "address-book": "Address Book",
 };

--- a/docs/wallet-management/gas.md
+++ b/docs/wallet-management/gas.md
@@ -69,6 +69,8 @@ Setting a gas limit below the estimate will cause the transaction to revert with
 
 On supported networks, KeeperHub can sponsor the **gas fee** of a workflow transaction through Turnkey's Gas Station, so a workflow can run even when the sending wallet holds no native gas token. Sponsorship is enabled per organization and metered against a monthly gas credit allowance shown on your billing page.
 
+Sponsorship also changes how the transaction appears on a block explorer. See [What Your Transaction Looks Like On-Chain](/wallet-management/onchain-appearance).
+
 ### What sponsorship covers
 
 Sponsorship pays the **transaction fee only**. It does not provide the assets your transaction moves. The native value a transaction sends (for example, the ETH amount in a Transfer Native Token action) is always debited from your own wallet.

--- a/docs/wallet-management/onchain-appearance.md
+++ b/docs/wallet-management/onchain-appearance.md
@@ -1,0 +1,98 @@
+---
+title: "What Your Transaction Looks Like On-Chain"
+description: "Why a workflow transaction can show an unfamiliar sender, an unfamiliar contract, and a value of 0 on a block explorer, and how to verify it correctly."
+---
+
+# What Your Transaction Looks Like On-Chain
+
+A workflow ran, KeeperHub reported success, and you opened a block explorer to
+check. The transaction shows a sender you do not recognise, a contract you do
+not recognise, and a value of 0.
+
+Nothing is wrong. This is what a gas-sponsored write looks like, and this page
+explains how to read it.
+
+## The short version
+
+When a write is gas-sponsored, your wallet is not the account that submits the
+transaction. A relayer submits it on your behalf and pays the fee, and your
+action runs as an internal call inside it.
+
+So on the explorer:
+
+| Field | What you see | Why |
+|-------|--------------|-----|
+| From | An address you do not recognise | The relayer that submitted and paid for the transaction |
+| To | A contract you do not recognise | The contract that executes the call on your wallet's behalf |
+| Value | `0` | No native token is attached to the outer call |
+| Status | Success | The transaction did what your workflow asked |
+
+Your own action, the transfer or the contract call you configured, is an
+**internal call** inside that transaction rather than the top-level one.
+
+## Verify with the transaction hash, not your wallet address
+
+This is the important part.
+
+Use the `transactionHash` (or the explorer link) that KeeperHub reports for the
+run. Open that hash directly. It is the authoritative record.
+
+Do **not** verify by opening your wallet address and looking through its
+transaction list. A sponsored transaction was not sent by your wallet, so it
+does not appear there. The list will look as though nothing happened, even
+though the transaction succeeded.
+
+On most explorers, the detail worth checking sits under the transaction's
+**Logs**, **Internal Transactions**, or **Token Transfers** tabs. That is where
+your actual call and any token movements appear.
+
+## Why the value shows 0
+
+Two things are worth separating.
+
+**The outer call carries no native token.** `Value` is the amount of the chain's
+native token attached to the top-level call. A token transfer moves an ERC-20
+balance through a contract call, and a contract call usually attaches nothing,
+so both show `0` even though assets moved. Check the token transfer list rather
+than the value field.
+
+**The fee was not paid by you.** With sponsorship the relayer pays the gas, so
+your wallet's native balance is unchanged by the fee.
+
+## Why your wallet may have code on it
+
+If you look up your organization wallet on an explorer, it may show a small
+amount of contract code rather than appearing as a plain address, and the
+explorer may label it as delegated or as a smart account.
+
+That is expected. On supported networks the wallet is delegated so it can be
+operated on your behalf while remaining your wallet, under your address, holding
+your assets. The delegation is a one-time setup per network, not something each
+workflow repeats.
+
+## When a transaction does come from your wallet
+
+Not every write is sponsored. When sponsorship does not apply, the transaction
+is sent directly from your wallet, pays gas from your own native balance, and
+appears in your wallet's transaction list in the ordinary way. The conditions
+that decide this are listed under
+[Gas Management](/wallet-management/gas#when-a-transaction-is-sponsored).
+
+Both routes produce a real transaction with a real hash. Only the shape on the
+explorer differs.
+
+## Checklist
+
+If a run reports success but the chain looks wrong:
+
+1. Open the `transactionHash` from the run, not your wallet address.
+2. Confirm the status is Success.
+3. Look at Logs, Internal Transactions, and Token Transfers for the actual call.
+4. Expect the sender and the top-level contract to be addresses you do not
+   recognise, and the value to be `0`.
+
+## Related
+
+- [Gas Management](/wallet-management/gas) covers sponsorship, what it pays for,
+  and when it applies.
+- [Turnkey Integration](/wallet-management/turnkey) covers the wallet itself.

--- a/docs/wallet-management/turnkey.md
+++ b/docs/wallet-management/turnkey.md
@@ -19,6 +19,12 @@ Turnkey generates and stores private keys inside secure hardware enclaves (TEEs)
 - **Private key export** -- export your key if you need to migrate to another solution
 - **Integrated operations** -- seamless signing for workflow transactions
 
+On networks where gas is sponsored, a workflow write is submitted on your
+wallet's behalf rather than directly by it, so on a block explorer it shows a
+sender and a contract you will not recognise and a value of `0`. See
+[What Your Transaction Looks Like On-Chain](/wallet-management/onchain-appearance)
+before concluding a run did not work.
+
 ## Wallet Funding
 
 Topping up your Turnkey EOA with native gas tokens (ETH on Ethereum, ETH on Base, MATIC on Polygon, SOL on Solana, etc.) is required for any workflow that broadcasts a transaction.


### PR DESCRIPTION
## Problem

A user ran a workflow, went to verify the write on a block explorer, and found a
sender they did not recognise, a contract they did not recognise, and a value of
`0`. Their first read was that the transaction had failed.

The mechanics were documented, but not the thing the user was actually looking
at. The Direct Execution API reference covers the sponsored path, framed around
an API field and buried in an API page. The gas page covers what sponsorship
pays for and when it applies, but says nothing about how the transaction then
appears on-chain. The Turnkey page, which is where someone goes when they have a
question about their wallet, describes it purely as an EOA.

Nothing anywhere explained the value of `0`.

## Change

Adds `wallet-management/onchain-appearance.md`, an onboarding-shaped page that
starts from what the user is staring at and works back to the cause:

- A table mapping each confusing field to its reason: the sender is the relayer
  that paid, the top-level contract is the one executing on the wallet's behalf,
  and the value is `0` because nothing native rides on the outer call.
- The instruction that matters: verify with the transaction hash the run
  reports, never by scanning the wallet's transaction list. A sponsored
  transaction is not sent by the wallet and will never appear there, so that
  list looks like nothing happened.
- Why `0` shows even when tokens moved, and where the real movement appears.
- Why the wallet may show a small amount of contract code on it.
- That not every write is sponsored, with a link to the conditions.

Cross-linked from the Turnkey and gas pages, and registered in the
wallet-management nav.

## Notes for review

Deliberately no example addresses and no mention of the delegation standard by
name. The reader of this page wants to know whether their money moved; the
protocol detail does not help them, and the API reference already carries the
technical framing.

The page also stays agnostic about which sponsorship route ran. It describes the
shape and points at the gas page for when sponsorship applies, rather than
asserting internal routing.
