### PR TITLE
fix: highlight Workflows by route and keep the fold button clear of the banner

### DIFF
--- a/components/navigation-sidebar.tsx
+++ b/components/navigation-sidebar.tsx
@@ -680,6 +680,8 @@ export function NavigationSidebar(): React.ReactNode {
 
   const workflowId =
     typeof params.workflowId === "string" ? params.workflowId : undefined;
+  const isWorkflowsPage =
+    pathname === "/workflows" || pathname.startsWith("/workflows/");
   const isHubPage = pathname === "/hub";
   const isAnalyticsPage = pathname === "/analytics";
   const isEarningsPage = pathname === "/earnings";
@@ -810,8 +812,9 @@ export function NavigationSidebar(): React.ReactNode {
   const offsets = computePanelOffsets(currentWidth, navState.state.panels);
 
   function isActive(id: string): boolean {
+    // Route-based like every other item; the flyout state is not "you are here".
     if (id === "workflows") {
-      return navState.state.panels.projects !== "closed";
+      return isWorkflowsPage;
     }
     if (id === "hub") {
       return isHubPage;
@@ -1092,7 +1095,7 @@ export function NavigationSidebar(): React.ReactNode {
         <Tooltip>
           <TooltipTrigger asChild>
             <button
-              className="pointer-events-auto fixed top-[62px] z-40 rounded-md p-1.5 text-muted-foreground transition-[left,colors] duration-200 ease-out hover:bg-muted hover:text-foreground"
+              className="pointer-events-auto fixed top-[calc(62px+var(--app-banner-height,0px))] z-40 rounded-md p-1.5 text-muted-foreground transition-[left,colors] duration-200 ease-out hover:bg-muted hover:text-foreground"
               data-flyout
               onClick={anyPanelExpanded ? navState.foldAll : navState.closeAll}
               style={{ left: offsets.rightEdge + 4 }}


### PR DESCRIPTION
Two nav fixes in the sidebar, one file.

## Workflows stayed highlighted everywhere

`isActive` tied the Workflows highlight to the flyout panel state rather than the
route, unlike every other nav item:

```ts
if (id === "workflows") {
  return navState.state.panels.projects !== "closed";
}
```

The panel deliberately stays open when routing to another page, its state is
persisted across reloads, and the check was `!== "closed"` so the collapsed strip
counted as active too. The result was Workflows rendering as the active item on
Analytics, Earnings, Held Payments, Activity and Hub, which turns the highlight
into noise rather than "you are here".

It now matches on the route, `/workflows` and `/workflows/[id]`, like the rest of
the items. Flyout open or collapsed no longer affects the highlight.

## The fold/close button was invisible for some people

The button outside the rightmost panel was pinned to a hardcoded `top-[62px]`,
while every other fixed nav element positions itself with
`top-[calc(60px+var(--app-banner-height,0px))]`.

When the announcement banner is showing it sets `--app-banner-height` to 36px.
The panels move down accordingly, the button did not, so it ended up inside the
header strip. The header is `z-50` and the button is `z-40`, so the header paints
over it and it vanishes.

This was reported as a Firefox problem, but it is not browser-specific. Banner
dismissal lives in localStorage, which is per browser, so anyone who dismissed
the banner in their usual browser sees the button there and loses it in a second
browser where it was never dismissed. Anyone who has not dismissed it at all
never sees the button.

The button now carries the same banner offset as the panels it tracks.

## Note on the ticket

The ticket asks for a close control to be added to the flyout header, on the
basis that no close control exists. There is one, the button described above, so
this changes its positioning rather than adding a second control. Worth updating
the ticket so the header does not gain a duplicate X later.
