### PR TITLE
fix: recover dev-login from drizzle migration drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Visit [http://localhost:3000](http://localhost:3000) to get started. The first r
 
 ### Local development troubleshooting
 
-- **`pnpm dev:login` fails after `pnpm db:push`:** Your schema is ahead of the Drizzle migration journal. Run `pnpm tsx scripts/backfill-drizzle-migrations.ts`, then retry. `dev:bootstrap` (invoked by `dev:login`) detects this drift automatically, runs the backfill script, and retries migrate once.
+- **`pnpm dev:login` fails after `pnpm db:push`:** Your schema is ahead of the Drizzle migration journal. `dev:bootstrap` (invoked by `dev:login`) backfills the journal before migrate when the `users` table exists and the journal is empty. If migrate then fails with a public-schema `already exists` collision while the journal still lags the schema, bootstrap backfills again (bounded with `--through` when the journal is partial) and retries migrate once. Manual fallback: `pnpm tsx scripts/backfill-drizzle-migrations.ts`, then retry.
 - **`db:push` vs `db:migrate`:** Use `pnpm db:push` only for fast local schema iteration. Staging and production apply file-based migrations via `pnpm db:migrate` on deploy.
 - **Local Postgres required:** `dev:login` and `dev:bootstrap` refuse to run unless `DATABASE_URL` points at a local host (for example `postgresql://postgres:postgres@localhost:5433/keeperhub` when using Docker Compose).
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ pnpm dev
 
 Visit [http://localhost:3000](http://localhost:3000) to get started. The first request triggers a Next.js dev compile that can take 30-60 seconds; subsequent requests are fast.
 
+### Local development troubleshooting
+
+- **`pnpm dev:login` fails after `pnpm db:push`:** Your schema is ahead of the Drizzle migration journal. Run `pnpm tsx scripts/backfill-drizzle-migrations.ts`, then retry. `dev:bootstrap` (invoked by `dev:login`) detects this drift automatically, runs the backfill script, and retries migrate once.
+- **`db:push` vs `db:migrate`:** Use `pnpm db:push` only for fast local schema iteration. Staging and production apply file-based migrations via `pnpm db:migrate` on deploy.
+- **Local Postgres required:** `dev:login` and `dev:bootstrap` refuse to run unless `DATABASE_URL` points at a local host (for example `postgresql://postgres:postgres@localhost:5433/keeperhub` when using Docker Compose).
+
 ## Running Modes
 
 ### Local Development (Simplest)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Visit [http://localhost:3000](http://localhost:3000) to get started. The first r
 
 ### Local development troubleshooting
 
-- **`pnpm dev:login` fails after `pnpm db:push`:** Your schema is ahead of the Drizzle migration journal. `dev:bootstrap` (invoked by `dev:login`) backfills the journal before migrate when the `users` table exists and the journal is empty. If migrate then fails with a public-schema `already exists` collision while the journal still lags the schema, bootstrap backfills again (bounded with `--through` when the journal is partial) and retries migrate once. Manual fallback: `pnpm tsx scripts/backfill-drizzle-migrations.ts`, then retry.
+- **`pnpm dev:login` fails after `pnpm db:push`:** Your schema is ahead of the Drizzle migration journal. `dev:bootstrap` (invoked by `dev:login`) backfills the journal before migrate when the `users` table exists and the journal is empty. If migrate then fails with a public-schema `already exists` collision while the journal still lags the schema, bootstrap backfills any missing journal hashes and retries migrate once. Manual fallback: `pnpm tsx scripts/backfill-drizzle-migrations.ts`, then retry.
 - **`db:push` vs `db:migrate`:** Use `pnpm db:push` only for fast local schema iteration. Staging and production apply file-based migrations via `pnpm db:migrate` on deploy.
 - **Local Postgres required:** `dev:login` and `dev:bootstrap` refuse to run unless `DATABASE_URL` points at a local host (for example `postgresql://postgres:postgres@localhost:5433/keeperhub` when using Docker Compose).
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Visit [http://localhost:3000](http://localhost:3000) to get started. The first r
 
 ### Local development troubleshooting
 
-- **`pnpm dev:login` fails after `pnpm db:push`:** Your schema is ahead of the Drizzle migration journal. `dev:bootstrap` (invoked by `dev:login`) backfills the journal before migrate when the `users` table exists and the journal is empty. If migrate then fails with a public-schema `already exists` collision while the journal still lags the schema, bootstrap backfills any missing journal hashes and retries migrate once. Manual fallback: `pnpm tsx scripts/backfill-drizzle-migrations.ts`, then retry.
+- **`pnpm dev:login` fails after `pnpm db:push`:** Your schema is ahead of the Drizzle migration journal. `dev:bootstrap` (invoked by `dev:login`) backfills the journal before migrating when the `users` table exists and the journal is empty. If a migration then fails because an object it creates already exists, while the journal still lags the schema, bootstrap marks every journal entry applied and retries once. `db:push` applies your whole working-tree schema, so that is the right set - but if you pulled migrations authored since your last push, run `pnpm db:push` again so their SQL is actually applied. Manual fallback: `pnpm tsx scripts/backfill-drizzle-migrations.ts`, then retry.
 - **`db:push` vs `db:migrate`:** Use `pnpm db:push` only for fast local schema iteration. Staging and production apply file-based migrations via `pnpm db:migrate` on deploy.
 - **Local Postgres required:** `dev:login` and `dev:bootstrap` refuse to run unless `DATABASE_URL` points at a local host (for example `postgresql://postgres:postgres@localhost:5433/keeperhub` when using Docker Compose).
 

--- a/scripts/dev-login.ts
+++ b/scripts/dev-login.ts
@@ -40,7 +40,6 @@ import * as http from "node:http";
 import * as path from "node:path";
 
 import { getDatabaseUrl } from "../lib/db/connection-utils";
-import { isMigrationDriftOutput } from "./lib/migration-drift";
 
 const ALLOWED_HOSTS = new Set([
   "localhost",
@@ -100,58 +99,13 @@ function runStep(
 ): void {
   console.log(`> ${label}`);
   const env = { ...process.env, ...extraEnv } as NodeJS.ProcessEnv;
-  const isBootstrap = script.includes("dev-bootstrap");
-
   const result = spawnSync("pnpm", ["tsx", script, ...args], {
-    stdio: isBootstrap ? ["ignore", "pipe", "pipe"] : "inherit",
+    stdio: "inherit",
     env,
-    encoding: isBootstrap ? "utf8" : undefined,
   });
-
-  if (result.status === 0) {
-    if (isBootstrap) {
-      const stdout =
-        typeof result.stdout === "string"
-          ? result.stdout
-          : (result.stdout?.toString() ?? "");
-      const stderr =
-        typeof result.stderr === "string"
-          ? result.stderr
-          : (result.stderr?.toString() ?? "");
-      const output = [stdout, stderr].filter(Boolean).join("\n");
-      if (output) {
-        process.stdout.write(output.endsWith("\n") ? output : `${output}\n`);
-      }
-    }
-    return;
+  if (result.status !== 0) {
+    throw new Error(`${label} exited with status ${result.status ?? "null"}`);
   }
-
-  if (isBootstrap) {
-    const stdout =
-      typeof result.stdout === "string"
-        ? result.stdout
-        : (result.stdout?.toString() ?? "");
-    const stderr =
-      typeof result.stderr === "string"
-        ? result.stderr
-        : (result.stderr?.toString() ?? "");
-    const output = [stdout, stderr].filter(Boolean).join("\n");
-
-    if (output) {
-      process.stderr.write(output);
-    }
-
-    if (isMigrationDriftOutput(output)) {
-      console.error(
-        "dev-login: bootstrap failed after migration drift recovery attempt"
-      );
-      console.error(
-        "dev-login: try manually: pnpm tsx scripts/backfill-drizzle-migrations.ts"
-      );
-    }
-  }
-
-  throw new Error(`${label} exited with status ${result.status ?? "null"}`);
 }
 
 function sleep(ms: number): Promise<void> {

--- a/scripts/dev-login.ts
+++ b/scripts/dev-login.ts
@@ -40,6 +40,7 @@ import * as http from "node:http";
 import * as path from "node:path";
 
 import { getDatabaseUrl } from "../lib/db/connection-utils";
+import { isMigrationDriftOutput } from "./lib/migration-drift";
 
 const ALLOWED_HOSTS = new Set([
   "localhost",
@@ -99,13 +100,58 @@ function runStep(
 ): void {
   console.log(`> ${label}`);
   const env = { ...process.env, ...extraEnv } as NodeJS.ProcessEnv;
+  const isBootstrap = script.includes("dev-bootstrap");
+
   const result = spawnSync("pnpm", ["tsx", script, ...args], {
-    stdio: "inherit",
+    stdio: isBootstrap ? ["ignore", "pipe", "pipe"] : "inherit",
     env,
+    encoding: isBootstrap ? "utf8" : undefined,
   });
-  if (result.status !== 0) {
-    throw new Error(`${label} exited with status ${result.status ?? "null"}`);
+
+  if (result.status === 0) {
+    if (isBootstrap) {
+      const stdout =
+        typeof result.stdout === "string"
+          ? result.stdout
+          : (result.stdout?.toString() ?? "");
+      const stderr =
+        typeof result.stderr === "string"
+          ? result.stderr
+          : (result.stderr?.toString() ?? "");
+      const output = [stdout, stderr].filter(Boolean).join("\n");
+      if (output) {
+        process.stdout.write(output.endsWith("\n") ? output : `${output}\n`);
+      }
+    }
+    return;
   }
+
+  if (isBootstrap) {
+    const stdout =
+      typeof result.stdout === "string"
+        ? result.stdout
+        : (result.stdout?.toString() ?? "");
+    const stderr =
+      typeof result.stderr === "string"
+        ? result.stderr
+        : (result.stderr?.toString() ?? "");
+    const output = [stdout, stderr].filter(Boolean).join("\n");
+
+    if (output) {
+      process.stderr.write(output);
+    }
+
+    if (isMigrationDriftOutput(output)) {
+      console.error(
+        "dev-login: bootstrap failed after migration drift recovery attempt"
+      );
+      console.error(
+        "dev-login: try manually: pnpm tsx scripts/backfill-drizzle-migrations.ts"
+      );
+    }
+  }
+
+  throw new Error(`${label} exited with status ${result.status ?? "null"}`);
 }
 
 function sleep(ms: number): Promise<void> {

--- a/scripts/lib/migration-drift.ts
+++ b/scripts/lib/migration-drift.ts
@@ -230,6 +230,25 @@ export function runDbMigrate(env: NodeJS.ProcessEnv = process.env): CommandResul
   return spawnPnpm(MIGRATE_COMMAND, ["db:migrate"], env);
 }
 
+/**
+ * Writes migrate/backfill failure output to stderr and throws with the
+ * failing command label. Used by `dev-bootstrap` after `runMigrateWithRecovery`.
+ */
+export function assertMigrateSucceeded(result: MigrateRecoveryResult): void {
+  if (result.ok) {
+    return;
+  }
+
+  if (result.output) {
+    process.stderr.write(result.output);
+    if (!result.output.endsWith("\n")) {
+      process.stderr.write("\n");
+    }
+  }
+  const command = result.failedCommand ?? MIGRATE_COMMAND;
+  throw new Error(`${command} exited with status ${result.status ?? "null"}`);
+}
+
 export async function runMigrateWithRecovery(
   databaseUrl: string,
   env: NodeJS.ProcessEnv = process.env,

--- a/scripts/lib/migration-drift.ts
+++ b/scripts/lib/migration-drift.ts
@@ -1,26 +1,61 @@
+import crypto from "node:crypto";
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
 import * as path from "node:path";
 
-const JOURNAL_COLLISION = /__drizzle_migrations/;
-const DUPLICATE_OR_EXISTS = /(already exists|duplicate key)/i;
+import postgres from "postgres";
+
+const ALREADY_EXISTS = /(already exists|duplicate key)/i;
+const PUBLIC_SCHEMA_COLLISION =
+  /(?:Failed query:\s*CREATE TABLE|relation "[^"]+" already exists)/i;
 
 const BACKFILL_SCRIPT = path.join(
   __dirname,
   "..",
   "backfill-drizzle-migrations.ts"
 );
+const JOURNAL_PATH = path.join(
+  __dirname,
+  "..",
+  "..",
+  "drizzle",
+  "meta",
+  "_journal.json"
+);
+const MIGRATIONS_DIR = path.join(__dirname, "..", "..", "drizzle");
+
+export const MIGRATE_COMMAND = "pnpm db:migrate";
+export const BACKFILL_COMMAND =
+  "pnpm tsx scripts/backfill-drizzle-migrations.ts";
+
+const SPAWN_MAX_BUFFER = 10 * 1024 * 1024;
+
+type JournalEntry = {
+  idx: number;
+  tag: string;
+  when: number;
+};
+
+export type PostgresClient = ReturnType<typeof postgres>;
 
 export type CommandResult = {
   ok: boolean;
   output: string;
   status: number | null;
+  failedCommand?: string;
 };
 
 export type MigrateRecoveryResult = {
   ok: boolean;
   output: string;
-  firstOutput: string;
   status: number | null;
+  failedCommand?: string;
+};
+
+export type JournalDriftState = {
+  usersExists: boolean;
+  journalCount: number;
+  expectedCount: number;
 };
 
 function combineOutput(
@@ -33,70 +68,201 @@ function combineOutput(
   return parts.join("\n");
 }
 
-export function isMigrationDriftOutput(output: string): boolean {
+function readJournalEntries(): JournalEntry[] {
+  const journal = JSON.parse(fs.readFileSync(JOURNAL_PATH, "utf8")) as {
+    entries: JournalEntry[];
+  };
+  return journal.entries.slice().sort((a, b) => a.idx - b.idx);
+}
+
+function hashMigrationFile(tag: string): string | null {
+  const sqlPath = path.join(MIGRATIONS_DIR, `${tag}.sql`);
+  if (!fs.existsSync(sqlPath)) {
+    return null;
+  }
+  const content = fs.readFileSync(sqlPath, "utf8");
+  return crypto.createHash("sha256").update(content).digest("hex");
+}
+
+export function getExpectedJournalCount(): number {
+  return readJournalEntries().length;
+}
+
+export function computeThroughTagFromHashes(
+  existingHashes: Set<string>
+): string | null {
+  if (existingHashes.size === 0) {
+    return null;
+  }
+
+  let highestPrefix: string | null = null;
+  for (const entry of readJournalEntries()) {
+    const hash = hashMigrationFile(entry.tag);
+    if (hash && existingHashes.has(hash)) {
+      const prefix = entry.tag.split("_")[0];
+      if (highestPrefix === null || prefix > highestPrefix) {
+        highestPrefix = prefix;
+      }
+    }
+  }
+  return highestPrefix;
+}
+
+export async function queryJournalDriftState(
+  client: PostgresClient
+): Promise<JournalDriftState> {
+  const usersExists = await client<{ exists: boolean }[]>`
+    SELECT EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = 'users'
+    ) AS exists
+  `;
+
+  const journalCount = await client<{ c: number }[]>`
+    SELECT COALESCE(
+      (SELECT COUNT(*)::int FROM drizzle.__drizzle_migrations),
+      0
+    ) AS c
+  `.catch(() => [{ c: 0 }]);
+
+  return {
+    usersExists: usersExists[0]?.exists ?? false,
+    journalCount: journalCount[0]?.c ?? 0,
+    expectedCount: getExpectedJournalCount(),
+  };
+}
+
+export function hasPublicSchemaCollisionOutput(output: string): boolean {
   const text = output.trim();
-  if (text.length === 0) {
+  if (text.length === 0 || !ALREADY_EXISTS.test(text)) {
     return false;
   }
 
-  return JOURNAL_COLLISION.test(text) && DUPLICATE_OR_EXISTS.test(text);
+  // Failures on drizzle-schema objects (journal table indexes, etc.) are not
+  // db:push drift even when the output also contains "already exists".
+  if (/Failed query:[^;\n]*"drizzle"/i.test(text)) {
+    return false;
+  }
+  if (/CREATE (?:TABLE|INDEX)[^;\n]*"drizzle"/i.test(text)) {
+    return false;
+  }
+
+  return PUBLIC_SCHEMA_COLLISION.test(text);
+}
+
+export async function shouldRecoverAfterMigrateFailure(
+  client: PostgresClient,
+  output: string
+): Promise<{ recover: boolean; throughTag: string | null }> {
+  const state = await queryJournalDriftState(client);
+
+  if (!state.usersExists || state.journalCount >= state.expectedCount) {
+    return { recover: false, throughTag: null };
+  }
+
+  if (!hasPublicSchemaCollisionOutput(output)) {
+    return { recover: false, throughTag: null };
+  }
+
+  if (state.journalCount === 0) {
+    return { recover: true, throughTag: null };
+  }
+
+  const existing = await client<{ hash: string }[]>`
+    SELECT hash FROM drizzle.__drizzle_migrations
+  `;
+  const existingHashes = new Set(existing.map((row) => row.hash));
+  const throughTag = computeThroughTagFromHashes(existingHashes);
+
+  return { recover: true, throughTag };
+}
+
+function spawnPnpm(
+  commandLabel: string,
+  args: string[],
+  env: NodeJS.ProcessEnv
+): CommandResult {
+  const result = spawnSync("pnpm", args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    env,
+    encoding: "utf8",
+    maxBuffer: SPAWN_MAX_BUFFER,
+  });
+
+  if (result.error) {
+    return {
+      ok: false,
+      output: result.error.message,
+      status: result.status,
+      failedCommand: commandLabel,
+    };
+  }
+
+  const output = combineOutput(result.stdout, result.stderr);
+  if (result.status === 0) {
+    return {
+      ok: true,
+      output,
+      status: result.status,
+    };
+  }
+
+  return {
+    ok: false,
+    output,
+    status: result.status,
+    failedCommand: commandLabel,
+  };
 }
 
 export function runBackfillScript(
-  env: NodeJS.ProcessEnv = process.env
+  options: {
+    through?: string | null;
+    env?: NodeJS.ProcessEnv;
+  } = {}
 ): CommandResult {
-  const result = spawnSync("pnpm", ["tsx", BACKFILL_SCRIPT], {
-    stdio: ["ignore", "pipe", "pipe"],
-    env,
-    encoding: "utf8",
-  });
+  const env = options.env ?? process.env;
+  const args = ["tsx", BACKFILL_SCRIPT];
+  if (options.through) {
+    args.push("--through", options.through);
+  }
 
-  const output = combineOutput(result.stdout, result.stderr);
-  return {
-    ok: result.status === 0,
-    output,
-    status: result.status,
-  };
+  return spawnPnpm(BACKFILL_COMMAND, args, env);
 }
 
-export function runDbMigrate(
-  env: NodeJS.ProcessEnv = process.env
-): CommandResult {
-  const result = spawnSync("pnpm", ["db:migrate"], {
-    stdio: ["ignore", "pipe", "pipe"],
-    env,
-    encoding: "utf8",
-  });
-
-  const output = combineOutput(result.stdout, result.stderr);
-  return {
-    ok: result.status === 0,
-    output,
-    status: result.status,
-  };
+export function runDbMigrate(env: NodeJS.ProcessEnv = process.env): CommandResult {
+  return spawnPnpm(MIGRATE_COMMAND, ["db:migrate"], env);
 }
 
-export function runMigrateWithRecovery(
+export async function runMigrateWithRecovery(
+  databaseUrl: string,
   env: NodeJS.ProcessEnv = process.env,
   log: (message: string) => void = (message) => console.log(message)
-): MigrateRecoveryResult {
+): Promise<MigrateRecoveryResult> {
   const first = runDbMigrate(env);
   if (first.ok) {
     return {
       ok: true,
       output: first.output,
-      firstOutput: first.output,
       status: first.status,
     };
   }
 
   const firstOutput = first.output;
-  if (!isMigrationDriftOutput(firstOutput)) {
+  const client = postgres(databaseUrl, { max: 1 });
+  let recovery: { recover: boolean; throughTag: string | null };
+  try {
+    recovery = await shouldRecoverAfterMigrateFailure(client, firstOutput);
+  } finally {
+    await client.end();
+  }
+
+  if (!recovery.recover) {
     return {
       ok: false,
       output: firstOutput,
-      firstOutput,
       status: first.status,
+      failedCommand: MIGRATE_COMMAND,
     };
   }
 
@@ -105,14 +271,17 @@ export function runMigrateWithRecovery(
   );
   log("dev-bootstrap: running backfill-drizzle-migrations.ts...");
 
-  const backfill = runBackfillScript(env);
+  const backfill = runBackfillScript({
+    through: recovery.throughTag,
+    env,
+  });
   if (!backfill.ok) {
     const output = [firstOutput, backfill.output].filter(Boolean).join("\n");
     return {
       ok: false,
       output,
-      firstOutput,
       status: backfill.status,
+      failedCommand: BACKFILL_COMMAND,
     };
   }
 
@@ -123,7 +292,6 @@ export function runMigrateWithRecovery(
     return {
       ok: true,
       output: retry.output,
-      firstOutput,
       status: retry.status,
     };
   }
@@ -132,7 +300,7 @@ export function runMigrateWithRecovery(
   return {
     ok: false,
     output,
-    firstOutput,
     status: retry.status,
+    failedCommand: MIGRATE_COMMAND,
   };
 }

--- a/scripts/lib/migration-drift.ts
+++ b/scripts/lib/migration-drift.ts
@@ -1,0 +1,138 @@
+import { spawnSync } from "node:child_process";
+import * as path from "node:path";
+
+const JOURNAL_COLLISION = /__drizzle_migrations/;
+const DUPLICATE_OR_EXISTS = /(already exists|duplicate key)/i;
+
+const BACKFILL_SCRIPT = path.join(
+  __dirname,
+  "..",
+  "backfill-drizzle-migrations.ts"
+);
+
+export type CommandResult = {
+  ok: boolean;
+  output: string;
+  status: number | null;
+};
+
+export type MigrateRecoveryResult = {
+  ok: boolean;
+  output: string;
+  firstOutput: string;
+  status: number | null;
+};
+
+function combineOutput(
+  stdout: string | Buffer | null | undefined,
+  stderr: string | Buffer | null | undefined
+): string {
+  const parts = [stdout, stderr]
+    .filter((value): value is string | Buffer => value != null && value !== "")
+    .map((value) => (typeof value === "string" ? value : value.toString()));
+  return parts.join("\n");
+}
+
+export function isMigrationDriftOutput(output: string): boolean {
+  const text = output.trim();
+  if (text.length === 0) {
+    return false;
+  }
+
+  return JOURNAL_COLLISION.test(text) && DUPLICATE_OR_EXISTS.test(text);
+}
+
+export function runBackfillScript(
+  env: NodeJS.ProcessEnv = process.env
+): CommandResult {
+  const result = spawnSync("pnpm", ["tsx", BACKFILL_SCRIPT], {
+    stdio: ["ignore", "pipe", "pipe"],
+    env,
+    encoding: "utf8",
+  });
+
+  const output = combineOutput(result.stdout, result.stderr);
+  return {
+    ok: result.status === 0,
+    output,
+    status: result.status,
+  };
+}
+
+export function runDbMigrate(
+  env: NodeJS.ProcessEnv = process.env
+): CommandResult {
+  const result = spawnSync("pnpm", ["db:migrate"], {
+    stdio: ["ignore", "pipe", "pipe"],
+    env,
+    encoding: "utf8",
+  });
+
+  const output = combineOutput(result.stdout, result.stderr);
+  return {
+    ok: result.status === 0,
+    output,
+    status: result.status,
+  };
+}
+
+export function runMigrateWithRecovery(
+  env: NodeJS.ProcessEnv = process.env,
+  log: (message: string) => void = (message) => console.log(message)
+): MigrateRecoveryResult {
+  const first = runDbMigrate(env);
+  if (first.ok) {
+    return {
+      ok: true,
+      output: first.output,
+      firstOutput: first.output,
+      status: first.status,
+    };
+  }
+
+  const firstOutput = first.output;
+  if (!isMigrationDriftOutput(firstOutput)) {
+    return {
+      ok: false,
+      output: firstOutput,
+      firstOutput,
+      status: first.status,
+    };
+  }
+
+  log(
+    "dev-bootstrap: migration drift detected (schema ahead of journal)"
+  );
+  log("dev-bootstrap: running backfill-drizzle-migrations.ts...");
+
+  const backfill = runBackfillScript(env);
+  if (!backfill.ok) {
+    const output = [firstOutput, backfill.output].filter(Boolean).join("\n");
+    return {
+      ok: false,
+      output,
+      firstOutput,
+      status: backfill.status,
+    };
+  }
+
+  log("dev-bootstrap: journal backfilled; retrying db:migrate once");
+
+  const retry = runDbMigrate(env);
+  if (retry.ok) {
+    return {
+      ok: true,
+      output: retry.output,
+      firstOutput,
+      status: retry.status,
+    };
+  }
+
+  const output = [firstOutput, retry.output].filter(Boolean).join("\n");
+  return {
+    ok: false,
+    output,
+    firstOutput,
+    status: retry.status,
+  };
+}

--- a/scripts/lib/migration-drift.ts
+++ b/scripts/lib/migration-drift.ts
@@ -2,32 +2,49 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import * as path from "node:path";
 
+import { drizzle } from "drizzle-orm/postgres-js";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
 import postgres from "postgres";
 
-const ALREADY_EXISTS = /(already exists|duplicate key)/i;
-const PUBLIC_SCHEMA_COLLISION =
-  /(?:Failed query:\s*CREATE TABLE|relation "[^"]+" already exists)/i;
+/**
+ * Recovery for the `db:push` -> `db:migrate` handoff in local development.
+ *
+ * Migrations run in-process here rather than through `pnpm db:migrate`.
+ * drizzle-kit's `migrate` command exits non-zero with no diagnostic at all -
+ * measured against 0.31.10, a failing migrate writes 0 bytes to stderr and only
+ * its banner to stdout, for a schema collision and for an unreachable database
+ * alike. Nothing can be classified from that, so the drift signal has to be the
+ * thrown error. `drizzle-orm/postgres-js/migrator` reads the same journal, uses
+ * the same sha256-of-file hash, and writes the same
+ * `drizzle.__drizzle_migrations` rows, so this is the same migration semantics
+ * with the error preserved.
+ */
+
 const MISSING_RELATION = /relation .* does not exist|undefined_table/i;
+const ALREADY_EXISTS = /already exists/i;
+
+/** SQLSTATEs for "this object is already there" - the shape db:push drift takes. */
+const DUPLICATE_OBJECT_CODES = new Set([
+  "42P07", // duplicate_table
+  "42701", // duplicate_column
+  "42710", // duplicate_object (constraint, type, index)
+  "42P06", // duplicate_schema
+]);
 
 const BACKFILL_SCRIPT = path.join(
   __dirname,
   "..",
   "backfill-drizzle-migrations.ts"
 );
-const JOURNAL_PATH = path.join(
-  __dirname,
-  "..",
-  "..",
-  "drizzle",
-  "meta",
-  "_journal.json"
-);
+const MIGRATIONS_DIR = path.join(__dirname, "..", "..", "drizzle");
+const JOURNAL_PATH = path.join(MIGRATIONS_DIR, "meta", "_journal.json");
 
-export const MIGRATE_COMMAND = "pnpm db:migrate";
+export const MIGRATE_LABEL = "database migration";
 export const BACKFILL_COMMAND =
   "pnpm tsx scripts/backfill-drizzle-migrations.ts";
 
 const SPAWN_MAX_BUFFER = 10 * 1024 * 1024;
+const MAX_CAUSE_DEPTH = 16;
 
 type JournalEntry = {
   idx: number;
@@ -41,14 +58,14 @@ export type CommandResult = {
   ok: boolean;
   output: string;
   status: number | null;
-  failedCommand?: string;
 };
 
 export type MigrateRecoveryResult = {
   ok: boolean;
+  /** Detail for stderr: the underlying failure, plus backfill output if run. */
   output: string;
-  status: number | null;
-  failedCommand?: string;
+  /** One-line reason, suitable for an Error message. */
+  reason?: string;
 };
 
 export type JournalDriftState = {
@@ -57,15 +74,12 @@ export type JournalDriftState = {
   expectedCount: number;
 };
 
-function combineOutput(
-  stdout: string | Buffer | null | undefined,
-  stderr: string | Buffer | null | undefined
-): string {
-  const parts = [stdout, stderr]
-    .filter((value): value is string | Buffer => value != null && value !== "")
-    .map((value) => (typeof value === "string" ? value : value.toString()));
-  return parts.join("\n");
-}
+type MaybePgError = {
+  code?: string;
+  message?: string;
+  name?: string;
+  cause?: unknown;
+};
 
 function readJournalEntries(): JournalEntry[] {
   const journal = JSON.parse(fs.readFileSync(JOURNAL_PATH, "utf8")) as {
@@ -78,31 +92,74 @@ export function getExpectedJournalCount(): number {
   return readJournalEntries().length;
 }
 
-/** True when Postgres reports the journal table (or schema) is missing. */
-export function isMissingRelationError(error: unknown): boolean {
-  if (!error || typeof error !== "object") {
-    return false;
+function matchesCause(
+  error: unknown,
+  predicate: (err: MaybePgError) => boolean
+): boolean {
+  let current: unknown = error;
+  // Bounded so a self-referential cause chain cannot spin here.
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth++) {
+    if (!current || typeof current !== "object") {
+      return false;
+    }
+    const err = current as MaybePgError;
+    if (predicate(err)) {
+      return true;
+    }
+    if (err.cause === undefined) {
+      return false;
+    }
+    current = err.cause;
   }
-
-  const err = error as {
-    code?: string;
-    message?: string;
-    cause?: unknown;
-  };
-
-  if (err.code === "42P01") {
-    return true;
-  }
-
-  if (typeof err.message === "string" && MISSING_RELATION.test(err.message)) {
-    return true;
-  }
-
-  if (err.cause !== undefined) {
-    return isMissingRelationError(err.cause);
-  }
-
   return false;
+}
+
+/** True when Postgres reports the journal table (or its schema) is missing. */
+export function isMissingRelationError(error: unknown): boolean {
+  return matchesCause(
+    error,
+    (err) =>
+      err.code === "42P01" ||
+      (typeof err.message === "string" && MISSING_RELATION.test(err.message))
+  );
+}
+
+/**
+ * True when a migration failed because an object it creates already exists -
+ * the signature of a schema applied by `db:push` ahead of the journal.
+ */
+export function isDuplicateObjectError(error: unknown): boolean {
+  return matchesCause(error, (err) => {
+    if (typeof err.code === "string") {
+      return DUPLICATE_OBJECT_CODES.has(err.code);
+    }
+    // Codes are the reliable signal. The message check only covers a wrapper
+    // that drops `code` while keeping the original text.
+    return typeof err.message === "string" && ALREADY_EXISTS.test(err.message);
+  });
+}
+
+/** Flattens an error and its cause chain into stderr-ready text. */
+export function describeError(error: unknown): string {
+  const lines: string[] = [];
+  let current: unknown = error;
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth++) {
+    if (!current || typeof current !== "object") {
+      if (current !== undefined && current !== null) {
+        lines.push(String(current));
+      }
+      break;
+    }
+    const err = current as MaybePgError;
+    const code = err.code ? ` [${err.code}]` : "";
+    const prefix = depth === 0 ? "" : "caused by: ";
+    lines.push(`${prefix}${err.name ?? "Error"}${code}: ${err.message ?? ""}`);
+    if (err.cause === undefined) {
+      break;
+    }
+    current = err.cause;
+  }
+  return lines.join("\n");
 }
 
 export async function queryJournalDriftState(
@@ -134,51 +191,39 @@ export async function queryJournalDriftState(
   };
 }
 
-export function hasPublicSchemaCollisionOutput(output: string): boolean {
-  const text = output.trim();
-  if (text.length === 0 || !ALREADY_EXISTS.test(text)) {
-    return false;
-  }
-
-  // Failures on drizzle-schema objects (journal table indexes, etc.) are not
-  // db:push drift even when the output also contains "already exists".
-  if (/Failed query:[^;\n]*"drizzle"/i.test(text)) {
-    return false;
-  }
-  if (/CREATE (?:TABLE|INDEX)[^;\n]*"drizzle"/i.test(text)) {
-    return false;
-  }
-
-  return PUBLIC_SCHEMA_COLLISION.test(text);
-}
-
+/**
+ * Decides whether a failed migration is `db:push` drift, from database state
+ * and the thrown error.
+ *
+ * The backfill this gates is unbounded. A duplicate-object failure means a
+ * pending migration tried to create something the database already has, and the
+ * only thing that puts objects ahead of the journal in a dev database is
+ * `db:push` - which applies the whole working-tree schema, i.e. the state after
+ * the last journal entry. So every entry is genuinely already applied. Bounding
+ * the backfill at the highest tag already recorded cannot help: those are
+ * exactly the entries the backfill must skip.
+ *
+ * The one case this marks too much: `db:push` at some commit, then pulling
+ * migrations authored after it, then bootstrapping without pushing again. Those
+ * are recorded without their SQL running; `runMigrateWithRecovery` says so.
+ */
 export async function shouldRecoverAfterMigrateFailure(
   client: PostgresClient,
-  output: string
-): Promise<{ recover: boolean; throughTag: string | null }> {
+  error: unknown
+): Promise<boolean> {
   const state = await queryJournalDriftState(client);
 
   if (!state.usersExists || state.journalCount >= state.expectedCount) {
-    return { recover: false, throughTag: null };
+    return false;
   }
 
-  if (!hasPublicSchemaCollisionOutput(output)) {
-    return { recover: false, throughTag: null };
-  }
-
-  // Schema is ahead of the journal (db:push drift). Backfill every missing
-  // journal hash — a journal-hash --through bound is a no-op because every
-  // candidate under that bound is already recorded. Schema-state bounding
-  // would need DDL-vs-catalog introspection we do not have.
-  return { recover: true, throughTag: null };
+  return isDuplicateObjectError(error);
 }
 
-function spawnPnpm(
-  commandLabel: string,
-  args: string[],
-  env: NodeJS.ProcessEnv
+export function runBackfillScript(
+  env: NodeJS.ProcessEnv = process.env
 ): CommandResult {
-  const result = spawnSync("pnpm", args, {
+  const result = spawnSync("pnpm", ["tsx", BACKFILL_SCRIPT], {
     stdio: ["ignore", "pipe", "pipe"],
     env,
     encoding: "utf8",
@@ -186,53 +231,20 @@ function spawnPnpm(
   });
 
   if (result.error) {
-    return {
-      ok: false,
-      output: result.error.message,
-      status: result.status,
-      failedCommand: commandLabel,
-    };
+    return { ok: false, output: result.error.message, status: result.status };
   }
 
-  const output = combineOutput(result.stdout, result.stderr);
-  if (result.status === 0) {
-    return {
-      ok: true,
-      output,
-      status: result.status,
-    };
-  }
+  const output = [result.stdout, result.stderr]
+    .filter((value) => value != null && value !== "")
+    .map((value) => (typeof value === "string" ? value : String(value)))
+    .join("\n");
 
-  return {
-    ok: false,
-    output,
-    status: result.status,
-    failedCommand: commandLabel,
-  };
-}
-
-export function runBackfillScript(
-  options: {
-    through?: string | null;
-    env?: NodeJS.ProcessEnv;
-  } = {}
-): CommandResult {
-  const env = options.env ?? process.env;
-  const args = ["tsx", BACKFILL_SCRIPT];
-  if (options.through) {
-    args.push("--through", options.through);
-  }
-
-  return spawnPnpm(BACKFILL_COMMAND, args, env);
-}
-
-export function runDbMigrate(env: NodeJS.ProcessEnv = process.env): CommandResult {
-  return spawnPnpm(MIGRATE_COMMAND, ["db:migrate"], env);
+  return { ok: result.status === 0, output, status: result.status };
 }
 
 /**
- * Writes migrate/backfill failure output to stderr and throws with the
- * failing command label. Used by `dev-bootstrap` after `runMigrateWithRecovery`.
+ * Writes failure detail to stderr and throws with the one-line reason. Used by
+ * `dev-bootstrap` after `runMigrateWithRecovery`.
  */
 export function assertMigrateSucceeded(result: MigrateRecoveryResult): void {
   if (result.ok) {
@@ -245,8 +257,42 @@ export function assertMigrateSucceeded(result: MigrateRecoveryResult): void {
       process.stderr.write("\n");
     }
   }
-  const command = result.failedCommand ?? MIGRATE_COMMAND;
-  throw new Error(`${command} exited with status ${result.status ?? "null"}`);
+  throw new Error(result.reason ?? `${MIGRATE_LABEL} failed`);
+}
+
+export type MigrateAttempt = { ok: boolean; error?: unknown };
+
+/**
+ * The migrator opens with `CREATE SCHEMA IF NOT EXISTS drizzle` and
+ * `CREATE TABLE IF NOT EXISTS ...__drizzle_migrations`, so Postgres raises these
+ * two notices on every run after the first. postgres.js prints the whole notice
+ * object by default; drop just these and let anything else through.
+ */
+const EXPECTED_NOTICE_CODES = new Set(["42P06", "42P07"]);
+
+function onNotice(notice: { code?: string; message?: string }): void {
+  if (notice.code && EXPECTED_NOTICE_CODES.has(notice.code)) {
+    return;
+  }
+  console.log(`notice: ${notice.message ?? ""}`);
+}
+
+/** Applies pending migrations in-process so failures surface as real errors. */
+export async function runMigrations(
+  databaseUrl: string
+): Promise<MigrateAttempt> {
+  let client: PostgresClient | null = null;
+  try {
+    // Inside the try: a malformed URL makes postgres() throw synchronously,
+    // and that belongs in the returned result like any other failure.
+    client = postgres(databaseUrl, { max: 1, onnotice: onNotice });
+    await migrate(drizzle(client), { migrationsFolder: MIGRATIONS_DIR });
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error };
+  } finally {
+    await client?.end().catch(() => undefined);
+  }
 }
 
 export async function runMigrateWithRecovery(
@@ -254,80 +300,67 @@ export async function runMigrateWithRecovery(
   env: NodeJS.ProcessEnv = process.env,
   log: (message: string) => void = (message) => console.log(message)
 ): Promise<MigrateRecoveryResult> {
-  const first = runDbMigrate(env);
+  const first = await runMigrations(databaseUrl);
   if (first.ok) {
-    return {
-      ok: true,
-      output: first.output,
-      status: first.status,
-    };
+    return { ok: true, output: "" };
   }
 
-  const firstOutput = first.output;
-  let client: PostgresClient | null = null;
-  let recovery: { recover: boolean; throughTag: string | null };
+  const firstOutput = describeError(first.error);
+  const migrateFailure: MigrateRecoveryResult = {
+    ok: false,
+    output: firstOutput,
+    reason: `${MIGRATE_LABEL} failed`,
+  };
 
+  // The probe is best-effort. If the migration failed because the database is
+  // unreachable, connecting here fails too, and letting that escape would
+  // replace the migration error the caller is about to print with a connection
+  // stack trace. Any probe failure means "cannot classify".
+  let shouldRecover: boolean;
   try {
-    client = postgres(databaseUrl, { max: 1 });
-    recovery = await shouldRecoverAfterMigrateFailure(client, firstOutput);
-  } catch {
-    // Probe failures must not hide the original migrate output.
-    return {
-      ok: false,
-      output: firstOutput,
-      status: first.status,
-      failedCommand: MIGRATE_COMMAND,
-    };
-  } finally {
-    if (client) {
+    const client = postgres(databaseUrl, { max: 1 });
+    try {
+      shouldRecover = await shouldRecoverAfterMigrateFailure(
+        client,
+        first.error
+      );
+    } finally {
       await client.end();
     }
+  } catch {
+    return migrateFailure;
   }
 
-  if (!recovery.recover) {
-    return {
-      ok: false,
-      output: firstOutput,
-      status: first.status,
-      failedCommand: MIGRATE_COMMAND,
-    };
+  if (!shouldRecover) {
+    return migrateFailure;
   }
 
+  log("dev-bootstrap: migration drift detected (schema ahead of journal)");
   log(
-    "dev-bootstrap: migration drift detected (schema ahead of journal)"
+    "dev-bootstrap: marking all journal entries applied - if you pulled new " +
+      "migrations since your last db:push, run pnpm db:push again afterwards"
   );
   log("dev-bootstrap: running backfill-drizzle-migrations.ts...");
 
-  const backfill = runBackfillScript({
-    through: recovery.throughTag,
-    env,
-  });
+  const backfill = runBackfillScript(env);
   if (!backfill.ok) {
-    const output = [firstOutput, backfill.output].filter(Boolean).join("\n");
     return {
       ok: false,
-      output,
-      status: backfill.status,
-      failedCommand: BACKFILL_COMMAND,
+      output: [firstOutput, backfill.output].filter(Boolean).join("\n"),
+      reason: `${BACKFILL_COMMAND} exited with status ${backfill.status ?? "null"}`,
     };
   }
 
-  log("dev-bootstrap: journal backfilled; retrying db:migrate once");
+  log("dev-bootstrap: journal backfilled; retrying migration once");
 
-  const retry = runDbMigrate(env);
+  const retry = await runMigrations(databaseUrl);
   if (retry.ok) {
-    return {
-      ok: true,
-      output: retry.output,
-      status: retry.status,
-    };
+    return { ok: true, output: "" };
   }
 
-  const output = [firstOutput, retry.output].filter(Boolean).join("\n");
   return {
     ok: false,
-    output,
-    status: retry.status,
-    failedCommand: MIGRATE_COMMAND,
+    output: [firstOutput, describeError(retry.error)].filter(Boolean).join("\n"),
+    reason: `${MIGRATE_LABEL} failed after journal backfill`,
   };
 }

--- a/scripts/lib/migration-drift.ts
+++ b/scripts/lib/migration-drift.ts
@@ -1,4 +1,3 @@
-import crypto from "node:crypto";
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import * as path from "node:path";
@@ -8,6 +7,7 @@ import postgres from "postgres";
 const ALREADY_EXISTS = /(already exists|duplicate key)/i;
 const PUBLIC_SCHEMA_COLLISION =
   /(?:Failed query:\s*CREATE TABLE|relation "[^"]+" already exists)/i;
+const MISSING_RELATION = /relation .* does not exist|undefined_table/i;
 
 const BACKFILL_SCRIPT = path.join(
   __dirname,
@@ -22,7 +22,6 @@ const JOURNAL_PATH = path.join(
   "meta",
   "_journal.json"
 );
-const MIGRATIONS_DIR = path.join(__dirname, "..", "..", "drizzle");
 
 export const MIGRATE_COMMAND = "pnpm db:migrate";
 export const BACKFILL_COMMAND =
@@ -75,37 +74,35 @@ function readJournalEntries(): JournalEntry[] {
   return journal.entries.slice().sort((a, b) => a.idx - b.idx);
 }
 
-function hashMigrationFile(tag: string): string | null {
-  const sqlPath = path.join(MIGRATIONS_DIR, `${tag}.sql`);
-  if (!fs.existsSync(sqlPath)) {
-    return null;
-  }
-  const content = fs.readFileSync(sqlPath, "utf8");
-  return crypto.createHash("sha256").update(content).digest("hex");
-}
-
 export function getExpectedJournalCount(): number {
   return readJournalEntries().length;
 }
 
-export function computeThroughTagFromHashes(
-  existingHashes: Set<string>
-): string | null {
-  if (existingHashes.size === 0) {
-    return null;
+/** True when Postgres reports the journal table (or schema) is missing. */
+export function isMissingRelationError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
   }
 
-  let highestPrefix: string | null = null;
-  for (const entry of readJournalEntries()) {
-    const hash = hashMigrationFile(entry.tag);
-    if (hash && existingHashes.has(hash)) {
-      const prefix = entry.tag.split("_")[0];
-      if (highestPrefix === null || prefix > highestPrefix) {
-        highestPrefix = prefix;
-      }
-    }
+  const err = error as {
+    code?: string;
+    message?: string;
+    cause?: unknown;
+  };
+
+  if (err.code === "42P01") {
+    return true;
   }
-  return highestPrefix;
+
+  if (typeof err.message === "string" && MISSING_RELATION.test(err.message)) {
+    return true;
+  }
+
+  if (err.cause !== undefined) {
+    return isMissingRelationError(err.cause);
+  }
+
+  return false;
 }
 
 export async function queryJournalDriftState(
@@ -123,7 +120,12 @@ export async function queryJournalDriftState(
       (SELECT COUNT(*)::int FROM drizzle.__drizzle_migrations),
       0
     ) AS c
-  `.catch(() => [{ c: 0 }]);
+  `.catch((error: unknown) => {
+    if (isMissingRelationError(error)) {
+      return [{ c: 0 }];
+    }
+    throw error;
+  });
 
   return {
     usersExists: usersExists[0]?.exists ?? false,
@@ -164,17 +166,11 @@ export async function shouldRecoverAfterMigrateFailure(
     return { recover: false, throughTag: null };
   }
 
-  if (state.journalCount === 0) {
-    return { recover: true, throughTag: null };
-  }
-
-  const existing = await client<{ hash: string }[]>`
-    SELECT hash FROM drizzle.__drizzle_migrations
-  `;
-  const existingHashes = new Set(existing.map((row) => row.hash));
-  const throughTag = computeThroughTagFromHashes(existingHashes);
-
-  return { recover: true, throughTag };
+  // Schema is ahead of the journal (db:push drift). Backfill every missing
+  // journal hash — a journal-hash --through bound is a no-op because every
+  // candidate under that bound is already recorded. Schema-state bounding
+  // would need DDL-vs-catalog introspection we do not have.
+  return { recover: true, throughTag: null };
 }
 
 function spawnPnpm(
@@ -249,12 +245,24 @@ export async function runMigrateWithRecovery(
   }
 
   const firstOutput = first.output;
-  const client = postgres(databaseUrl, { max: 1 });
+  let client: PostgresClient | null = null;
   let recovery: { recover: boolean; throughTag: string | null };
+
   try {
+    client = postgres(databaseUrl, { max: 1 });
     recovery = await shouldRecoverAfterMigrateFailure(client, firstOutput);
+  } catch {
+    // Probe failures must not hide the original migrate output.
+    return {
+      ok: false,
+      output: firstOutput,
+      status: first.status,
+      failedCommand: MIGRATE_COMMAND,
+    };
   } finally {
-    await client.end();
+    if (client) {
+      await client.end();
+    }
   }
 
   if (!recovery.recover) {

--- a/scripts/seed/dev-bootstrap.ts
+++ b/scripts/seed/dev-bootstrap.ts
@@ -31,6 +31,7 @@ import "dotenv/config";
 import { createHash, randomBytes, scrypt } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import {
+  assertMigrateSucceeded,
   queryJournalDriftState,
   runMigrateWithRecovery,
 } from "../lib/migration-drift";
@@ -162,18 +163,7 @@ function runChildScript(script: string, label: string): void {
 async function runMigrate(databaseUrl: string): Promise<void> {
   console.log("> pnpm db:migrate");
   const result = await runMigrateWithRecovery(databaseUrl, process.env);
-  if (result.ok) {
-    return;
-  }
-
-  if (result.output) {
-    process.stderr.write(result.output);
-    if (!result.output.endsWith("\n")) {
-      process.stderr.write("\n");
-    }
-  }
-  const command = result.failedCommand ?? "pnpm db:migrate";
-  throw new Error(`${command} exited with status ${result.status ?? "null"}`);
+  assertMigrateSucceeded(result);
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/seed/dev-bootstrap.ts
+++ b/scripts/seed/dev-bootstrap.ts
@@ -30,6 +30,9 @@ import "dotenv/config";
 
 import { createHash, randomBytes, scrypt } from "node:crypto";
 import { spawnSync } from "node:child_process";
+import {
+  runMigrateWithRecovery,
+} from "../lib/migration-drift";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -177,13 +180,20 @@ function runChildScript(script: string, label: string): void {
 
 function runMigrate(): void {
   console.log("> pnpm db:migrate");
-  const result = spawnSync("pnpm", ["db:migrate"], {
-    stdio: "inherit",
-    env: process.env,
-  });
-  if (result.status !== 0) {
-    throw new Error(`pnpm db:migrate exited with status ${result.status ?? "null"}`);
+  const result = runMigrateWithRecovery(process.env);
+  if (result.ok) {
+    return;
   }
+
+  if (result.output) {
+    process.stderr.write(result.output);
+    if (!result.output.endsWith("\n")) {
+      process.stderr.write("\n");
+    }
+  }
+  throw new Error(
+    `pnpm db:migrate exited with status ${result.status ?? "null"}`
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/seed/dev-bootstrap.ts
+++ b/scripts/seed/dev-bootstrap.ts
@@ -31,6 +31,7 @@ import "dotenv/config";
 import { createHash, randomBytes, scrypt } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import {
+  queryJournalDriftState,
   runMigrateWithRecovery,
 } from "../lib/migration-drift";
 import * as fs from "node:fs";
@@ -143,28 +144,8 @@ async function hashPassword(password: string): Promise<string> {
 async function maybeBackfillJournal(
   client: ReturnType<typeof postgres>
 ): Promise<boolean> {
-  const usersExists = await client<{ exists: boolean }[]>`
-    SELECT EXISTS (
-      SELECT 1 FROM information_schema.tables
-      WHERE table_schema = 'public' AND table_name = 'users'
-    ) AS exists
-  `;
-  if (!usersExists[0]?.exists) {
-    return false;
-  }
-
-  const journalCount = await client<{ c: number }[]>`
-    SELECT COALESCE(
-      (SELECT COUNT(*)::int FROM drizzle.__drizzle_migrations),
-      0
-    ) AS c
-  `.catch(() => [{ c: 0 }]);
-
-  if ((journalCount[0]?.c ?? 0) > 0) {
-    return false;
-  }
-
-  return true;
+  const state = await queryJournalDriftState(client);
+  return state.usersExists && state.journalCount === 0;
 }
 
 function runChildScript(script: string, label: string): void {

--- a/scripts/seed/dev-bootstrap.ts
+++ b/scripts/seed/dev-bootstrap.ts
@@ -9,9 +9,10 @@
  * Sequence:
  *   1. assertLocalDb()
  *   2. If users table exists AND drizzle.__drizzle_migrations is empty,
- *      run scripts/backfill-drizzle-migrations.ts so db:migrate skips the
- *      already-applied SQL. (db:push-bootstrapped DBs land here.)
- *   3. pnpm db:migrate (applies anything new).
+ *      run scripts/backfill-drizzle-migrations.ts so the migration run skips
+ *      the already-applied SQL. (db:push-bootstrapped DBs land here.)
+ *   3. Apply migrations in-process, recovering from db:push drift if the
+ *      journal still lags the schema (see scripts/lib/migration-drift.ts).
  *   4. seedPersistentTestUsers() for the e2e user/org set.
  *   5. Upsert the dev user (default dev@keeperhub.local) + org + membership.
  *   6. Read the local kh CLI token from ~/.config/kh/hosts.yml and upsert
@@ -161,7 +162,7 @@ function runChildScript(script: string, label: string): void {
 }
 
 async function runMigrate(databaseUrl: string): Promise<void> {
-  console.log("> pnpm db:migrate");
+  console.log("> apply migrations");
   const result = await runMigrateWithRecovery(databaseUrl, process.env);
   assertMigrateSucceeded(result);
 }

--- a/scripts/seed/dev-bootstrap.ts
+++ b/scripts/seed/dev-bootstrap.ts
@@ -178,9 +178,9 @@ function runChildScript(script: string, label: string): void {
   }
 }
 
-function runMigrate(): void {
+async function runMigrate(databaseUrl: string): Promise<void> {
   console.log("> pnpm db:migrate");
-  const result = runMigrateWithRecovery(process.env);
+  const result = await runMigrateWithRecovery(databaseUrl, process.env);
   if (result.ok) {
     return;
   }
@@ -191,9 +191,8 @@ function runMigrate(): void {
       process.stderr.write("\n");
     }
   }
-  throw new Error(
-    `pnpm db:migrate exited with status ${result.status ?? "null"}`
-  );
+  const command = result.failedCommand ?? "pnpm db:migrate";
+  throw new Error(`${command} exited with status ${result.status ?? "null"}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -524,7 +523,7 @@ async function main(): Promise<void> {
     await client.end();
   }
 
-  runMigrate();
+  await runMigrate(url);
 
   console.log("> seedPersistentTestUsers()");
   await seedPersistentTestUsers();

--- a/tests/unit/dev-bootstrap-migrate.test.ts
+++ b/tests/unit/dev-bootstrap-migrate.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const spawnSyncMock = vi.hoisted(() => vi.fn());
 const postgresMock = vi.hoisted(() => vi.fn());
 const endMock = vi.hoisted(() => vi.fn());
+const migrateMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", () => ({
   spawnSync: spawnSyncMock,
@@ -12,22 +13,33 @@ vi.mock("postgres", () => ({
   default: postgresMock,
 }));
 
+vi.mock("drizzle-orm/postgres-js", () => ({
+  drizzle: (client: unknown) => client,
+}));
+
+vi.mock("drizzle-orm/postgres-js/migrator", () => ({
+  migrate: migrateMock,
+}));
+
 import {
   assertMigrateSucceeded,
   BACKFILL_COMMAND,
-  MIGRATE_COMMAND,
+  MIGRATE_LABEL,
   runMigrateWithRecovery,
 } from "@/scripts/lib/migration-drift";
 
-const DB_PUSH_MIGRATE_FAILURE = `DrizzleQueryError: Failed query: CREATE TABLE "users" (
-	"id" text PRIMARY KEY NOT NULL,
-	"name" text NOT NULL,
-	"email" text NOT NULL
-);
-params:
-PostgresError: relation "users" already exists`;
-
 const BACKFILL_SCRIPT_SUFFIX = "backfill-drizzle-migrations.ts";
+const DB_URL = "postgresql://postgres:postgres@localhost:5433/keeperhub";
+
+function duplicateTableError(): Error {
+  const pgError = Object.assign(new Error('relation "users" already exists'), {
+    code: "42P07",
+    name: "PostgresError",
+  });
+  return Object.assign(new Error('Failed query: CREATE TABLE "users"'), {
+    cause: pgError,
+  });
+}
 
 function mockPostgresClient(options: {
   usersExists: boolean;
@@ -49,27 +61,26 @@ function mockPostgresClient(options: {
   postgresMock.mockReturnValue(Object.assign(client, { end: endMock }));
 }
 
-function mockSpawnSequence(
-  responses: Array<{
-    status: number | null;
-    stdout?: string;
-    stderr?: string;
-    error?: Error;
-  }>
-): void {
+/** Queues migrate() outcomes in call order: `null` succeeds, an error rejects. */
+function mockMigrateSequence(outcomes: Array<Error | null>): void {
   let call = 0;
-  spawnSyncMock.mockImplementation((_cmd, _args: string[]) => {
-    const response = responses[call] ?? {
-      status: 1,
-      stderr: "unexpected call",
-    };
+  migrateMock.mockImplementation(() => {
+    // Bounds check, not `??`: a queued `null` means success and is nullish.
+    const outcome =
+      call < outcomes.length
+        ? outcomes[call]
+        : new Error("unexpected migrate call");
     call += 1;
-    return {
-      status: response.status,
-      stdout: response.stdout ?? "",
-      stderr: response.stderr ?? "",
-      error: response.error,
-    };
+    return outcome ? Promise.reject(outcome) : Promise.resolve();
+  });
+}
+
+function mockBackfill(status: number, output = ""): void {
+  spawnSyncMock.mockReturnValue({
+    status,
+    stdout: output,
+    stderr: "",
+    error: undefined,
   });
 }
 
@@ -78,213 +89,131 @@ describe("runMigrateWithRecovery", () => {
     spawnSyncMock.mockReset();
     postgresMock.mockReset();
     endMock.mockReset();
+    migrateMock.mockReset();
   });
 
-  it("returns ok when the first migrate succeeds", async () => {
-    mockSpawnSequence([{ status: 0, stdout: "applied migrations" }]);
+  it("returns ok when the first migration succeeds, without probing", async () => {
+    mockMigrateSequence([null]);
 
-    const result = await runMigrateWithRecovery(
-      "postgresql://postgres:postgres@localhost:5433/keeperhub",
-      process.env,
-      () => undefined
-    );
+    const result = await runMigrateWithRecovery(DB_URL, process.env, () => {
+      /* silent */
+    });
 
     expect(result.ok).toBe(true);
-    expect(result.output).toContain("applied migrations");
-    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
-    expect(spawnSyncMock).toHaveBeenCalledWith(
-      "pnpm",
-      ["db:migrate"],
-      expect.objectContaining({ encoding: "utf8" })
-    );
-    expect(postgresMock).not.toHaveBeenCalled();
+    expect(migrateMock).toHaveBeenCalledTimes(1);
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+    // One client for the migration itself, none for a drift probe.
+    expect(postgresMock).toHaveBeenCalledTimes(1);
   });
 
-  it("runs backfill and retries when db:push drift is detected from DB state", async () => {
-    mockPostgresClient({ usersExists: true, journalCount: 0 });
-    mockSpawnSequence([
-      { status: 1, stderr: DB_PUSH_MIGRATE_FAILURE },
-      { status: 0, stdout: "backfilled journal" },
-      { status: 0, stdout: "retry migrate ok" },
-    ]);
+  it("backfills the whole journal and retries on duplicate-object drift", async () => {
+    mockPostgresClient({ usersExists: true, journalCount: 11 });
+    mockMigrateSequence([duplicateTableError(), null]);
+    mockBackfill(0, "Inserted 128, skipped 11");
 
     const logs: string[] = [];
-    const result = await runMigrateWithRecovery(
-      "postgresql://postgres:postgres@localhost:5433/keeperhub",
-      process.env,
-      (message) => logs.push(message)
+    const result = await runMigrateWithRecovery(DB_URL, process.env, (m) =>
+      logs.push(m)
     );
 
     expect(result.ok).toBe(true);
-    expect(result.output).toContain("retry migrate ok");
+    expect(migrateMock).toHaveBeenCalledTimes(2);
     expect(logs).toContain(
       "dev-bootstrap: migration drift detected (schema ahead of journal)"
     );
-    expect(logs).toContain(
-      "dev-bootstrap: journal backfilled; retrying db:migrate once"
-    );
-    expect(spawnSyncMock).toHaveBeenCalledTimes(3);
-    expect(spawnSyncMock).toHaveBeenNthCalledWith(
-      1,
-      "pnpm",
-      ["db:migrate"],
-      expect.any(Object)
-    );
-    expect(spawnSyncMock).toHaveBeenNthCalledWith(
-      2,
+    // Exact args: any reintroduced bound flag fails here.
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    expect(spawnSyncMock).toHaveBeenCalledWith(
       "pnpm",
       ["tsx", expect.stringContaining(BACKFILL_SCRIPT_SUFFIX)],
-      expect.any(Object)
+      expect.objectContaining({ encoding: "utf8" })
     );
-    expect(spawnSyncMock).toHaveBeenNthCalledWith(
-      3,
-      "pnpm",
-      ["db:migrate"],
-      expect.any(Object)
-    );
-    expect(endMock).toHaveBeenCalled();
   });
 
-  it("omits --through when the journal is partially populated", async () => {
-    mockPostgresClient({
-      usersExists: true,
-      journalCount: 1,
+  it("does not recover when the failure is not a duplicate object", async () => {
+    mockPostgresClient({ usersExists: true, journalCount: 11 });
+    mockMigrateSequence([
+      Object.assign(new Error("syntax error at end of input"), {
+        code: "42601",
+      }),
+    ]);
+
+    const result = await runMigrateWithRecovery(DB_URL, process.env, () => {
+      /* silent */
     });
-    mockSpawnSequence([
-      { status: 1, stderr: DB_PUSH_MIGRATE_FAILURE },
-      { status: 0, stdout: "backfilled journal" },
-      { status: 0, stdout: "retry migrate ok" },
-    ]);
 
-    const result = await runMigrateWithRecovery(
-      "postgresql://postgres:postgres@localhost:5433/keeperhub",
-      process.env,
-      () => undefined
-    );
-
-    expect(result.ok).toBe(true);
-    const backfillCall = spawnSyncMock.mock.calls[1];
-    expect(backfillCall?.[1]).toEqual([
-      "tsx",
-      expect.stringContaining(BACKFILL_SCRIPT_SUFFIX),
-    ]);
-    expect(backfillCall?.[1]).not.toEqual(
-      expect.arrayContaining(["--through"])
-    );
+    expect(result.ok).toBe(false);
+    expect(result.output).toContain("syntax error");
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+    expect(migrateMock).toHaveBeenCalledTimes(1);
   });
 
-  it("preserves first migrate output when the recovery probe fails", async () => {
-    mockSpawnSequence([{ status: 1, stderr: DB_PUSH_MIGRATE_FAILURE }]);
+  it("keeps the migration error when the drift probe cannot connect", async () => {
+    mockMigrateSequence([duplicateTableError()]);
+    let call = 0;
     postgresMock.mockImplementation(() => {
-      throw new Error("connect ECONNREFUSED");
+      call += 1;
+      // First call is the migration's own client; the second is the probe.
+      if (call === 1) {
+        return Object.assign(async () => [], { end: endMock });
+      }
+      throw new Error("connect ECONNREFUSED 127.0.0.1:5433");
     });
+    endMock.mockResolvedValue(undefined);
 
-    const result = await runMigrateWithRecovery(
-      "postgresql://postgres:postgres@localhost:5433/keeperhub",
-      process.env,
-      () => undefined
-    );
+    const result = await runMigrateWithRecovery(DB_URL, process.env, () => {
+      /* silent */
+    });
 
     expect(result.ok).toBe(false);
     expect(result.output).toContain('relation "users" already exists');
     expect(result.output).not.toContain("ECONNREFUSED");
-    expect(result.status).toBe(1);
-    expect(result.failedCommand).toBe(MIGRATE_COMMAND);
-    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    expect(spawnSyncMock).not.toHaveBeenCalled();
   });
 
-  it("preserves first migrate output when retry fails for another reason", async () => {
+  it("names the backfill command when the backfill itself fails", async () => {
     mockPostgresClient({ usersExists: true, journalCount: 0 });
-    mockSpawnSequence([
-      { status: 1, stderr: DB_PUSH_MIGRATE_FAILURE },
-      { status: 0, stdout: "backfilled journal" },
-      { status: 2, stderr: "connection refused" },
-    ]);
+    mockMigrateSequence([duplicateTableError()]);
+    mockBackfill(3, "backfill blew up");
 
-    const result = await runMigrateWithRecovery(
-      "postgresql://postgres:postgres@localhost:5433/keeperhub",
-      process.env,
-      () => undefined
-    );
+    const result = await runMigrateWithRecovery(DB_URL, process.env, () => {
+      /* silent */
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe(`${BACKFILL_COMMAND} exited with status 3`);
+    expect(result.output).toContain('relation "users" already exists');
+    expect(result.output).toContain("backfill blew up");
+    expect(migrateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps both failures when the retry fails for another reason", async () => {
+    mockPostgresClient({ usersExists: true, journalCount: 0 });
+    mockMigrateSequence([
+      duplicateTableError(),
+      new Error("connection terminated unexpectedly"),
+    ]);
+    mockBackfill(0);
+
+    const result = await runMigrateWithRecovery(DB_URL, process.env, () => {
+      /* silent */
+    });
 
     expect(result.ok).toBe(false);
     expect(result.output).toContain('relation "users" already exists');
-    expect(result.output).toContain("connection refused");
-    expect(result.status).toBe(2);
-    expect(result.failedCommand).toBe(MIGRATE_COMMAND);
-  });
-
-  it("does not run backfill for non-drift migrate failures", async () => {
-    mockPostgresClient({ usersExists: true, journalCount: 0 });
-    mockSpawnSequence([{ status: 1, stderr: "syntax error at or near" }]);
-
-    const result = await runMigrateWithRecovery(
-      "postgresql://postgres:postgres@localhost:5433/keeperhub",
-      process.env,
-      () => undefined
-    );
-
-    expect(result.ok).toBe(false);
-    expect(result.output).toContain("syntax error");
-    expect(result.failedCommand).toBe(MIGRATE_COMMAND);
-    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("reports backfill command failure instead of migrate", async () => {
-    mockPostgresClient({ usersExists: true, journalCount: 0 });
-    mockSpawnSequence([
-      { status: 1, stderr: DB_PUSH_MIGRATE_FAILURE },
-      { status: 3, stderr: "backfill failed" },
-    ]);
-
-    const result = await runMigrateWithRecovery(
-      "postgresql://postgres:postgres@localhost:5433/keeperhub",
-      process.env,
-      () => undefined
-    );
-
-    expect(result.ok).toBe(false);
-    expect(result.output).toContain('relation "users" already exists');
-    expect(result.output).toContain("backfill failed");
-    expect(result.status).toBe(3);
-    expect(result.failedCommand).toBe(BACKFILL_COMMAND);
-    expect(spawnSyncMock).toHaveBeenCalledTimes(2);
-  });
-
-  it("surfaces spawn errors with the failing command", async () => {
-    mockPostgresClient({ usersExists: true, journalCount: 0 });
-    mockSpawnSequence([
-      { status: 1, stderr: DB_PUSH_MIGRATE_FAILURE },
-      {
-        status: null,
-        error: new Error("spawnSync pnpm ENOENT"),
-      },
-    ]);
-
-    const result = await runMigrateWithRecovery(
-      "postgresql://postgres:postgres@localhost:5433/keeperhub",
-      process.env,
-      () => undefined
-    );
-
-    expect(result.ok).toBe(false);
-    expect(result.output).toContain("ENOENT");
-    expect(result.failedCommand).toBe(BACKFILL_COMMAND);
+    expect(result.output).toContain("connection terminated");
+    expect(result.reason).toContain("after journal backfill");
   });
 });
 
 describe("assertMigrateSucceeded", () => {
-  it("is a no-op when migrate succeeded", () => {
+  it("is a no-op when the migration succeeded", () => {
     expect(() =>
-      assertMigrateSucceeded({
-        ok: true,
-        output: "ok",
-        status: 0,
-      })
+      assertMigrateSucceeded({ ok: true, output: "" })
     ).not.toThrow();
   });
 
-  it("writes output to stderr and throws with failedCommand", () => {
+  it("writes output to stderr and throws with the reason", () => {
     const writeSpy = vi
       .spyOn(process.stderr, "write")
       .mockImplementation(() => true);
@@ -293,30 +222,25 @@ describe("assertMigrateSucceeded", () => {
       assertMigrateSucceeded({
         ok: false,
         output: "migrate blew up",
-        status: 1,
-        failedCommand: BACKFILL_COMMAND,
+        reason: `${BACKFILL_COMMAND} exited with status 3`,
       })
-    ).toThrowError(`${BACKFILL_COMMAND} exited with status 1`);
+    ).toThrowError(`${BACKFILL_COMMAND} exited with status 3`);
 
     expect(writeSpy).toHaveBeenCalledWith("migrate blew up");
     expect(writeSpy).toHaveBeenCalledWith("\n");
     writeSpy.mockRestore();
   });
 
-  it("falls back to pnpm db:migrate when failedCommand is missing", () => {
+  it("does not add a newline when the output already ends with one", () => {
     const writeSpy = vi
       .spyOn(process.stderr, "write")
       .mockImplementation(() => true);
 
     expect(() =>
-      assertMigrateSucceeded({
-        ok: false,
-        output: "failure already has newline\n",
-        status: null,
-      })
-    ).toThrowError(`${MIGRATE_COMMAND} exited with status null`);
+      assertMigrateSucceeded({ ok: false, output: "already newline\n" })
+    ).toThrowError(`${MIGRATE_LABEL} failed`);
 
-    expect(writeSpy).toHaveBeenCalledWith("failure already has newline\n");
+    expect(writeSpy).toHaveBeenCalledWith("already newline\n");
     expect(writeSpy).not.toHaveBeenCalledWith("\n");
     writeSpy.mockRestore();
   });

--- a/tests/unit/dev-bootstrap-migrate.test.ts
+++ b/tests/unit/dev-bootstrap-migrate.test.ts
@@ -13,6 +13,7 @@ vi.mock("postgres", () => ({
 }));
 
 import {
+  assertMigrateSucceeded,
   BACKFILL_COMMAND,
   MIGRATE_COMMAND,
   runMigrateWithRecovery,
@@ -269,5 +270,54 @@ describe("runMigrateWithRecovery", () => {
     expect(result.ok).toBe(false);
     expect(result.output).toContain("ENOENT");
     expect(result.failedCommand).toBe(BACKFILL_COMMAND);
+  });
+});
+
+describe("assertMigrateSucceeded", () => {
+  it("is a no-op when migrate succeeded", () => {
+    expect(() =>
+      assertMigrateSucceeded({
+        ok: true,
+        output: "ok",
+        status: 0,
+      })
+    ).not.toThrow();
+  });
+
+  it("writes output to stderr and throws with failedCommand", () => {
+    const writeSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    expect(() =>
+      assertMigrateSucceeded({
+        ok: false,
+        output: "migrate blew up",
+        status: 1,
+        failedCommand: BACKFILL_COMMAND,
+      })
+    ).toThrowError(`${BACKFILL_COMMAND} exited with status 1`);
+
+    expect(writeSpy).toHaveBeenCalledWith("migrate blew up");
+    expect(writeSpy).toHaveBeenCalledWith("\n");
+    writeSpy.mockRestore();
+  });
+
+  it("falls back to pnpm db:migrate when failedCommand is missing", () => {
+    const writeSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    expect(() =>
+      assertMigrateSucceeded({
+        ok: false,
+        output: "failure already has newline\n",
+        status: null,
+      })
+    ).toThrowError(`${MIGRATE_COMMAND} exited with status null`);
+
+    expect(writeSpy).toHaveBeenCalledWith("failure already has newline\n");
+    expect(writeSpy).not.toHaveBeenCalledWith("\n");
+    writeSpy.mockRestore();
   });
 });

--- a/tests/unit/dev-bootstrap-migrate.test.ts
+++ b/tests/unit/dev-bootstrap-migrate.test.ts
@@ -1,22 +1,89 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const spawnSyncMock = vi.hoisted(() => vi.fn());
+const postgresMock = vi.hoisted(() => vi.fn());
+const endMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", () => ({
   spawnSync: spawnSyncMock,
 }));
 
-import { runMigrateWithRecovery } from "@/scripts/lib/migration-drift";
+vi.mock("postgres", () => ({
+  default: postgresMock,
+}));
+
+import {
+  BACKFILL_COMMAND,
+  MIGRATE_COMMAND,
+  runMigrateWithRecovery,
+} from "@/scripts/lib/migration-drift";
+
+const DB_PUSH_MIGRATE_FAILURE = `DrizzleQueryError: Failed query: CREATE TABLE "users" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"email" text NOT NULL
+);
+params:
+PostgresError: relation "users" already exists`;
+
+const BACKFILL_SCRIPT_SUFFIX = "backfill-drizzle-migrations.ts";
+
+function hashFirstJournalMigration(): string {
+  const journalPath = path.join(
+    process.cwd(),
+    "drizzle",
+    "meta",
+    "_journal.json"
+  );
+  const journal = JSON.parse(fs.readFileSync(journalPath, "utf8")) as {
+    entries: Array<{ tag: string }>;
+  };
+  const tag = journal.entries[0]?.tag;
+  if (!tag) {
+    throw new Error("expected at least one journal entry");
+  }
+  const sqlPath = path.join(process.cwd(), "drizzle", `${tag}.sql`);
+  const content = fs.readFileSync(sqlPath, "utf8");
+  return crypto.createHash("sha256").update(content).digest("hex");
+}
+
+function mockPostgresClient(options: {
+  usersExists: boolean;
+  journalCount: number;
+  hashes?: string[];
+}): void {
+  endMock.mockResolvedValue(undefined);
+  const client = async (
+    strings: TemplateStringsArray
+  ): Promise<Array<{ exists?: boolean; c?: number; hash?: string }>> => {
+    const query = strings.join("");
+    if (query.includes("information_schema.tables")) {
+      return [{ exists: options.usersExists }];
+    }
+    if (query.includes("COUNT(*)") && query.includes("__drizzle_migrations")) {
+      return [{ c: options.journalCount }];
+    }
+    if (query.includes("SELECT hash FROM drizzle.__drizzle_migrations")) {
+      return (options.hashes ?? []).map((hash) => ({ hash }));
+    }
+    return [];
+  };
+  postgresMock.mockReturnValue(Object.assign(client, { end: endMock }));
+}
 
 function mockSpawnSequence(
   responses: Array<{
     status: number | null;
     stdout?: string;
     stderr?: string;
+    error?: Error;
   }>
 ): void {
   let call = 0;
-  spawnSyncMock.mockImplementation(() => {
+  spawnSyncMock.mockImplementation((_cmd, _args: string[]) => {
     const response = responses[call] ?? {
       status: 1,
       stderr: "unexpected call",
@@ -26,6 +93,7 @@ function mockSpawnSequence(
       status: response.status,
       stdout: response.stdout ?? "",
       stderr: response.stderr ?? "",
+      error: response.error,
     };
   });
 }
@@ -33,32 +101,43 @@ function mockSpawnSequence(
 describe("runMigrateWithRecovery", () => {
   beforeEach(() => {
     spawnSyncMock.mockReset();
+    postgresMock.mockReset();
+    endMock.mockReset();
   });
 
-  it("returns ok when the first migrate succeeds", () => {
+  it("returns ok when the first migrate succeeds", async () => {
     mockSpawnSequence([{ status: 0, stdout: "applied migrations" }]);
 
-    const result = runMigrateWithRecovery(process.env, () => undefined);
+    const result = await runMigrateWithRecovery(
+      "postgresql://postgres:postgres@localhost:5433/keeperhub",
+      process.env,
+      () => undefined
+    );
 
     expect(result.ok).toBe(true);
     expect(result.output).toContain("applied migrations");
     expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      "pnpm",
+      ["db:migrate"],
+      expect.objectContaining({ encoding: "utf8" })
+    );
+    expect(postgresMock).not.toHaveBeenCalled();
   });
 
-  it("runs backfill and retries when drift is detected", () => {
+  it("runs backfill and retries when db:push drift is detected from DB state", async () => {
+    mockPostgresClient({ usersExists: true, journalCount: 0 });
     mockSpawnSequence([
-      {
-        status: 1,
-        stderr:
-          "duplicate key value violates unique constraint on drizzle.__drizzle_migrations",
-      },
+      { status: 1, stderr: DB_PUSH_MIGRATE_FAILURE },
       { status: 0, stdout: "backfilled journal" },
       { status: 0, stdout: "retry migrate ok" },
     ]);
 
     const logs: string[] = [];
-    const result = runMigrateWithRecovery(process.env, (message) =>
-      logs.push(message)
+    const result = await runMigrateWithRecovery(
+      "postgresql://postgres:postgres@localhost:5433/keeperhub",
+      process.env,
+      (message) => logs.push(message)
     );
 
     expect(result.ok).toBe(true);
@@ -70,35 +149,126 @@ describe("runMigrateWithRecovery", () => {
       "dev-bootstrap: journal backfilled; retrying db:migrate once"
     );
     expect(spawnSyncMock).toHaveBeenCalledTimes(3);
+    expect(spawnSyncMock).toHaveBeenNthCalledWith(
+      1,
+      "pnpm",
+      ["db:migrate"],
+      expect.any(Object)
+    );
+    expect(spawnSyncMock).toHaveBeenNthCalledWith(
+      2,
+      "pnpm",
+      ["tsx", expect.stringContaining(BACKFILL_SCRIPT_SUFFIX)],
+      expect.any(Object)
+    );
+    expect(spawnSyncMock).toHaveBeenNthCalledWith(
+      3,
+      "pnpm",
+      ["db:migrate"],
+      expect.any(Object)
+    );
+    expect(endMock).toHaveBeenCalled();
   });
 
-  it("preserves first migrate output when retry fails for another reason", () => {
+  it("passes --through when the journal is partially populated", async () => {
+    const firstHash = hashFirstJournalMigration();
+    mockPostgresClient({
+      usersExists: true,
+      journalCount: 1,
+      hashes: [firstHash],
+    });
     mockSpawnSequence([
-      {
-        status: 1,
-        stderr:
-          "duplicate key value violates unique constraint on drizzle.__drizzle_migrations",
-      },
+      { status: 1, stderr: DB_PUSH_MIGRATE_FAILURE },
+      { status: 0, stdout: "backfilled journal" },
+      { status: 0, stdout: "retry migrate ok" },
+    ]);
+
+    await runMigrateWithRecovery(
+      "postgresql://postgres:postgres@localhost:5433/keeperhub",
+      process.env,
+      () => undefined
+    );
+
+    const backfillCall = spawnSyncMock.mock.calls[1];
+    expect(backfillCall?.[1]).toEqual(expect.arrayContaining(["--through"]));
+  });
+
+  it("preserves first migrate output when retry fails for another reason", async () => {
+    mockPostgresClient({ usersExists: true, journalCount: 0 });
+    mockSpawnSequence([
+      { status: 1, stderr: DB_PUSH_MIGRATE_FAILURE },
       { status: 0, stdout: "backfilled journal" },
       { status: 2, stderr: "connection refused" },
     ]);
 
-    const result = runMigrateWithRecovery(process.env, () => undefined);
+    const result = await runMigrateWithRecovery(
+      "postgresql://postgres:postgres@localhost:5433/keeperhub",
+      process.env,
+      () => undefined
+    );
 
     expect(result.ok).toBe(false);
-    expect(result.firstOutput).toContain("__drizzle_migrations");
-    expect(result.output).toContain("__drizzle_migrations");
+    expect(result.output).toContain('relation "users" already exists');
     expect(result.output).toContain("connection refused");
     expect(result.status).toBe(2);
+    expect(result.failedCommand).toBe(MIGRATE_COMMAND);
   });
 
-  it("does not run backfill for non-drift migrate failures", () => {
+  it("does not run backfill for non-drift migrate failures", async () => {
+    mockPostgresClient({ usersExists: true, journalCount: 0 });
     mockSpawnSequence([{ status: 1, stderr: "syntax error at or near" }]);
 
-    const result = runMigrateWithRecovery(process.env, () => undefined);
+    const result = await runMigrateWithRecovery(
+      "postgresql://postgres:postgres@localhost:5433/keeperhub",
+      process.env,
+      () => undefined
+    );
 
     expect(result.ok).toBe(false);
     expect(result.output).toContain("syntax error");
+    expect(result.failedCommand).toBe(MIGRATE_COMMAND);
     expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports backfill command failure instead of migrate", async () => {
+    mockPostgresClient({ usersExists: true, journalCount: 0 });
+    mockSpawnSequence([
+      { status: 1, stderr: DB_PUSH_MIGRATE_FAILURE },
+      { status: 3, stderr: "backfill failed" },
+    ]);
+
+    const result = await runMigrateWithRecovery(
+      "postgresql://postgres:postgres@localhost:5433/keeperhub",
+      process.env,
+      () => undefined
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.output).toContain('relation "users" already exists');
+    expect(result.output).toContain("backfill failed");
+    expect(result.status).toBe(3);
+    expect(result.failedCommand).toBe(BACKFILL_COMMAND);
+    expect(spawnSyncMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces spawn errors with the failing command", async () => {
+    mockPostgresClient({ usersExists: true, journalCount: 0 });
+    mockSpawnSequence([
+      { status: 1, stderr: DB_PUSH_MIGRATE_FAILURE },
+      {
+        status: null,
+        error: new Error("spawnSync pnpm ENOENT"),
+      },
+    ]);
+
+    const result = await runMigrateWithRecovery(
+      "postgresql://postgres:postgres@localhost:5433/keeperhub",
+      process.env,
+      () => undefined
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.output).toContain("ENOENT");
+    expect(result.failedCommand).toBe(BACKFILL_COMMAND);
   });
 });

--- a/tests/unit/dev-bootstrap-migrate.test.ts
+++ b/tests/unit/dev-bootstrap-migrate.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  spawnSync: spawnSyncMock,
+}));
+
+import { runMigrateWithRecovery } from "@/scripts/lib/migration-drift";
+
+function mockSpawnSequence(
+  responses: Array<{
+    status: number | null;
+    stdout?: string;
+    stderr?: string;
+  }>
+): void {
+  let call = 0;
+  spawnSyncMock.mockImplementation(() => {
+    const response = responses[call] ?? {
+      status: 1,
+      stderr: "unexpected call",
+    };
+    call += 1;
+    return {
+      status: response.status,
+      stdout: response.stdout ?? "",
+      stderr: response.stderr ?? "",
+    };
+  });
+}
+
+describe("runMigrateWithRecovery", () => {
+  beforeEach(() => {
+    spawnSyncMock.mockReset();
+  });
+
+  it("returns ok when the first migrate succeeds", () => {
+    mockSpawnSequence([{ status: 0, stdout: "applied migrations" }]);
+
+    const result = runMigrateWithRecovery(process.env, () => undefined);
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("applied migrations");
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs backfill and retries when drift is detected", () => {
+    mockSpawnSequence([
+      {
+        status: 1,
+        stderr:
+          "duplicate key value violates unique constraint on drizzle.__drizzle_migrations",
+      },
+      { status: 0, stdout: "backfilled journal" },
+      { status: 0, stdout: "retry migrate ok" },
+    ]);
+
+    const logs: string[] = [];
+    const result = runMigrateWithRecovery(process.env, (message) =>
+      logs.push(message)
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("retry migrate ok");
+    expect(logs).toContain(
+      "dev-bootstrap: migration drift detected (schema ahead of journal)"
+    );
+    expect(logs).toContain(
+      "dev-bootstrap: journal backfilled; retrying db:migrate once"
+    );
+    expect(spawnSyncMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("preserves first migrate output when retry fails for another reason", () => {
+    mockSpawnSequence([
+      {
+        status: 1,
+        stderr:
+          "duplicate key value violates unique constraint on drizzle.__drizzle_migrations",
+      },
+      { status: 0, stdout: "backfilled journal" },
+      { status: 2, stderr: "connection refused" },
+    ]);
+
+    const result = runMigrateWithRecovery(process.env, () => undefined);
+
+    expect(result.ok).toBe(false);
+    expect(result.firstOutput).toContain("__drizzle_migrations");
+    expect(result.output).toContain("__drizzle_migrations");
+    expect(result.output).toContain("connection refused");
+    expect(result.status).toBe(2);
+  });
+
+  it("does not run backfill for non-drift migrate failures", () => {
+    mockSpawnSequence([{ status: 1, stderr: "syntax error at or near" }]);
+
+    const result = runMigrateWithRecovery(process.env, () => undefined);
+
+    expect(result.ok).toBe(false);
+    expect(result.output).toContain("syntax error");
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/dev-bootstrap-migrate.test.ts
+++ b/tests/unit/dev-bootstrap-migrate.test.ts
@@ -1,6 +1,3 @@
-import crypto from "node:crypto";
-import fs from "node:fs";
-import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const spawnSyncMock = vi.hoisted(() => vi.fn());
@@ -31,43 +28,20 @@ PostgresError: relation "users" already exists`;
 
 const BACKFILL_SCRIPT_SUFFIX = "backfill-drizzle-migrations.ts";
 
-function hashFirstJournalMigration(): string {
-  const journalPath = path.join(
-    process.cwd(),
-    "drizzle",
-    "meta",
-    "_journal.json"
-  );
-  const journal = JSON.parse(fs.readFileSync(journalPath, "utf8")) as {
-    entries: Array<{ tag: string }>;
-  };
-  const tag = journal.entries[0]?.tag;
-  if (!tag) {
-    throw new Error("expected at least one journal entry");
-  }
-  const sqlPath = path.join(process.cwd(), "drizzle", `${tag}.sql`);
-  const content = fs.readFileSync(sqlPath, "utf8");
-  return crypto.createHash("sha256").update(content).digest("hex");
-}
-
 function mockPostgresClient(options: {
   usersExists: boolean;
   journalCount: number;
-  hashes?: string[];
 }): void {
   endMock.mockResolvedValue(undefined);
   const client = async (
     strings: TemplateStringsArray
-  ): Promise<Array<{ exists?: boolean; c?: number; hash?: string }>> => {
+  ): Promise<Array<{ exists?: boolean; c?: number }>> => {
     const query = strings.join("");
     if (query.includes("information_schema.tables")) {
       return [{ exists: options.usersExists }];
     }
     if (query.includes("COUNT(*)") && query.includes("__drizzle_migrations")) {
       return [{ c: options.journalCount }];
-    }
-    if (query.includes("SELECT hash FROM drizzle.__drizzle_migrations")) {
-      return (options.hashes ?? []).map((hash) => ({ hash }));
     }
     return [];
   };
@@ -170,12 +144,10 @@ describe("runMigrateWithRecovery", () => {
     expect(endMock).toHaveBeenCalled();
   });
 
-  it("passes --through when the journal is partially populated", async () => {
-    const firstHash = hashFirstJournalMigration();
+  it("omits --through when the journal is partially populated", async () => {
     mockPostgresClient({
       usersExists: true,
       journalCount: 1,
-      hashes: [firstHash],
     });
     mockSpawnSequence([
       { status: 1, stderr: DB_PUSH_MIGRATE_FAILURE },
@@ -183,14 +155,41 @@ describe("runMigrateWithRecovery", () => {
       { status: 0, stdout: "retry migrate ok" },
     ]);
 
-    await runMigrateWithRecovery(
+    const result = await runMigrateWithRecovery(
       "postgresql://postgres:postgres@localhost:5433/keeperhub",
       process.env,
       () => undefined
     );
 
+    expect(result.ok).toBe(true);
     const backfillCall = spawnSyncMock.mock.calls[1];
-    expect(backfillCall?.[1]).toEqual(expect.arrayContaining(["--through"]));
+    expect(backfillCall?.[1]).toEqual([
+      "tsx",
+      expect.stringContaining(BACKFILL_SCRIPT_SUFFIX),
+    ]);
+    expect(backfillCall?.[1]).not.toEqual(
+      expect.arrayContaining(["--through"])
+    );
+  });
+
+  it("preserves first migrate output when the recovery probe fails", async () => {
+    mockSpawnSequence([{ status: 1, stderr: DB_PUSH_MIGRATE_FAILURE }]);
+    postgresMock.mockImplementation(() => {
+      throw new Error("connect ECONNREFUSED");
+    });
+
+    const result = await runMigrateWithRecovery(
+      "postgresql://postgres:postgres@localhost:5433/keeperhub",
+      process.env,
+      () => undefined
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.output).toContain('relation "users" already exists');
+    expect(result.output).not.toContain("ECONNREFUSED");
+    expect(result.status).toBe(1);
+    expect(result.failedCommand).toBe(MIGRATE_COMMAND);
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
   });
 
   it("preserves first migrate output when retry fails for another reason", async () => {

--- a/tests/unit/migration-drift.test.ts
+++ b/tests/unit/migration-drift.test.ts
@@ -1,25 +1,29 @@
 import { describe, expect, it } from "vitest";
 import {
+  describeError,
   getExpectedJournalCount,
-  hasPublicSchemaCollisionOutput,
+  isDuplicateObjectError,
   isMissingRelationError,
   type PostgresClient,
   queryJournalDriftState,
   shouldRecoverAfterMigrateFailure,
 } from "@/scripts/lib/migration-drift";
 
-const DB_PUSH_MIGRATE_FAILURE = `DrizzleQueryError: Failed query: CREATE TABLE "users" (
-	"id" text PRIMARY KEY NOT NULL,
-	"name" text NOT NULL,
-	"email" text NOT NULL
-);
-params:
-    at migrate (/node_modules/drizzle-orm/pg-core/dialect.ts:123:11)
-PostgresError: relation "users" already exists`;
-
-const JOURNAL_INDEX_FAILURE = `DrizzleQueryError: Failed query: CREATE INDEX "idx_j" ON "drizzle"."__drizzle_migrations" ("id");
-params:
-PostgresError: relation "idx_j" already exists`;
+/**
+ * Shape captured from drizzle-orm's migrator failing against a database whose
+ * schema was applied by `db:push`: the outer error carries the statement, the
+ * postgres.js error underneath carries the SQLSTATE.
+ */
+function duplicateTableError(): Error {
+  const pgError = Object.assign(new Error('relation "users" already exists'), {
+    code: "42P07",
+    name: "PostgresError",
+  });
+  return Object.assign(
+    new Error('Failed query: CREATE TABLE "users" (\n\t"id" text\n)'),
+    { cause: pgError }
+  );
+}
 
 function createMockClient(options: {
   usersExists: boolean;
@@ -45,37 +49,12 @@ function createMockClient(options: {
   return Object.assign(client, { end }) as unknown as PostgresClient;
 }
 
-describe("hasPublicSchemaCollisionOutput", () => {
-  it("returns true for real db:push migrate failure output", () => {
-    expect(hasPublicSchemaCollisionOutput(DB_PUSH_MIGRATE_FAILURE)).toBe(true);
-  });
-
-  it("returns false for drizzle schema index collisions", () => {
-    expect(hasPublicSchemaCollisionOutput(JOURNAL_INDEX_FAILURE)).toBe(false);
-  });
-
-  it("returns false for syntax errors", () => {
-    expect(hasPublicSchemaCollisionOutput("syntax error at or near")).toBe(
-      false
-    );
-  });
-
-  it("returns false for connection errors", () => {
-    expect(hasPublicSchemaCollisionOutput("connection refused")).toBe(false);
-  });
-
-  it("returns false for empty output", () => {
-    expect(hasPublicSchemaCollisionOutput("")).toBe(false);
-    expect(hasPublicSchemaCollisionOutput("   ")).toBe(false);
-  });
-});
-
 describe("isMissingRelationError", () => {
-  it("matches Postgres undefined_table code", () => {
+  it("matches the undefined_table SQLSTATE", () => {
     expect(isMissingRelationError({ code: "42P01" })).toBe(true);
   });
 
-  it("matches relation does not exist messages", () => {
+  it("matches a relation-does-not-exist message without a code", () => {
     expect(
       isMissingRelationError({
         message: 'relation "drizzle.__drizzle_migrations" does not exist',
@@ -91,65 +70,116 @@ describe("isMissingRelationError", () => {
       })
     ).toBe(false);
   });
+
+  it("terminates on a self-referential cause chain", () => {
+    const looping: { code: string; cause?: unknown } = { code: "42501" };
+    looping.cause = looping;
+    expect(isMissingRelationError(looping)).toBe(false);
+  });
+});
+
+describe("isDuplicateObjectError", () => {
+  it("matches duplicate_table nested under the failing statement", () => {
+    expect(isDuplicateObjectError(duplicateTableError())).toBe(true);
+  });
+
+  it.each([
+    ["42P07", "duplicate_table"],
+    ["42701", "duplicate_column"],
+    ["42710", "duplicate_object"],
+    ["42P06", "duplicate_schema"],
+  ])("matches %s (%s)", (code) => {
+    expect(isDuplicateObjectError({ code })).toBe(true);
+  });
+
+  it("does not match a unique violation, which is data and not schema drift", () => {
+    expect(
+      isDuplicateObjectError({
+        code: "23505",
+        message: "duplicate key value violates unique constraint",
+      })
+    ).toBe(false);
+  });
+
+  it("does not match a syntax error", () => {
+    expect(
+      isDuplicateObjectError({ code: "42601", message: "syntax error at end" })
+    ).toBe(false);
+  });
+
+  it("does not match a connection failure", () => {
+    expect(
+      isDuplicateObjectError(new Error("connect ECONNREFUSED 127.0.0.1:5433"))
+    ).toBe(false);
+  });
+
+  it("falls back to the message only when no code is present", () => {
+    expect(
+      isDuplicateObjectError({ message: 'relation "users" already exists' })
+    ).toBe(true);
+  });
+});
+
+describe("describeError", () => {
+  it("renders the statement, the SQLSTATE and the cause chain", () => {
+    const text = describeError(duplicateTableError());
+    expect(text).toContain("Failed query:");
+    expect(text).toContain("caused by:");
+    expect(text).toContain("[42P07]");
+    expect(text).toContain('relation "users" already exists');
+  });
 });
 
 describe("queryJournalDriftState", () => {
   it("treats a missing journal table as count 0", async () => {
-    const client = createMockClient({
-      usersExists: true,
-      journalError: {
-        code: "42P01",
-        message: 'relation "drizzle.__drizzle_migrations" does not exist',
-      },
-    });
+    const state = await queryJournalDriftState(
+      createMockClient({
+        usersExists: true,
+        journalError: {
+          code: "42P01",
+          message: 'relation "drizzle.__drizzle_migrations" does not exist',
+        },
+      })
+    );
 
-    const state = await queryJournalDriftState(client);
     expect(state.journalCount).toBe(0);
     expect(state.usersExists).toBe(true);
+    expect(state.expectedCount).toBe(getExpectedJournalCount());
   });
 
-  it("rethrows permission errors instead of treating the journal as empty", async () => {
-    const client = createMockClient({
-      usersExists: true,
-      journalError: {
-        code: "42501",
-        message: "permission denied for table __drizzle_migrations",
-      },
-    });
-
-    await expect(queryJournalDriftState(client)).rejects.toMatchObject({
-      code: "42501",
-    });
+  it("rethrows permission errors instead of reporting an empty journal", async () => {
+    await expect(
+      queryJournalDriftState(
+        createMockClient({
+          usersExists: true,
+          journalError: {
+            code: "42501",
+            message: "permission denied for table __drizzle_migrations",
+          },
+        })
+      )
+    ).rejects.toMatchObject({ code: "42501" });
   });
 });
 
 describe("shouldRecoverAfterMigrateFailure", () => {
-  it("recovers when schema is ahead of an empty journal and output shows public collision", async () => {
-    const client = createMockClient({
-      usersExists: true,
-      journalCount: 0,
-    });
-
-    const result = await shouldRecoverAfterMigrateFailure(
-      client,
-      DB_PUSH_MIGRATE_FAILURE
-    );
-
-    expect(result).toEqual({ recover: true, throughTag: null });
+  it("recovers when the schema is ahead of an empty journal", async () => {
+    const client = createMockClient({ usersExists: true, journalCount: 0 });
+    expect(
+      await shouldRecoverAfterMigrateFailure(client, duplicateTableError())
+    ).toBe(true);
   });
 
-  it("recovers without a --through bound when the journal is partial", async () => {
+  it("recovers when the journal is partially populated", async () => {
+    // The case a journal-derived --through bound turned into a no-op: migrated
+    // partway, then db:push pulled the schema up to HEAD.
     const client = createMockClient({
       usersExists: true,
-      journalCount: 1,
+      journalCount: getExpectedJournalCount() - 1,
     });
-
-    const result = await shouldRecoverAfterMigrateFailure(
-      client,
-      DB_PUSH_MIGRATE_FAILURE
-    );
-
-    expect(result).toEqual({ recover: true, throughTag: null });
+    expect(
+      await shouldRecoverAfterMigrateFailure(client, duplicateTableError())
+    ).toBe(true);
   });
 
   it("does not recover when the journal is fully populated", async () => {
@@ -157,41 +187,28 @@ describe("shouldRecoverAfterMigrateFailure", () => {
       usersExists: true,
       journalCount: getExpectedJournalCount(),
     });
-
-    const result = await shouldRecoverAfterMigrateFailure(
-      client,
-      DB_PUSH_MIGRATE_FAILURE
-    );
-
-    expect(result).toEqual({ recover: false, throughTag: null });
+    expect(
+      await shouldRecoverAfterMigrateFailure(client, duplicateTableError())
+    ).toBe(false);
   });
 
-  it("does not recover for drizzle schema index collisions even when journal lags", async () => {
-    const client = createMockClient({
-      usersExists: true,
-      journalCount: 59,
-    });
-
-    const result = await shouldRecoverAfterMigrateFailure(
-      client,
-      JOURNAL_INDEX_FAILURE
-    );
-
-    expect(result).toEqual({ recover: false, throughTag: null });
+  it("does not recover on a fresh database with no public schema", async () => {
+    const client = createMockClient({ usersExists: false, journalCount: 0 });
+    expect(
+      await shouldRecoverAfterMigrateFailure(client, duplicateTableError())
+    ).toBe(false);
   });
 
-  it("does not recover for non-collision migrate failures", async () => {
-    const client = createMockClient({
-      usersExists: true,
-      journalCount: 0,
-    });
-
-    const result = await shouldRecoverAfterMigrateFailure(
-      client,
-      "syntax error at or near"
-    );
-
-    expect(result).toEqual({ recover: false, throughTag: null });
+  it("does not recover for a failure that is not a duplicate object", async () => {
+    const client = createMockClient({ usersExists: true, journalCount: 0 });
+    expect(
+      await shouldRecoverAfterMigrateFailure(
+        client,
+        Object.assign(new Error("syntax error at end of input"), {
+          code: "42601",
+        })
+      )
+    ).toBe(false);
   });
 });
 

--- a/tests/unit/migration-drift.test.ts
+++ b/tests/unit/migration-drift.test.ts
@@ -1,45 +1,133 @@
 import { describe, expect, it } from "vitest";
-import { isMigrationDriftOutput } from "@/scripts/lib/migration-drift";
+import {
+  getExpectedJournalCount,
+  hasPublicSchemaCollisionOutput,
+  type PostgresClient,
+  shouldRecoverAfterMigrateFailure,
+} from "@/scripts/lib/migration-drift";
 
-describe("isMigrationDriftOutput", () => {
-  it("returns true for journal duplicate key collisions", () => {
-    expect(
-      isMigrationDriftOutput(
-        "duplicate key value violates unique constraint on drizzle.__drizzle_migrations"
-      )
-    ).toBe(true);
+const DB_PUSH_MIGRATE_FAILURE = `DrizzleQueryError: Failed query: CREATE TABLE "users" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"email" text NOT NULL
+);
+params:
+    at migrate (/node_modules/drizzle-orm/pg-core/dialect.ts:123:11)
+PostgresError: relation "users" already exists`;
+
+const JOURNAL_INDEX_FAILURE = `DrizzleQueryError: Failed query: CREATE INDEX "idx_j" ON "drizzle"."__drizzle_migrations" ("id");
+params:
+PostgresError: relation "idx_j" already exists`;
+
+function createMockClient(options: {
+  usersExists: boolean;
+  journalCount: number;
+  hashes?: string[];
+}): PostgresClient {
+  const end = async (): Promise<void> => undefined;
+  const client = async (
+    strings: TemplateStringsArray
+  ): Promise<Array<{ exists?: boolean; c?: number; hash?: string }>> => {
+    const query = strings.join("");
+    if (query.includes("information_schema.tables")) {
+      return [{ exists: options.usersExists }];
+    }
+    if (query.includes("COUNT(*)") && query.includes("__drizzle_migrations")) {
+      return [{ c: options.journalCount }];
+    }
+    if (query.includes("SELECT hash FROM drizzle.__drizzle_migrations")) {
+      return (options.hashes ?? []).map((hash) => ({ hash }));
+    }
+    return [];
+  };
+  return Object.assign(client, { end }) as unknown as PostgresClient;
+}
+
+describe("hasPublicSchemaCollisionOutput", () => {
+  it("returns true for real db:push migrate failure output", () => {
+    expect(hasPublicSchemaCollisionOutput(DB_PUSH_MIGRATE_FAILURE)).toBe(true);
   });
 
-  it("returns true when journal table and already exists appear together", () => {
-    expect(
-      isMigrationDriftOutput(
-        "error in drizzle.__drizzle_migrations: already exists"
-      )
-    ).toBe(true);
+  it("returns false for drizzle schema index collisions", () => {
+    expect(hasPublicSchemaCollisionOutput(JOURNAL_INDEX_FAILURE)).toBe(false);
   });
 
-  it("returns false for relation already exists without journal context", () => {
-    expect(
-      isMigrationDriftOutput('ERROR: relation "users" already exists')
-    ).toBe(false);
-  });
-
-  it("returns false for connection errors", () => {
-    expect(isMigrationDriftOutput("connection refused")).toBe(false);
-  });
-
-  it("returns false for authentication failures", () => {
-    expect(isMigrationDriftOutput("password authentication failed")).toBe(
+  it("returns false for syntax errors", () => {
+    expect(hasPublicSchemaCollisionOutput("syntax error at or near")).toBe(
       false
     );
   });
 
-  it("returns false for syntax errors", () => {
-    expect(isMigrationDriftOutput("syntax error at or near")).toBe(false);
+  it("returns false for connection errors", () => {
+    expect(hasPublicSchemaCollisionOutput("connection refused")).toBe(false);
   });
 
   it("returns false for empty output", () => {
-    expect(isMigrationDriftOutput("")).toBe(false);
-    expect(isMigrationDriftOutput("   ")).toBe(false);
+    expect(hasPublicSchemaCollisionOutput("")).toBe(false);
+    expect(hasPublicSchemaCollisionOutput("   ")).toBe(false);
+  });
+});
+
+describe("shouldRecoverAfterMigrateFailure", () => {
+  it("recovers when schema is ahead of an empty journal and output shows public collision", async () => {
+    const client = createMockClient({
+      usersExists: true,
+      journalCount: 0,
+    });
+
+    const result = await shouldRecoverAfterMigrateFailure(
+      client,
+      DB_PUSH_MIGRATE_FAILURE
+    );
+
+    expect(result).toEqual({ recover: true, throughTag: null });
+  });
+
+  it("does not recover when the journal is fully populated", async () => {
+    const client = createMockClient({
+      usersExists: true,
+      journalCount: getExpectedJournalCount(),
+    });
+
+    const result = await shouldRecoverAfterMigrateFailure(
+      client,
+      DB_PUSH_MIGRATE_FAILURE
+    );
+
+    expect(result).toEqual({ recover: false, throughTag: null });
+  });
+
+  it("does not recover for drizzle schema index collisions even when journal lags", async () => {
+    const client = createMockClient({
+      usersExists: true,
+      journalCount: 59,
+    });
+
+    const result = await shouldRecoverAfterMigrateFailure(
+      client,
+      JOURNAL_INDEX_FAILURE
+    );
+
+    expect(result).toEqual({ recover: false, throughTag: null });
+  });
+
+  it("does not recover for non-collision migrate failures", async () => {
+    const client = createMockClient({
+      usersExists: true,
+      journalCount: 0,
+    });
+
+    const result = await shouldRecoverAfterMigrateFailure(
+      client,
+      "syntax error at or near"
+    );
+
+    expect(result).toEqual({ recover: false, throughTag: null });
+  });
+});
+
+describe("getExpectedJournalCount", () => {
+  it("reads a non-zero entry count from the journal file", () => {
+    expect(getExpectedJournalCount()).toBeGreaterThan(0);
   });
 });

--- a/tests/unit/migration-drift.test.ts
+++ b/tests/unit/migration-drift.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   getExpectedJournalCount,
   hasPublicSchemaCollisionOutput,
+  isMissingRelationError,
   type PostgresClient,
+  queryJournalDriftState,
   shouldRecoverAfterMigrateFailure,
 } from "@/scripts/lib/migration-drift";
 
@@ -21,22 +23,22 @@ PostgresError: relation "idx_j" already exists`;
 
 function createMockClient(options: {
   usersExists: boolean;
-  journalCount: number;
-  hashes?: string[];
+  journalCount?: number;
+  journalError?: unknown;
 }): PostgresClient {
   const end = async (): Promise<void> => undefined;
   const client = async (
     strings: TemplateStringsArray
-  ): Promise<Array<{ exists?: boolean; c?: number; hash?: string }>> => {
+  ): Promise<Array<{ exists?: boolean; c?: number }>> => {
     const query = strings.join("");
     if (query.includes("information_schema.tables")) {
       return [{ exists: options.usersExists }];
     }
     if (query.includes("COUNT(*)") && query.includes("__drizzle_migrations")) {
-      return [{ c: options.journalCount }];
-    }
-    if (query.includes("SELECT hash FROM drizzle.__drizzle_migrations")) {
-      return (options.hashes ?? []).map((hash) => ({ hash }));
+      if (options.journalError !== undefined) {
+        throw options.journalError;
+      }
+      return [{ c: options.journalCount ?? 0 }];
     }
     return [];
   };
@@ -68,11 +70,78 @@ describe("hasPublicSchemaCollisionOutput", () => {
   });
 });
 
+describe("isMissingRelationError", () => {
+  it("matches Postgres undefined_table code", () => {
+    expect(isMissingRelationError({ code: "42P01" })).toBe(true);
+  });
+
+  it("matches relation does not exist messages", () => {
+    expect(
+      isMissingRelationError({
+        message: 'relation "drizzle.__drizzle_migrations" does not exist',
+      })
+    ).toBe(true);
+  });
+
+  it("does not match permission errors", () => {
+    expect(
+      isMissingRelationError({
+        code: "42501",
+        message: "permission denied for table __drizzle_migrations",
+      })
+    ).toBe(false);
+  });
+});
+
+describe("queryJournalDriftState", () => {
+  it("treats a missing journal table as count 0", async () => {
+    const client = createMockClient({
+      usersExists: true,
+      journalError: {
+        code: "42P01",
+        message: 'relation "drizzle.__drizzle_migrations" does not exist',
+      },
+    });
+
+    const state = await queryJournalDriftState(client);
+    expect(state.journalCount).toBe(0);
+    expect(state.usersExists).toBe(true);
+  });
+
+  it("rethrows permission errors instead of treating the journal as empty", async () => {
+    const client = createMockClient({
+      usersExists: true,
+      journalError: {
+        code: "42501",
+        message: "permission denied for table __drizzle_migrations",
+      },
+    });
+
+    await expect(queryJournalDriftState(client)).rejects.toMatchObject({
+      code: "42501",
+    });
+  });
+});
+
 describe("shouldRecoverAfterMigrateFailure", () => {
   it("recovers when schema is ahead of an empty journal and output shows public collision", async () => {
     const client = createMockClient({
       usersExists: true,
       journalCount: 0,
+    });
+
+    const result = await shouldRecoverAfterMigrateFailure(
+      client,
+      DB_PUSH_MIGRATE_FAILURE
+    );
+
+    expect(result).toEqual({ recover: true, throughTag: null });
+  });
+
+  it("recovers without a --through bound when the journal is partial", async () => {
+    const client = createMockClient({
+      usersExists: true,
+      journalCount: 1,
     });
 
     const result = await shouldRecoverAfterMigrateFailure(

--- a/tests/unit/migration-drift.test.ts
+++ b/tests/unit/migration-drift.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { isMigrationDriftOutput } from "@/scripts/lib/migration-drift";
+
+describe("isMigrationDriftOutput", () => {
+  it("returns true for journal duplicate key collisions", () => {
+    expect(
+      isMigrationDriftOutput(
+        "duplicate key value violates unique constraint on drizzle.__drizzle_migrations"
+      )
+    ).toBe(true);
+  });
+
+  it("returns true when journal table and already exists appear together", () => {
+    expect(
+      isMigrationDriftOutput(
+        "error in drizzle.__drizzle_migrations: already exists"
+      )
+    ).toBe(true);
+  });
+
+  it("returns false for relation already exists without journal context", () => {
+    expect(
+      isMigrationDriftOutput('ERROR: relation "users" already exists')
+    ).toBe(false);
+  });
+
+  it("returns false for connection errors", () => {
+    expect(isMigrationDriftOutput("connection refused")).toBe(false);
+  });
+
+  it("returns false for authentication failures", () => {
+    expect(isMigrationDriftOutput("password authentication failed")).toBe(
+      false
+    );
+  });
+
+  it("returns false for syntax errors", () => {
+    expect(isMigrationDriftOutput("syntax error at or near")).toBe(false);
+  });
+
+  it("returns false for empty output", () => {
+    expect(isMigrationDriftOutput("")).toBe(false);
+    expect(isMigrationDriftOutput("   ")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Auto-recover from Drizzle migration journal drift after \pnpm db:push\: \dev:bootstrap\ detects drift, runs backfill, and retries migrate once.
- \dev:login\ surfaces bootstrap output on failure and preserves dev credentials on success.
- Local development troubleshooting documented in README (not public quickstart).

Split from the original combined PR; testnet onboarding chips are tracked separately.

## Test plan

- [x] \pnpm exec vitest run tests/unit/migration-drift.test.ts tests/unit/dev-bootstrap-migrate.test.ts\ (11 tests)
- [x] \pnpm type-check\
- [ ] Manual: \pnpm db:push\ then \pnpm dev:login\ — auto backfill + retry (requires local Postgres)
