### PR TITLE
fix: template plan gates, auth error envelope, and hackathon docs

### DIFF
--- a/app/api/auth/scan-intent/route.ts
+++ b/app/api/auth/scan-intent/route.ts
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
+import { ApiErrorCodes, apiError } from "@/lib/errors/api-envelope";
 import { recordScanIntent } from "@/lib/metrics/collectors/prometheus";
 
 const COOKIE_NAME = "pending_scan";
@@ -18,7 +19,12 @@ export async function POST(request: Request): Promise<NextResponse> {
   try {
     body = await request.json();
   } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    return apiError({
+      status: 400,
+      code: ApiErrorCodes.INVALID_INPUT,
+      detail: "Invalid JSON body",
+      requestHeaders: request.headers,
+    });
   }
 
   const intent =
@@ -27,20 +33,32 @@ export async function POST(request: Request): Promise<NextResponse> {
       : undefined;
 
   if (typeof intent !== "string" || intent.length === 0) {
-    return NextResponse.json({ error: "intent is required" }, { status: 400 });
+    return apiError({
+      status: 400,
+      code: ApiErrorCodes.INVALID_INPUT,
+      detail: "intent is required",
+      requestHeaders: request.headers,
+    });
   }
 
   if (intent.length > MAX_SCAN_INTENT_LENGTH) {
-    return NextResponse.json({ error: "intent too long" }, { status: 400 });
+    return apiError({
+      status: 400,
+      code: ApiErrorCodes.INVALID_INPUT,
+      detail: "intent too long",
+      requestHeaders: request.headers,
+    });
   }
 
   try {
     JSON.parse(intent);
   } catch {
-    return NextResponse.json(
-      { error: "intent must be valid JSON" },
-      { status: 400 }
-    );
+    return apiError({
+      status: 400,
+      code: ApiErrorCodes.INVALID_INPUT,
+      detail: "intent must be valid JSON",
+      requestHeaders: request.headers,
+    });
   }
 
   const cookieStore = await cookies();

--- a/app/api/auth/strict-signin/route.ts
+++ b/app/api/auth/strict-signin/route.ts
@@ -16,6 +16,7 @@ import {
   users,
   verifications,
 } from "@/lib/db/schema";
+import { ApiErrorCodes, apiError } from "@/lib/errors/api-envelope";
 import { HttpStatus } from "@/lib/http-status";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import {
@@ -103,15 +104,43 @@ type Body = {
   totpCode?: string;
 };
 
-function badRequest(error: string, code: string): NextResponse {
-  return NextResponse.json({ error, code }, { status: HttpStatus.BAD_REQUEST });
+function badRequest(
+  request: Request,
+  detail: string,
+  code: string
+): NextResponse {
+  return apiError({
+    status: HttpStatus.BAD_REQUEST,
+    code,
+    detail,
+    requestHeaders: request.headers,
+  });
 }
 
-function unauthorized(error: string, code: string): NextResponse {
-  return NextResponse.json(
-    { error, code },
-    { status: HttpStatus.UNAUTHORIZED }
-  );
+function unauthorized(
+  request: Request,
+  detail: string,
+  code: string
+): NextResponse {
+  return apiError({
+    status: HttpStatus.UNAUTHORIZED,
+    code,
+    detail,
+    requestHeaders: request.headers,
+  });
+}
+
+function serverError(
+  request: Request,
+  detail: string,
+  code: string
+): NextResponse {
+  return apiError({
+    status: HttpStatus.INTERNAL_SERVER_ERROR,
+    code,
+    detail,
+    requestHeaders: request.headers,
+  });
 }
 
 async function validateEmailOtp(
@@ -157,7 +186,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   try {
     body = (await request.json()) as Body;
   } catch {
-    return badRequest("Invalid JSON body", "bad_body");
+    return badRequest(request, "Invalid JSON body", "bad_body");
   }
 
   const email = body.email?.trim().toLowerCase() ?? "";
@@ -166,13 +195,21 @@ export async function POST(request: Request): Promise<NextResponse> {
   const totpCode = body.totpCode?.trim() ?? "";
 
   if (!(email && password)) {
-    return badRequest("Email and password are required", "missing_credentials");
+    return badRequest(
+      request,
+      "Email and password are required",
+      "missing_credentials"
+    );
   }
   if (emailOtp.length !== 6) {
-    return badRequest("Email code is required", "missing_email_otp");
+    return badRequest(request, "Email code is required", "missing_email_otp");
   }
   if (totpCode.length !== 6) {
-    return badRequest("Authenticator code is required", "missing_totp");
+    return badRequest(
+      request,
+      "Authenticator code is required",
+      "missing_totp"
+    );
   }
 
   // Per-email sliding window. Keys on the lowercased email so an
@@ -184,17 +221,13 @@ export async function POST(request: Request): Promise<NextResponse> {
   // confused user with typos still gets to land.
   const rateLimit = checkDualFactorRateLimit(email, "strict_signin");
   if (!rateLimit.allowed) {
-    return NextResponse.json(
-      {
-        error: "Too many attempts. Wait and try again.",
-        code: "rate_limited",
-        retryAfter: rateLimit.retryAfter,
-      },
-      {
-        status: HttpStatus.TOO_MANY_REQUESTS,
-        headers: { "Retry-After": String(rateLimit.retryAfter) },
-      }
-    );
+    return apiError({
+      status: HttpStatus.TOO_MANY_REQUESTS,
+      code: ApiErrorCodes.RATE_LIMITED,
+      detail: "Too many attempts. Wait and try again.",
+      requestHeaders: request.headers,
+      headers: { "Retry-After": String(rateLimit.retryAfter) },
+    });
   }
 
   const serverSecret = process.env.BETTER_AUTH_SECRET;
@@ -205,10 +238,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       new Error("BETTER_AUTH_SECRET missing"),
       { endpoint: "/api/auth/strict-signin" }
     );
-    return NextResponse.json(
-      { error: "Server misconfigured", code: "server_misconfigured" },
-      { status: HttpStatus.INTERNAL_SERVER_ERROR }
-    );
+    return serverError(request, "Server misconfigured", "server_misconfigured");
   }
 
   // 1. Look up the user. Single not-found-or-mismatch response so this
@@ -219,7 +249,7 @@ export async function POST(request: Request): Promise<NextResponse> {
     .where(eq(users.email, email))
     .limit(1);
   if (!user) {
-    return unauthorized("Invalid sign-in", "invalid_signin");
+    return unauthorized(request, "Invalid sign-in", "invalid_signin");
   }
 
   // 2. Validate password against the user's credential account.
@@ -231,17 +261,17 @@ export async function POST(request: Request): Promise<NextResponse> {
     )
     .limit(1);
   if (!credentialAccount?.password) {
-    return unauthorized("Invalid sign-in", "invalid_signin");
+    return unauthorized(request, "Invalid sign-in", "invalid_signin");
   }
   const passwordOk = await verifyPassword(password, credentialAccount.password);
   if (!passwordOk) {
-    return unauthorized("Invalid sign-in", "invalid_signin");
+    return unauthorized(request, "Invalid sign-in", "invalid_signin");
   }
 
   // 3. Validate the email OTP. Look-up only; do NOT consume yet.
   const emailOtpResult = await validateEmailOtp(email, emailOtp, serverSecret);
   if (!emailOtpResult.ok) {
-    return unauthorized("Invalid email code", "invalid_email_otp");
+    return unauthorized(request, "Invalid email code", "invalid_email_otp");
   }
 
   // 4. Validate TOTP against the user's two_factor row.
@@ -252,13 +282,14 @@ export async function POST(request: Request): Promise<NextResponse> {
     .limit(1);
   if (!totpRow) {
     return unauthorized(
+      request,
       "Two-factor not configured on this account",
       "totp_not_configured"
     );
   }
   const totpOk = await verifyUserTotp(totpRow.secret, totpCode, serverSecret);
   if (!totpOk) {
-    return unauthorized("Invalid authenticator code", "invalid_totp");
+    return unauthorized(request, "Invalid authenticator code", "invalid_totp");
   }
 
   // Three factors are now valid but we have not minted a session
@@ -333,15 +364,17 @@ export async function POST(request: Request): Promise<NextResponse> {
       err,
       { endpoint: "/api/auth/strict-signin", user_id: user.id }
     );
-    return NextResponse.json(
-      { error: "Sign-in failed at session step", code: "session_failed" },
-      { status: HttpStatus.INTERNAL_SERVER_ERROR }
+    return serverError(
+      request,
+      "Sign-in failed at session step",
+      "session_failed"
     );
   }
   if (twoFactorSetCookies.length === 0) {
-    return NextResponse.json(
-      { error: "Sign-in failed at session step", code: "session_failed" },
-      { status: HttpStatus.INTERNAL_SERVER_ERROR }
+    return serverError(
+      request,
+      "Sign-in failed at session step",
+      "session_failed"
     );
   }
 
@@ -369,15 +402,17 @@ export async function POST(request: Request): Promise<NextResponse> {
       err,
       { endpoint: "/api/auth/strict-signin", user_id: user.id }
     );
-    return NextResponse.json(
-      { error: "Sign-in failed at session step", code: "session_failed" },
-      { status: HttpStatus.INTERNAL_SERVER_ERROR }
+    return serverError(
+      request,
+      "Sign-in failed at session step",
+      "session_failed"
     );
   }
   if (sessionSetCookies.length === 0) {
-    return NextResponse.json(
-      { error: "Sign-in failed at session step", code: "session_failed" },
-      { status: HttpStatus.INTERNAL_SERVER_ERROR }
+    return serverError(
+      request,
+      "Sign-in failed at session step",
+      "session_failed"
     );
   }
 

--- a/app/api/auth/strict-signin/start/route.ts
+++ b/app/api/auth/strict-signin/start/route.ts
@@ -5,6 +5,8 @@ import { auth } from "@/lib/auth";
 import { readAllSetCookies } from "@/lib/auth-cookie-chain";
 import { db } from "@/lib/db";
 import { accounts, users } from "@/lib/db/schema";
+import { ApiErrorCodes, apiError } from "@/lib/errors/api-envelope";
+import { HttpStatus } from "@/lib/http-status";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { verifyPassword } from "@/lib/password";
 import { resolveClientIpFromHeaders } from "@/lib/security/login-risk";
@@ -42,23 +44,24 @@ export async function POST(request: Request): Promise<NextResponse> {
   try {
     body = (await request.json()) as Body;
   } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON body", code: "bad_body" },
-      { status: 400 }
-    );
+    return apiError({
+      status: HttpStatus.BAD_REQUEST,
+      code: "bad_body",
+      detail: "Invalid JSON body",
+      requestHeaders: request.headers,
+    });
   }
 
   const email = body.email?.trim().toLowerCase() ?? "";
   const password = body.password ?? "";
 
   if (!(email && password)) {
-    return NextResponse.json(
-      {
-        error: "Email and password are required",
-        code: "missing_credentials",
-      },
-      { status: 400 }
-    );
+    return apiError({
+      status: HttpStatus.BAD_REQUEST,
+      code: "missing_credentials",
+      detail: "Email and password are required",
+      requestHeaders: request.headers,
+    });
   }
 
   // F-013 / KEEP-738: this route verifies the credential password and returns a
@@ -81,17 +84,15 @@ export async function POST(request: Request): Promise<NextResponse> {
   if (!isE2eTestTraffic) {
     const rateLimit = checkCredentialAttemptRateLimit(email, clientIp);
     if (!rateLimit.allowed) {
-      return NextResponse.json(
-        {
-          error: "Too many attempts. Wait and try again.",
-          code: "rate_limited",
-          retryAfter: rateLimit.retryAfterSeconds,
+      return apiError({
+        status: HttpStatus.TOO_MANY_REQUESTS,
+        code: ApiErrorCodes.RATE_LIMITED,
+        detail: "Too many attempts. Wait and try again.",
+        requestHeaders: request.headers,
+        headers: {
+          "Retry-After": String(rateLimit.retryAfterSeconds),
         },
-        {
-          status: 429,
-          headers: { "Retry-After": String(rateLimit.retryAfterSeconds) },
-        }
-      );
+      });
     }
   }
 
@@ -107,10 +108,12 @@ export async function POST(request: Request): Promise<NextResponse> {
     .where(eq(users.email, email))
     .limit(1);
   if (!user) {
-    return NextResponse.json(
-      { error: "Invalid sign-in", code: "invalid_signin" },
-      { status: 401 }
-    );
+    return apiError({
+      status: HttpStatus.UNAUTHORIZED,
+      code: "invalid_signin",
+      detail: "Invalid sign-in",
+      requestHeaders: request.headers,
+    });
   }
 
   const [credentialAccount] = await db
@@ -121,28 +124,31 @@ export async function POST(request: Request): Promise<NextResponse> {
     )
     .limit(1);
   if (!credentialAccount?.password) {
-    return NextResponse.json(
-      { error: "Invalid sign-in", code: "invalid_signin" },
-      { status: 401 }
-    );
+    return apiError({
+      status: HttpStatus.UNAUTHORIZED,
+      code: "invalid_signin",
+      detail: "Invalid sign-in",
+      requestHeaders: request.headers,
+    });
   }
 
   const passwordOk = await verifyPassword(password, credentialAccount.password);
   if (!passwordOk) {
-    return NextResponse.json(
-      { error: "Invalid sign-in", code: "invalid_signin" },
-      { status: 401 }
-    );
+    return apiError({
+      status: HttpStatus.UNAUTHORIZED,
+      code: "invalid_signin",
+      detail: "Invalid sign-in",
+      requestHeaders: request.headers,
+    });
   }
 
   if (user.deactivatedAt) {
-    return NextResponse.json(
-      {
-        error: "Your account has been deactivated.",
-        code: "account_deactivated",
-      },
-      { status: 403 }
-    );
+    return apiError({
+      status: HttpStatus.FORBIDDEN,
+      code: "account_deactivated",
+      detail: "Your account has been deactivated.",
+      requestHeaders: request.headers,
+    });
   }
 
   // The account exists and the password matched, but the email isn't verified.
@@ -151,13 +157,12 @@ export async function POST(request: Request): Promise<NextResponse> {
   // instead of treating it as a generic 500. The password already matched, so
   // this does not widen account enumeration beyond a correct-password reveal.
   if (!user.emailVerified) {
-    return NextResponse.json(
-      {
-        error: "Please verify your email to continue.",
-        code: "email_not_verified",
-      },
-      { status: 403 }
-    );
+    return apiError({
+      status: HttpStatus.FORBIDDEN,
+      code: "email_not_verified",
+      detail: "Please verify your email to continue.",
+      requestHeaders: request.headers,
+    });
   }
 
   // Users without TOTP enrolled bypass the dual-factor flow. Mint the
@@ -185,10 +190,12 @@ export async function POST(request: Request): Promise<NextResponse> {
         err,
         { endpoint: "/api/auth/strict-signin/start", user_id: user.id }
       );
-      return NextResponse.json(
-        { error: "Sign-in failed", code: "signin_failed" },
-        { status: 500 }
-      );
+      return apiError({
+        status: HttpStatus.INTERNAL_SERVER_ERROR,
+        code: "signin_failed",
+        detail: "Sign-in failed",
+        requestHeaders: request.headers,
+      });
     }
   }
 
@@ -210,10 +217,12 @@ export async function POST(request: Request): Promise<NextResponse> {
       err,
       { endpoint: "/api/auth/strict-signin/start", user_id: user.id }
     );
-    return NextResponse.json(
-      { error: "Failed to send confirmation email", code: "email_send_failed" },
-      { status: 503 }
-    );
+    return apiError({
+      status: HttpStatus.SERVICE_UNAVAILABLE,
+      code: "email_send_failed",
+      detail: "Failed to send confirmation email",
+      requestHeaders: request.headers,
+    });
   }
 
   // No session, no cookie, just a green light to proceed to email

--- a/app/api/auth/template-intent/route.ts
+++ b/app/api/auth/template-intent/route.ts
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
+import { ApiErrorCodes, apiError } from "@/lib/errors/api-envelope";
 
 const COOKIE_NAME = "pending_template";
 const MAX_WORKFLOW_ID_LENGTH = 128;
@@ -17,7 +18,12 @@ export async function POST(request: Request): Promise<NextResponse> {
   try {
     body = await request.json();
   } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    return apiError({
+      status: 400,
+      code: ApiErrorCodes.INVALID_INPUT,
+      detail: "Invalid JSON body",
+      requestHeaders: request.headers,
+    });
   }
 
   const workflowId =
@@ -26,13 +32,20 @@ export async function POST(request: Request): Promise<NextResponse> {
       : undefined;
 
   if (typeof workflowId !== "string" || workflowId.length === 0) {
-    return NextResponse.json(
-      { error: "workflowId is required" },
-      { status: 400 }
-    );
+    return apiError({
+      status: 400,
+      code: ApiErrorCodes.INVALID_INPUT,
+      detail: "workflowId is required",
+      requestHeaders: request.headers,
+    });
   }
   if (workflowId.length > MAX_WORKFLOW_ID_LENGTH) {
-    return NextResponse.json({ error: "workflowId too long" }, { status: 400 });
+    return apiError({
+      status: 400,
+      code: ApiErrorCodes.INVALID_INPUT,
+      detail: "workflowId too long",
+      requestHeaders: request.headers,
+    });
   }
 
   const cookieStore = await cookies();

--- a/app/api/oauth/token/route.ts
+++ b/app/api/oauth/token/route.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 import { isUserDeactivated } from "@/lib/auth-deactivation-guard";
+import { ApiErrorCodes, apiError } from "@/lib/errors/api-envelope";
 import { HttpStatus } from "@/lib/http-status";
 import { createAccessToken } from "@/lib/mcp/oauth-auth";
 import {
@@ -23,8 +24,18 @@ import { isUserMemberOfOrganization } from "@/lib/workflow/access";
 
 export const dynamic = "force-dynamic";
 
-function jsonError(message: string, status: number): Response {
-  return Response.json({ error: message }, { status });
+function routeError(
+  request: Request,
+  detail: string,
+  status: number,
+  code: string
+): Response {
+  return apiError({
+    status,
+    code,
+    detail,
+    requestHeaders: request.headers,
+  });
 }
 
 function verifyPkceS256(verifier: string, challenge: string): boolean {
@@ -93,10 +104,20 @@ function verifyClientAuthentication(
   }
   const secret = extractClientSecret(request, params);
   if (!secret) {
-    return jsonError("client_secret is required for this client", 401);
+    return routeError(
+      request,
+      "client_secret is required for this client",
+      HttpStatus.UNAUTHORIZED,
+      ApiErrorCodes.UNAUTHORIZED
+    );
   }
   if (!secretMatches(secret, client.clientSecretHash)) {
-    return jsonError("Invalid client_secret", 401);
+    return routeError(
+      request,
+      "Invalid client_secret",
+      HttpStatus.UNAUTHORIZED,
+      ApiErrorCodes.UNAUTHORIZED
+    );
   }
   return null;
 }
@@ -121,7 +142,12 @@ async function handleAuthorizationCode(
 
   const client = await getOAuthClient(clientId);
   if (!client) {
-    return jsonError("Unknown client_id", 400);
+    return routeError(
+      request,
+      "Unknown client_id",
+      HttpStatus.BAD_REQUEST,
+      "invalid_client"
+    );
   }
 
   const clientAuthError = verifyClientAuthentication(client, request, params);
@@ -131,29 +157,48 @@ async function handleAuthorizationCode(
 
   const authCode = await getAuthCode(code);
   if (!authCode) {
-    return jsonError(
+    return routeError(
+      request,
       "Invalid or expired authorization code",
-      HttpStatus.BAD_REQUEST
+      HttpStatus.BAD_REQUEST,
+      "invalid_grant"
     );
   }
 
   if (authCode.clientId !== clientId) {
-    return jsonError("client_id mismatch", HttpStatus.BAD_REQUEST);
+    return routeError(
+      request,
+      "client_id mismatch",
+      HttpStatus.BAD_REQUEST,
+      ApiErrorCodes.INVALID_INPUT
+    );
   }
 
   if (authCode.redirectUri !== redirectUri) {
-    return jsonError("redirect_uri mismatch", HttpStatus.BAD_REQUEST);
+    return routeError(
+      request,
+      "redirect_uri mismatch",
+      HttpStatus.BAD_REQUEST,
+      ApiErrorCodes.INVALID_INPUT
+    );
   }
 
   if (authCode.codeChallengeMethod !== "S256") {
-    return jsonError(
+    return routeError(
+      request,
       "Unsupported code_challenge_method",
-      HttpStatus.BAD_REQUEST
+      HttpStatus.BAD_REQUEST,
+      ApiErrorCodes.INVALID_INPUT
     );
   }
 
   if (!verifyPkceS256(codeVerifier, authCode.codeChallenge)) {
-    return jsonError("Invalid code_verifier", HttpStatus.BAD_REQUEST);
+    return routeError(
+      request,
+      "Invalid code_verifier",
+      HttpStatus.BAD_REQUEST,
+      ApiErrorCodes.INVALID_INPUT
+    );
   }
 
   // Consume the code immediately (single use)
@@ -163,7 +208,12 @@ async function handleAuthorizationCode(
   // to the auth code and exchanging it. Without this, an auth code held
   // by an attacker would still buy a fresh access + refresh token pair.
   if (await isUserDeactivated(authCode.userId)) {
-    return jsonError("User account is deactivated", HttpStatus.UNAUTHORIZED);
+    return routeError(
+      request,
+      "User account is deactivated",
+      HttpStatus.UNAUTHORIZED,
+      ApiErrorCodes.UNAUTHORIZED
+    );
   }
 
   const accessToken = await createAccessToken({
@@ -206,7 +256,12 @@ async function handleRefreshToken(
 
   const client = await getOAuthClient(clientId);
   if (!client) {
-    return jsonError("Unknown client_id", HttpStatus.BAD_REQUEST);
+    return routeError(
+      request,
+      "Unknown client_id",
+      HttpStatus.BAD_REQUEST,
+      "invalid_client"
+    );
   }
 
   const clientAuthError = verifyClientAuthentication(client, request, params);
@@ -216,14 +271,21 @@ async function handleRefreshToken(
 
   const entry = await getRefreshToken(refreshTokenValue);
   if (!entry) {
-    return jsonError(
+    return routeError(
+      request,
       "Invalid or expired refresh token",
-      HttpStatus.BAD_REQUEST
+      HttpStatus.BAD_REQUEST,
+      "invalid_grant"
     );
   }
 
   if (entry.clientId !== clientId) {
-    return jsonError("client_id mismatch", HttpStatus.BAD_REQUEST);
+    return routeError(
+      request,
+      "client_id mismatch",
+      HttpStatus.BAD_REQUEST,
+      ApiErrorCodes.INVALID_INPUT
+    );
   }
 
   // Rotate the refresh token
@@ -234,7 +296,12 @@ async function handleRefreshToken(
   // gap on the refresh-exchange path so a stolen refresh token cannot
   // survive deactivation by repeatedly cycling itself.
   if (await isUserDeactivated(entry.userId)) {
-    return jsonError("User account is deactivated", HttpStatus.UNAUTHORIZED);
+    return routeError(
+      request,
+      "User account is deactivated",
+      HttpStatus.UNAUTHORIZED,
+      ApiErrorCodes.UNAUTHORIZED
+    );
   }
 
   // Re-check org membership before re-issuing. A refresh token outlives any
@@ -242,7 +309,12 @@ async function handleRefreshToken(
   // the org could keep cycling the refresh token into fresh org-scoped
   // access tokens indefinitely.
   if (!(await isUserMemberOfOrganization(entry.userId, entry.organizationId))) {
-    return jsonError("User is no longer a member of this organization", 401);
+    return routeError(
+      request,
+      "User is no longer a member of this organization",
+      HttpStatus.UNAUTHORIZED,
+      ApiErrorCodes.UNAUTHORIZED
+    );
   }
 
   const newRefreshToken = randomBytes(32).toString("hex");
@@ -275,10 +347,15 @@ export async function POST(request: Request): Promise<Response> {
   const rateLimit = checkIpRateLimit(ip, 30, 60_000);
   if (!rateLimit.allowed) {
     return applyRateLimitHeaders(
-      Response.json(
-        { error: "Too many requests" },
-        { status: HttpStatus.TOO_MANY_REQUESTS }
-      ),
+      apiError({
+        status: HttpStatus.TOO_MANY_REQUESTS,
+        code: ApiErrorCodes.RATE_LIMITED,
+        detail: "Too many requests",
+        requestHeaders: request.headers,
+        headers: rateLimit.retryAfter
+          ? { "Retry-After": String(rateLimit.retryAfter) }
+          : undefined,
+      }),
       rateLimit
     );
   }
@@ -294,7 +371,12 @@ export async function POST(request: Request): Promise<Response> {
       const body = (await request.json()) as Record<string, string>;
       params = new URLSearchParams(body);
     } catch {
-      return jsonError("Invalid request body", HttpStatus.BAD_REQUEST);
+      return routeError(
+        request,
+        "Invalid request body",
+        HttpStatus.BAD_REQUEST,
+        ApiErrorCodes.INVALID_INPUT
+      );
     }
   }
 
@@ -315,9 +397,11 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   return applyRateLimitHeaders(
-    jsonError(
+    routeError(
+      request,
       "Unsupported grant_type. Supported: authorization_code, refresh_token",
-      HttpStatus.BAD_REQUEST
+      HttpStatus.BAD_REQUEST,
+      ApiErrorCodes.INVALID_INPUT
     ),
     rateLimit
   );

--- a/app/api/workflows/public/route.ts
+++ b/app/api/workflows/public/route.ts
@@ -16,6 +16,7 @@ import {
   projectEdgesForPublicFeed,
   projectNodesForPublicFeed,
 } from "@/lib/workflow/public-feed-projection";
+import { workflowRequiresProPlan } from "@/lib/features/template-plan-gate";
 import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
 type TagInfo = { id: string; name: string; slug: string };
 
@@ -282,6 +283,7 @@ export async function GET(request: Request): Promise<NextResponse> {
       userVote: VoteDirection | null;
       canVote: boolean;
       duplicateCount: number;
+      requiresProPlan: boolean;
     };
 
     const mappedWorkflows = publicWorkflows.map(
@@ -296,6 +298,7 @@ export async function GET(request: Request): Promise<NextResponse> {
         userVote: userVotes[workflow.id] ?? null,
         canVote: userDuplications.has(workflow.id),
         duplicateCount: duplicateCounts[workflow.id] ?? 0,
+        requiresProPlan: workflowRequiresProPlan(workflow.nodes),
         createdAt: workflow.createdAt.toISOString(),
         updatedAt: workflow.updatedAt.toISOString(),
       })

--- a/components/hub/workflow-template-card.tsx
+++ b/components/hub/workflow-template-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowBigDown, ArrowBigUp, Star } from "lucide-react";
+import { ArrowBigDown, ArrowBigUp, Gem, Star } from "lucide-react";
 import type { KeyboardEvent, MouseEvent } from "react";
 import type { SavedWorkflow } from "@/lib/api-client";
 import type { VoteDirection } from "@/lib/workflow/editor/votes";
@@ -165,22 +165,35 @@ export function WorkflowTemplateCard({
           </div>
         )}
 
-        {/* Bottom row: vote cluster (LEFT) + Featured pill (RIGHT) */}
-        {(onVote || isFeatured) && (
+        {/* Bottom row: vote cluster (LEFT) + badges (RIGHT) */}
+        {(onVote || isFeatured || workflow.requiresProPlan) && (
           <div
             className={`pointer-events-auto mt-2 flex shrink-0 items-center gap-2 ${onVote ? "justify-between" : "justify-end"}`}
           >
             {onVote && (
               <VoteCluster onVote={onVote} score={score} userVote={userVote} />
             )}
-            {isFeatured && (
-              <span className="inline-flex h-[20px] shrink-0 items-center gap-1 rounded-full bg-[var(--color-bg-accent)] px-2">
-                <Star className="size-2.5 fill-[var(--color-text-accent)] text-[var(--color-text-accent)]" />
-                <span className="font-normal text-[0.625rem] text-[var(--color-text-accent)]">
-                  Featured
+            <div className="flex shrink-0 items-center gap-1.5">
+              {workflow.requiresProPlan && (
+                <span
+                  className="inline-flex h-[20px] shrink-0 items-center gap-1 rounded-full bg-[var(--color-bg-accent)] px-2"
+                  title="Requires Pro plan on free tier"
+                >
+                  <Gem className="size-2.5 text-[var(--color-text-accent)]" />
+                  <span className="font-normal text-[0.625rem] text-[var(--color-text-accent)]">
+                    Pro
+                  </span>
                 </span>
-              </span>
-            )}
+              )}
+              {isFeatured && (
+                <span className="inline-flex h-[20px] shrink-0 items-center gap-1 rounded-full bg-[var(--color-bg-accent)] px-2">
+                  <Star className="size-2.5 fill-[var(--color-text-accent)] text-[var(--color-text-accent)]" />
+                  <span className="font-normal text-[0.625rem] text-[var(--color-text-accent)]">
+                    Featured
+                  </span>
+                </span>
+              )}
+            </div>
           </div>
         )}
       </div>

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -33,6 +33,43 @@ reference for the full tool list and per-workflow details.
 The endpoint URL is also shown, with a copy button, in the dashboard under
 **Settings -> API Keys**.
 
+### OAuth vs API keys
+
+Browser OAuth (for example `/mcp` in Claude Code) mints a **Bearer OAuth access
+token**, not a `kh_` organization API key. The MCP server accepts either an
+OAuth access token or `Authorization: Bearer kh_...` on each request. Do not pass
+a `kh_` key to the OAuth token endpoint — it is rejected by design.
+
+| Auth method | Credential | Best for |
+|-------------|------------|----------|
+| OAuth (browser) | Short-lived Bearer access token | Interactive agents, Claude Code `/mcp` |
+| Organization API key (`kh_`) | Long-lived org key from Settings -> API Keys | Headless CI, scripts, Docker |
+
+For programmatic REST and MCP access without a browser redirect, create an
+organization key at **Settings -> API Keys**. See [MCP Server auth](/ai-tools/mcp-server)
+and [API Keys](/api/api-keys).
+
+### Local and Docker MCP
+
+Self-hosted KeeperHub exposes MCP at `http://localhost:3000/mcp`. OAuth
+redirect flows require a reachable callback URL; when that is impractical (for
+example inside Docker without a browser), prefer a `kh_` key:
+
+```bash
+claude mcp add --transport http --scope user keeperhub http://localhost:3000/mcp \
+  --header "Authorization: Bearer kh_your_key_here"
+```
+
+For local development with a browser, `pnpm dev:login` opens a signed-in
+Chromium session. Set `DEV_LOGIN_URL` if the app is not on `http://localhost:3000`.
+
+### Simulation is EVM-only
+
+`simulate: true` on MCP direct-execution tools (`execute_transfer`, etc.) works
+on **EVM chain IDs only**. Solana mainnet (`101`) and devnet (`103`) return a
+structured error with code `simulation_unsupported_chain` before any API call.
+See [section 6](#6-send-your-first-transaction-safely) for the full preflight flow.
+
 ## 2. Pick a key type
 
 KeeperHub has two key systems. They are not interchangeable.
@@ -42,8 +79,10 @@ KeeperHub has two key systems. They are not interchangeable.
 | `kh_` | Organization | `/api/keys` | REST API, MCP server, Claude Code plugin |
 | `wfb_` | User | `/api/api-keys` | Webhook trigger authentication |
 
-For programmatic API and MCP access, use an organization (`kh_`) key. Full
-details: [API Keys](/api/api-keys).
+For programmatic API and MCP access, use an organization (`kh_`) key. OAuth
+browser sign-in is a third MCP-only path (see [OAuth vs API keys](#oauth-vs-api-keys))
+and is not a substitute for `kh_` on REST endpoints. Full details:
+[API Keys](/api/api-keys).
 
 ## 3. Supported chains
 
@@ -91,7 +130,16 @@ tool. Faucet links are third-party and may change. See the full
 | Unauthenticated requests | 10 / minute |
 | Direct execution (per API key) | 60 / minute |
 
-Rate-limited requests return `429` with a `Retry-After` header. See
+Rate-limited requests return `429` with a `Retry-After` header (seconds or an
+HTTP-date). When you hit a limit:
+
+1. Read `Retry-After` and wait at least that many seconds before retrying.
+2. Use exponential backoff with a cap (for example 1s, 2s, 4s, up to 60s).
+3. On write operations, pass a stable `idempotency_key` so retries are safe.
+
+Workflow creation and AI generation can also return `upstream_cold_start` during
+serverless cold starts — retry with the same `idempotency_key` after the
+suggested delay. See [MCP Server cold starts](/ai-tools/mcp-server) and
 [Direct Execution](/api/direct-execution) for spending caps.
 
 ## 5. Sandbox
@@ -129,9 +177,10 @@ Example simulation on Base Sepolia:
 For an ERC-20 transfer, also pass the token's contract address as
 `token_address`. The Base Sepolia USDC address is listed in the table above.
 Any MCP tool error is a failed preflight and must stop the flow; revert details
-include the REST error JSON when available. Simulation is currently EVM-only,
-so `execute_transfer` rejects `simulate: true` for Solana chain IDs `101` and
-`103` and their aliases before making an API call.
+include the REST error JSON when available. As noted in [section 1](#simulation-is-evm-only),
+simulation is EVM-only — `execute_transfer` rejects `simulate: true` for Solana
+chain IDs `101` and `103` and their aliases with `simulation_unsupported_chain`
+before making an API call.
 See [MCP Server](/ai-tools/mcp-server#safely-preflight-direct-writes) for the
 tool flow and [Direct Execution](/api/direct-execution) for complete response
 and error handling details.

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -70,6 +70,8 @@ export type SavedWorkflow = WorkflowData & {
   userVote?: VoteDirection | null;
   canVote?: boolean;
   duplicateCount?: number;
+  /** True when the workflow uses Pro-gated actions on a free plan. */
+  requiresProPlan?: boolean;
   // Present when loaded via getById(id, { version }).
   isHistoricalVersion?: boolean;
   version?: number;

--- a/lib/features/template-plan-gate.ts
+++ b/lib/features/template-plan-gate.ts
@@ -1,0 +1,15 @@
+import {
+  extractActionTypeNodes,
+  validateWorkflowFeatures,
+} from "./workflow-validator";
+
+/**
+ * Returns true when a workflow uses features gated behind Pro (or higher) on
+ * the free plan. Used by the public marketplace feed to surface plan badges
+ * before a user duplicates a template.
+ */
+export function workflowRequiresProPlan(nodes: readonly unknown[]): boolean {
+  return (
+    validateWorkflowFeatures(extractActionTypeNodes(nodes), "free").length > 0
+  );
+}

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -250,6 +250,16 @@ const SOLANA_DIRECT_EXECUTION_CHAIN_IDS = new Set<number>([
   SUPPORTED_CHAIN_IDS.SOLANA_DEVNET,
 ]);
 
+export function buildSimulationUnsupportedChainError(chainId: number): Error {
+  return new Error(
+    JSON.stringify({
+      code: "simulation_unsupported_chain",
+      chainId,
+      hint: "Direct-execution simulation is EVM-only. Omit simulate for Solana or preflight with a Solana-aware client.",
+    })
+  );
+}
+
 function assertSimulationSupported(chainId: string, simulate?: boolean): void {
   if (!simulate) {
     return;
@@ -266,9 +276,7 @@ function assertSimulationSupported(chainId: string, simulate?: boolean): void {
     return;
   }
   if (SOLANA_DIRECT_EXECUTION_CHAIN_IDS.has(normalizedChainId)) {
-    throw new Error(
-      `Direct-execution simulation is currently EVM-only; Solana chain ${normalizedChainId} cannot be simulated. Do not broadcast unless you can preflight the transaction through a Solana-aware client.`
-    );
+    throw buildSimulationUnsupportedChainError(normalizedChainId);
   }
 }
 

--- a/tests/integration/auth-routes-envelope.test.ts
+++ b/tests/integration/auth-routes-envelope.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Integration tests for auth route error envelopes (KEEP-489 / FRICTION-08).
+ *
+ * Run with: pnpm vitest tests/integration/auth-routes-envelope.test.ts
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { mockCheckIpRateLimit } = vi.hoisted(() => ({
+  mockCheckIpRateLimit: vi.fn(),
+}));
+
+vi.mock("@/lib/mcp/rate-limit", () => ({
+  checkIpRateLimit: mockCheckIpRateLimit,
+  getClientIp: () => "127.0.0.1",
+}));
+
+vi.mock("@/lib/rate-limit-headers", () => ({
+  applyRateLimitHeaders: <T extends Response>(response: T): T => response,
+}));
+
+vi.mock("@/lib/metrics/collectors/prometheus", () => ({
+  recordScanIntent: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(() =>
+    Promise.resolve({
+      set: vi.fn(),
+      get: vi.fn(),
+    })
+  ),
+}));
+
+import { POST as scanIntentPost } from "@/app/api/auth/scan-intent/route";
+import { POST as strictSigninStartPost } from "@/app/api/auth/strict-signin/start/route";
+import { POST as oauthTokenPost } from "@/app/api/oauth/token/route";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type EnvelopeBody = {
+  error: string;
+  detail: string;
+  request_id: string;
+  hint?: string;
+  docs?: string;
+  code?: unknown;
+  message?: unknown;
+};
+
+function buildRequest(
+  url: string,
+  init?: RequestInit,
+  requestId?: string
+): Request {
+  const headers = new Headers(init?.headers);
+  if (requestId) {
+    headers.set("x-request-id", requestId);
+  }
+  return new Request(url, { ...init, headers });
+}
+
+describe("auth route error envelopes (FRICTION-08)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckIpRateLimit.mockReturnValue({
+      allowed: true,
+      limit: 30,
+      remaining: 29,
+      reset: Math.floor(Date.now() / 1000) + 60,
+    });
+  });
+
+  it("POST /api/auth/scan-intent returns invalid_input envelope for empty body", async () => {
+    const response = await scanIntentPost(
+      buildRequest("http://localhost/api/auth/scan-intent", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      })
+    );
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as EnvelopeBody;
+    expect(body.error).toBe("invalid_input");
+    expect(body.detail).toBe("intent is required");
+    expect(typeof body.request_id).toBe("string");
+    expect(UUID_REGEX.test(body.request_id)).toBe(true);
+    expect(body.code).toBeUndefined();
+    expect(body.message).toBeUndefined();
+  });
+
+  it("POST /api/auth/strict-signin/start returns envelope for missing credentials", async () => {
+    const response = await strictSigninStartPost(
+      buildRequest("http://localhost/api/auth/strict-signin/start", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "a@b.com" }),
+      })
+    );
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as EnvelopeBody;
+    expect(body.error).toBe("missing_credentials");
+    expect(body.detail).toBe("Email and password are required");
+    expect(typeof body.request_id).toBe("string");
+    expect(body.code).toBeUndefined();
+  });
+
+  it("POST /api/oauth/token returns rate_limited envelope when IP limit exceeded", async () => {
+    mockCheckIpRateLimit.mockReturnValue({
+      allowed: false,
+      retryAfter: 45,
+      limit: 30,
+      remaining: 0,
+      reset: Math.floor(Date.now() / 1000) + 45,
+    });
+
+    const response = await oauthTokenPost(
+      buildRequest("http://localhost/api/oauth/token", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ grant_type: "refresh_token" }),
+      })
+    );
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe("45");
+    const body = (await response.json()) as EnvelopeBody;
+    expect(body.error).toBe("rate_limited");
+    expect(body.detail).toBe("Too many requests");
+    expect(typeof body.request_id).toBe("string");
+  });
+});

--- a/tests/integration/oauth-token-route-deactivated.test.ts
+++ b/tests/integration/oauth-token-route-deactivated.test.ts
@@ -76,6 +76,12 @@ async function postForm(body: Record<string, string>): Promise<Response> {
   );
 }
 
+type EnvelopeBody = {
+  error: string;
+  detail: string;
+  request_id?: string;
+};
+
 function stubActiveOAuthClient(): void {
   mockGetOAuthClient.mockResolvedValue({
     clientId: TEST_CLIENT_ID,
@@ -146,8 +152,9 @@ describe("POST /api/oauth/token -- authorization_code grant", () => {
     });
 
     expect(response.status).toBe(401);
-    const body = (await response.json()) as { error?: string };
-    expect(body.error).toBe("User account is deactivated");
+    const body = (await response.json()) as EnvelopeBody;
+    expect(body.error).toBe("unauthorized");
+    expect(body.detail).toBe("User account is deactivated");
     expect(mockCreateAccessToken).not.toHaveBeenCalled();
     expect(mockStoreRefreshToken).not.toHaveBeenCalled();
   });
@@ -198,8 +205,9 @@ describe("POST /api/oauth/token -- refresh_token grant", () => {
     });
 
     expect(response.status).toBe(401);
-    const body = (await response.json()) as { error?: string };
-    expect(body.error).toBe("User is no longer a member of this organization");
+    const body = (await response.json()) as EnvelopeBody;
+    expect(body.error).toBe("unauthorized");
+    expect(body.detail).toBe("User is no longer a member of this organization");
     expect(mockIsMember).toHaveBeenCalledWith(TEST_USER_ID, TEST_ORG_ID);
     expect(mockDeleteRefreshToken).toHaveBeenCalledWith("refresh-1");
     expect(mockStoreRefreshToken).not.toHaveBeenCalled();
@@ -229,8 +237,9 @@ describe("POST /api/oauth/token -- refresh_token grant", () => {
     });
 
     expect(response.status).toBe(401);
-    const body = (await response.json()) as { error?: string };
-    expect(body.error).toBe("User account is deactivated");
+    const body = (await response.json()) as EnvelopeBody;
+    expect(body.error).toBe("unauthorized");
+    expect(body.detail).toBe("User account is deactivated");
     // The presented refresh token must still be invalidated -- attacker
     // does not get to keep replaying the same token after a deactivated
     // attempt.

--- a/tests/unit/mcp-simulation-error.test.ts
+++ b/tests/unit/mcp-simulation-error.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { buildSimulationUnsupportedChainError } from "@/lib/mcp/tools";
+
+describe("buildSimulationUnsupportedChainError", () => {
+  it("returns JSON with simulation_unsupported_chain code", () => {
+    const error = buildSimulationUnsupportedChainError(101);
+    const parsed = JSON.parse(error.message) as {
+      code: string;
+      chainId: number;
+      hint: string;
+    };
+    expect(parsed.code).toBe("simulation_unsupported_chain");
+    expect(parsed.chainId).toBe(101);
+    expect(parsed.hint).toContain("EVM-only");
+  });
+
+  it("includes chain id for Solana devnet", () => {
+    const error = buildSimulationUnsupportedChainError(103);
+    const parsed = JSON.parse(error.message) as { chainId: number };
+    expect(parsed.chainId).toBe(103);
+  });
+});

--- a/tests/unit/template-pro-plan-gate.test.ts
+++ b/tests/unit/template-pro-plan-gate.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { workflowRequiresProPlan } from "@/lib/features/template-plan-gate";
+
+describe("workflowRequiresProPlan", () => {
+  it("returns false for trigger + ungated actions only", () => {
+    const nodes = [
+      { id: "t1", data: { config: { triggerType: "Manual" } } },
+      { id: "n1", data: { config: { actionType: "Condition" } } },
+    ];
+    expect(workflowRequiresProPlan(nodes)).toBe(false);
+  });
+
+  it("returns true for webhook/send-webhook", () => {
+    const nodes = [
+      { id: "n1", data: { config: { actionType: "webhook/send-webhook" } } },
+    ];
+    expect(workflowRequiresProPlan(nodes)).toBe(true);
+  });
+
+  it("returns true for Database Query", () => {
+    const nodes = [
+      { id: "n1", data: { config: { actionType: "Database Query" } } },
+    ];
+    expect(workflowRequiresProPlan(nodes)).toBe(true);
+  });
+
+  it("returns false for empty or malformed nodes", () => {
+    expect(workflowRequiresProPlan([])).toBe(false);
+    expect(workflowRequiresProPlan([null, 42, "bad"])).toBe(false);
+    expect(workflowRequiresProPlan([{ id: "n1", data: { config: {} } }])).toBe(
+      false
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add `requiresProPlan` to the public marketplace feed and a **Pro** pill on hub template cards (grid view only; list row badge slot stays empty per HUBV2-08).
- Roll out KEEP-489 `apiError()` envelope on high-traffic auth routes: strict-signin, strict-signin/start, oauth/token, scan-intent, template-intent.
- Expand hackathon quickstart with OAuth vs `kh_` keys, local/Docker MCP, 429 backoff, and EVM-only simulate callout; MCP throws structured `simulation_unsupported_chain` for Solana simulate.

Fixes BUG-09, BUG-02 (docs-only), FRICTION-08, DOC-02, FRICTION-10.

## Test plan

- [x] `pnpm exec vitest run tests/unit/template-pro-plan-gate.test.ts tests/unit/mcp-simulation-error.test.ts tests/unit/api-error-envelope.test.ts tests/integration/auth-routes-envelope.test.ts` (31 passed)
- [x] `pnpm type-check`
- [x] Ultracite check on changed TS files
- [ ] `GET /api/workflows/public` — gated templates include `"requiresProPlan": true`
- [ ] Hub cards view — Pro pill on templates with Pro-gated actions
- [ ] `POST /api/auth/scan-intent` `{}` — `{ error: "invalid_input", detail, request_id }`
- [ ] MCP `execute_transfer` with `simulate: true` on Solana — `simulation_unsupported_chain`
