### PR TITLE
docs: add headless MCP quickstart + wallet identity warning

### DIFF
--- a/docs/ai-tools/agentic-wallet.md
+++ b/docs/ai-tools/agentic-wallet.md
@@ -10,7 +10,7 @@ KeeperHub paid workflows settle via [x402](https://docs.cdp.coinbase.com/x402) o
 This page covers the first-party **KeeperHub agentic wallet** (skill + npm package, server-side Turnkey custody) and the main third-party alternatives. Every wallet listed works with KeeperHub and with any other x402/MPP-compliant service.
 
 ## KeeperHub agentic wallet
-> **Wallet identity:** The CLI wallet created by `keeperhub-wallet add` and the MCP execution wallet are **different addresses**. The MCP server executes from a wallet managed by your organization's Turnkey integration, not the one in `~/.keeperhub/wallet.json`. Always call `list_integrations` via MCP to find the actual execution wallet address before funding.
+> **Wallet identity:** The CLI wallet created by `keeperhub-wallet add` and the MCP execution wallet are **different addresses**. The MCP server executes from a wallet managed by your organization's Turnkey integration, not the one in `~/.keeperhub/wallet.json`. If you are funding execution, use `list_integrations` to find the MCP execution wallet — it is different from the CLI wallet.
 
 
 A skill + npm package from KeeperHub. Custody is server-side in a per-wallet [Turnkey sub-organisation](https://docs.turnkey.com/concepts/sub-organizations), so no private key lands on disk. A `PreToolUse` hook gates every signing call against a three-tier (auto / ask / block) policy sourced from `~/.keeperhub/safety.json`.

--- a/docs/ai-tools/agentic-wallet.md
+++ b/docs/ai-tools/agentic-wallet.md
@@ -10,6 +10,8 @@ KeeperHub paid workflows settle via [x402](https://docs.cdp.coinbase.com/x402) o
 This page covers the first-party **KeeperHub agentic wallet** (skill + npm package, server-side Turnkey custody) and the main third-party alternatives. Every wallet listed works with KeeperHub and with any other x402/MPP-compliant service.
 
 ## KeeperHub agentic wallet
+> **Wallet identity:** The CLI wallet created by `keeperhub-wallet add` and the MCP execution wallet are **different addresses**. The MCP server executes from a wallet managed by your organization's Turnkey integration, not the one in `~/.keeperhub/wallet.json`. Always call `list_integrations` via MCP to find the actual execution wallet address before funding.
+
 
 A skill + npm package from KeeperHub. Custody is server-side in a per-wallet [Turnkey sub-organisation](https://docs.turnkey.com/concepts/sub-organizations), so no private key lands on disk. A `PreToolUse` hook gates every signing call against a three-tier (auto / ask / block) policy sourced from `~/.keeperhub/safety.json`.
 

--- a/docs/getting-started/_meta.ts
+++ b/docs/getting-started/_meta.ts
@@ -1,3 +1,4 @@
 export default {
   quickstart: "Quick Start Guide",
+  "first-transaction": "First Transaction via MCP",
 };

--- a/docs/getting-started/first-transaction.md
+++ b/docs/getting-started/first-transaction.md
@@ -9,7 +9,7 @@ This guide gets you from zero to a confirmed onchain transaction through KeeperH
 
 ## Prerequisites
 
-- Node.js 22+ (for built-in `fetch`)
+- Node.js 18+ (for built-in `fetch`)
 - A KeeperHub account (free — sign up at [app.keeperhub.com](https://app.keeperhub.com))
 - A small amount of USDC + ETH on Base (~$1 USDC and ~$0.10 ETH is plenty)
 
@@ -23,7 +23,7 @@ This guide gets you from zero to a confirmed onchain transaction through KeeperH
 
 Your KeeperHub wallet is automatically provisioned when you verify your email. Find its address via the UI:
 
-1. Click your profile icon → **Wallet**
+1. Click the **Wallet** button in the workflow toolbar (or find it in the billing PAYG section)
 2. Copy the wallet address (starts with `0x...`)
 
 > **Important:** If you also install the `@keeperhub/wallet` CLI (`keeperhub-wallet add`), that creates a **separate** wallet stored in `~/.keeperhub/wallet.json`. The CLI wallet and the MCP execution wallet are **different addresses**. Always fund the wallet shown in your KeeperHub dashboard or returned by `list_integrations` via MCP.
@@ -144,6 +144,7 @@ const execRes = await fetch(MCP_URL, {
         amount: "0.001",
         token_address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
         // No simulate field — this is the real thing
+        idempotency_key: `transfer-${Date.now()}`,  // Prevents duplicate execution on retry
       },
     },
   }),
@@ -153,6 +154,8 @@ const execData = await execRes.json();
 const result = JSON.parse(execData.result.content[0].text);
 console.log("Transaction:", result.transactionLink);
 ```
+
+> **Why `idempotency_key`:** If a network timeout leaves you unsure whether a transfer went through, re-sending the same request with the same key is safe — KeeperHub deduplicates. Without it, a retry could execute twice.
 
 ## Common Token Addresses
 

--- a/docs/getting-started/first-transaction.md
+++ b/docs/getting-started/first-transaction.md
@@ -26,7 +26,7 @@ Your KeeperHub wallet is automatically provisioned when you verify your email. F
 1. Click your profile icon → **Wallet**
 2. Copy the wallet address (starts with `0x...`)
 
-> **⚠️ Important:** If you also install the `@keeperhub/wallet` CLI (`keeperhub-wallet add`), that creates a **separate** wallet stored in `~/.keeperhub/wallet.json`. The CLI wallet and the MCP execution wallet are **different addresses**. Always fund the wallet shown in your KeeperHub dashboard or returned by `list_integrations` via MCP.
+> **Important:** If you also install the `@keeperhub/wallet` CLI (`keeperhub-wallet add`), that creates a **separate** wallet stored in `~/.keeperhub/wallet.json`. The CLI wallet and the MCP execution wallet are **different addresses**. Always fund the wallet shown in your KeeperHub dashboard or returned by `list_integrations` via MCP.
 
 ## Step 3: Fund Your Wallet
 
@@ -89,6 +89,7 @@ Always pass `simulate: true` before executing for real. This runs a dry-run with
 
 ```javascript
 // Simulate a USDC transfer on Base
+async function main() {
 const simRes = await fetch(MCP_URL, {
   method: "POST",
   headers: {
@@ -101,7 +102,7 @@ const simRes = await fetch(MCP_URL, {
     params: {
       name: "execute_transfer",
       arguments: {
-        chain_id: "8453",                                    // Base mainnet (STRING, not number)
+        chain_id: "8453",                                    // Base mainnet
         to_address: "0xYourWalletAddress",
         amount: "0.001",                                     // Human-readable amount
         token_address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", // USDC on Base
@@ -114,8 +115,11 @@ const simRes = await fetch(MCP_URL, {
 const simData = await simRes.json();
 if (simData.result.isError) {
   console.error("Simulation failed:", simData.result.content[0].text);
-  return; // Don't execute for real
+  throw new Error("Simulation failed — fix issues above before executing for real");
 }
+}
+
+main().catch(console.error);
 ```
 
 ## Step 6: Execute for Real
@@ -147,7 +151,7 @@ const execRes = await fetch(MCP_URL, {
 
 const execData = await execRes.json();
 const result = JSON.parse(execData.result.content[0].text);
-console.log("Transaction:", `https://basescan.org/tx/${result.txHash}`);
+console.log("Transaction:", result.transactionLink);
 ```
 
 ## Common Token Addresses
@@ -163,7 +167,7 @@ console.log("Transaction:", `https://basescan.org/tx/${result.txHash}`);
 
 1. **Two wallets exist** — the CLI wallet (`keeperhub-wallet add`) and the MCP execution wallet are different. Always check `list_integrations` to find the one MCP uses.
 
-2. **Session ID is in headers** — after `initialize`, grab `mcp-session-id` from the response headers. Without it, all subsequent calls fail silently.
+2. **Session ID is in headers** — after `initialize`, grab `mcp-session-id` from the response headers. Without it, subsequent calls return HTTP 400 with `code: -32003` ("Session not initialized").
 
 3. **Always simulate first** — pass `simulate: true` before executing. It catches balance issues and would-be reverts without spending gas.
 

--- a/docs/getting-started/first-transaction.md
+++ b/docs/getting-started/first-transaction.md
@@ -1,0 +1,172 @@
+---
+title: "First Transaction via MCP"
+description: "Connect to KeeperHub MCP from a plain Node.js script and execute your first onchain transfer in 15 minutes — no SDK, no Claude Code, no frameworks required."
+---
+
+# First Transaction via MCP (Headless Quick Start)
+
+This guide gets you from zero to a confirmed onchain transaction through KeeperHub MCP using plain Node.js — no Claude Code, no SDK, no framework. If you're building an autonomous agent or integrating KeeperHub into a backend, start here.
+
+## Prerequisites
+
+- Node.js 22+ (for built-in `fetch`)
+- A KeeperHub account (free — sign up at [app.keeperhub.com](https://app.keeperhub.com))
+- A small amount of USDC + ETH on Base (~$1 USDC and ~$0.10 ETH is plenty)
+
+## Step 1: Create an API Key
+
+1. Go to **Settings → API Keys → Organisation** tab
+2. Click **Create API Key**
+3. Copy the key — it starts with `kh_`
+
+## Step 2: Find Your Execution Wallet
+
+Your KeeperHub wallet is automatically provisioned when you verify your email. Find its address via the UI:
+
+1. Click your profile icon → **Wallet**
+2. Copy the wallet address (starts with `0x...`)
+
+> **⚠️ Important:** If you also install the `@keeperhub/wallet` CLI (`keeperhub-wallet add`), that creates a **separate** wallet stored in `~/.keeperhub/wallet.json`. The CLI wallet and the MCP execution wallet are **different addresses**. Always fund the wallet shown in your KeeperHub dashboard or returned by `list_integrations` via MCP.
+
+## Step 3: Fund Your Wallet
+
+Send to your execution wallet address on **Base** (not Ethereum mainnet — gas is too expensive there):
+
+- **0.5–1 USDC** — for transfers
+- **0.001–0.01 ETH** — for gas fees
+
+You can bridge to Base via [bridge.base.org](https://bridge.base.org) or buy directly on a DEX.
+
+## Step 4: The MCP Handshake
+
+KeeperHub MCP uses JSON-RPC 2.0 over HTTP. After calling `initialize`, you must:
+
+1. **Capture the session ID from the RESPONSE HEADERS** (not the body) — look for the `mcp-session-id` header
+2. **Send a `notifications/initialized` message** — this is required before any tool calls
+3. **Include the session ID header** on all subsequent requests
+
+```javascript
+const MCP_URL = "https://app.keeperhub.com/mcp";
+const API_KEY = process.env.KEEPERHUB_API_KEY;
+
+// 1. Initialize
+const initRes = await fetch(MCP_URL, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Authorization": `Bearer ${API_KEY}`,
+  },
+  body: JSON.stringify({
+    jsonrpc: "2.0", id: 1, method: "initialize",
+    params: {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "my-agent", version: "1.0.0" },
+    },
+  }),
+});
+
+// Session ID is in the HEADERS, not the body
+const sessionId = initRes.headers.get("mcp-session-id");
+
+// 2. Send initialized notification
+await fetch(MCP_URL, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Authorization": `Bearer ${API_KEY}`,
+    "mcp-session-id": sessionId,
+  },
+  body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+});
+
+// 3. Now you can call tools — always include the session ID header
+```
+
+## Step 5: Simulate Before You Execute
+
+Always pass `simulate: true` before executing for real. This runs a dry-run without signing or broadcasting — it catches balance issues, wrong addresses, and would-be reverts for free.
+
+```javascript
+// Simulate a USDC transfer on Base
+const simRes = await fetch(MCP_URL, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Authorization": `Bearer ${API_KEY}`,
+    "mcp-session-id": sessionId,
+  },
+  body: JSON.stringify({
+    jsonrpc: "2.0", id: 2, method: "tools/call",
+    params: {
+      name: "execute_transfer",
+      arguments: {
+        chain_id: "8453",                                    // Base mainnet (STRING, not number)
+        to_address: "0xYourWalletAddress",
+        amount: "0.001",                                     // Human-readable amount
+        token_address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", // USDC on Base
+        simulate: true,                                       // Dry run!
+      },
+    },
+  }),
+});
+
+const simData = await simRes.json();
+if (simData.result.isError) {
+  console.error("Simulation failed:", simData.result.content[0].text);
+  return; // Don't execute for real
+}
+```
+
+## Step 6: Execute for Real
+
+Same arguments, just remove `simulate`:
+
+```javascript
+const execRes = await fetch(MCP_URL, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Authorization": `Bearer ${API_KEY}`,
+    "mcp-session-id": sessionId,
+  },
+  body: JSON.stringify({
+    jsonrpc: "2.0", id: 3, method: "tools/call",
+    params: {
+      name: "execute_transfer",
+      arguments: {
+        chain_id: "8453",
+        to_address: "0xYourWalletAddress",
+        amount: "0.001",
+        token_address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        // No simulate field — this is the real thing
+      },
+    },
+  }),
+});
+
+const execData = await execRes.json();
+const result = JSON.parse(execData.result.content[0].text);
+console.log("Transaction:", `https://basescan.org/tx/${result.txHash}`);
+```
+
+## Common Token Addresses
+
+| Token | Chain | chain_id | token_address |
+|-------|-------|----------|---------------|
+| ETH (native) | Base | 8453 | (omit token_address) |
+| USDC | Base | 8453 | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| USDC | Ethereum | 1 | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` |
+| ETH (native) | Ethereum | 1 | (omit token_address) |
+
+## Gotchas
+
+1. **Two wallets exist** — the CLI wallet (`keeperhub-wallet add`) and the MCP execution wallet are different. Always check `list_integrations` to find the one MCP uses.
+
+2. **Session ID is in headers** — after `initialize`, grab `mcp-session-id` from the response headers. Without it, all subsequent calls fail silently.
+
+3. **Always simulate first** — pass `simulate: true` before executing. It catches balance issues and would-be reverts without spending gas.
+
+4. **Field names matter** — `execute_transfer` uses `to_address` (not `to`), `chain_id` (not `network`), and `token_address` (not `token`). Call `tools/list` to see the exact schema for any tool.
+
+5. **Fund the right wallet** — send USDC and ETH to the address from `list_integrations` or the dashboard, not the CLI wallet address.


### PR DESCRIPTION
## What this adds

### New guide: First Transaction via MCP

A headless quickstart for connecting to KeeperHub MCP from plain Node.js — no Claude Code, no SDK, no framework required. Covers:

- The full MCP handshake (initialize -> capture session ID from **response headers** -> notifications/initialized -> tool calls)
- Simulate-before-execute pattern with code examples
- Common token addresses (USDC on Base, USDC on Ethereum, native ETH)
- Gotchas section covering the 5 real friction points hit during onboarding

### Wallet identity warning

Added a callout to `docs/ai-tools/agentic-wallet.md` warning that the CLI wallet (`keeperhub-wallet add`) and the MCP execution wallet are **different addresses**. This is the #1 onboarding friction point — a new builder funds the CLI wallet, then MCP calls fail with insufficient balance.

## Why

Built an autonomous agent (https://github.com/Ai-Rook/rook-commerce-agent) that pays for API intelligence via x402 and executes onchain via KeeperHub MCP. Hit 5 real friction points during onboarding — this PR fixes 3 of them:

1. **Wallet identity mismatch** — CLI wallet != MCP exec wallet (fixed with warning)
2. **No headless quickstart** — only Claude Code setup docs existed (fixed with new guide)
3. **Missing common token addresses** — USDC contract not documented (fixed with reference table)

Remaining 2 (session ID in headers, simulate-before-execute) are covered in the new guide's gotchas section.

## Testing

The code examples in the new guide are extracted from a working agent that has executed real onchain transactions on Base:
- https://basescan.org/tx/0xe57f58ba4a953ee3edea7fd2acfbfcee307ca29ce329ceed3ac6ebef146f3bcd
- https://basescan.org/tx/0x50e379e71811bdec8239d535ae715725617e8dc9db000ae5e7271449074bf4d5
