### PR TITLE
feat: close per-execution receipt gaps in direct executions

### DIFF
--- a/app/api/execute/[...slug]/route.ts
+++ b/app/api/execute/[...slug]/route.ts
@@ -301,7 +301,14 @@ async function executeProtocolAction(
       output: result as unknown as Record<string, unknown>,
     });
   } else {
-    await failExecution(executionId, result.error);
+    // A failure that already reached the chain carries its hash,
+    // so the execution records which transaction failed and what the chain
+    // said about it, rather than leaving the hash only inside the message.
+    await failExecution(executionId, result.error, {
+      transactionHash: result.transactionHash,
+      chainId: result.chainId,
+      sponsored: result.sponsored,
+    });
   }
 
   const responseBody =

--- a/app/api/execute/[executionId]/status/route.ts
+++ b/app/api/execute/[executionId]/status/route.ts
@@ -80,6 +80,7 @@ export async function GET(
     transactionHash: execution.transactionHash,
     transactionLink: (output?.transactionLink as string) ?? null,
     sponsored: Boolean(output?.sponsored),
+    receipts: execution.receipts,
     result: output ?? null,
     error: execution.error,
     gasUsedWei: execution.gasUsedWei,

--- a/app/api/execute/_lib/execution-service.ts
+++ b/app/api/execute/_lib/execution-service.ts
@@ -124,15 +124,56 @@ export async function completeExecution(
   return { status, error };
 }
 
+type FailParams = {
+  // Present when the write reached the chain and failed there.
+  // A failed execution that broadcast a real transaction must still record
+  // which transaction, and what the chain says about it -- that is the case
+  // an operator most needs the receipt for. Omitted for pre-broadcast
+  // failures (validation, policy, RPC), where there is nothing to reconcile.
+  transactionHash?: string;
+  chainId?: number;
+  // Whether the write was routed through the gas-sponsored path. Recorded
+  // separately because `output` is not written on the failure path, and the
+  // status route derives `sponsored` from it -- without this a sponsored
+  // failure reports sponsored: false.
+  sponsored?: boolean;
+};
+
 export async function failExecution(
   executionId: string,
-  error: string
+  error: string,
+  params: FailParams = {}
 ): Promise<void> {
+  let receipts: DirectExecutionReceiptEntry[] = [];
+
+  if (params.transactionHash && params.chainId !== undefined) {
+    const { results } = await verifyExecutionReceipts([
+      { hash: params.transactionHash, chainId: params.chainId },
+    ]);
+    receipts = results.map((r) => ({
+      hash: r.hash,
+      chainId: r.chainId,
+      verified: r.verified,
+      receiptStatus: r.status,
+      blockNumber: r.blockNumber,
+      gasUsed: r.gasUsed,
+      verifiedAt: r.verifiedAt,
+    }));
+  }
+
   await db
     .update(directExecutions)
     .set({
       status: "failed",
       error,
+      ...(params.transactionHash
+        ? { transactionHash: params.transactionHash }
+        : {}),
+      ...(receipts.length > 0 ? { receipts } : {}),
+      ...(params.sponsored === undefined
+        ? {}
+        : // biome-ignore lint/suspicious/noExplicitAny: jsonb column accepts arbitrary serializable data
+          { output: { sponsored: params.sponsored } as any }),
       completedAt: new Date(),
     })
     .where(eq(directExecutions.id, executionId));

--- a/app/api/execute/_lib/types.ts
+++ b/app/api/execute/_lib/types.ts
@@ -1,3 +1,5 @@
+import type { DirectExecutionReceiptEntry } from "@/lib/db/schema";
+
 export type ExecutionStatus = "pending" | "running" | "completed" | "failed";
 
 export type ExecuteResponse = {
@@ -18,6 +20,11 @@ export type ExecutionStatusResponse = {
   transactionHash: string | null;
   transactionLink: string | null;
   sponsored: boolean;
+  // KEEP-1084: per-hash on-chain verification evidence behind `status`.
+  // completeExecution() has persisted this since KEEP-966; without it on the
+  // response a caller can see that an execution was gated but not what the
+  // gate observed. Empty for executions that claimed no transaction hash.
+  receipts: DirectExecutionReceiptEntry[];
   result: unknown;
   error: string | null;
   gasUsedWei: string | null;

--- a/app/api/execute/_lib/types.ts
+++ b/app/api/execute/_lib/types.ts
@@ -20,8 +20,9 @@ export type ExecutionStatusResponse = {
   transactionHash: string | null;
   transactionLink: string | null;
   sponsored: boolean;
-  // KEEP-1084: per-hash on-chain verification evidence behind `status`.
-  // completeExecution() has persisted this since KEEP-966; without it on the
+  // Per-hash on-chain verification evidence behind `status`.
+  // completeExecution() has persisted this since the reconciliation gate
+  // landed; without it on the
   // response a caller can see that an execution was gated but not what the
   // gate observed. Empty for executions that claimed no transaction hash.
   receipts: DirectExecutionReceiptEntry[];

--- a/app/api/execute/check-and-execute/route.ts
+++ b/app/api/execute/check-and-execute/route.ts
@@ -192,7 +192,14 @@ async function executeConditionalWrite(
       output: result as unknown as Record<string, unknown>,
     });
   } else {
-    await failExecution(executionId, result.error);
+    // A failure that already reached the chain carries its hash,
+    // so the execution records which transaction failed and what the chain
+    // said about it, rather than leaving the hash only inside the message.
+    await failExecution(executionId, result.error, {
+      transactionHash: result.transactionHash,
+      chainId: result.chainId,
+      sponsored: result.sponsored,
+    });
   }
 
   return recordIdempotentResponse(

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -211,7 +211,14 @@ async function handleWriteCall(
       output: result as unknown as Record<string, unknown>,
     });
   } else {
-    await failExecution(executionId, result.error);
+    // A failure that already reached the chain carries its hash,
+    // so the execution records which transaction failed and what the chain
+    // said about it, rather than leaving the hash only inside the message.
+    await failExecution(executionId, result.error, {
+      transactionHash: result.transactionHash,
+      chainId: result.chainId,
+      sponsored: result.sponsored,
+    });
   }
 
   return recordIdempotentResponse(

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -294,7 +294,14 @@ export async function POST(request: Request): Promise<NextResponse> {
       output: result as unknown as Record<string, unknown>,
     });
   } else {
-    await failExecution(executionId, result.error);
+    // A failure that already reached the chain carries its hash,
+    // so the execution records which transaction failed and what the chain
+    // said about it, rather than leaving the hash only inside the message.
+    await failExecution(executionId, result.error, {
+      transactionHash: result.transactionHash,
+      chainId: result.chainId,
+      sponsored: result.sponsored,
+    });
   }
 
   // 10. Return. A failed broadcast/verification is finalized (not released)

--- a/docs/api/direct-execution.md
+++ b/docs/api/direct-execution.md
@@ -39,8 +39,11 @@ you inspected is the transaction you send:
 4. Save the returned `executionId`, then poll
    `GET /api/execute/{executionId}/status`. Honor the
    `X-Poll-Interval-Hint` response header between polls.
-5. Treat the status response's `transactionHash` and `transactionLink` as the
-   authoritative onchain proof.
+5. Treat the status response's `receipts` as the authoritative onchain proof:
+   each entry is a receipt re-fetched from the chain, so `verified` and
+   `receiptStatus` say what actually happened. `transactionHash` and
+   `transactionLink` identify the transaction but are self-reported by the
+   write path.
 
 This sequence catches bad addresses, ABI mistakes, insufficient balances, and
 reverts before broadcast, while idempotency makes an interrupted client safe to
@@ -398,6 +401,17 @@ Check the status of a direct execution.
   "transactionHash": "0x...",
   "transactionLink": "https://etherscan.io/tx/0x...",
   "sponsored": false,
+  "receipts": [
+    {
+      "hash": "0x...",
+      "chainId": 11155111,
+      "verified": true,
+      "receiptStatus": "success",
+      "blockNumber": 11413447,
+      "gasUsed": "68115",
+      "verifiedAt": "2024-01-01T00:00:15Z"
+    }
+  ],
   "gasUsedWei": "21000000000000",
   "result": {...},
   "error": null,
@@ -405,6 +419,26 @@ Check the status of a direct execution.
   "completedAt": "2024-01-01T00:00:15Z"
 }
 ```
+
+**Receipts:**
+
+`receipts` carries one entry per transaction hash this execution claimed, each
+independently re-fetched from the chain before the execution was allowed to
+settle. It is the evidence behind `status`, not a restatement of it:
+
+- `verified`: whether this hash positively confirmed on-chain. An execution
+  settles as `completed` only when every entry is `true`.
+- `receiptStatus`: `success`, `reverted`, `safe_inner_failure` (the outer
+  transaction succeeded but a wrapped inner call failed), `not_found`, or
+  `timeout`. The last two mean verification could not reach a definitive
+  answer within its budget; they fail the execution closed rather than
+  optimistically settling it, so a `failed` execution carrying `timeout` may
+  describe a transaction that later lands.
+- `blockNumber` / `gasUsed`: read from the fetched receipt, not self-reported
+  by the write path.
+
+The array is empty for executions that claimed no transaction hash, such as
+read calls and simulations.
 
 **Status Values:**
 

--- a/docs/api/executions.md
+++ b/docs/api/executions.md
@@ -107,6 +107,15 @@ Returns real-time execution status with progress tracking.
 | `chainId` | number (optional) | EIP-155 chain id, when emitted by the step |
 | `network` | string (optional) | Network slug (e.g. `mainnet`, `arbitrum`) |
 | `iterationIndex` | number (optional) | 0-based For-Each loop index; present only for entries produced inside a For-Each iteration |
+| `verified` | boolean (optional) | Whether this hash positively confirmed on-chain. An execution settles as `success` only when every entry is `true` |
+| `receiptStatus` | string (optional) | `success`, `reverted`, `safe_inner_failure`, `not_found`, or `timeout` |
+| `blockNumber` | number (optional) | Block the transaction was mined in, read from the fetched receipt |
+| `gasUsed` | string (optional) | Gas used, read from the fetched receipt |
+| `verifiedAt` | string (optional) | ISO timestamp of the verification |
+
+The verification fields are populated when the execution reaches a terminal state: every claimed hash is re-fetched from the chain before the run is allowed to settle as `success`. `not_found` and `timeout` mean verification could not reach a definitive answer within its budget, and fail the run closed rather than settling it optimistically — an execution that failed with `timeout` may describe a transaction that later lands.
+
+Prefer these entries over per-step output when you need to know what actually happened. A step's own `transactionHash` in the logs endpoint below is self-reported at the moment the step ran, before any independent check; only the entries here carry `verified` and `receiptStatus`.
 
 An empty array carries one of two meanings: the run produced no on-chain writes, or the execution row was finalized before this field began being populated. The two cases are not distinguished at the response level — if the distinction matters for a historical row, the underlying hashes are reconstructable from per-step logs via the endpoint below. For full per-step input, output, error, and timing detail, also use the logs endpoint below.
 

--- a/lib/safe/allowance-module.ts
+++ b/lib/safe/allowance-module.ts
@@ -156,6 +156,16 @@ export type BuildExecTransactionOptions = {
  * Encode Safe.execTransaction() calldata for an owner-signed single-owner
  * Safe (threshold 1). Gas fields are zero so the Safe reads them from the
  * outer tx (standard "no refund" path).
+ *
+ * The zero safeTxGas/gasPrice below is also what makes an inner-call failure
+ * loud rather than silent. Safe ends execTransaction with
+ * `require(success || safeTxGas != 0 || gasPrice != 0)`, so with both zero a
+ * failing inner call reverts the entire outer transaction (receipt status 0).
+ * Set either non-zero and the same failure instead returns status 1 with an
+ * ExecutionFailure event, which every plain receipt.status check in this
+ * codebase would read as success -- only the finalize-time verifier decodes
+ * that event. Treat these zeros as load-bearing: making them configurable is a
+ * deliberate decision about swallowing failures, not a parameterisation.
  */
 export function buildExecTransactionCalldata(
   options: BuildExecTransactionOptions

--- a/lib/web3/chain-adapter/evm.ts
+++ b/lib/web3/chain-adapter/evm.ts
@@ -2,6 +2,7 @@ import { ethers } from "ethers";
 import { logWarn } from "@/lib/logging";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { getErrorMessage } from "@/lib/utils";
+import { OnChainRevertError } from "@/lib/web3/onchain-revert";
 import { submitSignedTransactionWithFailover } from "@/lib/web3/submit-signed";
 import type { AdaptiveGasStrategy, GasConfig } from "../gas-strategy";
 import type { NonceManager, NonceSession } from "../nonce-manager";
@@ -374,9 +375,11 @@ export class EvmChainAdapter implements ChainAdapter {
     // preflight and reverted only at inclusion time can still resolve here.
     // status 0 is authoritative: never report a reverted tx as confirmed.
     if (receipt.status === 0) {
-      throw new Error(
-        `Transaction ${receipt.hash} reverted on-chain (status 0, block ${receipt.blockNumber})`
-      );
+      throw new OnChainRevertError({
+        message: `Transaction ${receipt.hash} reverted on-chain (status 0, block ${receipt.blockNumber})`,
+        transactionHash: receipt.hash,
+        blockNumber: receipt.blockNumber,
+      });
     }
 
     await this.nonceManager.confirmTransaction(tx.hash);

--- a/lib/web3/onchain-revert.ts
+++ b/lib/web3/onchain-revert.ts
@@ -1,0 +1,50 @@
+import "server-only";
+
+/**
+ * Thrown when a directly-signed transaction was broadcast and then reverted
+ * on-chain (receipt status 0).
+ *
+ * Mirrors SponsoredTxRevertError on the sponsored path: both mean "a real
+ * transaction exists and it failed", as opposed to a pre-broadcast failure
+ * where no hash exists at all. Keeping the hash on the error rather than only
+ * inside the message is what lets the execution finalizer persist a structured
+ * receipt for the failure instead of leaving the hash recoverable only by
+ * parsing prose.
+ *
+ * The message is unchanged from the plain Error it replaces, so callers that
+ * only read `error.message` (workflow steps, log lines) behave identically.
+ */
+export class OnChainRevertError extends Error {
+  readonly kind = "onchain-revert" as const;
+  readonly transactionHash: string;
+  readonly blockNumber?: number;
+
+  constructor(opts: {
+    message: string;
+    transactionHash: string;
+    blockNumber?: number;
+  }) {
+    super(opts.message);
+    this.name = "OnChainRevertError";
+    this.transactionHash = opts.transactionHash;
+    this.blockNumber = opts.blockNumber;
+  }
+}
+
+export function isOnChainRevertError(
+  error: unknown
+): error is OnChainRevertError {
+  return (
+    error instanceof Error &&
+    (error as OnChainRevertError).kind === "onchain-revert"
+  );
+}
+
+/**
+ * Recover the hash of a transaction that reached the chain and failed, from
+ * whichever carrier the write path used. Returns undefined for pre-broadcast
+ * failures, where there is nothing to reconcile.
+ */
+export function revertedTransactionHash(error: unknown): string | undefined {
+  return isOnChainRevertError(error) ? error.transactionHash : undefined;
+}

--- a/lib/web3/sponsored-send-error.ts
+++ b/lib/web3/sponsored-send-error.ts
@@ -7,7 +7,12 @@ import {
 } from "@/lib/web3/turnkey-revert";
 
 export type SponsoredSendDecision =
-  | { fallback: false; error: string }
+  // `transactionHash` is set only when the sponsored transaction
+  // reached the chain and failed there, so a caller can tell "this hash exists
+  // and reverted" (reconcilable) from "nothing was broadcast" (nothing to
+  // reconcile). Absent for the accepted-but-unconfirmed case, where no hash is
+  // known yet.
+  | { fallback: false; error: string; transactionHash?: string }
   | { fallback: true };
 
 /**
@@ -48,6 +53,7 @@ export function resolveSponsoredSendError(
     return {
       fallback: false,
       error: `Transaction reverted: ${error.message} (tx ${error.txHash})`,
+      transactionHash: error.txHash,
     };
   }
 

--- a/lib/web3/verify-receipt.ts
+++ b/lib/web3/verify-receipt.ts
@@ -49,6 +49,22 @@ const VERIFY_CONCURRENCY_LIMIT = 20;
 // ExecutionFailure when the wrapped inner call reverted; Safe swallows that
 // as an event rather than reverting the whole transaction, so plain
 // receipt.status checks miss it entirely.
+//
+// Reachability, verified on Sepolia against a real owner-signed Safe: this
+// branch cannot fire for transactions KeeperHub itself builds.
+// buildExecTransactionCalldata in lib/safe/allowance-module.ts passes
+// safeTxGas=0, baseGas=0, gasPrice=0, and Safe's
+// `require(success || safeTxGas != 0 || gasPrice != 0)` therefore reverts the
+// whole outer transaction on inner failure -- receipt status 0, no logs,
+// caught by the plain status check above. With safeTxGas non-zero the same
+// call yields status 1 plus ExecutionFailure, which is what this decodes.
+//
+// It is kept because the cost is one topic comparison and the failure mode it
+// covers is silent: any future path that submits a Safe transaction it did not
+// construct (executing a queued transaction created in the Safe UI, say, where
+// safeTxGas is set by the proposer) reaches it immediately. Do not delete this
+// on the grounds that nothing currently triggers it -- delete it only if Safe
+// support itself is removed.
 const SAFE_EXECUTION_EVENTS_ABI = [
   "event ExecutionSuccess(bytes32 txHash, uint256 payment)",
   "event ExecutionFailure(bytes32 txHash, uint256 payment)",

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -174,6 +174,11 @@ const web3Plugin: IntegrationPlugin = {
           description: "The transaction hash of the successful transfer",
         },
         {
+          field: "chainId",
+          description:
+            "Chain the transaction was broadcast on. Required for on-chain receipt verification: a step that reports a transactionHash without a chainId fails the execution closed.",
+        },
+        {
           field: "error",
           description: "Error message if the transfer failed",
         },
@@ -238,6 +243,11 @@ const web3Plugin: IntegrationPlugin = {
         {
           field: "transactionHash",
           description: "The transaction hash of the successful transfer",
+        },
+        {
+          field: "chainId",
+          description:
+            "Chain the transaction was broadcast on. Required for on-chain receipt verification: a step that reports a transactionHash without a chainId fails the execution closed.",
         },
         {
           field: "transactionLink",
@@ -1281,6 +1291,11 @@ const web3Plugin: IntegrationPlugin = {
           description: "The transaction hash of the approval",
         },
         {
+          field: "chainId",
+          description:
+            "Chain the transaction was broadcast on. Required for on-chain receipt verification: a step that reports a transactionHash without a chainId fails the execution closed.",
+        },
+        {
           field: "transactionLink",
           description: "Explorer link to view the transaction",
         },
@@ -1458,6 +1473,11 @@ const web3Plugin: IntegrationPlugin = {
         {
           field: "transactionHash",
           description: "The transaction hash of the successful write",
+        },
+        {
+          field: "chainId",
+          description:
+            "Chain the transaction was broadcast on. Required for on-chain receipt verification: a step that reports a transactionHash without a chainId fails the execution closed.",
         },
         {
           field: "result",

--- a/plugins/web3/steps/approve-token-core.ts
+++ b/plugins/web3/steps/approve-token-core.ts
@@ -36,6 +36,7 @@ import {
 import { resolveGasLimitOverrides } from "@/lib/web3/gas-defaults";
 import { isSponsorshipSupported } from "@/lib/web3/turnkey-sponsorship-config";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
+import { revertedTransactionHash } from "@/lib/web3/onchain-revert";
 import { resolveSponsoredSendError } from "@/lib/web3/sponsored-send-error";
 import { executeSponsoredContractTransaction } from "@/lib/web3/sponsored-transaction-manager";
 import type { ExecutedCall } from "@/lib/web3/trace-decode";
@@ -98,6 +99,14 @@ export type ApproveTokenResult =
        * the revert payload was empty / unrecognised.
        */
       rejection?: RevertKind;
+      // Set only when a transaction reached the chain and failed
+      // there, so the finalizer can persist a receipt for the failure. Absent
+      // on pre-broadcast failures, where no transaction exists.
+      transactionHash?: string;
+      chainId?: number;
+      // True when the terminal failure came from the gas-sponsored path, so
+      // the finalizer can report the route accurately on a failed execution.
+      sponsored?: boolean;
     };
 
 /**
@@ -351,7 +360,14 @@ export async function approveTokenCore(
         chainId,
       });
       if (!decision.fallback) {
-        return { success: false, error: decision.error };
+        return {
+          success: false,
+          error: decision.error,
+          sponsored: true,
+          ...(decision.transactionHash
+            ? { transactionHash: decision.transactionHash, chainId }
+            : {}),
+        };
       }
     }
   }
@@ -507,6 +523,9 @@ export async function approveTokenCore(
           "Token approval failed"
         ),
         ...(rejection.kind !== "unknown" ? { rejection } : {}),
+        ...(revertedTransactionHash(error)
+          ? { transactionHash: revertedTransactionHash(error), chainId }
+          : {}),
       };
     }
   });

--- a/plugins/web3/steps/transfer-funds-core.ts
+++ b/plugins/web3/steps/transfer-funds-core.ts
@@ -42,6 +42,7 @@ import {
   computeSolanaLamportFee,
   SOLANA_BASE_FEE_LAMPORTS,
 } from "@/lib/web3/solana-fees";
+import { revertedTransactionHash } from "@/lib/web3/onchain-revert";
 import { resolveSponsoredSendError } from "@/lib/web3/sponsored-send-error";
 import { executeSponsoredTransaction } from "@/lib/web3/sponsored-transaction-manager";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
@@ -87,7 +88,19 @@ export type TransferFundsResult =
       effectiveGasPrice: string;
       sponsored?: boolean;
     }
-  | { success: false; error: string; rejection?: RevertKind };
+  | {
+      success: false;
+      error: string;
+      rejection?: RevertKind;
+      // Set only when a transaction reached the chain and failed
+      // there, so the finalizer can persist a receipt for the failure. Absent
+      // on pre-broadcast failures, where no transaction exists.
+      transactionHash?: string;
+      chainId?: number;
+      // True when the terminal failure came from the gas-sponsored path, so
+      // the finalizer can report the route accurately on a failed execution.
+      sponsored?: boolean;
+    };
 
 /**
  * Core transfer funds logic
@@ -314,7 +327,14 @@ export async function transferFundsCore(
         chainId,
       });
       if (!decision.fallback) {
-        return { success: false, error: decision.error };
+        return {
+          success: false,
+          error: decision.error,
+          sponsored: true,
+          ...(decision.transactionHash
+            ? { transactionHash: decision.transactionHash, chainId }
+            : {}),
+        };
       }
     }
   }
@@ -449,6 +469,9 @@ export async function transferFundsCore(
         success: false,
         error: formatContractError(error, undefined, "Transaction failed"),
         ...(rejection.kind !== "unknown" ? { rejection } : {}),
+        ...(revertedTransactionHash(error)
+          ? { transactionHash: revertedTransactionHash(error), chainId }
+          : {}),
       };
     }
   });

--- a/plugins/web3/steps/transfer-token-core.ts
+++ b/plugins/web3/steps/transfer-token-core.ts
@@ -40,6 +40,7 @@ import {
 import { resolveGasLimitOverrides } from "@/lib/web3/gas-defaults";
 import { isSponsorshipSupported } from "@/lib/web3/turnkey-sponsorship-config";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
+import { revertedTransactionHash } from "@/lib/web3/onchain-revert";
 import { resolveSponsoredSendError } from "@/lib/web3/sponsored-send-error";
 import { executeSponsoredContractTransaction } from "@/lib/web3/sponsored-transaction-manager";
 import type { ExecutedCall } from "@/lib/web3/trace-decode";
@@ -92,7 +93,19 @@ export type TransferTokenResult =
       // ones. Omitted when the RPC cannot trace the transaction.
       executedCall?: ExecutedCall;
     }
-  | { success: false; error: string; rejection?: RevertKind };
+  | {
+      success: false;
+      error: string;
+      rejection?: RevertKind;
+      // Set only when a transaction reached the chain and failed
+      // there, so the finalizer can persist a receipt for the failure. Absent
+      // on pre-broadcast failures, where no transaction exists.
+      transactionHash?: string;
+      chainId?: number;
+      // True when the terminal failure came from the gas-sponsored path, so
+      // the finalizer can report the route accurately on a failed execution.
+      sponsored?: boolean;
+    };
 
 /**
  * Parse token config from input and return a single token address.
@@ -441,7 +454,14 @@ export async function transferTokenCore(
         chainId,
       });
       if (!decision.fallback) {
-        return { success: false, error: decision.error };
+        return {
+          success: false,
+          error: decision.error,
+          sponsored: true,
+          ...(decision.transactionHash
+            ? { transactionHash: decision.transactionHash, chainId }
+            : {}),
+        };
       }
     }
   }
@@ -605,6 +625,9 @@ export async function transferTokenCore(
           "Token transfer failed"
         ),
         ...(rejection.kind !== "unknown" ? { rejection } : {}),
+        ...(revertedTransactionHash(error)
+          ? { transactionHash: revertedTransactionHash(error), chainId }
+          : {}),
       };
     }
   });

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -45,6 +45,7 @@ import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
 import { executeSponsoredContractTransaction } from "@/lib/web3/sponsored-transaction-manager";
 import type { ExecutedCall } from "@/lib/web3/trace-decode";
 import { traceExecutedCallWithFailover } from "@/lib/web3/trace-executed-call";
+import { revertedTransactionHash } from "@/lib/web3/onchain-revert";
 import { resolveSponsoredSendError } from "@/lib/web3/sponsored-send-error";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
 import {
@@ -105,6 +106,14 @@ export type WriteContractResult =
       error: string;
       rejection?: RevertKind;
       errorClass?: ExecutionErrorType;
+      // Set only when a transaction reached the chain and failed
+      // there, so the finalizer can persist a receipt for the failure. Absent
+      // on pre-broadcast failures, where no transaction exists.
+      transactionHash?: string;
+      chainId?: number;
+      // True when the terminal failure came from the gas-sponsored path, so
+      // the finalizer can report the route accurately on a failed execution.
+      sponsored?: boolean;
     };
 
 /**
@@ -428,7 +437,14 @@ export async function writeContractCore(
         chainId,
       });
       if (!decision.fallback) {
-        return { success: false, error: decision.error };
+        return {
+          success: false,
+          error: decision.error,
+          sponsored: true,
+          ...(decision.transactionHash
+            ? { transactionHash: decision.transactionHash, chainId }
+            : {}),
+        };
       }
     }
   }
@@ -555,10 +571,14 @@ export async function writeContractCore(
         }
       );
       const rejection = classifyRevert(error, contractInterface);
+      const revertedHash = revertedTransactionHash(error);
       return {
         success: false,
         error: formatContractError(error, contractInterface),
         ...(rejection.kind !== "unknown" ? { rejection } : {}),
+        ...(revertedHash
+          ? { transactionHash: revertedHash, chainId }
+          : {}),
       };
     }
   });

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -146,7 +146,7 @@
       "path": "/api/execute/{executionId}/status",
       "route_file": "app/api/execute/[executionId]/status/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 386
+      "line": 389
     },
     {
       "method": "GET",
@@ -342,21 +342,21 @@
       "path": "/api/execute/check-and-execute",
       "route_file": "app/api/execute/check-and-execute/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 223
+      "line": 226
     },
     {
       "method": "POST",
       "path": "/api/execute/contract-call",
       "route_file": "app/api/execute/contract-call/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 167
+      "line": 170
     },
     {
       "method": "POST",
       "path": "/api/execute/transfer",
       "route_file": "app/api/execute/transfer/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 105
+      "line": 108
     },
     {
       "method": "POST",

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -61,7 +61,7 @@
       "path": "/api/workflows/{workflowId}/executions",
       "route_file": "app/api/workflows/[workflowId]/executions/route.ts",
       "source": "docs/api/executions.md",
-      "line": 302
+      "line": 311
     },
     {
       "method": "GET",
@@ -237,7 +237,7 @@
       "path": "/api/workflows/executions/{executionId}/logs",
       "route_file": "app/api/workflows/executions/[executionId]/logs/route.ts",
       "source": "docs/api/executions.md",
-      "line": 159
+      "line": 168
     },
     {
       "method": "GET",
@@ -251,7 +251,7 @@
       "path": "/api/workflows/executions/{executionId}/wait",
       "route_file": "app/api/workflows/executions/[executionId]/wait/route.ts",
       "source": "docs/api/executions.md",
-      "line": 116
+      "line": 125
     },
     {
       "method": "GET",

--- a/tests/integration/direct-execution-api.test.ts
+++ b/tests/integration/direct-execution-api.test.ts
@@ -419,9 +419,41 @@ describe("Direct Execution API", () => {
       expect(data.status).toBe("failed");
       expect(data.transactionHash).toBeUndefined();
       expect(data.transactionLink).toBeUndefined();
+      // A pre-broadcast failure has no transaction to reconcile, so the
+      // finalizer is told there is no hash rather than being handed one.
       expect(mocks.failExecution).toHaveBeenCalledWith(
         "exec_1",
-        "Insufficient funds"
+        "Insufficient funds",
+        {
+          transactionHash: undefined,
+          chainId: undefined,
+          sponsored: undefined,
+        }
+      );
+    });
+
+    it("records the hash and route when a broadcast transaction reverts", async () => {
+      mocks.validateApiKey.mockResolvedValue(AUTH_CONTEXT);
+      mocks.checkRateLimit.mockReturnValue({ allowed: true });
+      mocks.transferFundsCore.mockResolvedValue({
+        success: false,
+        error: "Transaction reverted: execution reverted (tx 0xdead)",
+        transactionHash: "0xdead",
+        chainId: 11_155_111,
+        sponsored: true,
+      });
+
+      const response = await transferPOST(postRequest("/transfer", validBody));
+
+      expect(response.status).toBe(202);
+      expect(mocks.failExecution).toHaveBeenCalledWith(
+        "exec_1",
+        "Transaction reverted: execution reverted (tx 0xdead)",
+        {
+          transactionHash: "0xdead",
+          chainId: 11_155_111,
+          sponsored: true,
+        }
       );
     });
 

--- a/tests/integration/direct-execution-api.test.ts
+++ b/tests/integration/direct-execution-api.test.ts
@@ -924,6 +924,106 @@ describe("Direct Execution API", () => {
       expect(data.sponsored).toBe(true);
     });
 
+    it("returns the per-hash on-chain verification receipts", async () => {
+      setupPassingGuards();
+      const now = new Date();
+      mocks.statusDbResult = [
+        {
+          id: "exec_3",
+          organizationId: "org_test",
+          apiKeyId: "key_test",
+          type: "contract-call",
+          network: "11155111",
+          status: "completed",
+          transactionHash: "0xabc",
+          receipts: [
+            {
+              hash: "0xabc",
+              chainId: 11_155_111,
+              verified: true,
+              receiptStatus: "success",
+              blockNumber: 11_413_447,
+              gasUsed: "68115",
+              verifiedAt: now.toISOString(),
+            },
+          ],
+          gasUsedWei: "68115",
+          gasPriceWei: "500000221",
+          estimatedCostUsd: null,
+          retryCount: 0,
+          input: {},
+          output: { transactionLink: "https://etherscan.io/tx/0xabc" },
+          error: null,
+          createdAt: now,
+          completedAt: now,
+        },
+      ];
+
+      const response = await statusGET(getRequest("/exec_3/status"), {
+        params: Promise.resolve({ executionId: "exec_3" }),
+      });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.receipts).toHaveLength(1);
+      expect(data.receipts[0]).toMatchObject({
+        hash: "0xabc",
+        chainId: 11_155_111,
+        verified: true,
+        receiptStatus: "success",
+        blockNumber: 11_413_447,
+      });
+    });
+
+    it("exposes the failing receipt on an execution demoted by reconciliation", async () => {
+      // The demotion case is the one an operator actually needs: `status`
+      // alone says the run failed, `receipts` says which hash failed and why.
+      setupPassingGuards();
+      const now = new Date();
+      mocks.statusDbResult = [
+        {
+          id: "exec_4",
+          organizationId: "org_test",
+          apiKeyId: "key_test",
+          type: "contract-call",
+          network: "11155111",
+          status: "failed",
+          transactionHash: "0xdead",
+          receipts: [
+            {
+              hash: "0xdead",
+              chainId: 11_155_111,
+              verified: false,
+              receiptStatus: "reverted",
+              blockNumber: 11_413_412,
+              gasUsed: "43572",
+              verifiedAt: now.toISOString(),
+            },
+          ],
+          gasUsedWei: null,
+          gasPriceWei: null,
+          estimatedCostUsd: null,
+          retryCount: 0,
+          input: {},
+          output: {},
+          error:
+            "On-chain verification failed for 1 transaction: 0xdead (reverted on-chain)",
+          createdAt: now,
+          completedAt: now,
+        },
+      ];
+
+      const response = await statusGET(getRequest("/exec_4/status"), {
+        params: Promise.resolve({ executionId: "exec_4" }),
+      });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.status).toBe("failed");
+      expect(data.receipts[0].verified).toBe(false);
+      expect(data.receipts[0].receiptStatus).toBe("reverted");
+    });
+
     it("route exports GET only -- non-GET methods are intentionally 405 (Next.js auto-handler)", async () => {
       // Locks in the route's GET-only design. If a future change adds POST
       // (e.g. to "fix" 405s reported from upstream), this test forces the

--- a/tests/unit/onchain-revert.test.ts
+++ b/tests/unit/onchain-revert.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { TRANSACTION: "transaction" },
+  logSystemWarn: vi.fn(),
+  logUserError: vi.fn(),
+}));
+
+import {
+  isOnChainRevertError,
+  OnChainRevertError,
+  revertedTransactionHash,
+} from "@/lib/web3/onchain-revert";
+import { resolveSponsoredSendError } from "@/lib/web3/sponsored-send-error";
+import { SponsoredTxRevertError } from "@/lib/web3/turnkey-revert";
+
+const HASH =
+  "0x3d65002347c5f59f51e13cfc94d7cdbd4b1cf76304bee9c54707970286358ed2";
+
+describe("OnChainRevertError", () => {
+  it("keeps the hash reachable without parsing the message", () => {
+    const error = new OnChainRevertError({
+      message: `Transaction ${HASH} reverted on-chain (status 0, block 11413412)`,
+      transactionHash: HASH,
+      blockNumber: 11_413_412,
+    });
+
+    expect(isOnChainRevertError(error)).toBe(true);
+    expect(revertedTransactionHash(error)).toBe(HASH);
+    expect(error.blockNumber).toBe(11_413_412);
+  });
+
+  it("preserves the message so message-only callers are unaffected", () => {
+    const message = `Transaction ${HASH} reverted on-chain (status 0, block 11413412)`;
+    const error = new OnChainRevertError({ message, transactionHash: HASH });
+
+    expect(error.message).toBe(message);
+    expect(error instanceof Error).toBe(true);
+  });
+
+  it("reports no hash for a pre-broadcast failure", () => {
+    // Nothing reached the chain, so there is nothing to reconcile and the
+    // finalizer must not record a transaction that does not exist.
+    expect(
+      revertedTransactionHash(new Error("insufficient funds"))
+    ).toBeUndefined();
+    expect(isOnChainRevertError(new Error("boom"))).toBe(false);
+    expect(revertedTransactionHash(undefined)).toBeUndefined();
+  });
+});
+
+describe("resolveSponsoredSendError", () => {
+  const ctx = {
+    logPrefix: "[Write Contract]",
+    actionName: "write-contract",
+    chainId: 11_155_111,
+  };
+
+  it("surfaces the hash of a sponsored transaction that reverted on-chain", () => {
+    const decision = resolveSponsoredSendError(
+      new SponsoredTxRevertError({
+        message: "execution reverted",
+        txHash: HASH,
+        sendTransactionStatusId: "sts_1",
+        revertChain: [],
+      }),
+      ctx
+    );
+
+    expect(decision.fallback).toBe(false);
+    if (decision.fallback === false) {
+      expect(decision.transactionHash).toBe(HASH);
+      // The message keeps the hash too, so existing consumers still work.
+      expect(decision.error).toContain(HASH);
+    }
+  });
+
+  it("carries no hash when a pre-broadcast failure falls back to direct signing", () => {
+    const decision = resolveSponsoredSendError(new Error("policy denied"), ctx);
+
+    expect(decision.fallback).toBe(true);
+  });
+});

--- a/tests/unit/step-transaction-hash-chain-id.test.ts
+++ b/tests/unit/step-transaction-hash-chain-id.test.ts
@@ -160,3 +160,72 @@ describe("step results that report a transaction hash", () => {
     });
   }
 });
+
+/**
+ * The type-level guard above protects reconciliation itself. This one covers
+ * the schema the platform publishes to agents and step authors: an action
+ * that advertises `transactionHash` in its outputFields but not `chainId`
+ * gives a reader no signal that omitting the chain fails the execution
+ * closed, which is exactly how the field came to be missing in the first
+ * place.
+ */
+const NON_EVM_HASH_ACTIONS = new Set([
+  "call-solana-program-anchor",
+  "send-raw-solana-instruction",
+  "transfer-spl-token",
+]);
+
+type PublishedAction = {
+  slug: string;
+  outputFields: string[];
+};
+
+function collectPublishedActions(): PublishedAction[] {
+  const actions: PublishedAction[] = [];
+  for (const plugin of readdirSync(PLUGINS_DIR, { withFileTypes: true })) {
+    if (!plugin.isDirectory()) {
+      continue;
+    }
+    let source: string;
+    try {
+      source = readFileSync(join(PLUGINS_DIR, plugin.name, "index.ts"), "utf8");
+    } catch {
+      continue;
+    }
+    for (const block of source.split(/\n {4}\{\n/).slice(1)) {
+      const slug = block.match(/^ {6}slug: "([^"]+)"/m)?.[1];
+      const fields = block.match(/outputFields: \[([\s\S]*?)\n {6}\],/)?.[1];
+      if (slug && fields) {
+        actions.push({
+          slug,
+          outputFields: [...fields.matchAll(/field: "([^"]+)"/g)].map(
+            (m) => m[1] as string
+          ),
+        });
+      }
+    }
+  }
+  return actions;
+}
+
+describe("published action schemas that report a transaction hash", () => {
+  const published = collectPublishedActions().filter((a) =>
+    a.outputFields.includes("transactionHash")
+  );
+
+  it("finds the EVM write actions", () => {
+    expect(published.length).toBeGreaterThan(0);
+  });
+
+  for (const { slug, outputFields } of published) {
+    if (NON_EVM_HASH_ACTIONS.has(slug)) {
+      continue;
+    }
+    it(`documents chainId alongside it: ${slug}`, () => {
+      expect(
+        outputFields.includes("chainId"),
+        `action "${slug}" publishes transactionHash without chainId; a step author reading this schema gets no signal that omitting the chain fails the execution closed`
+      ).toBe(true);
+    });
+  }
+});

--- a/tests/unit/verify-receipt.test.ts
+++ b/tests/unit/verify-receipt.test.ts
@@ -187,6 +187,68 @@ describe("verifyExecutionReceipts", () => {
   });
 });
 
+/**
+ * Gas-sponsored writes are a wrapped execution, not a direct send: Turnkey's
+ * Gas Station delegates the org wallet via EIP-7702, and a relayer EOA calls
+ * an executor contract which invokes the wallet. The hash an execution claims
+ * is therefore the outer relayer transaction, and everything this module
+ * concludes about a sponsored write is a statement about that outer receipt.
+ *
+ * That is safe only while the executor propagates an inner failure to the
+ * outer status, which was confirmed against Sepolia: a sponsored write whose
+ * inner call reverted produced an outer receipt with status 0. These tests pin
+ * the consequence of that assumption. If the executor ever starts absorbing
+ * inner failures and returning status 1 -- the shape Safe already has -- the
+ * first test here keeps passing while production silently settles failed
+ * writes as success, so treat it as a statement of what we rely on Turnkey
+ * for, and not as proof that sponsorship is safe by construction.
+ */
+describe("sponsored (wrapped) executions", () => {
+  beforeEach(() => {
+    executeWithFailover.mockReset();
+    resolveRpcConfig.mockReset();
+    resolveRpcConfig.mockResolvedValue({
+      chainId: CHAIN_ID,
+      chainName: "ethereum",
+      primaryRpcUrl: "https://primary.example",
+      fallbackRpcUrl: "https://fallback.example",
+    });
+  });
+
+  it("fails closed when the outer relayer transaction reverted", async () => {
+    executeWithFailover.mockResolvedValueOnce(makeReceipt(0));
+
+    const { allVerified, results } = await verifyExecutionReceipts([
+      { hash: HASH, chainId: CHAIN_ID },
+    ]);
+
+    expect(allVerified).toBe(false);
+    expect(results[0]).toMatchObject({ verified: false, status: "reverted" });
+  });
+
+  it("verifies a sponsored write whose outer transaction succeeded", async () => {
+    // Logs come from the target contract rather than the wallet, because the
+    // executor invokes the delegated wallet which then calls the target. None
+    // of them are Safe execution events, so nothing should be decoded here.
+    executeWithFailover.mockResolvedValueOnce(
+      makeReceipt(1, [
+        {
+          topics: [
+            "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925",
+          ],
+        },
+      ])
+    );
+
+    const { allVerified, results } = await verifyExecutionReceipts([
+      { hash: HASH, chainId: CHAIN_ID },
+    ]);
+
+    expect(allVerified).toBe(true);
+    expect(results[0]).toMatchObject({ verified: true, status: "success" });
+  });
+});
+
 describe("describeVerificationFailure", () => {
   it("summarizes failed entries with hash and human-readable status", () => {
     const message = describeVerificationFailure([


### PR DESCRIPTION
## Summary

A live verification suite run against production after the on-chain reconciliation work shipped confirmed the core gate works: a workflow with an approve step finalizes `success` carrying `chainId`, `verified: true`, `receiptStatus: "success"`, `blockNumber` and `verifiedAt`, and a genuine on-chain revert correctly finalizes `failed`. It also surfaced gaps around the receipts half of that work. This closes them, one commit each.

## Changes

**Expose receipts on direct-execution status.** `completeExecution()` has persisted `direct_executions.receipts` since the reconciliation gate landed, but the status route never returned the column, so a direct-execute caller could see that an execution had been gated without seeing what the gate observed. The workflow path already exposes the equivalent via `transactionHashes[]`.

**Record hash and receipt on failed direct executions.** A direct execution whose write reached the chain and reverted recorded `transactionHash: null` and no receipt; the hash survived only inside the error message. The hash was being discarded at a type boundary rather than never known: `SponsoredTxRevertError` already carried `txHash`, and the direct path threw a plain `Error` whose message embedded the hash, but both were flattened into a string before reaching the finalizer.

- New `OnChainRevertError` mirrors `SponsoredTxRevertError` for directly-signed writes. The message is unchanged, so callers that only read `error.message` behave identically.
- `SponsoredSendDecision` carries `transactionHash` for the reverted case, and deliberately not for accepted-but-unconfirmed, where no hash is known.
- All four write cores propagate `transactionHash`/`chainId`/`sponsored` on their failure variant. Doing three of four would repeat the class of bug where one step forgot to propagate `chainId` and failed every approve workflow closed.
- `failExecution` verifies a known hash, persists the receipt, and records the sponsored route, which previously always reported `false` on failures because `output` is not written on that path.

Solana is unaffected: the typed error is thrown only by the EVM adapter, so base58 signatures never reach reconciliation.

**Publish `chainId` on write actions that report a transaction hash.** The four EVM write actions advertised `transactionHash` in their `outputFields` but not `chainId`, so the schema agents and step authors read gave no signal that the field exists, let alone that reconciliation is fail-closed without it. The existing type-level guard protects reconciliation; it does not protect the published contract. Adds a schema-layer guard sharing the same Solana exemption, verified in both directions.

**Cover the sponsored write path, record the Safe branch's reachability.** Two wrapped-execution paths reach the receipt verifier and only one had been reasoned about. Gas sponsorship is the default first-tried path and is itself a wrapped execution: the wallet is delegated via EIP-7702 and a relayer EOA calls an executor contract. Every conclusion the verifier draws about a sponsored write is a statement about that outer relayer receipt.

The Safe branch is the inverse case: correct, and unreachable for transactions built here. `execTransaction` is constructed with `safeTxGas` and `gasPrice` zero, and Safe then reverts the whole outer transaction on inner failure. Verified on Sepolia in both directions - zero gives status 0 and no logs, non-zero gives status 1 plus `ExecutionFailure`. Documented rather than removed: the cost is one topic comparison, and any path that submits a Safe transaction it did not construct reaches it immediately.

**Document the verification fields and which surface is authoritative.** The workflow receipt gained `verified`, `receiptStatus`, `blockNumber`, `gasUsed` and `verifiedAt`, but the `transactionHashes` table documented none of them. Also states the boundary: a step's `transactionHash` in the logs endpoint is self-reported at the moment the step ran, with no verification fields attached.

## Test plan

- [x] `tsc --noEmit` clean
- [x] biome clean on all changed files
- [x] 150 tests pass across the 9 affected unit and integration files
- [x] New `tests/unit/onchain-revert.test.ts`: hash reachable without parsing the message, message preserved for message-only callers, no hash for pre-broadcast failures, sponsored decision surfaces the hash
- [x] New status-route coverage for both a verified execution and one demoted by reconciliation
- [x] New coverage for a broadcast transaction that reverts, asserting the finalizer receives hash, chain and route
- [x] Schema guard verified in both directions - it fails when `chainId` is removed
- [x] Safe semantics verified on Sepolia against a real owner-signed Safe, both `safeTxGas` values

## Notes for review

Two judgment calls worth a second opinion:

The Safe gap was resolved as "document" rather than "make `safeTxGas` configurable". Making it configurable would manufacture the outer-success-inner-failure shape the branch exists to defend against, for no current benefit. The zeros in `buildExecTransactionCalldata` are now marked load-bearing so they are not softened into a config option without that being a deliberate decision.

The sponsored-path test pins a dependency, not a proof. Sponsorship is safe only while the executor propagates inner failures to the outer status. That was confirmed against Sepolia, but if it ever starts absorbing them the test keeps passing while production silently settles failed writes as success. The comment says so explicitly.

## Not included

Monitoring that splits reconciliation failures by error category - confirmed transaction outcomes versus the gate misfiring on RPC latency or receipt visibility - is a dashboard and alert rather than code in this repo, so there is nothing to commit here. It is arguably the highest-value follow-up: the gate is fail-closed, and the live incident it already caused was correct on-chain work reported as failure.
