### PR TITLE
fix: accept API keys on execution cancel and workflow go-live

### DIFF
--- a/app/api/executions/[executionId]/cancel/route.ts
+++ b/app/api/executions/[executionId]/cancel/route.ts
@@ -1,67 +1,37 @@
 import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import {
-  workflowExecutionLogs,
-  workflowExecutions,
-  workflows,
-} from "@/lib/db/schema";
+import { workflowExecutionLogs, workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
-import { getOrgContext } from "@/lib/middleware/org-context";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import { requireScope } from "@/lib/middleware/require-scope";
+import { resolveAuthorizedExecution } from "@/lib/workflow/execution-access";
 
 export async function POST(
-  _request: Request,
+  request: Request,
   context: { params: Promise<{ executionId: string }> }
 ): Promise<NextResponse> {
   try {
     const { executionId } = await context.params;
 
-    const orgContext = await getOrgContext();
-
-    if (!orgContext.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    if (!orgContext.organization?.id) {
+    // Cancelling is organization-scoped, so it resolves auth the same way its
+    // sibling execution routes do (status, logs, wait) rather than reading the
+    // session directly. That admits `kh_` keys, and applies the shared
+    // org-membership and soft-delete rules in one place.
+    const resolved = await resolveAuthorizedExecution(request, executionId);
+    if (!resolved.ok) {
       return NextResponse.json(
-        { error: "No organization found" },
-        { status: 400 }
+        { error: resolved.error },
+        { status: resolved.status }
       );
     }
 
-    // Fetch execution and verify it belongs to the user's org via the workflow
-    const execution = await db.query.workflowExecutions.findFirst({
-      where: eq(workflowExecutions.id, executionId),
-      columns: {
-        id: true,
-        status: true,
-        workflowId: true,
-        startedAt: true,
-      },
-    });
-
-    if (!execution) {
-      return NextResponse.json(
-        { error: "Execution not found" },
-        { status: 404 }
-      );
+    const scopeError = requireScope(resolved.auth.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
 
-    // Verify the workflow belongs to the user's organization
-    const workflow = await db.query.workflows.findFirst({
-      where: and(
-        eq(workflows.id, execution.workflowId),
-        eq(workflows.organizationId, orgContext.organization.id)
-      ),
-      columns: { id: true },
-    });
-
-    if (!workflow) {
-      return NextResponse.json(
-        { error: "Execution not found" },
-        { status: 404 }
-      );
-    }
+    const { execution } = resolved;
 
     if (execution.status !== "running") {
       return NextResponse.json(

--- a/app/api/workflows/[workflowId]/go-live/route.ts
+++ b/app/api/workflows/[workflowId]/go-live/route.ts
@@ -4,8 +4,14 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { publicTags, workflowPublicTags, workflows } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
-import { getOrgContext } from "@/lib/middleware/org-context";
-import { buildAuditMetadata, recordAuditEvent } from "@/lib/security/audit-log";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { requireScope } from "@/lib/middleware/require-scope";
+import {
+  buildActor,
+  buildAuditMetadata,
+  recordAuditEvent,
+} from "@/lib/security/audit-log";
 import { getWorkflowAccess } from "@/lib/workflow/access";
 
 export async function PUT(
@@ -15,10 +21,20 @@ export async function PUT(
   try {
     const { workflowId } = await context.params;
 
-    const orgContext = await getOrgContext();
+    // Listing a workflow is organization-scoped, so it resolves auth the same
+    // way the other workflow mutation routes do rather than reading the
+    // session directly. That admits `kh_` keys.
+    const authContext = await getDualAuthContext(request);
+    if ("error" in authContext) {
+      return NextResponse.json(
+        { error: authContext.error },
+        { status: authContext.status }
+      );
+    }
 
-    if (!orgContext.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    if (scopeError) {
+      return scopeError;
     }
 
     const workflow = await db.query.workflows.findFirst({
@@ -33,9 +49,9 @@ export async function PUT(
     }
 
     const access = await getWorkflowAccess(workflow, {
-      userId: orgContext.user.id,
-      organizationId: orgContext.organization?.id ?? null,
-      authMethod: "session",
+      userId: authContext.userId,
+      organizationId: authContext.organizationId,
+      authMethod: authContext.authMethod,
     });
 
     // KEEP-440: a soft-deleted workflow cannot be taken live.
@@ -137,11 +153,7 @@ export async function PUT(
           ).map((r) => r.name)
         : [];
     await recordAuditEvent({
-      actor: {
-        userId: orgContext.user.id,
-        organizationId: orgContext.organization?.id ?? null,
-        authMethod: "session",
-      },
+      actor: buildActor(authContext),
       action: mode === "public" ? "workflow.listed" : "workflow.listing_updated",
       resourceType: "workflow",
       resourceId: workflowId,

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -54,8 +54,10 @@ Endpoints whose semantics are organization-scoped accept `kh_` keys:
 - Workflow CRUD and execution: `/api/workflows`, including
   `POST /api/workflows/{workflowId}/execute` and execution history and status
   (`GET /api/workflows/{workflowId}/executions` and
-  `GET /api/workflows/executions/{executionId}/{status,logs,wait}`).
+  `GET /api/workflows/executions/{executionId}/{status,logs,wait}`), and
+  listing (`PUT /api/workflows/{workflowId}/go-live`).
   A few sub-paths are session-only; see [Session-only](#session-only) below
+- Execution cancellation: `POST /api/executions/{executionId}/cancel`
 - Direct execution: everything under `/api/execute` - `/transfer`,
   `/contract-call`, `/check-and-execute`, `/swap`, `/node`, protocol actions
   (`/api/execute/{protocol}/{action}`), and
@@ -77,7 +79,6 @@ Endpoints that act on a user account, hold credential material, or sit on a huma
 - **Authentication primitives**: creating organization API keys (`POST /api/keys`), creating/listing/deleting personal webhook keys (`/api/api-keys/*`), AI Gateway OAuth flows
 - **Human-in-the-loop wallet approvals**: agentic-wallet linking and approve/reject endpoints
 - **Per-user state**: workflow drafts, workflow ratings, leaving an organization
-- **Organization-scoped but session-gated**: `POST /api/executions/{executionId}/cancel` and `POST /api/workflows/{workflowId}/go-live`. These two do not follow the rationale above - their semantics are organization-scoped, but the routes resolve auth from the session only. Treat them as current implementation limits rather than deliberate boundaries.
 
 If you have a use case for session-only behavior over an API key, open an issue describing it. The boundary is deliberate: it keeps a leaked API key from escalating into account control or wallet drainage.
 

--- a/lib/workflow/execution-access.ts
+++ b/lib/workflow/execution-access.ts
@@ -3,8 +3,13 @@ import "server-only";
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { workflowExecutions } from "@/lib/db/schema";
-import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import {
+  type DualAuthContext,
+  getDualAuthContext,
+} from "@/lib/middleware/auth-helpers";
 import { getWorkflowAccess } from "@/lib/workflow/access";
+
+type AuthenticatedContext = Exclude<DualAuthContext, { error: string }>;
 
 function loadExecutionWithWorkflow(executionId: string) {
   return db.query.workflowExecutions.findFirst({
@@ -18,7 +23,7 @@ export type AuthorizedExecution = NonNullable<
 >;
 
 export type ExecutionAccessResult =
-  | { ok: true; execution: AuthorizedExecution }
+  | { ok: true; execution: AuthorizedExecution; auth: AuthenticatedContext }
   | { ok: false; status: number; error: string };
 
 /**
@@ -60,5 +65,5 @@ export async function resolveAuthorizedExecution(
     return { ok: false, status: 404, error: "Execution not found" };
   }
 
-  return { ok: true, execution };
+  return { ok: true, execution, auth: authContext };
 }

--- a/tests/unit/execution-cancel-route.test.ts
+++ b/tests/unit/execution-cancel-route.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const {
+  mockFindFirst,
+  mockGetDualAuthContext,
+  mockGetWorkflowAccess,
+  mockSet,
+  mockWhere,
+} = vi.hoisted(() => {
+  const where = vi.fn().mockResolvedValue(undefined);
+  const set = vi.fn(() => ({ where }));
+  return {
+    mockFindFirst: vi.fn(),
+    mockGetDualAuthContext: vi.fn(),
+    mockGetWorkflowAccess: vi.fn(),
+    mockSet: set,
+    mockWhere: where,
+  };
+});
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: { workflowExecutions: { findFirst: mockFindFirst } },
+    update: () => ({ set: mockSet }),
+  },
+}));
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: { id: "id" },
+  workflowExecutionLogs: { executionId: "execution_id", status: "status" },
+}));
+vi.mock("@/lib/middleware/auth-helpers", () => ({
+  getDualAuthContext: mockGetDualAuthContext,
+}));
+vi.mock("@/lib/workflow/access", () => ({
+  getWorkflowAccess: mockGetWorkflowAccess,
+}));
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "database" },
+  logSystemError: vi.fn(),
+}));
+
+const ROUTE = "@/app/api/executions/[executionId]/cancel/route";
+
+function makeRequest(): Request {
+  return new Request("https://app.keeperhub.com/api/executions/exec-1/cancel", {
+    method: "POST",
+  });
+}
+
+function makeContext(executionId: string) {
+  return { params: Promise.resolve({ executionId }) };
+}
+
+describe("POST cancel-execution route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: "user-1",
+      organizationId: "org-1",
+      authMethod: "api-key",
+      apiKeyId: "key-1",
+      isAnonymous: false,
+    });
+    mockGetWorkflowAccess.mockResolvedValue({
+      hasFullAccess: true,
+      isDeleted: false,
+    });
+    mockFindFirst.mockResolvedValue({
+      id: "exec-1",
+      status: "running",
+      startedAt: new Date(Date.now() - 1000),
+      workflow: { id: "wf-1", organizationId: "org-1" },
+    });
+  });
+
+  // The route previously resolved auth from the session only, so an org API
+  // key could start and poll an execution but never stop one.
+  it("lets an api-key caller cancel a running execution", async () => {
+    const { POST } = await import(ROUTE);
+    const response = await POST(makeRequest(), makeContext("exec-1"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "cancelled" })
+    );
+  });
+
+  it("rejects a caller without full access to the workflow", async () => {
+    mockGetWorkflowAccess.mockResolvedValue({
+      hasFullAccess: false,
+      isDeleted: false,
+    });
+
+    const { POST } = await import(ROUTE);
+    const response = await POST(makeRequest(), makeContext("exec-1"));
+
+    expect(response.status).toBe(404);
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("hides executions belonging to a soft-deleted workflow", async () => {
+    mockGetWorkflowAccess.mockResolvedValue({
+      hasFullAccess: true,
+      isDeleted: true,
+    });
+
+    const { POST } = await import(ROUTE);
+    const response = await POST(makeRequest(), makeContext("exec-1"));
+
+    expect(response.status).toBe(404);
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("refuses an OAuth token that lacks the write scope", async () => {
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: "user-1",
+      organizationId: "org-1",
+      authMethod: "oauth",
+      apiKeyId: null,
+      scope: "mcp:read",
+      isAnonymous: false,
+    });
+
+    const { POST } = await import(ROUTE);
+    const response = await POST(makeRequest(), makeContext("exec-1"));
+
+    expect(response.status).toBe(403);
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("propagates the auth error when the caller is unauthenticated", async () => {
+    mockGetDualAuthContext.mockResolvedValue({
+      error: "Unauthorized",
+      status: 401,
+    });
+
+    const { POST } = await import(ROUTE);
+    const response = await POST(makeRequest(), makeContext("exec-1"));
+
+    expect(response.status).toBe(401);
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("refuses to cancel an execution that is not running", async () => {
+    mockFindFirst.mockResolvedValue({
+      id: "exec-1",
+      status: "success",
+      startedAt: new Date(),
+      workflow: { id: "wf-1", organizationId: "org-1" },
+    });
+
+    const { POST } = await import(ROUTE);
+    const response = await POST(makeRequest(), makeContext("exec-1"));
+
+    expect(response.status).toBe(400);
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("marks in-flight step logs cancelled alongside the execution", async () => {
+    const { POST } = await import(ROUTE);
+    await POST(makeRequest(), makeContext("exec-1"));
+
+    expect(mockSet).toHaveBeenCalledTimes(2);
+    expect(mockWhere).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Problem

`POST /api/executions/{executionId}/cancel` and `PUT /api/workflows/{workflowId}/go-live` resolved auth through `getOrgContext()`, which reads the better-auth session only. No apiKey plugin is registered in `lib/auth.ts`, so a `kh_` bearer never resolves through that path; API keys are handled separately via `authenticateApiKey` / `getDualAuthContext`.

Both routes are organization-scoped in their semantics, and every sibling route on the same surface already accepts keys. The practical effect is that an API-key integration could start a workflow and poll its status but had no way to stop a running execution.

Found while reviewing the endpoint-scope docs correction in #1885.

## Changes

**Cancel** now routes through `resolveAuthorizedExecution`, the helper its siblings (status, logs, wait) already share, instead of hand-rolling an `organizationId` match. It picks up the shared org-membership and soft-delete rules, so a soft-deleted workflow now hides its executions here too rather than leaking existence. The helper returns the resolved auth context so the route can apply a `SCOPE_MCP_WRITE` check.

Moving off `getOrgContext` also brings cancel under the defence-in-depth CSRF origin check inside `getDualAuthContext`, which the session-only path skipped. The root proxy was the only enforcement before.

**Go-live** moves to `getDualAuthContext` with the same scope check. Its audit actor now uses `buildActor(authContext)` rather than an object literal that hardcoded `authMethod: "session"` and dropped `apiKeyId`, so key-authenticated listings are attributed correctly.

**Docs**: `docs/api/authentication.md` moves both endpoints into the accepted-on-API-keys list.

## Tests

`tests/unit/execution-cancel-route.test.ts` is new; the route had no coverage. It mocks at the auth-helpers level so it exercises the real `resolveAuthorizedExecution` change rather than stubbing it out, and covers api-key acceptance, the access and soft-delete 404s, scope refusal, the not-running guard, and the auth-error passthrough.

## Verification

- `tsc --noEmit` clean
- Full unit suite green (480 files, 20212 tests)
- New test 7/7
- Biome clean on the changed files. Note `app/api/workflows` is biome-ignored by config, so go-live is not linted.

## Risk

`ExecutionAccessResult` gains a field rather than changing one, so the three existing callers are unaffected; `tsc` covers that. The behaviour change for cancel is that it now applies org-membership and soft-delete checks it previously skipped, which is stricter, not looser.
