### PR TITLE
ci: block merge while the decision label is present

### DIFF
--- a/.github/workflows/decision-label-check.yml
+++ b/.github/workflows/decision-label-check.yml
@@ -1,0 +1,51 @@
+name: Decision Label Check
+
+# Blocks merge while the `decision` label is present.
+#
+# `decision` means the PR is waiting on a maintainer, not on the contributor:
+# an API shape that becomes a contract, a new dependency, a behaviour change to
+# an existing default, anything touching pricing, limits, auth or permissions,
+# or a product judgement the diff alone cannot settle.
+#
+# Why a merge gate rather than a convention: an open decision is easy to lose.
+# It lives in a review comment, the PR otherwise looks healthy, CI is green, and
+# it merges with the question never answered - the decision is then made by
+# default rather than on purpose. This turns that into a red check.
+#
+# Workflow:
+#   1. Reviewer raises a needs-decision finding and adds `decision`.
+#   2. This check fails, so the PR cannot merge.
+#   3. A maintainer answers the question in a comment on the PR, so the
+#      reasoning is on the record and not just in someone's head.
+#   4. They remove the label. The check re-runs and passes on `unlabeled`.
+#
+# Removing the label is the act of deciding. Do not remove it to unblock a
+# merge without answering - that is the failure mode this exists to prevent.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - staging
+      - prod
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  decision-label-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail while the decision label is present
+        env:
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+          if printf '%s' "$LABELS_JSON" | jq -e 'any(. == "decision")' >/dev/null; then
+            echo "::error::This PR carries the 'decision' label: it is blocked on a maintainer decision, not on the contributor."
+            echo "::error::Answer the open question in a comment on this PR, then remove the 'decision' label. This check re-runs on unlabeled."
+            echo "::error::Removing the label without answering defeats the gate - the decision then gets made by default at merge time."
+            exit 1
+          fi
+          echo "No 'decision' label; nothing is blocked on a maintainer."


### PR DESCRIPTION
Adds a `Decision Label Check` workflow that fails while the `decision` label is on a PR.

## What `decision` means

The PR is waiting on a maintainer, not on the contributor: an API shape that becomes a contract, a new dependency, a behaviour change to an existing default, anything touching pricing, limits, auth or permissions, or a product judgement the diff alone cannot settle.

It sits alongside the existing triage labels and answers a question neither of them can - **who is blocked?** `changes requested` says the contributor owes us work. `decision` says we owe them an answer. A PR can carry both.

## Why a merge gate rather than a convention

An open decision is easy to lose. It lives in a review comment, the PR otherwise looks healthy, CI is green, and it merges with the question never answered - at which point the decision has been made by default rather than on purpose. That is the failure mode this converts into a red check.

Removing the label is the act of deciding. The workflow's error message says so explicitly, because the obvious way to defeat the gate is to strip the label to unblock a merge.

## Behaviour

- Fails when `decision` is present, with an error pointing at what to do.
- Passes when it is absent.
- Triggers on `labeled` / `unlabeled` as well as the usual events, so the check flips as soon as the label changes rather than waiting for a push. Same approach as `db-prep-check`.
- `permissions: contents: read`, no checkout, no secrets - it only reads `github.event.pull_request.labels`.

## Follow-up (not in this PR)

To actually block merge rather than just show red, `decision-label-check` needs adding to the branch-protection ruleset for `staging`, `prod` and `main`, the same way `db-prep-check` is. That is a repo-settings change and deliberately not attempted here.

## Test plan

- [x] YAML parses; job, triggers, branches and permissions confirmed
- [x] jq predicate: `["decision","changes requested"]` fails, `["changes requested"]` passes, `[]` passes
- [ ] Confirm red on this PR once the `decision` label is applied, and green when removed
