### PR TITLE
fix(e2e): keep the getting-started launcher collapsed in playwright runs

### DIFF
--- a/lib/hooks/use-getting-started.ts
+++ b/lib/hooks/use-getting-started.ts
@@ -9,6 +9,7 @@ import {
   type SignalId,
   type Step,
 } from "@/lib/onboarding/getting-started-config";
+import { gettingStartedSuppressed } from "@/lib/onboarding/tours-disabled";
 
 /**
  * Persisted UI state + completion for the getting-started launcher (KEEP-878).
@@ -86,8 +87,11 @@ function readPersisted(userId: string | undefined): Persisted {
       // visible by default. Once they collapse or dismiss it, that choice is
       // persisted and honored. Guard on userId so the pre-hydration render
       // (userId undefined) stays collapsed and existing users do not flash open
-      // before their stored collapsed state loads.
-      return userId ? { ...fallback, state: "expanded" } : fallback;
+      // before their stored collapsed state loads. Playwright suppresses the
+      // auto-expand by cookie so the card never covers the canvas.
+      return userId && !gettingStartedSuppressed()
+        ? { ...fallback, state: "expanded" }
+        : fallback;
     }
     const parsed = JSON.parse(raw) as Partial<Persisted>;
     return {

--- a/lib/onboarding/tours-disabled.ts
+++ b/lib/onboarding/tours-disabled.ts
@@ -3,9 +3,23 @@
 // never blocks unrelated tests; the onboarding tests opt out to exercise them.
 const DISABLE_TOURS_COOKIE = "kh_disable_tours=1";
 
+// The first-run "Get started" launcher auto-expands into a card that overhangs
+// the sidebar onto the canvas, where it intercepts clicks on workflow nodes.
+// Playwright sets this cookie by default (see tests/e2e/playwright/fixtures.ts)
+// so the launcher stays collapsed; the getting-started tests opt out.
+const DISABLE_GETTING_STARTED_COOKIE = "kh_disable_gs=1";
+
 export function toursDisabled(): boolean {
   return (
     typeof document !== "undefined" &&
     document.cookie.includes(DISABLE_TOURS_COOKIE)
+  );
+}
+
+/** Whether the getting-started launcher should skip its first-run auto-expand. */
+export function gettingStartedSuppressed(): boolean {
+  return (
+    typeof document !== "undefined" &&
+    document.cookie.includes(DISABLE_GETTING_STARTED_COOKIE)
   );
 }

--- a/tests/e2e/playwright/fixtures.ts
+++ b/tests/e2e/playwright/fixtures.ts
@@ -60,6 +60,8 @@ export const test = base.extend<{
   apiRequest: AuthenticatedApiRequest;
   disableTours: boolean;
   _disableToursCookie: undefined;
+  disableGettingStarted: boolean;
+  _disableGettingStartedCookie: undefined;
 }>({
   _turnstileStub: [
     async ({ page }, use) => {
@@ -79,6 +81,28 @@ export const test = base.extend<{
         await context.addCookies([
           {
             name: "kh_disable_tours",
+            value: "1",
+            url: baseURL ?? "http://localhost:3000",
+          },
+        ]);
+      }
+      await use(undefined);
+    },
+    { auto: true },
+  ],
+  // The first-run "Get started" launcher auto-expands into a card wider than
+  // the sidebar, so it overhangs the canvas and intercepts clicks on workflow
+  // nodes. Every browser context is first-run, so it would expand in every
+  // test. Suppressed by default via a cookie the app checks
+  // (lib/onboarding/tours-disabled.ts); getting-started.test.ts opts back in
+  // with `test.use({ disableGettingStarted: false })`.
+  disableGettingStarted: [true, { option: true }],
+  _disableGettingStartedCookie: [
+    async ({ context, baseURL, disableGettingStarted }, use) => {
+      if (disableGettingStarted) {
+        await context.addCookies([
+          {
+            name: "kh_disable_gs",
             value: "1",
             url: baseURL ?? "http://localhost:3000",
           },

--- a/tests/e2e/playwright/getting-started.test.ts
+++ b/tests/e2e/playwright/getting-started.test.ts
@@ -5,6 +5,10 @@ import { expect, test } from "./fixtures";
 // user (no persisted state) it auto-expands into a single-branch (agent)
 // checklist and persists its state per user.
 
+// The rest of the suite suppresses the first-run auto-expand (see fixtures.ts)
+// so the card never covers the canvas; this file exercises it, so opt back in.
+test.use({ disableGettingStarted: false });
+
 // Clear any persisted launcher state so each test starts from the default
 // (a fresh, never-seen user), regardless of what a prior run left behind.
 async function resetLauncher(


### PR DESCRIPTION
## Problem

`e2e-playwright-ephemeral` failed on staging: `schedule-trigger.test.ts:18` timed out clicking `.react-flow__node-trigger`. The node resolved, was visible/enabled/stable, and every click attempt for 60s was intercepted.

The interceptor Playwright names is a step row inside the fixed left sidebar:

```
<div class="flex items-start gap-2 p-2"> from
<div class="pointer-events-auto fixed top-[calc(60px+var(--app-banner-height,0px))] bottom-0 left-0 z-40 ...">
subtree intercepts pointer events
```

The failure screenshot confirms it: the first-run "Get started" launcher is expanded over the canvas. The card is `w-80` (320px) anchored in a ~200px sidebar, so it overhangs the canvas by ~130px, and the trigger node's click point lands inside it.

## Root cause

`readPersisted` in `lib/hooks/use-getting-started.ts` returns `state: "expanded"` whenever there is no stored entry and a userId is known. Every Playwright browser context is first-run, so the launcher auto-expands in every test. It lands after auth hydration, so it races the click, and whether it actually covers the node depends on where `fitView` leaves the canvas - hence intermittent rather than a hard break. Any test that clicks a canvas node is exposed, not just this one.

## Fix

Suppress the first-run auto-expand behind a `kh_disable_gs` cookie, mirroring the existing `kh_disable_tours` mechanism for the driver.js tours:

- `lib/onboarding/tours-disabled.ts` - new `gettingStartedSuppressed()`
- `lib/hooks/use-getting-started.ts` - auto-expand gated on `!gettingStartedSuppressed()`
- `tests/e2e/playwright/fixtures.ts` - `disableGettingStarted` option, default `true`, sets the cookie
- `tests/e2e/playwright/getting-started.test.ts` - opts back in with `test.use({ disableGettingStarted: false })`

No behaviour change for real users: the cookie is only ever set by the Playwright fixture. Collapsed state renders the pill inside the sidebar, with no canvas overhang.

`onboarding.test.ts` needs no change - it seeds `state: "expanded"` into localStorage explicitly, which takes precedence over the first-run default.

## Verification

- `tsc --noEmit` clean
- `biome check` clean on the changed files
- CI here exercises the affected Playwright suites

## Not addressed

The trigger node renders partly under the left nav sidebar at all - `fitViewSidebarAware` compensates for the right panel width only, not the fixed left sidebar. Separate, cosmetic, left alone deliberately.
