### PR TITLE
docs: note that the wallet allowlist covers the token, not the recipient

### DIFF
--- a/docs/ai-tools/agentic-wallet.md
+++ b/docs/ai-tools/agentic-wallet.md
@@ -56,6 +56,12 @@ Every wallet signing call is gated by a `PreToolUse` hook that reads thresholds 
 
 The hook reads only the payment-challenge fields `amount`, `unit`, and the asset contract address from the tool payload. Forged fields like `trust-level hint` or `admin-override` are ignored by design.
 
+> **The allowlist covers which token is spent, not who receives it.**
+>
+> `allowlisted_contracts` and the [server-side contract allowlist](#server-side-hard-limits) both constrain the ERC-20 being transferred. Neither reads the challenge's `payTo` — the transfer recipient — so **any** address is a valid destination for a payment that clears the amount tiers. The hook is also stateless: it sees one payment at a time, so repeated payments each under `auto_approve_max_usd` all pass, bounded only by the [daily spend cap](#server-side-hard-limits).
+>
+> This is deliberate — `payTo` is the facilitator or service operator, not the contract being invoked, so it is not what a *contract* allowlist should match on. But it means "allowlist" here answers *what may be spent*, not *who may be paid*. If your agent should only ever pay a known set of services, enforce that in your own `PreToolUse` hook or in a wrapper around `paymentSigner`; the tiers above will not do it for you.
+
 ### Server-side hard limits
 
 Beyond the client-side hook, a set of Turnkey-enforced policies apply to every wallet and cannot be bypassed by editing `safety.json` or changing the agent's hook. They are created per sub-organisation at provision time and enforced by Turnkey itself on every signing activity:

--- a/docs/ai-tools/agentic-wallet.md
+++ b/docs/ai-tools/agentic-wallet.md
@@ -62,7 +62,7 @@ The hook reads only the payment-challenge fields `amount`, `unit`, and the asset
 >
 > **The recipient is constrained by `/sign`'s workflow binding instead.** A signing request must carry a `workflowSlug`; the route derives the expected recipient from that workflow's organisation wallet and rejects a mismatch with `403 PAYTO_MISMATCH`. So an arbitrary destination is refused — by the workflow binding, not by an allowlist and not by a Turnkey policy.
 >
-> Two consequences worth knowing. The client-side tiers approve without ever considering the recipient, so a local `allowlisted_contracts` entry gives no assurance about *where* funds go. And the hook is stateless — it sees one payment at a time, so repeated payments each under `auto_approve_max_usd` all pass. The bound on that is server-side: the [daily spend cap](#server-side-hard-limits), plus a server-side `ask` at 50 USDC and `block` at 100 USDC that apply on every signing request independently of `safety.json`.
+> Two consequences worth knowing. The client-side tiers approve without ever considering the recipient, so a local `allowlisted_contracts` entry gives no assurance about *where* funds go. And the hook is stateless — it sees one payment at a time, so repeated payments each under `auto_approve_max_usd` all pass. The bound on that is server-side: the [daily spend cap](#server-side-hard-limits), plus a server-side `ask` at 50 USDC and `block` above 100 USDC that apply on every signing request independently of `safety.json`.
 >
 > If your agent should only pay a specific subset of workflows, or should hold to a budget you set, enforce that in your own `PreToolUse` hook or in a wrapper around `paymentSigner`. The tiers above will not do it for you.
 
@@ -185,9 +185,11 @@ This is a custodial model. You are trusting KeeperHub to honour the policy limit
 
 A set of Turnkey policies, applied per sub-organisation at provision time and enforced by Turnkey itself (not by application code). Full list above under [Server-side hard limits](#server-side-hard-limits). Briefly: signing only against the Base USDC / Tempo USDC.e contracts, no `approve()` above 100 USDC, no `transfer()` or `transferFrom()` above 100 USDC, and EIP-712 signing restricted to allowlisted chain ids and verifying contracts.
 
-If KeeperHub's operator key is compromised, the attacker is still bound by these policies. They cannot approve an arbitrary contract to spend your balance, and they cannot sign against a contract outside the USDC allowlist.
+If KeeperHub's operator key is compromised, the attacker is still bound by these policies. They cannot approve an arbitrary contract to spend your balance, and they cannot sign against a contract outside [the allowlisted set](#server-side-hard-limits) — Base USDC, Tempo USDC.e, and the ERC-8004 `ReputationRegistry`. The registry is bound to Ethereum mainnet and restricted to `giveFeedback()`, so it moves no funds, but it is a third allowlisted destination and not a USDC contract.
 
-They also cannot drain funds to an arbitrary address — but that constraint comes from `/sign`'s workflow binding, not from the Turnkey policy set. The policy conditions cover `eth.tx.to` and `eth.eip_712.domain.verifying_contract`; neither is the transfer recipient. The recipient is checked when the signing request is served, by deriving it from the workflow being paid and rejecting anything else with `403 PAYTO_MISMATCH`. See [the note under Safety hooks](#safety-hooks).
+**The recipient constraint is weaker than the ones above, and the difference matters here.** An attacker also cannot drain funds to an arbitrary address — but that comes from `/sign`'s workflow binding, not from the Turnkey policy set. The policy conditions cover `eth.tx.to` and `eth.eip_712.domain.verifying_contract`; neither is the transfer recipient. `verifyWorkflowBinding` is application code that reads the `workflows` and `organizationWallets` tables and rejects a mismatch with `403 PAYTO_MISMATCH`.
+
+So the Turnkey policies survive a compromise of the application because Turnkey enforces them. The recipient pin holds only while the application and those records are intact — it is the compromised application checking itself. See [the note under Safety hooks](#safety-hooks).
 
 ### What happens if I lose `wallet.json`?
 

--- a/docs/ai-tools/agentic-wallet.md
+++ b/docs/ai-tools/agentic-wallet.md
@@ -56,11 +56,15 @@ Every wallet signing call is gated by a `PreToolUse` hook that reads thresholds 
 
 The hook reads only the payment-challenge fields `amount`, `unit`, and the asset contract address from the tool payload. Forged fields like `trust-level hint` or `admin-override` are ignored by design.
 
-> **The allowlist covers which token is spent, not who receives it.**
+> **The allowlists cover which token is spent. The recipient is pinned somewhere else.**
 >
-> `allowlisted_contracts` and the [server-side contract allowlist](#server-side-hard-limits) both constrain the ERC-20 being transferred. Neither reads the challenge's `payTo` — the transfer recipient — so **any** address is a valid destination for a payment that clears the amount tiers. The hook is also stateless: it sees one payment at a time, so repeated payments each under `auto_approve_max_usd` all pass, bounded only by the [daily spend cap](#server-side-hard-limits).
+> `allowlisted_contracts` and the [server-side contract allowlist](#server-side-hard-limits) both constrain the ERC-20 being transferred. Neither reads the challenge's `payTo` — so no *allowlist*, local or Turnkey, restricts who is paid. That is deliberate: `payTo` is the facilitator or service operator, not the contract being invoked, so it is not what a contract allowlist should match on.
 >
-> This is deliberate — `payTo` is the facilitator or service operator, not the contract being invoked, so it is not what a *contract* allowlist should match on. But it means "allowlist" here answers *what may be spent*, not *who may be paid*. If your agent should only ever pay a known set of services, enforce that in your own `PreToolUse` hook or in a wrapper around `paymentSigner`; the tiers above will not do it for you.
+> **The recipient is constrained by `/sign`'s workflow binding instead.** A signing request must carry a `workflowSlug`; the route derives the expected recipient from that workflow's organisation wallet and rejects a mismatch with `403 PAYTO_MISMATCH`. So an arbitrary destination is refused — by the workflow binding, not by an allowlist and not by a Turnkey policy.
+>
+> Two consequences worth knowing. The client-side tiers approve without ever considering the recipient, so a local `allowlisted_contracts` entry gives no assurance about *where* funds go. And the hook is stateless — it sees one payment at a time, so repeated payments each under `auto_approve_max_usd` all pass. The bound on that is server-side: the [daily spend cap](#server-side-hard-limits), plus a server-side `ask` at 50 USDC and `block` at 100 USDC that apply on every signing request independently of `safety.json`.
+>
+> If your agent should only pay a specific subset of workflows, or should hold to a budget you set, enforce that in your own `PreToolUse` hook or in a wrapper around `paymentSigner`. The tiers above will not do it for you.
 
 ### Server-side hard limits
 
@@ -181,7 +185,9 @@ This is a custodial model. You are trusting KeeperHub to honour the policy limit
 
 A set of Turnkey policies, applied per sub-organisation at provision time and enforced by Turnkey itself (not by application code). Full list above under [Server-side hard limits](#server-side-hard-limits). Briefly: signing only against the Base USDC / Tempo USDC.e contracts, no `approve()` above 100 USDC, no `transfer()` or `transferFrom()` above 100 USDC, and EIP-712 signing restricted to allowlisted chain ids and verifying contracts.
 
-If KeeperHub's operator key is compromised, the attacker is still bound by these policies. They cannot drain funds to an arbitrary address or approve an arbitrary contract to spend your balance.
+If KeeperHub's operator key is compromised, the attacker is still bound by these policies. They cannot approve an arbitrary contract to spend your balance, and they cannot sign against a contract outside the USDC allowlist.
+
+They also cannot drain funds to an arbitrary address — but that constraint comes from `/sign`'s workflow binding, not from the Turnkey policy set. The policy conditions cover `eth.tx.to` and `eth.eip_712.domain.verifying_contract`; neither is the transfer recipient. The recipient is checked when the signing request is served, by deriving it from the workflow being paid and rejecting anything else with `403 PAYTO_MISMATCH`. See [the note under Safety hooks](#safety-hooks).
 
 ### What happens if I lose `wallet.json`?
 


### PR DESCRIPTION
## What this adds

Six lines to `docs/ai-tools/agentic-wallet.md` stating that the wallet's allowlists constrain **which token is spent**, not **who receives it**.

## Why

The Safety hooks section is accurate — it already says the hook reads only `amount`, `unit`, and the asset contract address. What it does not say is the consequence, and the page uses the word *allowlist* eleven times without ever answering which of these two questions it settles:

- *what may be spent* — `allowlisted_contracts`, and the server-side contract allowlist
- *who may be paid* — nothing

`payTo` and *recipient* appear nowhere on the page. A reader who has just configured `allowlisted_contracts` and read "Signing is denied on any call whose target contract is not Base USDC" has been given every reason to believe their agent can only pay approved destinations. It can pay any address that clears the amount tiers.

The hook is also stateless, which compounds it: it sees one payment at a time, so N payments each under `auto_approve_max_usd` all pass. The daily cap bounds the total; nothing bounds the destination.

Reproducible against the published package in about a second, no key and no funds:

```js
import { createPreToolUseHook } from "@keeperhub/wallet";

const hook = await createPreToolUseHook();
await hook({
  tool_name: "keeperhub_wallet_sign",
  tool_input: {
    paymentChallenge: {
      amount: 4.99, unit: "usd",
      asset: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913", // allowlisted
      payTo: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",  // arbitrary
    },
  },
});
// -> { decision: "allow" }
```

## Framing

Written as deliberate design rather than as a defect, because that is what it is — `hook.ts` says so directly:

```
// NEVER reads challenge.payTo: that is the transfer recipient (the
// facilitator or service operator), not the ERC-20 contract being invoked.
```

That reasoning is correct. `payTo` is not the contract, so a *contract* allowlist should not match on it. The gap is not in the behaviour; it is in what the docs currently let a reader conclude about it. The note ends by pointing at where a recipient check does belong — the caller's own `PreToolUse` hook, or a wrapper around `paymentSigner`.

## Notes

- Docs only. No behaviour change.
- Touches the same file as #1902, but a different section (Safety hooks vs. the install steps), so they should not conflict.
- Both anchor links (`#server-side-hard-limits`) resolve to headings already on the page.
