### PR TITLE
docs: state which entry points the safety tiers actually cover

### DIFF
--- a/docs/ai-tools/agentic-wallet.md
+++ b/docs/ai-tools/agentic-wallet.md
@@ -70,26 +70,46 @@ The hook reads only the payment-challenge fields `amount`, `unit`, and the asset
 
 The tiers live in a `PreToolUse` hook, which is an **agent-framework** mechanism — `skill install` registers it in `~/.claude/settings.json`. Enforcement therefore depends on how the payment is initiated:
 
-| Entry point | auto / ask / block |
-|---|---|
-| **Claude Code** | **Yes** — `skill install` registers the hook in `~/.claude/settings.json` |
-| **Cursor, Cline, Windsurf, OpenCode** | **No.** `skill install` writes the skill file for these agents but does not register a hook — it prints a notice that the agent does not support auto-registered hooks. The skill is installed; the tiers are not enforced |
-| **`keeperhub-wallet-mcp`** (the wallet package's own stdio server) | **`block_threshold_usd` only, and only for x402.** Enforced inline before signing, because the hook fires on the MCP tool call where there is no payment shape yet. **MPP amounts are not checked** — the client never decodes the credential, so the cap check is skipped and the server-side limits are the only bound |
-| Your own code importing `@keeperhub/wallet` and calling `paymentSigner.fetch()` directly — a backend service, a scheduled job, a test harness | **No** — nothing reads `safety.json` on this path |
+Coverage is **per path, not per agent** — most agents get one of the two mechanisms but not both:
 
-The [server-side hard limits](#server-side-hard-limits) apply to every row and cannot be bypassed, so none of these is unbounded. But `~/.keeperhub/safety.json` does not read as framework-scoped — it is a user-level file, in a user-level directory, named after the package rather than after the agent. Someone who sets `block_threshold_usd: 10`, then runs their agent in Cursor or writes a script against the package, will reasonably expect that limit to hold. It will not.
+| Entry point | `PreToolUse` hook | MCP `block_threshold_usd` |
+|---|---|---|
+| **Claude Code** | **Yes** — `skill install` registers it in `~/.claude/settings.json` | Yes |
+| **Cursor, Windsurf, OpenCode** | **No** — `skill install` writes the skill file and prints a notice that the agent does not support auto-registered hooks | **Yes** — the MCP server is auto-registered, so paid `call_workflow` calls hit the cap |
+| **Cline** | **No** | **No** — no known MCP config location, so neither mechanism is registered |
+| **`keeperhub-wallet-mcp`** (the wallet package's own stdio server) | n/a — the hook fires on the MCP tool call, where there is no payment shape yet | **x402 only.** The cap is computed from the decoded x402 amount; **MPP amounts are not checked**, because the client never decodes the credential |
+| Your own code importing `@keeperhub/wallet` and calling `paymentSigner.fetch()` directly — a backend service, a scheduled job, a test harness | **No** | **No** — nothing reads `safety.json` on this path |
+| **`feedback`** — the MCP tool and the `keeperhub-wallet feedback` CLI command | **No** | **No** — see below |
+
+**`feedback` is gated by neither, and it spends real money.** It signs and broadcasts a `giveFeedback()` transaction on Ethereum mainnet, and its own tool description puts the cost at roughly $0.05–2 per call in native gas. The safety config is loaded at exactly one place — inside the `call_workflow` handler — so no other tool consults it. The hook does not catch it either: the tool's input schema declares `executionId`, `value`, `valueDecimals`, `comment`, `agentChainId`, `agentId` and `forceBroadcast`, none of which is a payment shape, so the hook short-circuits to `allow` before any tier is evaluated. Set `block_threshold_usd: 0.01`, ask the agent to rate five executions, and you will burn mainnet gas five times without a tier ever running.
+
+The [server-side hard limits](#server-side-hard-limits) cover the USDC payment rows and cannot be bypassed. They do **not** bound `feedback`: it signs on Ethereum mainnet under the ERC-8004 policy, and its native gas spend is outside the per-transfer and daily USDC caps.
+
+And `~/.keeperhub/safety.json` does not read as framework-scoped — it is a user-level file, in a user-level directory, named after the package rather than after the agent. Someone who sets `block_threshold_usd: 10`, then runs their agent in Cline or writes a script against the package, will reasonably expect that limit to hold. It will not.
 
 If you pay from your own code and want the tiers, call the exported hook before signing:
 
 ```ts
-import { createPreToolUseHook, paymentSigner } from "@keeperhub/wallet";
+import { createPreToolUseHook } from "@keeperhub/wallet";
 
 const hook = await createPreToolUseHook();
-const decision = await hook({
+
+const asset = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"; // Base USDC
+const payTo = "0x…";                                        // the recipient
+
+const { decision, reason } = await hook({
   tool_name: "keeperhub_wallet_sign",
   tool_input: { paymentChallenge: { amount: "10000", unit: "microUsdc", asset, payTo } },
 });
-if (decision.decision !== "allow") throw new Error(decision.reason ?? "refused");
+
+if (decision === "block") throw new Error(reason ?? "refused");
+if (decision === "ask") {
+  // No runtime here to render a prompt — decide deliberately. Proceeding is a
+  // choice to ignore the tier; refusing is a choice to be stricter than Claude
+  // Code, which would have asked the user.
+  throw new Error(`needs approval: ${reason ?? "above auto_approve_max_usd"}`);
+}
+// decision === "allow"
 ```
 
 Two things a non-interactive caller has to handle. The amount **must** carry an explicit `unit` — `"usd"` for a number, `"microUsdc"` for an integer string — and an untagged amount throws rather than being guessed at. And the hook can return `{decision: "ask"}`, which has no meaning without a runtime to render a prompt: a backend service has to decide for itself whether `ask` means proceed, refuse, or escalate.

--- a/docs/ai-tools/agentic-wallet.md
+++ b/docs/ai-tools/agentic-wallet.md
@@ -66,6 +66,20 @@ The hook reads only the payment-challenge fields `amount`, `unit`, and the asset
 >
 > If your agent should only pay a specific subset of workflows, or should hold to a budget you set, enforce that in your own `PreToolUse` hook or in a wrapper around `paymentSigner`. The tiers above will not do it for you.
 
+#### Where the tiers apply
+
+The tiers live in a `PreToolUse` hook, which is an **agent-framework** mechanism — `skill install` registers it in `~/.claude/settings.json`. Enforcement therefore depends on how the payment is initiated:
+
+| Entry point | auto / ask / block |
+|---|---|
+| A framework agent whose runtime fires `PreToolUse` (Claude Code, Cursor, Cline, Windsurf, OpenCode) | **Yes** — via the registered hook |
+| The KeeperHub MCP server | **`block_threshold_usd` only**, enforced inline before signing. The hook fires on the MCP tool call, where there is no payment shape yet, so it cannot see the 402 |
+| Your own code importing `@keeperhub/wallet` and calling `paymentSigner.fetch()` directly — a backend service, a scheduled job, a test harness, a non-Claude runtime | **No** — nothing reads `safety.json` on this path |
+
+The [server-side hard limits](#server-side-hard-limits) apply to all three and cannot be bypassed, so the last row is bounded rather than unbounded. But `~/.keeperhub/safety.json` does not read as framework-scoped — it is a user-level file, in a user-level directory, named after the package rather than after the agent. Someone who sets `block_threshold_usd: 10` and then writes a script against the package will reasonably expect that limit to hold, and it will not.
+
+If you pay from your own code and want the tiers, call the exported hook yourself before signing, or wrap `paymentSigner` so every payment passes the same check.
+
 ### Server-side hard limits
 
 Beyond the client-side hook, a set of Turnkey-enforced policies apply to every wallet and cannot be bypassed by editing `safety.json` or changing the agent's hook. They are created per sub-organisation at provision time and enforced by Turnkey itself on every signing activity:

--- a/docs/ai-tools/agentic-wallet.md
+++ b/docs/ai-tools/agentic-wallet.md
@@ -72,13 +72,27 @@ The tiers live in a `PreToolUse` hook, which is an **agent-framework** mechanism
 
 | Entry point | auto / ask / block |
 |---|---|
-| A framework agent whose runtime fires `PreToolUse` (Claude Code, Cursor, Cline, Windsurf, OpenCode) | **Yes** — via the registered hook |
-| The KeeperHub MCP server | **`block_threshold_usd` only**, enforced inline before signing. The hook fires on the MCP tool call, where there is no payment shape yet, so it cannot see the 402 |
-| Your own code importing `@keeperhub/wallet` and calling `paymentSigner.fetch()` directly — a backend service, a scheduled job, a test harness, a non-Claude runtime | **No** — nothing reads `safety.json` on this path |
+| **Claude Code** | **Yes** — `skill install` registers the hook in `~/.claude/settings.json` |
+| **Cursor, Cline, Windsurf, OpenCode** | **No.** `skill install` writes the skill file for these agents but does not register a hook — it prints a notice that the agent does not support auto-registered hooks. The skill is installed; the tiers are not enforced |
+| **`keeperhub-wallet-mcp`** (the wallet package's own stdio server) | **`block_threshold_usd` only, and only for x402.** Enforced inline before signing, because the hook fires on the MCP tool call where there is no payment shape yet. **MPP amounts are not checked** — the client never decodes the credential, so the cap check is skipped and the server-side limits are the only bound |
+| Your own code importing `@keeperhub/wallet` and calling `paymentSigner.fetch()` directly — a backend service, a scheduled job, a test harness | **No** — nothing reads `safety.json` on this path |
 
-The [server-side hard limits](#server-side-hard-limits) apply to all three and cannot be bypassed, so the last row is bounded rather than unbounded. But `~/.keeperhub/safety.json` does not read as framework-scoped — it is a user-level file, in a user-level directory, named after the package rather than after the agent. Someone who sets `block_threshold_usd: 10` and then writes a script against the package will reasonably expect that limit to hold, and it will not.
+The [server-side hard limits](#server-side-hard-limits) apply to every row and cannot be bypassed, so none of these is unbounded. But `~/.keeperhub/safety.json` does not read as framework-scoped — it is a user-level file, in a user-level directory, named after the package rather than after the agent. Someone who sets `block_threshold_usd: 10`, then runs their agent in Cursor or writes a script against the package, will reasonably expect that limit to hold. It will not.
 
-If you pay from your own code and want the tiers, call the exported hook yourself before signing, or wrap `paymentSigner` so every payment passes the same check.
+If you pay from your own code and want the tiers, call the exported hook before signing:
+
+```ts
+import { createPreToolUseHook, paymentSigner } from "@keeperhub/wallet";
+
+const hook = await createPreToolUseHook();
+const decision = await hook({
+  tool_name: "keeperhub_wallet_sign",
+  tool_input: { paymentChallenge: { amount: "10000", unit: "microUsdc", asset, payTo } },
+});
+if (decision.decision !== "allow") throw new Error(decision.reason ?? "refused");
+```
+
+Two things a non-interactive caller has to handle. The amount **must** carry an explicit `unit` — `"usd"` for a number, `"microUsdc"` for an integer string — and an untagged amount throws rather than being guessed at. And the hook can return `{decision: "ask"}`, which has no meaning without a runtime to render a prompt: a backend service has to decide for itself whether `ask` means proceed, refuse, or escalate.
 
 ### Server-side hard limits
 

--- a/docs/ai-tools/agentic-wallet.md
+++ b/docs/ai-tools/agentic-wallet.md
@@ -74,16 +74,16 @@ Coverage is **per path, not per agent** — most agents get one of the two mecha
 
 | Entry point | `PreToolUse` hook | MCP `block_threshold_usd` |
 |---|---|---|
-| **Claude Code** | **Yes** — `skill install` registers it in `~/.claude/settings.json` | Yes |
-| **Cursor, Windsurf, OpenCode** | **No** — `skill install` writes the skill file and prints a notice that the agent does not support auto-registered hooks | **Yes** — the MCP server is auto-registered, so paid `call_workflow` calls hit the cap |
+| **Claude Code** | **Yes** — `skill install` registers it in `~/.claude/settings.json` | **Registered, x402 only** — see the `keeperhub-wallet-mcp` row for what the cap does and does not cover |
+| **Cursor, Windsurf, OpenCode** | **No** — `skill install` writes the skill file and prints a notice that the agent does not support auto-registered hooks | **Registered, x402 only** — the MCP server is auto-registered, so a paid `call_workflow` hits the cap when the challenge is x402, and is unchecked when it is MPP |
 | **Cline** | **No** | **No** — no known MCP config location, so neither mechanism is registered |
 | **`keeperhub-wallet-mcp`** (the wallet package's own stdio server) | n/a — the hook fires on the MCP tool call, where there is no payment shape yet | **x402 only.** The cap is computed from the decoded x402 amount; **MPP amounts are not checked**, because the client never decodes the credential |
 | Your own code importing `@keeperhub/wallet` and calling `paymentSigner.fetch()` directly — a backend service, a scheduled job, a test harness | **No** | **No** — nothing reads `safety.json` on this path |
 | **`feedback`** — the MCP tool and the `keeperhub-wallet feedback` CLI command | **No** | **No** — see below |
 
-**`feedback` is gated by neither, and it spends real money.** It signs and broadcasts a `giveFeedback()` transaction on Ethereum mainnet, and its own tool description puts the cost at roughly $0.05–2 per call in native gas. The safety config is loaded at exactly one place — inside the `call_workflow` handler — so no other tool consults it. The hook does not catch it either: the tool's input schema declares `executionId`, `value`, `valueDecimals`, `comment`, `agentChainId`, `agentId` and `forceBroadcast`, none of which is a payment shape, so the hook short-circuits to `allow` before any tier is evaluated. Set `block_threshold_usd: 0.01`, ask the agent to rate five executions, and you will burn mainnet gas five times without a tier ever running.
+**`feedback` is gated by neither, and it spends real money.** It signs and broadcasts a `giveFeedback()` transaction on Ethereum mainnet, paid for in native ETH by the caller's own wallet — roughly $0.05 to $10 per call depending on the prevailing mainnet gas price. The safety config is loaded at exactly one place — inside the `call_workflow` handler — so no other tool consults it. The hook does not catch it either: the tool's input schema declares `executionId`, `value`, `valueDecimals`, `comment`, `agentChainId`, `agentId` and `forceBroadcast`, none of which is a payment shape, so the hook short-circuits to `allow` before any tier is evaluated. Set `block_threshold_usd: 0.01`, ask the agent to rate five executions, and you will burn mainnet gas five times without a tier ever running.
 
-The [server-side hard limits](#server-side-hard-limits) cover the USDC payment rows and cannot be bypassed. They do **not** bound `feedback`: it signs on Ethereum mainnet under the ERC-8004 policy, and its native gas spend is outside the per-transfer and daily USDC caps.
+The [server-side hard limits](#server-side-hard-limits) cover the USDC payment rows and cannot be bypassed. They reach `feedback` too, but only to constrain **what** it can do, not **how much** it can spend: Turnkey policies confine the transaction to the ERC-8004 ReputationRegistry contract, to Ethereum mainnet, and to the `giveFeedback()` selector alone. Nothing bounds the spend. The gas is native ETH rather than a USDC transfer, so the per-transfer and daily USDC caps do not apply to it, and no separate gas ceiling exists today.
 
 And `~/.keeperhub/safety.json` does not read as framework-scoped — it is a user-level file, in a user-level directory, named after the package rather than after the agent. Someone who sets `block_threshold_usd: 10`, then runs their agent in Cline or writes a script against the package, will reasonably expect that limit to hold. It will not.
 
@@ -102,7 +102,7 @@ const { decision, reason } = await hook({
   tool_input: { paymentChallenge: { amount: "10000", unit: "microUsdc", asset, payTo } },
 });
 
-if (decision === "block") throw new Error(reason ?? "refused");
+if (decision === "deny") throw new Error(reason ?? "refused by a safety tier");
 if (decision === "ask") {
   // No runtime here to render a prompt — decide deliberately. Proceeding is a
   // choice to ignore the tier; refusing is a choice to be stricter than Claude
@@ -112,7 +112,7 @@ if (decision === "ask") {
 // decision === "allow"
 ```
 
-Two things a non-interactive caller has to handle. The amount **must** carry an explicit `unit` — `"usd"` for a number, `"microUsdc"` for an integer string — and an untagged amount throws rather than being guessed at. And the hook can return `{decision: "ask"}`, which has no meaning without a runtime to render a prompt: a backend service has to decide for itself whether `ask` means proceed, refuse, or escalate.
+Three things a non-interactive caller has to handle. **The block tier returns `decision: "deny"`, not `"block"`** — the decision values are `"allow" | "deny" | "ask"`, and the tier names in the table above are not the values on the wire. Comparing against `"block"` is a type error under `tsc` and, in plain JavaScript, silently falls through to the allow path and signs the payment the hook just refused. The amount **must** carry an explicit `unit` — `"usd"` for a number, `"microUsdc"` for an integer string — and an untagged amount throws rather than being guessed at. And the hook can return `{decision: "ask"}`, which has no meaning without a runtime to render a prompt: a backend service has to decide for itself whether `ask` means proceed, refuse, or escalate.
 
 ### Server-side hard limits
 


### PR DESCRIPTION
## What this adds

A short subsection under **Safety hooks** naming which entry points the auto / ask / block tiers actually cover.

## Why

The tiers are enforced by a `PreToolUse` hook, and `skill install` registers it in `~/.claude/settings.json`. That makes enforcement a property of *how the payment was initiated*, and the page never says so — it reads as though the tiers are a property of the wallet.

Three entry points behave differently today:

| Entry point | auto / ask / block |
|---|---|
| Framework agent firing `PreToolUse` | all three |
| KeeperHub MCP server | `block_threshold_usd` only |
| `paymentSigner.fetch()` called directly from your own code | none |

Both non-obvious rows are documented in your own source. `mcp-server.ts`:

```
//   1. block_threshold_usd from ~/.keeperhub/safety.json is enforced inline
//      BEFORE the payment signs. The PreToolUse hook cannot see the 402
//      challenge (it fires on the MCP tool call, where there is no payment
//      shape yet — see hook.ts:hasPaymentShape), so the gate that would
//      normally fire there is replicated here.
```

And `payment-signer.ts` references no safety config at all — no `auto_approve_max_usd`, no `block_threshold_usd`, no `allowlisted_contracts`. Grepping the published package for any of those strings in that file returns nothing.

The division is defensible: the hook is a convenience for interactive agents, and Turnkey is the real ceiling. The note says exactly that, and links to the [server-side hard limits](#server-side-hard-limits) so the third row reads as *bounded*, not *unbounded*.

What makes it worth a paragraph is that `~/.keeperhub/safety.json` does not look framework-scoped. It is a user-level file, in a user-level directory, named after the package rather than after the agent. Someone who sets `block_threshold_usd: 10`, then writes a cron job or a backend service against the package, will reasonably believe that limit still applies. It does not, and nothing currently tells them.

The subsection closes by pointing at the fix: call the exported hook before signing, or wrap `paymentSigner`.

## Notes

- Docs only. No behaviour change.
- Same file as #1911 (also mine), different section — that one is about `payTo` in the tier table, this is about where the tiers run. They apply cleanly in either order; happy to rebase whichever lands second.
- Also touches the same file as #1902, but a different section again.
