### PR TITLE
docs: correct the default safety config and mark ask_threshold_usd inert

### DIFF
--- a/docs/ai-tools/agentic-wallet.md
+++ b/docs/ai-tools/agentic-wallet.md
@@ -60,7 +60,7 @@ The hook reads only the payment-challenge fields `amount`, `unit`, and the asset
 
 Beyond the client-side hook, a set of Turnkey-enforced policies apply to every wallet and cannot be bypassed by editing `safety.json` or changing the agent's hook. They are created per sub-organisation at provision time and enforced by Turnkey itself on every signing activity:
 
-- **Contract allowlist.** Signing is denied on any call whose target contract is not Base USDC (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`) or Tempo USDC.e (`0x20C000000000000000000000B9537D11c60E8b50`). On the EIP-712 (x402) signing path the same restriction is applied against the typed-data domain's verifying contract.
+- **Contract allowlist.** Signing is denied on any call whose target contract is not Base USDC (`0x833589fcd6edb6e08f4c7c32d4f71b54bda02913`) or Tempo USDC.e (`0x20c000000000000000000000b9537d11c60e8b50`). On the EIP-712 (x402) signing path the same restriction is applied against the typed-data domain's verifying contract.
 - **Per-transfer cap.** `transfer()` or `transferFrom()` of more than 100 USDC is denied. The same 100 USDC ceiling applies to EIP-3009 `TransferWithAuthorization` typed-data signing.
 - **Approval cap.** `approve()` above 100 USDC is denied. Anything over the same 100 USDC per-transfer ceiling is rejected.
 - **Chain allowlist.** EIP-712 signing is denied for any `domain.chainId` outside Base (8453), Tempo mainnet (4217), and Tempo testnet (42431).
@@ -88,20 +88,22 @@ When `~/.keeperhub/safety.json` is absent the hook applies these defaults:
 >
 > It is part of `DEFAULT_SAFETY_CONFIG` and is still parsed and range-checked — it must be `>= auto_approve_max_usd`, and `block_threshold_usd` must be `>= ask_threshold_usd` — but the hook does not consult it when deciding. The ask tier is bounded by `auto_approve_max_usd` and `block_threshold_usd` alone, as the table above describes. The field is retained for backward compatibility with existing configs (`KEEP-307`).
 >
-> **If you lower `block_threshold_usd` below 50, you must lower `ask_threshold_usd` to match.** A partial config is merged over the defaults, so writing only:
+> **Any edit that raises `auto_approve_max_usd` above 50, or lowers `block_threshold_usd` below 50, must write `ask_threshold_usd` too.** Both directions throw, and the default of 50 sits between them. A partial config is merged over the defaults, so writing only:
 >
 > ```json
 > { "auto_approve_max_usd": 1, "block_threshold_usd": 20 }
 > ```
 >
-> leaves `ask_threshold_usd` at its default of 50, which trips `block_threshold_usd must be >= ask_threshold_usd`. That error is thrown while the hook is being constructed, before any input is read, so the hook process exits non-zero — **and because it is registered against every tool call, the failure blocks the whole session rather than just wallet calls.** The only explanation is a single line on stderr.
+> leaves `ask_threshold_usd` at its default of 50, which trips `block_threshold_usd must be >= ask_threshold_usd`. The mirror case is just as easy to hit: `{ "auto_approve_max_usd": 60 }` leaves `ask_threshold_usd` at 50 and trips `ask_threshold_usd must be >= auto_approve_max_usd`.
 >
-> Write all three together, or leave `block_threshold_usd` at or above 50.
+> Either error is thrown while the hook is being constructed, before any input is read, so the hook process exits non-zero — **and because `skill install` registers it with `matcher: "*"`, the failure blocks the whole session rather than just wallet calls.** (A hand-registered hook with a narrower matcher fails only for the tools it matches.) The only explanation is a single line on stderr.
+>
+> Write all three together, or keep `auto_approve_max_usd` ≤ 50 ≤ `block_threshold_usd`.
 
 The two allowlisted addresses are the only tokens the client-side hook will authorise out of the box:
 
-- `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` — **Base USDC**. Canonical Circle USDC contract on Base mainnet (chain id 8453). Used by x402 challenges from KeeperHub and any other x402-compliant service.
-- `0x20C000000000000000000000B9537D11c60E8b50` — **Tempo USDC.e**. USDC bridge token on Tempo mainnet (chain id 4217). Used by MPP challenges from KeeperHub paid workflows that settle on Tempo.
+- `0x833589fcd6edb6e08f4c7c32d4f71b54bda02913` — **Base USDC**. Canonical Circle USDC contract on Base mainnet (chain id 8453). Used by x402 challenges from KeeperHub and any other x402-compliant service.
+- `0x20c000000000000000000000b9537d11c60e8b50` — **Tempo USDC.e**. USDC bridge token on Tempo mainnet (chain id 4217). Used by MPP challenges from KeeperHub paid workflows that settle on Tempo.
 
 `allowlisted_contracts` in `safety.json` is a client-side first-pass filter — the hook rejects signing calls whose target contract is not in this list. You can **narrow** it further (for example, remove Tempo USDC.e if your agent only pays on Base). You cannot **widen** it: adding a third contract here has no effect because the [server-side hard limits](#server-side-hard-limits) still restrict every signature to Base USDC + Tempo USDC.e. For access to other contracts, contact KeeperHub support so a sub-organisation with a different server-side allowlist can be provisioned.
 
@@ -214,7 +216,7 @@ Passkey-backed sub-orgs are a more secure option Turnkey supports natively, and 
 
 You can edit `~/.keeperhub/safety.json` (mode `0644`) to raise or lower `auto_approve_max_usd` and `block_threshold_usd`, or to narrow `allowlisted_contracts` (for example, drop Tempo USDC.e if your agent only pays on Base). The hook picks up changes on its next invocation.
 
-The file also carries `ask_threshold_usd`, which the hook does not consult but does validate. If you are lowering `block_threshold_usd` below 50, read [the note under Default safety config](#default-safety-config) first — a partial edit there fails validation in a way that blocks every tool call, not only wallet ones.
+The file also carries `ask_threshold_usd`, which the hook does not consult but does validate. If you are raising `auto_approve_max_usd` above 50 **or** lowering `block_threshold_usd` below 50, read [the note under Default safety config](#default-safety-config) first — either edit fails validation in a way that blocks every tool call, not only wallet ones.
 
 Raising thresholds raises your exposure. Widening the contract allowlist past the server-side default (Base USDC + Tempo USDC.e) has no effect on its own — the [server-side hard limits](#server-side-hard-limits) still block signatures against any other contract. If you need access to a different contract, contact KeeperHub support.
 

--- a/docs/ai-tools/agentic-wallet.md
+++ b/docs/ai-tools/agentic-wallet.md
@@ -75,6 +75,7 @@ When `~/.keeperhub/safety.json` is absent the hook applies these defaults:
 ```json
 {
   "auto_approve_max_usd": 5,
+  "ask_threshold_usd": 50,
   "block_threshold_usd": 100,
   "allowlisted_contracts": [
     "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
@@ -82,6 +83,10 @@ When `~/.keeperhub/safety.json` is absent the hook applies these defaults:
   ]
 }
 ```
+
+> **`ask_threshold_usd` is inert.** It is part of `DEFAULT_SAFETY_CONFIG` and is still parsed and range-checked — it must be `>= auto_approve_max_usd`, and `block_threshold_usd` must be `>= ask_threshold_usd` — but the hook does not consult it when deciding. The ask tier is bounded by `auto_approve_max_usd` and `block_threshold_usd` alone, as the table above describes. The field is retained for backward compatibility with existing configs (`KEEP-307`).
+>
+> Practically: setting it changes nothing, and setting it *inconsistently* fails config validation for a value that has no effect. Tune `auto_approve_max_usd` and `block_threshold_usd` instead.
 
 The two allowlisted addresses are the only tokens the client-side hook will authorise out of the box:
 

--- a/docs/ai-tools/agentic-wallet.md
+++ b/docs/ai-tools/agentic-wallet.md
@@ -78,15 +78,25 @@ When `~/.keeperhub/safety.json` is absent the hook applies these defaults:
   "ask_threshold_usd": 50,
   "block_threshold_usd": 100,
   "allowlisted_contracts": [
-    "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-    "0x20C000000000000000000000B9537D11c60E8b50"
+    "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+    "0x20c000000000000000000000b9537d11c60e8b50"
   ]
 }
 ```
 
-> **`ask_threshold_usd` is inert.** It is part of `DEFAULT_SAFETY_CONFIG` and is still parsed and range-checked — it must be `>= auto_approve_max_usd`, and `block_threshold_usd` must be `>= ask_threshold_usd` — but the hook does not consult it when deciding. The ask tier is bounded by `auto_approve_max_usd` and `block_threshold_usd` alone, as the table above describes. The field is retained for backward compatibility with existing configs (`KEEP-307`).
+> **`ask_threshold_usd` is inert, but it is not inconsequential.**
 >
-> Practically: setting it changes nothing, and setting it *inconsistently* fails config validation for a value that has no effect. Tune `auto_approve_max_usd` and `block_threshold_usd` instead.
+> It is part of `DEFAULT_SAFETY_CONFIG` and is still parsed and range-checked — it must be `>= auto_approve_max_usd`, and `block_threshold_usd` must be `>= ask_threshold_usd` — but the hook does not consult it when deciding. The ask tier is bounded by `auto_approve_max_usd` and `block_threshold_usd` alone, as the table above describes. The field is retained for backward compatibility with existing configs (`KEEP-307`).
+>
+> **If you lower `block_threshold_usd` below 50, you must lower `ask_threshold_usd` to match.** A partial config is merged over the defaults, so writing only:
+>
+> ```json
+> { "auto_approve_max_usd": 1, "block_threshold_usd": 20 }
+> ```
+>
+> leaves `ask_threshold_usd` at its default of 50, which trips `block_threshold_usd must be >= ask_threshold_usd`. That error is thrown while the hook is being constructed, before any input is read, so the hook process exits non-zero — **and because it is registered against every tool call, the failure blocks the whole session rather than just wallet calls.** The only explanation is a single line on stderr.
+>
+> Write all three together, or leave `block_threshold_usd` at or above 50.
 
 The two allowlisted addresses are the only tokens the client-side hook will authorise out of the box:
 
@@ -203,6 +213,8 @@ Passkey-backed sub-orgs are a more secure option Turnkey supports natively, and 
 ### Can I change the safety thresholds or the allowed contracts?
 
 You can edit `~/.keeperhub/safety.json` (mode `0644`) to raise or lower `auto_approve_max_usd` and `block_threshold_usd`, or to narrow `allowlisted_contracts` (for example, drop Tempo USDC.e if your agent only pays on Base). The hook picks up changes on its next invocation.
+
+The file also carries `ask_threshold_usd`, which the hook does not consult but does validate. If you are lowering `block_threshold_usd` below 50, read [the note under Default safety config](#default-safety-config) first — a partial edit there fails validation in a way that blocks every tool call, not only wallet ones.
 
 Raising thresholds raises your exposure. Widening the contract allowlist past the server-side default (Base USDC + Tempo USDC.e) has no effect on its own — the [server-side hard limits](#server-side-hard-limits) still block signatures against any other contract. If you need access to a different contract, contact KeeperHub support.
 


### PR DESCRIPTION
## What this fixes

Two things in **Default safety config**:

1. The JSON block did not match `DEFAULT_SAFETY_CONFIG`. It omitted `ask_threshold_usd`.
2. Nothing said the field is inert.

## The mismatch

`safety-config.ts`:

```ts
export const DEFAULT_SAFETY_CONFIG: SafetyConfig = {
  auto_approve_max_usd: 5,
  ask_threshold_usd: 50,      // absent from the documented block
  block_threshold_usd: 100,
  allowlisted_contracts: [ ... ],
};
```

The page says "When `~/.keeperhub/safety.json` is absent the hook applies these defaults" and then lists three of the four keys.

## Why the note is worth having

`ask_threshold_usd` is treated as a first-class field on the way in. It is merged from defaults, range-checked as a non-negative finite number, and ordering-checked against both neighbours:

```
safety.json: ask_threshold_usd must be >= auto_approve_max_usd
safety.json: block_threshold_usd must be >= ask_threshold_usd
```

And then `hook.ts` does not consult it:

```
* `ask_threshold_usd` is still read from safety.json for backward-compat
* with existing configs but is not consulted for decision-making. Tracked
* as KEEP-307 for the permanent architectural decision.
```

The source is candid about this, but nothing surfaces at the point of use. The result is a field that can only cost a user time in both directions: order it wrong and config validation rejects it; order it right and nothing changes. Someone tuning the middle threshold to widen or narrow the ask band gets silence either way, and the natural conclusion is that they misunderstood the tiers rather than that the knob is disconnected.

Since the field appears in the defaults, adding it to the documented block without a word on its status would have been worse — it would read as a third live threshold.

## Notes

- Docs only. No behaviour change, and the field's status is unchanged — this only writes down what `hook.ts` already says.
- Same file as #1911 and #1912 (both mine), all three in different sections. Happy to rebase in whatever order suits.
- An alternative or follow-up on the code side: have `loadSafetyConfig` emit a one-line warning when the key is present. Left out of this PR to keep it docs-only.
