### PR TITLE
fix(mcp): structured simulation_unsupported_chain error

### DIFF
--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -253,8 +253,9 @@ const SOLANA_DIRECT_EXECUTION_CHAIN_IDS = new Set<number>([
 export function buildSimulationUnsupportedChainError(chainId: number): Error {
   return new Error(
     JSON.stringify({
-      code: "simulation_unsupported_chain",
-      chainId,
+      error: "simulation_unsupported_chain",
+      message: "Direct-execution simulation is not supported on this chain.",
+      chain_id: chainId,
       hint: "Direct-execution simulation is EVM-only. Preflight with a Solana-aware client before broadcasting.",
     })
   );

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -255,7 +255,7 @@ export function buildSimulationUnsupportedChainError(chainId: number): Error {
     JSON.stringify({
       code: "simulation_unsupported_chain",
       chainId,
-      hint: "Direct-execution simulation is EVM-only. Omit simulate for Solana or preflight with a Solana-aware client.",
+      hint: "Direct-execution simulation is EVM-only. Preflight with a Solana-aware client before broadcasting.",
     })
   );
 }

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -250,6 +250,16 @@ const SOLANA_DIRECT_EXECUTION_CHAIN_IDS = new Set<number>([
   SUPPORTED_CHAIN_IDS.SOLANA_DEVNET,
 ]);
 
+export function buildSimulationUnsupportedChainError(chainId: number): Error {
+  return new Error(
+    JSON.stringify({
+      code: "simulation_unsupported_chain",
+      chainId,
+      hint: "Direct-execution simulation is EVM-only. Omit simulate for Solana or preflight with a Solana-aware client.",
+    })
+  );
+}
+
 function assertSimulationSupported(chainId: string, simulate?: boolean): void {
   if (!simulate) {
     return;
@@ -266,9 +276,7 @@ function assertSimulationSupported(chainId: string, simulate?: boolean): void {
     return;
   }
   if (SOLANA_DIRECT_EXECUTION_CHAIN_IDS.has(normalizedChainId)) {
-    throw new Error(
-      `Direct-execution simulation is currently EVM-only; Solana chain ${normalizedChainId} cannot be simulated. Do not broadcast unless you can preflight the transaction through a Solana-aware client.`
-    );
+    throw buildSimulationUnsupportedChainError(normalizedChainId);
   }
 }
 

--- a/tests/unit/mcp-simulation-error.test.ts
+++ b/tests/unit/mcp-simulation-error.test.ts
@@ -1,25 +1,144 @@
-import { describe, expect, it } from "vitest";
-import { buildSimulationUnsupportedChainError } from "@/lib/mcp/tools";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import {
+  buildSimulationUnsupportedChainError,
+  registerTools,
+} from "@/lib/mcp/tools";
+import { SUPPORTED_CHAIN_IDS } from "@/lib/rpc/types";
 
-describe("buildSimulationUnsupportedChainError", () => {
-  it("returns JSON with simulation_unsupported_chain code", () => {
-    const error = buildSimulationUnsupportedChainError(101);
-    const parsed = JSON.parse(error.message) as {
-      code: string;
-      chainId: number;
-      hint: string;
-    };
-    expect(parsed.code).toBe("simulation_unsupported_chain");
-    expect(parsed.chainId).toBe(101);
-    expect(parsed.hint).toBe(
-      "Direct-execution simulation is EVM-only. Preflight with a Solana-aware client before broadcasting."
-    );
-    expect(parsed.hint).not.toContain("Omit simulate");
+const SIMULATION_HINT =
+  "Direct-execution simulation is EVM-only. Preflight with a Solana-aware client before broadcasting.";
+
+type FetchMock = ReturnType<typeof vi.fn>;
+type ToolCallResult = {
+  isError?: boolean;
+  content?: Array<{ type: string; text?: string }>;
+};
+
+let fetchMock: FetchMock;
+
+beforeEach(() => {
+  fetchMock = vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      status: 202,
+      statusText: "Accepted",
+      headers: { get: () => "application/json" },
+      json: () =>
+        Promise.resolve({ executionId: "exec_1", status: "completed" }),
+      text: () => Promise.resolve(""),
+    })
+  );
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+type ConnectedClient = { client: Client; close: () => Promise<void> };
+
+async function connectedClient(): Promise<ConnectedClient> {
+  const server = new McpServer({
+    name: "simulation-error-test",
+    version: "0.0.0",
+  });
+  registerTools(server, "http://internal", "Bearer test", SCOPE_MCP_WRITE);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client({
+    name: "simulation-error-test-client",
+    version: "0.0.0",
   });
 
-  it("includes chain id for Solana devnet", () => {
-    const error = buildSimulationUnsupportedChainError(103);
-    const parsed = JSON.parse(error.message) as { chainId: number };
-    expect(parsed.chainId).toBe(103);
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+
+  return {
+    client,
+    close: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+async function callTool(
+  name: string,
+  args: Record<string, unknown>
+): Promise<ToolCallResult> {
+  const { client, close } = await connectedClient();
+  try {
+    return (await client.callTool({
+      name,
+      arguments: args,
+    })) as ToolCallResult;
+  } finally {
+    await close();
+  }
+}
+
+describe("buildSimulationUnsupportedChainError", () => {
+  it("returns JSON aligned with the scope-denied envelope keys", () => {
+    const error = buildSimulationUnsupportedChainError(
+      SUPPORTED_CHAIN_IDS.SOLANA_MAINNET
+    );
+    const parsed = JSON.parse(error.message) as {
+      error: string;
+      message: string;
+      chain_id: number;
+      hint: string;
+    };
+    expect(parsed.error).toBe("simulation_unsupported_chain");
+    expect(parsed.message).toBe(
+      "Direct-execution simulation is not supported on this chain."
+    );
+    expect(parsed.chain_id).toBe(SUPPORTED_CHAIN_IDS.SOLANA_MAINNET);
+    expect(parsed.hint).toBe(SIMULATION_HINT);
+  });
+
+  it("includes chain_id for Solana devnet", () => {
+    const error = buildSimulationUnsupportedChainError(
+      SUPPORTED_CHAIN_IDS.SOLANA_DEVNET
+    );
+    const parsed = JSON.parse(error.message) as { chain_id: number };
+    expect(parsed.chain_id).toBe(SUPPORTED_CHAIN_IDS.SOLANA_DEVNET);
+  });
+});
+
+describe("execute_transfer simulate on Solana surfaces structured error", () => {
+  it("returns isError with simulation_unsupported_chain in content text", async () => {
+    const result = await callTool("execute_transfer", {
+      chain_id: String(SUPPORTED_CHAIN_IDS.SOLANA_MAINNET),
+      to_address: "So11111111111111111111111111111111111111112",
+      amount: "0.1",
+      simulate: true,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const text = (result.content ?? [])
+      .map((part) => part.text ?? "")
+      .join("\n");
+    const parsed = JSON.parse(text) as {
+      error: string;
+      message: string;
+      chain_id: number;
+      hint: string;
+    };
+    expect(parsed.error).toBe("simulation_unsupported_chain");
+    expect(parsed.message).toBe(
+      "Direct-execution simulation is not supported on this chain."
+    );
+    expect(parsed.chain_id).toBe(SUPPORTED_CHAIN_IDS.SOLANA_MAINNET);
+    expect(parsed.hint).toBe(SIMULATION_HINT);
   });
 });

--- a/tests/unit/mcp-simulation-error.test.ts
+++ b/tests/unit/mcp-simulation-error.test.ts
@@ -11,7 +11,10 @@ describe("buildSimulationUnsupportedChainError", () => {
     };
     expect(parsed.code).toBe("simulation_unsupported_chain");
     expect(parsed.chainId).toBe(101);
-    expect(parsed.hint).toContain("EVM-only");
+    expect(parsed.hint).toBe(
+      "Direct-execution simulation is EVM-only. Preflight with a Solana-aware client before broadcasting."
+    );
+    expect(parsed.hint).not.toContain("Omit simulate");
   });
 
   it("includes chain id for Solana devnet", () => {

--- a/tests/unit/mcp-simulation-error.test.ts
+++ b/tests/unit/mcp-simulation-error.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { buildSimulationUnsupportedChainError } from "@/lib/mcp/tools";
+
+describe("buildSimulationUnsupportedChainError", () => {
+  it("returns JSON with simulation_unsupported_chain code", () => {
+    const error = buildSimulationUnsupportedChainError(101);
+    const parsed = JSON.parse(error.message) as {
+      code: string;
+      chainId: number;
+      hint: string;
+    };
+    expect(parsed.code).toBe("simulation_unsupported_chain");
+    expect(parsed.chainId).toBe(101);
+    expect(parsed.hint).toContain("EVM-only");
+  });
+
+  it("includes chain id for Solana devnet", () => {
+    const error = buildSimulationUnsupportedChainError(103);
+    const parsed = JSON.parse(error.message) as { chainId: number };
+    expect(parsed.chainId).toBe(103);
+  });
+});


### PR DESCRIPTION
## Summary

- Return machine-readable JSON (`simulation_unsupported_chain`) when MCP direct-execution tools receive `simulate: true` on Solana chains, instead of a plain-text error string.

Supersedes the MCP simulate portion of #1897 (bundled PR split per review).

## Test plan

- [x] `pnpm vitest run tests/unit/mcp-simulation-error.test.ts` (2 passed)
- [x] `pnpm type-check`
- [x] Biome check on touched files
- [ ] MCP `execute_transfer` with `simulate: true` on Solana — `simulation_unsupported_chain` in error payload
