### PR TITLE
docs: hackathon quickstart auth, rate limits, and simulate

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -66,9 +66,16 @@ Chromium session. Set `DEV_LOGIN_URL` if the app is not on `http://localhost:300
 ### Simulation is EVM-only
 
 `simulate: true` on MCP direct-execution tools (`execute_transfer`, etc.) works
-on **EVM chain IDs only**. Solana mainnet (`101`) and devnet (`103`) return a
-structured error with code `simulation_unsupported_chain` before any API call.
-See [section 6](#6-send-your-first-transaction-safely) for the full preflight flow.
+on **EVM chain IDs only**. Solana mainnet (`101`) and devnet (`103`) cause the
+MCP tool to throw an error whose **message** is JSON. Parse it and stop the flow
+when `code` is `simulation_unsupported_chain`:
+
+```json
+{ "code": "simulation_unsupported_chain", "chainId": 101, "hint": "..." }
+```
+
+Do not read `err.code` on the thrown error — that property is undefined. See
+[section 6](#6-send-your-first-transaction-safely) for the full preflight flow.
 
 ## 2. Pick a key type
 
@@ -79,10 +86,11 @@ KeeperHub has two key systems. They are not interchangeable.
 | `kh_` | Organization | `/api/keys` | REST API, MCP server, Claude Code plugin |
 | `wfb_` | User | `/api/api-keys` | Webhook trigger authentication |
 
-For programmatic API and MCP access, use an organization (`kh_`) key. OAuth
-browser sign-in is a third MCP-only path (see [OAuth vs API keys](#oauth-vs-api-keys))
-and is not a substitute for `kh_` on REST endpoints. Full details:
-[API Keys](/api/api-keys).
+For programmatic API and MCP access, use an organization (`kh_`) key when you
+need a long-lived credential. OAuth access tokens are a first-class REST
+principal (`Authorization: Bearer …`) with their own scope model, but they are
+browser-minted and short-lived — see [OAuth vs API keys](#oauth-vs-api-keys).
+Full details: [API Keys](/api/api-keys).
 
 ## 3. Supported chains
 
@@ -130,15 +138,14 @@ tool. Faucet links are third-party and may change. See the full
 | Unauthenticated requests | 10 / minute |
 | Direct execution (per API key) | 60 / minute |
 
-Rate-limited requests return `429` with a `Retry-After` header (seconds or an
-HTTP-date). When you hit a limit:
+Rate-limited requests return `429` with a `Retry-After` header (delta seconds).
+When you hit a limit:
 
 1. Read `Retry-After` and wait at least that many seconds before retrying.
-2. Use exponential backoff with a cap (for example 1s, 2s, 4s, up to 60s).
-3. On write operations, pass a stable `idempotency_key` so retries are safe.
+2. Use exponential backoff with a cap (for example 1s, 2s, 4s, up to 30s; max 5 attempts).
+3. On write operations, pass a stable idempotency key: `Idempotency-Key` header on REST, `idempotency_key` on MCP direct-execution tools.
 
-For MCP cold-start behavior and direct-execution spending caps, see
-[MCP Server](/ai-tools/mcp-server) and [Direct Execution](/api/direct-execution).
+For direct-execution spending caps, see [Direct Execution](/api/direct-execution).
 
 ## 5. Sandbox
 
@@ -176,9 +183,9 @@ For an ERC-20 transfer, also pass the token's contract address as
 `token_address`. The Base Sepolia USDC address is listed in the table above.
 Any MCP tool error is a failed preflight and must stop the flow; revert details
 include the REST error JSON when available. As noted in [section 1](#simulation-is-evm-only),
-simulation is EVM-only — `execute_transfer` rejects `simulate: true` for Solana
-chain IDs `101` and `103` and their aliases with `simulation_unsupported_chain`
-before making an API call.
-See [MCP Server](/ai-tools/mcp-server#safely-preflight-direct-writes) for the
+simulation is EVM-only — on Solana chain IDs `101` and `103` (and their aliases),
+`execute_transfer` with `simulate: true` throws before any API call; parse the
+error message as JSON and treat `code: "simulation_unsupported_chain"` as a hard
+stop. See [MCP Server](/ai-tools/mcp-server#safely-preflight-direct-writes) for the
 tool flow and [Direct Execution](/api/direct-execution) for complete response
 and error handling details.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -33,6 +33,43 @@ reference for the full tool list and per-workflow details.
 The endpoint URL is also shown, with a copy button, in the dashboard under
 **Settings -> API Keys**.
 
+### OAuth vs API keys
+
+Browser OAuth (for example `/mcp` in Claude Code) mints a **Bearer OAuth access
+token**, not a `kh_` organization API key. The MCP server accepts either an
+OAuth access token or `Authorization: Bearer kh_...` on each request. Do not pass
+a `kh_` key to the OAuth token endpoint — it is rejected by design.
+
+| Auth method | Credential | Best for |
+|-------------|------------|----------|
+| OAuth (browser) | Short-lived Bearer access token | Interactive agents, Claude Code `/mcp` |
+| Organization API key (`kh_`) | Long-lived org key from Settings -> API Keys | Headless CI, scripts, Docker |
+
+For programmatic REST and MCP access without a browser redirect, create an
+organization key at **Settings -> API Keys**. See [MCP Server auth](/ai-tools/mcp-server)
+and [API Keys](/api/api-keys).
+
+### Local and Docker MCP
+
+Self-hosted KeeperHub exposes MCP at `http://localhost:3000/mcp`. OAuth
+redirect flows require a reachable callback URL; when that is impractical (for
+example inside Docker without a browser), prefer a `kh_` key:
+
+```bash
+claude mcp add --transport http --scope user keeperhub http://localhost:3000/mcp \
+  --header "Authorization: Bearer kh_your_key_here"
+```
+
+For local development with a browser, `pnpm dev:login` opens a signed-in
+Chromium session. Set `DEV_LOGIN_URL` if the app is not on `http://localhost:3000`.
+
+### Simulation is EVM-only
+
+`simulate: true` on MCP direct-execution tools (`execute_transfer`, etc.) works
+on **EVM chain IDs only**. Solana mainnet (`101`) and devnet (`103`) return a
+structured error with code `simulation_unsupported_chain` before any API call.
+See [section 6](#6-send-your-first-transaction-safely) for the full preflight flow.
+
 ## 2. Pick a key type
 
 KeeperHub has two key systems. They are not interchangeable.
@@ -42,8 +79,10 @@ KeeperHub has two key systems. They are not interchangeable.
 | `kh_` | Organization | `/api/keys` | REST API, MCP server, Claude Code plugin |
 | `wfb_` | User | `/api/api-keys` | Webhook trigger authentication |
 
-For programmatic API and MCP access, use an organization (`kh_`) key. Full
-details: [API Keys](/api/api-keys).
+For programmatic API and MCP access, use an organization (`kh_`) key. OAuth
+browser sign-in is a third MCP-only path (see [OAuth vs API keys](#oauth-vs-api-keys))
+and is not a substitute for `kh_` on REST endpoints. Full details:
+[API Keys](/api/api-keys).
 
 ## 3. Supported chains
 
@@ -91,8 +130,15 @@ tool. Faucet links are third-party and may change. See the full
 | Unauthenticated requests | 10 / minute |
 | Direct execution (per API key) | 60 / minute |
 
-Rate-limited requests return `429` with a `Retry-After` header. See
-[Direct Execution](/api/direct-execution) for spending caps.
+Rate-limited requests return `429` with a `Retry-After` header (seconds or an
+HTTP-date). When you hit a limit:
+
+1. Read `Retry-After` and wait at least that many seconds before retrying.
+2. Use exponential backoff with a cap (for example 1s, 2s, 4s, up to 60s).
+3. On write operations, pass a stable `idempotency_key` so retries are safe.
+
+For MCP cold-start behavior and direct-execution spending caps, see
+[MCP Server](/ai-tools/mcp-server) and [Direct Execution](/api/direct-execution).
 
 ## 5. Sandbox
 
@@ -129,9 +175,10 @@ Example simulation on Base Sepolia:
 For an ERC-20 transfer, also pass the token's contract address as
 `token_address`. The Base Sepolia USDC address is listed in the table above.
 Any MCP tool error is a failed preflight and must stop the flow; revert details
-include the REST error JSON when available. Simulation is currently EVM-only,
-so `execute_transfer` rejects `simulate: true` for Solana chain IDs `101` and
-`103` and their aliases before making an API call.
+include the REST error JSON when available. As noted in [section 1](#simulation-is-evm-only),
+simulation is EVM-only — `execute_transfer` rejects `simulate: true` for Solana
+chain IDs `101` and `103` and their aliases with `simulation_unsupported_chain`
+before making an API call.
 See [MCP Server](/ai-tools/mcp-server#safely-preflight-direct-writes) for the
 tool flow and [Direct Execution](/api/direct-execution) for complete response
 and error handling details.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,8 +37,9 @@ The endpoint URL is also shown, with a copy button, in the dashboard under
 
 Browser OAuth (for example `/mcp` in Claude Code) mints a **Bearer OAuth access
 token**, not a `kh_` organization API key. The MCP server accepts either an
-OAuth access token or `Authorization: Bearer kh_...` on each request. Do not pass
-a `kh_` key to the OAuth token endpoint — it is rejected by design.
+OAuth access token or `Authorization: Bearer kh_...` on each request. The OAuth
+token endpoint expects an OAuth `client_id` / `client_secret`, not a `kh_` org
+key — a `kh_` value fails client authentication as an invalid secret.
 
 | Auth method | Credential | Best for |
 |-------------|------------|----------|
@@ -66,16 +67,35 @@ Chromium session. Set `DEV_LOGIN_URL` if the app is not on `http://localhost:300
 ### Simulation is EVM-only
 
 `simulate: true` on MCP direct-execution tools (`execute_transfer`, etc.) works
-on **EVM chain IDs only**. Solana mainnet (`101`) and devnet (`103`) cause the
-MCP tool to throw an error whose **message** is JSON. Parse it and stop the flow
-when `code` is `simulation_unsupported_chain`:
+on **EVM chain IDs only**. On Solana mainnet (`101`) and devnet (`103`), the
+tool call **resolves** with `isError: true` — it does not throw to the MCP
+client. Check that flag, then parse the JSON in `content[0].text` and stop when
+`error` is `simulation_unsupported_chain`:
 
-```json
-{ "code": "simulation_unsupported_chain", "chainId": 101, "hint": "..." }
+```js
+const result = await client.callTool({
+  name: "execute_transfer",
+  arguments: args,
+});
+if (result.isError) {
+  const payload = JSON.parse(result.content[0].text);
+  if (payload.error === "simulation_unsupported_chain") {
+    // hard stop — do not broadcast
+  }
+}
 ```
 
-Do not read `err.code` on the thrown error — that property is undefined. See
-[section 6](#6-send-your-first-transaction-safely) for the full preflight flow.
+```json
+{
+  "error": "simulation_unsupported_chain",
+  "message": "Direct-execution simulation is not supported on this chain.",
+  "chain_id": 101,
+  "hint": "Direct-execution simulation is EVM-only. Preflight with a Solana-aware client before broadcasting."
+}
+```
+
+See [section 6](#6-send-your-first-transaction-safely) for the full preflight
+flow.
 
 ## 2. Pick a key type
 
@@ -134,8 +154,8 @@ tool. Faucet links are third-party and may change. See the full
 
 | Context | Limit |
 |---|---|
-| Authenticated requests | 100 / minute |
-| Unauthenticated requests | 10 / minute |
+| MCP (per organization) | 120 / minute |
+| Public MCP tools/call (per IP) | 10 / minute |
 | Direct execution (per API key) | 60 / minute |
 
 Rate-limited requests return `429` with a `Retry-After` header (delta seconds).
@@ -181,11 +201,12 @@ Example simulation on Base Sepolia:
 
 For an ERC-20 transfer, also pass the token's contract address as
 `token_address`. The Base Sepolia USDC address is listed in the table above.
-Any MCP tool error is a failed preflight and must stop the flow; revert details
-include the REST error JSON when available. As noted in [section 1](#simulation-is-evm-only),
-simulation is EVM-only — on Solana chain IDs `101` and `103` (and their aliases),
-`execute_transfer` with `simulate: true` throws before any API call; parse the
-error message as JSON and treat `code: "simulation_unsupported_chain"` as a hard
-stop. See [MCP Server](/ai-tools/mcp-server#safely-preflight-direct-writes) for the
-tool flow and [Direct Execution](/api/direct-execution) for complete response
-and error handling details.
+Any MCP tool result with `isError: true` is a failed preflight and must stop
+the flow; revert details include the REST error JSON when available. As noted
+in [section 1](#simulation-is-evm-only), simulation is EVM-only — on Solana
+chain IDs `101` and `103` (and their aliases), `execute_transfer` with
+`simulate: true` resolves with `isError: true` before any API call; parse
+`content[0].text` as JSON and treat `error: "simulation_unsupported_chain"` as
+a hard stop. See [MCP Server](/ai-tools/mcp-server#safely-preflight-direct-writes)
+for the tool flow and [Direct Execution](/api/direct-execution) for complete
+response and error handling details.

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -253,8 +253,9 @@ const SOLANA_DIRECT_EXECUTION_CHAIN_IDS = new Set<number>([
 export function buildSimulationUnsupportedChainError(chainId: number): Error {
   return new Error(
     JSON.stringify({
-      code: "simulation_unsupported_chain",
-      chainId,
+      error: "simulation_unsupported_chain",
+      message: "Direct-execution simulation is not supported on this chain.",
+      chain_id: chainId,
       hint: "Direct-execution simulation is EVM-only. Preflight with a Solana-aware client before broadcasting.",
     })
   );

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -255,7 +255,7 @@ export function buildSimulationUnsupportedChainError(chainId: number): Error {
     JSON.stringify({
       code: "simulation_unsupported_chain",
       chainId,
-      hint: "Direct-execution simulation is EVM-only. Omit simulate for Solana or preflight with a Solana-aware client.",
+      hint: "Direct-execution simulation is EVM-only. Preflight with a Solana-aware client before broadcasting.",
     })
   );
 }

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -250,6 +250,16 @@ const SOLANA_DIRECT_EXECUTION_CHAIN_IDS = new Set<number>([
   SUPPORTED_CHAIN_IDS.SOLANA_DEVNET,
 ]);
 
+export function buildSimulationUnsupportedChainError(chainId: number): Error {
+  return new Error(
+    JSON.stringify({
+      code: "simulation_unsupported_chain",
+      chainId,
+      hint: "Direct-execution simulation is EVM-only. Omit simulate for Solana or preflight with a Solana-aware client.",
+    })
+  );
+}
+
 function assertSimulationSupported(chainId: string, simulate?: boolean): void {
   if (!simulate) {
     return;
@@ -266,9 +276,7 @@ function assertSimulationSupported(chainId: string, simulate?: boolean): void {
     return;
   }
   if (SOLANA_DIRECT_EXECUTION_CHAIN_IDS.has(normalizedChainId)) {
-    throw new Error(
-      `Direct-execution simulation is currently EVM-only; Solana chain ${normalizedChainId} cannot be simulated. Do not broadcast unless you can preflight the transaction through a Solana-aware client.`
-    );
+    throw buildSimulationUnsupportedChainError(normalizedChainId);
   }
 }
 

--- a/tests/unit/mcp-simulation-error.test.ts
+++ b/tests/unit/mcp-simulation-error.test.ts
@@ -1,25 +1,144 @@
-import { describe, expect, it } from "vitest";
-import { buildSimulationUnsupportedChainError } from "@/lib/mcp/tools";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import {
+  buildSimulationUnsupportedChainError,
+  registerTools,
+} from "@/lib/mcp/tools";
+import { SUPPORTED_CHAIN_IDS } from "@/lib/rpc/types";
 
-describe("buildSimulationUnsupportedChainError", () => {
-  it("returns JSON with simulation_unsupported_chain code", () => {
-    const error = buildSimulationUnsupportedChainError(101);
-    const parsed = JSON.parse(error.message) as {
-      code: string;
-      chainId: number;
-      hint: string;
-    };
-    expect(parsed.code).toBe("simulation_unsupported_chain");
-    expect(parsed.chainId).toBe(101);
-    expect(parsed.hint).toBe(
-      "Direct-execution simulation is EVM-only. Preflight with a Solana-aware client before broadcasting."
-    );
-    expect(parsed.hint).not.toContain("Omit simulate");
+const SIMULATION_HINT =
+  "Direct-execution simulation is EVM-only. Preflight with a Solana-aware client before broadcasting.";
+
+type FetchMock = ReturnType<typeof vi.fn>;
+type ToolCallResult = {
+  isError?: boolean;
+  content?: Array<{ type: string; text?: string }>;
+};
+
+let fetchMock: FetchMock;
+
+beforeEach(() => {
+  fetchMock = vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      status: 202,
+      statusText: "Accepted",
+      headers: { get: () => "application/json" },
+      json: () =>
+        Promise.resolve({ executionId: "exec_1", status: "completed" }),
+      text: () => Promise.resolve(""),
+    })
+  );
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+type ConnectedClient = { client: Client; close: () => Promise<void> };
+
+async function connectedClient(): Promise<ConnectedClient> {
+  const server = new McpServer({
+    name: "simulation-error-test",
+    version: "0.0.0",
+  });
+  registerTools(server, "http://internal", "Bearer test", SCOPE_MCP_WRITE);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client({
+    name: "simulation-error-test-client",
+    version: "0.0.0",
   });
 
-  it("includes chain id for Solana devnet", () => {
-    const error = buildSimulationUnsupportedChainError(103);
-    const parsed = JSON.parse(error.message) as { chainId: number };
-    expect(parsed.chainId).toBe(103);
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+
+  return {
+    client,
+    close: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+async function callTool(
+  name: string,
+  args: Record<string, unknown>
+): Promise<ToolCallResult> {
+  const { client, close } = await connectedClient();
+  try {
+    return (await client.callTool({
+      name,
+      arguments: args,
+    })) as ToolCallResult;
+  } finally {
+    await close();
+  }
+}
+
+describe("buildSimulationUnsupportedChainError", () => {
+  it("returns JSON aligned with the scope-denied envelope keys", () => {
+    const error = buildSimulationUnsupportedChainError(
+      SUPPORTED_CHAIN_IDS.SOLANA_MAINNET
+    );
+    const parsed = JSON.parse(error.message) as {
+      error: string;
+      message: string;
+      chain_id: number;
+      hint: string;
+    };
+    expect(parsed.error).toBe("simulation_unsupported_chain");
+    expect(parsed.message).toBe(
+      "Direct-execution simulation is not supported on this chain."
+    );
+    expect(parsed.chain_id).toBe(SUPPORTED_CHAIN_IDS.SOLANA_MAINNET);
+    expect(parsed.hint).toBe(SIMULATION_HINT);
+  });
+
+  it("includes chain_id for Solana devnet", () => {
+    const error = buildSimulationUnsupportedChainError(
+      SUPPORTED_CHAIN_IDS.SOLANA_DEVNET
+    );
+    const parsed = JSON.parse(error.message) as { chain_id: number };
+    expect(parsed.chain_id).toBe(SUPPORTED_CHAIN_IDS.SOLANA_DEVNET);
+  });
+});
+
+describe("execute_transfer simulate on Solana surfaces structured error", () => {
+  it("returns isError with simulation_unsupported_chain in content text", async () => {
+    const result = await callTool("execute_transfer", {
+      chain_id: String(SUPPORTED_CHAIN_IDS.SOLANA_MAINNET),
+      to_address: "So11111111111111111111111111111111111111112",
+      amount: "0.1",
+      simulate: true,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const text = (result.content ?? [])
+      .map((part) => part.text ?? "")
+      .join("\n");
+    const parsed = JSON.parse(text) as {
+      error: string;
+      message: string;
+      chain_id: number;
+      hint: string;
+    };
+    expect(parsed.error).toBe("simulation_unsupported_chain");
+    expect(parsed.message).toBe(
+      "Direct-execution simulation is not supported on this chain."
+    );
+    expect(parsed.chain_id).toBe(SUPPORTED_CHAIN_IDS.SOLANA_MAINNET);
+    expect(parsed.hint).toBe(SIMULATION_HINT);
   });
 });

--- a/tests/unit/mcp-simulation-error.test.ts
+++ b/tests/unit/mcp-simulation-error.test.ts
@@ -11,7 +11,10 @@ describe("buildSimulationUnsupportedChainError", () => {
     };
     expect(parsed.code).toBe("simulation_unsupported_chain");
     expect(parsed.chainId).toBe(101);
-    expect(parsed.hint).toContain("EVM-only");
+    expect(parsed.hint).toBe(
+      "Direct-execution simulation is EVM-only. Preflight with a Solana-aware client before broadcasting."
+    );
+    expect(parsed.hint).not.toContain("Omit simulate");
   });
 
   it("includes chain id for Solana devnet", () => {

--- a/tests/unit/mcp-simulation-error.test.ts
+++ b/tests/unit/mcp-simulation-error.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { buildSimulationUnsupportedChainError } from "@/lib/mcp/tools";
+
+describe("buildSimulationUnsupportedChainError", () => {
+  it("returns JSON with simulation_unsupported_chain code", () => {
+    const error = buildSimulationUnsupportedChainError(101);
+    const parsed = JSON.parse(error.message) as {
+      code: string;
+      chainId: number;
+      hint: string;
+    };
+    expect(parsed.code).toBe("simulation_unsupported_chain");
+    expect(parsed.chainId).toBe(101);
+    expect(parsed.hint).toContain("EVM-only");
+  });
+
+  it("includes chain id for Solana devnet", () => {
+    const error = buildSimulationUnsupportedChainError(103);
+    const parsed = JSON.parse(error.message) as { chainId: number };
+    expect(parsed.chainId).toBe(103);
+  });
+});


### PR DESCRIPTION
## Summary

- Expand hackathon quickstart with OAuth vs API keys, rate limits, idempotency, and EVM-only simulate guidance.
- Remove unverified `upstream_cold_start` error code (not emitted by any API route); link to MCP and Direct Execution docs instead.

Supersedes the docs portion of #1897 (bundled PR split per review).

## Test plan

- [x] `pnpm type-check`
- [x] Grep confirms `upstream_cold_start` absent from repo
- [ ] Docs review: rate-limit and simulate sections match current API behavior
