### PR TITLE
feat(billing): move the free trial onto the Pro 25k plan card

### DIFF
--- a/components/billing/billing-page.tsx
+++ b/components/billing/billing-page.tsx
@@ -20,7 +20,7 @@ import { BillingDetails } from "./billing-details";
 import { BillingHistory } from "./billing-history";
 import { BillingStatus } from "./billing-status";
 import { PricingTable } from "./pricing-table";
-import type { GasCreditCapsMap } from "./pricing-table/types";
+import type { GasCreditCapsMap, TrialInfo } from "./pricing-table/types";
 
 type SubscriptionResponse = {
   subscription: {
@@ -29,6 +29,7 @@ type SubscriptionResponse = {
     interval: string | null;
   };
   gasCreditCaps?: GasCreditCapsMap;
+  trial?: TrialInfo;
 };
 
 function AuthGate({
@@ -88,6 +89,7 @@ export function BillingPage(): React.ReactElement {
   const [gasCreditCaps, setGasCreditCaps] = useState<
     GasCreditCapsMap | undefined
   >(undefined);
+  const [trial, setTrial] = useState<TrialInfo | undefined>(undefined);
   const [refreshKey, setRefreshKey] = useState(0);
   const [planLoaded, setPlanLoaded] = useState(false);
   const isAnonymous = !session?.user || session.user.isAnonymous;
@@ -126,6 +128,7 @@ export function BillingPage(): React.ReactElement {
             : null
         );
         setGasCreditCaps(data.gasCreditCaps);
+        setTrial(data.trial);
       }
     } catch (error) {
       console.error("[Billing] Failed to fetch plan:", error);
@@ -139,6 +142,7 @@ export function BillingPage(): React.ReactElement {
     setCurrentPlan("free");
     setCurrentTier(null);
     setCurrentInterval(null);
+    setTrial(undefined);
     setPlanLoaded(false);
     setRefreshKey((k) => k + 1);
     fetchPlan().catch(() => undefined);
@@ -194,13 +198,16 @@ export function BillingPage(): React.ReactElement {
 
           <div className="border-t border-border/50 pt-8" id="plans-section">
             <h2 className="text-xl font-semibold mb-4">Plans</h2>
+            {/* The trial tier is part of the key: it decides the Pro card's
+                default selection, which is initial state inside the table. */}
             <PricingTable
               currentInterval={currentInterval}
               currentPlan={currentPlan}
               currentTier={currentTier}
               gasCreditCaps={gasCreditCaps}
-              key={`${currentPlan}-${currentTier ?? "none"}-${currentInterval ?? "none"}-${String(refreshKey)}`}
+              key={`${currentPlan}-${currentTier ?? "none"}-${currentInterval ?? "none"}-${trial?.eligible === true ? trial.tier : "no-trial"}-${String(refreshKey)}`}
               onPlanUpdated={handlePlanUpdated}
+              trial={trial}
             />
           </div>
 

--- a/components/billing/billing-status.tsx
+++ b/components/billing/billing-status.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Info, Sparkles } from "lucide-react";
+import { Info } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useOverlay } from "@/components/overlays/overlay-provider";
@@ -282,32 +282,6 @@ function UpgradeSuggestionBanner({
         </Button>
       </div>
     </div>
-  );
-}
-
-// Compact "Start free trial" trigger shown beside the plan title for eligible
-// free orgs. Opens the trial offer modal (plan options + benefits).
-function StartTrialButton({
-  days,
-  tier,
-  usage,
-}: {
-  days: number;
-  tier: TierKey;
-  usage: SubscriptionData["usage"] | undefined;
-}): React.ReactElement {
-  const { open } = useOverlay();
-  return (
-    <button
-      className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-keeperhub-green-dark/30 bg-keeperhub-green-dark/10 px-3 py-1.5 font-medium text-keeperhub-green-dark text-xs transition-colors hover:bg-keeperhub-green-dark/20"
-      onClick={() =>
-        open(TrialUpsellModal, { days, tier, usage }, { size: "2xl" })
-      }
-      type="button"
-    >
-      <Sparkles className="size-3.5" />
-      Start free trial
-    </button>
   );
 }
 
@@ -718,7 +692,6 @@ function BillingStatusContent({
   gasCredits,
   overageCharges,
   suggestion,
-  trial,
   portalLoading,
   onManageBilling,
 }: {
@@ -727,7 +700,6 @@ function BillingStatusContent({
   gasCredits: GasCreditsData | undefined;
   overageCharges: OverageCharge[];
   suggestion: SuggestionData | null;
-  trial: SubscriptionData["trial"] | undefined;
   portalLoading: boolean;
   onManageBilling: () => void;
 }): React.ReactElement {
@@ -778,14 +750,6 @@ function BillingStatusContent({
       "border-keeperhub-green-dark/40 bg-keeperhub-green-dark/10 text-keeperhub-green-dark";
   }
   const badgeVariant = isCanceling ? "outline" : statusVariant;
-  // Only offer the trial to engaged free orgs (>= 50% of the free cap used),
-  // matching the global upsell modal's threshold.
-  const usedRatio =
-    usage && usage.executionLimit > 0
-      ? usage.executionsUsed / usage.executionLimit
-      : 0;
-  const canStartTrial =
-    plan === "free" && trial?.eligible === true && usedRatio >= 0.5;
 
   const renewalMessage = getRenewalMessage(
     sub?.status ?? "active",
@@ -820,9 +784,6 @@ function BillingStatusContent({
             </p>
           )}
         </div>
-        {canStartTrial && trial && (
-          <StartTrialButton days={trial.days} tier={trial.tier} usage={usage} />
-        )}
       </div>
 
       {usage && (
@@ -910,7 +871,6 @@ export function BillingStatus(): React.ReactElement {
         portalLoading={portalLoading}
         sub={sub}
         suggestion={suggestion}
-        trial={data?.trial}
         usage={data?.usage}
       />
     </Card>

--- a/components/billing/billing-status.tsx
+++ b/components/billing/billing-status.tsx
@@ -291,10 +291,12 @@ function ManageTrialButton({
   currentTier,
   currentInterval,
   days,
+  trialEndsAt,
 }: {
   currentTier: TierKey;
   currentInterval: BillingInterval;
   days: number;
+  trialEndsAt: string | null;
 }): React.ReactElement {
   const { open } = useOverlay();
   return (
@@ -302,7 +304,13 @@ function ManageTrialButton({
       onClick={() =>
         open(
           TrialUpsellModal,
-          { days, tier: currentTier, isUpdate: true, currentInterval },
+          {
+            days,
+            tier: currentTier,
+            isUpdate: true,
+            currentInterval,
+            trialEndsAt: trialEndsAt ?? undefined,
+          },
           { size: "2xl" }
         )
       }
@@ -849,6 +857,7 @@ export function BillingStatus(): React.ReactElement {
                 currentInterval={trialInterval}
                 currentTier={trialTier}
                 days={data?.trial?.days ?? 14}
+                trialEndsAt={sub?.currentPeriodEnd ?? null}
               />
             )}
             {plan !== "free" && (

--- a/components/billing/pricing-table/index.tsx
+++ b/components/billing/pricing-table/index.tsx
@@ -25,12 +25,14 @@ import {
   SPONSORSHIP_TESTNET_NAMES,
 } from "@/lib/web3/sponsorship-chains-meta";
 import { ConfirmPlanChangeDialog } from "../confirm-plan-change-dialog";
-import type { GasCreditCapsMap, PricingTableProps } from "./types";
+import type { GasCreditCapsMap, PricingTableProps, TrialInfo } from "./types";
 import {
   cancelSubscription,
   computeDisplayPrice,
   getButtonLabel,
+  getTierPrice,
   isCurrentPlan,
+  isTrialSelection,
   resolveExecutions,
   startCheckout,
 } from "./utils";
@@ -48,6 +50,9 @@ type ConfirmTarget = {
   planName: PlanName;
   tierKey: TierKey | null;
   appInterval: BillingInterval;
+  // Opt-in to the free trial. Set only for the trial offer (Pro at the resolved
+  // trial tier); every other selection pays now. The server re-checks it.
+  trial: boolean;
 };
 
 type CheckoutHandlers = {
@@ -85,14 +90,13 @@ function formatCardGas(capCents: number): string {
 // -- Checkout orchestration (mirrors the previous per-card PlanCard logic) --
 
 async function executeCheckout(
-  planName: PlanName,
-  tierKey: TierKey | null,
-  appInterval: BillingInterval,
+  target: ConfirmTarget,
   handlers: Pick<
     CheckoutHandlers,
     "onPlanUpdated" | "setLoadingCardId" | "setConfirmOpen"
   >
 ): Promise<void> {
+  const { planName, tierKey, appInterval, trial } = target;
   handlers.setLoadingCardId(planName);
   try {
     if (planName === "free") {
@@ -116,7 +120,9 @@ async function executeCheckout(
       await handlers.onPlanUpdated?.();
       return;
     }
-    const updated = await startCheckout(planName, tierKey, appInterval);
+    const updated = await startCheckout(planName, tierKey, appInterval, {
+      trial,
+    });
     if (updated) {
       handlers.setConfirmOpen(false);
       await handlers.onPlanUpdated?.();
@@ -129,11 +135,10 @@ async function executeCheckout(
 }
 
 function handleSubscribe(
-  planName: PlanName,
-  tierKey: TierKey | null,
-  appInterval: BillingInterval,
+  target: ConfirmTarget,
   handlers: CheckoutHandlers
 ): void {
+  const { planName, tierKey, appInterval } = target;
   if (planName === "enterprise") {
     window.open(
       "mailto:human@keeperhub.com?subject=Enterprise%20Plan",
@@ -154,7 +159,7 @@ function handleSubscribe(
     return;
   }
   if (planName === "free" && handlers.hasSubscription) {
-    handlers.setConfirmTarget({ planName, tierKey, appInterval });
+    handlers.setConfirmTarget(target);
     handlers.setConfirmOpen(true);
     return;
   }
@@ -162,11 +167,11 @@ function handleSubscribe(
     return;
   }
   if (handlers.hasSubscription) {
-    handlers.setConfirmTarget({ planName, tierKey, appInterval });
+    handlers.setConfirmTarget(target);
     handlers.setConfirmOpen(true);
     return;
   }
-  executeCheckout(planName, tierKey, appInterval, handlers).catch(() => {
+  executeCheckout(target, handlers).catch(() => {
     // handled inside executeCheckout
   });
 }
@@ -179,6 +184,7 @@ function buildFreeCard(params: {
   gasCreditCaps?: GasCreditCapsMap;
   hasSubscription: boolean;
   loading: boolean;
+  trialOffered: boolean;
   onSelect: (context: PricingCtaContext) => void;
 }): PkgPricingCard {
   const {
@@ -187,6 +193,7 @@ function buildFreeCard(params: {
     gasCreditCaps,
     hasSubscription,
     loading,
+    trialOffered,
     onSelect,
   } = params;
   const plan = PLANS.free;
@@ -196,7 +203,9 @@ function buildFreeCard(params: {
   return {
     id: "free",
     name: "Pay per execution",
-    highlight: isCurrent,
+    // While the trial is on offer the green border marks it, not the plan the
+    // org is already on. The CURRENT badge still says where they stand.
+    highlight: isCurrent && !trialOffered,
     badgeText: isCurrent ? "CURRENT" : undefined,
     metricsLabel: "Includes per month",
     fixedPrice: freePriceDisplay,
@@ -228,6 +237,7 @@ function buildTieredCard(params: {
   gasCreditCaps?: GasCreditCapsMap;
   hasSubscription: boolean;
   loading: boolean;
+  trialDays: number | null;
   onSelect: (context: PricingCtaContext) => void;
 }): PkgPricingCard {
   const {
@@ -240,6 +250,7 @@ function buildTieredCard(params: {
     gasCreditCaps,
     hasSubscription,
     loading,
+    trialDays,
     onSelect,
   } = params;
   const plan = PLANS[planName];
@@ -253,13 +264,15 @@ function buildTieredCard(params: {
   );
   const capCents = gasCreditCaps?.[planName] ?? plan.features.gasCreditsCents;
   const gas = formatCardGas(capCents);
-  const isHighlighted = currentPlan === planName;
+  const isHighlighted = currentPlan === planName || trialDays !== null;
+  const activeTier = plan.tiers.find((tier) => tier.key === selectedTier);
+  const trialPrice = activeTier ? getTierPrice(activeTier, interval) : null;
 
   return {
     id: planName,
     name: plan.name,
     highlight: isHighlighted,
-    badgeText: isHighlighted ? "CURRENT" : undefined,
+    badgeText: buildTieredBadgeText(currentPlan === planName, trialDays),
     metricsLabel: "Includes per month",
     tiers: plan.tiers.map((tier) => ({
       key: tier.key,
@@ -270,15 +283,43 @@ function buildTieredCard(params: {
     })),
     tierKey: selectedTier ?? undefined,
     cta: {
-      label: getButtonLabel(planName, isCurrent, loading, hasSubscription),
+      label: getButtonLabel(
+        planName,
+        isCurrent,
+        loading,
+        hasSubscription,
+        trialDays
+      ),
       onClick: onSelect,
-      variant: "secondary",
+      variant: trialDays === null ? "secondary" : "primary",
       disabled: isCurrent || loading,
     },
-    footnote: plan.overage.enabled
-      ? `$${plan.overage.ratePerThousand}/1K additional executions`
-      : undefined,
+    footnote: buildTieredFootnote(plan, trialDays, trialPrice),
   };
+}
+
+function buildTieredBadgeText(
+  isCurrentPlanCard: boolean,
+  trialDays: number | null
+): string | undefined {
+  if (isCurrentPlanCard) {
+    return "CURRENT";
+  }
+  return trialDays === null ? undefined : `${trialDays}-DAY FREE TRIAL`;
+}
+
+function buildTieredFootnote(
+  plan: (typeof PLANS)[TieredPlanName],
+  trialDays: number | null,
+  trialPrice: number | null
+): string | undefined {
+  // Keep this to one line: the footnote pill wraps and unbalances the card.
+  if (trialDays !== null && trialPrice !== null) {
+    return `$0 today, then $${trialPrice}/mo`;
+  }
+  return plan.overage.enabled
+    ? `$${plan.overage.ratePerThousand}/1K additional executions`
+    : undefined;
 }
 
 function buildEnterpriseCard(params: {
@@ -342,6 +383,7 @@ function buildCards(params: {
   hasSubscription: boolean;
   loadingCardId: PlanName | null;
   freePriceDisplay: string;
+  proTrialDays: number | null;
   onSelect: (planName: PlanName, context: PricingCtaContext) => void;
 }): PkgPricingCard[] {
   const {
@@ -354,6 +396,7 @@ function buildCards(params: {
     hasSubscription,
     loadingCardId,
     freePriceDisplay,
+    proTrialDays,
     onSelect,
   } = params;
 
@@ -364,6 +407,7 @@ function buildCards(params: {
       gasCreditCaps,
       hasSubscription,
       loading: loadingCardId === "free",
+      trialOffered: proTrialDays !== null,
       onSelect: (context) => onSelect("free", context),
     }),
     buildTieredCard({
@@ -376,6 +420,7 @@ function buildCards(params: {
       gasCreditCaps,
       hasSubscription,
       loading: loadingCardId === "pro",
+      trialDays: proTrialDays,
       onSelect: (context) => onSelect("pro", context),
     }),
     buildTieredCard({
@@ -388,6 +433,7 @@ function buildCards(params: {
       gasCreditCaps,
       hasSubscription,
       loading: loadingCardId === "business",
+      trialDays: null,
       onSelect: (context) => onSelect("business", context),
     }),
     buildEnterpriseCard({
@@ -623,10 +669,7 @@ function buildComparisonColumns(): PkgComparisonColumn[] {
 
 // -- Confirm dialog derived data --
 
-type DialogData = {
-  planName: PlanName;
-  tierKey: TierKey | null;
-  appInterval: BillingInterval;
+type DialogData = ConfirmTarget & {
   price: number;
   tierLabel: string | null;
   currentExecutions: number;
@@ -638,10 +681,11 @@ function buildDialogData(
   currentPlan: PlanName,
   currentTier: TierKey | null | undefined
 ): DialogData {
-  const resolved = target ?? {
-    planName: "free" as PlanName,
+  const resolved: ConfirmTarget = target ?? {
+    planName: "free",
     tierKey: null,
-    appInterval: "monthly" as BillingInterval,
+    appInterval: "monthly",
+    trial: false,
   };
   const activeTier = PLANS[resolved.planName].tiers.find(
     (tier) => tier.key === resolved.tierKey
@@ -650,6 +694,7 @@ function buildDialogData(
     planName: resolved.planName,
     tierKey: resolved.tierKey,
     appInterval: resolved.appInterval,
+    trial: resolved.trial,
     price:
       computeDisplayPrice(
         resolved.planName,
@@ -664,21 +709,35 @@ function buildDialogData(
   };
 }
 
+// The trial tier the Pro card opens on when the offer is live, so the trial is
+// the default selection rather than something the user has to find.
+function resolveDefaultProTier(
+  currentPlan: PlanName,
+  currentTier: TierKey | null | undefined,
+  trial: TrialInfo | undefined
+): TierKey | null {
+  if (currentPlan === "pro" && currentTier) {
+    return currentTier;
+  }
+  if (trial?.eligible === true) {
+    return trial.tier;
+  }
+  return PLANS.pro.tiers[0]?.key ?? null;
+}
+
 export function PricingTable({
   currentPlan = "free",
   currentTier,
   currentInterval,
   gasCreditCaps,
+  trial,
   onPlanUpdated,
 }: PricingTableProps): React.ReactElement {
   const [interval, setInterval] = useState<BillingInterval>("monthly");
   const [selectedTierByCard, setSelectedTierByCard] = useState<
     Record<TieredPlanName, TierKey | null>
   >({
-    pro:
-      currentPlan === "pro" && currentTier
-        ? currentTier
-        : (PLANS.pro.tiers[0]?.key ?? null),
+    pro: resolveDefaultProTier(currentPlan, currentTier, trial),
     business:
       currentPlan === "business" && currentTier
         ? currentTier
@@ -726,9 +785,12 @@ export function PricingTable({
   function onCardCta(planName: PlanName, context: PricingCtaContext): void {
     const tierKey = (context.tierKey as TierKey | undefined) ?? null;
     handleSubscribe(
-      planName,
-      tierKey,
-      pkgIntervalToApp(context.interval),
+      {
+        planName,
+        tierKey,
+        appInterval: pkgIntervalToApp(context.interval),
+        trial: isTrialSelection(trial, planName, tierKey),
+      },
       handlers
     );
   }
@@ -743,6 +805,11 @@ export function PricingTable({
   }
 
   const freePriceDisplay = formatFreePrice(paygPriceUsdc);
+  // Only the trial tier selection carries the offer; picking another Pro tier
+  // turns the card back into a pay-now card.
+  const proTrialDays = isTrialSelection(trial, "pro", selectedTierByCard.pro)
+    ? (trial?.days ?? null)
+    : null;
   const cards = buildCards({
     currentPlan,
     currentTier,
@@ -753,6 +820,7 @@ export function PricingTable({
     hasSubscription,
     loadingCardId,
     freePriceDisplay,
+    proTrialDays,
     onSelect: onCardCta,
   });
 
@@ -791,9 +859,12 @@ export function PricingTable({
         newTier={dialogData.tierKey}
         onConfirm={() =>
           executeCheckout(
-            dialogData.planName,
-            dialogData.tierKey,
-            dialogData.appInterval,
+            {
+              planName: dialogData.planName,
+              tierKey: dialogData.tierKey,
+              appInterval: dialogData.appInterval,
+              trial: dialogData.trial,
+            },
             handlers
           )
         }

--- a/components/billing/pricing-table/index.tsx
+++ b/components/billing/pricing-table/index.tsx
@@ -220,7 +220,9 @@ function buildFreeCard(params: {
     cta: {
       label: getButtonLabel("free", isCurrent, loading, hasSubscription),
       onClick: onSelect,
-      variant: "primary",
+      // Downgrading is not something to lead with: on a paid plan this button
+      // cancels, so it stays quiet while the plans being sold are filled.
+      variant: hasSubscription ? "secondary" : "primary",
       disabled: isCurrent || loading,
     },
     footnote: `${plan.features.maxExecutionsPerMonth.toLocaleString()} free / mo, then pay-as-you-go`,

--- a/components/billing/pricing-table/types.ts
+++ b/components/billing/pricing-table/types.ts
@@ -21,6 +21,7 @@ export type PricingTableProps = {
   currentTier?: TierKey | null;
   currentInterval?: BillingInterval | null;
   gasCreditCaps?: GasCreditCapsMap;
+  trial?: TrialInfo;
   onPlanUpdated?: () => Promise<void>;
 };
 

--- a/components/billing/pricing-table/utils.ts
+++ b/components/billing/pricing-table/utils.ts
@@ -5,8 +5,9 @@ import {
   PLANS,
   type PlanName,
   type TierKey,
+  TRIAL_PLAN_NAME,
 } from "@/lib/billing/plans";
-import type { PlanTierItem } from "./types";
+import type { PlanTierItem, TrialInfo } from "./types";
 
 export function formatPrice(price: number): string {
   return `$${price}`;
@@ -36,17 +37,42 @@ export function computeDisplayPrice(
   return getTierPrice(activeTier, interval);
 }
 
+/**
+ * Whether a plan/tier selection is the free-trial offer rather than a pay-now
+ * purchase. The trial rides on one plan and one tier only: Pro at the tier the
+ * server resolved (25k by default). Every other Pro tier, and every other plan,
+ * is paid. Display and checkout intent both read this; the checkout route
+ * re-checks eligibility server-side.
+ */
+export function isTrialSelection(
+  trial: TrialInfo | undefined,
+  planName: PlanName,
+  tierKey: TierKey | null
+): boolean {
+  return (
+    trial?.eligible === true &&
+    planName === TRIAL_PLAN_NAME &&
+    tierKey === trial.tier
+  );
+}
+
+// `trialDays` is set only when the card's current selection is the trial offer
+// (Pro at the server-resolved trial tier for an eligible org).
 export function getButtonLabel(
   planName: PlanName,
   isCurrent: boolean,
   loading: boolean,
-  hasSubscription: boolean
+  hasSubscription: boolean,
+  trialDays?: number | null
 ): string {
   if (loading) {
     return hasSubscription ? "Updating..." : "Redirecting...";
   }
   if (isCurrent) {
     return "Current Plan";
+  }
+  if (trialDays) {
+    return `Start ${trialDays}-day free trial`;
   }
   if (planName === "free") {
     return hasSubscription ? "Downgrade to Free" : "Free";

--- a/components/billing/trial-upsell-modal.tsx
+++ b/components/billing/trial-upsell-modal.tsx
@@ -4,11 +4,20 @@ import { Check, Sparkles, X } from "lucide-react";
 import { useState } from "react";
 import { useOverlay } from "@/components/overlays/overlay-provider";
 import { Button } from "@/components/ui/button";
-import { type BillingInterval, PLANS, type TierKey } from "@/lib/billing/plans";
+import {
+  type BillingInterval,
+  PLANS,
+  type PlanName,
+  type TierKey,
+  TRIAL_PLAN_NAME,
+} from "@/lib/billing/plans";
 import { cn } from "@/lib/utils";
+import type { PlanTierItem } from "./pricing-table/types";
 import { getTierPrice, startCheckout } from "./pricing-table/utils";
 
 const PRO = PLANS.pro;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MONTHS_PER_YEAR = 12;
 
 // Plan-level Pro perks (execution volume is chosen per-tier below).
 const PRO_BENEFITS: readonly string[] = [
@@ -19,12 +28,60 @@ const PRO_BENEFITS: readonly string[] = [
   "Overage billing, no hard cap",
 ];
 
+type PlanChoice = PlanTierItem & { plan: PlanName };
+
+// What a trialing org can move to from here: every Pro tier, plus the entry
+// Business tier as the next step up. The rest of the range is on the plans table.
+const PLAN_CHOICES: readonly PlanChoice[] = [
+  ...PRO.tiers.map((tier) => ({ ...tier, plan: "pro" as PlanName })),
+  ...PLANS.business.tiers
+    .slice(0, 1)
+    .map((tier) => ({ ...tier, plan: "business" as PlanName })),
+];
+
+function choiceId(plan: PlanName, tier: TierKey): string {
+  return `${plan}:${tier}`;
+}
+
+function annualSaving(choice: PlanChoice): number {
+  return (choice.monthlyPrice - choice.monthlyPriceAnnual) * MONTHS_PER_YEAR;
+}
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "long",
+  day: "numeric",
+  year: "numeric",
+});
+
+function daysUntil(endsAt: string): number {
+  return Math.max(
+    0,
+    Math.ceil((new Date(endsAt).getTime() - Date.now()) / DAY_MS)
+  );
+}
+
+// "11 days left. Converts on August 18, 2026." Falls back to the configured
+// trial length when the end date has not been read back from the provider yet.
+function trialTimingLine(
+  trialEndsAt: string | undefined,
+  days: number
+): string {
+  if (!trialEndsAt) {
+    return `${days}-day free trial.`;
+  }
+  const left = daysUntil(trialEndsAt);
+  const converts = dateFormatter.format(new Date(trialEndsAt));
+  const unit = left === 1 ? "day" : "days";
+  return `${left} ${unit} left. Converts on ${converts}.`;
+}
+
 /**
  * Pro trial modal. `tier` is the server-resolved Pro trial tier. Two modes:
  * - Start (default): offer the free trial to an eligible free org.
- * - Update (isUpdate): let a trialing org pick the billing interval its trial
- *   converts to; the trial continues and is billed at that rate, $0 now.
- * Both send trial:true so the server keeps/starts the trial; plan cards never do.
+ * - Update (isUpdate): let a trialing org pick what its trial converts to.
+ *   Staying on the trial tier keeps the trial (only the interval changes, $0
+ *   now); picking a bigger plan ends the trial and bills immediately.
+ * trial:true is sent only while the selection stays on the trial plan/tier.
  */
 export function TrialUpsellModal({
   overlayId,
@@ -33,6 +90,7 @@ export function TrialUpsellModal({
   usage,
   isUpdate = false,
   currentInterval,
+  trialEndsAt,
   onNeverShowAgain,
 }: {
   overlayId: string;
@@ -41,19 +99,33 @@ export function TrialUpsellModal({
   usage?: { executionsUsed: number; executionLimit: number };
   isUpdate?: boolean;
   currentInterval?: BillingInterval;
+  trialEndsAt?: string;
   onNeverShowAgain?: () => void;
 }): React.ReactElement {
   const { close } = useOverlay();
   const [interval, setInterval] = useState<BillingInterval>(
     currentInterval ?? "monthly"
   );
+  const [selectedId, setSelectedId] = useState<string>(
+    choiceId(TRIAL_PLAN_NAME, tier)
+  );
   const [loading, setLoading] = useState(false);
 
   const trialTier = PRO.tiers.find((t) => t.key === tier) ?? PRO.tiers[0];
-  const price = getTierPrice(trialTier, interval);
-  // A trial is a single tier, so in update mode the only thing to change is the
-  // billing interval it converts to.
-  const noChange = isUpdate && interval === (currentInterval ?? "monthly");
+  const selected =
+    PLAN_CHOICES.find((c) => choiceId(c.plan, c.key) === selectedId) ??
+    PLAN_CHOICES[0];
+  // Start mode only ever offers the trial tier; update mode offers the range.
+  const active: PlanChoice = isUpdate
+    ? selected
+    : { ...trialTier, plan: TRIAL_PLAN_NAME };
+  const price = getTierPrice(active, interval);
+
+  // Staying on the trial plan/tier keeps the trial alive; anything else ends it
+  // and is charged now, so the copy and the checkout intent both branch here.
+  const staysOnTrial = active.plan === TRIAL_PLAN_NAME && active.key === tier;
+  const noChange =
+    isUpdate && staysOnTrial && interval === (currentInterval ?? "monthly");
 
   // Start mode leads with the reason the offer shows: nearing the free cap.
   const quotaLine =
@@ -65,8 +137,8 @@ export function TrialUpsellModal({
     setLoading(true);
     try {
       // trial:true keeps/starts the trial; the server re-checks eligibility.
-      const ok = await startCheckout("pro", tier, interval, {
-        trial: true,
+      const ok = await startCheckout(active.plan, active.key, interval, {
+        trial: staysOnTrial,
       });
       // In update mode Stripe updates in place (no redirect); refresh the page
       // to reflect the new tier. Start mode redirects to Checkout instead.
@@ -102,10 +174,14 @@ export function TrialUpsellModal({
               : `Try Pro free for ${days} days`}
           </h2>
           {isUpdate ? (
-            <p className="text-muted-foreground text-sm">
-              Choose the billing interval your trial converts to. Your trial
-              continues and is billed at that rate when it ends.
-            </p>
+            <>
+              <p className="font-medium text-foreground text-sm">
+                {trialTimingLine(trialEndsAt, days)}
+              </p>
+              <p className="text-muted-foreground text-sm">
+                Choose the plan and billing interval your trial converts to.
+              </p>
+            </>
           ) : (
             <>
               <p className="font-medium text-foreground text-sm">{quotaLine}</p>
@@ -137,50 +213,48 @@ export function TrialUpsellModal({
         </ul>
 
         <div className="space-y-3">
-          <div className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-sidebar p-1">
-            {(["monthly", "yearly"] as const).map((value) => (
-              <button
-                className={cn(
-                  "rounded-full px-3 py-1 font-medium text-xs transition-colors",
-                  interval === value
-                    ? "bg-keeperhub-green-dark text-white"
-                    : "text-muted-foreground hover:text-foreground"
-                )}
-                key={value}
-                onClick={() => setInterval(value)}
-                type="button"
-              >
-                {value === "monthly" ? "Monthly" : "Annual"}
-              </button>
-            ))}
-          </div>
+          <IntervalToggle
+            interval={interval}
+            onChange={setInterval}
+            saving={annualSaving(active)}
+          />
 
-          <div className="flex items-center justify-between rounded-lg border border-keeperhub-green-dark/60 bg-keeperhub-green-dark/10 px-3 py-2.5 text-sm">
-            <span className="flex items-center gap-2 font-medium">
-              {trialTier.executions.toLocaleString()} executions
-              {isUpdate && (
-                <span className="rounded-full bg-muted px-1.5 py-0.5 font-medium text-[10px] text-muted-foreground uppercase">
-                  Current
-                </span>
-              )}
-            </span>
-            <span className="text-muted-foreground">${price}/mo</span>
-          </div>
+          {isUpdate ? (
+            <div className="space-y-2">
+              {PLAN_CHOICES.map((choice) => (
+                <PlanChoiceRow
+                  choice={choice}
+                  interval={interval}
+                  isCurrent={
+                    choice.plan === TRIAL_PLAN_NAME && choice.key === tier
+                  }
+                  isSelected={choiceId(choice.plan, choice.key) === selectedId}
+                  key={choiceId(choice.plan, choice.key)}
+                  onSelect={setSelectedId}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="flex items-center justify-between rounded-lg border border-keeperhub-green-dark/60 bg-keeperhub-green-dark/10 px-3 py-2.5 text-sm">
+              <span className="font-medium">
+                {trialTier.executions.toLocaleString()} executions
+              </span>
+              <span className="text-muted-foreground">${price}/mo</span>
+            </div>
+          )}
         </div>
       </div>
 
       <div className="mt-2 flex flex-col gap-3 border-border/50 border-t px-6 py-4">
         <p className="text-muted-foreground text-xs">
-          {isUpdate
-            ? `No charge now. From the trial end, $${price}/mo.`
-            : `After the trial, $${price}/mo. Cancel anytime before it ends and you will not be charged.`}
+          {getFooterNote({ isUpdate, staysOnTrial, price })}
         </p>
         <Button
           className="w-full rounded-full"
           disabled={loading || noChange}
           onClick={handleSubmit}
         >
-          {getButtonLabel({ isUpdate, loading, days })}
+          {getButtonLabel({ isUpdate, staysOnTrial, loading, days })}
         </Button>
         <div className="flex items-center justify-between">
           {onNeverShowAgain ? (
@@ -207,17 +281,126 @@ export function TrialUpsellModal({
   );
 }
 
+function IntervalToggle({
+  interval,
+  onChange,
+  saving,
+}: {
+  interval: BillingInterval;
+  onChange: (value: BillingInterval) => void;
+  saving: number;
+}): React.ReactElement {
+  return (
+    <div className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-sidebar p-1">
+      {(["monthly", "yearly"] as const).map((value) => (
+        <button
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-full px-3 py-1 font-medium text-xs transition-colors",
+            interval === value
+              ? "bg-keeperhub-green-dark text-white"
+              : "text-muted-foreground hover:text-foreground"
+          )}
+          key={value}
+          onClick={() => onChange(value)}
+          type="button"
+        >
+          {value === "monthly" ? "Monthly" : "Annual"}
+          {value === "yearly" && saving > 0 && (
+            <span
+              className={cn(
+                "text-[10px]",
+                interval === value
+                  ? "text-white/80"
+                  : "text-keeperhub-green-dark"
+              )}
+            >
+              save ${saving}/yr
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function PlanChoiceRow({
+  choice,
+  interval,
+  isCurrent,
+  isSelected,
+  onSelect,
+}: {
+  choice: PlanChoice;
+  interval: BillingInterval;
+  isCurrent: boolean;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+}): React.ReactElement {
+  const label =
+    choice.plan === TRIAL_PLAN_NAME
+      ? `${choice.executions.toLocaleString()} executions`
+      : `${PLANS[choice.plan].name} ${choice.executions.toLocaleString()}`;
+
+  return (
+    <button
+      className={cn(
+        "flex w-full items-center justify-between rounded-lg border px-3 py-2.5 text-left text-sm transition-colors",
+        isSelected
+          ? "border-keeperhub-green-dark/60 bg-keeperhub-green-dark/10"
+          : "border-border/60 hover:border-border"
+      )}
+      onClick={() => onSelect(choiceId(choice.plan, choice.key))}
+      type="button"
+    >
+      <span className="flex items-center gap-2 font-medium">
+        {label}
+        {isCurrent && (
+          <span className="rounded-full bg-muted px-1.5 py-0.5 font-medium text-[10px] text-muted-foreground uppercase">
+            Current
+          </span>
+        )}
+      </span>
+      <span className="text-muted-foreground">
+        ${getTierPrice(choice, interval)}/mo
+      </span>
+    </button>
+  );
+}
+
+function getFooterNote({
+  isUpdate,
+  staysOnTrial,
+  price,
+}: {
+  isUpdate: boolean;
+  staysOnTrial: boolean;
+  price: number;
+}): string {
+  if (!isUpdate) {
+    return `After the trial, $${price}/mo. Cancel anytime before it ends and you will not be charged.`;
+  }
+  if (staysOnTrial) {
+    return `No charge now. From the trial end, $${price}/mo.`;
+  }
+  return `This ends your trial and bills the new plan today, then $${price}/mo.`;
+}
+
 function getButtonLabel({
   isUpdate,
+  staysOnTrial,
   loading,
   days,
 }: {
   isUpdate: boolean;
+  staysOnTrial: boolean;
   loading: boolean;
   days: number;
 }): string {
-  if (isUpdate) {
-    return loading ? "Updating..." : "Update trial plan";
+  if (!isUpdate) {
+    return loading ? "Redirecting..." : `Start ${days}-day free trial`;
   }
-  return loading ? "Redirecting..." : `Start ${days}-day free trial`;
+  if (loading) {
+    return "Updating...";
+  }
+  return staysOnTrial ? "Update trial plan" : "Upgrade now";
 }

--- a/lib/billing/plans.ts
+++ b/lib/billing/plans.ts
@@ -56,20 +56,16 @@ const VALID_TIER_KEYS: ReadonlySet<string> = new Set<TierKey>([
   "1m",
 ]);
 
-// A free trial applies to a single Pro tier, chosen server-side from the
-// TRIAL_TIER env (resolved in lib/billing/trial.ts, no public env). These are
-// the tiers that value may select; anything else falls back to the default.
-// Every other plan and tier is pay-now.
+// A free trial applies to the entry Pro tier only. Whether trials run at all is
+// the TRIALS_ENABLED flag; the tier they run on is not an operating knob, so
+// TRIAL_TIER (resolved in lib/billing/trial.ts) accepts nothing else and any
+// other value falls back to the default. Every other plan and tier is pay-now.
 export const TRIAL_PLAN_NAME: PlanName = "pro";
 // Pay-as-you-go is offered on this plan only; every other plan either bills
 // overage past its included limit or is unlimited.
 export const PAYG_PLAN_NAME: PlanName = "free";
 export const DEFAULT_TRIAL_TIER_KEY: TierKey = "25k";
-export const TRIAL_ELIGIBLE_TIER_KEYS: readonly TierKey[] = [
-  "25k",
-  "50k",
-  "100k",
-];
+export const TRIAL_ELIGIBLE_TIER_KEYS: readonly TierKey[] = ["25k"];
 
 export function isValidPlanName(value: unknown): value is PlanName {
   return typeof value === "string" && VALID_PLAN_NAMES.has(value);

--- a/lib/billing/trial.ts
+++ b/lib/billing/trial.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_TRIAL_TIER_KEY,
   isConfigurableTrialTier,
   type PlanName,
+  parsePlanName,
   type TierKey,
   TRIAL_PLAN_NAME,
 } from "./plans";
@@ -119,8 +120,14 @@ export function isTrialEligible(
   if (!sub) {
     return true;
   }
-  // Never while currently subscribed to a paid plan.
-  if (sub.providerSubscriptionId != null || sub.plan !== "free") {
+  // Never while currently subscribed to a paid plan. The plan column is free
+  // text and every other read path runs it through parsePlanName, so parse here
+  // too: a raw compare calls an org ineligible over a value the rest of the app
+  // already treats as free (pay-as-you-go orgs, legacy rows).
+  if (
+    sub.providerSubscriptionId != null ||
+    parsePlanName(sub.plan) !== "free"
+  ) {
     return false;
   }
   // First-timer: never trialed, and not a previously-subscribed-then-reset org.

--- a/tests/unit/billing-pricing-table-trial.test.ts
+++ b/tests/unit/billing-pricing-table-trial.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { TrialInfo } from "@/components/billing/pricing-table/types";
+import {
+  getButtonLabel,
+  isTrialSelection,
+} from "@/components/billing/pricing-table/utils";
+
+const ELIGIBLE: TrialInfo = { eligible: true, days: 14, tier: "25k" };
+
+describe("isTrialSelection", () => {
+  it("accepts Pro at the resolved trial tier", () => {
+    expect(isTrialSelection(ELIGIBLE, "pro", "25k")).toBe(true);
+  });
+
+  it("rejects the other Pro tiers", () => {
+    expect(isTrialSelection(ELIGIBLE, "pro", "50k")).toBe(false);
+    expect(isTrialSelection(ELIGIBLE, "pro", "100k")).toBe(false);
+  });
+
+  it("rejects other plans", () => {
+    expect(isTrialSelection(ELIGIBLE, "business", "250k")).toBe(false);
+    expect(isTrialSelection(ELIGIBLE, "enterprise", null)).toBe(false);
+    expect(isTrialSelection(ELIGIBLE, "free", null)).toBe(false);
+  });
+
+  it("rejects an ineligible or absent trial offer", () => {
+    expect(
+      isTrialSelection({ ...ELIGIBLE, eligible: false }, "pro", "25k")
+    ).toBe(false);
+    expect(isTrialSelection(undefined, "pro", "25k")).toBe(false);
+  });
+
+  it("follows the tier the server resolved, not a hardcoded 25k", () => {
+    const at50k: TrialInfo = { eligible: true, days: 14, tier: "50k" };
+    expect(isTrialSelection(at50k, "pro", "50k")).toBe(true);
+    expect(isTrialSelection(at50k, "pro", "25k")).toBe(false);
+  });
+});
+
+describe("getButtonLabel", () => {
+  it("offers the trial when the selection carries trial days", () => {
+    expect(getButtonLabel("pro", false, false, false, 14)).toBe(
+      "Start 14-day free trial"
+    );
+  });
+
+  it("falls back to the paid label without trial days", () => {
+    expect(getButtonLabel("pro", false, false, false, null)).toBe(
+      "Choose plan"
+    );
+    expect(getButtonLabel("pro", false, false, false)).toBe("Choose plan");
+  });
+
+  it("keeps the current-plan and loading labels ahead of the trial offer", () => {
+    expect(getButtonLabel("pro", true, false, true, 14)).toBe("Current Plan");
+    expect(getButtonLabel("pro", false, true, false, 14)).toBe(
+      "Redirecting..."
+    );
+  });
+});

--- a/tests/unit/billing-trial.test.ts
+++ b/tests/unit/billing-trial.test.ts
@@ -134,6 +134,13 @@ describe("isTrialEligible", () => {
     expect(isTrialEligible(makeSub(), "pro", "25k")).toBe(true);
   });
 
+  // The plan column is free text and unknown values read as free everywhere
+  // else, so eligibility must not disagree with what the org is shown as.
+  it("is eligible for a row whose plan parses to free", () => {
+    expect(isTrialEligible(makeSub({ plan: "payg" }), "pro", "25k")).toBe(true);
+    expect(isTrialEligible(makeSub({ plan: "" }), "pro", "25k")).toBe(true);
+  });
+
   it("is not eligible for non-Pro plans", () => {
     expect(isTrialEligible(undefined, "business", "250k")).toBe(false);
     expect(isTrialEligible(undefined, "enterprise", null)).toBe(false);

--- a/tests/unit/billing-trial.test.ts
+++ b/tests/unit/billing-trial.test.ts
@@ -79,11 +79,11 @@ describe("getTrialTier", () => {
     expect(getTrialTier()).toBe("25k");
   });
 
-  it("reads a valid configured Pro tier", () => {
+  it("stays on 25k for the higher Pro tiers", () => {
     vi.stubEnv("TRIAL_TIER", "50k");
-    expect(getTrialTier()).toBe("50k");
+    expect(getTrialTier()).toBe("25k");
     vi.stubEnv("TRIAL_TIER", "100k");
-    expect(getTrialTier()).toBe("100k");
+    expect(getTrialTier()).toBe("25k");
   });
 
   it("falls back to the default for a non-Pro or unknown tier", () => {
@@ -99,20 +99,20 @@ describe("isTrialPlan", () => {
     vi.unstubAllEnvs();
   });
 
-  it("is true only for the configured trial tier (default 25k)", () => {
+  it("is true only for the trial tier (25k)", () => {
     expect(isTrialPlan("pro", "25k")).toBe(true);
   });
 
-  it("is false for Pro tiers other than the configured one", () => {
+  it("is false for the paid Pro tiers", () => {
     expect(isTrialPlan("pro", "50k")).toBe(false);
     expect(isTrialPlan("pro", "100k")).toBe(false);
     expect(isTrialPlan("pro", null)).toBe(false);
   });
 
-  it("follows the configured tier from env", () => {
+  it("stays on 25k even when env asks for another tier", () => {
     vi.stubEnv("TRIAL_TIER", "50k");
-    expect(isTrialPlan("pro", "50k")).toBe(true);
-    expect(isTrialPlan("pro", "25k")).toBe(false);
+    expect(isTrialPlan("pro", "25k")).toBe(true);
+    expect(isTrialPlan("pro", "50k")).toBe(false);
   });
 
   it("is false for other plans", () => {


### PR DESCRIPTION
Starting a trial used to live in a separate pill button next to the plan title, shown only to free orgs that had already burned half their monthly executions. The plan cards right below it sold the same Pro plan and said nothing about a trial being available.

The trial now lives on the Pro card itself. When an org is eligible and the card sits on the entry tier, that card takes the highlight, badges the trial, and its button starts it. The free card keeps its CURRENT badge but gives up the green border so only one card reads as the default. Selecting a higher Pro tier turns it straight back into a pay-now card. The standalone button is gone.

The offer is gated by the trials flag and server-side eligibility alone, with no usage threshold, so every eligible org sees it on the billing page. The usage-based upsell modal keeps its own threshold and still fires from any page.

## Trial tier is pinned

`TRIAL_TIER` could previously move the trial onto the 50k or 100k tier. Only the entry tier is trial-eligible now, and any other value falls back to it. The env var is fed from Parameter Store in staging and prod and is now inert, so that wiring can be dropped in a follow-up.

Worth knowing before merge: any org currently trialing on a higher tier stops counting as being on the trial plan, so a plan change from the trial modal would end its trial and bill immediately. Check what staging's Parameter Store value is set to.

## Eligibility no longer disagrees with the UI

`plan` is a plain text column, and `parsePlanName` exists so unknown values degrade to `free`. Eligibility was the one place comparing the raw string, so a row holding anything other than the literal `free` read as Free everywhere in the UI while being silently barred from the trial, with no error to explain it. It now parses the value like every other read path does.

## Two UI fixes on top

The free card's button was filled green on every plan, which made cancelling the loudest control on the page once subscribed. It now renders quiet for subscribed orgs.

The trial modal offered only a billing interval and opened with its button disabled, so it was effectively a dead end. It now shows how much trial is left and when it converts, prices the annual saving on the toggle, and lists the Pro tiers plus entry Business. Staying on the trial tier keeps the trial at $0. Moving up ends it and bills today, which the copy and the button now state outright, matching what Stripe actually does there (`trial_end: "now"` with `proration_behavior: "always_invoice"`).
