### PR TITLE
feat(billing): make pay-as-you-go the default for every free org

### DIFF
--- a/app/api/billing/payg/route.ts
+++ b/app/api/billing/payg/route.ts
@@ -27,6 +27,7 @@ type PaygStatus = {
   priceUsdc: string;
   treasuryConfigured: boolean;
   chainId: number;
+  /** Decimal USDC. "0" blocks all spend rather than meaning "no cap". */
   caps: { dailyUsdc: string; periodUsdc: string };
   usage: {
     periodStart: string;
@@ -89,9 +90,10 @@ export async function GET(request: Request): Promise<NextResponse> {
 }
 
 /**
- * Parse a decimal USDC cap into a 6-dp raw string; "" / undefined -> "0" (no
- * cap). Throws on a malformed value so the caller returns 400 rather than
- * silently treating garbage as "0" (which would disable the spend cap).
+ * Parse a decimal USDC cap into a 6-dp raw string. A cap left blank is "0", and
+ * "0" blocks all spend, so an omitted cap is never read as unlimited. Throws on
+ * a malformed value so the caller returns 400 rather than silently treating
+ * garbage as a cap.
  */
 function parseCap(value: unknown): string {
   if (value === undefined || value === null || value === "") {
@@ -121,8 +123,8 @@ export async function POST(request: Request): Promise<NextResponse> {
       chainId?: number;
     };
 
-    let dailyCapRaw: string;
-    let periodCapRaw: string;
+    let dailyCapRaw: string | null;
+    let periodCapRaw: string | null;
     try {
       dailyCapRaw = parseCap(body.dailyCapUsdc);
       periodCapRaw = parseCap(body.periodCapUsdc);

--- a/app/api/billing/payg/route.ts
+++ b/app/api/billing/payg/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from "next/server";
 import { isBillingEnabled } from "@/lib/billing/feature-flag";
 import {
-  deletePaygConfig,
-  getPaygConfig,
+  getPaygSettings,
   upsertPaygConfig,
 } from "@/lib/billing/payg/config-store";
 import { PAYG_DEFAULT_CHAIN_ID } from "@/lib/billing/payg/constants";
@@ -25,7 +24,6 @@ import {
 import { buildAuditMetadata, recordAuditEvent } from "@/lib/security/audit-log";
 
 type PaygStatus = {
-  enabled: boolean;
   priceUsdc: string;
   treasuryConfigured: boolean;
   chainId: number;
@@ -36,34 +34,30 @@ type PaygStatus = {
     periodExecutions: number;
     periodSpentUsdc: string;
     dailySpentUsdc: string;
-  } | null;
+  };
 };
 
 async function buildPaygStatus(organizationId: string): Promise<PaygStatus> {
-  const config = await getPaygConfig(organizationId);
-  const chainId = config?.chainId ?? PAYG_DEFAULT_CHAIN_ID;
+  const settings = await getPaygSettings(organizationId);
   const priceRaw = getPaygExecutionPriceRaw();
 
   const usage = await getCurrentPaygUsage(organizationId);
 
   return {
-    enabled: config !== null,
     priceUsdc: usdcRawToDecimal(priceRaw),
-    treasuryConfigured: getPaygTreasuryOrNull(chainId) !== null,
-    chainId,
+    treasuryConfigured: getPaygTreasuryOrNull(settings.chainId) !== null,
+    chainId: settings.chainId,
     caps: {
-      dailyUsdc: usdcRawToDecimal(BigInt(config?.dailyCapRaw ?? "0")),
-      periodUsdc: usdcRawToDecimal(BigInt(config?.periodCapRaw ?? "0")),
+      dailyUsdc: usdcRawToDecimal(BigInt(settings.dailyCapRaw)),
+      periodUsdc: usdcRawToDecimal(BigInt(settings.periodCapRaw)),
     },
-    usage: usage
-      ? {
-          periodStart: usage.periodStart.toISOString(),
-          periodEnd: usage.periodEnd.toISOString(),
-          periodExecutions: usage.periodExecutions,
-          periodSpentUsdc: usdcRawToDecimal(usage.periodSpentRaw),
-          dailySpentUsdc: usdcRawToDecimal(usage.dailySpentRaw),
-        }
-      : null,
+    usage: {
+      periodStart: usage.periodStart.toISOString(),
+      periodEnd: usage.periodEnd.toISOString(),
+      periodExecutions: usage.periodExecutions,
+      periodSpentUsdc: usdcRawToDecimal(usage.periodSpentRaw),
+      dailySpentUsdc: usdcRawToDecimal(usage.dailySpentRaw),
+    },
   };
 }
 
@@ -149,7 +143,7 @@ export async function POST(request: Request): Promise<NextResponse> {
 
     // PAYG is a free-tier feature: it lets a free org keep running past its
     // included limit. Paid plans have their own executions/overage, so only
-    // free-plan orgs may enable it.
+    // free-plan orgs set caps here.
     if ((await getOrgPlan(orgId)) !== PAYG_PLAN_NAME) {
       return NextResponse.json(
         { error: "Pay-as-you-go is available on the free plan only" },
@@ -157,7 +151,6 @@ export async function POST(request: Request): Promise<NextResponse> {
       );
     }
 
-    const alreadyEnabled = (await getPaygConfig(orgId)) !== null;
     await upsertPaygConfig({
       organizationId: orgId,
       dailyCapRaw,
@@ -167,7 +160,7 @@ export async function POST(request: Request): Promise<NextResponse> {
 
     await recordAuditEvent({
       actor: { userId, organizationId: orgId, authMethod: "session" },
-      action: alreadyEnabled ? "payg.caps_updated" : "payg.enabled",
+      action: "payg.caps_updated",
       resourceType: "subscription",
       resourceId: orgId,
       after: { dailyCapRaw, periodCapRaw, chainId },
@@ -176,47 +169,12 @@ export async function POST(request: Request): Promise<NextResponse> {
 
     return NextResponse.json(await buildPaygStatus(orgId));
   } catch (error) {
-    logSystemError(ErrorCategory.BILLING, "[PAYG] Enable error", error, {
+    logSystemError(ErrorCategory.BILLING, "[PAYG] Caps update error", error, {
       endpoint: "/api/billing/payg",
       operation: "post",
     });
     return NextResponse.json(
       { error: "Failed to update pay-as-you-go settings" },
-      { status: 500 }
-    );
-  }
-}
-
-export async function DELETE(request: Request): Promise<NextResponse> {
-  if (!isBillingEnabled()) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
-  }
-
-  const auth = await requireOrgOwner();
-  if ("error" in auth) {
-    return auth.error;
-  }
-  const { orgId, userId } = auth;
-
-  try {
-    await deletePaygConfig(orgId);
-
-    await recordAuditEvent({
-      actor: { userId, organizationId: orgId, authMethod: "session" },
-      action: "payg.disabled",
-      resourceType: "subscription",
-      resourceId: orgId,
-      metadata: buildAuditMetadata(request),
-    });
-
-    return NextResponse.json(await buildPaygStatus(orgId));
-  } catch (error) {
-    logSystemError(ErrorCategory.BILLING, "[PAYG] Disable error", error, {
-      endpoint: "/api/billing/payg",
-      operation: "delete",
-    });
-    return NextResponse.json(
-      { error: "Failed to disable pay-as-you-go" },
       { status: 500 }
     );
   }

--- a/app/welcome/layout.tsx
+++ b/app/welcome/layout.tsx
@@ -4,13 +4,13 @@ import { AnimatePresence, motion } from "motion/react";
 import { LayoutRouterContext } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import { usePathname } from "next/navigation";
 import { type ReactNode, useContext, useEffect, useRef } from "react";
+import { WELCOME_STEPS } from "@/components/welcome/welcome-shell";
 
-// Order used to decide the transition direction between wizard steps.
-const STEP_ORDER = [
+// Order used to decide the transition direction between wizard steps. Derived
+// from the wizard itself so a new step cannot drift out of this list.
+const STEP_ORDER: string[] = [
   "/welcome",
-  "/welcome/create-org",
-  "/welcome/invite-members",
-  "/welcome/connect-agent",
+  ...WELCOME_STEPS.map((step) => step.path),
 ];
 
 const variants = {

--- a/components/billing/billing-status.tsx
+++ b/components/billing/billing-status.tsx
@@ -17,6 +17,7 @@ import { BILLING_ALERTS, BILLING_API } from "@/lib/billing/constants";
 import {
   type BillingInterval,
   billsOverage,
+  PAYG_PLAN_NAME,
   PLANS,
   type PlanName,
   parsePlanName,
@@ -430,12 +431,12 @@ function ExecutionUsageBar({
   used,
   limit,
   plan,
-  paygEnabled,
+  paygCovered,
 }: {
   used: number;
   limit: number;
   plan: PlanName;
-  paygEnabled: boolean;
+  paygCovered: boolean;
 }): React.ReactElement {
   const isUnlimited = limit === -1;
   const percent = isUnlimited ? 0 : Math.min((used / limit) * 100, 100);
@@ -443,9 +444,9 @@ function ExecutionUsageBar({
   const isNearLimit = !isUnlimited && percent >= 80;
   const hasOverage = PLANS[plan].overage.enabled;
   const overageRate = PLANS[plan].overage.ratePerThousand;
-  // Free orgs with PAYG on keep running past the limit (charged per execution),
-  // so treat it like overage: no hard block, no destructive styling.
-  const overflowCovered = hasOverage || paygEnabled;
+  // Free orgs keep running past the limit (charged per execution), so treat it
+  // like overage: no hard block, no destructive styling.
+  const overflowCovered = hasOverage || paygCovered;
 
   function resolveBarColor(): string {
     if (isOverLimit && !overflowCovered) {
@@ -522,12 +523,12 @@ function ExecutionUsageBar({
           will be added to your next invoice.
         </p>
       )}
-      {isOverLimit && !hasOverage && paygEnabled && (
+      {isOverLimit && !hasOverage && paygCovered && (
         <p className="text-muted-foreground text-xs">
           Beyond your free limit, each execution is charged via pay-as-you-go.
         </p>
       )}
-      {isOverLimit && !hasOverage && !paygEnabled && (
+      {isOverLimit && !(hasOverage || paygCovered) && (
         <p className="text-destructive text-xs">
           You have reached your monthly execution limit. Upgrade your plan to
           continue.
@@ -714,30 +715,9 @@ function BillingStatusContent({
   const plan = parsePlanName(sub?.plan);
   const planDef = PLANS[plan];
 
-  // Free orgs can enable pay-as-you-go to keep running past the free limit, so
-  // the over-limit message must not tell them to upgrade when PAYG is on.
-  const [paygEnabled, setPaygEnabled] = useState(false);
-  useEffect(() => {
-    if (plan !== "free") {
-      setPaygEnabled(false);
-      return;
-    }
-    let cancelled = false;
-    async function loadPaygEnabled(): Promise<void> {
-      const res = await fetch(BILLING_API.PAYG);
-      if (!res.ok) {
-        return;
-      }
-      const data = (await res.json()) as { enabled?: boolean };
-      if (!cancelled) {
-        setPaygEnabled(Boolean(data.enabled));
-      }
-    }
-    loadPaygEnabled().catch(() => undefined);
-    return () => {
-      cancelled = true;
-    };
-  }, [plan]);
+  // Free orgs keep running past the free limit on pay-as-you-go, so the
+  // over-limit message must not tell them to upgrade.
+  const paygCovered = plan === PAYG_PLAN_NAME;
 
   const status = sub?.status ?? "active";
   const statusVariant = STATUS_VARIANT[status] ?? "outline";
@@ -797,7 +777,7 @@ function BillingStatusContent({
       {usage && (
         <ExecutionUsageBar
           limit={usage.executionLimit}
-          paygEnabled={paygEnabled}
+          paygCovered={paygCovered}
           plan={plan}
           used={usage.executionsUsed}
         />

--- a/components/billing/payg-section.tsx
+++ b/components/billing/payg-section.tsx
@@ -448,7 +448,7 @@ function Metric({
   );
 }
 
-/** A spend cap, edited in place. Empty means no limit. */
+/** A spend cap, edited in place. Left blank it saves as 0, which spends nothing. */
 function CapField({
   id,
   label,

--- a/components/billing/payg-section.tsx
+++ b/components/billing/payg-section.tsx
@@ -36,11 +36,7 @@ import {
 } from "@/components/ui/tooltip";
 import { toChecksumAddress } from "@/lib/address-utils";
 import { BILLING_API } from "@/lib/billing/constants";
-import {
-  PAYG_PLAN_NAME,
-  PLANS,
-  type PlanName,
-} from "@/lib/billing/plans";
+import { PAYG_PLAN_NAME, PLANS, type PlanName } from "@/lib/billing/plans";
 import { useDebounce } from "@/lib/hooks/use-debounce";
 import { useOrganization } from "@/lib/hooks/use-organization";
 import type { PageMeta } from "@/lib/pagination";

--- a/components/billing/payg-section.tsx
+++ b/components/billing/payg-section.tsx
@@ -58,13 +58,11 @@ const TRAILING_ZEROS_RE = /0+$/;
 const TRAILING_DOT_RE = /\.$/;
 
 /**
- * Blank a "0" cap for the input, and drop the API's zero padding so a cap reads
- * as the amount the user typed: "5.000000" -> "5", "0.500000" -> "0.5".
+ * A cap as the user typed it, dropping the API's zero padding: "5.000000" ->
+ * "5", "0.500000" -> "0.5", "0.000000" -> "0". A zero cap shows as 0 rather
+ * than an empty field, because it means spend nothing, not "unset".
  */
 function capToInput(decimal: string): string {
-  if (Number(decimal) === 0) {
-    return "";
-  }
   return decimal.includes(".")
     ? decimal.replace(TRAILING_ZEROS_RE, "").replace(TRAILING_DOT_RE, "")
     : decimal;
@@ -425,9 +423,9 @@ export function PaygSection({
       </div>
 
       <p className="text-muted-foreground text-xs">
-        Amounts in USDC. Leave a cap empty for no limit. Executions that would
-        exceed a cap are blocked with a clear reason and recorded as a billing
-        error on the run.
+        Amounts in USDC. A cap of 0 spends nothing. Executions that would exceed
+        a cap are blocked with a clear reason and recorded as a billing error on
+        the run.
       </p>
 
       <PaygChargesTable key={orgId} />
@@ -490,7 +488,7 @@ function CapField({
         id={id}
         inputMode="decimal"
         onChange={(e) => onChange(e.target.value)}
-        placeholder="No limit"
+        placeholder="0"
         value={value}
       />
     </div>

--- a/components/billing/payg-section.tsx
+++ b/components/billing/payg-section.tsx
@@ -14,16 +14,7 @@ import { toast } from "sonner";
 import { Pager } from "@/components/activity/pager";
 import { useOverlay } from "@/components/overlays/overlay-provider";
 import { WalletOverlay } from "@/components/overlays/wallet-overlay";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
@@ -42,7 +33,6 @@ import { useOrganization } from "@/lib/hooks/use-organization";
 import type { PageMeta } from "@/lib/pagination";
 
 type PaygStatus = {
-  enabled: boolean;
   priceUsdc: string;
   treasuryConfigured: boolean;
   chainId: number;
@@ -53,7 +43,7 @@ type PaygStatus = {
     periodExecutions: number;
     periodSpentUsdc: string;
     dailySpentUsdc: string;
-  } | null;
+  };
 };
 
 const FREE_LIMIT = PLANS[PAYG_PLAN_NAME].features.maxExecutionsPerMonth;
@@ -64,14 +54,20 @@ function formatUsdc(decimal: string): string {
   })}`;
 }
 
-/** Blank a "0" cap for the input; anything else round-trips as-is. */
-function capToInput(decimal: string): string {
-  return Number(decimal) === 0 ? "" : decimal;
-}
+const TRAILING_ZEROS_RE = /0+$/;
+const TRAILING_DOT_RE = /\.$/;
 
-/** A "0" cap reads as no limit; anything else shows the USDC value. */
-function capDisplay(decimal: string): string {
-  return Number(decimal) === 0 ? "No limit" : formatUsdc(decimal);
+/**
+ * Blank a "0" cap for the input, and drop the API's zero padding so a cap reads
+ * as the amount the user typed: "5.000000" -> "5", "0.500000" -> "0.5".
+ */
+function capToInput(decimal: string): string {
+  if (Number(decimal) === 0) {
+    return "";
+  }
+  return decimal.includes(".")
+    ? decimal.replace(TRAILING_ZEROS_RE, "").replace(TRAILING_DOT_RE, "")
+    : decimal;
 }
 
 function formatDate(iso: string): string {
@@ -213,7 +209,7 @@ function PaygWalletFunding({
       <div className="hidden self-stretch bg-border/60 sm:col-start-2 sm:row-span-2 sm:block" />
 
       <p className="text-foreground text-xs sm:col-start-3 sm:row-start-1">
-        Top up: send USDC on {chainName} to
+        To top up, send USDC on {chainName} to your organization wallet:
       </p>
 
       <div className="flex min-w-0 items-center gap-1.5 sm:col-start-3 sm:row-start-2">
@@ -249,7 +245,8 @@ function PaygWalletFunding({
 
 /**
  * Pay-as-you-go controls for a free org, rendered inside the Current Plan card.
- * Caps show as read-only labels; enabling and editing them happen in a modal.
+ * It is on for every free org, so the only setting is the spend caps, edited
+ * in place.
  */
 export function PaygSection({
   plan,
@@ -258,14 +255,23 @@ export function PaygSection({
 }): React.ReactElement | null {
   const { organization } = useOrganization();
   const orgId = organization?.id;
-  // Only one plan can turn pay-as-you-go on. Others reach this component to
-  // read charges they settled while they were on it, and get history only.
+  // Only one plan carries pay-as-you-go. Others reach this component to read
+  // charges they settled while they were on it, and get history only.
   const canUsePayg = plan === PAYG_PLAN_NAME;
 
   const [status, setStatus] = useState<PaygStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [modalOpen, setModalOpen] = useState(false);
+  const [daily, setDaily] = useState("");
+  const [period, setPeriod] = useState("");
+
+  // Saved caps are the source of truth for the fields, so applying a status
+  // (initial load, org switch, save response) resets any half-typed edit.
+  const applyStatus = useCallback((next: PaygStatus): void => {
+    setStatus(next);
+    setDaily(capToInput(next.caps.dailyUsdc));
+    setPeriod(capToInput(next.caps.periodUsdc));
+  }, []);
 
   const load = useCallback(async (): Promise<void> => {
     setLoading(true);
@@ -278,64 +284,40 @@ export function PaygSection({
       if (!res.ok) {
         throw new Error(`status ${res.status}`);
       }
-      setStatus((await res.json()) as PaygStatus);
+      applyStatus((await res.json()) as PaygStatus);
     } catch (error) {
       console.error("[PaygSection] Failed to load status:", error);
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [applyStatus]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: orgId re-triggers on org switch
   useEffect(() => {
     load().catch(() => undefined);
   }, [load, orgId]);
 
-  async function saveCaps(
-    dailyCap: string,
-    periodCap: string,
-    enabling: boolean
-  ): Promise<void> {
+  async function saveCaps(): Promise<void> {
     setSaving(true);
     try {
       const res = await fetch(BILLING_API.PAYG, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          dailyCapUsdc: dailyCap,
-          periodCapUsdc: periodCap,
+          dailyCapUsdc: daily,
+          periodCapUsdc: period,
         }),
       });
       const data = (await res.json()) as PaygStatus & { error?: string };
       if (!res.ok) {
-        toast.error(data.error ?? "Could not update pay-as-you-go");
+        toast.error(data.error ?? "Could not update your spend caps");
         return;
       }
-      setStatus(data);
-      setModalOpen(false);
-      toast.success(enabling ? "Pay-as-you-go enabled" : "Spending caps saved");
+      applyStatus(data);
+      toast.success("Spend caps saved");
     } catch (error) {
       console.error("[PaygSection] Save failed:", error);
-      toast.error("Could not update pay-as-you-go");
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  async function disable(): Promise<void> {
-    setSaving(true);
-    try {
-      const res = await fetch(BILLING_API.PAYG, { method: "DELETE" });
-      const data = (await res.json()) as PaygStatus & { error?: string };
-      if (!res.ok) {
-        toast.error(data.error ?? "Could not disable pay-as-you-go");
-        return;
-      }
-      setStatus(data);
-      toast.success("Pay-as-you-go disabled");
-    } catch (error) {
-      console.error("[PaygSection] Disable failed:", error);
-      toast.error("Could not disable pay-as-you-go");
+      toast.error("Could not update your spend caps");
     } finally {
       setSaving(false);
     }
@@ -357,44 +339,20 @@ export function PaygSection({
   // Nothing here is actionable off the pay-as-you-go plan, so show the settled
   // charges alone. The table renders nothing when there are none.
   if (!canUsePayg) {
-    return <PaygChargesTable key={orgId} paygEnabled={false} standalone />;
+    return <PaygChargesTable key={orgId} standalone />;
   }
 
   const priceConfigured = Number(status.priceUsdc) > 0;
   const available = status.treasuryConfigured && priceConfigured;
+  const dirty =
+    daily !== capToInput(status.caps.dailyUsdc) ||
+    period !== capToInput(status.caps.periodUsdc);
 
   return (
     <div className="space-y-3 border-border/40 border-t pt-4">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <Zap className="size-4 text-keeperhub-green-dark" />
-          <span className="font-medium text-sm">Pay per execution</span>
-          {status.enabled && (
-            <Badge className="border border-keeperhub-green-dark/20 bg-keeperhub-green-dark/10 text-keeperhub-green-dark">
-              Active
-            </Badge>
-          )}
-        </div>
-        {status.enabled ? (
-          <Button
-            disabled={saving}
-            onClick={disable}
-            size="sm"
-            type="button"
-            variant="ghost"
-          >
-            Disable
-          </Button>
-        ) : (
-          <Button
-            disabled={saving || !available}
-            onClick={() => setModalOpen(true)}
-            size="sm"
-            type="button"
-          >
-            Enable pay-as-you-go
-          </Button>
-        )}
+      <div className="flex items-center gap-2">
+        <Zap className="size-4 text-keeperhub-green-dark" />
+        <span className="font-medium text-sm">Pay per execution</span>
       </div>
 
       <p className="text-muted-foreground text-xs">
@@ -416,67 +374,63 @@ export function PaygSection({
         </p>
       )}
 
-      {status.enabled && status.usage && (
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <Metric
-            label="This period"
-            value={`${status.usage.periodExecutions} runs`}
-          />
-          <Metric
-            label="Spent this period"
-            value={formatUsdc(status.usage.periodSpentUsdc)}
-          />
-          <Metric
-            label="Spent today"
-            value={formatUsdc(status.usage.dailySpentUsdc)}
-          />
-          <Metric
-            label="Period"
-            value={`${formatDate(status.usage.periodStart)} - ${formatDate(
-              status.usage.periodEnd
-            )}`}
-          />
-        </div>
-      )}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Metric
+          label="This month"
+          value={`${status.usage.periodExecutions} runs`}
+        />
+        <Metric
+          label="Spent this month"
+          value={formatUsdc(status.usage.periodSpentUsdc)}
+        />
+        <Metric
+          label="Spent today"
+          value={formatUsdc(status.usage.dailySpentUsdc)}
+        />
+        <Metric
+          label="Period"
+          value={`${formatDate(status.usage.periodStart)} - ${formatDate(
+            status.usage.periodEnd
+          )}`}
+        />
+      </div>
 
-      {status.enabled && (
-        <div className="flex flex-wrap items-end justify-between gap-3">
-          <div className="flex flex-wrap gap-x-8 gap-y-2">
-            <CapLabel
-              hint="Resets daily at 00:00 UTC"
-              label="Daily spend cap"
-              value={capDisplay(status.caps.dailyUsdc)}
-            />
-            <CapLabel
-              label="Per-period spend cap"
-              value={capDisplay(status.caps.periodUsdc)}
-            />
-          </div>
-          <Button
-            disabled={saving}
-            onClick={() => setModalOpen(true)}
-            size="sm"
-            type="button"
-            variant="outline"
-          >
-            Edit caps
-          </Button>
-        </div>
-      )}
+      <div className="flex flex-wrap items-end gap-3">
+        <CapField
+          hint="Resets daily at 00:00 UTC"
+          id="payg-daily-cap"
+          label="Daily spend cap"
+          onChange={setDaily}
+          value={daily}
+        />
+        <CapField
+          hint="Resets at the start of each billing month"
+          id="payg-period-cap"
+          label="Monthly spend cap"
+          onChange={setPeriod}
+          value={period}
+        />
+        <Button
+          disabled={saving || !(dirty && available)}
+          onClick={() => {
+            saveCaps().catch(() => undefined);
+          }}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          {saving && <Loader2 className="size-4 animate-spin" />}
+          Save caps
+        </Button>
+      </div>
 
-      {/* Not gated on status.enabled: disabling deletes the config row, but the
-          settled charges are real transactions and stay visible. */}
-      <PaygChargesTable key={orgId} paygEnabled={status.enabled} />
+      <p className="text-muted-foreground text-xs">
+        Amounts in USDC. Leave a cap empty for no limit. Executions that would
+        exceed a cap are blocked with a clear reason and recorded as a billing
+        error on the run.
+      </p>
 
-      <PaygCapsDialog
-        enabling={!status.enabled}
-        initialDaily={capToInput(status.caps.dailyUsdc)}
-        initialPeriod={capToInput(status.caps.periodUsdc)}
-        onConfirm={(daily, period) => saveCaps(daily, period, !status.enabled)}
-        onOpenChange={setModalOpen}
-        open={modalOpen}
-        saving={saving}
-      />
+      <PaygChargesTable key={orgId} />
     </div>
   );
 }
@@ -496,122 +450,50 @@ function Metric({
   );
 }
 
-function CapLabel({
+/** A spend cap, edited in place. Empty means no limit. */
+function CapField({
+  id,
   label,
   value,
   hint,
+  onChange,
 }: {
+  id: string;
   label: string;
   value: string;
-  hint?: string;
+  hint: string;
+  onChange: (next: string) => void;
 }): React.ReactElement {
   return (
-    <div className="space-y-0.5">
+    <div className="space-y-1.5">
       <div className="flex items-center gap-1">
-        <p className="text-muted-foreground text-xs">{label}</p>
-        {hint && (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  aria-label={hint}
-                  className="inline-flex text-muted-foreground/70 transition-colors hover:text-foreground"
-                  type="button"
-                >
-                  <Info className="size-3" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent>{hint}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        )}
+        <Label className="text-muted-foreground text-xs" htmlFor={id}>
+          {label}
+        </Label>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                aria-label={hint}
+                className="inline-flex text-muted-foreground/70 transition-colors hover:text-foreground"
+                type="button"
+              >
+                <Info className="size-3" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{hint}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       </div>
-      <p className="font-medium text-sm">{value}</p>
+      <Input
+        className="h-8 w-32"
+        id={id}
+        inputMode="decimal"
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="No limit"
+        value={value}
+      />
     </div>
-  );
-}
-
-function PaygCapsDialog({
-  open,
-  onOpenChange,
-  enabling,
-  initialDaily,
-  initialPeriod,
-  saving,
-  onConfirm,
-}: {
-  open: boolean;
-  onOpenChange: (next: boolean) => void;
-  enabling: boolean;
-  initialDaily: string;
-  initialPeriod: string;
-  saving: boolean;
-  onConfirm: (daily: string, period: string) => void;
-}): React.ReactElement {
-  const [daily, setDaily] = useState(initialDaily);
-  const [period, setPeriod] = useState(initialPeriod);
-
-  useEffect(() => {
-    if (open) {
-      setDaily(initialDaily);
-      setPeriod(initialPeriod);
-    }
-  }, [open, initialDaily, initialPeriod]);
-
-  return (
-    <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>
-            {enabling ? "Enable pay-as-you-go" : "Edit spend caps"}
-          </DialogTitle>
-          <DialogDescription>
-            Set optional USDC spend caps. Executions that would exceed a cap are
-            blocked with a clear reason and recorded as a billing error on the
-            run. Leave a field empty for no limit.
-          </DialogDescription>
-        </DialogHeader>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <div className="space-y-1.5">
-            <Label htmlFor="payg-daily-cap">Daily spend cap (USDC)</Label>
-            <Input
-              id="payg-daily-cap"
-              inputMode="decimal"
-              onChange={(e) => setDaily(e.target.value)}
-              placeholder="No limit"
-              value={daily}
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="payg-period-cap">Per-period spend cap (USDC)</Label>
-            <Input
-              id="payg-period-cap"
-              inputMode="decimal"
-              onChange={(e) => setPeriod(e.target.value)}
-              placeholder="No limit"
-              value={period}
-            />
-          </div>
-        </div>
-        <DialogFooter>
-          <Button
-            onClick={() => onOpenChange(false)}
-            type="button"
-            variant="ghost"
-          >
-            Cancel
-          </Button>
-          <Button
-            disabled={saving}
-            onClick={() => onConfirm(daily, period)}
-            type="button"
-          >
-            {saving && <Loader2 className="size-4 animate-spin" />}
-            {enabling ? "Enable" : "Save caps"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
   );
 }
 
@@ -638,10 +520,8 @@ function formatDateTime(iso: string): string {
  * paging resets to the first page for the new org.
  */
 function PaygChargesTable({
-  paygEnabled,
   standalone = false,
 }: {
-  paygEnabled: boolean;
   /** Render as its own block rather than a continuation of the section above. */
   standalone?: boolean;
 }): React.ReactElement | null {
@@ -720,10 +600,10 @@ function PaygChargesTable({
         {open && (
           <>
             <div className="flex flex-wrap items-center justify-between gap-2">
-              {!paygEnabled && (
+              {standalone && (
                 <p className="text-muted-foreground text-xs">
-                  Pay-as-you-go is off. These are charges from when it was
-                  active.
+                  Pay-as-you-go covers the free plan. These are charges from
+                  when this organization was on it.
                 </p>
               )}
               <Input

--- a/components/billing/pricing-table/index.tsx
+++ b/components/billing/pricing-table/index.tsx
@@ -46,6 +46,8 @@ const PLAN_ORDER: readonly PlanName[] = [
   "enterprise",
 ];
 
+const MONTHS_PER_YEAR = 12;
+
 type ConfirmTarget = {
   planName: PlanName;
   tierKey: TierKey | null;
@@ -296,7 +298,7 @@ function buildTieredCard(params: {
       variant: trialDays === null ? "secondary" : "primary",
       disabled: isCurrent || loading,
     },
-    footnote: buildTieredFootnote(plan, trialDays, trialPrice),
+    footnote: buildTieredFootnote(plan, trialDays, trialPrice, interval),
   };
 }
 
@@ -313,11 +315,16 @@ function buildTieredBadgeText(
 function buildTieredFootnote(
   plan: (typeof PLANS)[TieredPlanName],
   trialDays: number | null,
-  trialPrice: number | null
+  trialPrice: number | null,
+  interval: BillingInterval
 ): string | undefined {
   // Keep this to one line: the footnote pill wraps and unbalances the card.
+  // An annual trial converts to a year charged up front, so quote that total
+  // rather than the per-month rate the headline shows.
   if (trialDays !== null && trialPrice !== null) {
-    return `$0 today, then $${trialPrice}/mo`;
+    return interval === "yearly"
+      ? `$0 today, then $${(trialPrice * MONTHS_PER_YEAR).toLocaleString()}/yr`
+      : `$0 today, then $${trialPrice}/mo`;
   }
   return plan.overage.enabled
     ? `$${plan.overage.ratePerThousand}/1K additional executions`

--- a/components/welcome/previews.tsx
+++ b/components/welcome/previews.tsx
@@ -1249,12 +1249,10 @@ function DecorativeNodeCard({
 }
 
 export function PayPerExecutionPreview({
-  enabled,
   priceLabel,
   dailyCap,
   periodCap,
 }: {
-  enabled: boolean;
   priceLabel: string;
   dailyCap: string;
   periodCap: string;
@@ -1284,13 +1282,10 @@ export function PayPerExecutionPreview({
                 <h3 className="font-semibold text-lg">Aave collateral guard</h3>
               </div>
               <Badge
-                className={cn(
-                  "gap-1 border-keeperhub-green/30 text-keeperhub-green",
-                  enabled ? "bg-keeperhub-green/10" : "bg-muted"
-                )}
+                className="gap-1 border-keeperhub-green/30 bg-keeperhub-green/10 text-keeperhub-green"
                 variant="outline"
               >
-                {enabled ? "Live" : "Preview"}
+                Live
               </Badge>
             </div>
 

--- a/components/welcome/steps/pay-per-execution-step.tsx
+++ b/components/welcome/steps/pay-per-execution-step.tsx
@@ -8,14 +8,15 @@ import { PayPerExecutionPreview } from "@/components/welcome/previews";
 import { WelcomeShell } from "@/components/welcome/welcome-shell";
 import { toChecksumAddress } from "@/lib/address-utils";
 import { BILLING_API } from "@/lib/billing/constants";
-import { PAYG_DEFAULT_CHAIN_ID } from "@/lib/billing/payg/constants";
+import {
+  PAYG_DEFAULT_CHAIN_ID,
+  PAYG_DEFAULT_DAILY_CAP_USDC,
+  PAYG_DEFAULT_PERIOD_CAP_USDC,
+} from "@/lib/billing/payg/constants";
 
 const NEXT_PATH = "/welcome/connect-agent";
 const BACK_PATH = "/welcome/invite-members";
 const BASE_CHAIN_ID = 8453;
-// Default spending caps seeded from this step; both are editable in Billing.
-const DEFAULT_DAILY_CAP_USDC = "5";
-const DEFAULT_PERIOD_CAP_USDC = "50";
 
 type PaygStatus = {
   priceUsdc: string;
@@ -137,7 +138,6 @@ export function PayPerExecutionStep(): React.ReactElement {
   const [walletAddress, setWalletAddress] = useState<string | null>(null);
   const [balances, setBalances] = useState<ChainBalance[]>([]);
   const [balanceLoading, setBalanceLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -213,48 +213,16 @@ export function PayPerExecutionStep(): React.ReactElement {
       .catch(() => undefined);
   };
 
-  const goNext = (): void => router.push(NEXT_PATH);
-
-  // Seed the default spending caps, then advance. The caps are a convenience,
-  // not a gate, so a failure surfaces a toast and still moves the user on.
-  const handleContinue = (): void => {
-    setSaving(true);
-    fetch(BILLING_API.PAYG, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        dailyCapUsdc: DEFAULT_DAILY_CAP_USDC,
-        periodCapUsdc: DEFAULT_PERIOD_CAP_USDC,
-      }),
-    })
-      .then(async (res) => {
-        if (!res.ok) {
-          const data = (await res.json().catch(() => ({}))) as {
-            error?: string;
-          };
-          toast.error(data.error ?? "Could not save your spending caps");
-        }
-      })
-      .catch(() => {
-        toast.error("Could not save your spending caps");
-      })
-      .finally(() => {
-        setSaving(false);
-        goNext();
-      });
-  };
-
   return (
     <WelcomeShell
-      busy={saving}
       description="Every organization gets 5,000 free executions a month. Pay-as-you-go keeps your workflows running past the free tier."
       nextLabel="Continue"
       onBack={() => router.push(BACK_PATH)}
-      onNext={handleContinue}
+      onNext={() => router.push(NEXT_PATH)}
       preview={
         <PayPerExecutionPreview
-          dailyCap={`$${DEFAULT_DAILY_CAP_USDC}`}
-          periodCap={`$${DEFAULT_PERIOD_CAP_USDC}`}
+          dailyCap={`$${PAYG_DEFAULT_DAILY_CAP_USDC}`}
+          periodCap={`$${PAYG_DEFAULT_PERIOD_CAP_USDC}`}
           priceLabel={priceLabel}
         />
       }

--- a/components/welcome/steps/pay-per-execution-step.tsx
+++ b/components/welcome/steps/pay-per-execution-step.tsx
@@ -13,13 +13,11 @@ import { PAYG_DEFAULT_CHAIN_ID } from "@/lib/billing/payg/constants";
 const NEXT_PATH = "/welcome/connect-agent";
 const BACK_PATH = "/welcome/invite-members";
 const BASE_CHAIN_ID = 8453;
-// Default spending caps applied when a user enables pay-as-you-go here; both are
-// editable later in Billing.
+// Default spending caps seeded from this step; both are editable in Billing.
 const DEFAULT_DAILY_CAP_USDC = "5";
 const DEFAULT_PERIOD_CAP_USDC = "50";
 
 type PaygStatus = {
-  enabled: boolean;
   priceUsdc: string;
   treasuryConfigured: boolean;
   chainId: number;
@@ -139,7 +137,7 @@ export function PayPerExecutionStep(): React.ReactElement {
   const [walletAddress, setWalletAddress] = useState<string | null>(null);
   const [balances, setBalances] = useState<ChainBalance[]>([]);
   const [balanceLoading, setBalanceLoading] = useState(true);
-  const [enabling, setEnabling] = useState(false);
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -217,10 +215,10 @@ export function PayPerExecutionStep(): React.ReactElement {
 
   const goNext = (): void => router.push(NEXT_PATH);
 
-  // Enable pay-as-you-go with default spending caps, then advance. On failure we
-  // stay on the step so the user can retry or skip.
-  const handleEnableAndContinue = (): void => {
-    setEnabling(true);
+  // Seed the default spending caps, then advance. The caps are a convenience,
+  // not a gate, so a failure surfaces a toast and still moves the user on.
+  const handleContinue = (): void => {
+    setSaving(true);
     fetch(BILLING_API.PAYG, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -234,30 +232,28 @@ export function PayPerExecutionStep(): React.ReactElement {
           const data = (await res.json().catch(() => ({}))) as {
             error?: string;
           };
-          toast.error(data.error ?? "Could not enable pay-as-you-go");
-          return;
+          toast.error(data.error ?? "Could not save your spending caps");
         }
-        toast.success("Pay-as-you-go enabled");
-        goNext();
       })
       .catch(() => {
-        toast.error("Could not enable pay-as-you-go");
+        toast.error("Could not save your spending caps");
       })
-      .finally(() => setEnabling(false));
+      .finally(() => {
+        setSaving(false);
+        goNext();
+      });
   };
 
   return (
     <WelcomeShell
-      busy={enabling}
-      description="Every organization gets 5,000 free executions a month. Turn on pay-as-you-go to keep workflows running past the free tier."
-      nextLabel="Enable pay-as-you-go"
+      busy={saving}
+      description="Every organization gets 5,000 free executions a month. Pay-as-you-go keeps your workflows running past the free tier."
+      nextLabel="Continue"
       onBack={() => router.push(BACK_PATH)}
-      onNext={handleEnableAndContinue}
-      onSkip={goNext}
+      onNext={handleContinue}
       preview={
         <PayPerExecutionPreview
           dailyCap={`$${DEFAULT_DAILY_CAP_USDC}`}
-          enabled={payg?.enabled ?? false}
           periodCap={`$${DEFAULT_PERIOD_CAP_USDC}`}
           priceLabel={priceLabel}
         />
@@ -274,7 +270,7 @@ export function PayPerExecutionStep(): React.ReactElement {
             wallet. No credit card required.
           </li>
           <li>
-            Enabling sets a $5 daily and $50 monthly spending cap. Change or
+            You start with a $5 daily and $50 monthly spending cap. Change or
             remove them anytime in Billing.
           </li>
         </ul>
@@ -288,8 +284,8 @@ export function PayPerExecutionStep(): React.ReactElement {
         />
 
         <p className="text-muted-foreground text-xs">
-          Optional now. If you skip, you can enable pay-as-you-go anytime in
-          Billing.
+          You can fund the wallet later. Workflows run on the free tier until
+          you do.
         </p>
       </div>
     </WelcomeShell>

--- a/deploy/pr-environment/values.template.yaml
+++ b/deploy/pr-environment/values.template.yaml
@@ -387,6 +387,34 @@ env:
   GAS_CREDITS_ENTERPRISE_CENTS:
     type: kv
     value: "10000"
+  # Pay As You Go: per-execution USDC price and per-chain treasury (8453 =
+  # Base). Empty price or unset treasury disables charging, which is what left
+  # the billing page showing "not available in this environment" with no
+  # per-execution price.
+  PAYG_EXECUTION_PRICE_USDC:
+    type: kv
+    value: "0.01"
+  PAYG_TREASURY_ADDRESS_8453:
+    type: parameterStore
+    name: payg-treasury-address-8453
+    parameter_name: /eks/techops-staging/keeperhub/payg-treasury-address-8453
+  # x402 settlement for the charges above. Without these the page reports
+  # pay-as-you-go as available and then every charge fails at settlement, so
+  # they belong with the two vars above rather than apart from them.
+  BASE_RPC_URL:
+    type: kv
+    value: "https://mainnet.base.org"
+  X402_FACILITATOR_URL:
+    type: kv
+    value: "https://api.cdp.coinbase.com/platform/v2/x402"
+  CDP_API_KEY_ID:
+    type: parameterStore
+    name: cdp-api-key-id
+    parameter_name: /eks/techops-staging/keeperhub/cdp-api-key-id
+  CDP_API_KEY_SECRET:
+    type: parameterStore
+    name: cdp-api-key-secret
+    parameter_name: /eks/techops-staging/keeperhub/cdp-api-key-secret
   SIMPLE_ACCOUNT_7702_ADDRESS:
     type: parameterStore
     name: simple-account-7702-address

--- a/drizzle/0139_payg_zero_spend_cap_means_zero.sql
+++ b/drizzle/0139_payg_zero_spend_cap_means_zero.sql
@@ -1,0 +1,21 @@
+-- Pay-as-you-go spend caps: "0" is a real zero, not "unlimited".
+--
+-- The guard skipped any cap of 0, so "0" was the encoding for no limit. An org
+-- that wanted to spend nothing had no way to say it: typing 0 read back as
+-- "No limit" and every charge went through. The guard now enforces 0 like any
+-- other cap, which blocks all pay-as-you-go spend.
+--
+-- Every existing "0" was written under the old meaning, so leaving it would
+-- silently switch those orgs from unlimited to blocked on deploy. They move to
+-- the standard defaults instead: $5 daily, $50 monthly (USDC 6-decimal raw).
+-- Caps that were set to a real amount are a deliberate choice and are left
+-- alone.
+--
+-- No client can persist a deliberate "0" until the code shipping with this
+-- migration is live, so this backfill cannot clobber an intentional zero.
+--
+-- payg_config holds one row per organization; the update is small and the lock
+-- is brief (no @requires-db-prep needed).
+UPDATE "payg_config" SET "daily_cap_raw" = '5000000' WHERE "daily_cap_raw" = '0';
+--> statement-breakpoint
+UPDATE "payg_config" SET "period_cap_raw" = '50000000' WHERE "period_cap_raw" = '0';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -974,6 +974,13 @@
       "when": 1785711210006,
       "tag": "0138_keep_966_direct_execution_receipts",
       "breakpoints": true
+    },
+    {
+      "idx": 139,
+      "version": "7",
+      "when": 1785859810382,
+      "tag": "0139_payg_zero_spend_cap_means_zero",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/billing/payg/autopay.ts
+++ b/lib/billing/payg/autopay.ts
@@ -172,6 +172,16 @@ export async function autopayForExecution(params: {
     return { ok: false, reason: "not_eligible" };
   }
 
+  // A cap of 0 can never accommodate a charge, so refuse before claiming. This
+  // keeps "spend nothing" independent of the window arithmetic below (a claim
+  // made just before UTC midnight falls outside the new day's window, which
+  // would otherwise let a single charge through) and saves an insert/delete on
+  // every execution.
+  const zeroCap = zeroCapBlock(config);
+  if (zeroCap) {
+    return { ok: false, reason: zeroCap };
+  }
+
   // Claim the (org, execution) slot with a pending row before settling. The
   // unique constraint makes this the idempotency latch: exactly one caller wins
   // the insert and settles; a concurrent caller loses and backs off. The
@@ -236,11 +246,24 @@ function settledOrRefuse(existing: {
   return { ok: false, reason: "payment_failed" };
 }
 
+/** The cap set to 0, which no charge can ever fit under, or null. */
+function zeroCapBlock(config: {
+  dailyCapRaw: string;
+  periodCapRaw: string;
+}): PaygBlockReason | null {
+  if (BigInt(config.dailyCapRaw) === BigInt(0)) {
+    return "daily_cap";
+  }
+  if (BigInt(config.periodCapRaw) === BigInt(0)) {
+    return "period_cap";
+  }
+  return null;
+}
+
 /**
  * The daily/period cap breached by the reserved total (settled + pending), or
- * null when both are within their configured caps. Every cap is enforced,
- * including 0: the amount reserved for this execution alone breaches a zero
- * cap, so an org that set 0 is never charged.
+ * null when both are within their configured caps. Every cap is enforced; a
+ * cap of 0 is refused earlier, before the claim.
  */
 async function checkCapsReserved(
   organizationId: string,

--- a/lib/billing/payg/autopay.ts
+++ b/lib/billing/payg/autopay.ts
@@ -236,37 +236,37 @@ function settledOrRefuse(existing: {
   return { ok: false, reason: "payment_failed" };
 }
 
-/** The daily/period cap breached by the reserved total (settled + pending),
- * or null when both are within their configured caps. */
+/**
+ * The daily/period cap breached by the reserved total (settled + pending), or
+ * null when both are within their configured caps. Every cap is enforced,
+ * including 0: the amount reserved for this execution alone breaches a zero
+ * cap, so an org that set 0 is never charged.
+ */
 async function checkCapsReserved(
   organizationId: string,
   config: { dailyCapRaw: string; periodCapRaw: string; startedAt: Date }
 ): Promise<PaygBlockReason | null> {
   const dailyCapRaw = BigInt(config.dailyCapRaw);
-  if (dailyCapRaw > BigInt(0)) {
-    const reservedToday = await getPaygSpentRaw(
-      organizationId,
-      startOfUtcDay(),
-      undefined,
-      { includePending: true }
-    );
-    if (reservedToday > dailyCapRaw) {
-      return "daily_cap";
-    }
+  const reservedToday = await getPaygSpentRaw(
+    organizationId,
+    startOfUtcDay(),
+    undefined,
+    { includePending: true }
+  );
+  if (reservedToday > dailyCapRaw) {
+    return "daily_cap";
   }
 
   const periodCapRaw = BigInt(config.periodCapRaw);
-  if (periodCapRaw > BigInt(0)) {
-    const period = getPaygPeriod(config.startedAt);
-    const reservedPeriod = await getPaygSpentRaw(
-      organizationId,
-      period.start,
-      period.end,
-      { includePending: true }
-    );
-    if (reservedPeriod > periodCapRaw) {
-      return "period_cap";
-    }
+  const period = getPaygPeriod(config.startedAt);
+  const reservedPeriod = await getPaygSpentRaw(
+    organizationId,
+    period.start,
+    period.end,
+    { includePending: true }
+  );
+  if (reservedPeriod > periodCapRaw) {
+    return "period_cap";
   }
 
   return null;

--- a/lib/billing/payg/autopay.ts
+++ b/lib/billing/payg/autopay.ts
@@ -11,7 +11,7 @@ import {
 } from "@/lib/agentic-wallet/sign-typed-data";
 import { facilitatorClient } from "@/lib/payments/x402/server";
 import { getOrganizationWallet } from "@/lib/web3/wallet-helpers";
-import { getPaygConfig } from "./config-store";
+import { getPaygSettings } from "./config-store";
 import {
   evmNetworkId,
   PAYG_PAYMENT_STATUS,
@@ -149,10 +149,7 @@ export async function autopayForExecution(params: {
 }): Promise<AutopayResult> {
   const { organizationId, executionId } = params;
 
-  const config = await getPaygConfig(organizationId);
-  if (!config) {
-    return { ok: false, reason: "not_eligible" };
-  }
+  const config = await getPaygSettings(organizationId);
 
   // Idempotency: never settle a second on-chain transfer for one execution.
   // A settled row returns its recorded tx; a pending row means another attempt

--- a/lib/billing/payg/charge.ts
+++ b/lib/billing/payg/charge.ts
@@ -10,7 +10,6 @@ import {
 import { getOrgSubscription } from "@/lib/billing/plans-server";
 import { db } from "@/lib/db";
 import { autopayForExecution } from "./autopay";
-import { getPaygConfig } from "./config-store";
 import { type PaygBlockReason, paygBlockMessage } from "./errors";
 
 export type PaygChargeResult =
@@ -23,19 +22,15 @@ export type PaygChargeMaybe =
 
 /**
  * Charge an execution only if it is billable under PAYG: the org is on the free
- * plan, has PAYG enabled, and has already used its included monthly executions.
- * For the inline direct-execute routes, which do not know the billing state at
- * the charge point. Executions within the free bucket, non-free plans, and
- * PAYG-disabled orgs return `applicable: false` and are not charged.
+ * plan and has already used its included monthly executions. For the inline
+ * direct-execute routes, which do not know the billing state at the charge
+ * point. Executions within the free bucket and non-free plans return
+ * `applicable: false` and are not charged.
  */
 export async function chargePaygIfBillable(params: {
   organizationId: string;
   executionId: string;
 }): Promise<PaygChargeMaybe> {
-  const config = await getPaygConfig(params.organizationId);
-  if (!config) {
-    return { applicable: false };
-  }
   const sub = await getOrgSubscription(params.organizationId);
   const plan = parsePlanName(sub?.plan);
   if (plan !== "free") {

--- a/lib/billing/payg/charge.ts
+++ b/lib/billing/payg/charge.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { countMonthlyExecutionsForAdmission } from "@/lib/billing/execution-limit-core";
+import { isBillingEnabled } from "@/lib/billing/feature-flag";
 import {
   getPlanLimits,
   PLANS,
@@ -21,16 +22,21 @@ export type PaygChargeMaybe =
   | ({ applicable: true } & PaygChargeResult);
 
 /**
- * Charge an execution only if it is billable under PAYG: the org is on the free
- * plan and has already used its included monthly executions. For the inline
- * direct-execute routes, which do not know the billing state at the charge
- * point. Executions within the free bucket and non-free plans return
+ * Charge an execution only if it is billable under PAYG: billing is on, the org
+ * is on the free plan, and it has already used its included monthly executions.
+ * For the inline direct-execute routes, which do not know the billing state at
+ * the charge point. Executions within the free bucket and non-free plans return
  * `applicable: false` and are not charged.
  */
 export async function chargePaygIfBillable(params: {
   organizationId: string;
   executionId: string;
 }): Promise<PaygChargeMaybe> {
+  // With billing off there is no UI to read or set spend caps, so never move
+  // money: the run proceeds unbilled rather than being blocked.
+  if (!isBillingEnabled()) {
+    return { applicable: false };
+  }
   const sub = await getOrgSubscription(params.organizationId);
   const plan = parsePlanName(sub?.plan);
   if (plan !== "free") {

--- a/lib/billing/payg/config-store.ts
+++ b/lib/billing/payg/config-store.ts
@@ -11,7 +11,10 @@ import {
 } from "./constants";
 import { usdcDecimalToRaw } from "./usdc";
 
-/** The spend caps and billing-period anchor in force for an org. */
+/**
+ * The spend caps and billing-period anchor in force for an org. Caps always
+ * carry a value: "0" blocks all spend rather than meaning "unset".
+ */
 export type PaygSettings = {
   dailyCapRaw: string;
   periodCapRaw: string;
@@ -74,6 +77,7 @@ export async function getPaygSettings(
  */
 export async function upsertPaygConfig(params: {
   organizationId: string;
+  /** "0" blocks all spend; there is no "unset" cap. */
   dailyCapRaw: string;
   periodCapRaw: string;
   chainId: number;

--- a/lib/billing/payg/config-store.ts
+++ b/lib/billing/payg/config-store.ts
@@ -2,9 +2,26 @@ import "server-only";
 
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
+import { organization } from "@/lib/db/schema";
 import { type PaygConfig, paygConfig } from "@/lib/db/schema-extensions";
+import {
+  PAYG_DEFAULT_CHAIN_ID,
+  PAYG_DEFAULT_DAILY_CAP_USDC,
+  PAYG_DEFAULT_PERIOD_CAP_USDC,
+} from "./constants";
+import { usdcDecimalToRaw } from "./usdc";
 
-/** The org's PAYG config row (spend caps + enable anchor), or null. */
+/** The spend caps and billing-period anchor in force for an org. */
+export type PaygSettings = {
+  dailyCapRaw: string;
+  periodCapRaw: string;
+  chainId: number;
+  startedAt: Date;
+  /** False while the org is still on the defaults below. */
+  customized: boolean;
+};
+
+/** The org's PAYG config row (spend caps + period anchor), or null. */
 export async function getPaygConfig(
   organizationId: string
 ): Promise<PaygConfig | null> {
@@ -17,10 +34,43 @@ export async function getPaygConfig(
 }
 
 /**
+ * The caps to enforce for an org. Pay-as-you-go covers every free-tier org, so
+ * a missing config row is not "off": it means the org never set its own caps
+ * and runs on the defaults, anchored to when the organization was created.
+ */
+export async function getPaygSettings(
+  organizationId: string
+): Promise<PaygSettings> {
+  const config = await getPaygConfig(organizationId);
+  if (config) {
+    return {
+      dailyCapRaw: config.dailyCapRaw,
+      periodCapRaw: config.periodCapRaw,
+      chainId: config.chainId,
+      startedAt: config.startedAt,
+      customized: true,
+    };
+  }
+
+  const rows = await db
+    .select({ createdAt: organization.createdAt })
+    .from(organization)
+    .where(eq(organization.id, organizationId))
+    .limit(1);
+
+  return {
+    dailyCapRaw: usdcDecimalToRaw(PAYG_DEFAULT_DAILY_CAP_USDC).toString(),
+    periodCapRaw: usdcDecimalToRaw(PAYG_DEFAULT_PERIOD_CAP_USDC).toString(),
+    chainId: PAYG_DEFAULT_CHAIN_ID,
+    startedAt: rows[0]?.createdAt ?? new Date(),
+    customized: false,
+  };
+}
+
+/**
  * Create or update the org's PAYG config. `started_at` (the billing-period
  * anchor) is set once on insert and preserved on updates, so editing caps does
- * not reset the period. A fresh anchor comes from disabling (which deletes the
- * row) and re-enabling.
+ * not reset the period.
  */
 export async function upsertPaygConfig(params: {
   organizationId: string;
@@ -45,11 +95,4 @@ export async function upsertPaygConfig(params: {
         updatedAt: new Date(),
       },
     });
-}
-
-/** Remove the org's PAYG config (on disable), so a later re-enable re-anchors. */
-export async function deletePaygConfig(organizationId: string): Promise<void> {
-  await db
-    .delete(paygConfig)
-    .where(eq(paygConfig.organizationId, organizationId));
 }

--- a/lib/billing/payg/constants.ts
+++ b/lib/billing/payg/constants.ts
@@ -1,6 +1,14 @@
 /** Base mainnet chain id -- the only network PAYG settles on today. */
 export const PAYG_DEFAULT_CHAIN_ID = 8453;
 
+/**
+ * Spend caps every free-tier org starts with. Pay-as-you-go covers all of them,
+ * so these bound the spend of an org that has never opened Billing to set its
+ * own. Decimal USDC; the server converts to raw units.
+ */
+export const PAYG_DEFAULT_DAILY_CAP_USDC = "5";
+export const PAYG_DEFAULT_PERIOD_CAP_USDC = "50";
+
 /** `payg_payments.status` values. */
 export const PAYG_PAYMENT_STATUS = {
   settled: "settled",

--- a/lib/billing/payg/usage.ts
+++ b/lib/billing/payg/usage.ts
@@ -11,6 +11,7 @@ export type PaygCurrentUsage = {
   periodExecutions: number;
   periodSpentRaw: bigint;
   dailySpentRaw: bigint;
+  /** 0n blocks all spend rather than meaning "unset". */
   dailyCapRaw: bigint;
   periodCapRaw: bigint;
   chainId: number;

--- a/lib/billing/payg/usage.ts
+++ b/lib/billing/payg/usage.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { getPaygConfig } from "./config-store";
+import { getPaygSettings } from "./config-store";
 import { getPaygSpentRaw, getPaygUsage } from "./payments";
 import { getPaygPeriod, startOfUtcDay } from "./period";
 
@@ -18,16 +18,13 @@ export type PaygCurrentUsage = {
 
 /**
  * Current-period PAYG usage for reporting + guard rails: executions charged and
- * USDC spent this period (window anchored to the enable date), today's spend,
- * and the configured caps. Null if the org has no PAYG config.
+ * USDC spent this period, today's spend, and the caps in force. Every free-tier
+ * org has usage to report, on its own caps or the defaults.
  */
 export async function getCurrentPaygUsage(
   organizationId: string
-): Promise<PaygCurrentUsage | null> {
-  const config = await getPaygConfig(organizationId);
-  if (!config) {
-    return null;
-  }
+): Promise<PaygCurrentUsage> {
+  const config = await getPaygSettings(organizationId);
   const period = getPaygPeriod(config.startedAt);
   const [usage, dailySpentRaw] = await Promise.all([
     getPaygUsage(organizationId, period.start, period.end),

--- a/lib/billing/plans-server.ts
+++ b/lib/billing/plans-server.ts
@@ -9,7 +9,6 @@ import {
   decideExecutionLimit,
   effectiveExecutionLimit,
 } from "./execution-limit-core";
-import { getPaygConfig } from "./payg/config-store";
 import {
   type BillingInterval,
   getPlanLimits,
@@ -285,11 +284,11 @@ export async function checkExecutionLimit(
         debtExecutions,
         effectiveLimit,
       };
-    // Free plan at its included limit: if PAYG is enabled, allow the run so it
-    // can be charged per-execution via x402 downstream (the charge is the real
-    // gate); otherwise block. PAYG is a free-tier feature only.
+    // Free plan at its included limit: allow the run so it can be charged
+    // per-execution via x402 downstream. PAYG covers every free org, and the
+    // charge (wallet balance and spend caps) is the real gate.
     case "blocked_limit":
-      if (plan === "free" && (await getPaygConfig(organizationId)) !== null) {
+      if (plan === "free") {
         return {
           allowed: true,
           isOverage: false,

--- a/lib/billing/plans-server.ts
+++ b/lib/billing/plans-server.ts
@@ -9,6 +9,7 @@ import {
   decideExecutionLimit,
   effectiveExecutionLimit,
 } from "./execution-limit-core";
+import { isBillingEnabled } from "./feature-flag";
 import {
   type BillingInterval,
   getPlanLimits,
@@ -286,9 +287,10 @@ export async function checkExecutionLimit(
       };
     // Free plan at its included limit: allow the run so it can be charged
     // per-execution via x402 downstream. PAYG covers every free org, and the
-    // charge (wallet balance and spend caps) is the real gate.
+    // charge (wallet balance and spend caps) is the real gate. With billing off
+    // nothing downstream can charge, so the included limit is the gate again.
     case "blocked_limit":
-      if (plan === "free") {
+      if (plan === "free" && isBillingEnabled()) {
         return {
           allowed: true,
           isOverage: false,

--- a/lib/db/schema-extensions.ts
+++ b/lib/db/schema-extensions.ts
@@ -1354,9 +1354,13 @@ export type NewWorkflowHistory = typeof workflowHistory.$inferInsert;
  * Pay As You Go config table
  *
  * One row per org on the PAYG plan. Holds the user-set spend caps and the
- * enable anchor. The current billing period is the monthly window anchored to
+ * period anchor. The current billing period is the monthly window anchored to
  * `startedAt` that contains now (computed, not stored) and bounds the per-period
  * cap + usage reporting. Amounts are USDC 6-decimal raw units stored as text.
+ *
+ * Both caps always carry a value: "0" is a real zero that blocks all spend, not
+ * an "unset" that waves charges through. An org with no row at all runs on the
+ * PAYG_DEFAULT_* caps.
  */
 export const paygConfig = pgTable(
   "payg_config",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "ioredis": "5.4.2",
     "jose": "^6.2.2",
     "jotai": "^2.19.0",
-    "keeperhub-pricing-ui": "^0.1.1",
+    "keeperhub-pricing-ui": "^0.1.2",
     "lucide-react": "^0.577.0",
     "motion": "^12.38.0",
     "mppx": "^0.5.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,8 +212,8 @@ importers:
         specifier: ^2.19.0
         version: 2.19.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.14)(react@19.2.4)
       keeperhub-pricing-ui:
-        specifier: ^0.1.1
-        version: 0.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^0.1.2
+        version: 0.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.4)
@@ -7170,8 +7170,8 @@ packages:
     resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
     engines: {node: '>=18'}
 
-  keeperhub-pricing-ui@0.1.1:
-    resolution: {integrity: sha512-E9PKIv23V8CUoUVxcVqoWKwpVwCqq2/r0RttE3MbZa5SHOjCcPNAt/gfLiaTn1BiPC5+CeRCZiM8vuqM5UlDOA==}
+  keeperhub-pricing-ui@0.1.2:
+    resolution: {integrity: sha512-LhGdxZ7VonCDPrOaPwo6mbhgIKUD79ybdHopUZNjd1M8jFcoUDIM3T1e1NjUBVSUemaK0EHH8R0M63teZcFvZw==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
@@ -17381,7 +17381,7 @@ snapshots:
 
   jwt-decode@4.0.0: {}
 
-  keeperhub-pricing-ui@0.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  keeperhub-pricing-ui@0.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)

--- a/tests/integration/payg-enable-route.test.ts
+++ b/tests/integration/payg-enable-route.test.ts
@@ -90,7 +90,16 @@ describe("POST /api/billing/payg (spend caps)", () => {
     );
   });
 
-  it("treats an empty cap as no limit (raw 0)", async () => {
+  it("persists an explicit 0 cap as 0 rather than dropping it", async () => {
+    const res = await POST(postCaps({ dailyCapUsdc: "0", periodCapUsdc: "0" }));
+
+    expect(res.status).toBe(200);
+    expect(upsertPaygConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ dailyCapRaw: "0", periodCapRaw: "0" })
+    );
+  });
+
+  it("treats a cap left blank as 0", async () => {
     const res = await POST(postCaps({ dailyCapUsdc: "", periodCapUsdc: "" }));
 
     expect(res.status).toBe(200);

--- a/tests/integration/payg-enable-route.test.ts
+++ b/tests/integration/payg-enable-route.test.ts
@@ -27,18 +27,26 @@ vi.mock("@/lib/billing/payg/pricing", () => ({
 const upsertPaygConfig = vi.fn(async (..._a: unknown[]) => undefined);
 vi.mock("@/lib/billing/payg/config-store", () => ({
   upsertPaygConfig: (...a: unknown[]) => upsertPaygConfig(...a),
-  deletePaygConfig: vi.fn(async () => undefined),
-  getPaygConfig: vi.fn(async () => ({
-    id: "cfg_1",
-    organizationId: "org_1",
+  getPaygSettings: vi.fn(async () => ({
     chainId: 8453,
     dailyCapRaw: "0",
     periodCapRaw: "0",
     startedAt: new Date("2026-01-01T00:00:00Z"),
+    customized: true,
   })),
 }));
 vi.mock("@/lib/billing/payg/usage", () => ({
-  getCurrentPaygUsage: vi.fn(async () => null),
+  getCurrentPaygUsage: vi.fn(async () => ({
+    startedAt: new Date("2026-01-01T00:00:00Z"),
+    periodStart: new Date("2026-01-01T00:00:00Z"),
+    periodEnd: new Date("2026-02-01T00:00:00Z"),
+    periodExecutions: 0,
+    periodSpentRaw: BigInt(0),
+    dailySpentRaw: BigInt(0),
+    dailyCapRaw: BigInt(0),
+    periodCapRaw: BigInt(0),
+    chainId: 8453,
+  })),
 }));
 vi.mock("@/lib/middleware/auth-helpers", () => ({
   resolveOrganizationId: vi.fn(async () => ({ organizationId: "org_1" })),
@@ -66,7 +74,7 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("POST /api/billing/payg enable (spend caps)", () => {
+describe("POST /api/billing/payg (spend caps)", () => {
   it("accepts caps typed with a leading dot (.5) and persists the raw amounts", async () => {
     const res = await POST(
       postCaps({ dailyCapUsdc: ".5", periodCapUsdc: "1" })
@@ -82,7 +90,7 @@ describe("POST /api/billing/payg enable (spend caps)", () => {
     );
   });
 
-  it("treats an empty cap as no limit (raw 0) and still enables", async () => {
+  it("treats an empty cap as no limit (raw 0)", async () => {
     const res = await POST(postCaps({ dailyCapUsdc: "", periodCapUsdc: "" }));
 
     expect(res.status).toBe(200);

--- a/tests/unit/billing-plans-server.test.ts
+++ b/tests/unit/billing-plans-server.test.ts
@@ -170,31 +170,29 @@ describe("checkExecutionLimit", () => {
     });
   });
 
-  it("blocks free plan when at limit", async () => {
+  // Pay-as-you-go covers every free org past its included limit, so admission
+  // allows the run and the per-execution charge is the gate.
+  it("allows free plan at limit for the pay-as-you-go charge to gate", async () => {
     mockSelectReturning([]);
     mockExecuteReturning([{ count: 5000 }]);
 
     const result = await checkExecutionLimit("org_1");
     expect(result).toEqual({
-      allowed: false,
-      limit: 5000,
-      used: 5000,
-      plan: "free",
+      allowed: true,
+      isOverage: false,
       debtExecutions: 0,
       effectiveLimit: 5000,
     });
   });
 
-  it("blocks free plan when over limit", async () => {
+  it("allows free plan over limit for the pay-as-you-go charge to gate", async () => {
     mockSelectReturning([]);
     mockExecuteReturning([{ count: 6000 }]);
 
     const result = await checkExecutionLimit("org_1");
     expect(result).toEqual({
-      allowed: false,
-      limit: 5000,
-      used: 6000,
-      plan: "free",
+      allowed: true,
+      isOverage: false,
       debtExecutions: 0,
       effectiveLimit: 5000,
     });

--- a/tests/unit/billing-plans-server.test.ts
+++ b/tests/unit/billing-plans-server.test.ts
@@ -198,6 +198,29 @@ describe("checkExecutionLimit", () => {
     });
   });
 
+  // Nothing downstream can charge with billing off, so the included limit has
+  // to block again rather than letting free executions run without end.
+  it("blocks free plan over limit when billing is disabled", async () => {
+    const original = process.env.NEXT_PUBLIC_BILLING_ENABLED;
+    process.env.NEXT_PUBLIC_BILLING_ENABLED = "false";
+    mockSelectReturning([]);
+    mockExecuteReturning([{ count: 6000 }]);
+
+    try {
+      const result = await checkExecutionLimit("org_1");
+      expect(result).toEqual({
+        allowed: false,
+        limit: 5000,
+        used: 6000,
+        plan: "free",
+        debtExecutions: 0,
+        effectiveLimit: 5000,
+      });
+    } finally {
+      process.env.NEXT_PUBLIC_BILLING_ENABLED = original;
+    }
+  });
+
   it("blocks paid plan when canceled (overage disabled)", async () => {
     mockSelectReturning([{ plan: "pro", tier: "25k", status: "canceled" }]);
     mockExecuteReturning([{ count: 30_000 }]);

--- a/tests/unit/mcp-execute-arg-coercion.test.ts
+++ b/tests/unit/mcp-execute-arg-coercion.test.ts
@@ -258,20 +258,23 @@ describe("MCP execute tools accept the natural first-guess encoding (#1841)", ()
       "execute_check_and_execute",
       ["contract_address", "chain_id", "function_name", "condition", "action"],
     ],
-  ])("keeps every %s field in the published required list", async (toolName, required) => {
-    const { client, close } = await connectedClient();
-    try {
-      const listed = await client.listTools();
-      const tool = listed.tools.find((t) => t.name === toolName);
-      if (!tool) {
-        throw new Error(`${toolName} is not exposed`);
+  ])(
+    "keeps every %s field in the published required list",
+    async (toolName, required) => {
+      const { client, close } = await connectedClient();
+      try {
+        const listed = await client.listTools();
+        const tool = listed.tools.find((t) => t.name === toolName);
+        if (!tool) {
+          throw new Error(`${toolName} is not exposed`);
+        }
+        const schema = tool.inputSchema as { required?: string[] };
+        expect(schema.required).toEqual(required);
+      } finally {
+        await close();
       }
-      const schema = tool.inputSchema as { required?: string[] };
-      expect(schema.required).toEqual(required);
-    } finally {
-      await close();
     }
-  });
+  );
 
   it("keeps the nested condition value required", async () => {
     const { client, close } = await connectedClient();
@@ -280,11 +283,12 @@ describe("MCP execute tools accept the natural first-guess encoding (#1841)", ()
       const tool = listed.tools.find(
         (t) => t.name === "execute_check_and_execute"
       );
-      const properties = (
-        tool?.inputSchema as {
-          properties: Record<string, { required?: string[] }>;
-        }
-      ).properties;
+      if (!tool) {
+        throw new Error("execute_check_and_execute is not exposed");
+      }
+      const { properties } = tool.inputSchema as {
+        properties: Record<string, { required?: string[] }>;
+      };
 
       expect(properties.condition?.required).toEqual(["operator", "value"]);
     } finally {

--- a/tests/unit/payg-autopay.test.ts
+++ b/tests/unit/payg-autopay.test.ts
@@ -26,11 +26,11 @@ vi.mock("@/lib/address-utils", () => ({
 
 // --- Config / wallet / pricing / treasury, driven per test via state. ---
 const state = vi.hoisted(() => ({
-  config: null as null | {
-    chainId: number;
-    dailyCapRaw: string;
-    periodCapRaw: string;
-    startedAt: Date;
+  config: {
+    chainId: 8453,
+    dailyCapRaw: "0",
+    periodCapRaw: "0",
+    startedAt: new Date("2026-01-01T00:00:00Z"),
   },
   wallet: null as null | {
     turnkeySubOrgId: string | null;
@@ -40,7 +40,7 @@ const state = vi.hoisted(() => ({
   treasury: null as string | null,
 }));
 vi.mock("@/lib/billing/payg/config-store", () => ({
-  getPaygConfig: vi.fn(async () => state.config),
+  getPaygSettings: vi.fn(async () => state.config),
 }));
 vi.mock("@/lib/web3/wallet-helpers", () => ({
   getOrganizationWallet: vi.fn(async () => state.wallet),

--- a/tests/unit/payg-autopay.test.ts
+++ b/tests/unit/payg-autopay.test.ts
@@ -28,8 +28,8 @@ vi.mock("@/lib/address-utils", () => ({
 const state = vi.hoisted(() => ({
   config: {
     chainId: 8453,
-    dailyCapRaw: "0",
-    periodCapRaw: "0",
+    dailyCapRaw: "1000000",
+    periodCapRaw: "1000000",
     startedAt: new Date("2026-01-01T00:00:00Z"),
   },
   wallet: null as null | {
@@ -72,10 +72,12 @@ const PARAMS = { organizationId: "org_1", executionId: "exec_1" };
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Caps well above the per-execution price, so only the tests that set a
+  // tighter cap exercise the guard.
   state.config = {
     chainId: 8453,
-    dailyCapRaw: "0",
-    periodCapRaw: "0",
+    dailyCapRaw: "1000000",
+    periodCapRaw: "1000000",
     startedAt: new Date("2026-01-01T00:00:00Z"),
   };
   state.wallet = { turnkeySubOrgId: "sub_1", walletAddress: "0xabc" };
@@ -186,7 +188,7 @@ describe("autopayForExecution claim-before-settle", () => {
     state.config = {
       chainId: 8453,
       dailyCapRaw: "10000",
-      periodCapRaw: "0",
+      periodCapRaw: "1000000",
       startedAt: new Date("2026-01-01T00:00:00Z"),
     };
     getPaygSpentRaw.mockResolvedValue(BigInt(20_000)); // reserved (incl. claim) > cap
@@ -208,11 +210,47 @@ describe("autopayForExecution claim-before-settle", () => {
   it("releases the claim and returns period_cap when the reserved total exceeds the period cap", async () => {
     state.config = {
       chainId: 8453,
-      dailyCapRaw: "0",
+      dailyCapRaw: "1000000",
       periodCapRaw: "10000",
       startedAt: new Date("2026-01-01T00:00:00Z"),
     };
     getPaygSpentRaw.mockResolvedValue(BigInt(20_000));
+
+    const result = await autopayForExecution(PARAMS);
+
+    expect(releasePaygClaim).toHaveBeenCalledWith("org_1", "exec_1");
+    expect(facilitatorSettle).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: false, reason: "period_cap" });
+  });
+
+  // A zero cap means spend nothing, so it is enforced like any other cap
+  // rather than read as "unset" and skipped.
+  it("blocks on a daily cap of 0 even with no prior spend", async () => {
+    state.config = {
+      chainId: 8453,
+      dailyCapRaw: "0",
+      periodCapRaw: "1000000",
+      startedAt: new Date("2026-01-01T00:00:00Z"),
+    };
+    // Only this execution's own claim is reserved.
+    getPaygSpentRaw.mockResolvedValue(BigInt(10_000));
+
+    const result = await autopayForExecution(PARAMS);
+
+    expect(releasePaygClaim).toHaveBeenCalledWith("org_1", "exec_1");
+    expect(facilitatorSettle).not.toHaveBeenCalled();
+    expect(markPaygPaymentSettled).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: false, reason: "daily_cap" });
+  });
+
+  it("blocks on a period cap of 0 even with no prior spend", async () => {
+    state.config = {
+      chainId: 8453,
+      dailyCapRaw: "1000000",
+      periodCapRaw: "0",
+      startedAt: new Date("2026-01-01T00:00:00Z"),
+    };
+    getPaygSpentRaw.mockResolvedValue(BigInt(10_000));
 
     const result = await autopayForExecution(PARAMS);
 

--- a/tests/unit/payg-autopay.test.ts
+++ b/tests/unit/payg-autopay.test.ts
@@ -223,38 +223,38 @@ describe("autopayForExecution claim-before-settle", () => {
     expect(result).toEqual({ ok: false, reason: "period_cap" });
   });
 
-  // A zero cap means spend nothing, so it is enforced like any other cap
-  // rather than read as "unset" and skipped.
-  it("blocks on a daily cap of 0 even with no prior spend", async () => {
+  // A cap of 0 means spend nothing. It is refused before the claim, so it holds
+  // even when the reserved total reads as 0 (an empty window), which is what a
+  // "reserved > cap" comparison alone would let through.
+  it("blocks on a daily cap of 0 without claiming, even with zero reserved", async () => {
     state.config = {
       chainId: 8453,
       dailyCapRaw: "0",
       periodCapRaw: "1000000",
       startedAt: new Date("2026-01-01T00:00:00Z"),
     };
-    // Only this execution's own claim is reserved.
-    getPaygSpentRaw.mockResolvedValue(BigInt(10_000));
+    getPaygSpentRaw.mockResolvedValue(BigInt(0));
 
     const result = await autopayForExecution(PARAMS);
 
-    expect(releasePaygClaim).toHaveBeenCalledWith("org_1", "exec_1");
+    expect(claimPaygPayment).not.toHaveBeenCalled();
     expect(facilitatorSettle).not.toHaveBeenCalled();
     expect(markPaygPaymentSettled).not.toHaveBeenCalled();
     expect(result).toEqual({ ok: false, reason: "daily_cap" });
   });
 
-  it("blocks on a period cap of 0 even with no prior spend", async () => {
+  it("blocks on a period cap of 0 without claiming, even with zero reserved", async () => {
     state.config = {
       chainId: 8453,
       dailyCapRaw: "1000000",
       periodCapRaw: "0",
       startedAt: new Date("2026-01-01T00:00:00Z"),
     };
-    getPaygSpentRaw.mockResolvedValue(BigInt(10_000));
+    getPaygSpentRaw.mockResolvedValue(BigInt(0));
 
     const result = await autopayForExecution(PARAMS);
 
-    expect(releasePaygClaim).toHaveBeenCalledWith("org_1", "exec_1");
+    expect(claimPaygPayment).not.toHaveBeenCalled();
     expect(facilitatorSettle).not.toHaveBeenCalled();
     expect(result).toEqual({ ok: false, reason: "period_cap" });
   });

--- a/tests/unit/payg-charge-gate.test.ts
+++ b/tests/unit/payg-charge-gate.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/db", () => ({ db: {} }));
+
+const getOrgSubscription = vi.fn();
+vi.mock("@/lib/billing/plans-server", () => ({
+  getOrgSubscription: (...a: unknown[]) => getOrgSubscription(...a),
+}));
+
+const countMonthlyExecutionsForAdmission = vi.fn();
+vi.mock("@/lib/billing/execution-limit-core", () => ({
+  countMonthlyExecutionsForAdmission: (...a: unknown[]) =>
+    countMonthlyExecutionsForAdmission(...a),
+}));
+
+const autopayForExecution = vi.fn();
+vi.mock("@/lib/billing/payg/autopay", () => ({
+  autopayForExecution: (...a: unknown[]) => autopayForExecution(...a),
+}));
+
+import { chargePaygIfBillable } from "@/lib/billing/payg/charge";
+
+const PARAMS = { organizationId: "org_1", executionId: "exec_1" };
+const FREE_LIMIT = 5000;
+
+const originalFlag = process.env.NEXT_PUBLIC_BILLING_ENABLED;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.NEXT_PUBLIC_BILLING_ENABLED = "true";
+  getOrgSubscription.mockResolvedValue({ plan: "free", tier: null });
+  countMonthlyExecutionsForAdmission.mockResolvedValue(FREE_LIMIT + 1);
+  autopayForExecution.mockResolvedValue({ ok: true, txHash: "0xtx" });
+});
+
+afterEach(() => {
+  process.env.NEXT_PUBLIC_BILLING_ENABLED = originalFlag;
+});
+
+describe("chargePaygIfBillable gating", () => {
+  it("charges a free org that is past its included executions", async () => {
+    const result = await chargePaygIfBillable(PARAMS);
+
+    expect(autopayForExecution).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ applicable: true, ok: true, txHash: "0xtx" });
+  });
+
+  // With billing off there is no UI to read or set spend caps, so no money may
+  // move. The run is unbilled rather than blocked.
+  it("never charges when billing is disabled", async () => {
+    process.env.NEXT_PUBLIC_BILLING_ENABLED = "false";
+
+    const result = await chargePaygIfBillable(PARAMS);
+
+    expect(autopayForExecution).not.toHaveBeenCalled();
+    expect(getOrgSubscription).not.toHaveBeenCalled();
+    expect(result).toEqual({ applicable: false });
+  });
+
+  it("does not charge a paid plan", async () => {
+    getOrgSubscription.mockResolvedValue({ plan: "pro", tier: "25k" });
+
+    const result = await chargePaygIfBillable(PARAMS);
+
+    expect(autopayForExecution).not.toHaveBeenCalled();
+    expect(result).toEqual({ applicable: false });
+  });
+
+  it("does not charge inside the included free bucket", async () => {
+    countMonthlyExecutionsForAdmission.mockResolvedValue(FREE_LIMIT - 1);
+
+    const result = await chargePaygIfBillable(PARAMS);
+
+    expect(autopayForExecution).not.toHaveBeenCalled();
+    expect(result).toEqual({ applicable: false });
+  });
+});

--- a/tests/unit/rpc-config.test.ts
+++ b/tests/unit/rpc-config.test.ts
@@ -337,43 +337,41 @@ describe("RPC Config Resolution", () => {
       { json: "solana-devnet", public: PUBLIC_RPCS.SOLANA_DEVNET },
     ];
 
-    it.each(chainKeys)("should resolve $json from JSON config", ({
-      json,
-      public: publicDefault,
-    }) => {
-      const rpcConfig: RpcConfig = {
-        [json]: { primaryRpcUrl: `https://${json}.json.example.com` },
-      };
+    it.each(chainKeys)(
+      "should resolve $json from JSON config",
+      ({ json, public: publicDefault }) => {
+        const rpcConfig: RpcConfig = {
+          [json]: { primaryRpcUrl: `https://${json}.json.example.com` },
+        };
 
-      const result = getRpcUrl({
-        rpcConfig,
-        jsonKey: json,
-        envValue: undefined,
-        publicDefault,
-        type: "primary",
-      });
+        const result = getRpcUrl({
+          rpcConfig,
+          jsonKey: json,
+          envValue: undefined,
+          publicDefault,
+          type: "primary",
+        });
 
-      expect(result).toBe(`https://${json}.json.example.com`);
-    });
+        expect(result).toBe(`https://${json}.json.example.com`);
+      }
+    );
 
-    it.each(
-      chainKeys
-    )("should fall back to public default for $json when no config", ({
-      json,
-      public: publicDefault,
-    }) => {
-      const rpcConfig: RpcConfig = {};
+    it.each(chainKeys)(
+      "should fall back to public default for $json when no config",
+      ({ json, public: publicDefault }) => {
+        const rpcConfig: RpcConfig = {};
 
-      const result = getRpcUrl({
-        rpcConfig,
-        jsonKey: json,
-        envValue: undefined,
-        publicDefault,
-        type: "primary",
-      });
+        const result = getRpcUrl({
+          rpcConfig,
+          jsonKey: json,
+          envValue: undefined,
+          publicDefault,
+          type: "primary",
+        });
 
-      expect(result).toBe(publicDefault);
-    });
+        expect(result).toBe(publicDefault);
+      }
+    );
   });
 
   describe("edge cases", () => {


### PR DESCRIPTION
## Pay-as-you-go is always on for free orgs

It stops being something an org turns on. The enable and disable buttons are gone, along with the `DELETE /api/billing/payg` endpoint behind them.

There was never an `enabled` column: the flag was the existence of a `payg_config` row, and every gate read it. `getPaygSettings` now always resolves, returning the org's row if it has one and the $5 daily / $50 monthly defaults otherwise, anchored to when the organization was created. The row still exists, but it only records whether an org has customised its caps; nothing gates on it.

Admission no longer consults the config. A free org past its included 5,000 executions is allowed through and the charge is the gate: wallet balance and spend caps decide. The practical effect, and the reason this needs a careful read: a free org that used to hard block at 5,000 now keeps running and is charged USDC.

## A cap of 0 means zero, not unlimited

The guard skipped any cap of 0, so 0 was the encoding for no limit. An org that wanted to spend nothing had no way to say it: typing 0 read back as "No limit" and every charge still settled.

Caps now always carry a value. 0 is refused before the payment slot is claimed, which keeps it independent of the window arithmetic below it: a claim made just before UTC midnight falls outside the new day's window, so a `reserved > cap` comparison alone would let a single charge through. A field left blank saves as 0.

## Previous orgs

Migration 0139 backfills. Every stored 0 was written under the old meaning, so leaving it would flip those orgs from unlimited to fully blocked on deploy. They move to the standard defaults; caps set to a real amount are a deliberate choice and are left alone. Applied against a dev database whose rows happened to cover every case:

| Before | After | Why |
|---|---|---|
| `$10 / 0` | `$10 / $50` | $10 daily was deliberate, kept; period was old-unlimited |
| `$5 / $50` | unchanged | already explicit |
| `$0.50 / 0` | `$0.50 / $50` | $0.50 daily kept |
| `0 / $50` | `$5 / $50` | daily was old-unlimited |

Orgs with no row need no migration; they resolve to the defaults. `payg_config` holds one row per organization, so the update is small and the lock is brief. No db-prep directive needed.

## Onboarding

The pay-per-execution step is informational now: no skip link, the button says Continue, and nothing on it talks about enabling anything. It writes nothing, since the server supplies the defaults, which also removes a failure path that could strand someone on a step with no way forward.

Separately, `/welcome/pay-per-execution` was missing from the transition order list, so `indexOf` returned -1 for it and both directions animated backwards around that step. The list is derived from `WELCOME_STEPS` now so it cannot drift again.

## Billing page

Caps are edited in place instead of in a modal, with Save beside the fields and disabled until something changes. Values render as typed (`5`, not `5.000000`). "Per-period" is "Monthly" throughout.

## Pricing card

The annual view advertised the monthly price to someone who had already chosen annual, and never stated what actually gets charged. It now reads "billed annually at $468", and the trial pill reads "$0 today, then $468/yr" rather than "$39/mo" for a subscription that bills a year up front. The card copy ships in `keeperhub-pricing-ui` 0.1.2 (KeeperHub/pricing-ui#4), bumped here; the trial pill is built in this repo.

## One guard restored

Removing the flag lost an implicit kill switch. With billing off the API returns 404, so no org could ever create a config row and nothing was charged. Resolved settings replaced that row with defaults, which left the charge path live in an environment that gives the user no way to see or set spend caps. The charge path now returns not applicable when billing is off, so runs proceed unbilled rather than blocked, and admission stops waving free-plan overflow through when nothing downstream can charge for it.

## Notes for review

- The default caps of $5 and $50 are the values onboarding used to write. They are the only thing bounding spend for an org that never opens Billing.
- Overage on paid plans has no equivalent cap. A free org's exposure is bounded by the caps and its wallet balance; a paid org's is not bounded at all. Unchanged here, but worth a decision.
- The pay-as-you-go period stays anchored to a date while free executions reset on the first of the month. Both are monthly windows, but not the same month. Left alone because changing it would shift existing orgs mid-cycle.
- `PAYG_OVERFLOW_REASON` has no consumer, and the `chargePaygIfBillable` docstring claims the executor charges enqueued runs when no executor caller exists. Both predate this branch and suggest enqueued runs may not be charging.
- `payg_config` columns remain `NOT NULL DEFAULT '0'`, and that default now means block all spend. Nothing reaches it today because the API always writes both caps.
- The first commit clears three files that were already failing the repo-wide lint on staging, which the pre-commit gate blocks on. Unrelated to the rest.
