### PR TITLE
test(e2e): walk the onboarding wizard one step per call

### DIFF
--- a/tests/e2e/playwright/onboarding-gating.test.ts
+++ b/tests/e2e/playwright/onboarding-gating.test.ts
@@ -20,6 +20,7 @@ const WELCOME_ROOT = /\/welcome$/;
 const WELCOME_ANY = /\/welcome/;
 const CREATE_ORG = /\/welcome\/create-org/;
 const INVITE_MEMBERS = /\/welcome\/invite-members/;
+const PAY_PER_EXECUTION = /\/welcome\/pay-per-execution/;
 const CONNECT_AGENT = /\/welcome\/connect-agent/;
 
 test.describe("welcome gating: visitors", () => {
@@ -126,9 +127,12 @@ test.describe("onboarding wizard: new signup", () => {
       }).toPass({ timeout: 30_000 });
     };
 
-    // Skipping each step is enough to walk the wizard to the end.
+    // Walk one step per call. Only the first two steps are skippable; the
+    // pay-per-execution step has no skip because pay-as-you-go covers every
+    // free org, so it is advanced with its own control.
     await advance("Skip", INVITE_MEMBERS);
-    await advance("Skip", CONNECT_AGENT);
+    await advance("Skip", PAY_PER_EXECUTION);
+    await advance("Continue", CONNECT_AGENT);
 
     // Finish marks onboarding complete and lands the user on the canvas.
     const finishButton = page.getByRole("button", { name: "Finish" });


### PR DESCRIPTION
Fixes the onboarding wizard test that started failing on staging after #1923.

## Problem

The walk clicked Skip twice for three steps and leaned on the `toPass` retry
loop to click Skip again on whichever step it landed on. That worked while
pay-per-execution had a skip link. It no longer does, so the loop sat on that
step with nothing to click until it timed out.

Failure was at `onboarding-gating.test.ts:131`, on `advance("Skip", CONNECT_AGENT)`.

## Change

Each step advances by its own control, which pins the wizard shape instead of
letting a retry paper over a mismatch.

Verified against the running app:

```
/welcome/invite-members     Skip, Back      -> Skip     -> /welcome/pay-per-execution
/welcome/pay-per-execution  Continue, Back  -> Continue -> /welcome/connect-agent
/welcome/connect-agent      Finish, Back
```

## Notes

Only this test walks the wizard UI. Everything else short-circuits it via
`/api/user/onboarding/complete` in `utils/auth.ts`, so nothing else is affected.

The invitations failure in the same CI run was reported as flaky and passed on
retry. It is in the invite flow and unrelated to this change.
