### PR TITLE
fix(docs-site): point edit links at the staging branch

### DIFF
--- a/docs-site/app/[[...mdxPath]]/page.tsx
+++ b/docs-site/app/[[...mdxPath]]/page.tsx
@@ -31,8 +31,17 @@ export default async function Page(props: PageProps) {
   const { default: MDXContent, ...rest } = result;
   const Wrapper = useMDXComponents().wrapper;
 
+  // `content` is a symlink to `../docs`, so Nextra reports filePath as
+  // `content/<page>.md` while git only knows the file as `docs/<page>.md`.
+  // The theme builds "Edit this page" as docsRepositoryBase + filePath, so the
+  // symlink segment has to come off here or every link 404s on GitHub.
+  const metadata = { ...rest.metadata };
+  if (typeof metadata.filePath === "string") {
+    metadata.filePath = metadata.filePath.replace(/^content\//, "");
+  }
+
   return (
-    <Wrapper {...rest}>
+    <Wrapper {...rest} metadata={metadata}>
       <MDXContent {...props} params={params} />
     </Wrapper>
   );

--- a/docs-site/theme.config.tsx
+++ b/docs-site/theme.config.tsx
@@ -25,7 +25,7 @@ const config = {
     link: "https://github.com/KeeperHub/keeperhub",
   },
   docsRepositoryBase:
-    "https://github.com/KeeperHub/keeperhub/edit/main/docs",
+    "https://github.com/KeeperHub/keeperhub/edit/staging/docs",
   footer: {
     content: (
       <span style={{ color: "#7a9ca8", fontSize: "13px" }}>


### PR DESCRIPTION
## What

Two changes that together make "Edit this page" resolve. Both halves are needed; the first revision of this PR only had the first.

1. `docs-site/theme.config.tsx:28` — `docsRepositoryBase` targets `staging` instead of `main`.
2. `docs-site/app/[[...mdxPath]]/page.tsx` — strip the leading `content/` segment from `metadata.filePath` before it reaches the theme wrapper.

## Why both

The theme builds the URL as `docsRepositoryBase + '/' + filePath` (`nextra-theme-docs/src/components/toc.tsx`). Two things are wrong with the result today:

- `main` is thousands of commits behind and carries no `docs/` tree, so the base is unreachable.
- `docs-site/content` is a symlink to `../docs`. Nextra resolves `filePath` relative to `docs-site/`, so it reports `content/quickstart.md`, but git only knows that file as `docs/quickstart.md`. GitHub does not traverse the symlink either — `contents/docs-site/content/quickstart.md` returns 404 — so pointing the base at `docs-site` does not help.

Fixing only the branch moves the 404 from `main` to `staging`. Correcting `filePath` at the point where the wrapper receives it keeps `docsRepositoryBase` meaningful for its other consumer (the feedback link) and leaves the content directory where the deploy workflow, Dockerfile and path filters expect it.

## Verification

Production build of `docs-site` (`pnpm build`, 172 pages), with `content` materialised as a real directory to match the deployed layout:

Before (branch change only):
```
https://github.com/KeeperHub/keeperhub/edit/staging/docs/content/quickstart.md   -> 404
```

After (both changes):
```
https://github.com/KeeperHub/keeperhub/edit/staging/docs/quickstart.md
https://github.com/KeeperHub/keeperhub/edit/staging/docs/api/authentication.md
https://github.com/KeeperHub/keeperhub/edit/staging/docs/ai-tools/mcp-server.md
```

All 172 rendered edit links were extracted from the built HTML and checked one by one against the contents API on `staging`: 172/172 resolve, 0 still contain `/content/`. `pnpm build` compiles clean and the TypeScript step passes.

## Noted, not addressed here

`docs.keeperhub.com` deploys from `prod`, not `staging`. `staging` is still the right edit target since that is where PRs land, but a page renamed on `staging` after the last promotion to `prod` will 404 until the site redeploys. Happy to follow up separately if you would rather the base track `prod`.
