### PR TITLE
fix: skip gas sponsorship for loopback and private-range RPCs

### DIFF
--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -1198,20 +1198,6 @@ jobs:
           # instead of blowing the shard timeout. The other chain-1 suites
           # run fine cold and stay gated on ANVIL_FORK_MAINNET_URL alone.
           PROTOCOL_FORK_CACHED: ${{ steps.fork-cache.outputs.dir != '' && '1' || '' }}
-          # Non-empty only on the direct-signing path (bare-metal app, i.e.
-          # image_tag empty: build-app builds with
-          # NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED=false, so fork writes sign
-          # directly and mine fast). The staging-push docker path runs the
-          # production image with gas sponsorship on, routing writes through
-          # Turnkey sponsorship - measured ~10x slower and flaky on a fork
-          # (aave-v3 18s -> 256s, lido 14s -> 204s, pre-flight-simulation
-          # failures). morpho's setup write chain is the longest in the
-          # registry and only fits the shard budget on the direct-sign path, so
-          # it also gates on this: it runs in the nightly full sweep and
-          # self-skips on the docker staging push until that path is moved to
-          # direct signing. Tracked separately; the other suites tolerate the
-          # slow path today.
-          PROTOCOL_DIRECT_SIGN: ${{ inputs.image_tag == '' && '1' || '' }}
           # PR-gate/nightly split: PR-triggered runs shrink each phase to
           # its first runnable action (run-fixture.ts) and the floor
           # derivation above switches to the representatives floor with

--- a/lib/safe-fetch.ts
+++ b/lib/safe-fetch.ts
@@ -380,7 +380,7 @@ function blockedMessage(ctx: BlockContext): string {
   return `Outbound request to ${ctx.hostname}${ipPart} blocked by SSRF policy (${ctx.reason}).`;
 }
 
-function stripIpv6Brackets(hostname: string): string {
+export function stripIpv6Brackets(hostname: string): string {
   if (hostname.startsWith("[") && hostname.endsWith("]")) {
     return hostname.slice(1, -1);
   }

--- a/lib/web3/sponsored-transaction-manager.ts
+++ b/lib/web3/sponsored-transaction-manager.ts
@@ -9,6 +9,7 @@ import {
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { getMetricsCollector } from "@/lib/metrics";
 import { MetricNames } from "@/lib/metrics/types";
+import { isBlockedHost, isBlockedIp } from "@/lib/safe-fetch";
 import { isTestnetChain } from "@/lib/web3/chainlink-feeds";
 import { createSponsoredClient } from "@/lib/web3/sponsored-client";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
@@ -51,6 +52,24 @@ type SponsoredContractTxParams = {
 };
 
 /**
+ * A sponsored write against a loopback or private-range RPC can never land --
+ * Turnkey's Gas Station broadcasts from its own infrastructure, not from the
+ * caller's network. Skipping here (rather than attempting sponsorship and
+ * falling back after failure) also avoids a no-fallback hang: a sponsored
+ * activity Turnkey accepts but can never confirm raises without returning
+ * null.
+ */
+function isSponsorshipBlockedRpc(rpcUrl: string): boolean {
+  let hostname: string;
+  try {
+    hostname = new URL(rpcUrl).hostname;
+  } catch {
+    return false;
+  }
+  return isBlockedHost(hostname).blocked || isBlockedIp(hostname).blocked;
+}
+
+/**
  * Attempt to execute a transaction via Turnkey Gas Station sponsorship.
  *
  * Returns the result if sponsorship succeeds, or null if sponsorship is
@@ -62,6 +81,10 @@ export async function executeSponsoredTransaction(
   params: SponsoredTxParams
 ): Promise<SponsoredTransactionResult> {
   if (!isGasSponsorshipEnabled()) {
+    return null;
+  }
+
+  if (isSponsorshipBlockedRpc(params.rpcUrl)) {
     return null;
   }
 
@@ -116,6 +139,10 @@ export async function executeSponsoredContractTransaction(
   params: SponsoredContractTxParams
 ): Promise<SponsoredTransactionResult> {
   if (!isGasSponsorshipEnabled()) {
+    return null;
+  }
+
+  if (isSponsorshipBlockedRpc(params.rpcUrl)) {
     return null;
   }
 

--- a/lib/web3/sponsored-transaction-manager.ts
+++ b/lib/web3/sponsored-transaction-manager.ts
@@ -9,7 +9,11 @@ import {
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { getMetricsCollector } from "@/lib/metrics";
 import { MetricNames } from "@/lib/metrics/types";
-import { isBlockedHost, isBlockedIp } from "@/lib/safe-fetch";
+import {
+  isBlockedHost,
+  isBlockedIp,
+  stripIpv6Brackets,
+} from "@/lib/safe-fetch";
 import { isTestnetChain } from "@/lib/web3/chainlink-feeds";
 import { createSponsoredClient } from "@/lib/web3/sponsored-client";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
@@ -52,17 +56,17 @@ type SponsoredContractTxParams = {
 };
 
 /**
- * A sponsored write against a loopback or private-range RPC can never land --
- * Turnkey's Gas Station broadcasts from its own infrastructure, not from the
- * caller's network. Skipping here (rather than attempting sponsorship and
- * falling back after failure) also avoids a no-fallback hang: a sponsored
- * activity Turnkey accepts but can never confirm raises without returning
- * null.
+ * A sponsored write against a loopback or private-range RPC can never land,
+ * since Turnkey's Gas Station broadcasts from its own infrastructure, not
+ * from the caller's network. Skipping here (rather than attempting
+ * sponsorship and falling back after failure) also avoids a no-fallback
+ * hang: a sponsored activity Turnkey accepts but can never confirm raises
+ * without returning null.
  */
 function isSponsorshipBlockedRpc(rpcUrl: string): boolean {
   let hostname: string;
   try {
-    hostname = new URL(rpcUrl).hostname;
+    hostname = stripIpv6Brackets(new URL(rpcUrl).hostname);
   } catch {
     return false;
   }

--- a/tests/e2e/vitest/protocol-coverage/morpho/ethereum/coverage.test.ts
+++ b/tests/e2e/vitest/protocol-coverage/morpho/ethereum/coverage.test.ts
@@ -18,20 +18,14 @@ const PROTOCOL = "morpho";
 const CHAIN_ID = "1";
 // morpho has the registry's longest setup write chain (two token
 // provisions, three approvals, vault interactions), so it only fits the
-// shard budget on the fast path: a warmed, pinned fork cache
-// (PROTOCOL_FORK_CACHED, so reads are served locally) AND the direct-signing
-// app path (PROTOCOL_DIRECT_SIGN, so writes mine fast instead of going
-// through slow/flaky Turnkey gas sponsorship). Both hold in the nightly
-// full sweep, where it runs; on the staging-push docker path writes are
-// sponsored (~10x slower) so it self-skips there rather than blowing the
-// shard timeout. The sibling chain-1 suites tolerate the slow path and gate
-// on ANVIL_FORK_MAINNET_URL alone.
+// shard budget against a warmed, pinned fork cache (PROTOCOL_FORK_CACHED,
+// so reads are served locally). The sibling chain-1 suites tolerate a cold
+// fork and gate on ANVIL_FORK_MAINNET_URL alone.
 const SKIP_INFRA_TESTS =
   !(
     process.env.DATABASE_URL &&
     process.env.ANVIL_FORK_MAINNET_URL &&
-    process.env.PROTOCOL_FORK_CACHED &&
-    process.env.PROTOCOL_DIRECT_SIGN
+    process.env.PROTOCOL_FORK_CACHED
   ) || process.env.SKIP_INFRA_TESTS === "true";
 
 describe.skipIf(SKIP_INFRA_TESTS)(`${PROTOCOL} (Ethereum)`, () => {

--- a/tests/unit/sponsored-transaction-manager.test.ts
+++ b/tests/unit/sponsored-transaction-manager.test.ts
@@ -299,6 +299,37 @@ describe("executeSponsoredTransaction", () => {
       expect.anything()
     );
   });
+
+  it.each([
+    ["loopback hostname", "http://localhost:8548"],
+    ["loopback IP literal", "http://127.0.0.1:8548"],
+    ["RFC1918 private range", "http://10.0.0.5:8545"],
+  ])(
+    "returns null without attempting sponsorship for a %s rpcUrl",
+    async (_label, rpcUrl) => {
+      setupSuccessfulSponsorship();
+
+      const result = await executeSponsoredTransaction({
+        ...baseTxParams,
+        rpcUrl,
+      });
+
+      expect(result).toBeNull();
+      expect(mockIsSponsorshipSupported).not.toHaveBeenCalled();
+      expect(mockCheckGasCredits).not.toHaveBeenCalled();
+      expect(mockCreateSponsoredClient).not.toHaveBeenCalled();
+      expect(mockSubmitTurnkeySponsoredTransaction).not.toHaveBeenCalled();
+    }
+  );
+
+  it("still attempts sponsorship for a public rpcUrl", async () => {
+    setupSuccessfulSponsorship();
+
+    const result = await executeSponsoredTransaction(baseTxParams);
+
+    expect(result).not.toBeNull();
+    expect(mockCreateSponsoredClient).toHaveBeenCalled();
+  });
 });
 
 describe("executeSponsoredContractTransaction", () => {
@@ -338,5 +369,20 @@ describe("executeSponsoredContractTransaction", () => {
         data: "0xencoded",
       })
     );
+  });
+
+  it("returns null without attempting sponsorship for a loopback rpcUrl", async () => {
+    setupSuccessfulSponsorship();
+
+    const result = await executeSponsoredContractTransaction({
+      ...baseContractParams,
+      rpcUrl: "http://localhost:8548",
+    });
+
+    expect(result).toBeNull();
+    expect(mockIsSponsorshipSupported).not.toHaveBeenCalled();
+    expect(mockCheckGasCredits).not.toHaveBeenCalled();
+    expect(mockCreateSponsoredClient).not.toHaveBeenCalled();
+    expect(mockSubmitTurnkeySponsoredTransaction).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/sponsored-transaction-manager.test.ts
+++ b/tests/unit/sponsored-transaction-manager.test.ts
@@ -96,6 +96,14 @@ const baseContractParams = {
   args: [42],
 };
 
+const blockedRpcUrls: [string, string][] = [
+  ["loopback hostname", "http://localhost:8548"],
+  ["loopback IP literal", "http://127.0.0.1:8548"],
+  ["RFC1918 private range", "http://10.0.0.5:8545"],
+  ["IPv6 loopback", "http://[::1]:8548"],
+  ["IPv6 unique-local range", "http://[fc00::1]:8548"],
+];
+
 function setupSuccessfulSponsorship(): void {
   mockIsSponsorshipSupported.mockReturnValue(true);
   mockIsTestnetChain.mockReturnValue(false);
@@ -300,11 +308,7 @@ describe("executeSponsoredTransaction", () => {
     );
   });
 
-  it.each([
-    ["loopback hostname", "http://localhost:8548"],
-    ["loopback IP literal", "http://127.0.0.1:8548"],
-    ["RFC1918 private range", "http://10.0.0.5:8545"],
-  ])(
+  it.each(blockedRpcUrls)(
     "returns null without attempting sponsorship for a %s rpcUrl",
     async (_label, rpcUrl) => {
       setupSuccessfulSponsorship();
@@ -371,18 +375,21 @@ describe("executeSponsoredContractTransaction", () => {
     );
   });
 
-  it("returns null without attempting sponsorship for a loopback rpcUrl", async () => {
-    setupSuccessfulSponsorship();
+  it.each(blockedRpcUrls)(
+    "returns null without attempting sponsorship for a %s rpcUrl",
+    async (_label, rpcUrl) => {
+      setupSuccessfulSponsorship();
 
-    const result = await executeSponsoredContractTransaction({
-      ...baseContractParams,
-      rpcUrl: "http://localhost:8548",
-    });
+      const result = await executeSponsoredContractTransaction({
+        ...baseContractParams,
+        rpcUrl,
+      });
 
-    expect(result).toBeNull();
-    expect(mockIsSponsorshipSupported).not.toHaveBeenCalled();
-    expect(mockCheckGasCredits).not.toHaveBeenCalled();
-    expect(mockCreateSponsoredClient).not.toHaveBeenCalled();
-    expect(mockSubmitTurnkeySponsoredTransaction).not.toHaveBeenCalled();
-  });
+      expect(result).toBeNull();
+      expect(mockIsSponsorshipSupported).not.toHaveBeenCalled();
+      expect(mockCheckGasCredits).not.toHaveBeenCalled();
+      expect(mockCreateSponsoredClient).not.toHaveBeenCalled();
+      expect(mockSubmitTurnkeySponsoredTransaction).not.toHaveBeenCalled();
+    }
+  );
 });


### PR DESCRIPTION
## Summary

- Skip Turnkey Gas Station sponsorship in `executeSponsoredTransaction` / `executeSponsoredContractTransaction` when the target `rpcUrl` resolves to a loopback or private-range address, using the existing `isBlockedHost`/`isBlockedIp` SSRF helpers in `lib/safe-fetch.ts`. A sponsored write against a local anvil fork can never land (Turnkey broadcasts from its own infrastructure), so this converges the docker/staging-push and bare-metal/nightly protocol-coverage e2e paths onto direct signing for fork writes without touching `NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED` anywhere.
- Remove the `PROTOCOL_DIRECT_SIGN` stopgap and revert morpho's e2e gate back to cache + fork-url only, now that the app-level check handles direct signing on both paths.
- Confirmed against `chain-config/production.json` that no production chain routes through a loopback or private-range RPC, so this is a no-op in prod.

## Test plan

- [x] `pnpm vitest run tests/unit/sponsored-transaction-manager.test.ts` - 21 pass, including new loopback/RFC1918 cases
- [x] `pnpm vitest run tests/unit/write-contract-core.test.ts tests/unit/transfer-token-core.test.ts tests/unit/approve-token.test.ts tests/unit/write-contract-fail-on-error.test.ts tests/unit/write-contract-value-cap.test.ts` - 41 pass, no regression in the KEEP-137 private-mempool gate
- [x] `pnpm type-check` clean
- [x] `pnpm check` clean (0 errors)
- [ ] `protocol-coverage-ephemeral` on this PR's docker/staging-push path - confirm shard 4 (with morpho included) completes within the 23m budget; per-suite timings from this run will drive a follow-up shard rebalance