### PR TITLE
ci: rebalance protocol-coverage shards on measured direct-sign timing

### DIFF
--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -824,9 +824,9 @@ jobs:
     if: ${{ !cancelled() && needs.should-run.outputs.run-e2e == 'true' && (needs.build-app.result == 'success' || needs.build-app.result == 'skipped') }}
     # The suites share one anvil mainnet fork and one wallet, so they run
     # serially within a shard (vitest fileParallelism is off). The full sweep
-    # is ~50 min serial and does not fit one runner, so the protocols are
-    # split across shards balanced by measured runtime, keeping the two
-    # ~10-minute suites (pendle, superfluid) in different shards. The
+    # does not fit one runner, so the protocols are split across shards
+    # balanced by measured per-suite direct-sign runtime, keeping the three
+    # heaviest suites (sky, morpho, spark) in separate shards. The
     # protocol-coverage-floor job merges the shard results and enforces the
     # executed floor + suite completeness across the whole sweep. Adding a
     # protocol means adding it to a shard below; the completeness guard fails
@@ -839,13 +839,13 @@ jobs:
       matrix:
         include:
           - shard: 1
-            suites: superfluid/ethereum chronicle/ethereum rocket-pool/ethereum uniswap/ethereum
+            suites: sky/ethereum pendle/ethereum curve/ethereum rocket-pool/ethereum
           - shard: 2
-            suites: pendle/ethereum safe/ethereum chainlink/ethereum wrapped/ethereum
+            suites: morpho/ethereum ajna/base uniswap/ethereum lido/ethereum safe/ethereum
           - shard: 3
-            suites: ethena/ethereum curve/ethereum frax-ether-v2/ethereum spark/ethereum
+            suites: spark/ethereum superfluid/ethereum chainlink/ethereum chronicle/ethereum
           - shard: 4
-            suites: aave-v3/ethereum lido/ethereum sky/ethereum yearn/ethereum ajna/base morpho/ethereum
+            suites: ethena/ethereum yearn/ethereum aave-v3/ethereum frax-ether-v2/ethereum wrapped/ethereum
     runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && inputs.caller_event != 'pull_request' && 'arc-keeperhub-build' || 'ubuntu-latest' }}
     # Always staging: e2e validates against test credentials, never prod.
     environment: staging


### PR DESCRIPTION
## Summary

- Rebalance the `protocol-coverage-ephemeral` shard matrix in `e2e-tests-ephemeral.yml` using real per-suite timings pulled from the first staging push after the docker path started direct-signing fork writes.
- Before: shard 4 (aave-v3, lido, sky, yearn, ajna, morpho) ran 256s of test time vs. 55-141s for shards 1-3 - morpho's return to the docker path made it the clear outlier.
- After: greedy longest-first bin packing across all 18 suites (535s total measured), keeping the three heaviest suites (sky, morpho, spark) in separate shards. New shards measure 132-136s each.
- Updated the stale comment above the matrix, which referenced pre-fix numbers ("~10-minute suites (pendle, superfluid)") that no longer describe the actual heaviest suites.

## Measured before/after (seconds, "Run protocol-coverage tests" step)

| Shard | Suites | Time |
| --- | --- | --- |
| Before 1 | superfluid, chronicle, rocket-pool, uniswap | 83s |
| Before 2 | pendle, safe, chainlink, wrapped | 55s |
| Before 3 | ethena, curve, frax-ether-v2, spark | 141s |
| Before 4 | aave-v3, lido, sky, yearn, ajna, morpho | 256s |
| After 1 | sky, pendle, curve, rocket-pool | 133s |
| After 2 | morpho, ajna, uniswap, lido, safe | 134s |
| After 3 | spark, superfluid, chainlink, chronicle | 136s |
| After 4 | ethena, yearn, aave-v3, frax-ether-v2, wrapped | 132s |

## Test plan

- [x] Confirmed the suite set is identical before/after (no suite added or dropped) via a diff of the sorted suite lists
- [x] Timings sourced directly from the `protocol-results-N.json` artifacts of the staging-push run that followed the direct-sign fix, not estimated
- [ ] Next staging push - confirm all 4 shards complete within the 23m per-shard budget with the new assignments