### PR TITLE
chore: collapse verbose matrix job names in protocol e2e workflows

### DIFF
--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -401,6 +401,7 @@ jobs:
   # chains.test.ts executes exactly that chain and the executed-test floor is
   # per-chain. See specs/protocol-coverage-methodology.md.
   tier1-simulations-l2:
+    name: tier1-simulations-l2 (${{ matrix.name }})
     needs: should-run
     if: needs.should-run.outputs.run-e2e == 'true'
     runs-on: ubuntu-latest
@@ -818,6 +819,7 @@ jobs:
   # chain 1 since the chronicle/superfluid re-homing; ajna runs against
   # live Base, reads only).
   protocol-coverage-ephemeral:
+    name: protocol-coverage-ephemeral (shard ${{ matrix.shard }})
     needs: [should-run, build-app]
     # Same gate as e2e-vitest-ephemeral: build-app skipped (Docker path)
     # or succeeded admits this job; failed or cancelled blocks it.


### PR DESCRIPTION
## Summary

- GitHub Actions defaults to listing every matrix key's value in a job's display name when the job has no explicit `name:` override.
- `tier1-simulations-l2` showed all five matrix keys, e.g. `(arbitrum, 42161, 0xa4b1, https://arbitrum-one-rpc.publicnode.com, 12)`.
- `protocol-coverage-ephemeral` showed the full, truncated suite list, e.g. `(4, aave-v3/ethereum lido/ethereum sky/ethereum yearn/ethereum ajna/b...`.
- Added a `name:` override to each: `tier1-simulations-l2 (arbitrum)` and `protocol-coverage-ephemeral (shard 4)`.
- Neither job is a required status check in the branch-protection ruleset, so this is a purely cosmetic rename with no CI-gating side effects.

## Test plan

- [x] `docker run rhysd/actionlint` against the modified file - only two pre-existing shellcheck info notices remain, unchanged by this diff
- [x] Confirmed via `gh api repos/KeeperHub/keeperhub/rulesets/14211237` that neither job name appears in the required status checks list
- [ ] Next e2e run - confirm both jobs render with the short names in the Actions UI