### PR TITLE
fix: classify wallet funding and on-chain revert failures as user

### DIFF
--- a/lib/errors/__tests__/classify.test.ts
+++ b/lib/errors/__tests__/classify.test.ts
@@ -174,6 +174,60 @@ describe("classifyExecutionError", () => {
     });
   });
 
+  // Message shapes below are taken verbatim from production execution rows.
+  // Before these rules existed they all fell through to the catch-all and
+  // paged the System Error alert as if KeeperHub had failed.
+  describe("user-config: wallet funding and on-chain outcomes", () => {
+    it.each([
+      "Insufficient USDC balance. Have: 0.5, Need: 1",
+      "Insufficient ETH balance. Have: 0.05, Need: 0.051",
+      "Insufficient USDT balance. Have: 0, Need: 25",
+      "Insufficient SOL balance. Have: 0 lamports, Need: 5000 lamports (5000 fee)",
+      "Transaction reverted: Execution reverted on chain (tx 0xbadab698fa3d746b7ba3ff6c87b6baf40271f4650be01f1118eb16)",
+    ])("classifies %s as transaction + user", (input) => {
+      const r = classifyExecutionError(input);
+      expect(r.errorCategory).toBe(ErrorCategory.TRANSACTION);
+      expect(r.errorType).toBe("user");
+      expect(r.code).toBeNull();
+    });
+
+    it("Wallet has no token account for mint: configuration + user", () => {
+      const r = classifyExecutionError(
+        "Wallet has no token account for mint 4zMMC9srt5Ri5X14GAgXhaHii5GnPAEERYPJgZJDncDU"
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.CONFIGURATION);
+      expect(r.errorType).toBe("user");
+    });
+
+    it("typedData.domain.chainId on an unsupported chain: validation + user", () => {
+      const r = classifyExecutionError(
+        "typedData.domain.chainId 137 is not a supported chain"
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.VALIDATION);
+      expect(r.errorType).toBe("user");
+    });
+
+    // The funding rules are start-anchored on purpose. An RPC exhaustion
+    // message can quote a provider body that contains the same phrase, and
+    // that must stay a KeeperHub-managed RPC fault rather than being
+    // reattributed to the workflow author.
+    it("keeps an RPC exhaustion message system even when it quotes a balance error", () => {
+      const r = classifyExecutionError(
+        "RPC failed on both endpoints. Primary: Insufficient ETH balance. Have: 0.05, Need: 0.051. Fallback: timeout"
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.NETWORK_RPC);
+      expect(r.errorType).toBe("system");
+    });
+
+    it("still defaults a genuinely unknown engine failure to system", () => {
+      const r = classifyExecutionError(
+        "Insufficient. balance without the expected shape"
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.WORKFLOW_ENGINE);
+      expect(r.errorType).toBe("system");
+    });
+  });
+
   describe("user-config: bad request/auth to an external endpoint (4xx)", () => {
     it.each([
       'HTTP 401: {"error":"unauthorized"}',

--- a/lib/errors/classify.ts
+++ b/lib/errors/classify.ts
@@ -142,6 +142,33 @@ const RULES: readonly Rule[] = [
     errorType: ExecutionErrorType.USER,
     code: null,
   },
+  // The step reported a revert directly rather than through the finalize
+  // gate's `On-chain verification failed` wrapper. Same outcome, same bucket.
+  {
+    pattern: /^Transaction reverted:/i,
+    errorCategory: ErrorCategory.TRANSACTION,
+    errorType: ExecutionErrorType.USER,
+    code: null,
+  },
+  // The author's wallet does not hold enough of the asset (or native gas
+  // token) for the transfer the workflow asked for. Observed shapes are
+  // `Insufficient USDC balance. Have: N, Need: N` and the Solana lamports
+  // variant. Anchored so an RPC-exhaustion message that quotes a provider
+  // body containing this phrase still falls through to the system RPC rules.
+  {
+    pattern: /^Insufficient \S+ balance\b/i,
+    errorCategory: ErrorCategory.TRANSACTION,
+    errorType: ExecutionErrorType.USER,
+    code: null,
+  },
+  // Solana: the destination wallet has no associated token account for the
+  // mint the author configured, so the transfer cannot be routed.
+  {
+    pattern: /^Wallet has no token account for mint/i,
+    errorCategory: ErrorCategory.CONFIGURATION,
+    errorType: ExecutionErrorType.USER,
+    code: null,
+  },
   {
     pattern: /^Invalid contract address/i,
     errorCategory: ErrorCategory.VALIDATION,
@@ -276,6 +303,15 @@ const RULES: readonly Rule[] = [
   },
   {
     pattern: /Unsupported network:/i,
+    errorCategory: ErrorCategory.VALIDATION,
+    errorType: ExecutionErrorType.USER,
+    code: null,
+  },
+  // Typed-data signing against a chain the platform does not support -- the
+  // author picked it. Anchored on the field name for the same reason as the
+  // rules above: the phrase can appear inside a quoted provider response.
+  {
+    pattern: /^typedData\.domain\.chainId\b.*is not a supported chain/i,
     errorCategory: ErrorCategory.VALIDATION,
     errorType: ExecutionErrorType.USER,
     code: null,


### PR DESCRIPTION
## Problem

The System Error P2 alert counts workflow executions whose classification resolves to `error_type="system"`. Unmatched messages deliberately fall through to `WORKFLOW_ENGINE` / `system` so unknown engine faults still page, but several recurring families were reaching that default and paging as if KeeperHub had failed.

A P2 page fired on prod on 2026-08-05 and auto-resolved three minutes later. Nothing in the firing window was a platform fault. Checking the whole picture, every system-typed execution error in prod over the preceding 24h carried error code `C-0001`, the catch-all default, across four organizations. Not one matched a deliberate system rule.

## Change

Four start-anchored rules for the families that are plainly the workflow author's responsibility:

| Message shape | Classification |
| --- | --- |
| `Insufficient <ASSET> balance. Have: N, Need: N` | `transaction` / `user` |
| `Transaction reverted: ...` | `transaction` / `user` |
| `Wallet has no token account for mint ...` | `configuration` / `user` |
| `typedData.domain.chainId N is not a supported chain` | `validation` / `user` |

Every pattern is anchored at the start of the message. An RPC-exhaustion message can quote a provider response body containing the same phrase, and that must keep falling through to the KeeperHub-managed RPC rules and stay `system`. There is an explicit regression test for that ordering.

The positive test cases use message shapes taken verbatim from production execution rows, not invented strings.

## Validation

Replaying seven days of real production messages through the patched classifier moves 75 executions off the alert and leaves the RPC failures untouched.

For the specific page that prompted this: the firing window held six system-typed errors, five of them insufficient-balance or reverted-tx. With this change only one remains in that window, below the alert threshold, so it would not have fired.

Run locally: full unit suite (486 files, 20,290 tests), `type-check`, `biome check` on the changed source file, and `check:api-docs`, all green.

## Deliberately not included

The largest remaining family is `RPC failed on primary endpoint: timeout`. Those come from workflows using the private-mempool toggle, where the swap repoints primary at a third-party relay and clears the fallback, so a single message covers both a KeeperHub-managed endpoint and a third-party one. Telling those apart needs a separate design decision and is tracked on its own.