### PR TITLE
fix(scripts): widen api-docs route check to cover table and TypeScript formats

### DIFF
--- a/scripts/check-api-docs-routes.ts
+++ b/scripts/check-api-docs-routes.ts
@@ -3,15 +3,37 @@
 /**
  * Static guard against docs-vs-code drift in the public API.
  *
- * For every (METHOD, /api/path) advertised inside a fenced ```http block
- * under docs/api/**.md, this script asserts that the corresponding
- * Next.js App Router route file (app/api/<segments>/route.ts) exists and
- * exports a handler for that method. Path parameters in docs (`{id}`) are
- * mapped to the filesystem convention (`[id]`).
+ * For every (METHOD, /api/path) a page under docs/api/**.md advertises,
+ * this script asserts that the corresponding Next.js App Router route file
+ * (app/api/<segments>/route.ts) exists and exports a handler for that
+ * method. Path parameters in docs (`{id}`) are mapped to the filesystem
+ * convention (`[id]`).
+ *
+ * Three declaration formats are read, because pages use all three:
+ *
+ *   1. `http-fence`  - a fenced ```http block. The canonical form.
+ *   2. `inline-code` - a `POST /api/keys` code span in prose or in a
+ *                      markdown table cell. The method has to sit inside
+ *                      the same span as the path, which is what keeps a
+ *                      docs-site link like [User API](/api/user) - no
+ *                      method, no span - from being read as a route.
+ *   3. `code-sample` - a path literal passed as the first argument of a
+ *                      call inside a ```ts / ```js block: api("/api/user"),
+ *                      post("/api/keys", ...), api(`/api/x/${id}/y`). The
+ *                      method comes from the helper name, else from a
+ *                      `method: "POST"` in that same call, else GET.
+ *                      A URL assembled from variables (fetch(BASE + path))
+ *                      is out of reach and is deliberately not guessed at.
+ *
+ * When the same endpoint is declared twice, the artifact records the
+ * highest-priority format in the order above, so adding formats 2 and 3
+ * never rewrites an entry an ```http fence already owns.
  *
  * Exits non-zero on any drift. Also emits specs/api-coverage.json so the
  * post-deploy live HEAD check (deploy-keeperhub.yaml) reads the same
- * source of truth without re-parsing markdown in YAML.
+ * source of truth without re-parsing markdown in YAML. Note that the
+ * exit code is not the only signal: CI diffs the regenerated artifact
+ * separately, so a clean exit with an uncommitted artifact still fails.
  *
  * Routes that exist in code but appear in no docs file are surfaced as
  * warnings, not failures - many internal/cron/og/auth routes are
@@ -41,11 +63,21 @@ const HTTP_METHODS: readonly HttpMethod[] = [
   "DELETE",
 ] as const;
 
-type DocumentedEndpoint = {
+export type EndpointFormat = "http-fence" | "inline-code" | "code-sample";
+
+// Lower wins when the same endpoint is declared in more than one format.
+const FORMAT_PRIORITY: Record<EndpointFormat, number> = {
+  "http-fence": 0,
+  "inline-code": 1,
+  "code-sample": 2,
+};
+
+export type DocumentedEndpoint = {
   method: HttpMethod;
   path: string; // canonical, with {param} placeholders
   source: string; // docs file (repo-relative)
   line: number; // 1-based line in source
+  format: EndpointFormat;
 };
 
 type Drift =
@@ -85,6 +117,58 @@ const UNDOCUMENTED_PREFIX_ALLOWLIST: readonly string[] = [
   "/api/mcp/", // documented via MCP catalog, not REST docs
 ];
 
+// Catch-all route files that genuinely own their whole subtree, so a
+// documented path under them is served even though no file bears its name.
+// Better Auth mounts every /api/auth/* endpoint - siwe/nonce, siwe/verify,
+// sign-up/email - inside one handler, which is why documenting them is not
+// drift.
+//
+// This is an allowlist rather than a denylist on purpose. The other two
+// catch-alls must not resolve anything:
+//   - app/api/[...slug]/route.ts answers 404 for unmatched paths and
+//     exports every method, so it would make this guard pass for any path.
+//   - app/api/execute/[...slug]/route.ts dispatches protocol actions at
+//     runtime, so it would swallow a typo like /api/execute/tarnsfer that
+//     the exact-match check catches today.
+const DELEGATED_CATCH_ALL_ROUTES: readonly string[] = [
+  "app/api/auth/[...all]/route.ts",
+];
+
+const CODE_SAMPLE_LANGS: ReadonlySet<string> = new Set([
+  "ts",
+  "tsx",
+  "typescript",
+  "js",
+  "jsx",
+  "javascript",
+]);
+
+// `POST /api/keys` inside a single code span - the form tables and prose use.
+const INLINE_CODE_ENDPOINT_RE =
+  /`\s*(GET|POST|PUT|PATCH|DELETE)\s+(\/api\/[^`\s]+)\s*`/g;
+
+// helper("/api/...") or helper(`/api/...`) - the path as the first argument.
+const CALL_PATH_LITERAL_RE = /([\w$]+)\s*\(\s*(["'`])(\/api\/[^"'`\n]*)\2/g;
+
+const METHOD_OPTION_RE = /\bmethod\s*:\s*["'`](GET|POST|PUT|PATCH|DELETE)["'`]/i;
+
+// Request helpers whose name carries the verb: post(...), del(...).
+const HELPER_METHODS: ReadonlyMap<string, HttpMethod> = new Map([
+  ["get", "GET"],
+  ["post", "POST"],
+  ["put", "PUT"],
+  ["patch", "PATCH"],
+  ["del", "DELETE"],
+  ["delete", "DELETE"],
+]);
+
+// Characters a canonical route path may contain once placeholders are
+// normalised. Anything else means we did not understand the literal, and a
+// guess would be worse than a miss.
+const PLAUSIBLE_ROUTE_PATH_RE = /^\/api\/[A-Za-z0-9\-_./{}]*$/u;
+
+const FENCE_RE = /^\s*```(\S*)/;
+
 function walkFiles(dir: string, suffix: string): string[] {
   const out: string[] = [];
   for (const name of readdirSync(dir)) {
@@ -100,56 +184,203 @@ function walkFiles(dir: string, suffix: string): string[] {
 }
 
 /**
- * Parse every fenced ```http block in a markdown file and extract
- * (method, path) lines. Returns matches with 1-based line numbers.
+ * Strip the query string, trailing sentence punctuation and trailing
+ * slashes. We only validate the route, not its query parameters.
  */
-function parseDocsFile(absPath: string): DocumentedEndpoint[] {
-  const text = readFileSync(absPath, "utf8");
-  const lines = text.split(/\r?\n/);
+function canonicalizePath(rawPath: string): string {
+  return rawPath
+    .split("?")[0]
+    .replace(/[).,;]+$/u, "")
+    .replace(/\/+$/u, "");
+}
+
+/**
+ * Turn a template-literal path into a canonical one:
+ *   /api/execute/${exec.executionId}/status
+ *     -> /api/execute/{executionId}/status
+ * The last identifier of the interpolation names the parameter, so a
+ * sample and the prose that documents the same route collapse to one
+ * entry instead of two. Returns null when the result is not a shape we
+ * can reason about.
+ */
+export function canonicalizeSamplePath(rawPath: string): string | null {
+  const withPlaceholders = rawPath.replace(
+    /\$\{([^}]*)\}/gu,
+    (_match: string, expression: string) => {
+      const identifiers = expression.match(/[A-Za-z_$][\w$]*/gu);
+      const name = identifiers?.at(-1) ?? "param";
+      return `{${name}}`;
+    }
+  );
+  const canonical = canonicalizePath(withPlaceholders);
+  return PLAUSIBLE_ROUTE_PATH_RE.test(canonical) ? canonical : null;
+}
+
+/**
+ * Walk forward from `start` to the `)` that closes the call, skipping
+ * string and template contents so a paren inside a literal cannot end the
+ * span early. `ceiling` bounds the walk at the next path literal in the
+ * block, so an unbalanced paren in a comment can never let one call's
+ * `method:` be attributed to another call's path.
+ */
+function callArgumentSpan(text: string, start: number, ceiling: number): string {
+  let depth = 1;
+  let index = start;
+  let quote: string | null = null;
+  while (index < ceiling && depth > 0) {
+    const char = text[index];
+    if (quote !== null) {
+      if (char === "\\") {
+        index += 2;
+        continue;
+      }
+      if (char === quote) {
+        quote = null;
+      }
+      index++;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      index++;
+      continue;
+    }
+    if (char === "(") {
+      depth++;
+    } else if (char === ")") {
+      depth--;
+    }
+    index++;
+  }
+  return text.slice(start, index);
+}
+
+/**
+ * Extract endpoints from a ```ts / ```js sample. `startLine` is the
+ * 1-based line of the block's opening fence.
+ */
+export function parseCodeSampleBlock(
+  block: string,
+  startLine: number,
+  source: string
+): DocumentedEndpoint[] {
+  const matches = [...block.matchAll(CALL_PATH_LITERAL_RE)];
   const endpoints: DocumentedEndpoint[] = [];
-  let inHttpBlock = false;
-  for (let i = 0; i < lines.length; i++) {
-    const raw = lines[i];
-    if (/^```http\b/.test(raw)) {
-      inHttpBlock = true;
+  for (const [position, match] of matches.entries()) {
+    const [whole, helper, , rawPath] = match;
+    const matchIndex = match.index ?? 0;
+    const path = canonicalizeSamplePath(rawPath);
+    if (path === null) {
       continue;
     }
-    if (inHttpBlock && raw.startsWith("```")) {
-      inHttpBlock = false;
-      continue;
-    }
-    if (!inHttpBlock) {
-      continue;
-    }
-    const match = raw.match(/^\s*(GET|POST|PUT|PATCH|DELETE)\s+(\/api\/\S+)/);
-    if (!match) {
-      continue;
-    }
-    const method = match[1] as HttpMethod;
-    // Strip query string and trailing punctuation; we only validate the
-    // route, not its query parameters.
-    const rawPath = match[2].split("?")[0].replace(/[).,;]+$/u, "");
-    const canonical = rawPath.replace(/\/+$/u, "");
+    const ceiling = matches[position + 1]?.index ?? block.length;
+    const span = callArgumentSpan(block, matchIndex + whole.length, ceiling);
+    const fromOption = span.match(METHOD_OPTION_RE);
+    const method =
+      HELPER_METHODS.get(helper.toLowerCase()) ??
+      ((fromOption?.[1].toUpperCase() as HttpMethod | undefined) ?? "GET");
+    // Lines are counted in the block, then offset by the fence line.
+    const linesBefore = block.slice(0, matchIndex).split("\n").length - 1;
     endpoints.push({
       method,
-      path: canonical,
-      source: relative(REPO_ROOT, absPath),
-      line: i + 1,
+      path,
+      source,
+      line: startLine + 1 + linesBefore,
+      format: "code-sample",
     });
   }
   return endpoints;
 }
 
 /**
- * Collapse every dynamic segment (`{x}`, `[x]`, `[...x]`) to a stable
- * wildcard so /api/runs/{id} and /api/runs/[executionId] hash to the
- * same shape. Static segments are preserved verbatim.
+ * Parse one markdown page in document order across all three formats.
+ * Returns matches with 1-based line numbers.
+ */
+export function parseMarkdownEndpoints(
+  text: string,
+  source: string
+): DocumentedEndpoint[] {
+  const lines = text.split(/\r?\n/);
+  const endpoints: DocumentedEndpoint[] = [];
+  let fenceLang: string | null = null;
+  let fenceStart = 0;
+  let sampleLines: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    const fence = raw.match(FENCE_RE);
+    if (fence) {
+      if (fenceLang === null) {
+        fenceLang = fence[1].toLowerCase();
+        fenceStart = i + 1;
+        sampleLines = [];
+      } else {
+        if (CODE_SAMPLE_LANGS.has(fenceLang)) {
+          endpoints.push(
+            ...parseCodeSampleBlock(sampleLines.join("\n"), fenceStart, source)
+          );
+        }
+        fenceLang = null;
+      }
+      continue;
+    }
+    if (fenceLang === "http") {
+      const match = raw.match(/^\s*(GET|POST|PUT|PATCH|DELETE)\s+(\/api\/\S+)/);
+      if (match) {
+        endpoints.push({
+          method: match[1] as HttpMethod,
+          path: canonicalizePath(match[2]),
+          source,
+          line: i + 1,
+          format: "http-fence",
+        });
+      }
+      continue;
+    }
+    if (fenceLang !== null) {
+      if (CODE_SAMPLE_LANGS.has(fenceLang)) {
+        sampleLines.push(raw);
+      }
+      continue;
+    }
+    for (const match of raw.matchAll(INLINE_CODE_ENDPOINT_RE)) {
+      const path = canonicalizePath(match[2]);
+      if (!PLAUSIBLE_ROUTE_PATH_RE.test(path)) {
+        continue;
+      }
+      endpoints.push({
+        method: match[1] as HttpMethod,
+        path,
+        source,
+        line: i + 1,
+        format: "inline-code",
+      });
+    }
+  }
+  return endpoints;
+}
+
+function parseDocsFile(absPath: string): DocumentedEndpoint[] {
+  return parseMarkdownEndpoints(
+    readFileSync(absPath, "utf8"),
+    relative(REPO_ROOT, absPath)
+  );
+}
+
+/**
+ * Collapse every dynamic segment (`{x}`, `[x]`, `[...x]`, `{...x}`) to a
+ * stable wildcard so /api/runs/{id} and /api/runs/[executionId] hash to
+ * the same shape. Static segments are preserved verbatim.
+ *
+ * Catch-alls collapse to `**` rather than `*`. Both spellings are matched:
+ * indexRouteFiles rewrites `[...slug]` to `{...slug}` before shaping, so
+ * only checking the bracket form would silently shape every catch-all as
+ * an ordinary parameter.
  */
 function pathShape(p: string): string {
   return p
     .split("/")
     .map((seg) => {
-      if (/^\[\.\.\..+\]$/u.test(seg)) {
+      if (/^\[\.\.\..+\]$/u.test(seg) || /^\{\.\.\..+\}$/u.test(seg)) {
         return "**";
       }
       if (/^\[.+\]$/u.test(seg) || /^\{.+\}$/u.test(seg)) {
@@ -163,13 +394,16 @@ function pathShape(p: string): string {
 /**
  * Walk app/api/**.route.ts(x) once and return:
  *   shapeIndex: path-shape -> route file (repo-relative)
+ *   catchAlls:  prefix-shape -> route file, for [...slug] segments
  *   routeFiles: list of (absPath, route URL with {param} placeholders)
  */
 function indexRouteFiles(): {
   shapeIndex: Map<string, string>;
+  catchAlls: { prefixShape: string; rel: string }[];
   routeFiles: { abs: string; routePath: string }[];
 } {
   const shapeIndex = new Map<string, string>();
+  const catchAlls: { prefixShape: string; rel: string }[] = [];
   const routeFiles: { abs: string; routePath: string }[] = [];
   const files = walkFiles(APP_API_DIR, "route.ts").concat(
     walkFiles(APP_API_DIR, "route.tsx")
@@ -195,8 +429,43 @@ function indexRouteFiles(): {
     if (!shapeIndex.has(shape)) {
       shapeIndex.set(shape, rel);
     }
+    if (shape.endsWith("/**") && DELEGATED_CATCH_ALL_ROUTES.includes(rel)) {
+      catchAlls.push({ prefixShape: shape.slice(0, -"/**".length), rel });
+    }
   }
-  return { shapeIndex, routeFiles };
+  return { shapeIndex, catchAlls, routeFiles };
+}
+
+/**
+ * Resolve a documented path to the route file that would serve it.
+ *
+ * An exact shape match wins. Otherwise the path falls through to the
+ * nearest allowlisted catch-all (see DELEGATED_CATCH_ALL_ROUTES), which is
+ * what the App Router itself does: Better Auth serves every /api/auth/*
+ * path from app/api/auth/[...all]/route.ts, so a page documenting
+ * POST /api/auth/siwe/nonce is not drift even though no file bears that
+ * name.
+ */
+function resolveRouteFile(
+  path: string,
+  shapeIndex: Map<string, string>,
+  catchAlls: { prefixShape: string; rel: string }[]
+): string | null {
+  const shape = pathShape(path);
+  const exact = shapeIndex.get(shape);
+  if (exact) {
+    return exact;
+  }
+  let best: { prefixShape: string; rel: string } | null = null;
+  for (const candidate of catchAlls) {
+    if (!shape.startsWith(`${candidate.prefixShape}/`)) {
+      continue;
+    }
+    if (best === null || candidate.prefixShape.length > best.prefixShape.length) {
+      best = candidate;
+    }
+  }
+  return best?.rel ?? null;
 }
 
 /**
@@ -245,16 +514,43 @@ function exportedMethods(absRouteFile: string): Set<HttpMethod> {
   return found;
 }
 
-function collectDocumentedEndpoints(): DocumentedEndpoint[] {
+function countByFormat(endpoints: DocumentedEndpoint[]): string {
+  const formats: EndpointFormat[] = [
+    "http-fence",
+    "inline-code",
+    "code-sample",
+  ];
+  return formats
+    .map(
+      (format) =>
+        `${format} ${endpoints.filter((ep) => ep.format === format).length}`
+    )
+    .join(", ");
+}
+
+function collectDocumentedEndpoints(): {
+  endpoints: DocumentedEndpoint[];
+  declared: DocumentedEndpoint[];
+} {
   if (!existsSync(DOCS_DIR)) {
     throw new Error(`docs/api directory not found at ${DOCS_DIR}`);
   }
   const docFiles = walkFiles(DOCS_DIR, ".md");
   const all = docFiles.flatMap(parseDocsFile);
-  // Deduplicate (a path may be re-mentioned in the same file).
+  // Deduplicate (a path may be re-mentioned in the same file, or in
+  // several formats). Highest-priority format wins, document order breaks
+  // ties, so an ```http fence keeps ownership of the entry it already had.
+  const byPriority = all
+    .map((endpoint, order) => ({ endpoint, order }))
+    .sort(
+      (a, b) =>
+        FORMAT_PRIORITY[a.endpoint.format] - FORMAT_PRIORITY[b.endpoint.format] ||
+        a.order - b.order
+    )
+    .map((entry) => entry.endpoint);
   const seen = new Set<string>();
   const out: DocumentedEndpoint[] = [];
-  for (const ep of all) {
+  for (const ep of byPriority) {
     const key = `${ep.method} ${ep.path}`;
     if (seen.has(key)) {
       continue;
@@ -262,16 +558,17 @@ function collectDocumentedEndpoints(): DocumentedEndpoint[] {
     seen.add(key);
     out.push(ep);
   }
-  return out;
+  return { endpoints: out, declared: all };
 }
 
 function validate(
   endpoints: DocumentedEndpoint[],
-  shapeIndex: Map<string, string>
+  shapeIndex: Map<string, string>,
+  catchAlls: { prefixShape: string; rel: string }[]
 ): Drift[] {
   const drifts: Drift[] = [];
   for (const ep of endpoints) {
-    const routeFile = shapeIndex.get(pathShape(ep.path));
+    const routeFile = resolveRouteFile(ep.path, shapeIndex, catchAlls);
     if (!routeFile) {
       drifts.push({
         kind: "missing-file",
@@ -316,7 +613,8 @@ function reportUndocumentedRoutes(
 
 function writeCoverageArtifact(
   endpoints: DocumentedEndpoint[],
-  shapeIndex: Map<string, string>
+  shapeIndex: Map<string, string>,
+  catchAlls: { prefixShape: string; rel: string }[]
 ) {
   mkdirSync(dirname(COVERAGE_OUT), { recursive: true });
   // Stable ordering so the artifact diff is reviewable. Sort by raw code
@@ -337,7 +635,7 @@ function writeCoverageArtifact(
   });
   const json = {
     endpoints: sorted.map((ep) => {
-      const routeFile = shapeIndex.get(pathShape(ep.path)) ?? null;
+      const routeFile = resolveRouteFile(ep.path, shapeIndex, catchAlls);
       const streaming =
         routeFile !== null && isStreamingRoute(join(REPO_ROOT, routeFile));
       return {
@@ -354,16 +652,37 @@ function writeCoverageArtifact(
 }
 
 function main(): number {
-  const endpoints = collectDocumentedEndpoints();
-  const { shapeIndex, routeFiles } = indexRouteFiles();
-  const drifts = validate(endpoints, shapeIndex);
-  writeCoverageArtifact(endpoints, shapeIndex);
+  const { endpoints, declared } = collectDocumentedEndpoints();
+  const { shapeIndex, catchAlls, routeFiles } = indexRouteFiles();
+  const drifts = validate(endpoints, shapeIndex, catchAlls);
+  writeCoverageArtifact(endpoints, shapeIndex, catchAlls);
 
   console.log(
     `Scanned ${endpoints.length} documented endpoints across docs/api/`
   );
+  // Two counts, because they answer different questions: the first says
+  // which format owns each entry after dedup, the second says how much
+  // each parser actually read. A format can legitimately own zero entries
+  // while still checking dozens of declarations - a code sample calling a
+  // route the prose already documents is exactly that case.
+  console.log(`  entries by format: ${countByFormat(endpoints)}`);
+  console.log(`  declarations read: ${countByFormat(declared)}`);
 
   if (drifts.length > 0) {
+    // One endpoint can now be declared on several pages and in several
+    // formats, and dedup keeps only one of them. Listing every site keeps
+    // a drift report from sending the fixer to one page while an identical
+    // stale mention sits on another.
+    const sitesByKey = new Map<string, string[]>();
+    for (const ep of declared) {
+      const key = `${ep.method} ${ep.path}`;
+      const site = `${ep.source}:${ep.line}`;
+      const sites = sitesByKey.get(key) ?? [];
+      if (!sites.includes(site)) {
+        sites.push(site);
+      }
+      sitesByKey.set(key, sites);
+    }
     console.error("\nDRIFT detected:\n");
     for (const d of drifts) {
       const { method, path, source, line } = d.endpoint;
@@ -372,7 +691,11 @@ function main(): number {
           ? `no route file matches the URL pattern ${d.expectedShape}`
           : `${d.routeFile} exists but does not export ${method}`;
       console.error(`  ${method} ${path}`);
-      console.error(`    documented in ${source}:${line}`);
+      for (const site of sitesByKey.get(`${method} ${path}`) ?? [
+        `${source}:${line}`,
+      ]) {
+        console.error(`    documented in ${site}`);
+      }
       console.error(`    ${reason}\n`);
     }
   }
@@ -396,4 +719,12 @@ function main(): number {
   return 0;
 }
 
-process.exit(main());
+// Only execute when run directly (not when imported in tests).
+const isMain =
+  process.argv[1] &&
+  (process.argv[1].endsWith("check-api-docs-routes.ts") ||
+    process.argv[1].endsWith("check-api-docs-routes.js"));
+
+if (isMain) {
+  process.exit(main());
+}

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -230,7 +230,7 @@
       "path": "/api/user/wallet/balances",
       "route_file": "app/api/user/wallet/balances/route.ts",
       "source": "docs/api/user.md",
-      "line": 75
+      "line": 80
     },
     {
       "method": "GET",
@@ -343,6 +343,27 @@
       "route_file": "app/api/api-keys/route.ts",
       "source": "docs/api/api-keys.md",
       "line": 136
+    },
+    {
+      "method": "POST",
+      "path": "/api/auth/sign-up/email",
+      "route_file": "app/api/auth/[...all]/route.ts",
+      "source": "docs/api/headless-onboarding.md",
+      "line": 36
+    },
+    {
+      "method": "POST",
+      "path": "/api/auth/siwe/nonce",
+      "route_file": "app/api/auth/[...all]/route.ts",
+      "source": "docs/api/headless-onboarding.md",
+      "line": 14
+    },
+    {
+      "method": "POST",
+      "path": "/api/auth/siwe/verify",
+      "route_file": "app/api/auth/[...all]/route.ts",
+      "source": "docs/api/headless-onboarding.md",
+      "line": 14
     },
     {
       "method": "POST",

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -227,6 +227,13 @@
     },
     {
       "method": "GET",
+      "path": "/api/user/wallet/balances",
+      "route_file": "app/api/user/wallet/balances/route.ts",
+      "source": "docs/api/user.md",
+      "line": 75
+    },
+    {
+      "method": "GET",
       "path": "/api/workflows",
       "route_file": "app/api/workflows/route.ts",
       "source": "docs/api/workflows.md",
@@ -360,6 +367,13 @@
     },
     {
       "method": "POST",
+      "path": "/api/executions/{executionId}/cancel",
+      "route_file": "app/api/executions/[executionId]/cancel/route.ts",
+      "source": "docs/api/authentication.md",
+      "line": 60
+    },
+    {
+      "method": "POST",
       "path": "/api/hub/featured",
       "route_file": "app/api/hub/featured/route.ts",
       "source": "docs/api/workflows.md",
@@ -437,10 +451,24 @@
     },
     {
       "method": "POST",
+      "path": "/api/workflow/{workflowId}/execute",
+      "route_file": "app/api/workflow/[workflowId]/execute/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 230
+    },
+    {
+      "method": "POST",
       "path": "/api/workflows/create",
       "route_file": "app/api/workflows/create/route.ts",
       "source": "docs/api/workflows.md",
       "line": 84
+    },
+    {
+      "method": "POST",
+      "path": "/api/workflows/{id}/execute",
+      "route_file": "app/api/workflows/[workflowId]/execute/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 184
     },
     {
       "method": "POST",

--- a/tests/unit/check-api-docs-routes.test.ts
+++ b/tests/unit/check-api-docs-routes.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import {
+  canonicalizeSamplePath,
+  parseCodeSampleBlock,
+  parseMarkdownEndpoints,
+} from "../../scripts/check-api-docs-routes";
+
+const SOURCE = "docs/api/fixture.md";
+
+function page(...lines: string[]): string {
+  return lines.join("\n");
+}
+
+describe("parseMarkdownEndpoints - http fences", () => {
+  it("reads a fenced http block and reports a 1-based line number", () => {
+    const text = page("# Keys", "", "```http", "POST /api/keys", "```");
+
+    expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([
+      {
+        method: "POST",
+        path: "/api/keys",
+        source: SOURCE,
+        line: 4,
+        format: "http-fence",
+      },
+    ]);
+  });
+
+  it("drops the query string from a fenced path", () => {
+    const text = page("```http", "GET /api/runs?limit=10", "```");
+
+    expect(parseMarkdownEndpoints(text, SOURCE)[0].path).toBe("/api/runs");
+  });
+});
+
+describe("parseMarkdownEndpoints - inline code spans", () => {
+  it("reads endpoints out of a markdown table cell", () => {
+    const text = page(
+      "| Step | Call |",
+      "|---|---|",
+      "| Sign in | `POST /api/auth/siwe/nonce`, then `POST /api/auth/siwe/verify` |",
+      "| Find the wallet | `GET /api/user` -> `walletAddress` |"
+    );
+
+    expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([
+      {
+        method: "POST",
+        path: "/api/auth/siwe/nonce",
+        source: SOURCE,
+        line: 3,
+        format: "inline-code",
+      },
+      {
+        method: "POST",
+        path: "/api/auth/siwe/verify",
+        source: SOURCE,
+        line: 3,
+        format: "inline-code",
+      },
+      {
+        method: "GET",
+        path: "/api/user",
+        source: SOURCE,
+        line: 4,
+        format: "inline-code",
+      },
+    ]);
+  });
+
+  it("reads an endpoint out of a prose sentence", () => {
+    const text = "Call `POST /api/execute/transfer` with `simulate: true`.";
+
+    expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([
+      {
+        method: "POST",
+        path: "/api/execute/transfer",
+        source: SOURCE,
+        line: 1,
+        format: "inline-code",
+      },
+    ]);
+  });
+
+  it("ignores a docs-site link, which carries a path but no method", () => {
+    const text = page(
+      "See the [User API](/api/user) reference.",
+      "See also [POST /api/keys](/api/keys) for keys."
+    );
+
+    expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([]);
+  });
+
+  it("ignores a method and a path that sit in separate code spans", () => {
+    const text = "Send `POST` to `/api/keys` to create a key.";
+
+    expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([]);
+  });
+
+  it("ignores an unformatted mention in prose", () => {
+    const text = "Older builds answered POST /api/keys/legacy with a 301.";
+
+    expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([]);
+  });
+
+  it("ignores an endpoint quoted inside a json sample", () => {
+    // Verbatim from docs/api/index.md. /api/integrations/wallet has no
+    // route file, so reading this hint as a declaration would fail CI.
+    const text = page(
+      "```json",
+      "{",
+      '  "error": "wallet_not_configured",',
+      '  "hint": "POST /api/integrations/wallet to provision a wallet"',
+      "}",
+      "```"
+    );
+
+    expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([]);
+  });
+});
+
+describe("parseMarkdownEndpoints - code samples", () => {
+  it("infers the method from the helper name, and reads a sample once", () => {
+    // The comment holds a code span, which outside a fence would be read
+    // as a second declaration of the same endpoint.
+    const text = page(
+      "```ts",
+      "// `POST /api/keys` answers the first call with a challenge",
+      'const key = await post("/api/keys", { name: "ci" });',
+      "```"
+    );
+
+    expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([
+      {
+        method: "POST",
+        path: "/api/keys",
+        source: SOURCE,
+        line: 3,
+        format: "code-sample",
+      },
+    ]);
+  });
+
+  it("infers the method from a method option when the helper is neutral", () => {
+    const text = page(
+      "```ts",
+      'const res = await fetch("/api/execute/transfer", {',
+      '  method: "POST",',
+      "  headers,",
+      "});",
+      "```"
+    );
+
+    expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([
+      {
+        method: "POST",
+        path: "/api/execute/transfer",
+        source: SOURCE,
+        line: 2,
+        format: "code-sample",
+      },
+    ]);
+  });
+
+  it("falls back to GET when neither the helper nor the options name a method", () => {
+    const text = page("```ts", 'const me = await api("/api/user");', "```");
+
+    expect(parseMarkdownEndpoints(text, SOURCE)[0].method).toBe("GET");
+  });
+
+  it("names the path parameter after the last identifier of a template hole", () => {
+    const text = page(
+      "```ts",
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: the placeholder is the markdown fixture's content, not this file's
+      "const status = await api(`/api/execute/${exec.executionId}/status`);",
+      "```"
+    );
+
+    expect(parseMarkdownEndpoints(text, SOURCE)[0].path).toBe(
+      "/api/execute/{executionId}/status"
+    );
+  });
+
+  it("reads js fences as well as ts fences", () => {
+    const text = page("```js", 'await del("/api/keys/{keyId}");', "```");
+
+    expect(parseMarkdownEndpoints(text, SOURCE)[0].method).toBe("DELETE");
+  });
+
+  it("leaves a URL assembled from variables alone", () => {
+    const text = page("```ts", "await fetch(BASE + path, { headers });", "```");
+
+    expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([]);
+  });
+});
+
+describe("parseCodeSampleBlock", () => {
+  it("offsets line numbers by the opening fence line", () => {
+    const block = page("const a = 1;", 'await post("/api/keys");');
+
+    expect(parseCodeSampleBlock(block, 10, SOURCE)[0].line).toBe(12);
+  });
+
+  it("does not carry one call's method over to the next call", () => {
+    // The unclosed paren in the comment means the first call's argument
+    // span never balances; without a ceiling it would run on into the
+    // second call and pick up its method.
+    const block = page(
+      'const me = await api("/api/user", {',
+      "  // the wrapper adds Authorization (and the org header",
+      "  headers,",
+      "});",
+      'const key = await api("/api/keys", { method: "POST" });'
+    );
+
+    expect(
+      parseCodeSampleBlock(block, 1, SOURCE).map((endpoint) => [
+        endpoint.method,
+        endpoint.path,
+      ])
+    ).toEqual([
+      ["GET", "/api/user"],
+      ["POST", "/api/keys"],
+    ]);
+  });
+
+  it("is not confused by a paren inside a string argument", () => {
+    const block = 'await api("/api/keys", { name: "ci (prod)" });';
+
+    expect(parseCodeSampleBlock(block, 1, SOURCE)).toHaveLength(1);
+  });
+});
+
+describe("canonicalizeSamplePath", () => {
+  it("turns a template hole into a named parameter", () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: the placeholder is the docs sample's content, not this file's
+    expect(canonicalizeSamplePath("/api/runs/${run.id}")).toBe(
+      "/api/runs/{id}"
+    );
+  });
+
+  it("strips the query string and a trailing slash", () => {
+    expect(canonicalizeSamplePath("/api/runs/?limit=10")).toBe("/api/runs");
+  });
+
+  it("rejects a literal that is not shaped like a route", () => {
+    expect(canonicalizeSamplePath("/api/keys - the key endpoint")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

The check only read fenced `http` blocks. A page that declares its endpoints in
a table, in prose, or in a runnable code sample was scanned, reported clean, and
checked against nothing.

Three formats are read now:

| Format | Shape | Method from |
| --- | --- | --- |
| `http-fence` | a fenced `http` block, as before | the line |
| `inline-code` | `` `POST /api/keys` `` in prose or a table cell | the span |
| `code-sample` | a path literal as the first argument of a call inside a `ts` / `js` block | the helper name, else a `method:` option in the same call, else GET |

The method has to sit inside the same code span as the path. That is what
separates the link in `workflows.md:184`, whose text is a code span holding both
a method and a path, from a docs-site link like `[User API](/api/user)`, which is
navigation. It also means an unformatted prose mention is not read as a
declaration.

Two supporting changes:

- **Catch-all resolution.** Better Auth serves every `/api/auth/*` path from
  `app/api/auth/[...all]/route.ts`, so a documented path now resolves through a
  catch-all route file, which is what the App Router does. Only that file is
  allowed to absorb a subtree. The 404 fallback `app/api/[...slug]` is excluded
  by name: it exports every method, so letting it match would make this check
  pass for any path at all. I found that by mutating a documented path to a typo
  and watching the check stay green.
- **Format priority.** When one endpoint is declared twice, the `http` fence
  keeps ownership of the artifact entry. `specs/api-coverage.json` therefore only
  grows, no existing entry is rewritten, and the post-deploy probe in
  `deploy-keeperhub.yaml` reads the same `.endpoints[].method/.path/.streaming`
  shape as before. `format` is parser-internal and is not written to the artifact.

## Why

Your comment on #1834: "Your separate PR widening `check-api-docs-routes.ts` is
still wanted - you were right that it does not belong in a docs change, and right
that this page will rot silently without it."

The page in #1908 puts its call list in a table and its calls in `ts` samples,
and adds no `http` fences, so the current parser reads exactly none of its
declarations.

## What it turns up on staging

Four endpoints that were documented and unchecked. All four resolve to a route
file that exports the method, so there is no drift to fix - they are the 28 added
lines in `specs/api-coverage.json`:

| Endpoint | Declared in |
| --- | --- |
| `GET /api/user/wallet/balances` | `user.md:75`, prose |
| `POST /api/executions/{executionId}/cancel` | `authentication.md:60`, a bullet |
| `POST /api/workflows/{id}/execute` | `workflows.md:184`, inside a link |
| `POST /api/workflow/{workflowId}/execute` | `workflows.md:230`, the backward-compatible singular |

## Verified

On `staging`:

```
Scanned 74 documented endpoints across docs/api/
  entries by format: http-fence 70, inline-code 4, code-sample 0
  declarations read: http-fence 72, inline-code 19, code-sample 0
No docs-vs-code drift detected.
specs/api-coverage.json: 28 insertions(+), 0 deletions(-)
```

On the head of #1908, with these two files applied:

```
Scanned 77 documented endpoints across docs/api/
  entries by format: http-fence 70, inline-code 7, code-sample 0
  declarations read: http-fence 72, inline-code 30, code-sample 13
No docs-vs-code drift detected.
specs/api-coverage.json: 49 insertions(+), 0 deletions(-)
```

All 13 sample declarations on that page collapse onto endpoints its own table
already declares. The page agrees with itself, which is the thing the check
previously could not observe in either direction.

`tests/unit/check-api-docs-routes.test.ts` is 20 tests on vitest 4.1.2. Each
false-positive case was checked by mutating the parser and watching exactly one
test go red:

| Mutation | Test that fails |
| --- | --- |
| argument span runs to the end of the block instead of stopping at the next path literal | one call's `method:` is attributed to the previous call's path |
| route-shape guard dropped | a literal like `"/api/keys - the key endpoint"` is accepted as a path |
| code-span backticks made optional | an unformatted prose mention is read as a declaration |
| fenced blocks no longer skipped by the prose scanner | a code span in a sample's comment is read as a second declaration |

Also clean: `biome check` on the test file (biome 2.4.10, ultracite 6.5.1), and
`tsc --noEmit` with the repo's compiler options on both changed files. That type
check covered the two files, not the whole project.

CI has not run: this is a fork PR, so workflows wait on your approval.

## Limits

- A path under `app/api/auth/[...all]` is checked to subtree plus method, not to
  the exact path, so `/api/auth/siwe/nonceX` still resolves. Tightening that
  means teaching the script Better Auth's route table, which would rot faster
  than the docs do.
- `bash` / `curl` fences are not read. A curl line carries its method in `-X` or
  implies POST from `--data`, which is a second grammar - say the word if you
  want it and I will add it.
- A URL assembled from variables, `fetch(BASE + path)`, is not guessed at.
- Landing order: the artifact here was generated on `staging`. If #1908 merges
  first, this branch needs `pnpm check:api-docs` re-run and the artifact
  recommitted at 49 lines rather than 28. The separate
  `git diff --exit-code specs/api-coverage.json` step in `pr-checks.yml` fails
  loudly if that is missed; ping me and I will rebase.

---

_Disclosure: written, tested and opened autonomously by Pico, an AI agent, as
with #1834, #1835 and #1848. If AI-authored contributions are not welcome here,
close it and I will not resubmit._
