### PR TITLE
fix(execute): accept mcp:read for direct-execution dry runs

### DIFF
--- a/app/api/execute/check-and-execute/route.ts
+++ b/app/api/execute/check-and-execute/route.ts
@@ -13,7 +13,7 @@ import {
   recordIdempotentResponse,
   withIdempotencyHeartbeat,
 } from "@/lib/idempotency";
-import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import { SCOPE_MCP_READ, SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { requireScope } from "@/lib/middleware/require-scope";
 import { applyRateLimitHeaders } from "@/lib/rate-limit-headers";
 import { getErrorMessage } from "@/lib/utils";
@@ -227,7 +227,33 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 
-  const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE);
+  // Parsed before the scope gate because the required scope depends on
+  // whether this is a dry run.
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: HttpStatus.BAD_REQUEST }
+    );
+  }
+
+  const simulateFlag = parseSimulateFlag(body);
+  if (!simulateFlag.ok) {
+    return NextResponse.json(
+      { error: simulateFlag.error, field: "simulate" },
+      { status: HttpStatus.BAD_REQUEST }
+    );
+  }
+
+  // A dry run never signs, broadcasts, or reserves, so mcp:read satisfies it.
+  // parseSimulateFlag is strict-boolean, so a non-boolean `simulate` is
+  // rejected above rather than downgrading the requirement.
+  const scopeError = requireScope(
+    apiKeyCtx.scope,
+    simulateFlag.simulate ? SCOPE_MCP_READ : SCOPE_MCP_WRITE
+  );
   if (scopeError) {
     return scopeError;
   }
@@ -249,16 +275,6 @@ export async function POST(request: Request): Promise<NextResponse> {
   const executionGuard = await enforceExecutionLimit(apiKeyCtx.organizationId);
   if (executionGuard.blocked) {
     return executionGuard.response;
-  }
-
-  let body: Record<string, unknown>;
-  try {
-    body = (await request.json()) as Record<string, unknown>;
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON body" },
-      { status: HttpStatus.BAD_REQUEST }
-    );
   }
 
   const validation = validateCheckAndExecuteInput(body);
@@ -357,14 +373,6 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   // Dry-run path on the action: still evaluates the condition (which is
   // read-only), but simulates the write instead of broadcasting.
-  // Triggered by strict boolean `simulate: true` on the body.
-  const simulateFlag = parseSimulateFlag(body);
-  if (!simulateFlag.ok) {
-    return NextResponse.json(
-      { error: simulateFlag.error, field: "simulate" },
-      { status: HttpStatus.BAD_REQUEST }
-    );
-  }
   if (simulateFlag.simulate) {
     return applyRateLimitHeaders(
       await simulateConditionalWrite(

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -14,7 +14,7 @@ import {
   recordIdempotentResponse,
   withIdempotencyHeartbeat,
 } from "@/lib/idempotency";
-import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import { SCOPE_MCP_READ, SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { requireScope } from "@/lib/middleware/require-scope";
 import { applyRateLimitHeaders } from "@/lib/rate-limit-headers";
 import { getErrorMessage } from "@/lib/utils";
@@ -244,7 +244,33 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 
-  const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE);
+  // Parsed before the scope gate because the required scope depends on
+  // whether this is a dry run.
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: HttpStatus.BAD_REQUEST }
+    );
+  }
+
+  const simulateFlag = parseSimulateFlag(body);
+  if (!simulateFlag.ok) {
+    return NextResponse.json(
+      { error: simulateFlag.error, field: "simulate" },
+      { status: HttpStatus.BAD_REQUEST }
+    );
+  }
+
+  // A dry run never signs, broadcasts, or reserves, so mcp:read satisfies it.
+  // parseSimulateFlag is strict-boolean, so a non-boolean `simulate` is
+  // rejected above rather than downgrading the requirement.
+  const scopeError = requireScope(
+    apiKeyCtx.scope,
+    simulateFlag.simulate ? SCOPE_MCP_READ : SCOPE_MCP_WRITE
+  );
   if (scopeError) {
     return scopeError;
   }
@@ -266,16 +292,6 @@ export async function POST(request: Request): Promise<NextResponse> {
   const executionGuard = await enforceExecutionLimit(apiKeyCtx.organizationId);
   if (executionGuard.blocked) {
     return executionGuard.response;
-  }
-
-  let body: Record<string, unknown>;
-  try {
-    body = (await request.json()) as Record<string, unknown>;
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON body" },
-      { status: HttpStatus.BAD_REQUEST }
-    );
   }
 
   const validation = validateContractCallInput(body);
@@ -322,15 +338,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   }
 
   // Dry-run path: validate inputs, simulate via provider.call + estimateGas,
-  // never broadcast, never reserve a directExecutions row. Triggered by
-  // strict boolean `simulate: true` on the body.
-  const simulateFlag = parseSimulateFlag(body);
-  if (!simulateFlag.ok) {
-    return NextResponse.json(
-      { error: simulateFlag.error, field: "simulate" },
-      { status: HttpStatus.BAD_REQUEST }
-    );
-  }
+  // never broadcast, never reserve a directExecutions row.
   if (simulateFlag.simulate) {
     return applyRateLimitHeaders(
       await handleSimulateCall(body, resolvedAbi, apiKeyCtx.organizationId),

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -14,7 +14,7 @@ import {
   recordIdempotentResponse,
   withIdempotencyHeartbeat,
 } from "@/lib/idempotency";
-import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import { SCOPE_MCP_READ, SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { requireScope } from "@/lib/middleware/require-scope";
 import { applyRateLimitHeaders } from "@/lib/rate-limit-headers";
 import { transferFundsCore } from "@/plugins/web3/steps/transfer-funds-core";
@@ -50,7 +50,33 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 
-  const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE);
+  // Parsed before the scope gate because the required scope depends on
+  // whether this is a dry run.
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: HttpStatus.BAD_REQUEST }
+    );
+  }
+
+  const simulateFlag = parseSimulateFlag(body);
+  if (!simulateFlag.ok) {
+    return NextResponse.json(
+      { error: simulateFlag.error, field: "simulate" },
+      { status: HttpStatus.BAD_REQUEST }
+    );
+  }
+
+  // A dry run never signs, broadcasts, or reserves, so mcp:read satisfies it.
+  // parseSimulateFlag is strict-boolean, so a non-boolean `simulate` is
+  // rejected above rather than downgrading the requirement.
+  const scopeError = requireScope(
+    apiKeyCtx.scope,
+    simulateFlag.simulate ? SCOPE_MCP_READ : SCOPE_MCP_WRITE
+  );
   if (scopeError) {
     return scopeError;
   }
@@ -74,17 +100,6 @@ export async function POST(request: Request): Promise<NextResponse> {
   const executionGuard = await enforceExecutionLimit(apiKeyCtx.organizationId);
   if (executionGuard.blocked) {
     return executionGuard.response;
-  }
-
-  // 3. Parse body
-  let body: Record<string, unknown>;
-  try {
-    body = (await request.json()) as Record<string, unknown>;
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON body" },
-      { status: HttpStatus.BAD_REQUEST }
-    );
   }
 
   // 4. Validate input
@@ -122,17 +137,9 @@ export async function POST(request: Request): Promise<NextResponse> {
   }
 
   // 5.5 Dry-run path: validate inputs, simulate via estimateGas only,
-  // never broadcast, never reserve. Triggered by strict boolean
-  // `simulate: true` on the body. Token-transfer simulates resolve the
+  // never broadcast, never reserve. Token-transfer simulates resolve the
   // token address via the same parseTokenAddress helper the broadcast
   // path uses and fetch on-chain decimals when not provided.
-  const simulateFlag = parseSimulateFlag(body);
-  if (!simulateFlag.ok) {
-    return NextResponse.json(
-      { error: simulateFlag.error, field: "simulate" },
-      { status: HttpStatus.BAD_REQUEST }
-    );
-  }
   if (simulateFlag.simulate) {
     if (isTokenTransfer) {
       const result = await simulateTokenTransfer({

--- a/docs/api/direct-execution.md
+++ b/docs/api/direct-execution.md
@@ -315,6 +315,8 @@ Add `"simulate": true` to any of the standard request bodies:
 
 `simulate` must be a strict boolean — `true` or `false`. Strings (`"true"`), numbers (`1`), and other non-boolean values are rejected with HTTP 400 to prevent silent fall-through to a real broadcast. There is no query-string form; the body field is the only way to request a dry run.
 
+Because a dry run never signs or broadcasts, an OAuth token scoped `mcp:read` may run one. Removing `simulate` to broadcast requires `mcp:write`.
+
 ### Response — successful simulate
 
 ```json
@@ -503,6 +505,20 @@ Direct execution endpoints return detailed error information:
 **Common Error Codes:**
 
 - `401`: Invalid or missing API key
+- `403`: The daily spending cap is exceeded, or an OAuth token lacks the scope the request needs (`insufficient_scope`). API keys are unaffected by scope.
 - `422`: Wallet not configured, code `WALLET_NOT_CONFIGURED` (see [Wallet Management](/wallet-management/turnkey))
 - `429`: Rate limit exceeded
 - `400`: Invalid request parameters
+
+An `insufficient_scope` response names both scopes so the caller can reauthorize with the right one:
+
+```json
+{
+  "error": "insufficient_scope",
+  "message": "This endpoint requires the `mcp:write` OAuth scope. The current token has `mcp:read`.",
+  "required_scope": "mcp:write",
+  "granted_scope": "mcp:read"
+}
+```
+
+Broadcasting requires `mcp:write`. A dry run (`simulate: true`) neither signs nor broadcasts, so `mcp:read` is sufficient.

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -3,7 +3,12 @@ import { z } from "zod";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { SUPPORTED_CHAIN_IDS } from "@/lib/rpc/types";
 import { withToolLogging } from "./logging";
-import { getRequiredScopeForTool, isToolAllowed } from "./oauth-scopes";
+import {
+  getRequiredScopeForTool,
+  isToolAllowed,
+  SCOPE_MCP_READ,
+  scopeSatisfies,
+} from "./oauth-scopes";
 
 type ScopeDeniedContent = {
   content: [{ type: "text"; text: string }];
@@ -54,10 +59,22 @@ function buildScopeDeniedResult(
 // biome-ignore lint/suspicious/noExplicitAny: SDK ToolCallback uses complex generic overloads that cannot be expressed without any
 type AnyToolHandler = (...args: any[]) => unknown;
 
+/**
+ * A tool whose requirement drops to mcp:read for some argument shapes.
+ * `isToolAllowed` matches on tool name alone, so a write tool with a
+ * read-only mode needs the arguments to decide.
+ */
+type ReadOnlyWhen = (args: unknown) => boolean;
+
+/** The execute tools are writes unless the caller asked for a dry run. */
+const isSimulationRequest: ReadOnlyWhen = (args) =>
+  (args as { simulate?: unknown } | undefined)?.simulate === true;
+
 function withScopeCheck<H extends AnyToolHandler>(
   toolName: string,
   scope: string | undefined,
-  handler: H
+  handler: H,
+  readOnlyWhen?: ReadOnlyWhen
 ): H {
   if (scope === undefined) {
     return handler;
@@ -65,6 +82,12 @@ function withScopeCheck<H extends AnyToolHandler>(
   const wrapped = (
     ...args: Parameters<H>
   ): ReturnType<H> | ScopeDeniedContent => {
+    // A dry run neither signs nor broadcasts, so mcp:read is enough. The
+    // predicate tests for strict `true`, matching the REST routes' strict
+    // boolean parse, so a non-boolean cannot downgrade the requirement.
+    if (readOnlyWhen?.(args[0]) && scopeSatisfies(scope, SCOPE_MCP_READ)) {
+      return handler(...args) as ReturnType<H>;
+    }
     if (!isToolAllowed(toolName, scope)) {
       return buildScopeDeniedResult(toolName, scope);
     }
@@ -1217,27 +1240,31 @@ export function registerTools(
       idempotency_key: IDEMPOTENCY_KEY_ARG,
     },
     { title: "Transfer Funds", readOnlyHint: false, destructiveHint: true },
-    withScopeCheck("execute_transfer", scope, async (args) =>
-      withToolLogging("execute_transfer", undefined, async () => {
-        assertSimulationSupported(args.chain_id, args.simulate);
-        const data = await callApi(
-          internalApiBaseUrl,
-          authHeader,
-          "/api/execute/transfer",
-          "POST",
-          {
-            chainId: args.chain_id,
-            recipientAddress: args.to_address,
-            amount: args.amount,
-            tokenAddress: args.token_address,
-            simulate: args.simulate,
-          },
-          args.idempotency_key
-        );
-        return {
-          content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
-        };
-      })
+    withScopeCheck(
+      "execute_transfer",
+      scope,
+      async (args) =>
+        withToolLogging("execute_transfer", undefined, async () => {
+          assertSimulationSupported(args.chain_id, args.simulate);
+          const data = await callApi(
+            internalApiBaseUrl,
+            authHeader,
+            "/api/execute/transfer",
+            "POST",
+            {
+              chainId: args.chain_id,
+              recipientAddress: args.to_address,
+              amount: args.amount,
+              tokenAddress: args.token_address,
+              simulate: args.simulate,
+            },
+            args.idempotency_key
+          );
+          return {
+            content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+          };
+        }),
+      isSimulationRequest
     )
   );
 
@@ -1269,31 +1296,35 @@ export function registerTools(
       idempotency_key: IDEMPOTENCY_KEY_ARG,
     },
     { title: "Contract Call", readOnlyHint: false, destructiveHint: true },
-    withScopeCheck("execute_contract_call", scope, async (args) =>
-      withToolLogging("execute_contract_call", undefined, async () => {
-        assertSimulationSupported(args.chain_id, args.simulate);
-        const data = await callApi(
-          internalApiBaseUrl,
-          authHeader,
-          "/api/execute/contract-call",
-          "POST",
-          {
-            contractAddress: args.contract_address,
-            chainId: args.chain_id,
-            functionName: args.function_name,
-            functionArgs: args.function_args,
-            abi: args.abi,
-            value: args.value,
-            gasLimitMultiplier: args.gas_limit_multiplier,
-            priorityFeeGwei: args.priority_fee_gwei,
-            simulate: args.simulate,
-          },
-          args.idempotency_key
-        );
-        return {
-          content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
-        };
-      })
+    withScopeCheck(
+      "execute_contract_call",
+      scope,
+      async (args) =>
+        withToolLogging("execute_contract_call", undefined, async () => {
+          assertSimulationSupported(args.chain_id, args.simulate);
+          const data = await callApi(
+            internalApiBaseUrl,
+            authHeader,
+            "/api/execute/contract-call",
+            "POST",
+            {
+              contractAddress: args.contract_address,
+              chainId: args.chain_id,
+              functionName: args.function_name,
+              functionArgs: args.function_args,
+              abi: args.abi,
+              value: args.value,
+              gasLimitMultiplier: args.gas_limit_multiplier,
+              priorityFeeGwei: args.priority_fee_gwei,
+              simulate: args.simulate,
+            },
+            args.idempotency_key
+          );
+          return {
+            content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+          };
+        }),
+      isSimulationRequest
     )
   );
 
@@ -1339,36 +1370,40 @@ export function registerTools(
       idempotency_key: IDEMPOTENCY_KEY_ARG,
     },
     { title: "Check and Execute", readOnlyHint: false, destructiveHint: true },
-    withScopeCheck("execute_check_and_execute", scope, async (args) =>
-      withToolLogging("execute_check_and_execute", undefined, async () => {
-        assertSimulationSupported(args.chain_id, args.simulate);
-        const data = await callApi(
-          internalApiBaseUrl,
-          authHeader,
-          "/api/execute/check-and-execute",
-          "POST",
-          {
-            contractAddress: args.contract_address,
-            chainId: args.chain_id,
-            functionName: args.function_name,
-            functionArgs: args.function_args,
-            abi: args.abi,
-            condition: args.condition,
-            action: {
-              contractAddress: args.action.contract_address,
-              functionName: args.action.function_name,
-              functionArgs: args.action.function_args,
-              abi: args.action.abi,
-              gasLimitMultiplier: args.action.gas_limit_multiplier,
+    withScopeCheck(
+      "execute_check_and_execute",
+      scope,
+      async (args) =>
+        withToolLogging("execute_check_and_execute", undefined, async () => {
+          assertSimulationSupported(args.chain_id, args.simulate);
+          const data = await callApi(
+            internalApiBaseUrl,
+            authHeader,
+            "/api/execute/check-and-execute",
+            "POST",
+            {
+              contractAddress: args.contract_address,
+              chainId: args.chain_id,
+              functionName: args.function_name,
+              functionArgs: args.function_args,
+              abi: args.abi,
+              condition: args.condition,
+              action: {
+                contractAddress: args.action.contract_address,
+                functionName: args.action.function_name,
+                functionArgs: args.action.function_args,
+                abi: args.action.abi,
+                gasLimitMultiplier: args.action.gas_limit_multiplier,
+              },
+              simulate: args.simulate,
             },
-            simulate: args.simulate,
-          },
-          args.idempotency_key
-        );
-        return {
-          content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
-        };
-      })
+            args.idempotency_key
+          );
+          return {
+            content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+          };
+        }),
+      isSimulationRequest
     )
   );
 

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -146,7 +146,7 @@
       "path": "/api/execute/{executionId}/status",
       "route_file": "app/api/execute/[executionId]/status/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 424
+      "line": 426
     },
     {
       "method": "GET",

--- a/tests/unit/execute-simulate-scope.test.ts
+++ b/tests/unit/execute-simulate-scope.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// A dry run is read-only, so mcp:read must satisfy the execute routes when
+// `simulate: true` is set. Drives the real handlers with real minted tokens;
+// only the chain and DB boundaries are stubbed.
+
+vi.mock("server-only", () => ({}));
+
+const {
+  mockUsersFindFirst,
+  mockIsMember,
+  mockAuthenticateApiKey,
+  mockSimulateToken,
+} = vi.hoisted(() => ({
+  mockUsersFindFirst: vi.fn(),
+  mockIsMember: vi.fn(),
+  mockAuthenticateApiKey: vi.fn(),
+  mockSimulateToken: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: { query: { users: { findFirst: mockUsersFindFirst } } },
+}));
+vi.mock("@/lib/db/schema", () => ({ users: { id: "id" } }));
+vi.mock("@sentry/nextjs", () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+  captureEvent: vi.fn(),
+  withScope: vi.fn(),
+}));
+vi.mock("@/lib/workflow/access", () => ({
+  isUserMemberOfOrganization: mockIsMember,
+}));
+vi.mock("@/lib/api-key-auth", () => ({
+  authenticateApiKey: mockAuthenticateApiKey,
+}));
+vi.mock("@/lib/billing/execution-guard", () => ({
+  enforceExecutionLimit: vi.fn().mockResolvedValue({ blocked: false }),
+}));
+vi.mock("@/lib/db/org-helpers", () => ({
+  enterApiExecuteErrorContext: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/web3/wallet-helpers", () => ({
+  organizationHasWallet: vi.fn().mockResolvedValue(true),
+  getOrganizationWalletAddress: vi
+    .fn()
+    .mockResolvedValue("0xaa0000000000000000000000000000000000aa00"),
+}));
+vi.mock("@/lib/execute/simulate", () => ({
+  simulateTokenTransfer: mockSimulateToken,
+  simulateNativeTransfer: vi.fn(),
+}));
+
+const TEST_SECRET = "test-secret-32-bytes-long-enough-for-hs256";
+process.env.OAUTH_JWT_SECRET = TEST_SECRET;
+
+const { createAccessToken } = await import("@/lib/mcp/oauth-auth");
+const { POST: transferPost } = await import("@/app/api/execute/transfer/route");
+
+const ORG = "org-under-test";
+const USER = "user-under-test";
+
+const SIMULATE_BODY = {
+  chainId: "84532",
+  recipientAddress: "0xcc0000000000000000000000000000000000cc00",
+  tokenAddress: "0xdd0000000000000000000000000000000000dd00",
+  amount: "1.0",
+  simulate: true,
+};
+
+async function post(
+  authorization: string,
+  body: Record<string, unknown>
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const request = new Request("http://localhost/api/execute/transfer", {
+    method: "POST",
+    headers: {
+      Authorization: authorization,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  const response = await transferPost(request);
+  let parsed: Record<string, unknown> = {};
+  try {
+    parsed = (await response.json()) as Record<string, unknown>;
+  } catch {
+    // non-JSON body
+  }
+  return { status: response.status, body: parsed };
+}
+
+async function bearerFor(scope: string): Promise<string> {
+  return `Bearer ${await createAccessToken({ sub: USER, org: ORG, scope })}`;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUsersFindFirst.mockResolvedValue({ deactivatedAt: null });
+  mockIsMember.mockResolvedValue(true);
+  mockAuthenticateApiKey.mockResolvedValue({ authenticated: false });
+  mockSimulateToken.mockResolvedValue({
+    success: true,
+    status: "simulated",
+    from: "0xaa0000000000000000000000000000000000aa00",
+    to: "0xdd0000000000000000000000000000000000dd00",
+    value: "0",
+    gasEstimate: "51000",
+    simulatedReturnValue: true,
+    wouldRevert: false,
+  });
+});
+
+describe("execute/transfer scope gate", () => {
+  it("admits an mcp:read token for a dry run", async () => {
+    const r = await post(await bearerFor("mcp:read"), SIMULATE_BODY);
+    expect(r.status).toBe(200);
+    expect(r.body.status).toBe("simulated");
+    expect(mockSimulateToken).toHaveBeenCalledOnce();
+  });
+
+  it("still blocks an mcp:read token when simulate is omitted", async () => {
+    const { simulate, ...broadcast } = SIMULATE_BODY;
+    const r = await post(await bearerFor("mcp:read"), broadcast);
+    expect(r.status).toBe(403);
+    expect(r.body.error).toBe("insufficient_scope");
+    expect(r.body.required_scope).toBe("mcp:write");
+  });
+
+  it("still blocks an mcp:read token when simulate is false", async () => {
+    const r = await post(await bearerFor("mcp:read"), {
+      ...SIMULATE_BODY,
+      simulate: false,
+    });
+    expect(r.status).toBe(403);
+    expect(r.body.error).toBe("insufficient_scope");
+  });
+
+  // The strict-boolean parse is what stops a truthy non-boolean from
+  // selecting the read requirement and then falling through to broadcast.
+  it("rejects a non-boolean simulate before the scope decision", async () => {
+    const r = await post(await bearerFor("mcp:read"), {
+      ...SIMULATE_BODY,
+      simulate: "true",
+    });
+    expect(r.status).toBe(400);
+    expect(r.body.field).toBe("simulate");
+    expect(mockSimulateToken).not.toHaveBeenCalled();
+  });
+
+  it("admits an mcp:write token for a dry run", async () => {
+    const r = await post(await bearerFor("mcp:write"), SIMULATE_BODY);
+    expect(r.status).toBe(200);
+    expect(r.body.status).toBe("simulated");
+  });
+
+  it("admits a kh_ API key, which carries no scope", async () => {
+    mockAuthenticateApiKey.mockResolvedValue({
+      authenticated: true,
+      organizationId: ORG,
+      apiKeyId: "key-1",
+    });
+    const r = await post("Bearer kh_live_example", SIMULATE_BODY);
+    expect(r.status).toBe(200);
+    expect(r.body.status).toBe("simulated");
+  });
+});

--- a/tests/unit/mcp-simulate-scope.test.ts
+++ b/tests/unit/mcp-simulate-scope.test.ts
@@ -1,0 +1,98 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SCOPE_MCP_READ } from "@/lib/mcp/oauth-scopes";
+import { registerTools } from "@/lib/mcp/tools";
+
+// The execute tools live in WRITE_TOOLS, but isToolAllowed matches on tool
+// name alone. A dry run is read-only, so an mcp:read token must be able to
+// call them with simulate: true.
+
+type RegisteredTool = {
+  name: string;
+  handler: (...args: unknown[]) => unknown;
+};
+
+function makeMockServer(): {
+  server: McpServer;
+  registeredTools: RegisteredTool[];
+} {
+  const registeredTools: RegisteredTool[] = [];
+  const server = {
+    tool: vi.fn(
+      (
+        name: string,
+        _description: string,
+        _schema: unknown,
+        _annotations: unknown,
+        handler: (...args: unknown[]) => unknown
+      ) => {
+        registeredTools.push({ name, handler });
+      }
+    ),
+  } as unknown as McpServer;
+  return { server, registeredTools };
+}
+
+const EXECUTE_TOOLS = [
+  "execute_transfer",
+  "execute_contract_call",
+  "execute_check_and_execute",
+] as const;
+
+function handlerFor(name: string): (...args: unknown[]) => unknown {
+  const { server, registeredTools } = makeMockServer();
+  registerTools(server, "http://internal", "Bearer test", SCOPE_MCP_READ);
+  const tool = registeredTools.find((t) => t.name === name);
+  if (!tool) {
+    throw new Error(`tool ${name} was not registered`);
+  }
+  return tool.handler;
+}
+
+function parseResult(result: unknown): Record<string, unknown> {
+  const envelope = result as { content: [{ text: string }] };
+  return JSON.parse(envelope.content[0].text) as Record<string, unknown>;
+}
+
+const BASE_ARGS = {
+  chain_id: "84532",
+  to_address: "0xcc0000000000000000000000000000000000cc00",
+  amount: "1.0",
+  contract_address: "0xdd0000000000000000000000000000000000dd00",
+  function_name: "transfer",
+  abi: "[]",
+  condition: { type: "always" },
+  action: {},
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: () => Promise.resolve({ status: "simulated", wouldRevert: false }),
+    })
+  );
+});
+
+describe("MCP execute tools under an mcp:read token", () => {
+  it.each(EXECUTE_TOOLS)("%s admits simulate: true", async (name) => {
+    const result = await handlerFor(name)({ ...BASE_ARGS, simulate: true });
+    expect(parseResult(result).error).not.toBe("insufficient_scope");
+  });
+
+  it.each(EXECUTE_TOOLS)("%s denies a broadcast", async (name) => {
+    const result = await handlerFor(name)(BASE_ARGS);
+    const body = parseResult(result);
+    expect(body.error).toBe("insufficient_scope");
+    expect(body.required_scope).toBe("mcp:write");
+  });
+
+  // A truthy non-boolean must not downgrade the requirement.
+  it.each(EXECUTE_TOOLS)("%s denies a string simulate", async (name) => {
+    const result = await handlerFor(name)({ ...BASE_ARGS, simulate: "true" });
+    expect(parseResult(result).error).toBe("insufficient_scope");
+  });
+});


### PR DESCRIPTION
An OAuth token scoped `mcp:read` could not run a direct-execution simulation. All three execute routes ran `requireScope(mcp:write)` before parsing the `simulate` flag, so a dry run was rejected with 403 `insufficient_scope` before the read-only branch was ever reached, even though it never signs, broadcasts, or reserves a spending cap.

Reported externally as a suspected entitlement or wallet-activation problem. It is neither. There is no per-org Direct Execution gate, and a dry run needs no wallet, funding, or cap configuration.

## What changed

The routes now parse the body and the simulate flag ahead of the gate, requiring `mcp:read` for a dry run and `mcp:write` for a broadcast. The MCP layer gets the same treatment: `isToolAllowed` matches on tool name alone, so `withScopeCheck` takes an optional argument-aware predicate that the three execute tools use to resolve a simulated call to the read requirement.

Letting a body field select the required scope is safe because `parseSimulateFlag` is strict-boolean. A truthy non-boolean is rejected with a 400 rather than downgrading the requirement, and both simulate branches return without reaching a broadcast path. That strictness is load-bearing and should not be relaxed.

API-key callers are unaffected. `scopeSatisfies` treats an undefined scope as full access and the api-key branch never sets one.

## Behaviour

Exactly one cell moves. Broadcasting is untouched at every scope.

| Credential | `simulate: true` before | `simulate: true` after | broadcast |
|---|---|---|---|
| `mcp:read` | 403 `insufficient_scope` | 200 simulated | 403 `insufficient_scope` |
| `mcp:write` | 200 simulated | 200 simulated | proceeds |
| API key | 200 simulated | 200 simulated | proceeds |

A non-boolean `simulate` (for example the string `"true"`) is rejected with a 400 before the scope decision, so it cannot select the read requirement and then fall through to a broadcast.

## Also

Documents 403 and the `insufficient_scope` envelope, which the direct-execution error table omitted entirely.