### PR TITLE
docs: EIP-55 address-format note for web3 actions, list_action_schemas size hint

### DIFF
--- a/docs/ai-tools/mcp-server.md
+++ b/docs/ai-tools/mcp-server.md
@@ -216,7 +216,7 @@ and the authoritative safe first-write sequence.
 
 | Tool | Description |
 |------|-------------|
-| `list_action_schemas` | List available action schemas, triggers, and supported chains. Each chain includes a `status` field (stable, experimental, deprecated). |
+| `list_action_schemas` | List available action schemas, triggers, and supported chains. Each chain includes a `status` field (stable, experimental, deprecated). The unfiltered response is large (~600 KB); pass `category` (e.g. `web3`) to keep it context-friendly for agents. |
 | `get_plugin` | Get schema details for a specific plugin or integration type. |
 | `search_plugins` | Deprecated. Use `list_action_schemas` instead. |
 

--- a/docs/plugins/web3.md
+++ b/docs/plugins/web3.md
@@ -7,6 +7,8 @@ description: "Blockchain operations including balance checks, contract interacti
 
 Interact with EVM-compatible blockchain networks and Solana. Read-only actions work without credentials. Write actions require a connected Turnkey wallet.
 
+> **Address format.** EVM address parameters (Spender Address, Recipient Address, Contract Address, custom token addresses) are checked at execution time with strict EIP-55 rules (`ethers.isAddress`): all-lowercase passes, mixed-case must be a valid checksum. A mixed-case address that fails the checksum is rejected only when the run executes, with an action-specific error (for example `Invalid spender address: 0x…`) — not at workflow creation or validation. When in doubt, lowercase the address.
+
 ## Actions
 
 | Action | Category | Credentials | Description |


### PR DESCRIPTION
Two small documentation additions, both from failure modes we hit in the field.

**1. Address format note in the Web3 plugin doc** (`docs/plugins/web3.md`)

Workflow creation and `validate_workflow` accept a mixed-case EVM address that fails the EIP-55 checksum; the run then fails only at execution time with an action-specific error — `approve-token` reports `Invalid spender address: 0x…` (which reads like an allowlist rejection, not a checksum problem), `write-contract` reports a checksum error. Nothing in the docs currently warns about this, and the trap cost us several billable executions plus a couple of hours chasing a phantom allowlist. One callout after the plugin intro covers every address-taking action.

**2. Response-size hint for `list_action_schemas`** (`docs/ai-tools/mcp-server.md`)

The unfiltered response is ~600 KB / ~17.5k lines — larger than the working context of the AI agents the MCP server is built for. The `category` parameter already solves this; the tools-reference row now mentions the size and points to the parameter.

---

Context: found while building an on-call agent for the Agents Onchain hackathon — an SRE bot that monitors KeeperHub workflow executions, diagnoses failures with an LLM, and repairs semantic failures autonomously ([repo](https://github.com/henessay/execution-sre), [field notes](https://github.com/henessay/execution-sre/blob/main/docs/bounty/WRITEUP.md)).
