### PR TITLE
fix: match every query term in search_protocol_actions

### DIFF
--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -1442,6 +1442,30 @@ export function registerTools(
 // Protocol meta-tools (replaces individual per-action tool registration)
 // =============================================================================
 
+const QUERY_TERM_SPLIT_RE = /\s+/;
+
+// An empty result reads as "the platform cannot do this", so name the
+// filters that can hide an action the caller asked for.
+function buildNoActionMatchHint(args: {
+  query?: string;
+  protocol?: string;
+}): string {
+  const parts = [
+    "No action matched this search, which does not mean the capability is missing.",
+  ];
+  if (args.query) {
+    parts.push(
+      `Every word in query "${args.query}" must appear in an action's label, description, or actionType. Retry with a single keyword such as "swap", "balance", or "borrow".`
+    );
+  }
+  if (args.protocol) {
+    parts.push(
+      `The protocol filter "${args.protocol}" must match a protocol slug exactly (e.g. "uniswap", not "uniswap-v3"). Drop it to search every protocol.`
+    );
+  }
+  return parts.join(" ");
+}
+
 export function registerMetaTools(
   server: McpServer,
   internalApiBaseUrl: string,
@@ -1457,7 +1481,7 @@ export function registerMetaTools(
         .string()
         .optional()
         .describe(
-          "Keyword search across action names and descriptions (e.g., 'ETH balance', 'borrow', 'swap')"
+          "Keyword search across action names, descriptions, and action types. Every word must match, so fewer words match more actions (e.g., 'ETH balance', 'borrow', 'swap'). Omit to list every action."
         ),
       protocol: z
         .string()
@@ -1500,15 +1524,19 @@ export function registerMetaTools(
 
         let results = Object.values(actions);
 
-        // Client-side keyword filtering
+        // Every term must appear somewhere in the action's searchable
+        // text, so a phrase like "token swap" matches instead of being
+        // treated as one literal substring that never occurs.
         if (args.query) {
-          const q = args.query.toLowerCase();
-          results = results.filter(
-            (a) =>
-              a.label?.toLowerCase().includes(q) ||
-              a.description?.toLowerCase().includes(q) ||
-              a.actionType?.toLowerCase().includes(q)
-          );
+          const terms = args.query
+            .toLowerCase()
+            .split(QUERY_TERM_SPLIT_RE)
+            .filter(Boolean);
+          results = results.filter((a) => {
+            const haystack =
+              `${a.label ?? ""} ${a.description ?? ""} ${a.actionType ?? ""}`.toLowerCase();
+            return terms.every((term) => haystack.includes(term));
+          });
         }
 
         // Return compact results
@@ -1526,7 +1554,13 @@ export function registerMetaTools(
             {
               type: "text",
               text: JSON.stringify(
-                { count: compact.length, actions: compact },
+                {
+                  count: compact.length,
+                  actions: compact,
+                  ...(compact.length === 0
+                    ? { hint: buildNoActionMatchHint(args) }
+                    : {}),
+                },
                 null,
                 2
               ),

--- a/tests/unit/mcp-meta-tools.test.ts
+++ b/tests/unit/mcp-meta-tools.test.ts
@@ -1136,3 +1136,112 @@ describe("POST /api/mcp/workflows/[slug]/call: write workflow returns calldata",
     expect(mockGenerateCalldata).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// search_protocol_actions query filtering
+// ---------------------------------------------------------------------------
+
+describe("search_protocol_actions: query filtering", () => {
+  const SCHEMA_ACTIONS = {
+    "uniswap/swap-exact-input": {
+      actionType: "uniswap/swap-exact-input",
+      label: "Uniswap V3: Swap Exact Input",
+      description:
+        "Swap an exact amount of input tokens for as many output tokens as possible (single-hop)",
+    },
+    "web3/approve-token": {
+      actionType: "web3/approve-token",
+      label: "Approve ERC20 Token",
+      description:
+        "Approve a spender contract to spend ERC20 tokens on behalf of your wallet (required before swaps and DeFi interactions)",
+    },
+    "web3/check-balance": {
+      actionType: "web3/check-balance",
+      label: "Get Native Token Balance",
+      description: "Get native token balance (ETH, MATIC, etc.) of any address",
+    },
+  };
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        headers: { get: (_key: string) => "application/json" },
+        json: async () => ({ actions: SCHEMA_ACTIONS }),
+        text: async () => "",
+      })
+    );
+  });
+
+  async function invokeSearch(args: Record<string, unknown>) {
+    const { server, registeredTools } = makeMockServer();
+    const { registerMetaTools } = await import("@/lib/mcp/tools");
+    registerMetaTools(server, "http://localhost:3000", "Bearer tok");
+    const tool = registeredTools.find(
+      (t) => t.name === "search_protocol_actions"
+    );
+    if (!tool) {
+      throw new Error("search_protocol_actions not registered");
+    }
+    const result = (await tool.handler(args)) as {
+      content: [{ text: string }];
+    };
+    return JSON.parse(result.content[0].text) as {
+      count: number;
+      actions: Array<{ actionType: string }>;
+      hint?: string;
+    };
+  }
+
+  it("Test 29: multi-word query matches actions carrying every term", async () => {
+    const body = await invokeSearch({ query: "token swap" });
+    expect(body.actions.map((a) => a.actionType)).toEqual([
+      "uniswap/swap-exact-input",
+      "web3/approve-token",
+    ]);
+  });
+
+  it("Test 30: term order does not change the result set", async () => {
+    const forward = await invokeSearch({ query: "token swap" });
+    const reversed = await invokeSearch({ query: "swap token" });
+    expect(reversed.actions.map((a) => a.actionType)).toEqual(
+      forward.actions.map((a) => a.actionType)
+    );
+  });
+
+  it("Test 31: the advertised 'ETH balance' example matches", async () => {
+    const body = await invokeSearch({ query: "ETH balance" });
+    expect(body.actions.map((a) => a.actionType)).toEqual([
+      "web3/check-balance",
+    ]);
+  });
+
+  it("Test 32: single-word query still matches across all three fields", async () => {
+    const body = await invokeSearch({ query: "swap" });
+    expect(body.count).toBe(2);
+  });
+
+  it("Test 33: an unmatched query returns a hint naming the query", async () => {
+    const body = await invokeSearch({ query: "perpetual futures" });
+    expect(body.count).toBe(0);
+    expect(body.hint).toContain("perpetual futures");
+    expect(body.hint).toContain("does not mean the capability is missing");
+  });
+
+  it("Test 34: an unmatched protocol filter is called out in the hint", async () => {
+    const body = await invokeSearch({
+      query: "zzz-no-match",
+      protocol: "uniswap-v3",
+    });
+    expect(body.hint).toContain("uniswap-v3");
+    expect(body.hint).toContain("Drop it to search every protocol");
+  });
+
+  it("Test 35: omitting the query returns every action", async () => {
+    const body = await invokeSearch({});
+    expect(body.count).toBe(3);
+    expect(body.hint).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

`search_protocol_actions` tested the whole `query` string as one literal
substring against each field, so any query containing a space returned
nothing. `swap` found 26 actions; `token swap` found none, and the
advertised `ETH balance` example matched nothing either.

An empty result reads to an agent as "the platform cannot do this", so a
phrasing problem was surfacing as a missing capability.

## Change

- Split the query on whitespace and require every term to appear in the
  action's label, description, or actionType.
- Return a hint alongside `count: 0` naming the query and protocol filter
  that produced it, so the caller knows to broaden rather than conclude.
- Update the `query` parameter description so its examples work.

Seven unit tests cover multi-word queries, term-order independence, the
advertised example, the hint, and the unfiltered listing.
