### PR TITLE
fix: explain ABI output mismatches instead of relaying the decoder error

### DIFF
--- a/lib/web3/decode-revert-error.ts
+++ b/lib/web3/decode-revert-error.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+import { redactAllUrls } from "@/lib/rpc/scrub-rpc-urls";
 
 /**
  * Well-known custom error selectors that appear frequently in contracts
@@ -107,13 +108,74 @@ export function decodeRevertReason(
   return;
 }
 
+const ETHERS_VERSION_FRAGMENT_RE = /,?\s*version=[\w.+-]+/g;
+
+type DecodeFailure = {
+  code?: unknown;
+  value?: unknown;
+  info?: { method?: unknown; signature?: unknown };
+};
+
+function findFunctionOutputs(
+  contractInterface: ethers.Interface | undefined,
+  key: string | undefined
+): readonly ethers.ParamType[] | undefined {
+  if (!(contractInterface && key)) {
+    return;
+  }
+  try {
+    return contractInterface.getFunction(key)?.outputs;
+  } catch {
+    // Ambiguous or absent in this ABI.
+    return;
+  }
+}
+
+/**
+ * The raw ethers BAD_DATA text describes the decoder's problem, not the
+ * caller's. The supplied ABI is the one place worth looking, so name it.
+ */
+function describeOutputMismatch(
+  error: unknown,
+  contractInterface?: ethers.Interface
+): string | undefined {
+  if (!error || typeof error !== "object") {
+    return;
+  }
+  const err = error as DecodeFailure;
+  if (err.code !== "BAD_DATA" || typeof err.value !== "string") {
+    return;
+  }
+
+  const method =
+    typeof err.info?.method === "string" ? err.info.method : undefined;
+  const signature =
+    typeof err.info?.signature === "string" ? err.info.signature : undefined;
+  const outputs = findFunctionOutputs(
+    contractInterface,
+    signature ?? method
+  )?.map((output) => output.type);
+  const declared =
+    outputs && outputs.length > 0
+      ? `${outputs.length} output${outputs.length === 1 ? "" : "s"} (${outputs.join(", ")})`
+      : "a return value";
+  const forFunction = method ? ` for ${method}` : "";
+
+  if (err.value === "0x") {
+    return `Contract returned no data, but the ABI you supplied declares ${declared}${forFunction}. If this function returns nothing, use outputs: [].`;
+  }
+
+  return `Contract returned ${ethers.dataLength(err.value)} bytes, which does not match the ${declared} the ABI you supplied declares${forFunction}. Check the output types against the contract.`;
+}
+
 /**
  * Build a user-facing error message for a contract call failure.
  *
  * If the revert data can be decoded, produces a message like:
  *   "Contract call failed: Unauthorized()"
  *
- * Otherwise falls back to the raw ethers.js error message.
+ * Otherwise falls back to the raw ethers.js error message, minus the
+ * ethers version, which describes our internals rather than the input.
  */
 export function formatContractError(
   error: unknown,
@@ -127,8 +189,18 @@ export function formatContractError(
     return `${label}: ${decoded}`;
   }
 
+  const mismatch = describeOutputMismatch(error, contractInterface);
+  if (mismatch) {
+    return `${label}: ${mismatch}`;
+  }
+
   const message = error instanceof Error ? error.message : String(error);
-  return `${label}: ${message}`;
+  // Every URL an ethers contract error carries is one of our provider
+  // endpoints, so the host goes too, not just the key.
+  const cleaned = redactAllUrls(
+    message.replace(ETHERS_VERSION_FRAGMENT_RE, "")
+  );
+  return `${label}: ${cleaned}`;
 }
 
 /**

--- a/tests/unit/decode-revert-error.test.ts
+++ b/tests/unit/decode-revert-error.test.ts
@@ -6,6 +6,7 @@ vi.mock("server-only", () => ({}));
 import {
   classifyRevert,
   decodeRevertReason,
+  formatContractError,
 } from "@/lib/web3/decode-revert-error";
 
 /**
@@ -235,5 +236,88 @@ describe("decodeRevertReason: string-form fallback", () => {
     expect(decodeRevertReason({ data: "0x" })).toBeUndefined();
     expect(decodeRevertReason({})).toBeUndefined();
     expect(decodeRevertReason(null)).toBeUndefined();
+  });
+});
+
+describe("formatContractError: ABI output mismatch", () => {
+  const MEMO_ABI = [
+    "function transferWithMemo(address,uint256,bytes32) returns (bool)",
+  ];
+
+  function badDataError(abi: string[], data: string): unknown {
+    const iface = new ethers.Interface(abi);
+    try {
+      iface.decodeFunctionResult("transferWithMemo", data);
+    } catch (error) {
+      return error;
+    }
+    throw new Error("expected decodeFunctionResult to throw");
+  }
+
+  it("names the supplied ABI when the contract returns no data", () => {
+    const iface = new ethers.Interface(MEMO_ABI);
+    const message = formatContractError(badDataError(MEMO_ABI, "0x"), iface);
+    expect(message).toBe(
+      "Contract call failed: Contract returned no data, but the ABI you supplied declares 1 output (bool) for transferWithMemo. If this function returns nothing, use outputs: []."
+    );
+  });
+
+  it("reports the byte count when the returned data is the wrong shape", () => {
+    const iface = new ethers.Interface([
+      "function transferWithMemo(address,uint256,bytes32) returns (bool,uint256)",
+    ]);
+    const message = formatContractError(
+      badDataError(
+        [
+          "function transferWithMemo(address,uint256,bytes32) returns (bool,uint256)",
+        ],
+        `0x${"00".repeat(32)}`
+      ),
+      iface
+    );
+    expect(message).toContain("Contract returned 32 bytes");
+    expect(message).toContain("2 outputs (bool, uint256)");
+  });
+
+  it("still describes the mismatch without the contract interface", () => {
+    const message = formatContractError(badDataError(MEMO_ABI, "0x"));
+    expect(message).toContain("declares a return value for transferWithMemo");
+  });
+
+  it("leaves revert errors and their decoded reason untouched", () => {
+    expect(
+      formatContractError({ data: encodeStringRevert("LK: not yet due") })
+    ).toBe("Contract call failed: Error(LK: not yet due)");
+  });
+
+  it("redacts a keyed provider URL from a pass-through message", () => {
+    const message = formatContractError(
+      new Error(
+        'could not coalesce error (info={ "requestUrl": "https://lb.drpc.live/ethereum/FAKE_TEST_KEY_DO_NOT_USE_AAAAAAAAAAAAAAAAAAAA" }, code=UNKNOWN_ERROR)'
+      )
+    );
+    expect(message).not.toContain("drpc.live");
+    expect(message).not.toContain("FAKE_TEST_KEY");
+    expect(message).toContain("[REDACTED-URL]");
+  });
+
+  it("redacts an internal provider host carrying no key", () => {
+    const message = formatContractError(
+      new Error(
+        'server response 500 (info={ "requestUrl": "https://rpc-internal.example.invalid/ethereum" }, code=SERVER_ERROR)'
+      )
+    );
+    expect(message).not.toContain("rpc-internal.example.invalid");
+    expect(message).toContain("[REDACTED-URL]");
+  });
+
+  it("drops the ethers version from pass-through messages", () => {
+    const message = formatContractError(
+      new Error(
+        'missing revert data (action="estimateGas", code=CALL_EXCEPTION, version=6.16.0)'
+      )
+    );
+    expect(message).not.toContain("version=");
+    expect(message).toContain("code=CALL_EXCEPTION");
   });
 });


### PR DESCRIPTION
## What

A caller-supplied ABI declaring outputs the function does not return
failed with raw ethers text: `could not decode result data (value="0x",
info={...}, code=BAD_DATA, version=6.16.0)`. That describes the decoder's
problem, not the ABI behind it, and the ABI is the one place worth
looking. Declaring `outputs: [{ type: "bool" }]` by analogy with ERC-20
`transfer` is the natural instinct for a non-standard token method.

## Change

- Translate the `BAD_DATA` failure into the mismatch it represents,
  naming the declared outputs and the fix: use `outputs: []` when the
  function returns nothing. Covers the read path and the write preflight,
  since both go through the same formatter.
- Pass-through messages now drop the ethers version and every URL. The
  direct execute API does not go through the workflow-step scrubber, so
  an RPC failover error could previously surface a provider host and key
  to the caller.
