### PR TITLE
docs: describe both on-chain transaction shapes, not just the sponsored one

### DIFF
--- a/docs/wallet-management/onchain-appearance.md
+++ b/docs/wallet-management/onchain-appearance.md
@@ -1,24 +1,35 @@
 ---
 title: "What Your Transaction Looks Like On-Chain"
-description: "Why a workflow transaction can show an unfamiliar sender, an unfamiliar contract, and a value of 0 on a block explorer, and how to verify it correctly."
+description: "How a workflow transaction appears on a block explorer, why the sender and the fee differ between sponsored networks and Tempo, and how to verify a run correctly."
 ---
 
 # What Your Transaction Looks Like On-Chain
 
 A workflow ran, KeeperHub reported success, and you opened a block explorer to
-check. The transaction shows a sender you do not recognise, a contract you do
-not recognise, and a value of 0.
+check. What you see there depends on the network.
 
-Nothing is wrong. This is what a gas-sponsored write looks like, and this page
-explains how to read it.
+A write takes one of two shapes. On a gas-sponsored network the transaction is
+submitted by a relayer, so the sender is an address you do not recognise. On
+every other network, Tempo included, the transaction is sent by your own wallet
+and the sender is your own address. Both are normal. This page explains how to
+read each one.
 
-## The short version
+## Which shape applies
 
-When a write is gas-sponsored, your wallet is not the account that submits the
-transaction. A relayer submits it on your behalf and pays the fee, and your
-action runs as an internal call inside it.
+| Network | Shape |
+|---------|-------|
+| Ethereum, Base, Polygon, Arbitrum, and their testnets | Sponsored, when the [conditions](/wallet-management/gas#when-a-transaction-is-sponsored) are met |
+| Tempo | Sent from your own wallet |
+| Any other network | Sent from your own wallet |
 
-So on the explorer:
+Sponsorship is conditional even on a supported network. If it does not apply to
+a given run, that transaction takes the direct shape instead.
+
+## A sponsored write
+
+Your wallet is not the account that submits the transaction. A relayer submits
+it on your behalf and pays the fee, and your action runs as an internal call
+inside it.
 
 | Field | What you see | Why |
 |-------|--------------|-----|
@@ -30,12 +41,43 @@ So on the explorer:
 Your own action, the transfer or the contract call you configured, is an
 **internal call** inside that transaction rather than the top-level one.
 
+## A write sent from your own wallet
+
+| Field | What you see | Why |
+|-------|--------------|-----|
+| From | Your own wallet address | Your wallet signed and submitted the transaction |
+| To | The contract or recipient you configured | Your action is the top-level call |
+| Value | `0` for a token transfer or contract call | Token movements are not native value; see below |
+| Status | Success | The transaction did what your workflow asked |
+
+Because your wallet is the sender, the transaction also appears in your
+wallet's own transaction list on the explorer.
+
+## Who pays the fee, and in what
+
+This is the part that differs most between networks.
+
+**Sponsored.** The relayer pays the gas in the network's native token. Your
+wallet's native balance is unchanged by the fee, and the fee never appears as a
+debit against your address.
+
+**Sent from your own wallet, on a network with a native token.** Gas comes out
+of your own native balance in the usual way.
+
+**Sent from your own wallet, on Tempo.** Tempo has no native gas token. The fee
+is paid in a stablecoin from your own balance and appears as a token transfer
+inside the same receipt as your payment.
+
+That last case is worth reading deliberately if you are doing agent
+accounting. Because the fee is denominated in the same stablecoin you are
+moving, cost and revenue arrive in one unit: you can read both off the same
+receipt and close the books without a conversion step. Keep a small stablecoin
+balance in the wallet so it can cover fees.
+
 ## Verify with the transaction hash, not your wallet address
 
-This is the important part.
-
 Use the `transactionHash` (or the explorer link) that KeeperHub reports for the
-run. Open that hash directly. It is the authoritative record.
+run. Open that hash directly. It is the authoritative record on every network.
 
 Do **not** verify by opening your wallet address and looking through its
 transaction list. A sponsored transaction was not sent by your wallet, so it
@@ -44,20 +86,15 @@ though the transaction succeeded.
 
 On most explorers, the detail worth checking sits under the transaction's
 **Logs**, **Internal Transactions**, or **Token Transfers** tabs. That is where
-your actual call and any token movements appear.
+your actual call, any token movements, and on Tempo the fee transfer appear.
 
 ## Why the value shows 0
 
-Two things are worth separating.
-
-**The outer call carries no native token.** `Value` is the amount of the chain's
-native token attached to the top-level call. A token transfer moves an ERC-20
-balance through a contract call, and a contract call usually attaches nothing,
-so both show `0` even though assets moved. Check the token transfer list rather
-than the value field.
-
-**The fee was not paid by you.** With sponsorship the relayer pays the gas, so
-your wallet's native balance is unchanged by the fee.
+`Value` is the amount of the chain's native token attached to the top-level
+call. A token transfer moves an ERC-20 balance through a contract call, and a
+contract call usually attaches nothing, so both show `0` even though assets
+moved. This holds in both shapes. Check the token transfer list rather than the
+value field.
 
 ## Why your wallet may have code on it
 
@@ -70,17 +107,6 @@ operated on your behalf while remaining your wallet, under your address, holding
 your assets. The delegation is a one-time setup per network, not something each
 workflow repeats.
 
-## When a transaction does come from your wallet
-
-Not every write is sponsored. When sponsorship does not apply, the transaction
-is sent directly from your wallet, pays gas from your own native balance, and
-appears in your wallet's transaction list in the ordinary way. The conditions
-that decide this are listed under
-[Gas Management](/wallet-management/gas#when-a-transaction-is-sponsored).
-
-Both routes produce a real transaction with a real hash. Only the shape on the
-explorer differs.
-
 ## Checklist
 
 If a run reports success but the chain looks wrong:
@@ -88,11 +114,14 @@ If a run reports success but the chain looks wrong:
 1. Open the `transactionHash` from the run, not your wallet address.
 2. Confirm the status is Success.
 3. Look at Logs, Internal Transactions, and Token Transfers for the actual call.
-4. Expect the sender and the top-level contract to be addresses you do not
-   recognise, and the value to be `0`.
+4. Check the sender against the shape for that network. On a sponsored network,
+   expect a sender and a top-level contract you do not recognise. On Tempo and
+   elsewhere, expect your own address.
+5. Expect a value of `0` for token transfers and contract calls either way.
 
 ## Related
 
 - [Gas Management](/wallet-management/gas) covers sponsorship, what it pays for,
   and when it applies.
+- [Tempo](/plugins/tempo) covers stablecoin payments, memos, and fees on Tempo.
 - [Turnkey Integration](/wallet-management/turnkey) covers the wallet itself.


### PR DESCRIPTION
## What

The page presented the sponsored shape as universal: unfamiliar sender,
unfamiliar top-level contract, value of 0. That holds on Ethereum, Base,
Polygon and Arbitrum, and is wrong everywhere else. Tempo is not a
sponsored network, so its writes are sent by the user's own wallet, and a
reader who followed the page and then checked a Tempo receipt was told to
expect a sender they would not recognise and saw their own address.

## Change

- Split into the two shapes, with a table of which network takes which.
- New fees section covering all three cases: sponsored, own wallet with a
  native token, and Tempo, where there is no native gas token and the fee
  is paid in the same stablecoin being moved and lands as a token
  transfer in the same receipt.
- Fix the checklist, which asserted the sponsored shape unconditionally.

`turnkey.md` already scopes its cross-reference to sponsored networks and
needs no change.
