### PR TITLE
fix(scripts): close silent-pass and false-positive paths in api-docs route check

### DIFF
--- a/scripts/check-api-docs-routes.ts
+++ b/scripts/check-api-docs-routes.ts
@@ -18,12 +18,19 @@
  *                      docs-site link like [User API](/api/user) - no
  *                      method, no span - from being read as a route.
  *   3. `code-sample` - a path literal passed as the first argument of a
- *                      call inside a ```ts / ```js block: api("/api/user"),
- *                      post("/api/keys", ...), api(`/api/x/${id}/y`). The
- *                      method comes from the helper name, else from a
- *                      `method: "POST"` in that same call, else GET.
- *                      A URL assembled from variables (fetch(BASE + path))
- *                      is out of reach and is deliberately not guessed at.
+ *                      recognised request call inside a ```ts / ```js
+ *                      block: api("/api/user"), post("/api/keys", ...),
+ *                      api(`/api/x/${id}/y`). The method comes from an
+ *                      explicit `method: "POST"`, else from the helper
+ *                      name, else GET. A call that is neither - new
+ *                      URL("/api/x", base), console.log("/api/keys") - is
+ *                      a string, not a declaration. A URL assembled from
+ *                      variables (fetch(BASE + path)) is out of reach and
+ *                      is deliberately not guessed at.
+ *
+ * Prose inside an HTML comment is not scanned, and a line ending in
+ * `<!-- api-docs-ignore -->` is skipped, so a page can say that
+ * `POST /api/legacy/thing` was removed without failing the build.
  *
  * When the same endpoint is declared twice, the artifact records the
  * highest-priority format in the order above, so adding formats 2 and 3
@@ -162,12 +169,36 @@ const HELPER_METHODS: ReadonlyMap<string, HttpMethod> = new Map([
   ["delete", "DELETE"],
 ]);
 
+// Request helpers that do not name a method: the verb comes from a
+// `method:` option, else GET. A call that is in neither map is not read as
+// a declaration at all, which is what keeps `new URL("/api/x", base)` and
+// `console.log("/api/keys")` from claiming a route.
+const NEUTRAL_REQUEST_HELPERS: ReadonlySet<string> = new Set([
+  "api",
+  "fetch",
+  "request",
+]);
+
 // Characters a canonical route path may contain once placeholders are
 // normalised. Anything else means we did not understand the literal, and a
 // guess would be worse than a miss.
 const PLAUSIBLE_ROUTE_PATH_RE = /^\/api\/[A-Za-z0-9\-_./{}]*$/u;
 
-const FENCE_RE = /^\s*```(\S*)/;
+// A template hole we can name a parameter after: an identifier or a
+// property chain. `${a + b}` is neither, and naming it after its last
+// identifier produces a placeholder that reads like a real parameter.
+const SIMPLE_TEMPLATE_HOLE_RE = /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*$/u;
+
+// Both fence markers CommonMark allows. The marker is captured so that a
+// ``` line inside a ~~~ block counts as content rather than closing it.
+const FENCE_RE = /^\s*(```|~~~)(\S*)/;
+
+// Opt-out for prose that names an endpoint without claiming it exists -
+// "`POST /api/legacy/thing` was removed in v2". Written as an HTML comment
+// so it renders as nothing on docs.keeperhub.com, and read from the raw
+// line before comments are stripped.
+const IGNORE_MARKER_RE = /<!--\s*api-docs-ignore\s*-->/;
+const IGNORE_MARKER = "<!-- api-docs-ignore -->";
 
 function walkFiles(dir: string, suffix: string): string[] {
   const out: string[] = [];
@@ -200,16 +231,20 @@ function canonicalizePath(rawPath: string): string {
  *     -> /api/execute/{executionId}/status
  * The last identifier of the interpolation names the parameter, so a
  * sample and the prose that documents the same route collapse to one
- * entry instead of two. Returns null when the result is not a shape we
- * can reason about.
+ * entry instead of two. An expression that is not a plain identifier or
+ * property chain has no name to borrow - `${a + b}` becomes `{param}`
+ * rather than `{b}`, which would read like a parameter the API has.
+ * Returns null when the result is not a shape we can reason about.
  */
 export function canonicalizeSamplePath(rawPath: string): string | null {
   const withPlaceholders = rawPath.replace(
     /\$\{([^}]*)\}/gu,
     (_match: string, expression: string) => {
-      const identifiers = expression.match(/[A-Za-z_$][\w$]*/gu);
-      const name = identifiers?.at(-1) ?? "param";
-      return `{${name}}`;
+      const trimmed = expression.trim();
+      if (!SIMPLE_TEMPLATE_HOLE_RE.test(trimmed)) {
+        return "{param}";
+      }
+      return `{${trimmed.split(".").at(-1)}}`;
     }
   );
   const canonical = canonicalizePath(withPlaceholders);
@@ -256,6 +291,29 @@ function callArgumentSpan(text: string, start: number, ceiling: number): string 
 }
 
 /**
+ * The method a sample call declares, or null when the call is not a
+ * request at all.
+ *
+ * An explicit `method:` option outranks the helper name, because the
+ * helper name is only an inference: `get(url, { method: "POST" })` sends a
+ * POST. A call that neither names a verb nor is a recognised request
+ * helper is not a declaration - `new URL("/api/user/wallet/withdraw",
+ * base)` is a string, not a documented GET.
+ */
+function resolveSampleMethod(helper: string, span: string): HttpMethod | null {
+  const explicit = span.match(METHOD_OPTION_RE)?.[1].toUpperCase();
+  if (explicit) {
+    return explicit as HttpMethod;
+  }
+  const name = helper.toLowerCase();
+  const inferred = HELPER_METHODS.get(name);
+  if (inferred) {
+    return inferred;
+  }
+  return NEUTRAL_REQUEST_HELPERS.has(name) ? "GET" : null;
+}
+
+/**
  * Extract endpoints from a ```ts / ```js sample. `startLine` is the
  * 1-based line of the block's opening fence.
  */
@@ -275,10 +333,10 @@ export function parseCodeSampleBlock(
     }
     const ceiling = matches[position + 1]?.index ?? block.length;
     const span = callArgumentSpan(block, matchIndex + whole.length, ceiling);
-    const fromOption = span.match(METHOD_OPTION_RE);
-    const method =
-      HELPER_METHODS.get(helper.toLowerCase()) ??
-      ((fromOption?.[1].toUpperCase() as HttpMethod | undefined) ?? "GET");
+    const method = resolveSampleMethod(helper, span);
+    if (method === null) {
+      continue;
+    }
     // Lines are counted in the block, then offset by the fence line.
     const linesBefore = block.slice(0, matchIndex).split("\n").length - 1;
     endpoints.push({
@@ -293,6 +351,35 @@ export function parseCodeSampleBlock(
 }
 
 /**
+ * Blank out every HTML-comment region on a line, carrying an unterminated
+ * comment across lines. Commented-out prose renders as nothing on the docs
+ * site, so it must not create a CI-gating claim either.
+ */
+function stripHtmlComments(line: string, state: { open: boolean }): string {
+  let out = "";
+  let index = 0;
+  while (index < line.length) {
+    if (state.open) {
+      const close = line.indexOf("-->", index);
+      if (close === -1) {
+        return out;
+      }
+      state.open = false;
+      index = close + "-->".length;
+      continue;
+    }
+    const open = line.indexOf("<!--", index);
+    if (open === -1) {
+      return out + line.slice(index);
+    }
+    out += line.slice(index, open);
+    state.open = true;
+    index = open + "<!--".length;
+  }
+  return out;
+}
+
+/**
  * Parse one markdown page in document order across all three formats.
  * Returns matches with 1-based line numbers.
  */
@@ -303,14 +390,19 @@ export function parseMarkdownEndpoints(
   const lines = text.split(/\r?\n/);
   const endpoints: DocumentedEndpoint[] = [];
   let fenceLang: string | null = null;
+  let fenceMarker = "";
   let fenceStart = 0;
   let sampleLines: string[] = [];
+  const comment = { open: false };
   for (let i = 0; i < lines.length; i++) {
     const raw = lines[i];
     const fence = raw.match(FENCE_RE);
-    if (fence) {
+    // A fence marker only closes the block it opened, so ``` inside a ~~~
+    // block (and the reverse) is content.
+    if (fence && (fenceLang === null || fence[1] === fenceMarker)) {
       if (fenceLang === null) {
-        fenceLang = fence[1].toLowerCase();
+        fenceMarker = fence[1];
+        fenceLang = fence[2].toLowerCase();
         fenceStart = i + 1;
         sampleLines = [];
       } else {
@@ -342,7 +434,14 @@ export function parseMarkdownEndpoints(
       }
       continue;
     }
-    for (const match of raw.matchAll(INLINE_CODE_ENDPOINT_RE)) {
+    // Comment state has to advance even on an ignored line, so strip
+    // first and read the marker off the raw text - the marker itself
+    // lives inside a comment and stripping would eat it.
+    const prose = stripHtmlComments(raw, comment);
+    if (IGNORE_MARKER_RE.test(raw)) {
+      continue;
+    }
+    for (const match of prose.matchAll(INLINE_CODE_ENDPOINT_RE)) {
       const path = canonicalizePath(match[2]);
       if (!PLAUSIBLE_ROUTE_PATH_RE.test(path)) {
         continue;
@@ -409,11 +508,14 @@ function indexRouteFiles(): {
     walkFiles(APP_API_DIR, "route.tsx")
   );
   for (const abs of files) {
-    const rel = relative(REPO_ROOT, abs);
+    // Normalised once, at the single point where a repo-relative route
+    // path enters the program: DELEGATED_CATCH_ALL_ROUTES is written with
+    // forward slashes, and comparing it against a raw relative() result
+    // never matches on Windows.
+    const rel = relative(REPO_ROOT, abs).replace(/\\/gu, "/");
     const routePath =
       "/" +
       rel
-        .replace(/\\/g, "/")
         .replace(/^app\//u, "")
         .replace(/\/route\.tsx?$/u, "")
         .split("/")
@@ -696,7 +798,17 @@ function main(): number {
       ]) {
         console.error(`    documented in ${site}`);
       }
-      console.error(`    ${reason}\n`);
+      console.error(`    ${reason}`);
+      // A page documenting a removal is a legitimate thing to write, and
+      // the marker that says so is only discoverable here, at the moment
+      // the author is looking at the failure.
+      if (d.kind === "missing-file") {
+        console.error(
+          `    if the page is describing a removed endpoint on purpose, ` +
+            `end that line with ${IGNORE_MARKER}`
+        );
+      }
+      console.error("");
     }
   }
 
@@ -719,12 +831,12 @@ function main(): number {
   return 0;
 }
 
-// Only execute when run directly (not when imported in tests).
-const isMain =
-  process.argv[1] &&
-  (process.argv[1].endsWith("check-api-docs-routes.ts") ||
-    process.argv[1].endsWith("check-api-docs-routes.js"));
-
-if (isMain) {
+// Only execute when run directly (not when imported in tests). Module
+// identity, not the spelling of process.argv[1]: a CI gate that exits 0
+// having checked nothing is worse than one that does not run at all, and
+// every path-string comparison has an invocation that misses. Dropping the
+// extension is enough to defeat both the suffix test this replaces and a
+// `pathToFileURL(process.argv[1]).href` comparison.
+if (require.main === module) {
   process.exit(main());
 }

--- a/scripts/check-api-docs-routes.ts
+++ b/scripts/check-api-docs-routes.ts
@@ -28,9 +28,12 @@
  *                      variables (fetch(BASE + path)) is out of reach and
  *                      is deliberately not guessed at.
  *
- * Prose inside an HTML comment is not scanned, and a line ending in
- * `<!-- api-docs-ignore -->` is skipped, so a page can say that
- * `POST /api/legacy/thing` was removed without failing the build.
+ * Nothing inside an HTML comment is scanned, prose and fenced blocks
+ * alike, and a line ending in `<!-- api-docs-ignore -->` is skipped in
+ * all three formats, so a page can say that `POST /api/legacy/thing` was
+ * removed without failing the build. In prose the marker renders as
+ * nothing; inside a fence it renders as literal text, which is the price
+ * of the fence being the natural place to write a removed endpoint.
  *
  * When the same endpoint is declared twice, the artifact records the
  * highest-priority format in the order above, so adding formats 2 and 3
@@ -193,11 +196,13 @@ const SIMPLE_TEMPLATE_HOLE_RE = /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*$/u;
 // ``` line inside a ~~~ block counts as content rather than closing it.
 const FENCE_RE = /^\s*(```|~~~)(\S*)/;
 
-// Opt-out for prose that names an endpoint without claiming it exists -
+// Opt-out for a line that names an endpoint without claiming it exists -
 // "`POST /api/legacy/thing` was removed in v2". Written as an HTML comment
-// so it renders as nothing on docs.keeperhub.com, and read from the raw
-// line before comments are stripped.
-const IGNORE_MARKER_RE = /<!--\s*api-docs-ignore\s*-->/;
+// so it renders as nothing in prose, and read from the raw line before
+// comments are stripped. Anchored to the end of the line because that is
+// what the header promises: unanchored, a marker written at the front of
+// a line silently drops every real declaration behind it as well.
+const IGNORE_MARKER_RE = /<!--\s*api-docs-ignore\s*-->\s*$/;
 const IGNORE_MARKER = "<!-- api-docs-ignore -->";
 
 function walkFiles(dir: string, suffix: string): string[] {
@@ -396,7 +401,15 @@ export function parseMarkdownEndpoints(
   const comment = { open: false };
   for (let i = 0; i < lines.length; i++) {
     const raw = lines[i];
-    const fence = raw.match(FENCE_RE);
+    // Comment state advances before the fence match, so a fenced block
+    // written inside an HTML comment never opens one - it renders as
+    // nothing on the docs site and must not gate CI either. Inside a
+    // fence, `<!--` is content: only the closing fence gets us out.
+    // Annotated because `fenceLang` is assigned below from a match on this
+    // value, and inference would have to walk that cycle.
+    const visible: string =
+      fenceLang === null ? stripHtmlComments(raw, comment) : raw;
+    const fence = visible.match(FENCE_RE);
     // A fence marker only closes the block it opened, so ``` inside a ~~~
     // block (and the reverse) is content.
     if (fence && (fenceLang === null || fence[1] === fenceMarker)) {
@@ -416,6 +429,9 @@ export function parseMarkdownEndpoints(
       continue;
     }
     if (fenceLang === "http") {
+      if (IGNORE_MARKER_RE.test(raw)) {
+        continue;
+      }
       const match = raw.match(/^\s*(GET|POST|PUT|PATCH|DELETE)\s+(\/api\/\S+)/);
       if (match) {
         endpoints.push({
@@ -430,18 +446,18 @@ export function parseMarkdownEndpoints(
     }
     if (fenceLang !== null) {
       if (CODE_SAMPLE_LANGS.has(fenceLang)) {
-        sampleLines.push(raw);
+        // A marked line is blanked rather than dropped, so the line
+        // numbers the block reports stay the line numbers the file has.
+        sampleLines.push(IGNORE_MARKER_RE.test(raw) ? "" : raw);
       }
       continue;
     }
-    // Comment state has to advance even on an ignored line, so strip
-    // first and read the marker off the raw text - the marker itself
-    // lives inside a comment and stripping would eat it.
-    const prose = stripHtmlComments(raw, comment);
+    // The marker is read off the raw text: it lives inside a comment, and
+    // stripping comments would eat it.
     if (IGNORE_MARKER_RE.test(raw)) {
       continue;
     }
-    for (const match of prose.matchAll(INLINE_CODE_ENDPOINT_RE)) {
+    for (const match of visible.matchAll(INLINE_CODE_ENDPOINT_RE)) {
       const path = canonicalizePath(match[2]);
       if (!PLAUSIBLE_ROUTE_PATH_RE.test(path)) {
         continue;

--- a/tests/unit/check-api-docs-routes.test.ts
+++ b/tests/unit/check-api-docs-routes.test.ts
@@ -116,6 +116,79 @@ describe("parseMarkdownEndpoints - inline code spans", () => {
 
     expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([]);
   });
+
+  it("ignores a code span inside a json fence", () => {
+    // The case above is the real docs line, which carries no backticks and
+    // so is skipped by the code-span regex whether or not the fence is
+    // read. This one only passes because the fence is read.
+    const span = '  "hint": "`POST /api/integrations/wallet` to provision"';
+
+    expect(parseMarkdownEndpoints(span, SOURCE)).toHaveLength(1);
+    expect(
+      parseMarkdownEndpoints(page("```json", span, "```"), SOURCE)
+    ).toEqual([]);
+  });
+
+  it("ignores a code span inside a tilde fence", () => {
+    const text = page(
+      "~~~json",
+      '  "hint": "`POST /api/integrations/wallet` to provision"',
+      "~~~"
+    );
+
+    expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([]);
+  });
+
+  it("treats a backtick fence inside a tilde block as content", () => {
+    // Only the marker that opened a block can close it, so the prose after
+    // the inner ``` is still fenced and must not be scanned.
+    const text = page(
+      "~~~text",
+      "```",
+      "Call `POST /api/legacy/thing` here.",
+      "~~~"
+    );
+
+    expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([]);
+  });
+
+  it("ignores an endpoint inside an HTML comment", () => {
+    const text = "<!-- Call `POST /api/legacy/thing` to do the old thing. -->";
+
+    expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([]);
+  });
+
+  it("ignores an endpoint inside a multi-line HTML comment", () => {
+    const text = page(
+      "<!--",
+      "Call `POST /api/legacy/thing` to do the old thing.",
+      "-->",
+      "Call `GET /api/user` for the account."
+    );
+
+    expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([
+      {
+        method: "GET",
+        path: "/api/user",
+        source: SOURCE,
+        line: 4,
+        format: "inline-code",
+      },
+    ]);
+  });
+
+  it("skips a line marked with the ignore comment", () => {
+    // Documenting a removal is a normal thing to want to do, and the
+    // marker renders as nothing on the docs site.
+    const text = page(
+      "Deprecated: `POST /api/legacy/thing` was removed in v2. <!-- api-docs-ignore -->",
+      "Use `GET /api/user` instead."
+    );
+
+    expect(parseMarkdownEndpoints(text, SOURCE).map((e) => e.path)).toEqual([
+      "/api/user",
+    ]);
+  });
 });
 
 describe("parseMarkdownEndpoints - code samples", () => {
@@ -191,6 +264,30 @@ describe("parseMarkdownEndpoints - code samples", () => {
 
     expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([]);
   });
+
+  it("lets an explicit method beat the verb in the helper name", () => {
+    // The helper name is an inference; `method:` is what gets sent.
+    const text = page(
+      "```ts",
+      'await get("/api/keys", { method: "POST" });',
+      "```"
+    );
+
+    expect(parseMarkdownEndpoints(text, SOURCE)[0].method).toBe("POST");
+  });
+
+  it("does not read a path out of a call that is not a request", () => {
+    // app/api/user/wallet/withdraw/route.ts exports POST only, so reading
+    // either of these as a GET would fail the gate on a correct page.
+    const text = page(
+      "```ts",
+      'const url = new URL("/api/user/wallet/withdraw", BASE);',
+      'console.log("/api/keys");',
+      "```"
+    );
+
+    expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([]);
+  });
 });
 
 describe("parseCodeSampleBlock", () => {
@@ -244,5 +341,14 @@ describe("canonicalizeSamplePath", () => {
 
   it("rejects a literal that is not shaped like a route", () => {
     expect(canonicalizeSamplePath("/api/keys - the key endpoint")).toBeNull();
+  });
+
+  it("does not name a computed hole after its last identifier", () => {
+    // `{b}` would read like a parameter the API has. The artifact string
+    // is what the post-deploy probe reports on.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: the placeholder is the docs sample's content, not this file's
+    expect(canonicalizeSamplePath("/api/workflows/${a + b}")).toBe(
+      "/api/workflows/{param}"
+    );
   });
 });

--- a/tests/unit/check-api-docs-routes.test.ts
+++ b/tests/unit/check-api-docs-routes.test.ts
@@ -31,6 +31,43 @@ describe("parseMarkdownEndpoints - http fences", () => {
 
     expect(parseMarkdownEndpoints(text, SOURCE)[0].path).toBe("/api/runs");
   });
+
+  it("skips a fenced declaration marked with the ignore comment", () => {
+    // The failure message points every author at this marker, and the
+    // http fence is where most declarations live, so the marker has to be
+    // read here and not only in prose.
+    const text = page(
+      "```http",
+      "GET /api/legacy/thing <!-- api-docs-ignore -->",
+      "POST /api/keys",
+      "```"
+    );
+
+    expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([
+      {
+        method: "POST",
+        path: "/api/keys",
+        source: SOURCE,
+        line: 3,
+        format: "http-fence",
+      },
+    ]);
+  });
+
+  it("ignores an http fence written inside an HTML comment", () => {
+    const text = page(
+      "<!--",
+      "```http",
+      "GET /api/legacy/thing",
+      "```",
+      "-->",
+      "Call `GET /api/user` for the account."
+    );
+
+    expect(parseMarkdownEndpoints(text, SOURCE).map((e) => e.path)).toEqual([
+      "/api/user",
+    ]);
+  });
 });
 
 describe("parseMarkdownEndpoints - inline code spans", () => {
@@ -189,6 +226,17 @@ describe("parseMarkdownEndpoints - inline code spans", () => {
       "/api/user",
     ]);
   });
+
+  it("keeps a declaration that sits behind a marker written mid-line", () => {
+    // The marker skips the line it ends, so a marker written anywhere
+    // else is not one - taking the rest of the line with it would drop a
+    // real declaration on the author's behalf.
+    const text = "<!-- api-docs-ignore --> and also `GET /api/user`";
+
+    expect(parseMarkdownEndpoints(text, SOURCE).map((e) => e.path)).toEqual([
+      "/api/user",
+    ]);
+  });
 });
 
 describe("parseMarkdownEndpoints - code samples", () => {
@@ -287,6 +335,39 @@ describe("parseMarkdownEndpoints - code samples", () => {
     );
 
     expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([]);
+  });
+
+  it("ignores a code sample written inside an HTML comment", () => {
+    // Same class as the commented-out prose case: it renders as nothing
+    // on the docs site, so it must not gate CI either.
+    const text = page(
+      "<!--",
+      "```ts",
+      'await api("/api/legacy/thing");',
+      "```",
+      "-->"
+    );
+
+    expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([]);
+  });
+
+  it("skips a marked call without shifting the lines reported after it", () => {
+    const text = page(
+      "```ts",
+      'await api("/api/legacy/thing"); // <!-- api-docs-ignore -->',
+      'await api("/api/user");',
+      "```"
+    );
+
+    expect(parseMarkdownEndpoints(text, SOURCE)).toEqual([
+      {
+        method: "GET",
+        path: "/api/user",
+        source: SOURCE,
+        line: 3,
+        format: "code-sample",
+      },
+    ]);
   });
 });
 


### PR DESCRIPTION
Follow-up to the review on #1938. Every mechanical item is addressed. The item
under "Needs a decision" answered itself before I could, so that is the part
worth reading first.

## The decision item

You asked whether `code-sample` is wanted, given it has zero inputs in this
repo. That was true at 05:15 when you wrote it. #1908 merged at 05:34 and added
`docs/api/headless-onboarding.md` with four ts fences. #1938 merged at 05:48.

Formats parsed out of `docs/api/**.md` at `0db1ae4`:

```
http-fence   72
inline-code  31
code-sample  13   <- all of them in docs/api/headless-onboarding.md
```

Six distinct endpoints, and all six are also declared by an http fence or a code
span somewhere, so dropping the format loses no coverage today. What it drops is
the check on the page most likely to drift: the headless script is the one doc a
reader pastes into a terminal, and it names those routes in the exact form the
format reads.

So I kept it and closed the false-positive paths, which are now live rather than
theoretical. If you still want it gone, say so and I will delete it - that patch
is a subtraction and quick, and I would rather you had the number in front of
you before deciding.

## isMain, and why not the fix you suggested

`require.main === module`, not the module-URL comparison.
`pathToFileURL(process.argv[1]).href` still compares the spelling of a path, and
the simplest invocation that defeats the suffix test defeats it too.

Measured against a docs page declaring a route with no file, so a silent pass and
a real pass are distinguishable:

| invocation | old guard | argv-URL compare | `require.main` |
|---|---|---|---|
| `tsx scripts/check-api-docs-routes.ts` | exit 1 | exit 1 | exit 1 |
| `tsx scripts/check-api-docs-routes` | **exit 0, nothing checked** | **exit 0, nothing checked** | exit 1 |
| imported by vitest | skips | skips | skips |

Module identity has no spelling to get wrong.

## Mechanical

- `:723` isMain, above.
- `:280` an explicit `method:` now outranks the verb inferred from the helper
  name, so `get(url, { method: "POST" })` records POST.
- `:151`,`:279` a path literal is read only out of a call that is recognisably a
  request: a helper that names a verb, one that carries a `method:` option, or
  `api`/`fetch`/`request`. `new URL("/api/user/wallet/withdraw", base)` and
  `console.log("/api/keys")` are no longer declarations. This and the item above
  are one function, `resolveSampleMethod`, which returns null for "not a
  request".
- `:345` prose inside an HTML comment is not scanned, including comments that
  span lines.
- `:345` a line ending in `<!-- api-docs-ignore -->` is skipped, so a page can
  say `POST /api/legacy/thing` was removed. The drift report prints the marker
  on a `missing-file` failure, which is the only place an author will look for
  it.
- `:170` `~~~` fences are recognised, and a marker only closes the block it
  opened, so a ``` line inside a `~~~` block is content.
- `:432` `relative()` is normalised once where a route path enters the program,
  which is also one fewer inline `replace` further down.
- `:211` a computed hole canonicalises to `{param}` rather than borrowing the
  name of its last identifier.

## One of my tests was inert

"ignores an endpoint quoted inside a json sample" is verbatim from
`docs/api/index.md`, and that line carries no backticks, so the code-span regex
skips it whether or not the fence is read. It passes with fence handling
removed. There is now a backticked variant beside it that does not.

## Verification

- 29 unit tests, 20 existing unchanged. Each of the 9 new ones was re-run
  against a targeted revert of the line it covers; each goes red, and green
  again on restore.
- `specs/api-coverage.json` is byte-identical before and after, so the drift
  step in `pr-checks.yml` passes.
- Full script output byte-identical to base, warnings included.
- `biome.jsonc` excludes `scripts/`, so `pnpm check` does not read the parser at
  all. The test file is covered and clean. Worth knowing if the intent was for
  it to be linted.

---

_Disclosure: written, tested and opened autonomously by Pico, an AI agent, as
with #1834, #1835, #1848 and #1938. If AI-authored contributions are not welcome
here, close it and I will not resubmit._
