### PR TITLE
fix: correct docs-site edit links in every build shape

### DIFF
--- a/.github/workflows/pr-docs-site-build.yaml
+++ b/.github/workflows/pr-docs-site-build.yaml
@@ -32,3 +32,73 @@ jobs:
     uses: ./.github/workflows/build-docs-image.yml
     with:
       push: false
+
+  # The "Edit this page" links are built from a branch name hardcoded in
+  # theme.config.tsx, and nothing downstream notices when that name goes wrong.
+  # It pointed at `main` for roughly seven months while every link 404'd.
+  #
+  # Note that `main` was never deleted - it still exists, it had simply stopped
+  # receiving docs. So "does the branch exist" would have passed throughout the
+  # outage and is not the property worth asserting. What matters is whether the
+  # configured branch actually carries the docs the links point into, which is
+  # checked here by resolving the base branch's docs paths against it.
+  #
+  # Uses git rather than the contents API: no rate limit, no token, and one
+  # fetch instead of one request per page.
+  edit-link-target:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Assert docsRepositoryBase resolves to a branch carrying the docs
+        run: |
+          set -euo pipefail
+          config=docs-site/theme.config.tsx
+
+          # The property is split across lines by the formatter, so match the
+          # URL anywhere in the file rather than anchoring on the key.
+          url=$(grep -oE 'https://github\.com/[^"]+/edit/[^"]+' "$config" | head -n1)
+          if [ -z "$url" ]; then
+            echo "::error file=$config::could not find a .../edit/... URL to check"
+            exit 1
+          fi
+          echo "docsRepositoryBase: $url"
+
+          rest=${url#https://github.com/}
+          # Assumes the branch name contains no slash; a slashed branch makes
+          # the branch/path split ambiguous from the URL alone. The fetch below
+          # then fails loudly rather than passing silently.
+          branch=$(echo "$rest" | cut -d/ -f4)
+          path=$(echo "$rest" | cut -d/ -f5-)
+          base="${GITHUB_BASE_REF}"
+          echo "configured branch: $branch, docs path: $path, PR base: $base"
+
+          if [ ! -d "$path" ]; then
+            echo "::error file=$config::path '$path' is not a directory in this repo - every edit link 404s"
+            exit 1
+          fi
+
+          # Both refs in one fetch so they cannot straddle a merge landing
+          # between two separate calls.
+          if ! git fetch --no-tags --depth=1 origin \
+                "+refs/heads/$branch:refs/remotes/editlink/configured" \
+                "+refs/heads/$base:refs/remotes/editlink/base" 2>/dev/null; then
+            echo "::error file=$config::branch '$branch' does not exist on origin - every edit link 404s"
+            exit 1
+          fi
+
+          missing=0
+          checked=0
+          while read -r file; do
+            checked=$((checked + 1))
+            if ! git cat-file -e "refs/remotes/editlink/configured:$file" 2>/dev/null; then
+              missing=$((missing + 1))
+              [ "$missing" -le 10 ] && echo "  missing on $branch: $file"
+            fi
+          done < <(git ls-tree -r --name-only refs/remotes/editlink/base -- "$path")
+
+          echo "checked $checked docs files against '$branch': $missing missing"
+          if [ "$missing" -gt 0 ]; then
+            echo "::error file=$config::'$branch' is missing $missing of $checked docs files - those edit links 404"
+            exit 1
+          fi

--- a/docs-site/app/[[...mdxPath]]/page.tsx
+++ b/docs-site/app/[[...mdxPath]]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { generateStaticParamsFor, importPage } from "nextra/pages";
+import { toDocsRelativePath } from "../../lib/docs-file-path";
 import { useMDXComponents } from "../../mdx-components";
 
 export const generateStaticParams = generateStaticParamsFor("mdxPath");
@@ -31,13 +32,13 @@ export default async function Page(props: PageProps) {
   const { default: MDXContent, ...rest } = result;
   const Wrapper = useMDXComponents().wrapper;
 
-  // `content` is a symlink to `../docs`, so Nextra reports filePath as
-  // `content/<page>.md` while git only knows the file as `docs/<page>.md`.
-  // The theme builds "Edit this page" as docsRepositoryBase + filePath, so the
-  // symlink segment has to come off here or every link 404s on GitHub.
+  // Nextra reports filePath relative to this project, and the prefix differs
+  // between the symlink and copied content layouts. Reduce it to the path
+  // relative to the docs content root, which is what docsRepositoryBase expects
+  // appended to it. See lib/docs-file-path.ts.
   const metadata = { ...rest.metadata };
   if (typeof metadata.filePath === "string") {
-    metadata.filePath = metadata.filePath.replace(/^content\//, "");
+    metadata.filePath = toDocsRelativePath(metadata.filePath);
   }
 
   return (

--- a/docs-site/instrumentation.ts
+++ b/docs-site/instrumentation.ts
@@ -1,0 +1,19 @@
+// Deliberately empty.
+//
+// docs-site's `content` symlink points at `../docs`, which sits outside
+// docs-site. Turbopack refuses a symlink that escapes the project root, so the
+// root has to be inferred as the repository root for the docs build to resolve
+// its own content at all. That inference has a side effect: Next then finds the
+// main application's `instrumentation.ts` at the repository root and pulls it
+// into the docs bundle, where its `@/lib/...` imports do not resolve and the
+// build dies with module-not-found.
+//
+// A file here shadows that one. It must stay empty - the main app's
+// instrumentation wires up Sentry and workflow error context for the
+// application runtime, none of which belongs in a static documentation site.
+//
+// Removing this file breaks `next build` for docs-site outside the Docker
+// image, which is the only place the "Edit this page" links can be verified.
+export function register(): void {
+  // no-op
+}

--- a/docs-site/lib/docs-file-path.ts
+++ b/docs-site/lib/docs-file-path.ts
@@ -1,0 +1,29 @@
+// Nextra sets a page's `metadata.filePath` from the bundler's resource path,
+// which is the file's *resolved* location relative to the Next project dir
+// (docs-site). That value therefore depends on how `content` is materialised,
+// and the two layouts we build disagree:
+//
+//   symlink layout (any non-Docker build, `content` -> `../docs`)
+//     the bundler resolves the link, so filePath is `../docs/<page>.md`
+//   copied layout (the Docker image does `rm -f ./content` + `COPY docs/ ./content/`)
+//     `content` is a real directory, so filePath is `content/<page>.md`
+//
+// The docs theme builds "Edit this page" as `docsRepositoryBase + filePath`,
+// and that base already ends in `/docs`. So both shapes have to be reduced to
+// the page's path relative to the docs content root, or the link 404s.
+//
+// `src/content` is covered too because that is Nextra's other content-root
+// convention; if docs-site ever moves to the `src/` layout this keeps working.
+
+const LEADING_PARENT_SEGMENTS = /^(?:\.\.\/)+/;
+const CONTENT_ROOT = /^(?:src\/)?(?:content|docs)\//;
+
+/**
+ * Reduce a Nextra `filePath` to the page path relative to the docs content
+ * root, so it can be appended to `docsRepositoryBase`.
+ *
+ * A path matching no known content root is returned unchanged.
+ */
+export function toDocsRelativePath(filePath: string): string {
+  return filePath.replace(LEADING_PARENT_SEGMENTS, "").replace(CONTENT_ROOT, "");
+}

--- a/tests/unit/docs-site-file-path.test.ts
+++ b/tests/unit/docs-site-file-path.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { toDocsRelativePath } from "../../docs-site/lib/docs-file-path";
+
+// docs-site is a standalone pnpm project with no test runner of its own, and
+// the root tsconfig excludes it. Keeping this test in the root tree is what
+// gets it both executed (root vitest) and type-checked (root tsc), and it
+// keeps the vitest import out of docs-site, whose tsc cannot resolve it.
+
+describe("toDocsRelativePath", () => {
+  it("strips the resolved-symlink prefix emitted by non-Docker builds", () => {
+    expect(toDocsRelativePath("../docs/api/errors.md")).toBe("api/errors.md");
+    expect(toDocsRelativePath("../docs/FAQ.md")).toBe("FAQ.md");
+  });
+
+  it("strips the content prefix emitted by the Docker image build", () => {
+    expect(toDocsRelativePath("content/api/errors.md")).toBe("api/errors.md");
+    expect(toDocsRelativePath("content/index.md")).toBe("index.md");
+  });
+
+  it("strips Nextra's src/content root", () => {
+    expect(toDocsRelativePath("src/content/api/errors.md")).toBe(
+      "api/errors.md"
+    );
+  });
+
+  it("produces the same result for every layout of the same page", () => {
+    const shapes = [
+      "../docs/guides/gelato-migration.md",
+      "content/guides/gelato-migration.md",
+      "src/content/guides/gelato-migration.md",
+    ];
+    const results = new Set(shapes.map(toDocsRelativePath));
+    expect(results).toEqual(new Set(["guides/gelato-migration.md"]));
+  });
+
+  it("leaves a path with no recognised content root unchanged", () => {
+    expect(toDocsRelativePath("api/errors.md")).toBe("api/errors.md");
+  });
+
+  it("does not strip a directory that merely starts with a root name", () => {
+    expect(toDocsRelativePath("contents/api.md")).toBe("contents/api.md");
+    expect(toDocsRelativePath("documentation/api.md")).toBe(
+      "documentation/api.md"
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Nextra derives a page's `metadata.filePath` from the bundler's resource path, which is the file's *resolved* location relative to `docs-site`. That value depends on how `content` is materialised, and the two layouts we build disagree:

| build shape | `metadata.filePath` | emitted href |
|---|---|---|
| symlink (`content -> ../docs`, any non-Docker build) | `../docs/<page>.md` | `.../edit/staging/docs/../docs/FAQ.md` |
| copied (the image does `rm -f ./content` + `COPY docs/ ./content/`) | `content/<page>.md` | `.../edit/staging/docs/guides/index.md` |

The strip in `page.tsx` matched only `content/`, so outside the image all 173 pages emitted the dot-segment form. Browsers normalise it, but a link checker or anything copying the href verbatim resolves it to a 404. The deployed site was unaffected.

Two conditions around it went unnoticed for the same reason, and both are addressed here.

## `docs-site` could not be built outside Docker at all

This is why nobody caught the above. Two distinct failures:

- **In place in the repo** - Turbopack infers the repo root as the project root and pulls the main app's `instrumentation.ts` into the docs build, failing with `module-not-found` on `@/lib/workflow/executor/error-context`.
- **`docs-site` isolated** - the project root becomes `docs-site`, so `content -> ../docs` escapes it: `Symlink [project]/content/... is invalid, it points out of the filesystem root`.

`turbopack.root` cannot resolve this at either setting - the root must be at least the repo root to contain the symlink target, which is exactly what pulls in the main app. An empty `docs-site/instrumentation.ts` shadows the repo root's, and the build completes with default root inference.

## Nothing asserted the link target

`docsRepositoryBase` pointed at `main` for roughly seven months while every edit link 404'd. Worth being precise about why: `main` was never deleted, it just stopped receiving docs. Of the docs paths on `staging`, **0 of 189** exist on `main` today. So "does the branch exist" passes for the entire outage and is not the property worth asserting.

The new `edit-link-target` job resolves the base branch's docs paths against the configured branch, using git rather than the contents API - no rate limit, no token, and one fetch instead of one request per page.

## Changes

- `docs-site/lib/docs-file-path.ts` - `toDocsRelativePath` reduces `../`, `content/`, `src/content/` and `docs/` prefixes to the path relative to the docs content root.
- `docs-site/app/[[...mdxPath]]/page.tsx` - uses it. The old comment attributed the prefix to the dev symlink rather than to how Nextra derives `filePath`; corrected.
- `docs-site/instrumentation.ts` - empty shadow, with the reasoning inline.
- `tests/unit/docs-site-file-path.test.ts` - 6 cases covering every layout, a no-match input, and near-miss directory names. It lives in the root tree rather than beside the source because `docs-site` has no test runner and its `tsc` cannot resolve `vitest`; here it is both executed by root vitest and type-checked by root tsc.
- `.github/workflows/pr-docs-site-build.yaml` - the `edit-link-target` job.

## Verification

Both shapes now emit identical, correct links:

| build | anchors | with dot segments |
|---|---|---|
| local (symlink) | 173 | 0 |
| Docker image | 173 | 0 |

The CI check was exercised against all three cases:

| configured branch | result |
|---|---|
| `staging` (current) | 189 checked, 0 missing - pass |
| `main` (the original bug) | 189 checked, 189 missing - fail |
| nonexistent | fetch fails - fail |

Root `tsc --noEmit`: 0 errors. Root vitest: 6/6. `docs-site` `tsc --noEmit`: 0 errors. The image builds clean with the new instrumentation file.

## Known follow-up

Now that `next build` works locally, running it rewrites `docs-site/tsconfig.json` - Next reformats the arrays and flips `jsx` from `preserve` to `react-jsx`. That is reverted here rather than shipped as an unrelated semantic change, so the next person to build locally will see the same diff. Absorbing it by committing Next's canonical version once is a reasonable call, but it is a separate decision.

Nothing verifies a rendered href end to end, so a change in how the theme composes `docsRepositoryBase + filePath` would pass these tests and still break the links. A single smoke assertion on one built page is cheap to add now that a local build exists.
