### PR TITLE
docs: validate_workflow operates on a stored workflow, not a candidate graph

### DIFF
--- a/docs/ai-tools/mcp-server.md
+++ b/docs/ai-tools/mcp-server.md
@@ -146,7 +146,7 @@ The server registers more than 30 tools. Call `tools_documentation` (or `list_ac
 | `create_workflow` | Create a workflow with nodes and edges. Created disabled by default; pass `enabled=true` to make schedule, event, block, or webhook triggers fire immediately. |
 | `update_workflow` | Update a workflow's name, description, nodes, edges, project/tag assignment, or enabled state. Set `enabled=false` to stop triggers without deleting the workflow. |
 | `delete_workflow` | Permanently delete a workflow. This action is irreversible. |
-| `validate_workflow` | Check a workflow's structural and Web3-specific correctness before creating or executing it. |
+| `validate_workflow` | Check an already-created workflow's structural and Web3-specific correctness before executing or listing it. Operates on a stored `workflowId`, not a candidate graph — see [Validate Workflow](./mcp-validate-workflow.md#limitations). |
 | `prepare_test_pin_data` | Return the JSON Schema each node expects as pin data, so an agent can construct valid test inputs. |
 
 ### Execution

--- a/docs/ai-tools/mcp-server.md
+++ b/docs/ai-tools/mcp-server.md
@@ -146,7 +146,7 @@ The server registers more than 30 tools. Call `tools_documentation` (or `list_ac
 | `create_workflow` | Create a workflow with nodes and edges. Created disabled by default; pass `enabled=true` to make schedule, event, block, or webhook triggers fire immediately. |
 | `update_workflow` | Update a workflow's name, description, nodes, edges, project/tag assignment, or enabled state. Set `enabled=false` to stop triggers without deleting the workflow. |
 | `delete_workflow` | Permanently delete a workflow. This action is irreversible. |
-| `validate_workflow` | Check an already-created workflow's structural and Web3-specific correctness before executing or listing it. Operates on a stored `workflowId`, not a candidate graph — see [Validate Workflow](./mcp-validate-workflow.md#limitations). |
+| `validate_workflow` | Check an already-created workflow's structural and Web3-specific correctness before executing or listing it. Takes a stored `workflowId`, not a candidate graph, so it runs after `create_workflow`. See [Validate Workflow](./mcp-validate-workflow.md#limitations). |
 | `prepare_test_pin_data` | Return the JSON Schema each node expects as pin data, so an agent can construct valid test inputs. |
 
 ### Execution

--- a/docs/ai-tools/mcp-validate-workflow.md
+++ b/docs/ai-tools/mcp-validate-workflow.md
@@ -1,11 +1,11 @@
 ---
 title: "Validate Workflow"
-description: "Use the validate_workflow MCP tool to check a workflow's structural, listing-eligibility, and Web3-specific correctness before creation or publication."
+description: "Use the validate_workflow MCP tool to check a stored workflow's structural, listing-eligibility, and Web3-specific correctness before execution or publication."
 ---
 
 # validate_workflow
 
-`validate_workflow` checks a stored workflow for structural correctness, marketplace listing eligibility, and Web3-specific configuration problems before you call `create_workflow` or list the workflow on the marketplace. It returns typed error and warning items with precise parameter paths, designed for automated recovery loops.
+`validate_workflow` checks a stored workflow for structural correctness, marketplace listing eligibility, and Web3-specific configuration problems before you execute it or list it on the marketplace. It runs after `create_workflow`, not before: see [Limitations](#limitations). It returns typed error and warning items with precise parameter paths, designed for automated recovery loops.
 
 The tool runs two tiers of checks. The fast tier (default) makes zero network calls and finishes in under 300 ms. The deep tier (`deepCheck: true`) additionally resolves on-chain ABIs for every contract reference and compares them against the declared ABIs, adding up to 3 seconds of latency.
 


### PR DESCRIPTION
The docs describe `validate_workflow` as checking a workflow's correctness "before creating or executing it", but the deployed tool requires an existing `workflowId` and rejects a candidate graph. So the documented flow (validate, then create) is not reachable.

Two places said this, and they contradicted the same file's own Limitations section, which is correct:

- `docs/ai-tools/mcp-server.md`, the MCP tools summary table
- `docs/ai-tools/mcp-validate-workflow.md`, the reference page's intro and frontmatter description ("before you call `create_workflow`")

Both now say the tool operates on a stored workflow and point at Limitations. No behaviour change, docs only.

### How I hit it

I built an MCP client against the live server for the Agents Onchain Hackathon, and tried to validate a generated graph before persisting it, per the summary line. The call came back with a missing-`workflowId` error. This matters more for agents than for people: an LLM assembling nodes and edges gets action types and `sourceHandle` values wrong routinely, so "validate the candidate, repair, retry" is the loop you reach for first, and the docs currently point at it.

Worth saying that the workaround in Limitations (create first, then validate) is fine once you know it. The cost here was twenty minutes of believing the summary line.

### Other findings

Five more came out of the same integration, written up with proposed fixes here: https://github.com/harshkas4na/chaos-keeper/blob/main/docs/teardown.md

Short version: `get_wallet_integration` returns JSON-RPC `-32603` (internal error) when called with no arguments object, which reads as "the server is down" on a first tool call. An executed workflow can't be deleted and there's no `delete_execution` tool, so the 409 tells you to do something the API doesn't offer. `get_execution`'s response shape is undocumented, mixes string and number types for the same fields, reports `progress.percentage: 0` on completed runs, and returns node logs unordered. And `transactionHashes` is an array of receipt objects rather than the strings the name implies, which silently cost me a wrong result until I read the raw payload.

Happy to open any of those as separate PRs if they're useful. Told from the outside, so some may already be known or intentional.
