### PR TITLE
fix: check gas affordability before acquiring the wallet nonce lock

### DIFF
--- a/lib/errors/__tests__/classify.test.ts
+++ b/lib/errors/__tests__/classify.test.ts
@@ -344,12 +344,13 @@ describe("classifyExecutionError", () => {
       expect(r.errorType).toBe("system");
     });
 
-    it("Failed to acquire nonce lock: workflow_engine + system", () => {
+    it("wallet saturated: configuration + user, no code", () => {
       const r = classifyExecutionError(
-        "Failed to acquire nonce lock for 0xae36bc35098e24bbaed3dee86ec4653eb88a71a9:1 after 50 attempts"
+        "Wallet is saturated: could not acquire the nonce lock for 0xae36bc35098e24bbaed3dee86ec4653eb88a71a9:1 after 120s. Transactions from one wallet are sent one at a time, so reduce this workflow's trigger rate or spread writes across additional wallets."
       );
-      expect(r.errorCategory).toBe(ErrorCategory.WORKFLOW_ENGINE);
-      expect(r.errorType).toBe("system");
+      expect(r.errorCategory).toBe(ErrorCategory.CONFIGURATION);
+      expect(r.errorType).toBe("user");
+      expect(r.code).toBeNull();
     });
   });
 

--- a/lib/errors/__tests__/error-codes.test.ts
+++ b/lib/errors/__tests__/error-codes.test.ts
@@ -80,7 +80,6 @@ describe("classifyExecutionError code contract", () => {
       "Execution timed out: no progress for 30 minutes",
       'Step "x" exceeded max retries (1 retry)',
       "Unknown action type: condition",
-      "Failed to acquire nonce lock for 0xabc:1 after 50 attempts",
       "Workflow terminated by SIGTERM signal",
       "Cannot find module './credential-map'",
       "TURNKEY_API_PUBLIC_KEY and TURNKEY_API_PRIVATE_KEY must be set",

--- a/lib/errors/classify.ts
+++ b/lib/errors/classify.ts
@@ -431,11 +431,14 @@ const RULES: readonly Rule[] = [
     errorType: ExecutionErrorType.SYSTEM,
     code: "E-0003",
   },
+  // Writes from one wallet are serialized, so exhausting the lock budget means
+  // the workflow is asking for more throughput than a single wallet has. That
+  // is the author's configuration, not an engine fault: user error, no code.
   {
-    pattern: /^Failed to acquire nonce lock/i,
-    errorCategory: ErrorCategory.WORKFLOW_ENGINE,
-    errorType: ExecutionErrorType.SYSTEM,
-    code: "E-0003",
+    pattern: /^Wallet is saturated: could not acquire the nonce lock/i,
+    errorCategory: ErrorCategory.CONFIGURATION,
+    errorType: ExecutionErrorType.USER,
+    code: null,
   },
 
   // System: deploy bugs / missing modules / missing secrets

--- a/lib/redis-cache.ts
+++ b/lib/redis-cache.ts
@@ -1,0 +1,49 @@
+import "server-only";
+
+import { getRedis } from "@/lib/redis";
+
+/**
+ * Read-through cache over the best-effort app-tier Redis.
+ *
+ * Inherits the contract from `lib/redis`: Redis is a cross-replica
+ * optimisation, never a source of truth. Every failure mode (no client,
+ * unreachable, corrupt value, rejected write) degrades to calling `read`, so a
+ * caller behaves identically with Redis absent, just with more round-trips.
+ *
+ * Keys must come from `lib/redis-keys` so namespaces cannot drift.
+ */
+export async function cachedRead<T>(input: {
+  key: string;
+  ttlSeconds: number;
+  /** Parse a cached string back to `T`. May throw; a throw is treated as a miss. */
+  decode: (raw: string) => T;
+  encode: (value: T) => string;
+  /** Source of truth, called on any miss. */
+  read: () => Promise<T>;
+}): Promise<T> {
+  const { key, ttlSeconds, decode, encode, read } = input;
+  const redis = getRedis();
+
+  if (redis) {
+    try {
+      const hit = await redis.get(key);
+      if (hit !== null) {
+        return decode(hit);
+      }
+    } catch {
+      // Unreachable or unparseable: fall through to the source of truth.
+    }
+  }
+
+  const value = await read();
+
+  if (redis) {
+    try {
+      await redis.set(key, encode(value), "EX", ttlSeconds);
+    } catch {
+      // A cache write failure must not fail the caller.
+    }
+  }
+
+  return value;
+}

--- a/lib/redis-keys.ts
+++ b/lib/redis-keys.ts
@@ -28,3 +28,13 @@ export function newDeviceNotifyClaimKey(
 export function trustedCountryKey(userId: string, country: string): string {
   return deploymentKey("trust-country", userId, country);
 }
+
+/** Short-lived cache of a holder's native balance in wei, for the gas preflight. */
+export function nativeBalanceKey(chainId: number, address: string): string {
+  return deploymentKey("gas-balance", String(chainId), address.toLowerCase());
+}
+
+/** Short-lived cache of a chain's gas price in wei, for the gas preflight. */
+export function gasPriceKey(chainId: number): string {
+  return deploymentKey("gas-price", String(chainId));
+}

--- a/lib/web3/gas-preflight.ts
+++ b/lib/web3/gas-preflight.ts
@@ -5,7 +5,7 @@ import {
   describeNativeShortfall,
   getNativeSymbol,
 } from "@/lib/execute/native-balance";
-import { getRedis } from "@/lib/redis";
+import { cachedRead } from "@/lib/redis-cache";
 import { gasPriceKey, nativeBalanceKey } from "@/lib/redis-keys";
 import type { getRpcProvider } from "@/lib/rpc/provider-factory";
 import { SIGNER_MODE, type SignerMode } from "@/lib/safe/signer-resolver";
@@ -55,35 +55,18 @@ export function resolveFundingHolder(
     : walletAddress;
 }
 
-/** Read-through cache for a chain value. Best-effort: Redis never gates the read. */
-async function cachedWeiValue(
+/** Read-through cache for a wei-denominated chain value. */
+function cachedWeiValue(
   key: string,
   read: () => Promise<bigint>
 ): Promise<bigint> {
-  const redis = getRedis();
-
-  if (redis) {
-    try {
-      const hit = await redis.get(key);
-      if (hit !== null) {
-        return BigInt(hit);
-      }
-    } catch {
-      // Miss, unreachable, or an unparseable value: fall through to the chain.
-    }
-  }
-
-  const value = await read();
-
-  if (redis) {
-    try {
-      await redis.set(key, value.toString(), "EX", CACHE_TTL_SECONDS);
-    } catch {
-      // A cache write failure must not fail the preflight.
-    }
-  }
-
-  return value;
+  return cachedRead({
+    key,
+    ttlSeconds: CACHE_TTL_SECONDS,
+    decode: BigInt,
+    encode: String,
+    read,
+  });
 }
 
 /**

--- a/lib/web3/gas-preflight.ts
+++ b/lib/web3/gas-preflight.ts
@@ -1,0 +1,141 @@
+import "server-only";
+
+import type { ethers } from "ethers";
+import {
+  describeNativeShortfall,
+  getNativeSymbol,
+} from "@/lib/execute/native-balance";
+import { getRedis } from "@/lib/redis";
+import { gasPriceKey, nativeBalanceKey } from "@/lib/redis-keys";
+import type { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { SIGNER_MODE, type SignerMode } from "@/lib/safe/signer-resolver";
+
+/**
+ * Affordability preflight for the direct-signing write paths, run *before* the
+ * per-wallet nonce lock is acquired.
+ *
+ * A wallet that cannot pay must not join the lock queue. It would hold the lock
+ * through a full RPC failover round and then fail at broadcast, while every
+ * other execution for the same wallet and chain waits behind it. Answering the
+ * question first turns that into an immediate, actionable user error.
+ *
+ * Distinct from the value-only check in `lib/execute/native-balance`: this one
+ * asks whether the holder can cover gas at all, which is the case a
+ * `write-contract` call with no payable value never otherwise checks.
+ */
+
+type RpcManager = Awaited<ReturnType<typeof getRpcProvider>>;
+
+/**
+ * Cheapest possible EVM transaction. No call can cost less, so a holder below
+ * `value + this floor` provably cannot pay and rejecting it is never a false
+ * positive. Deliberately not the call's real gas estimate: that needs a built
+ * transaction, and over-estimating here would reject affordable work.
+ */
+const MIN_TX_GAS_UNITS = BigInt(21_000);
+
+/**
+ * Long enough to collapse a burst on one wallet into a few chain reads, short
+ * enough that funding the wallet takes effect promptly.
+ */
+const CACHE_TTL_SECONDS = 10;
+
+export type GasPreflightResult =
+  | { affordable: true }
+  | { affordable: false; message: string };
+
+/** The address gas is actually drawn from: the Safe in safe modes, else the EOA. */
+export function resolveFundingHolder(
+  signerMode: SignerMode,
+  walletAddress: string
+): string {
+  return signerMode.kind === SIGNER_MODE.SAFE_ROLE ||
+    signerMode.kind === SIGNER_MODE.SAFE
+    ? signerMode.safeAddress
+    : walletAddress;
+}
+
+/** Read-through cache for a chain value. Best-effort: Redis never gates the read. */
+async function cachedWeiValue(
+  key: string,
+  read: () => Promise<bigint>
+): Promise<bigint> {
+  const redis = getRedis();
+
+  if (redis) {
+    try {
+      const hit = await redis.get(key);
+      if (hit !== null) {
+        return BigInt(hit);
+      }
+    } catch {
+      // Miss, unreachable, or an unparseable value: fall through to the chain.
+    }
+  }
+
+  const value = await read();
+
+  if (redis) {
+    try {
+      await redis.set(key, value.toString(), "EX", CACHE_TTL_SECONDS);
+    } catch {
+      // A cache write failure must not fail the preflight.
+    }
+  }
+
+  return value;
+}
+
+/**
+ * Whether `holderAddress` can cover `valueWei` plus the minimum gas any
+ * transaction costs on `chainId`.
+ *
+ * Fails open on any RPC or lookup error: this is an optimisation ahead of the
+ * real send, not an authorisation gate, so a provider blip must not become a
+ * user-facing rejection.
+ */
+export async function preflightGasBalance(input: {
+  rpcManager: RpcManager;
+  chainId: number;
+  holderAddress: string;
+  valueWei?: bigint;
+}): Promise<GasPreflightResult> {
+  const { rpcManager, chainId, holderAddress } = input;
+  const valueWei = input.valueWei ?? BigInt(0);
+
+  let balance: bigint;
+  let gasPrice: bigint;
+  try {
+    balance = await cachedWeiValue(
+      nativeBalanceKey(chainId, holderAddress),
+      () =>
+        rpcManager.executeWithFailover(
+          (p) => p.getBalance(holderAddress),
+          "preflight"
+        )
+    );
+    gasPrice = await cachedWeiValue(gasPriceKey(chainId), async () => {
+      const fees: ethers.FeeData = await rpcManager.executeWithFailover(
+        (p) => p.getFeeData(),
+        "preflight"
+      );
+      return fees.maxFeePerGas ?? fees.gasPrice ?? BigInt(0);
+    });
+  } catch {
+    return { affordable: true };
+  }
+
+  const required = valueWei + MIN_TX_GAS_UNITS * gasPrice;
+  if (balance >= required) {
+    return { affordable: true };
+  }
+
+  const shortfall = describeNativeShortfall({
+    symbol: await getNativeSymbol(chainId),
+    balance,
+    required,
+    holder: holderAddress,
+  });
+
+  return { affordable: false, message: shortfall.message };
+}

--- a/lib/web3/nonce-manager.ts
+++ b/lib/web3/nonce-manager.ts
@@ -22,8 +22,8 @@ import { db } from "@/lib/db";
 import { pendingTransactions, walletLocks } from "@/lib/db/schema-extensions";
 import {
   ErrorCategory,
-  logSystemError,
   logSystemWarn,
+  logUserError,
   logWarn,
 } from "@/lib/logging";
 
@@ -482,15 +482,19 @@ export class NonceManager {
       await this.sleep(this.lockRetryDelayMs);
     }
 
-    // Acquire failure after the full retry budget — emit a metric so the
-    // operations team gets paged on repeated failures rather than finding
-    // out via support tickets like in KEEP-344.
-    const failure = new Error(
-      `Failed to acquire nonce lock for ${walletAddress}:${chainId} ` +
-        `after ${this.maxLockRetries} attempts`
+    // Exhausting the budget means the wallet is oversubscribed, not that the
+    // engine faulted: writes from one wallet are serialized by design, and the
+    // lock is the only thing that measures the overload. Reported as a user
+    // error so it carries an actionable message and counts a metric without
+    // paging, and phrased so the author knows which lever to pull.
+    const waitSeconds = Math.round(
+      (this.maxLockRetries * this.lockRetryDelayMs) / 1000
     );
-    logSystemError(
-      ErrorCategory.INFRASTRUCTURE,
+    const failure = new Error(
+      `Wallet is saturated: could not acquire the nonce lock for ${walletAddress}:${chainId} after ${waitSeconds}s. Transactions from one wallet are sent one at a time, so reduce this workflow's trigger rate or spread writes across additional wallets.`
+    );
+    logUserError(
+      ErrorCategory.CONFIGURATION,
       "[NonceManager] acquire_failed",
       failure,
       {

--- a/plugins/web3/steps/approve-token-core.ts
+++ b/plugins/web3/steps/approve-token-core.ts
@@ -27,6 +27,10 @@ import {
   executeContractCallAsSafe,
 } from "@/lib/safe/execute-as-safe";
 import { resolveSignerForNode, SIGNER_MODE } from "@/lib/safe/signer-resolver";
+import {
+  preflightGasBalance,
+  resolveFundingHolder,
+} from "@/lib/web3/gas-preflight";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import {
   classifyRevert,
@@ -374,6 +378,19 @@ export async function approveTokenCore(
 
   // Fall back to direct signing with nonce management and RPC failover
   const adapter = getChainAdapter(chainId);
+
+  // Answer gas affordability before queueing on the wallet's nonce lock. A
+  // holder that cannot pay would otherwise take the lock, spend a full failover
+  // round discovering that at broadcast, and stall every other execution for
+  // the same wallet behind it.
+  const gasCheck = await preflightGasBalance({
+    rpcManager,
+    chainId,
+    holderAddress: resolveFundingHolder(signerMode, walletAddress),
+  });
+  if (!gasCheck.affordable) {
+    return { success: false, error: gasCheck.message };
+  }
 
   return withNonceSession(txContext, walletAddress, async (session) => {
     // Initialize wallet signer

--- a/plugins/web3/steps/transfer-funds-core.ts
+++ b/plugins/web3/steps/transfer-funds-core.ts
@@ -34,6 +34,10 @@ import {
   executeNativeTransferAsSafe,
 } from "@/lib/safe/execute-as-safe";
 import { resolveSignerForNode, SIGNER_MODE } from "@/lib/safe/signer-resolver";
+import {
+  preflightGasBalance,
+  resolveFundingHolder,
+} from "@/lib/web3/gas-preflight";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import {
   classifyRevert,
@@ -345,6 +349,21 @@ export async function transferFundsCore(
 
   // Fall back to direct signing with nonce management and RPC failover
   const adapter = getChainAdapter(chainId);
+
+  // Answer affordability before queueing on the wallet's nonce lock. A holder
+  // that cannot pay would otherwise take the lock, spend a full failover round
+  // discovering that at broadcast, and stall every other execution for the
+  // same wallet behind it. The in-session check below stays as the backstop
+  // for when this one fails open on an RPC error.
+  const gasCheck = await preflightGasBalance({
+    rpcManager,
+    chainId,
+    holderAddress: resolveFundingHolder(signerMode, walletAddress),
+    valueWei: amountInWei,
+  });
+  if (!gasCheck.affordable) {
+    return { success: false, error: gasCheck.message };
+  }
 
   return withNonceSession(txContext, walletAddress, async (session) => {
     let signer: Awaited<ReturnType<typeof initializeWalletSigner>>;

--- a/plugins/web3/steps/transfer-token-core.ts
+++ b/plugins/web3/steps/transfer-token-core.ts
@@ -31,6 +31,10 @@ import {
   executeContractCallAsSafe,
 } from "@/lib/safe/execute-as-safe";
 import { resolveSignerForNode, SIGNER_MODE } from "@/lib/safe/signer-resolver";
+import {
+  preflightGasBalance,
+  resolveFundingHolder,
+} from "@/lib/web3/gas-preflight";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import {
   classifyRevert,
@@ -468,6 +472,20 @@ export async function transferTokenCore(
 
   // Fall back to direct signing with nonce management and RPC failover
   const adapter = getChainAdapter(chainId);
+
+  // Answer gas affordability before queueing on the wallet's nonce lock. A
+  // holder that cannot pay would otherwise take the lock, spend a full failover
+  // round discovering that at broadcast, and stall every other execution for
+  // the same wallet behind it. The ERC-20 balance check above covers the token
+  // side; this one covers the native gas the transfer still has to pay for.
+  const gasCheck = await preflightGasBalance({
+    rpcManager,
+    chainId,
+    holderAddress: resolveFundingHolder(signerMode, walletAddress),
+  });
+  if (!gasCheck.affordable) {
+    return { success: false, error: gasCheck.message };
+  }
 
   return withNonceSession(txContext, walletAddress, async (session) => {
     // Initialize wallet signer

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -32,6 +32,10 @@ import {
   executeContractCallAsSafe,
 } from "@/lib/safe/execute-as-safe";
 import { resolveSignerForNode, SIGNER_MODE } from "@/lib/safe/signer-resolver";
+import {
+  preflightGasBalance,
+  resolveFundingHolder,
+} from "@/lib/web3/gas-preflight";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import {
   classifyRevert,
@@ -521,6 +525,20 @@ export async function writeContractCore(
 
   // Fall back to direct signing with nonce management and RPC failover
   const adapter = getChainAdapter(chainId);
+
+  // Answer affordability before queueing on the wallet's nonce lock. A holder
+  // that cannot pay would otherwise take the lock, spend a full failover round
+  // discovering that at broadcast, and stall every other execution for the
+  // same wallet behind it.
+  const gasCheck = await preflightGasBalance({
+    rpcManager,
+    chainId,
+    holderAddress: resolveFundingHolder(signerMode, walletAddress),
+    valueWei: parsedEthValue,
+  });
+  if (!gasCheck.affordable) {
+    return { success: false, error: gasCheck.message };
+  }
 
   return withNonceSession(txContext, walletAddress, async (session) => {
     // Initialize wallet signer

--- a/specs/error-codes/system-error-codes.md
+++ b/specs/error-codes/system-error-codes.md
@@ -167,7 +167,7 @@ shows; it never reveals internal detail.
 | `C-0004` | Common           | no        | Internal authentication / secret-store failure              | auth                  | Internal error (C-0004). Our team has been notified; please contact support if it persists. |
 | `E-0001` | Executor         | yes       | Execution timed out                                         | workflow_engine       | The run timed out (E-0001). Please try again. |
 | `E-0002` | Executor         | yes       | Step exceeded max retries                                   | workflow_engine       | A step failed repeatedly (E-0002). Please try again. |
-| `E-0003` | Executor         | yes       | Engine fault (unknown action, nonce lock, drain timeout)    | workflow_engine       | Internal error (E-0003). Please wait a few minutes and try again. |
+| `E-0003` | Executor         | yes       | Engine fault (unknown action, drain timeout)                | workflow_engine       | Internal error (E-0003). Please wait a few minutes and try again. |
 | `E-0004` | Executor         | yes       | Message processing failed (executor consumer backstop)      | infrastructure        | The run could not be processed (E-0004). Please wait a few minutes and try again. |
 | `N-0001` | Network          | yes       | RPC endpoint unavailable                                    | network_rpc           | A network provider was unavailable (N-0001). Please try again shortly. |
 | `N-0002` | Network          | yes       | Network connectivity error (DNS / reset / timeout)          | network_rpc           | Internal network error (N-0002). Please wait a few minutes and try again. |

--- a/tests/e2e/vitest/nonce-manager.test.ts
+++ b/tests/e2e/vitest/nonce-manager.test.ts
@@ -38,7 +38,8 @@ const TEST_WALLET_NORMALIZED = TEST_WALLET.toLowerCase();
 const TEST_CHAIN_ID = 11_155_111; // Sepolia
 
 // Regex patterns for assertions (at top level for performance)
-const FAILED_LOCK_REGEX = /Failed to acquire nonce lock/;
+const FAILED_LOCK_REGEX =
+  /Wallet is saturated: could not acquire the nonce lock/;
 
 // Mock provider that returns controlled nonce values
 function createMockProvider(transactionCount: number) {

--- a/tests/unit/gas-preflight.test.ts
+++ b/tests/unit/gas-preflight.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { mockGetRedis } = vi.hoisted(() => ({
+  mockGetRedis: vi.fn(() => null),
+}));
+
+vi.mock("@/lib/redis", () => ({ getRedis: mockGetRedis }));
+
+vi.mock("@/lib/execute/native-balance", () => ({
+  getNativeSymbol: () => Promise.resolve("ETH"),
+  describeNativeShortfall: (input: { balance: bigint; required: bigint }) => ({
+    message: `Insufficient ETH balance. Have: ${input.balance}, Need: ${input.required}`,
+  }),
+}));
+
+import { SIGNER_MODE } from "@/lib/safe/signer-resolver";
+import {
+  preflightGasBalance,
+  resolveFundingHolder,
+} from "@/lib/web3/gas-preflight";
+
+const HOLDER = "0x7a459d6b50823f4a6f870a90504d12d082b9b28b";
+const GAS_PRICE = BigInt(1_000_000_000);
+// MIN_TX_GAS_UNITS (21000) * GAS_PRICE
+const MIN_COST = BigInt(21_000) * GAS_PRICE;
+
+function rpcManagerReturning(balance: bigint) {
+  return {
+    executeWithFailover: (fn: (p: unknown) => unknown) =>
+      Promise.resolve(
+        fn({
+          getBalance: () => Promise.resolve(balance),
+          getFeeData: () => Promise.resolve({ maxFeePerGas: GAS_PRICE }),
+        })
+      ),
+  } as never;
+}
+
+describe("preflightGasBalance", () => {
+  beforeEach(() => {
+    mockGetRedis.mockReturnValue(null);
+  });
+
+  it("rejects an empty wallet before it can reach the nonce lock", async () => {
+    const result = await preflightGasBalance({
+      rpcManager: rpcManagerReturning(BigInt(0)),
+      chainId: 16_602,
+      holderAddress: HOLDER,
+    });
+
+    expect(result.affordable).toBe(false);
+  });
+
+  it("rejects dust that cannot cover the cheapest possible transaction", async () => {
+    const result = await preflightGasBalance({
+      rpcManager: rpcManagerReturning(MIN_COST - BigInt(1)),
+      chainId: 16_602,
+      holderAddress: HOLDER,
+    });
+
+    expect(result.affordable).toBe(false);
+  });
+
+  it("allows a holder that covers the gas floor", async () => {
+    const result = await preflightGasBalance({
+      rpcManager: rpcManagerReturning(MIN_COST),
+      chainId: 16_602,
+      holderAddress: HOLDER,
+    });
+
+    expect(result.affordable).toBe(true);
+  });
+
+  it("counts the payable value on top of gas", async () => {
+    const result = await preflightGasBalance({
+      rpcManager: rpcManagerReturning(MIN_COST),
+      chainId: 16_602,
+      holderAddress: HOLDER,
+      valueWei: BigInt(1),
+    });
+
+    expect(result.affordable).toBe(false);
+  });
+
+  it("fails open when the chain read throws, so a provider blip is not a rejection", async () => {
+    const rpcManager = {
+      executeWithFailover: () => Promise.reject(new Error("rpc down")),
+    } as never;
+
+    const result = await preflightGasBalance({
+      rpcManager,
+      chainId: 16_602,
+      holderAddress: HOLDER,
+    });
+
+    expect(result.affordable).toBe(true);
+  });
+});
+
+describe("resolveFundingHolder", () => {
+  it("uses the EOA in eoa mode", () => {
+    expect(
+      resolveFundingHolder(
+        { kind: SIGNER_MODE.EOA, ownerAddress: "0xowner" },
+        HOLDER
+      )
+    ).toBe(HOLDER);
+  });
+
+  it("uses the Safe address in safe mode, since gas comes from the Safe", () => {
+    expect(
+      resolveFundingHolder(
+        {
+          kind: SIGNER_MODE.SAFE,
+          ownerAddress: "0xowner",
+          safeAddress: "0xsafe",
+          safeWalletId: "sw_1",
+        },
+        HOLDER
+      )
+    ).toBe("0xsafe");
+  });
+});

--- a/tests/unit/nonce-manager.test.ts
+++ b/tests/unit/nonce-manager.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const FAILED_LOCK_REGEX = /Failed to acquire nonce lock/;
+const FAILED_LOCK_REGEX =
+  /Wallet is saturated: could not acquire the nonce lock/;
 
 vi.mock("server-only", () => ({}));
 
@@ -38,18 +39,22 @@ vi.mock("@/lib/db/schema-extensions", () => ({
   },
 }));
 
-const { mockLogSystemError, mockLogSystemWarn, mockLogWarn } = vi.hoisted(
-  () => ({
+const { mockLogSystemError, mockLogSystemWarn, mockLogUserError, mockLogWarn } =
+  vi.hoisted(() => ({
     mockLogSystemError: vi.fn(),
     mockLogSystemWarn: vi.fn(),
+    mockLogUserError: vi.fn(),
     mockLogWarn: vi.fn(),
-  })
-);
+  }));
 
 vi.mock("@/lib/logging", () => ({
-  ErrorCategory: { INFRASTRUCTURE: "infrastructure" },
+  ErrorCategory: {
+    INFRASTRUCTURE: "infrastructure",
+    CONFIGURATION: "configuration",
+  },
   logSystemError: mockLogSystemError,
   logSystemWarn: mockLogSystemWarn,
+  logUserError: mockLogUserError,
   logWarn: mockLogWarn,
 }));
 
@@ -244,10 +249,10 @@ describe("NonceManager", () => {
         )
       ).rejects.toThrow(FAILED_LOCK_REGEX);
 
-      // Observability: failure emits a structured log so ops gets paged
-      // instead of waiting for support tickets (KEEP-344).
-      expect(mockLogSystemError).toHaveBeenCalledWith(
-        "infrastructure",
+      // Saturation is the author's configuration, so it counts a metric
+      // without paging.
+      expect(mockLogUserError).toHaveBeenCalledWith(
+        "configuration",
         expect.stringContaining("acquire_failed"),
         expect.any(Error),
         expect.objectContaining({
@@ -256,6 +261,7 @@ describe("NonceManager", () => {
           execution_id: "exec_123",
         })
       );
+      expect(mockLogSystemError).not.toHaveBeenCalled();
     });
 
     it("warns when taking over an expired lock from a prior holder", async () => {

--- a/tests/unit/redis-cache.test.ts
+++ b/tests/unit/redis-cache.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { mockGetRedis } = vi.hoisted(() => ({ mockGetRedis: vi.fn() }));
+
+vi.mock("@/lib/redis", () => ({ getRedis: mockGetRedis }));
+
+import { cachedRead } from "@/lib/redis-cache";
+
+function args(read: () => Promise<bigint>) {
+  return {
+    key: "prod:gas-balance:1:0xabc",
+    ttlSeconds: 10,
+    decode: BigInt,
+    encode: String,
+    read,
+  };
+}
+
+describe("cachedRead", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls the source of truth when no Redis is configured", async () => {
+    mockGetRedis.mockReturnValue(null);
+    const read = vi.fn(() => Promise.resolve(BigInt(7)));
+
+    expect(await cachedRead(args(read))).toBe(BigInt(7));
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the decoded hit without calling the source of truth", async () => {
+    mockGetRedis.mockReturnValue({
+      get: () => Promise.resolve("42"),
+      set: vi.fn(),
+    });
+    const read = vi.fn(() => Promise.resolve(BigInt(7)));
+
+    expect(await cachedRead(args(read))).toBe(BigInt(42));
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it("populates the cache on a miss", async () => {
+    const set = vi.fn(() => Promise.resolve("OK"));
+    mockGetRedis.mockReturnValue({ get: () => Promise.resolve(null), set });
+    const read = vi.fn(() => Promise.resolve(BigInt(7)));
+
+    expect(await cachedRead(args(read))).toBe(BigInt(7));
+    expect(set).toHaveBeenCalledWith("prod:gas-balance:1:0xabc", "7", "EX", 10);
+  });
+
+  it("treats an unparseable cached value as a miss", async () => {
+    mockGetRedis.mockReturnValue({
+      get: () => Promise.resolve("not-a-number"),
+      set: vi.fn(),
+    });
+    const read = vi.fn(() => Promise.resolve(BigInt(7)));
+
+    expect(await cachedRead(args(read))).toBe(BigInt(7));
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls through when the read throws", async () => {
+    mockGetRedis.mockReturnValue({
+      get: () => Promise.reject(new Error("redis down")),
+      set: vi.fn(),
+    });
+    const read = vi.fn(() => Promise.resolve(BigInt(7)));
+
+    expect(await cachedRead(args(read))).toBe(BigInt(7));
+  });
+
+  it("still returns the value when the cache write fails", async () => {
+    mockGetRedis.mockReturnValue({
+      get: () => Promise.resolve(null),
+      set: () => Promise.reject(new Error("redis down")),
+    });
+    const read = vi.fn(() => Promise.resolve(BigInt(7)));
+
+    expect(await cachedRead(args(read))).toBe(BigInt(7));
+  });
+});


### PR DESCRIPTION
## Problem

Writes from one wallet are serialized by a per-wallet-and-chain lock. An
execution that cannot pay for gas still took that lock, spent a full RPC
failover round discovering it at broadcast, and stalled every other execution
for the same wallet behind it. Under a high-rate event trigger the queue never
drained and waiters exhausted the 120s acquire budget.

The lock failure was also classified as a system engine fault, so wallet
saturation paged as an internal error.

## Changes

**Gas preflight before the lock.** New `lib/web3/gas-preflight.ts`, wired ahead
of `withNonceSession` in the four direct-signing write paths (write-contract,
transfer-funds, transfer-token, approve-token). It compares the funding
holder's native balance against the payable value plus the cheapest possible
transaction's gas.

Three design points:

- The floor is 21,000 gas, not a real estimate. No EVM transaction can cost
  less, so a rejection is never a false positive. A real estimate needs a built
  transaction and would risk rejecting affordable work.
- It fails open. Any RPC or lookup error returns affordable and lets the real
  send report the truth, so a provider blip cannot become a user-facing
  rejection.
- Balance and gas price are cached in Redis for 10s, best-effort. A burst on one
  wallet collapses to a few chain reads instead of one per execution. Redis
  being unavailable changes throughput, not behaviour.

**Lock exhaustion reclassified.** Saturation means the workflow asks for more
throughput than one wallet can serialize, which is the author's configuration,
not an engine fault. It now throws an actionable message naming the lever to
pull, and calls `logUserError(CONFIGURATION, ...)` so it keeps the Prometheus
counter without paging Sentry. The classifier maps it to configuration/user
with no code. E-0003 stays for genuine engine faults.

This also removes a split-series problem on dashboards: the throw site was
logging `infrastructure` while the classifier persisted `workflow_engine`.
