### PR TITLE
fix: bill overage on the invoice that closes the period

### DIFF
--- a/keeperhub-executor/billing-guard.ts
+++ b/keeperhub-executor/billing-guard.ts
@@ -4,6 +4,7 @@ import {
   countMonthlyExecutionsForAdmission,
   decideExecutionLimit,
   effectiveExecutionLimit,
+  statusAllowsOverage,
 } from "../lib/billing/execution-limit-core";
 import {
   getPlanLimits,
@@ -107,7 +108,7 @@ export async function checkExecutionLimitForExecutor(
     used,
     debtExecutions,
     overageEnabled: planDef.overage.enabled,
-    subscriptionActive: sub?.status === "active",
+    statusAllowsOverage: statusAllowsOverage(sub?.status),
   });
 
   switch (outcome) {

--- a/lib/billing/execution-limit-core.ts
+++ b/lib/billing/execution-limit-core.ts
@@ -222,6 +222,21 @@ export type ExecutionLimitOutcome =
   | "blocked_limit";
 
 /**
+ * Whether a subscription status may run past the included limit on overage.
+ *
+ * A trial includes the plan's monthly executions at no charge, but it is not a
+ * licence to run unlimited: past the included quota the excess is billed like
+ * any paid period, and the card collected at checkout covers it. Every other
+ * status (past_due, canceled, incomplete) stops at the limit instead, since
+ * there is no settled payment relationship to bill the excess against.
+ */
+export function statusAllowsOverage(
+  status: string | null | undefined
+): boolean {
+  return status === "active" || status === "trialing";
+}
+
+/**
  * The allow/overage/block decision for a non-unlimited plan. Callers handle the
  * unlimited (maxExecutionsPerMonth === -1) case before reaching here, since it
  * intentionally skips the debt and count queries.
@@ -231,7 +246,7 @@ export function decideExecutionLimit(params: {
   used: number;
   debtExecutions: number;
   overageEnabled: boolean;
-  subscriptionActive: boolean;
+  statusAllowsOverage: boolean;
 }): ExecutionLimitOutcome {
   if (params.debtExecutions > 0 && params.overageEnabled) {
     return "blocked_debt";
@@ -239,7 +254,7 @@ export function decideExecutionLimit(params: {
   if (params.used < params.maxExecutionsPerMonth) {
     return "within_limit";
   }
-  if (params.overageEnabled && params.subscriptionActive) {
+  if (params.overageEnabled && params.statusAllowsOverage) {
     return "overage";
   }
   return "blocked_limit";

--- a/lib/billing/handle-billing-event.ts
+++ b/lib/billing/handle-billing-event.ts
@@ -22,6 +22,11 @@ import type { BillingProvider, BillingWebhookEvent } from "./provider";
 
 const LOG_PREFIX = "[Billing Handler]";
 
+// A row still holding the closing period reads as already-ended at the moment
+// the renewal invoice is created, so only clock skew can misread it. The other
+// candidate period ends a full cycle away, well outside this allowance.
+const PERIOD_ROLL_SKEW_MS = 10 * 60 * 1000;
+
 // Numeric ranking used to label plan changes as upgrade/downgrade. Same-plan
 // tier changes (e.g. Pro 25k -> Pro 50k) are labeled "tier_change" since the
 // dashboard tracks them separately from plan-level moves.
@@ -89,6 +94,10 @@ export async function handleBillingEvent(
     }
     case "subscription.deleted": {
       await handleSubscriptionDeleted(data);
+      break;
+    }
+    case "invoice.created": {
+      await handleInvoiceCreated(data);
       break;
     }
     case "invoice.paid": {
@@ -286,6 +295,66 @@ function buildSubscriptionUpdate(
   }
 
   return update;
+}
+
+/**
+ * Put the closing period's overage on the renewal invoice that closes it.
+ *
+ * The provider emits this while the renewal invoice is still a draft, which is
+ * the only window in which an invoice item can be added to it. Billing from
+ * subscription.updated instead is always too late: that event fires once the
+ * invoice already exists, so the item is left pending and lands on the next
+ * cycle's invoice a month later.
+ */
+async function handleInvoiceCreated(
+  data: BillingWebhookEvent["data"]
+): Promise<void> {
+  const { providerSubscriptionId, invoiceId, billingReason } = data;
+
+  // Only a cycle renewal closes a period; one-off and proration invoices do not.
+  if (
+    !(providerSubscriptionId && invoiceId) ||
+    billingReason !== "subscription_cycle"
+  ) {
+    return;
+  }
+
+  const current = await findSubscriptionByProviderId(providerSubscriptionId);
+  if (
+    !(
+      current?.currentPeriodStart instanceof Date &&
+      current.currentPeriodEnd instanceof Date
+    )
+  ) {
+    return;
+  }
+
+  // The row holds the closing period only until subscription.updated advances
+  // it. If that event won the race it already billed this period, so there is
+  // nothing left to attach.
+  if (current.currentPeriodEnd.getTime() > Date.now() + PERIOD_ROLL_SKEW_MS) {
+    logWarn(
+      `${LOG_PREFIX} invoice.created arrived after the period advanced; overage stays on the following invoice`,
+      { org_id: current.organizationId }
+    );
+    return;
+  }
+
+  try {
+    await billOverageForOrg(
+      current.organizationId,
+      current.currentPeriodStart,
+      current.currentPeriodEnd,
+      { invoiceId }
+    );
+  } catch (error) {
+    logSystemWarn(
+      ErrorCategory.BILLING,
+      `${LOG_PREFIX} Failed to bill overage onto the closing invoice (will be retried by scan)`,
+      error,
+      { org_id: current.organizationId }
+    );
+  }
 }
 
 async function handleSubscriptionUpdated(

--- a/lib/billing/overage.ts
+++ b/lib/billing/overage.ts
@@ -6,10 +6,15 @@ import {
   organizationSubscriptions,
   overageBillingRecords,
 } from "@/lib/db/schema";
-import { ErrorCategory, logUserError } from "@/lib/logging";
+import { ErrorCategory, logSystemWarn, logUserError } from "@/lib/logging";
 import { getMetricsCollector } from "@/lib/metrics";
 import { MetricNames } from "@/lib/metrics/types";
 import { getPlanLimits, PLANS, parsePlanName, parseTierKey } from "./plans";
+import type {
+  BillingProvider,
+  CreateInvoiceItemParams,
+  CreateInvoiceItemResult,
+} from "./provider";
 import { getBillingProvider } from "./providers";
 
 const LOG_PREFIX = "[Overage Billing]";
@@ -19,15 +24,51 @@ type OverageResult =
   | { billed: true; overageCount: number; totalChargeCents: number };
 
 /**
+ * Create the invoice item on `invoiceId`, retrying unattached if that fails.
+ *
+ * Attaching only works while the invoice is still a draft. If it finalized
+ * first the attached call is rejected, and the retry keeps the charge as a
+ * pending item on the following invoice rather than dropping it.
+ */
+async function createItemWithFallback(
+  provider: BillingProvider,
+  params: Omit<CreateInvoiceItemParams, "invoiceId">,
+  invoiceId: string | undefined,
+  organizationId: string
+): Promise<CreateInvoiceItemResult> {
+  if (!invoiceId) {
+    return await provider.createInvoiceItem(params);
+  }
+
+  try {
+    return await provider.createInvoiceItem({ ...params, invoiceId });
+  } catch (error) {
+    logSystemWarn(
+      ErrorCategory.BILLING,
+      `${LOG_PREFIX} Could not attach to the closing invoice, falling back to the next one`,
+      error,
+      { org_id: organizationId }
+    );
+    return await provider.createInvoiceItem(params);
+  }
+}
+
+/**
  * Bill overage executions for an organization's billing period.
  *
  * Idempotent: if a record already exists for the given org + period, it skips.
- * Creates a Stripe invoice item that attaches to the customer's next invoice.
+ *
+ * Pass `invoiceId` (the still-draft renewal invoice for the cycle that just
+ * closed) to put the charge on that invoice, so the org pays its overage on the
+ * same invoice that closes the period. Without it the item is left pending and
+ * the provider only sweeps it into the following cycle's invoice, a full
+ * billing cycle later.
  */
 export async function billOverageForOrg(
   organizationId: string,
   periodStart: Date,
-  periodEnd: Date
+  periodEnd: Date,
+  options?: { invoiceId?: string }
 ): Promise<OverageResult> {
   const sub = await db.query.organizationSubscriptions.findFirst({
     where: eq(organizationSubscriptions.organizationId, organizationId),
@@ -127,7 +168,7 @@ export async function billOverageForOrg(
 
   try {
     const provider = getBillingProvider();
-    const { invoiceItemId } = await provider.createInvoiceItem({
+    const itemParams = {
       customerId: sub.providerCustomerId,
       amount: totalChargeCents,
       currency: "usd",
@@ -138,7 +179,14 @@ export async function billOverageForOrg(
         periodEnd: periodEnd.toISOString(),
         overageCount: String(overageCount),
       },
-    });
+    };
+
+    const { invoiceItemId } = await createItemWithFallback(
+      provider,
+      itemParams,
+      options?.invoiceId,
+      organizationId
+    );
 
     await db
       .update(overageBillingRecords)

--- a/lib/billing/plans-server.ts
+++ b/lib/billing/plans-server.ts
@@ -8,6 +8,7 @@ import {
   countMonthlyExecutionsForAdmission,
   decideExecutionLimit,
   effectiveExecutionLimit,
+  statusAllowsOverage,
 } from "./execution-limit-core";
 import { isBillingEnabled } from "./feature-flag";
 import {
@@ -262,7 +263,7 @@ export async function checkExecutionLimit(
     used,
     debtExecutions,
     overageEnabled: planDef.overage.enabled,
-    subscriptionActive: sub?.status === "active",
+    statusAllowsOverage: statusAllowsOverage(sub?.status),
   });
 
   switch (outcome) {

--- a/lib/billing/provider.ts
+++ b/lib/billing/provider.ts
@@ -19,6 +19,7 @@ export type BillingWebhookEvent = {
     | "checkout.completed"
     | "subscription.updated"
     | "subscription.deleted"
+    | "invoice.created"
     | "invoice.paid"
     | "invoice.payment_failed"
     | "invoice.overdue"
@@ -35,6 +36,9 @@ export type BillingWebhookEvent = {
     periodStart?: Date;
     periodEnd?: Date | null;
     invoiceUrl?: string;
+    // Stripe's billing_reason, used to tell a cycle renewal invoice apart from
+    // a one-off or proration invoice.
+    billingReason?: string;
     // Metadata from Stripe used to resolve custom enterprise plans whose price
     // IDs aren't in the env-var map. Subscription metadata takes precedence.
     subscriptionMetadata?: Record<string, string>;
@@ -82,6 +86,9 @@ export type CreateInvoiceItemParams = {
   currency: string;
   description: string;
   metadata?: Record<string, string>;
+  // Attach to this specific draft invoice. Without it the item is left pending
+  // and the provider only sweeps it into whichever invoice is created next.
+  invoiceId?: string;
 };
 
 export type CreateInvoiceItemResult = {

--- a/lib/billing/providers/stripe.ts
+++ b/lib/billing/providers/stripe.ts
@@ -40,6 +40,7 @@ const EVENT_TYPE_MAP: Record<string, BillingWebhookEvent["type"] | undefined> =
     "checkout.session.completed": "checkout.completed",
     "customer.subscription.updated": "subscription.updated",
     "customer.subscription.deleted": "subscription.deleted",
+    "invoice.created": "invoice.created",
     "invoice.paid": "invoice.paid",
     "invoice.payment_failed": "invoice.payment_failed",
     "invoice.overdue": "invoice.overdue",
@@ -155,6 +156,7 @@ function normalizeInvoiceEvent(
       providerCustomerId: customerId ?? undefined,
       invoiceId: invoice.id ?? undefined,
       invoiceUrl: invoice.hosted_invoice_url ?? undefined,
+      billingReason: invoice.billing_reason ?? undefined,
     },
   };
 }
@@ -396,6 +398,7 @@ export class StripeBillingProvider implements BillingProvider {
           "subscription.deleted"
         );
 
+      case "invoice.created":
       case "invoice.paid":
       case "invoice.payment_failed":
       case "invoice.overdue":
@@ -569,6 +572,7 @@ export class StripeBillingProvider implements BillingProvider {
       currency: params.currency,
       description: params.description,
       metadata: params.metadata,
+      ...(params.invoiceId && { invoice: params.invoiceId }),
     });
     return { invoiceItemId: item.id };
   }

--- a/tests/unit/billing-execution-limit-core.test.ts
+++ b/tests/unit/billing-execution-limit-core.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetExecutionCountCacheForTest,
   countMonthlyExecutionsForAdmission,
+  decideExecutionLimit,
+  statusAllowsOverage,
 } from "@/lib/billing/execution-limit-core";
 
 type FakeDb = { execute: ReturnType<typeof vi.fn> };
@@ -349,5 +351,93 @@ describe("countMonthlyExecutionsForAdmission", () => {
       )
     ).toBe(400_000);
     expect(db.execute).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("statusAllowsOverage", () => {
+  it("allows an active subscription past the included limit", () => {
+    expect(statusAllowsOverage("active")).toBe(true);
+  });
+
+  it("allows a trial past the included limit so the excess is billed", () => {
+    expect(statusAllowsOverage("trialing")).toBe(true);
+  });
+
+  it.each([
+    "past_due",
+    "canceled",
+    "incomplete",
+    "unpaid",
+    null,
+    undefined,
+  ])("stops %s at the included limit", (status) => {
+    expect(statusAllowsOverage(status)).toBe(false);
+  });
+});
+
+describe("decideExecutionLimit", () => {
+  const AT_LIMIT = {
+    maxExecutionsPerMonth: 25_000,
+    used: 25_000,
+    debtExecutions: 0,
+    overageEnabled: true,
+  };
+
+  it("bills a trial for the excess rather than blocking it", () => {
+    expect(
+      decideExecutionLimit({
+        ...AT_LIMIT,
+        statusAllowsOverage: statusAllowsOverage("trialing"),
+      })
+    ).toBe("overage");
+  });
+
+  it("leaves a trial under its included quota alone", () => {
+    expect(
+      decideExecutionLimit({
+        ...AT_LIMIT,
+        used: 24_999,
+        statusAllowsOverage: statusAllowsOverage("trialing"),
+      })
+    ).toBe("within_limit");
+  });
+
+  it("bills an active subscription for the excess", () => {
+    expect(
+      decideExecutionLimit({
+        ...AT_LIMIT,
+        statusAllowsOverage: statusAllowsOverage("active"),
+      })
+    ).toBe("overage");
+  });
+
+  it("blocks a past_due subscription at the limit", () => {
+    expect(
+      decideExecutionLimit({
+        ...AT_LIMIT,
+        statusAllowsOverage: statusAllowsOverage("past_due"),
+      })
+    ).toBe("blocked_limit");
+  });
+
+  it("blocks a plan without overage at the limit", () => {
+    expect(
+      decideExecutionLimit({
+        ...AT_LIMIT,
+        overageEnabled: false,
+        statusAllowsOverage: statusAllowsOverage("active"),
+      })
+    ).toBe("blocked_limit");
+  });
+
+  it("blocks on outstanding debt before considering the count", () => {
+    expect(
+      decideExecutionLimit({
+        ...AT_LIMIT,
+        used: 0,
+        debtExecutions: 500,
+        statusAllowsOverage: statusAllowsOverage("trialing"),
+      })
+    ).toBe("blocked_debt");
   });
 });

--- a/tests/unit/billing-handle-event.test.ts
+++ b/tests/unit/billing-handle-event.test.ts
@@ -244,6 +244,88 @@ describe("handleBillingEvent", () => {
     });
   });
 
+  describe("invoice.created", () => {
+    const closedPeriod = {
+      organizationId: "org_1",
+      providerSubscriptionId: "sub_1",
+      providerPriceId: process.env.STRIPE_PRICE_PRO_25K_MONTHLY,
+      plan: "pro",
+      tier: "25k",
+      status: "active",
+      cancelAtPeriodEnd: false,
+      currentPeriodStart: new Date("2025-01-01"),
+      currentPeriodEnd: new Date("2025-02-01"),
+    };
+
+    it("bills the closed period onto the invoice that closes it", async () => {
+      mockSelectReturning([closedPeriod]);
+
+      const event = makeEvent("invoice.created", {
+        providerSubscriptionId: "sub_1",
+        invoiceId: "in_closing",
+        billingReason: "subscription_cycle",
+      });
+
+      await handleBillingEvent(event, createMockProvider());
+
+      expect(mockBillOverageForOrg).toHaveBeenCalledWith(
+        "org_1",
+        new Date("2025-01-01"),
+        new Date("2025-02-01"),
+        { invoiceId: "in_closing" }
+      );
+    });
+
+    it("ignores invoices that do not close a cycle", async () => {
+      mockSelectReturning([closedPeriod]);
+
+      const event = makeEvent("invoice.created", {
+        providerSubscriptionId: "sub_1",
+        invoiceId: "in_oneoff",
+        billingReason: "subscription_update",
+      });
+
+      await handleBillingEvent(event, createMockProvider());
+
+      expect(mockBillOverageForOrg).not.toHaveBeenCalled();
+    });
+
+    it("skips when the subscription row already advanced past the closed period", async () => {
+      mockSelectReturning([
+        {
+          ...closedPeriod,
+          currentPeriodStart: new Date("2099-01-01"),
+          currentPeriodEnd: new Date("2099-02-01"),
+        },
+      ]);
+
+      const event = makeEvent("invoice.created", {
+        providerSubscriptionId: "sub_1",
+        invoiceId: "in_closing",
+        billingReason: "subscription_cycle",
+      });
+
+      await handleBillingEvent(event, createMockProvider());
+
+      expect(mockBillOverageForOrg).not.toHaveBeenCalled();
+    });
+
+    it("does not throw when billing the closing invoice fails", async () => {
+      mockSelectReturning([closedPeriod]);
+      mockBillOverageForOrg.mockRejectedValue(new Error("Stripe down"));
+
+      const event = makeEvent("invoice.created", {
+        providerSubscriptionId: "sub_1",
+        invoiceId: "in_closing",
+        billingReason: "subscription_cycle",
+      });
+
+      await expect(
+        handleBillingEvent(event, createMockProvider())
+      ).resolves.toBeUndefined();
+    });
+  });
+
   describe("subscription.updated", () => {
     it("updates plan when price changes", async () => {
       mockSelectReturning([

--- a/tests/unit/billing-overage.test.ts
+++ b/tests/unit/billing-overage.test.ts
@@ -242,4 +242,96 @@ describe("billOverageForOrg", () => {
     });
     expect(getBillingProvider).not.toHaveBeenCalled();
   });
+
+  it("attaches the charge to the closing invoice when one is given", async () => {
+    mockFindFirstSub.mockResolvedValue({
+      plan: "pro",
+      tier: "25k",
+      status: "active",
+      providerCustomerId: "cus_123",
+    });
+    mockFindFirstOverage.mockResolvedValue(undefined);
+    mockExecutionCount(26_500);
+    mockReturning.mockResolvedValue([{ id: "rec_1" }]);
+
+    const mockCreateInvoiceItem = vi
+      .fn()
+      .mockResolvedValue({ invoiceItemId: "ii_123" });
+    mockBillingProvider({ createInvoiceItem: mockCreateInvoiceItem });
+
+    const result = await billOverageForOrg("org_1", periodStart, periodEnd, {
+      invoiceId: "in_closing",
+    });
+
+    expect(result).toEqual({
+      billed: true,
+      overageCount: 1500,
+      totalChargeCents: 300,
+    });
+    expect(mockCreateInvoiceItem).toHaveBeenCalledTimes(1);
+    expect(mockCreateInvoiceItem).toHaveBeenCalledWith(
+      expect.objectContaining({ invoiceId: "in_closing" })
+    );
+  });
+
+  it("retries unattached when the closing invoice can no longer take the item", async () => {
+    mockFindFirstSub.mockResolvedValue({
+      plan: "pro",
+      tier: "25k",
+      status: "active",
+      providerCustomerId: "cus_123",
+    });
+    mockFindFirstOverage.mockResolvedValue(undefined);
+    mockExecutionCount(26_500);
+    mockReturning.mockResolvedValue([{ id: "rec_1" }]);
+
+    const mockCreateInvoiceItem = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Invoice is no longer editable"))
+      .mockResolvedValueOnce({ invoiceItemId: "ii_pending" });
+    mockBillingProvider({ createInvoiceItem: mockCreateInvoiceItem });
+
+    const result = await billOverageForOrg("org_1", periodStart, periodEnd, {
+      invoiceId: "in_closing",
+    });
+
+    expect(result).toEqual({
+      billed: true,
+      overageCount: 1500,
+      totalChargeCents: 300,
+    });
+    expect(mockCreateInvoiceItem).toHaveBeenCalledTimes(2);
+    expect(mockCreateInvoiceItem).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ invoiceId: expect.anything() })
+    );
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "billed",
+        providerInvoiceItemId: "ii_pending",
+      })
+    );
+  });
+
+  it("leaves the item unattached when no closing invoice is given", async () => {
+    mockFindFirstSub.mockResolvedValue({
+      plan: "pro",
+      tier: "25k",
+      status: "active",
+      providerCustomerId: "cus_123",
+    });
+    mockFindFirstOverage.mockResolvedValue(undefined);
+    mockExecutionCount(26_500);
+    mockReturning.mockResolvedValue([{ id: "rec_1" }]);
+
+    const mockCreateInvoiceItem = vi
+      .fn()
+      .mockResolvedValue({ invoiceItemId: "ii_123" });
+    mockBillingProvider({ createInvoiceItem: mockCreateInvoiceItem });
+
+    await billOverageForOrg("org_1", periodStart, periodEnd);
+
+    expect(mockCreateInvoiceItem).toHaveBeenCalledWith(
+      expect.not.objectContaining({ invoiceId: expect.anything() })
+    );
+  });
 });


### PR DESCRIPTION
Two billing fixes on the overage path.

## Overage landed a cycle late

Overage was billed from the `subscription.updated` handler. Stripe only emits that once the renewal invoice already exists, and the invoice item was created with no invoice attached, so it stayed pending and was swept into the following cycle's invoice.

An org therefore went a full billing cycle between exceeding its limit and paying for it, and the oldest execution in a period waited close to two months. The invoice that closed the period showed only the subscription fee.

Handle `invoice.created` for `billing_reason === "subscription_cycle"`. Stripe emits that while the renewal invoice is still a draft, which is the only window in which an invoice item can be added to it, so the charge lands on the invoice that closes the period it belongs to.

- `billOverageForOrg` takes an optional `invoiceId` and passes it through to `invoiceItems.create`
- If the draft finalized before the event was handled, the attached create is retried unattached so the charge is deferred rather than lost
- `subscription.updated` and the scan endpoint stay as fallbacks; the unique index on `(organization_id, period_start, period_end)` makes a second trigger a no-op

## Trials were blocked instead of billed

The overage branch in `decideExecutionLimit` required `status === "active"`, so a trialing subscription fell through to `blocked_limit` and, on a paid plan, the execution was refused outright.

The included quota is free during a trial, but going past it is not: the excess is billed like any paid period, against the card collected at checkout (`payment_method_collection: "always"`). Blocking also disagreed with the billing side, which has no status check at all and would charge a trial period's excess if one ever accumulated.

Both decision sites now route through a shared `statusAllowsOverage` helper so they cannot drift. Every other status (`past_due`, `canceled`, `incomplete`, `unpaid`) still stops at the limit. `decideExecutionLimit` had no direct test coverage; it does now.

## Deploy requirement

`invoice.created` must be added to the Stripe webhook endpoint's enabled events or the new handler never fires.

While there: `invoice.paid`, `invoice.payment_failed`, `invoice.overdue`, `invoice.payment_action_required` and `customer.subscription.deleted` are handled in code but are not subscribed, so those handlers have never run in production. `invoice.paid` is what stamps `provider_invoice_id` and clears a settled overage row from the billing page.

Existing pending invoice items are unaffected and still land on the next invoice. The first fix applies from the next cycle roll forward.

## Known gap, not addressed here

Admission counts the calendar month while overage bills the subscription period. A trial that crosses a month boundary gets its admission counter reset mid-trial, so it can run past the included quota twice over and be billed for the difference without the usage meter ever showing it over. That is now reachable on trials because they no longer stop at the limit.
