### PR TITLE
docs: correct the API reference where it disagrees with the API

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -9,7 +9,7 @@ description: "Frequently asked questions about KeeperHub - getting started, secu
 
 ### What is KeeperHub?
 
-KeeperHub is a no-code blockchain automation platform. You build visual workflows that monitor onchain state, execute transactions, and send notifications -- without writing code or managing infrastructure. It works with Ethereum, Base, Arbitrum, Polygon, and other EVM-compatible chains.
+KeeperHub is a no-code blockchain automation platform. You build visual workflows that monitor onchain state, execute transactions, and send notifications -- without writing code or managing infrastructure. It works with Ethereum, Base, Arbitrum, Polygon, and other EVM-compatible chains, and with Solana for native SOL and SPL token transfers.
 
 People use it for things like treasury monitoring, DeFi position management, event-driven alerting, and recurring onchain operations (reward distribution, collateral top-ups, that sort of thing).
 
@@ -33,6 +33,8 @@ If you do need custom logic, the [Code Plugin](/plugins/code) runs JavaScript in
 ### What blockchains does KeeperHub support?
 
 KeeperHub supports a range of EVM chains, including Ethereum, Base, Arbitrum, Optimism, Polygon, BNB Chain, Avalanche, and others, plus their testnets (Sepolia, Base Sepolia, and more). The live, authoritative list is always available from `GET /api/chains`. Gas defaults are applied automatically per chain; L2s like Base and Arbitrum use lower gas multipliers since their estimates tend to be tighter.
+
+Solana mainnet and devnet are also supported, for native SOL transfers and SPL token transfers. Your Turnkey wallet carries a Solana address alongside its EVM address. Contract calls, protocol plugins, and simulation are EVM only today, so a Solana workflow is built from the transfer actions in the [Web3 Plugin](/plugins/web3).
 
 Some protocol plugins only work on certain chains. Ajna is Base-only, Sky converters are Ethereum-only, and so on. Check each plugin's docs for specifics.
 

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -43,6 +43,26 @@ KeeperHub has two types of API keys:
 - Only the key prefix is stored for identification
 - Revoke keys immediately if compromised
 
+## Checking a key works
+
+Use `GET /api/keys` as the probe in a health check or first-run script. It is
+organization-scoped, read-only, and returns `keyPrefix` for each key, so a
+diagnostic can name the key it is holding without printing it.
+
+```bash
+curl -sf -H "Authorization: Bearer kh_your_api_key" \
+  https://app.keeperhub.com/api/keys
+```
+
+A `200` means the credential is valid and scoped to an organization. A `401`
+means the key is wrong, revoked, or absent.
+
+`GET /api/chains` serves the chain catalog to anyone, credential or not, because
+the list is public information. It answers `200` for an invalid key as readily
+as a valid one, so it tells you the host is reachable rather than that your
+credential works. Reach for it to check connectivity, and for `GET /api/keys`
+to check authentication.
+
 ## Endpoint scope
 
 Session authentication is accepted everywhere. API keys (`kh_`) are accepted only on **organization-scoped** endpoints, the ones whose action and result depend on the caller's organization rather than on the individual user behind the key. Wallets, billing, and spending caps are all attached to the organization, so a key that authorizes on-chain spend or billable usage is necessarily organization-scoped.
@@ -63,7 +83,9 @@ Endpoints whose semantics are organization-scoped accept `kh_` keys:
   (`/api/execute/{protocol}/{action}`), and
   `GET /api/execute/{executionId}/status`
 - Integrations: `/api/integrations`
-- Projects, tags, public tags, supported chains
+- Projects, tags, public tags, supported chains (`GET /api/chains` serves the
+  chain catalog to anyone, with or without a credential; see
+  [Checking a key works](#checking-a-key-works))
 - Organization-scoped billing and analytics
 - Organization management (e.g. renaming an organization)
 - Organization API keys (`GET /api/keys`, `DELETE /api/keys/{keyId}`); creation requires session

--- a/docs/api/chains.md
+++ b/docs/api/chains.md
@@ -13,7 +13,10 @@ Access supported blockchain networks and contract information.
 GET /api/chains
 ```
 
-Returns all supported blockchain networks.
+Returns all supported blockchain networks. The catalog is public, so this
+endpoint answers with or without a credential. To confirm an API key is valid,
+call `GET /api/keys` instead. See
+[Checking a key works](/api/authentication#checking-a-key-works).
 
 ### Query Parameters
 

--- a/docs/api/direct-execution.md
+++ b/docs/api/direct-execution.md
@@ -55,7 +55,7 @@ a transaction.
 
 Send an `Idempotency-Key` header to safely retry a request without risking a double-execution. The key is any client-chosen string (for example an agent-side transaction id, ideally a UUID). Every guarantee below depends on the retry sending the **same** key, so a caller that reconstructs a request rather than replaying a buffered one must derive its key deterministically: see [Choosing a stable key](#choosing-a-stable-key).
 
-- **Replay**: a retry with the same key and the same request body returns the original response (same `executionId`, same status) without executing again, plus an `idempotentReplay` marker described below.
+- **Replay**: a retry with the same key and the same request body returns the original response (same `executionId`, same status) without executing again, plus an `idempotentReplay` marker described below. Replay lasts 24 hours from the original request. Past that the stored response is gone and the same key executes again, silently, so a job that repeats on a cadence of a day or longer needs a time bucket in its key: see [Choosing a stable key](#choosing-a-stable-key).
 - **Conflict**: reusing a key with a different request body returns `409` with code `idempotency_conflict` and the `originalExecutionId` the key first produced. Use a new key for genuinely different work, not for a retry of the same work whose body was reconstructed: see [Choosing a stable key](#choosing-a-stable-key).
 - **In progress**: a duplicate that arrives while the first request is still running returns `409` with code `idempotency_in_progress`; retry shortly.
 - **Scope**: keys are scoped per organization and per endpoint, so the same key is shared across an org's API keys but does not collide between `/transfer`, `/contract-call`, `/check-and-execute`, and a workflow webhook.
@@ -112,6 +112,13 @@ The separator is a single ASCII vertical bar, `U+007C`, with no surrounding whit
 `taskId` is whatever the caller already uses to name the work: an invoice number, a
 payroll period, a job id. It must be stable across a retry of the same work and
 different for different work.
+
+Work that repeats on a schedule needs the period in the `taskId`, not just the job name.
+A daily job keyed on `nightly-sweep` alone derives the same key on every run, and because
+the replay window is 24 hours it lands near the boundary each time: sometimes inside the
+window, where the run is swallowed as a replay, sometimes outside it, where the run
+executes. Including the period, as in `nightly-sweep-2026-08-06`, makes each run distinct
+work with a full 24 hours of retry protection of its own.
 
 Canonicalize each part before joining:
 
@@ -377,7 +384,7 @@ Read a contract value, evaluate a condition, and conditionally execute a write o
 ```json
 {
   "executed": false,
-  "condition": {
+  "conditionResult": {
     "met": false,
     "observedValue": "500000000000000000",
     "targetValue": "1000000000000000000",
@@ -393,7 +400,7 @@ Read a contract value, evaluate a condition, and conditionally execute a write o
   "executed": true,
   "executionId": "direct_123",
   "status": "completed",
-  "condition": {
+  "conditionResult": {
     "met": true,
     "observedValue": "1500000000000000000",
     "targetValue": "1000000000000000000",
@@ -402,11 +409,17 @@ Read a contract value, evaluate a condition, and conditionally execute a write o
 }
 ```
 
+The request field is `condition` and the response field is `conditionResult`, on
+both the broadcast and the `simulate: true` paths. A parser written once against
+this endpoint works for both.
+
 ## Dry-Run Simulation
 
 All three execute endpoints (`/api/execute/transfer`, `/api/execute/contract-call`, `/api/execute/check-and-execute`) accept a `simulate` flag on the body. When set to boolean `true`, the endpoint validates inputs, resolves the org's from-address, encodes the call, and runs `provider.estimateGas` + `provider.call` against the chain — **without** signing or broadcasting a transaction.
 
 No row is inserted into the execution audit table, no funds are reserved against the spending cap, and no transaction hash is produced. Use it to pre-flight a transaction (catch reverts, allowance mismatches, balance shortfalls, ABI mistakes) before spending gas.
+
+A simulation that reports the call would revert answers with HTTP `400` and `wouldRevert: true`. That status describes the transaction, not the request: the simulation itself ran, and the body carries the decoded reason your client wants. Read `wouldRevert` before classifying a `400` from these endpoints, so a generic "non-2xx means the call failed" wrapper does not discard the answer. The distinguishing marker is the `wouldRevert` field, which is present only on simulate responses.
 
 ### Request
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -30,14 +30,54 @@ See [Authentication](/api/authentication) for the full scope.
 
 ## Response Format
 
-All responses are returned as JSON with the following structure:
+All responses are JSON. Successful responses come in three shapes, by resource
+kind. There is no `data` wrapper on any endpoint.
 
-### Success Response
+### Single resource
+
+A read or write of one resource returns that resource as a bare object.
+
 ```json
 {
-  "data": { ... }
+  "id": "wf_123",
+  "name": "Treasury monitor"
 }
 ```
+
+`GET /api/user`, `GET /api/workflows/{workflowId}` and the direct-execution
+endpoints all answer this way.
+
+### Paginated collection
+
+A collection that paginates returns items alongside page metadata and links.
+
+```json
+{
+  "items": [ ... ],
+  "meta": { "total": 42, "page": 1, "pageSize": 20, "totalPages": 3 },
+  "_links": {
+    "self": "...", "first": "...", "prev": null, "next": "...", "last": "..."
+  }
+}
+```
+
+`GET /api/keys`, `GET /api/workflows/{workflowId}/history` and
+`GET /api/security/audit` answer this way. Read `items`, and follow
+`_links.next` until it is `null`.
+
+### Bare array
+
+List endpoints that do not paginate return a plain JSON array with no envelope.
+`GET /api/chains` and `GET /api/workflows` both answer this way.
+
+```json
+[
+  { "chainId": 1, "name": "Ethereum Mainnet" }
+]
+```
+
+When writing a generic client, key the unwrapping on the endpoint rather than
+sniffing the body.
 
 ### Error Response
 
@@ -70,6 +110,15 @@ Clients should:
 - Capture `request_id` (or read the `x-request-id` response header) and include it when reporting issues.
 
 A short list of canonical `error` codes is reused across endpoints: `unauthorized`, `insufficient_scope`, `not_found`, `invalid_input`, `conflict`, `rate_limited`, `internal_error`. Endpoint-specific codes (e.g. `wallet_not_configured`, `web3_integration_exists`) are documented on the page for the resource that raises them.
+
+### Direct Execution errors
+
+The `/api/execute/*` endpoints answer with a human-readable sentence in `error`,
+`field` naming the offending input where one applies, and `details` carrying
+context. Where a machine-readable code exists it is in `code`, for example
+`insufficient_balance` on a simulation that ran out of native currency. Branch
+on the HTTP status and on `code`, and treat `error` there as prose to log or
+show. See [Direct Execution](/api/direct-execution) for the per-endpoint shapes.
 
 The `x-request-id` request header is honored when present: send any value (≤ 128 chars, no control characters) and it is reflected back on both the `request_id` response field and the `x-request-id` response header.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ description: "KeeperHub is the execution and reliability layer for AI agents ope
 
 # Overview
 
-KeeperHub is the execution and reliability layer for AI agents operating onchain. Build visual workflows that monitor onchain state, execute transactions, and send notifications -- without writing code or managing infrastructure. Works with Ethereum, Base, Arbitrum, Polygon, and other EVM-compatible chains.
+KeeperHub is the execution and reliability layer for AI agents operating onchain. Build visual workflows that monitor onchain state, execute transactions, and send notifications -- without writing code or managing infrastructure. Works with Ethereum, Base, Arbitrum, Polygon, and other EVM-compatible chains, and with Solana for native SOL and SPL token transfers.
 
 Whether you are a protocol team automating treasury operations, a security team responding to threats, or an AI agent executing onchain actions, KeeperHub handles gas estimation, transaction ordering, retries, and wallet security so you can focus on what to automate, not how to keep it running.
 
@@ -61,6 +61,10 @@ When a step fails, KeeperHub retries with configurable behavior. Failed runs are
 ### Supported Chains
 
 KeeperHub operates on Ethereum, Base, Arbitrum, Polygon, Sepolia, and additional EVM-compatible networks. Chain-specific gas defaults are applied automatically based on network conditions and trigger type. See [Gas Management](/wallet-management/gas) for details.
+
+Solana mainnet and devnet are supported for native SOL transfers and SPL token transfers. The same Turnkey wallet holds both an EVM and a Solana address. Contract calls, protocol plugins, and dry runs are EVM only today. See [Web3 Plugin](/plugins/web3) for the Solana actions and [Turnkey Wallets](/wallet-management/turnkey) for how the addresses are provisioned.
+
+The live, authoritative chain list is `GET /api/chains`.
 
 ### Turnkey Wallets
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -45,6 +45,18 @@ KeeperHub has two key systems. They are not interchangeable.
 For programmatic API and MCP access, use an organization (`kh_`) key. Full
 details: [API Keys](/api/api-keys).
 
+Confirm the key works before building on it:
+
+```bash
+curl -sf -H "Authorization: Bearer kh_your_api_key" \
+  https://app.keeperhub.com/api/keys
+```
+
+`GET /api/keys` is the auth probe: a `200` means the credential is valid and
+scoped to an organization, a `401` means it is not. Point health checks and
+first-run scripts at this endpoint. `GET /api/chains` is public and answers
+either way, so it reports reachability rather than a working credential.
+
 No browser available? Sign-up is captcha-gated and key creation needs a signed
 confirmation, so a script or agent starts from wallet sign-in instead:
 [Headless Onboarding](/api/headless-onboarding) is the same first thirty minutes

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -139,14 +139,14 @@
       "path": "/api/chains/{chainId}/abi",
       "route_file": "app/api/chains/[chainId]/abi/route.ts",
       "source": "docs/api/chains.md",
-      "line": 116
+      "line": 119
     },
     {
       "method": "GET",
       "path": "/api/execute/{executionId}/status",
       "route_file": "app/api/execute/[executionId]/status/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 536
+      "line": 549
     },
     {
       "method": "GET",
@@ -189,6 +189,13 @@
       "route_file": "app/api/public-tags/route.ts",
       "source": "docs/api/tags.md",
       "line": 88
+    },
+    {
+      "method": "GET",
+      "path": "/api/security/audit",
+      "route_file": "app/api/security/audit/route.ts",
+      "source": "docs/api/index.md",
+      "line": 65
     },
     {
       "method": "GET",
@@ -296,6 +303,13 @@
       "line": 13
     },
     {
+      "method": "GET",
+      "path": "/api/workflows/{workflowId}/history",
+      "route_file": "app/api/workflows/[workflowId]/history/route.ts",
+      "source": "docs/api/index.md",
+      "line": 64
+    },
+    {
       "method": "PATCH",
       "path": "/api/address-book/{entryId}",
       "route_file": "app/api/address-book/[entryId]/route.ts",
@@ -370,28 +384,28 @@
       "path": "/api/execute/check-and-execute",
       "route_file": "app/api/execute/check-and-execute/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 336
+      "line": 343
     },
     {
       "method": "POST",
       "path": "/api/execute/contract-call",
       "route_file": "app/api/execute/contract-call/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 280
+      "line": 287
     },
     {
       "method": "POST",
       "path": "/api/execute/transfer",
       "route_file": "app/api/execute/transfer/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 218
+      "line": 225
     },
     {
       "method": "POST",
       "path": "/api/executions/{executionId}/cancel",
       "route_file": "app/api/executions/[executionId]/cancel/route.ts",
       "source": "docs/api/authentication.md",
-      "line": 60
+      "line": 80
     },
     {
       "method": "POST",


### PR DESCRIPTION
The API reference describes behaviour the code does not have in five places. Each was verified against the routes before changing the text.

**Response envelope.** The overview stated all responses are wrapped in `data`. No route in `app/api` has ever done that. Replaced with the three real shapes: a bare object for a single resource, `{items, meta, _links}` for a paginated collection, and a bare array for the list endpoints that do not paginate.

**check-and-execute.** Both response examples showed the condition under `condition`. The route emits `conditionResult` on every path, broadcast and simulate alike, so a client written from the page reads undefined and fails quietly in the "no condition data" direction. The request field is still `condition`, and that example was already correct.

**Solana.** The overview and FAQ described EVM chains only. The platform has shipped Solana native and SPL transfers for months and provisions a Solana address on the same Turnkey wallet. Both pages now name Solana and state that contract calls, protocol plugins and dry runs are EVM only, so the scope is not oversold.

**Auth probe.** `GET /api/chains` has no session or key check and answers 200 for an invalid credential, while the authentication page listed it under "Accepted on API keys". A first-run health check therefore reports success on a key that does not work. Documented `GET /api/keys` as the auth probe, with a new section on the authentication page and a check in the quickstart.

**Simulation and idempotency.** A would-revert simulate answers 400, which a generic client reads as a transport failure and discards. The page now says to check `wouldRevert` before classifying the status. The 24 hour replay window moved next to the replay behaviour it qualifies, with guidance to put the period in the key for work that repeats on a schedule.

Also documented the direct-execution error shape, where `error` carries a sentence and the machine-readable value is in `code`.

Verification: `docs-site` builds clean, 173 pages indexed. Every relative link and anchor added here resolves to a real page and heading.
