### PR TITLE
fix: guard the schema builder against non-array stored schemas

### DIFF
--- a/components/workflow/config/action-config-renderer.tsx
+++ b/components/workflow/config/action-config-renderer.tsx
@@ -32,13 +32,14 @@ import { computeSelector, findAbiFunction } from "@/lib/abi/utils";
 import { evaluateShowWhen } from "@/lib/workflow/editor/show-when";
 import { parseAddressBookSelection } from "@/lib/address-book-selection";
 import { toChecksumAddress } from "@/lib/address-utils";
+import { parseSchemaFields } from "@/lib/schema-fields";
 import { getCustomFieldRenderer } from "@/lib/workflow/editor/extension-registry";
 import {
   type ActionConfigField,
   type ActionConfigFieldBase,
   isFieldGroup,
 } from "@/plugins/registry";
-import { SchemaBuilder, type SchemaField } from "./schema-builder";
+import { SchemaBuilder } from "./schema-builder";
 
 type FieldProps = {
   field: ActionConfigFieldBase;
@@ -447,7 +448,7 @@ function SchemaBuilderField(props: FieldProps) {
     <SchemaBuilder
       disabled={props.disabled}
       onChange={(schema) => props.onChange(JSON.stringify(schema))}
-      schema={props.value ? (JSON.parse(props.value) as SchemaField[]) : []}
+      schema={parseSchemaFields(props.value)}
     />
   );
 }

--- a/components/workflow/config/action-config.tsx
+++ b/components/workflow/config/action-config.tsx
@@ -30,6 +30,7 @@ import {
 import { SqlTemplateEditor } from "@/components/ui/sql-template-editor";
 import { TemplateCodeEditor } from "@/components/ui/template-code-editor";
 import { actionRequiresCredentials } from "@/lib/integration-helpers";
+import { parseSchemaFields } from "@/lib/schema-fields";
 import { ConditionQueryBuilder } from "@/components/workflow/condition-query-builder";
 import type { ConditionGroup } from "@/lib/workflow/nodes/condition/builder-types";
 import {
@@ -69,7 +70,7 @@ import {
   getIntegration,
 } from "@/plugins/registry";
 import { ActionConfigRenderer } from "./action-config-renderer";
-import { SchemaBuilder, type SchemaField } from "./schema-builder";
+import { SchemaBuilder } from "./schema-builder";
 import { Web3ConnectionSelect } from "./web3-connection-select";
 
 type ConfigValue = string | boolean | Record<string, unknown> | undefined;
@@ -114,11 +115,7 @@ function DatabaseQueryFields({
           onChange={(schema) =>
             onUpdateConfig("dbSchema", JSON.stringify(schema))
           }
-          schema={
-            config?.dbSchema
-              ? (JSON.parse(config.dbSchema as string) as SchemaField[])
-              : []
-          }
+          schema={parseSchemaFields(config?.dbSchema)}
         />
       </div>
       <div className="space-y-2">

--- a/components/workflow/config/schema-builder.tsx
+++ b/components/workflow/config/schema-builder.tsx
@@ -14,16 +14,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { type SchemaField, toSchemaFields } from "@/lib/schema-fields";
 
-export type SchemaField = {
-  id?: string;
-  name: string;
-  type: "string" | "number" | "boolean" | "array" | "object";
-  itemType?: "string" | "number" | "boolean" | "object";
-  fields?: SchemaField[];
-  description?: string;
-  required?: boolean;
-};
+export type { SchemaField };
 
 type SchemaBuilderProps = {
   schema: SchemaField[];
@@ -198,7 +191,7 @@ export function SchemaBuilder({
                   disabled={disabled}
                   level={level + 1}
                   onChange={(fields) => updateNestedFields(index, fields)}
-                  schema={field.fields || []}
+                  schema={toSchemaFields(field.fields)}
                 />
               </div>
             )}
@@ -210,7 +203,7 @@ export function SchemaBuilder({
                   disabled={disabled}
                   level={level + 1}
                   onChange={(fields) => updateNestedFields(index, fields)}
-                  schema={field.fields || []}
+                  schema={toSchemaFields(field.fields)}
                 />
               </div>
             )}

--- a/components/workflow/config/trigger-config.tsx
+++ b/components/workflow/config/trigger-config.tsx
@@ -26,10 +26,11 @@ import {
 } from "@/components/ui/select";
 import { TimezoneSelect } from "@/components/ui/timezone-select";
 import { parseIntervalSeconds } from "@/lib/cron-utils";
+import { parseSchemaFields } from "@/lib/schema-fields";
 import type { ActionConfigField } from "@/plugins/registry";
 import { ActionConfigRenderer } from "./action-config-renderer";
 import { CronScheduleBuilder } from "./cron-schedule-builder";
-import { SchemaBuilder, type SchemaField } from "./schema-builder";
+import { SchemaBuilder } from "./schema-builder";
 
 type TriggerConfigProps = {
   config: Record<string, unknown>;
@@ -150,18 +151,7 @@ export function TriggerConfig({
               onChange={(schema) =>
                 onUpdateConfig("webhookSchema", JSON.stringify(schema))
               }
-              schema={(() => {
-                if (!config?.webhookSchema) {
-                  return [];
-                }
-                try {
-                  return JSON.parse(
-                    config.webhookSchema as string
-                  ) as SchemaField[];
-                } catch {
-                  return [];
-                }
-              })()}
+              schema={parseSchemaFields(config?.webhookSchema)}
             />
             <p className="text-muted-foreground text-xs">
               Define the expected structure of the incoming webhook payload.

--- a/lib/schema-fields.ts
+++ b/lib/schema-fields.ts
@@ -1,0 +1,31 @@
+/**
+ * Schema definitions edited by the SchemaBuilder are persisted as JSON strings
+ * in node config, so a stored value can be any JSON shape by the time it is
+ * read back. These helpers narrow it to the array the builder renders.
+ */
+
+export type SchemaField = {
+  id?: string;
+  name: string;
+  type: "string" | "number" | "boolean" | "array" | "object";
+  itemType?: "string" | "number" | "boolean" | "object";
+  fields?: SchemaField[];
+  description?: string;
+  required?: boolean;
+};
+
+export function toSchemaFields(value: unknown): SchemaField[] {
+  return Array.isArray(value) ? (value as SchemaField[]) : [];
+}
+
+export function parseSchemaFields(raw: unknown): SchemaField[] {
+  if (typeof raw !== "string") {
+    return toSchemaFields(raw);
+  }
+
+  try {
+    return toSchemaFields(JSON.parse(raw));
+  } catch {
+    return [];
+  }
+}

--- a/tests/unit/schema-fields.test.ts
+++ b/tests/unit/schema-fields.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSchemaFields, toSchemaFields } from "@/lib/schema-fields";
+
+describe("parseSchemaFields", () => {
+  it("parses a stored array of fields", () => {
+    const raw = JSON.stringify([
+      { name: "amount", type: "number" },
+      { name: "token", type: "string" },
+    ]);
+
+    expect(parseSchemaFields(raw)).toEqual([
+      { name: "amount", type: "number" },
+      { name: "token", type: "string" },
+    ]);
+  });
+
+  it("returns an empty array when the stored JSON is an object", () => {
+    expect(parseSchemaFields('{"amount":"number"}')).toEqual([]);
+  });
+
+  it("returns an empty array for other non-array JSON values", () => {
+    expect(parseSchemaFields('"amount"')).toEqual([]);
+    expect(parseSchemaFields("42")).toEqual([]);
+    expect(parseSchemaFields("null")).toEqual([]);
+    expect(parseSchemaFields("true")).toEqual([]);
+  });
+
+  it("returns an empty array for malformed JSON", () => {
+    expect(parseSchemaFields("{not json")).toEqual([]);
+  });
+
+  it("returns an empty array for empty and missing values", () => {
+    expect(parseSchemaFields("")).toEqual([]);
+    expect(parseSchemaFields(undefined)).toEqual([]);
+    expect(parseSchemaFields(null)).toEqual([]);
+  });
+
+  it("accepts an already-parsed array without re-parsing", () => {
+    const fields = [{ name: "amount", type: "number" }];
+
+    expect(parseSchemaFields(fields)).toEqual(fields);
+  });
+});
+
+describe("toSchemaFields", () => {
+  it("passes arrays through and replaces everything else with an empty array", () => {
+    const nested = [{ name: "inner", type: "string" }];
+
+    expect(toSchemaFields(nested)).toBe(nested);
+    expect(toSchemaFields({ inner: "string" })).toEqual([]);
+    expect(toSchemaFields(undefined)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

`SchemaBuilder` maps its `schema` prop directly, and every call site handed it an
unguarded parse result. These schemas live in node config as JSON strings, so any
non-array shape that gets written is read back and thrown on:

| call site | guard before |
|---|---|
| `SchemaBuilderField` (`action-config-renderer.tsx`) | none, `JSON.parse` uncaught |
| `dbSchema` (`action-config.tsx`) | none, `JSON.parse` uncaught |
| `webhookSchema` (`trigger-config.tsx`) | `try/catch`, but no array check, so a stored object parses cleanly and then throws on `.map` |

Sentry `KEEPERHUB-PRODUCTION-3K`, 5 events on `/workflows/:workflowId`. The minified
frame is the `schema.map((field, index) => ...)` in `schema-builder.tsx`.

The nested recursion has the same defect one level down: `field.fields || []` passes a
stored object straight through to the child `SchemaBuilder`.

## Changes

- `lib/schema-fields.ts` owns the `SchemaField` type plus `parseSchemaFields` (stored
  JSON string) and `toSchemaFields` (already-parsed value). Both yield an empty list
  unless the value is really an array. `schema-builder.tsx` re-exports the type, so no
  existing importer changes.
- All three call sites parse through the helper, replacing the hand-rolled try/catch
  IIFE in `trigger-config.tsx`.
- The two nested-field sites use `toSchemaFields` instead of `|| []`.
- `tests/unit/schema-fields.test.ts` covers object, scalar, null, malformed, empty and
  already-parsed inputs.

## Verification

`pnpm check` 0 errors, `pnpm type-check` clean, unit suite 493 files / 20393 tests green.
