### PR TITLE
fix: report a malformed ABI instead of crashing the argument renderer

### DIFF
--- a/components/workflow/config/action-config-renderer.tsx
+++ b/components/workflow/config/action-config-renderer.tsx
@@ -26,9 +26,14 @@ import { TemplateBadgeTextarea } from "@/components/ui/template-badge-textarea";
 import { SaveAddressBookmark } from "@/components/address-book/save-address-bookmark";
 import type { AbiComponent } from "@/components/workflow/config/abi-types";
 import { ArrayInputField } from "@/components/workflow/config/array-input-field";
+import { MalformedAbiArgsNotice } from "@/components/workflow/config/malformed-abi-notice";
 import { TupleInputField } from "@/components/workflow/config/tuple-input-field";
+import {
+  isValidAbiInput,
+  resolveFunctionInputs,
+} from "@/lib/abi/function-inputs";
 import { parseAbiFunctionArgs } from "@/lib/abi/parse-args";
-import { computeSelector, findAbiFunction } from "@/lib/abi/utils";
+import { computeSelector } from "@/lib/abi/utils";
 import { evaluateShowWhen } from "@/lib/workflow/editor/show-when";
 import { parseAddressBookSelection } from "@/lib/address-book-selection";
 import { toChecksumAddress } from "@/lib/address-utils";
@@ -498,15 +503,19 @@ export function AbiFunctionSelectField({
       }
 
       return filtered.map((func) => {
-        const inputs = func.inputs || [];
+        const inputs = Array.isArray(func.inputs) ? func.inputs : [];
+        // A parameter with no type cannot be encoded, so the function is still
+        // listed (selecting it explains the problem) but gets no selector.
+        const complete = inputs.every(isValidAbiInput);
+        const inputTypes = inputs.map((input: { type?: unknown }) =>
+          typeof input?.type === "string" ? input.type : "?"
+        );
         const params = inputs
-          .map(
-            (input: { name: string; type: string }) =>
-              `${input.type} ${input.name}`
+          .map((input: { name?: unknown }, index: number) =>
+            `${inputTypes[index]} ${typeof input?.name === "string" ? input.name : ""}`.trim()
           )
           .join(", ");
-        const inputTypes = inputs.map((input: { type: string }) => input.type);
-        const selector = computeSelector(func.name, inputs);
+        const selector = complete ? computeSelector(func.name, inputs) : null;
         const isOverloaded = (nameCounts.get(func.name) ?? 0) > 1;
         const key = isOverloaded
           ? `${func.name}(${inputTypes.join(",")})`
@@ -544,9 +553,11 @@ export function AbiFunctionSelectField({
             <div className="flex flex-col items-start">
               <span>
                 {func.label}{" "}
-                <code className="text-muted-foreground text-xs">
-                  ({func.selector})
-                </code>
+                {func.selector && (
+                  <code className="text-muted-foreground text-xs">
+                    ({func.selector})
+                  </code>
+                )}
               </span>
               <span className="text-muted-foreground text-xs">
                 {func.stateMutability}
@@ -573,36 +584,10 @@ export function AbiFunctionArgsField({
   functionValue,
 }: AbiFunctionArgsProps) {
   // Parse the function inputs from the ABI
-  const functionInputs = React.useMemo(() => {
-    if (
-      !(abiValue && functionValue) ||
-      abiValue.trim() === "" ||
-      functionValue.trim() === ""
-    ) {
-      return [];
-    }
-
-    try {
-      const abi = JSON.parse(abiValue);
-      if (!Array.isArray(abi)) {
-        return [];
-      }
-
-      const func = findAbiFunction(abi, functionValue);
-
-      if (!func?.inputs) {
-        return [];
-      }
-
-      return func.inputs.map((input) => ({
-        name: input.name || "unnamed",
-        type: input.type,
-        components: input.components,
-      }));
-    } catch {
-      return [];
-    }
-  }, [abiValue, functionValue]);
+  const { inputs: functionInputs, malformed } = React.useMemo(
+    () => resolveFunctionInputs(abiValue, functionValue),
+    [abiValue, functionValue]
+  );
 
   // Use local state to manage arg values - this prevents race conditions on blur
   const [localArgValues, setLocalArgValues] = React.useState<unknown[]>(() =>
@@ -634,6 +619,10 @@ export function AbiFunctionArgsField({
     // Propagate to parent (outside of setState to avoid render-phase updates)
     onChange(JSON.stringify(newArgs));
   };
+
+  if (malformed) {
+    return <MalformedAbiArgsNotice />;
+  }
 
   if (functionInputs.length === 0) {
     return (

--- a/components/workflow/config/args-list-field.tsx
+++ b/components/workflow/config/args-list-field.tsx
@@ -4,18 +4,15 @@ import { Plus, Trash2 } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { TemplateBadgeInput } from "@/components/ui/template-badge-input";
-import type { AbiComponent } from "@/components/workflow/config/abi-types";
 import { ArrayInputField } from "@/components/workflow/config/array-input-field";
+import { MalformedAbiArgsNotice } from "@/components/workflow/config/malformed-abi-notice";
 import { TupleInputField } from "@/components/workflow/config/tuple-input-field";
 import { coerceAbiArgValue } from "@/lib/abi/parse-args";
-import { findAbiFunction } from "@/lib/abi/utils";
+import {
+  type AbiFunctionInput,
+  resolveFunctionInputs,
+} from "@/lib/abi/function-inputs";
 import type { ActionConfigFieldBase } from "@/plugins/registry";
-
-type FunctionInput = {
-  name: string;
-  type: string;
-  components?: AbiComponent[];
-};
 
 type ArgSetEntry = {
   id: number;
@@ -25,31 +22,8 @@ type ArgSetEntry = {
 export function parseFunctionInputs(
   abiValue: string,
   functionValue: string
-): FunctionInput[] {
-  if (!(abiValue && functionValue && abiValue.trim() && functionValue.trim())) {
-    return [];
-  }
-
-  try {
-    const abi: unknown = JSON.parse(abiValue);
-    if (!Array.isArray(abi)) {
-      return [];
-    }
-
-    const func = findAbiFunction(abi, functionValue);
-
-    if (!(func?.inputs && Array.isArray(func.inputs))) {
-      return [];
-    }
-
-    return func.inputs.map((input) => ({
-      name: input.name || "unnamed",
-      type: input.type,
-      components: input.components,
-    }));
-  } catch {
-    return [];
-  }
+): AbiFunctionInput[] {
+  return resolveFunctionInputs(abiValue, functionValue).inputs;
 }
 
 export function parseArgsListValue(
@@ -120,8 +94,8 @@ export function ArgsListField({
     return idCounter.current;
   };
 
-  const functionInputs = useMemo(
-    () => parseFunctionInputs(abiValue, functionValue),
+  const { inputs: functionInputs, malformed } = useMemo(
+    () => resolveFunctionInputs(abiValue, functionValue),
     [abiValue, functionValue]
   );
 
@@ -175,6 +149,10 @@ export function ArgsListField({
       return { ...entry, values: newValues };
     });
     updateEntries(updated);
+  }
+
+  if (malformed) {
+    return <MalformedAbiArgsNotice />;
   }
 
   if (paramCount === 0) {

--- a/components/workflow/config/malformed-abi-notice.tsx
+++ b/components/workflow/config/malformed-abi-notice.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+/**
+ * Shown instead of an argument list when the ABI cannot describe the selected
+ * function's parameters. Rendering a partial list would let the user submit an
+ * incomplete contract call, so no fields are offered until the ABI is fixed.
+ */
+export function MalformedAbiArgsNotice(): React.ReactNode {
+  return (
+    <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-destructive text-sm">
+      The parameters for this function could not be read from the ABI. Check
+      that the ABI above is valid JSON and that every parameter has a type.
+    </div>
+  );
+}

--- a/lib/abi/function-inputs.ts
+++ b/lib/abi/function-inputs.ts
@@ -1,0 +1,89 @@
+import { type AbiItemComponent, findAbiFunction } from "@/lib/abi/utils";
+
+export type AbiFunctionInput = {
+  name: string;
+  type: string;
+  components?: AbiItemComponent[];
+};
+
+/**
+ * The ABI is user-pasted JSON, so `type` is only a compile-time guarantee.
+ * An input without one cannot be rendered or encoded, and tuple components
+ * are checked the same way because they drive their own input renderers.
+ */
+export function isValidAbiInput(input: unknown): boolean {
+  if (!input || typeof input !== "object") {
+    return false;
+  }
+
+  const { type, components } = input as {
+    type?: unknown;
+    components?: unknown;
+  };
+
+  if (typeof type !== "string" || type === "") {
+    return false;
+  }
+
+  if (components === undefined) {
+    return true;
+  }
+
+  return Array.isArray(components) && components.every(isValidAbiInput);
+}
+
+export type ResolvedFunctionInputs = {
+  inputs: AbiFunctionInput[];
+  /**
+   * The ABI could not be read well enough to render a complete argument list.
+   * Callers must surface this rather than rendering `inputs`, which is empty
+   * here: a short list would encode an incomplete call.
+   */
+  malformed: boolean;
+};
+
+const EMPTY: ResolvedFunctionInputs = { inputs: [], malformed: false };
+const MALFORMED: ResolvedFunctionInputs = { inputs: [], malformed: true };
+
+export function resolveFunctionInputs(
+  abiValue: string | undefined | null,
+  functionValue: string | undefined | null
+): ResolvedFunctionInputs {
+  if (!(abiValue?.trim() && functionValue?.trim())) {
+    return EMPTY;
+  }
+
+  let abi: unknown;
+  try {
+    abi = JSON.parse(abiValue);
+  } catch {
+    return MALFORMED;
+  }
+
+  if (!Array.isArray(abi)) {
+    return MALFORMED;
+  }
+
+  const func = findAbiFunction(abi, functionValue);
+  if (!func) {
+    return EMPTY;
+  }
+
+  const inputs = func.inputs;
+  if (!Array.isArray(inputs)) {
+    return inputs === undefined ? EMPTY : MALFORMED;
+  }
+
+  if (!inputs.every(isValidAbiInput)) {
+    return MALFORMED;
+  }
+
+  return {
+    inputs: inputs.map((input) => ({
+      name: input.name || "unnamed",
+      type: input.type,
+      components: input.components,
+    })),
+    malformed: false,
+  };
+}

--- a/lib/abi/utils.ts
+++ b/lib/abi/utils.ts
@@ -19,6 +19,11 @@ type AbiInput = {
  * and a tuple[] becomes "(uint32,bytes32)[]"
  */
 function canonicalType(input: AbiInput): string {
+  // The ABI is user-supplied, so `type` can be absent at runtime. Fail loudly
+  // rather than fabricating a signature that would encode the wrong call.
+  if (typeof input?.type !== "string") {
+    throw new Error("ABI input is missing a type");
+  }
   if (!(input.type.startsWith("tuple") && input.components)) {
     return input.type;
   }
@@ -90,7 +95,8 @@ export function findAbiFunction(
     if (item == null || item.type !== "function" || item.name !== name) {
       return false;
     }
-    const inputTypes = (item.inputs ?? []).map((i) => i.type);
+    const rawInputs = Array.isArray(item.inputs) ? item.inputs : [];
+    const inputTypes = rawInputs.map((i) => i?.type);
     if (inputTypes.length !== targetTypes.length) {
       return false;
     }

--- a/tests/unit/abi-function-inputs.test.ts
+++ b/tests/unit/abi-function-inputs.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isValidAbiInput,
+  resolveFunctionInputs,
+} from "@/lib/abi/function-inputs";
+
+const TRANSFER_ABI = JSON.stringify([
+  {
+    name: "transfer",
+    type: "function",
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+  },
+]);
+
+const MISSING_TYPE_ABI = JSON.stringify([
+  {
+    name: "transfer",
+    type: "function",
+    inputs: [{ name: "to", type: "address" }, { name: "amount" }],
+  },
+]);
+
+const MISSING_TUPLE_COMPONENT_TYPE_ABI = JSON.stringify([
+  {
+    name: "execute",
+    type: "function",
+    inputs: [
+      {
+        name: "call",
+        type: "tuple",
+        components: [{ name: "target", type: "address" }, { name: "data" }],
+      },
+    ],
+  },
+]);
+
+const NO_PARAMS_ABI = JSON.stringify([
+  { name: "totalSupply", type: "function", inputs: [] },
+]);
+
+describe("resolveFunctionInputs", () => {
+  it("returns the inputs of a well-formed function", () => {
+    expect(resolveFunctionInputs(TRANSFER_ABI, "transfer")).toEqual({
+      inputs: [
+        { name: "to", type: "address", components: undefined },
+        { name: "amount", type: "uint256", components: undefined },
+      ],
+      malformed: false,
+    });
+  });
+
+  it("reports malformed and withholds every input when one has no type", () => {
+    const result = resolveFunctionInputs(MISSING_TYPE_ABI, "transfer");
+
+    expect(result.malformed).toBe(true);
+    expect(result.inputs).toEqual([]);
+  });
+
+  it("reports malformed when a tuple component has no type", () => {
+    const result = resolveFunctionInputs(
+      MISSING_TUPLE_COMPONENT_TYPE_ABI,
+      "execute"
+    );
+
+    expect(result.malformed).toBe(true);
+    expect(result.inputs).toEqual([]);
+  });
+
+  it("reports malformed for unparseable and non-array ABIs", () => {
+    expect(resolveFunctionInputs("not json", "transfer").malformed).toBe(true);
+    expect(
+      resolveFunctionInputs('{"not":"an array"}', "transfer").malformed
+    ).toBe(true);
+  });
+
+  it("is not malformed when nothing has been selected yet", () => {
+    expect(resolveFunctionInputs("", "transfer")).toEqual({
+      inputs: [],
+      malformed: false,
+    });
+    expect(resolveFunctionInputs(TRANSFER_ABI, "")).toEqual({
+      inputs: [],
+      malformed: false,
+    });
+  });
+
+  it("is not malformed when the function is absent or takes no parameters", () => {
+    expect(resolveFunctionInputs(TRANSFER_ABI, "missing")).toEqual({
+      inputs: [],
+      malformed: false,
+    });
+    expect(resolveFunctionInputs(NO_PARAMS_ABI, "totalSupply")).toEqual({
+      inputs: [],
+      malformed: false,
+    });
+  });
+
+  it("defaults unnamed parameters to 'unnamed'", () => {
+    const abi = JSON.stringify([
+      {
+        name: "test",
+        type: "function",
+        inputs: [{ name: "", type: "uint256" }],
+      },
+    ]);
+
+    expect(resolveFunctionInputs(abi, "test").inputs).toEqual([
+      { name: "unnamed", type: "uint256", components: undefined },
+    ]);
+  });
+});
+
+describe("isValidAbiInput", () => {
+  it("accepts inputs with a non-empty string type", () => {
+    expect(isValidAbiInput({ name: "to", type: "address" })).toBe(true);
+  });
+
+  it("rejects missing, empty and non-string types", () => {
+    expect(isValidAbiInput({ name: "to" })).toBe(false);
+    expect(isValidAbiInput({ name: "to", type: "" })).toBe(false);
+    expect(isValidAbiInput({ name: "to", type: 1 })).toBe(false);
+    expect(isValidAbiInput(null)).toBe(false);
+    expect(isValidAbiInput("address")).toBe(false);
+  });
+
+  it("recurses into tuple components", () => {
+    expect(
+      isValidAbiInput({
+        type: "tuple",
+        components: [{ type: "address" }],
+      })
+    ).toBe(true);
+    expect(
+      isValidAbiInput({
+        type: "tuple",
+        components: [{ name: "data" }],
+      })
+    ).toBe(false);
+    expect(isValidAbiInput({ type: "tuple", components: {} })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

The ABI is user-pasted JSON and the only runtime check is `Array.isArray`, after which
it is treated as `AbiItem[]`. `input.type` is declared `string` but can be absent, and
consumers call string methods on it:

- `args-list-field.tsx`, `input.type.endsWith("[]")`
- `action-config-renderer.tsx`, the same expression in `AbiFunctionArgsField`
- `tuple-input-field.tsx`, `comp.type.startsWith("uint")` for tuple components
- `lib/abi/utils.ts`, `canonicalType` calls `input.type.startsWith`

Sentry `KEEPERHUB-PRODUCTION-3N` on `/workflows/:workflowId`, caught by the error
boundary. The minified frame is the argument map in `AbiFunctionArgsField`.

Filtering the bad input out is not an option: a short argument list renders fewer fields
than the function takes and would encode an incomplete contract call, which is worse
than a crash the boundary already contains.

## Changes

- `lib/abi/function-inputs.ts` resolves a function's inputs to `{ inputs, malformed }`.
  Validation recurses into tuple components, since those drive their own renderers. When
  malformed, `inputs` is empty and callers must surface that state rather than render.
- Both argument renderers (`ArgsListField`, `AbiFunctionArgsField`) show
  `MalformedAbiArgsNotice`. The existing empty state says "This function has no
  parameters", which would be untrue here, so this case gets its own copy.
- `parseFunctionInputs` keeps its signature and delegates to the resolver.

Two related conditions on the same data, misleading rather than crashing:

- One input without a type made `computeSelector` throw inside the function-select memo,
  and the `catch` returned `[]`. A single bad entry anywhere in the ABI emptied the whole
  dropdown to "No functions found in ABI". Functions with unencodable parameters are now
  listed without a signature, so the user can select one and read the explanation.
- `canonicalType` threw a bare `TypeError` from deep inside. It now throws a named error
  instead, rather than fabricating a type and producing a selector for the wrong call.

## Verification

`pnpm check` 0 errors, `pnpm type-check` clean, unit suite 493 files / 20396 tests green.
New `tests/unit/abi-function-inputs.test.ts` covers a missing input type, a missing tuple
component type, unparseable and non-array ABIs, and the not-yet-selected cases. The
existing `args-list-field` and `abi-utils` suites pass unchanged.
