### PR TITLE
feat(analytics): split wallet and sponsored gas on the Gas Spent KPI

### DIFF
--- a/components/analytics/kpi-cards.tsx
+++ b/components/analytics/kpi-cards.tsx
@@ -18,8 +18,10 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import type { TimeRange } from "@/lib/analytics/types";
 import {
   analyticsLoadingAtom,
+  analyticsRangeAtom,
   analyticsSummaryAtom,
 } from "@/lib/atoms/analytics";
 import { cn } from "@/lib/utils";
@@ -48,6 +50,17 @@ function formatGasAsEth(weiString: string): string {
   return `${eth.toFixed(4)} ETH`;
 }
 
+// Wallet-paid and sponsored gas are tracked in separate ledgers, so the headline
+// figure is their sum. BigInt keeps the addition exact before the lossy
+// Number() conversion that formatting needs.
+function addWeiStrings(a: string, b: string): string {
+  try {
+    return (BigInt(a) + BigInt(b)).toString();
+  } catch {
+    return a;
+  }
+}
+
 function computeDelta(current: number, previous: number): number | null {
   if (previous === 0) {
     return current > 0 ? 100 : null;
@@ -58,11 +71,13 @@ function computeDelta(current: number, previous: number): number | null {
 type DeltaDisplayProps = {
   delta: number | null;
   invertColor?: boolean;
+  tooltip?: string;
 };
 
 function DeltaDisplay({
   delta,
   invertColor = false,
+  tooltip,
 }: DeltaDisplayProps): ReactNode {
   if (delta === null) {
     return null;
@@ -70,15 +85,12 @@ function DeltaDisplay({
 
   const isPositive = delta > 0;
   const isNeutral = delta === 0;
-
-  if (isNeutral) {
-    return <span className="text-xs text-muted-foreground">0%</span>;
-  }
-
   const isGood = invertColor ? !isPositive : isPositive;
   const Icon = isPositive ? ArrowUp : ArrowDown;
 
-  return (
+  const content = isNeutral ? (
+    <span className="text-xs font-medium">0%</span>
+  ) : (
     <span
       className={cn(
         "flex items-center gap-0.5 text-xs font-medium",
@@ -91,7 +103,37 @@ function DeltaDisplay({
       {Math.abs(delta).toFixed(2)}%
     </span>
   );
+
+  if (!tooltip) {
+    return content;
+  }
+
+  return (
+    <span className="flex items-center gap-1">
+      {content}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            aria-label="About this percentage"
+            className="inline-flex items-center text-muted-foreground/70 transition-colors hover:text-foreground"
+            type="button"
+          >
+            <Info className="size-3" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-xs">{tooltip}</TooltipContent>
+      </Tooltip>
+    </span>
+  );
 }
+
+const COMPARISON_LABELS: Record<TimeRange, string> = {
+  "1h": "the previous hour",
+  "24h": "the previous 24 hours",
+  "7d": "the previous 7 days",
+  "30d": "the previous 30 days",
+  custom: "the preceding period of equal length",
+};
 
 function SkeletonCard(): ReactNode {
   return (
@@ -109,62 +151,96 @@ function SkeletonCard(): ReactNode {
   );
 }
 
+type KpiBreakdownLine = {
+  key: string;
+  text: string;
+  highlighted?: boolean;
+};
+
 type KpiCardProps = {
+  cardKey: string;
   icon: ReactNode;
   label: string;
   value: string;
   delta: number | null;
+  deltaTooltip?: string;
   invertDeltaColor?: boolean;
   iconClassName?: string;
-  secondaryValue?: string;
-  secondaryTooltip?: string;
+  breakdown?: readonly KpiBreakdownLine[];
+  tooltip?: string;
 };
 
 function KpiCard({
+  cardKey,
   icon,
   label,
   value,
   delta,
+  deltaTooltip,
   invertDeltaColor = false,
   iconClassName,
-  secondaryValue,
-  secondaryTooltip,
+  breakdown,
+  tooltip,
 }: KpiCardProps): ReactNode {
   return (
-    <Card>
+    <Card data-kpi={cardKey} data-testid="kpi-card">
       <CardContent className="pt-0">
-        <div className="flex items-start justify-between">
-          <div className="space-y-1">
-            <p className="text-sm text-muted-foreground">{label}</p>
-            <p className="text-2xl font-bold tracking-tight">{value}</p>
-            {secondaryValue ? (
-              <div className="flex items-center gap-1">
-                <span className="font-medium text-green-600 text-xs dark:text-green-400">
-                  {secondaryValue}
-                </span>
-                {secondaryTooltip ? (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        aria-label="About sponsored gas"
-                        className="inline-flex items-center text-muted-foreground/70 transition-colors hover:text-foreground"
-                        type="button"
-                      >
-                        <Info className="size-3" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent className="max-w-xs">
-                      {secondaryTooltip}
-                    </TooltipContent>
-                  </Tooltip>
-                ) : null}
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 space-y-1">
+            <div className="flex items-center gap-1">
+              <p className="text-sm text-muted-foreground">{label}</p>
+              {tooltip ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      aria-label={`About ${label}`}
+                      className="inline-flex items-center text-muted-foreground/70 transition-colors hover:text-foreground"
+                      type="button"
+                    >
+                      <Info className="size-3" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs">
+                    {tooltip}
+                  </TooltipContent>
+                </Tooltip>
+              ) : null}
+            </div>
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+              <p
+                className="whitespace-nowrap font-bold text-2xl tracking-tight xl:text-xl"
+                data-testid="kpi-value"
+              >
+                {value}
+              </p>
+              <DeltaDisplay
+                delta={delta}
+                invertColor={invertDeltaColor}
+                tooltip={deltaTooltip}
+              />
+            </div>
+            {breakdown && breakdown.length > 0 ? (
+              <div className="space-y-0.5">
+                {breakdown.map((line) => (
+                  <p
+                    className={cn(
+                      "text-xs font-medium",
+                      line.highlighted
+                        ? "text-green-600 dark:text-green-400"
+                        : "text-foreground"
+                    )}
+                    data-kpi-line={line.key}
+                    key={line.key}
+                  >
+                    {line.text}
+                  </p>
+                ))}
               </div>
             ) : null}
-            <DeltaDisplay delta={delta} invertColor={invertDeltaColor} />
           </div>
           <div
             className={cn(
-              "flex size-10 items-center justify-center rounded-lg",
+              "flex size-10 shrink-0 items-center justify-center rounded-lg",
               iconClassName ?? "bg-primary/10 text-primary"
             )}
           >
@@ -179,11 +255,16 @@ function KpiCard({
 export function KpiCards(): ReactNode {
   const summary = useAtomValue(analyticsSummaryAtom);
   const loading = useAtomValue(analyticsLoadingAtom);
+  const range = useAtomValue(analyticsRangeAtom);
 
   const cards = useMemo(() => {
     if (!summary) {
       return null;
     }
+
+    const versus = COMPARISON_LABELS[range];
+    const deltaTooltip = (metric: string): string =>
+      `Change in ${metric} compared with ${versus}.`;
 
     const prev = summary.previousPeriod;
 
@@ -205,9 +286,18 @@ export function KpiCards(): ReactNode {
         ? computeDelta(summary.avgDurationMs, prev.avgDurationMs)
         : null;
 
+    const walletGasWei = summary.totalGasWei;
+    const sponsoredGasWei = summary.sponsoredGasWei;
+    const totalGasWei = addWeiStrings(walletGasWei, sponsoredGasWei);
+
     const gasDelta = prev
-      ? computeDelta(Number(summary.totalGasWei), Number(prev.totalGasWei))
+      ? computeDelta(
+          Number(totalGasWei),
+          Number(addWeiStrings(prev.totalGasWei, prev.sponsoredGasWei))
+        )
       : null;
+
+    const hasSponsoredGas = sponsoredGasWei !== "0" && sponsoredGasWei !== "";
 
     return [
       {
@@ -216,6 +306,7 @@ export function KpiCards(): ReactNode {
         label: "Total Runs",
         value: summary.totalRuns.toLocaleString(),
         delta: totalRunsDelta,
+        deltaTooltip: deltaTooltip("total runs"),
         invertDeltaColor: false,
         iconClassName: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
       },
@@ -225,6 +316,7 @@ export function KpiCards(): ReactNode {
         label: "Success Rate",
         value: `${(summary.successRate * 100).toFixed(2)}%`,
         delta: successRateDelta,
+        deltaTooltip: deltaTooltip("success rate"),
         invertDeltaColor: false,
         iconClassName: "bg-green-500/10 text-green-600 dark:text-green-400",
       },
@@ -234,6 +326,7 @@ export function KpiCards(): ReactNode {
         label: "Avg Duration",
         value: formatDuration(summary.avgDurationMs),
         delta: durationDelta,
+        deltaTooltip: deltaTooltip("average run duration"),
         invertDeltaColor: true,
         iconClassName: "bg-orange-500/10 text-orange-600 dark:text-orange-400",
       },
@@ -241,26 +334,37 @@ export function KpiCards(): ReactNode {
         key: "gas-spent",
         icon: <Fuel className="size-5" />,
         label: "Gas Spent",
-        value: formatGasAsEth(summary.totalGasWei),
+        value: formatGasAsEth(totalGasWei),
         delta: gasDelta,
+        deltaTooltip: deltaTooltip("total gas spent"),
         invertDeltaColor: true,
         iconClassName: "bg-purple-500/10 text-purple-600 dark:text-purple-400",
-        secondaryValue:
-          summary.sponsoredGasWei && summary.sponsoredGasWei !== "0"
-            ? `${formatGasAsEth(summary.sponsoredGasWei)} sponsored`
-            : undefined,
-        secondaryTooltip:
-          "The portion of gas KeeperHub sponsored on your behalf on supported networks this period.",
+        breakdown: hasSponsoredGas
+          ? ([
+              {
+                key: "wallet",
+                text: `${formatGasAsEth(walletGasWei)} from wallet`,
+              },
+              {
+                key: "sponsored",
+                text: `${formatGasAsEth(sponsoredGasWei)} sponsored`,
+                highlighted: true,
+              },
+            ] as const)
+          : undefined,
+        tooltip: hasSponsoredGas
+          ? "Total gas your automations spent on-chain this period, split by who paid. 'From wallet' comes out of your wallet balance. 'Sponsored' is covered by KeeperHub on supported networks."
+          : "Total gas your automations spent on-chain this period, paid from your wallet balance.",
       },
     ] as const;
-  }, [summary]);
+  }, [summary, range]);
 
   const isReady = !(loading && !summary);
 
   if (loading && !summary) {
     return (
       <div
-        className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4"
+        className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4"
         data-ready={String(isReady)}
         data-testid="kpi-cards"
       >
@@ -278,24 +382,22 @@ export function KpiCards(): ReactNode {
 
   return (
     <div
-      className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4"
+      className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4"
       data-ready={String(isReady)}
       data-testid="kpi-cards"
     >
       {cards.map((card) => (
         <KpiCard
+          breakdown={"breakdown" in card ? card.breakdown : undefined}
+          cardKey={card.key}
           delta={card.delta}
+          deltaTooltip={card.deltaTooltip}
           icon={card.icon}
           iconClassName={card.iconClassName}
           invertDeltaColor={card.invertDeltaColor}
           key={card.key}
           label={card.label}
-          secondaryTooltip={
-            "secondaryTooltip" in card ? card.secondaryTooltip : undefined
-          }
-          secondaryValue={
-            "secondaryValue" in card ? card.secondaryValue : undefined
-          }
+          tooltip={"tooltip" in card ? card.tooltip : undefined}
           value={card.value}
         />
       ))}

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -75,8 +75,13 @@ export type AnalyticsSummary = {
   cancelledCount: number;
   successRate: number;
   avgDurationMs: number | null;
+  /** Gas paid by the org's own wallet over the range, in wei. */
   totalGasWei: string;
-  /** Subset of gas paid by KeeperHub sponsorship over the range, in wei. */
+  /**
+   * Gas paid by KeeperHub sponsorship over the range, in wei, read from the
+   * gas-credit ledger. Disjoint from `totalGasWei`, so the headline figure the
+   * Gas Spent KPI renders is the two added together.
+   */
   sponsoredGasWei: string;
   activeRuns: number;
   previousPeriod: {

--- a/tests/e2e/playwright/analytics-gas.test.ts
+++ b/tests/e2e/playwright/analytics-gas.test.ts
@@ -30,12 +30,11 @@ test.describe("Analytics Gas Tracking", () => {
       { timeout: 15_000 }
     );
 
-    // Find the Gas Spent KPI card
-    const gasLabel = page.locator('p.text-sm:has-text("Gas Spent")');
-    await expect(gasLabel).toBeVisible({ timeout: 10_000 });
+    // Headline value is wallet-paid plus sponsored gas for the range
+    const gasCard = page.locator('[data-kpi="gas-spent"]');
+    await expect(gasCard).toBeVisible({ timeout: 10_000 });
 
-    // The value is the sibling <p> with text-2xl
-    const gasValue = gasLabel.locator("..").locator("p.text-2xl");
+    const gasValue = gasCard.getByTestId("kpi-value");
     await expect(gasValue).toBeVisible();
     await expect(gasValue).not.toHaveText("0 ETH", { timeout: 10_000 });
   });


### PR DESCRIPTION
## What

The Gas Spent card showed only wallet-paid gas as its headline, with sponsored gas as a secondary line beneath it. The percentage compared the headline against the previous period, but nothing on the card said so, so the two amounts read as though the percentage related them.

- Headline is now wallet plus sponsored, with both amounts broken out below it
- The delta compares total against total, so it applies to the number beside it
- Each card gains an info icon naming the comparison window for its percentage
- The gas card gains an info icon explaining which side paid for which amount
- Value and delta share one line on every card so the percentages align across the row

## Layout

At four across, the longest value wrapped mid-number. The grid now goes four across at `xl` instead of `lg`, and the headline steps down one size there. Between 1024 and 1279 it is a 2x2 grid. Checked at 1440, 1024, 768 and 390 with no horizontal overflow.

## On the two figures

Wallet-paid gas comes from the execution rows, sponsored gas from the gas-credit ledger. They are separate ledgers, so the headline adds them. The `AnalyticsSummary` doc comment previously described sponsored gas as a subset of the total, which would make that addition a double count; it now describes the actual relationship.

Sponsored runs do write into the wallet-paid column today, but in gas units rather than wei, so their contribution is around 1e-10 ETH and rounds away at four decimals. That is tracked separately and should be resolved before anyone changes what the sponsored path stores, since fixing it without also subtracting sponsored from the wallet figure would make this card double count.

## Tests

`analytics-gas.test.ts` anchored the value via `gasLabel.locator("..")`, which the markup change broke. Cards now expose `data-kpi` and `data-testid="kpi-value"` and the test uses those. Full unit suite passes, lint and type-check clean.