### PR TITLE
feat(template): AgentGuard pause-protected vault starter for Agents Onchain

### DIFF
--- a/docs/getting-started/_meta.ts
+++ b/docs/getting-started/_meta.ts
@@ -1,5 +1,5 @@
 export default {
   quickstart: "Quick Start Guide",
   "agent-quickstart": "Agent Quick Start",
-  "agentguard-pause-template": "AgentGuard: Pause-Protected Vault Starter Template",
+  "agentguard-pause-template": "Pause-Protected Vault Starter",
 };

--- a/docs/getting-started/_meta.ts
+++ b/docs/getting-started/_meta.ts
@@ -1,4 +1,5 @@
 export default {
   quickstart: "Quick Start Guide",
   "agent-quickstart": "Agent Quick Start",
+  "agentguard-pause-template": "AgentGuard: Pause-Protected Vault Starter Template",
 };

--- a/docs/getting-started/agentguard-pause-template.md
+++ b/docs/getting-started/agentguard-pause-template.md
@@ -1,0 +1,168 @@
+---
+title: "AgentGuard: Pause-Protected Vault Starter Template"
+description: "Go from zero to your first on-chain protection transaction with a pause-protected vault — deploy a SecurityVault, run the workflow, and pause it on-chain via KeeperHub."
+---
+
+# AgentGuard: Pause-Protected Vault Starter Template
+
+This template is the fastest way to get from zero to a **real protection
+transaction executed on-chain through KeeperHub**. It was built for the
+KeeperHub Agents Onchain hackathon and doubles as a reusable onboarding path:
+
+```
+deploy SecurityVault  →  run the AgentGuard pause workflow  →  vault is
+paused on-chain (real tx)  →  inspect the audit trail
+```
+
+The agent never holds the private key: KeeperHub's execution layer
+broadcasts the `pause()` call from the organization's Turnkey wallet, and
+every run is recorded in the KeeperHub audit trail.
+
+## What you get
+
+| Asset | Path |
+|---|---|
+| Starter workflow fixture | `scripts/seed/fixtures/agentguard-pause.ts` |
+| Minimal SecurityVault contract | Hardhat / Foundry, see contract below |
+| This tutorial | `docs/getting-started/agentguard-pause-template.md` |
+
+The fixture embeds the full `SecurityVault` ABI, so the workflow runs even
+before the contract is verified on a block explorer — no manual ABI entry.
+
+## How it works
+
+```
+Manual trigger ──► web3/write-contract: pause("risk score 70 >= 70")
+                        │
+                        ▼
+              KeeperHub execution layer
+              (broadcasts from the org's Turnkey guardian wallet)
+                        │
+                        ▼
+              SecurityVault.pause() on-chain (VaultPaused event)
+```
+
+## Step 1: Deploy a SecurityVault
+
+Use any EVM chain KeeperHub supports. The example below is Sepolia
+(`11155111`); swap in `8453` for Base mainnet.
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @notice Minimal pause-protected vault. Only the guardian (the KeeperHub
+///         org wallet) or the owner can pause; only the owner can unpause.
+contract SecurityVault is Ownable {
+    address public guardian;
+    address public recovery;
+    bool public paused;
+
+    event VaultPaused(address indexed by, uint256 ts, string reason);
+    event VaultUnpaused(address indexed by, uint256 ts);
+    event GuardianChanged(address indexed oldGuardian, address indexed newGuardian);
+    event RecoveryChanged(address indexed oldRecovery, address indexed newRecovery);
+
+    modifier onlyGuardian() {
+        require(msg.sender == guardian || msg.sender == owner(), "UnauthorizedGuardian");
+        _;
+    }
+
+    constructor(address _guardian, address _recovery) Ownable(msg.sender) {
+        require(_recovery != address(0), "RecoveryCannotBeZero");
+        guardian = _guardian;
+        recovery = _recovery;
+    }
+
+    function pause(string calldata reason) external onlyGuardian {
+        require(!paused, "AlreadyPaused");
+        paused = true;
+        emit VaultPaused(msg.sender, block.timestamp, reason);
+    }
+
+    function unpause() external onlyOwner {
+        paused = false;
+        emit VaultUnpaused(msg.sender, block.timestamp);
+    }
+
+    function setGuardian(address _guardian) external onlyOwner {
+        emit GuardianChanged(guardian, _guardian);
+        guardian = _guardian;
+    }
+
+    function setRecovery(address _recovery) external onlyOwner {
+        emit RecoveryChanged(recovery, _recovery);
+        recovery = _recovery;
+    }
+}
+```
+
+Deploy it with your preferred toolchain (Hardhat, Foundry, Remix). The
+**guardian address must be your KeeperHub organization wallet** — that is the
+account the execution layer broadcasts from. You can find it in the KeeperHub
+dashboard under **Wallet**, or via:
+
+```bash
+npx -p @keeperhub/wallet keeperhub-wallet info   # prints the org wallet
+```
+
+Note the deployed `contractAddress`.
+
+## Step 2: Point the fixture at your vault
+
+Open `scripts/seed/fixtures/agentguard-pause.ts` and replace the placeholder
+`contractAddress` with your deployment:
+
+```ts
+contractAddress: "0xYourDeployedVaultAddress",
+```
+
+If you deployed to Base mainnet, also change:
+
+```ts
+network: 8453, // Base mainnet (default in the fixture is Sepolia 11155111)
+```
+
+## Step 3: Seed and run the workflow
+
+Seed the workflow into your local database (the seeder is idempotent — safe
+to re-run):
+
+```bash
+pnpm db:seed-agentguard-pause
+```
+
+Or, without a local database, import the fixture into the visual workflow
+builder and click **Run** — the Manual trigger fires immediately.
+
+## Step 4: Verify the protection transaction
+
+After the run completes, open the workflow run in KeeperHub:
+
+1. The run shows the submitted transaction hash.
+2. On the block explorer, confirm the `VaultPaused` event was emitted from
+   your vault address.
+3. Confirm the vault is paused:
+
+```bash
+# Sepolia example (swap RPC/chain for Base)
+cast call <vaultAddress> "paused()(bool)" --rpc-url https://ethereum-sepolia-rpc.publicnode.com
+# → true
+```
+
+Every execution is recorded in the KeeperHub audit trail with its trigger,
+simulation result, submitted transaction, gas used, outcome, and timestamp —
+so the protection action is fully re-checkable.
+
+## That's it
+
+You went from zero to a real on-chain protection transaction through
+KeeperHub in four steps — no private key ever left the Turnkey enclave.
+
+See also:
+
+- [Quick Start Guide](./quickstart)
+- [Workflow Builder docs](/docs/workflows)
+- [KeeperHub Execution](/docs/keeper-runs)

--- a/docs/getting-started/agentguard-pause-template.md
+++ b/docs/getting-started/agentguard-pause-template.md
@@ -46,8 +46,9 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @notice Pause-protected vault. Only the guardian (the KeeperHub org
 ///         wallet) or the owner can pause; only the owner can unpause.
-///         Emergency withdrawals move the balance to a pre-registered
-///         recovery address and are not blocked by the paused state.
+///         Management changes are locked while paused. Emergency withdrawals
+///         move the balance to a pre-registered recovery address and are not
+///         blocked by the paused state.
 contract SecurityVault is Ownable {
     address public guardian;
     address public recovery;
@@ -64,7 +65,15 @@ contract SecurityVault is Ownable {
         _;
     }
 
+    /// @dev Locks management changes during protection so an attack cannot
+    ///      rewire the vault mid-incident.
+    modifier whenNotPaused() {
+        require(!paused, "VaultPaused");
+        _;
+    }
+
     constructor(address _guardian, address _recovery) Ownable(msg.sender) {
+        require(_guardian != address(0), "GuardianCannotBeZero");
         require(_recovery != address(0), "RecoveryCannotBeZero");
         guardian = _guardian;
         recovery = _recovery;
@@ -91,14 +100,29 @@ contract SecurityVault is Ownable {
         emit EmergencyWithdraw(recovery, amount, runId);
     }
 
-    function setGuardian(address _guardian) external onlyOwner {
+    function setGuardian(address _guardian) external onlyOwner whenNotPaused {
         emit GuardianChanged(guardian, _guardian);
         guardian = _guardian;
     }
 
-    function setRecovery(address _recovery) external onlyOwner {
+    function setRecovery(address _recovery) external onlyOwner whenNotPaused {
         emit RecoveryChanged(recovery, _recovery);
         recovery = _recovery;
+    }
+
+    /// @dev Override Ownable to lock ownership transfer during protection.
+    function transferOwnership(address newOwner)
+        public
+        override
+        onlyOwner
+        whenNotPaused
+    {
+        super.transferOwnership(newOwner);
+    }
+
+    /// @dev Override Ownable to lock ownership renouncement during protection.
+    function renounceOwnership() public override onlyOwner whenNotPaused {
+        super.renounceOwnership();
     }
 
     receive() external payable {}

--- a/docs/getting-started/agentguard-pause-template.md
+++ b/docs/getting-started/agentguard-pause-template.md
@@ -133,10 +133,9 @@ Build the workflow in the visual builder — no code or local repository needed:
      generates it with `forge inspect` or Hardhat's artifact).
 3. Save the workflow.
 
-> **Contributors**: the same workflow ships as a seedable fixture —
-> `scripts/seed/fixtures/agentguard-pause.ts` — with a matching seeder
-> (`pnpm db:seed-agentguard-pause`). The fixture keeps `contractAddress`
-> empty on purpose; fill in your own deployment before seeding.
+> The same pattern — a pause-protected vault with a guardian-controlled
+> emergency action — is reusable for any kill-switch or emergency-control
+> workflow you want to guard behind the KeeperHub execution layer.
 
 ## Step 4: Run and verify
 

--- a/docs/getting-started/agentguard-pause-template.md
+++ b/docs/getting-started/agentguard-pause-template.md
@@ -1,38 +1,26 @@
 ---
 title: "AgentGuard: Pause-Protected Vault Starter Template"
-description: "Go from zero to your first on-chain protection transaction with a pause-protected vault — deploy a SecurityVault, run the workflow, and pause it on-chain via KeeperHub."
+description: "Deploy a pause-protected vault and pause it on-chain through KeeperHub — a reusable pattern for guarding funds behind a guardian wallet."
 ---
 
 # AgentGuard: Pause-Protected Vault Starter Template
 
-This template is the fastest way to get from zero to a **real protection
-transaction executed on-chain through KeeperHub**. It was built for the
-KeeperHub Agents Onchain hackathon and doubles as a reusable onboarding path:
+This template shows how to guard funds behind a pause-protected vault and
+pause it on-chain through KeeperHub:
 
 ```
-deploy SecurityVault  →  run the AgentGuard pause workflow  →  vault is
-paused on-chain (real tx)  →  inspect the audit trail
+deploy SecurityVault  →  create the pause workflow  →  run it  →  the vault
+is paused on-chain (a real transaction)  →  inspect the audit trail
 ```
 
-The agent never holds the private key: KeeperHub's execution layer
-broadcasts the `pause()` call from the organization's Turnkey wallet, and
-every run is recorded in the KeeperHub audit trail.
-
-## What you get
-
-| Asset | Path |
-|---|---|
-| Starter workflow fixture | `scripts/seed/fixtures/agentguard-pause.ts` |
-| Minimal SecurityVault contract | Hardhat / Foundry, see contract below |
-| This tutorial | `docs/getting-started/agentguard-pause-template.md` |
-
-The fixture embeds the full `SecurityVault` ABI, so the workflow runs even
-before the contract is verified on a block explorer — no manual ABI entry.
+The agent never holds the private key: KeeperHub's execution layer broadcasts
+the `pause()` call from the organization's Turnkey wallet, and every run is
+recorded in the KeeperHub audit trail.
 
 ## How it works
 
 ```
-Manual trigger ──► web3/write-contract: pause("risk score 70 >= 70")
+Manual trigger ──► web3/write-contract: pause("reason")
                         │
                         ▼
               KeeperHub execution layer
@@ -41,6 +29,9 @@ Manual trigger ──► web3/write-contract: pause("risk score 70 >= 70")
                         ▼
               SecurityVault.pause() on-chain (VaultPaused event)
 ```
+
+The pattern is reusable for any emergency-control workflow — pause,
+emergency withdrawal, or a kill switch on a contract you control.
 
 ## Step 1: Deploy a SecurityVault
 
@@ -53,8 +44,10 @@ pragma solidity ^0.8.24;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 
-/// @notice Minimal pause-protected vault. Only the guardian (the KeeperHub
-///         org wallet) or the owner can pause; only the owner can unpause.
+/// @notice Pause-protected vault. Only the guardian (the KeeperHub org
+///         wallet) or the owner can pause; only the owner can unpause.
+///         Emergency withdrawals move the balance to a pre-registered
+///         recovery address and are not blocked by the paused state.
 contract SecurityVault is Ownable {
     address public guardian;
     address public recovery;
@@ -62,6 +55,7 @@ contract SecurityVault is Ownable {
 
     event VaultPaused(address indexed by, uint256 ts, string reason);
     event VaultUnpaused(address indexed by, uint256 ts);
+    event EmergencyWithdraw(address indexed to, uint256 amount, bytes32 runId);
     event GuardianChanged(address indexed oldGuardian, address indexed newGuardian);
     event RecoveryChanged(address indexed oldRecovery, address indexed newRecovery);
 
@@ -87,6 +81,16 @@ contract SecurityVault is Ownable {
         emit VaultUnpaused(msg.sender, block.timestamp);
     }
 
+    /// @notice Move the full balance to `recovery`. A protection action:
+    ///         deliberately not blocked by `paused`.
+    function emergencyWithdraw(bytes32 runId) external onlyGuardian {
+        uint256 amount = address(this).balance;
+        require(amount > 0, "VaultIsEmpty");
+        (bool ok, ) = recovery.call{value: amount}("");
+        require(ok, "TransferFailed");
+        emit EmergencyWithdraw(recovery, amount, runId);
+    }
+
     function setGuardian(address _guardian) external onlyOwner {
         emit GuardianChanged(guardian, _guardian);
         guardian = _guardian;
@@ -96,50 +100,47 @@ contract SecurityVault is Ownable {
         emit RecoveryChanged(recovery, _recovery);
         recovery = _recovery;
     }
+
+    receive() external payable {}
 }
 ```
 
-Deploy it with your preferred toolchain (Hardhat, Foundry, Remix). The
-**guardian address must be your KeeperHub organization wallet** — that is the
-account the execution layer broadcasts from. You can find it in the KeeperHub
-dashboard under **Wallet**, or via:
+Deploy it with your preferred toolchain (Hardhat, Foundry, Remix). Note the
+deployed `contractAddress`.
 
-```bash
-npx -p @keeperhub/wallet keeperhub-wallet info   # prints the org wallet
-```
+## Step 2: Find your organization wallet
 
-Note the deployed `contractAddress`.
+The **guardian address must be your KeeperHub organization wallet** — that is
+the account the execution layer broadcasts from.
 
-## Step 2: Point the fixture at your vault
+1. Open the KeeperHub dashboard.
+2. Go to the **Wallet** page (profile icon, top right).
+3. Copy the organization wallet address and pass it as `_guardian` when you
+   deploy the contract.
 
-Open `scripts/seed/fixtures/agentguard-pause.ts` and replace the placeholder
-`contractAddress` with your deployment:
+## Step 3: Create the pause workflow
 
-```ts
-contractAddress: "0xYourDeployedVaultAddress",
-```
+Build the workflow in the visual builder — no code or local repository needed:
 
-If you deployed to Base mainnet, also change:
+1. **New Workflow** → add a **Manual** trigger.
+2. Add a **Write Contract** action:
+   - **Network**: the chain you deployed on (e.g. Sepolia).
+   - **Contract Address**: your deployed `contractAddress`.
+   - **Function**: `pause`.
+   - **Arguments**: a reason string, e.g. `risk score 70 >= 70`.
+   - **ABI**: the workflow fetches the ABI automatically for verified
+     contracts. If yours is unverified, paste the ABI (the contract above
+     generates it with `forge inspect` or Hardhat's artifact).
+3. Save the workflow.
 
-```ts
-network: 8453, // Base mainnet (default in the fixture is Sepolia 11155111)
-```
+> **Contributors**: the same workflow ships as a seedable fixture —
+> `scripts/seed/fixtures/agentguard-pause.ts` — with a matching seeder
+> (`pnpm db:seed-agentguard-pause`). The fixture keeps `contractAddress`
+> empty on purpose; fill in your own deployment before seeding.
 
-## Step 3: Seed and run the workflow
+## Step 4: Run and verify
 
-Seed the workflow into your local database (the seeder is idempotent — safe
-to re-run):
-
-```bash
-pnpm db:seed-agentguard-pause
-```
-
-Or, without a local database, import the fixture into the visual workflow
-builder and click **Run** — the Manual trigger fires immediately.
-
-## Step 4: Verify the protection transaction
-
-After the run completes, open the workflow run in KeeperHub:
+Click **Run** on the workflow. After it completes:
 
 1. The run shows the submitted transaction hash.
 2. On the block explorer, confirm the `VaultPaused` event was emitted from
@@ -158,11 +159,12 @@ so the protection action is fully re-checkable.
 
 ## That's it
 
-You went from zero to a real on-chain protection transaction through
-KeeperHub in four steps — no private key ever left the Turnkey enclave.
+You now have a pause-protected vault with a one-click emergency control,
+broadcast through KeeperHub — and the private key never left the Turnkey
+enclave.
 
 See also:
 
 - [Quick Start Guide](./quickstart)
-- [Workflow Builder docs](/docs/workflows)
-- [KeeperHub Execution](/docs/keeper-runs)
+- [Workflow Builder docs](/workflows)
+- [KeeperHub Execution](/keeper-runs)

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "db:seed-workflows": "tsx scripts/seed/seed-protocol-workflows.ts",
     "db:seed-onboarding": "tsx scripts/seed/seed-onboarding-workflows.ts",
     "db:seed-all": "pnpm db:seed && pnpm db:seed-test-wallet && pnpm db:seed-workflows",
+    "db:seed-agentguard-pause": "tsx scripts/seed/seed-agentguard-pause.ts",
     "dev:bootstrap": "tsx scripts/seed/dev-bootstrap.ts",
     "dev:mint-cookie": "tsx scripts/dev-mint-session.ts",
     "dev:login": "tsx scripts/dev-login.ts",

--- a/scripts/seed/dev-bootstrap.ts
+++ b/scripts/seed/dev-bootstrap.ts
@@ -61,6 +61,7 @@ import {
   DEV_WORKFLOW_FIXTURES,
 } from "./fixtures/dev-workflows";
 import { seedOnboardingWorkflows } from "./seed-onboarding-workflows";
+import { seedAgentGuardPause } from "./seed-agentguard-pause";
 
 // ---------------------------------------------------------------------------
 // Hostname guard
@@ -524,6 +525,12 @@ async function main(): Promise<void> {
     console.log(
       `  + onboarding: ${onboarding.created} created, ${onboarding.refreshed} refreshed, ` +
         `${onboarding.skipped} skipped (user-edited)`
+    );
+
+    const agentguard = await seedAgentGuardPause(db, identity);
+    console.log(
+      `  + agentguard-pause: ${agentguard.created} created, ${agentguard.refreshed} refreshed, ` +
+        `${agentguard.skipped} skipped (user-edited)`
     );
 
     // Use sql to keep schema imports honest: this is just a smoke-test count.

--- a/scripts/seed/fixtures/agentguard-pause.ts
+++ b/scripts/seed/fixtures/agentguard-pause.ts
@@ -263,7 +263,7 @@ const RAW_FIXTURES: AgentGuardPauseFixture[] = [
           contractAddress:
             "0xBda3ca77aC1442f13A57b136430C383DBf7DC891", // replace with your deployed vault
           abiFunction: "pause",
-          functionArgs: ['["risk score 70 >= 70"]'],
+          functionArgs: '["risk score 70 >= 70"]',
           abi: JSON.stringify(SECURITY_VAULT_ABI),
         },
         400

--- a/scripts/seed/fixtures/agentguard-pause.ts
+++ b/scripts/seed/fixtures/agentguard-pause.ts
@@ -1,0 +1,277 @@
+/**
+ * AgentGuard pause-protected vault starter template.
+ *
+ * A public hub workflow that pauses a SecurityVault on-chain. This is the
+ * "zero to first protection transaction" starter for the KeeperHub Agents
+ * Onchain hackathon track: deploy a minimal SecurityVault (or paste your
+ * own contract address), then trigger this workflow to pause it via the
+ * `web3/write-contract` action — executed by the KeeperHub execution layer,
+ * so the agent never holds the private key.
+ *
+ * Companion tutorial: docs/getting-started/agentguard-pause-template.md
+ *
+ * The ABI is embedded so the workflow runs even before the contract is
+ * verified on a block explorer (unverified contracts cannot be auto-fetched).
+ *
+ * Placeholder values for user-specific fields (contract address) are the
+ * default SecurityVault shipped with the template; replace `contractAddress`
+ * with your own deployment after following the tutorial.
+ */
+
+import { computeAutoLayout } from "@/lib/workflow/editor/auto-layout";
+import {
+  buildActionNode,
+  buildEdge,
+  buildTriggerNode,
+  type WorkflowNodeJson,
+} from "@/lib/workflow/node-builders";
+
+export type AgentGuardPauseFixture = {
+  id: string;
+  listedSlug: string;
+  name: string;
+  description: string;
+  featuredProtocol: string;
+  nodes: unknown[];
+  edges: unknown[];
+};
+
+function withAutoLayout(
+  fixture: AgentGuardPauseFixture
+): AgentGuardPauseFixture {
+  const positions = computeAutoLayout(
+    fixture.nodes as unknown as Parameters<typeof computeAutoLayout>[0],
+    fixture.edges as unknown as Parameters<typeof computeAutoLayout>[1]
+  );
+  const nodes = (fixture.nodes as WorkflowNodeJson[]).map((node) => {
+    const pos = positions.get(node.id);
+    return pos ? { ...node, position: pos } : node;
+  });
+  return { ...fixture, nodes };
+}
+
+// Minimal SecurityVault ABI (pause / unpause / emergencyWithdraw + Ownable).
+// Keep in sync with the starter contract in the tutorial.
+const SECURITY_VAULT_ABI = [
+  {
+    inputs: [
+      { internalType: "address", name: "_guardian", type: "address" },
+      { internalType: "address", name: "_recovery", type: "address" },
+    ],
+    stateMutability: "nonpayable",
+    type: "constructor",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "oldGuardian",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "newGuardian",
+        type: "address",
+      },
+    ],
+    name: "GuardianChanged",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "runId",
+        type: "bytes32",
+      },
+    ],
+    name: "EmergencyWithdraw",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "oldRecovery",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "newRecovery",
+        type: "address",
+      },
+    ],
+    name: "RecoveryChanged",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "by",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "ts",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "string",
+        name: "reason",
+        type: "string",
+      },
+    ],
+    name: "VaultPaused",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "by",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "ts",
+        type: "uint256",
+      },
+    ],
+    name: "VaultUnpaused",
+    type: "event",
+  },
+  {
+    inputs: [],
+    name: "emergencyWithdraw",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "guardian",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "owner",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "string", name: "reason", type: "string" }],
+    name: "pause",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "paused",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "recovery",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "_guardian", type: "address" }],
+    name: "setGuardian",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "_recovery", type: "address" }],
+    name: "setRecovery",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "newOwner", type: "address" }],
+    name: "transferOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "unpause",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  { stateMutability: "payable", type: "receive" },
+] as const;
+
+const RAW_FIXTURES: AgentGuardPauseFixture[] = [
+  {
+    id: "agentguard-pause-vault",
+    listedSlug: "agentguard-pause",
+    name: "AgentGuard: Pause SecurityVault",
+    description:
+      "Manually pause a SecurityVault on-chain via a web3/write-contract action. The KeeperHub execution layer broadcasts the pause, so the agent never holds the private key.",
+    featuredProtocol: "security-vault",
+    nodes: [
+      buildTriggerNode("trigger-1", {
+        triggerType: "Manual",
+      }),
+      buildActionNode(
+        "step-1",
+        "Pause SecurityVault",
+        "Call pause(string) on the SecurityVault contract — broadcast by the KeeperHub execution layer (guardian account)",
+        {
+          actionType: "web3/write-contract",
+          network: 11155111, // Sepolia — change to 8453 for Base mainnet
+          contractAddress:
+            "0xBda3ca77aC1442f13A57b136430C383DBf7DC891", // replace with your deployed vault
+          abiFunction: "pause",
+          functionArgs: ['["risk score 70 >= 70"]'],
+          abi: JSON.stringify(SECURITY_VAULT_ABI),
+        },
+        400
+      ),
+    ],
+    edges: [buildEdge("trigger-1", "step-1")],
+  },
+];
+
+export const AGENTGUARD_PAUSE_FIXTURES: AgentGuardPauseFixture[] =
+  RAW_FIXTURES.map(withAutoLayout);

--- a/scripts/seed/fixtures/agentguard-pause.ts
+++ b/scripts/seed/fixtures/agentguard-pause.ts
@@ -2,11 +2,10 @@
  * AgentGuard pause-protected vault starter template.
  *
  * A public hub workflow that pauses a SecurityVault on-chain. This is the
- * "zero to first protection transaction" starter for the KeeperHub Agents
- * Onchain hackathon track: deploy a minimal SecurityVault (or paste your
- * own contract address), then trigger this workflow to pause it via the
- * `web3/write-contract` action — executed by the KeeperHub execution layer,
- * so the agent never holds the private key.
+ * "zero to first protection transaction" starter: deploy a minimal
+ * SecurityVault (or paste your own contract address), then trigger this
+ * workflow to pause it via the `web3/write-contract` action — executed by
+ * the KeeperHub execution layer, so the agent never holds the private key.
  *
  * Companion tutorial: docs/getting-started/agentguard-pause-template.md
  *
@@ -229,6 +228,13 @@ const SECURITY_VAULT_ABI = [
   {
     inputs: [{ internalType: "address", name: "newOwner", type: "address" }],
     name: "transferOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "renounceOwnership",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",

--- a/scripts/seed/fixtures/agentguard-pause.ts
+++ b/scripts/seed/fixtures/agentguard-pause.ts
@@ -260,8 +260,7 @@ const RAW_FIXTURES: AgentGuardPauseFixture[] = [
         {
           actionType: "web3/write-contract",
           network: 11155111, // Sepolia — change to 8453 for Base mainnet
-          contractAddress:
-            "0xBda3ca77aC1442f13A57b136430C383DBf7DC891", // replace with your deployed vault
+          contractAddress: "", // fill in your deployed vault address
           abiFunction: "pause",
           functionArgs: '["risk score 70 >= 70"]',
           abi: JSON.stringify(SECURITY_VAULT_ABI),

--- a/scripts/seed/fixtures/agentguard-pause.ts
+++ b/scripts/seed/fixtures/agentguard-pause.ts
@@ -169,7 +169,9 @@ const SECURITY_VAULT_ABI = [
     type: "event",
   },
   {
-    inputs: [],
+    inputs: [
+      { internalType: "bytes32", name: "runId", type: "bytes32" },
+    ],
     name: "emergencyWithdraw",
     outputs: [],
     stateMutability: "nonpayable",

--- a/scripts/seed/seed-agentguard-pause.ts
+++ b/scripts/seed/seed-agentguard-pause.ts
@@ -1,0 +1,203 @@
+#!/usr/bin/env tsx
+
+/**
+ * Seed the AgentGuard pause-protected vault starter workflow into the
+ * database.
+ *
+ * The workflow gets `visibility: "public"` and a `listedSlug` so it can be
+ * cloned into a builder's org from the workflow library. The contract address
+ * is intentionally left empty in the fixture — the builder fills in their own
+ * deployment after following the tutorial
+ * (docs/getting-started/agentguard-pause-template.md).
+ *
+ * Idempotent: same semantics as seed-onboarding-workflows.ts.
+ *
+ * Standalone usage:
+ *   pnpm db:seed-agentguard-pause [--user=<email>]
+ *
+ * The `--user` flag controls which user's org receives the workflow.
+ * Defaults to SEED_EMAIL or "dev@keeperhub.local".
+ *
+ * Also exported as `seedAgentGuardPause(db, identity)` for use from
+ * dev-bootstrap.ts.
+ */
+
+import "dotenv/config";
+
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+
+import { getDatabaseUrl } from "../../lib/db/connection-utils";
+import { member, users, workflows } from "../../lib/db/schema";
+import {
+  AGENTGUARD_PAUSE_FIXTURES,
+  type AgentGuardPauseFixture,
+} from "./fixtures/agentguard-pause";
+
+/** Gap in ms between seededAt and updatedAt that indicates a user edit. */
+export const USER_EDIT_EPSILON_MS = 5_000;
+
+type Identity = { userId: string; orgId: string };
+
+type SeedResult = { created: number; refreshed: number; skipped: number };
+
+export async function seedAgentGuardPause(
+  db: ReturnType<typeof drizzle>,
+  identity: Identity
+): Promise<SeedResult> {
+  const result: SeedResult = { created: 0, refreshed: 0, skipped: 0 };
+  const now = new Date();
+
+  for (const fixture of AGENTGUARD_PAUSE_FIXTURES) {
+    const existing = await db
+      .select({
+        id: workflows.id,
+        updatedAt: workflows.updatedAt,
+        seededAt: workflows.seededAt,
+        deletedAt: workflows.deletedAt,
+      })
+      .from(workflows)
+      .where(eq(workflows.id, fixture.id))
+      .limit(1);
+
+    if (!existing[0]) {
+      await db.insert(workflows).values({
+        id: fixture.id,
+        name: fixture.name,
+        description: fixture.description,
+        userId: identity.userId,
+        organizationId: identity.orgId,
+        nodes: fixture.nodes,
+        edges: fixture.edges,
+        visibility: "public",
+        enabled: true,
+        featured: false,
+        featuredProtocol: fixture.featuredProtocol,
+        listedSlug: fixture.listedSlug,
+        seededAt: now,
+        createdAt: now,
+        updatedAt: now,
+        deletedAt: null,
+      });
+      result.created++;
+      continue;
+    }
+
+    const row = existing[0];
+    const updatedMs = row.updatedAt?.getTime() ?? 0;
+    const seededMs = row.seededAt?.getTime() ?? 0;
+    // seededAt=null means the row was not seeded by this script — skip.
+    // seededAt set but updatedAt diverges by more than epsilon means the user
+    // has edited the workflow since we last seeded it — skip.
+    const userEdited =
+      row.seededAt === null || updatedMs - seededMs > USER_EDIT_EPSILON_MS;
+
+    if (userEdited) {
+      result.skipped++;
+      continue;
+    }
+
+    await db
+      .update(workflows)
+      .set({
+        name: fixture.name,
+        description: fixture.description,
+        userId: identity.userId,
+        organizationId: identity.orgId,
+        nodes: fixture.nodes,
+        edges: fixture.edges,
+        visibility: "public",
+        enabled: true,
+        featured: false,
+        featuredProtocol: fixture.featuredProtocol,
+        listedSlug: fixture.listedSlug,
+        seededAt: now,
+        updatedAt: now,
+        deletedAt: null,
+      })
+      .where(eq(workflows.id, fixture.id));
+    result.refreshed++;
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Standalone CLI
+// ---------------------------------------------------------------------------
+
+async function resolveIdentity(
+  db: ReturnType<typeof drizzle>,
+  email: string
+): Promise<Identity | null> {
+  const userRow = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1);
+
+  if (!userRow[0]) {
+    console.log(`User not found: ${email} -- skipping AgentGuard seed`);
+    return null;
+  }
+
+  const userId = userRow[0].id;
+
+  const memberRow = await db
+    .select({ organizationId: member.organizationId })
+    .from(member)
+    .where(eq(member.userId, userId))
+    .limit(1);
+
+  if (!memberRow[0]) {
+    console.log(`User ${email} has no organization membership -- skipping AgentGuard seed`);
+    return null;
+  }
+
+  return { userId, orgId: memberRow[0].organizationId };
+}
+
+async function main(): Promise<void> {
+  const emailArg = process.argv
+    .slice(2)
+    .find((a) => a.startsWith("--user="))
+    ?.split("=")[1];
+  const email =
+    emailArg ?? process.env.SEED_EMAIL ?? "dev@keeperhub.local";
+
+  const url = getDatabaseUrl();
+  const client = postgres(url, { max: 1 });
+  const db = drizzle(client);
+
+  try {
+    const identity = await resolveIdentity(db, email);
+    if (!identity) {
+      return;
+    }
+    console.log(`Seeding AgentGuard pause workflow into org ${identity.orgId} (user ${email})`);
+
+    const result = await seedAgentGuardPause(db, identity);
+    console.log(
+      `  created: ${result.created}  refreshed: ${result.refreshed}  skipped (user-edited): ${result.skipped}`
+    );
+    console.log(`  total fixtures: ${AGENTGUARD_PAUSE_FIXTURES.length}`);
+  } finally {
+    await client.end();
+  }
+}
+
+// Main-guard so `import { USER_EDIT_EPSILON_MS } from ...` in tests/unit
+// doesn't fire main() at module load (which would try to connect to PG and
+// throw an unhandled rejection in the unit test pool).
+const isMain =
+  process.argv[1] &&
+  (process.argv[1].endsWith("seed-agentguard-pause.ts") ||
+    process.argv[1].endsWith("seed-agentguard-pause.js"));
+
+if (isMain) {
+  main().catch((err: unknown) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tests/unit/seed-agentguard-pause.test.ts
+++ b/tests/unit/seed-agentguard-pause.test.ts
@@ -35,6 +35,13 @@ vi.mock("drizzle-orm", () => ({
   eq: (a: unknown, b: unknown) => ({ a, b }),
 }));
 
+// The seeder imports drizzle from here at module scope; the unit test never
+// calls main() (so drizzle() is never invoked), but mocking the module keeps
+// importing the seeder free of postgres-js side effects in the test pool.
+vi.mock("drizzle-orm/postgres-js", () => ({
+  drizzle: () => ({}) as never,
+}));
+
 vi.mock("../../lib/db/connection-utils", () => ({
   getDatabaseUrl: () => "postgres://mock",
 }));

--- a/tests/unit/seed-agentguard-pause.test.ts
+++ b/tests/unit/seed-agentguard-pause.test.ts
@@ -1,0 +1,250 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// drizzles uses these at module scope; keep them as no-ops so importing the
+// seeder does not try to touch a real DB in the unit test pool.
+vi.mock("dotenv/config", () => ({}));
+vi.mock("postgres", () => {
+  return { default: () => ({ end: vi.fn() }) };
+});
+
+const {
+  mockSelect,
+  mockInsert,
+  mockUpdate,
+  mockFrom,
+  mockWhere,
+  mockLimit,
+} = vi.hoisted(() => ({
+  mockSelect: vi.fn(),
+  mockInsert: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockFrom: vi.fn(),
+  mockWhere: vi.fn(),
+  mockLimit: vi.fn(),
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflows: { id: "workflows.id", name: "workflows.name" },
+  users: { id: "users.id" },
+  member: { organizationId: "member.organizationId" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: (a: unknown, b: unknown) => ({ a, b }),
+}));
+
+vi.mock("../../lib/db/connection-utils", () => ({
+  getDatabaseUrl: () => "postgres://mock",
+}));
+
+import {
+  AGENTGUARD_PAUSE_FIXTURES,
+  type AgentGuardPauseFixture,
+} from "@/scripts/seed/fixtures/agentguard-pause";
+import {
+  USER_EDIT_EPSILON_MS,
+  seedAgentGuardPause,
+} from "@/scripts/seed/seed-agentguard-pause";
+
+// A drizzle-shaped db whose select/insert/update chain is fully mocked.
+function makeDb(existingRows: unknown[]) {
+  mockSelect.mockReturnValue({
+    from: mockFrom,
+  });
+  mockFrom.mockReturnValue({
+    where: mockWhere,
+  });
+  mockWhere.mockReturnValue({
+    limit: mockLimit,
+  });
+  mockLimit.mockResolvedValue(existingRows);
+
+  mockInsert.mockReturnValue({
+    values: vi.fn().mockResolvedValue(undefined),
+  });
+  mockUpdate.mockReturnValue({
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    }),
+  });
+
+  return {
+    select: mockSelect,
+    insert: mockInsert,
+    update: mockUpdate,
+  };
+}
+
+const IDENTITY = { userId: "user-1", orgId: "org-1" };
+
+describe("AGENTGUARD_PAUSE_FIXTURES", () => {
+  it("has exactly one fixture", () => {
+    expect(AGENTGUARD_PAUSE_FIXTURES).toHaveLength(1);
+  });
+
+  it("has unique ids and listedSlugs", () => {
+    const ids = AGENTGUARD_PAUSE_FIXTURES.map((f) => f.id);
+    const slugs = AGENTGUARD_PAUSE_FIXTURES.map((f) => f.listedSlug);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  for (const fixture of AGENTGUARD_PAUSE_FIXTURES) {
+    describe(`fixture: ${fixture.id}`, () => {
+      it("has required string fields", () => {
+        expect(typeof fixture.id).toBe("string");
+        expect(typeof fixture.listedSlug).toBe("string");
+        expect(typeof fixture.name).toBe("string");
+        expect(typeof fixture.description).toBe("string");
+        expect(typeof fixture.featuredProtocol).toBe("string");
+        expect(fixture.id.length).toBeGreaterThan(0);
+        expect(fixture.listedSlug.length).toBeGreaterThan(0);
+        expect(fixture.name.length).toBeGreaterThan(0);
+      });
+
+      it("has at least one node and one edge", () => {
+        expect((fixture.nodes as unknown[]).length).toBeGreaterThan(0);
+        expect((fixture.edges as unknown[]).length).toBeGreaterThan(0);
+      });
+
+      it("edge source and target IDs reference existing nodes", () => {
+        type NodeLike = { id: string };
+        type EdgeLike = { source: string; target: string };
+        const nodeIds = new Set(
+          (fixture.nodes as NodeLike[]).map((n) => n.id)
+        );
+        for (const edge of fixture.edges as EdgeLike[]) {
+          expect(
+            nodeIds.has(edge.source),
+            `edge source "${edge.source}" missing from nodes`
+          ).toBe(true);
+          expect(
+            nodeIds.has(edge.target),
+            `edge target "${edge.target}" missing from nodes`
+          ).toBe(true);
+        }
+      });
+
+      it("first node is a Manual trigger", () => {
+        type NodeLike = {
+          id: string;
+          data?: { config?: { triggerType?: string } };
+        };
+        const first = (fixture.nodes as NodeLike[])[0];
+        expect(first.id).toBe("trigger-1");
+        expect(first.data?.config?.triggerType).toBe("Manual");
+      });
+
+      it("pause action targets an empty contract address by default", () => {
+        type NodeLike = {
+          id: string;
+          data?: {
+            config?: {
+              actionType?: string;
+              abiFunction?: string;
+              contractAddress?: string;
+            };
+          };
+        };
+        const pause = (fixture.nodes as NodeLike[]).find(
+          (n) => n.id === "step-1"
+        );
+        expect(pause?.data?.config?.actionType).toBe("web3/write-contract");
+        expect(pause?.data?.config?.abiFunction).toBe("pause");
+        expect(pause?.data?.config?.contractAddress).toBe("");
+      });
+    });
+  }
+});
+
+describe("USER_EDIT_EPSILON_MS", () => {
+  it("is 5000 ms", () => {
+    expect(USER_EDIT_EPSILON_MS).toBe(5000);
+  });
+});
+
+describe("seedAgentGuardPause", () => {
+  const FIXTURE = AGENTGUARD_PAUSE_FIXTURES[0] as AgentGuardPauseFixture;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("inserts the fixture when the workflow does not exist (created)", async () => {
+    const db = makeDb([]);
+    const result = await seedAgentGuardPause(
+      db as never,
+      IDENTITY
+    );
+
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ created: 1, refreshed: 0, skipped: 0 });
+  });
+
+  it("refreshes the fixture when it was seeded and not user-edited (refreshed)", async () => {
+    const seededAt = new Date();
+    const updatedAt = new Date(seededAt.getTime() + 1_000); // within epsilon
+    const db = makeDb([
+      {
+        id: FIXTURE.id,
+        updatedAt,
+        seededAt,
+        deletedAt: null,
+      },
+    ]);
+
+    const result = await seedAgentGuardPause(
+      db as never,
+      IDENTITY
+    );
+
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ created: 0, refreshed: 1, skipped: 0 });
+  });
+
+  it("skips when seededAt is null (not seeded by this script)", async () => {
+    const db = makeDb([
+      {
+        id: FIXTURE.id,
+        updatedAt: new Date(),
+        seededAt: null,
+        deletedAt: null,
+      },
+    ]);
+
+    const result = await seedAgentGuardPause(
+      db as never,
+      IDENTITY
+    );
+
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(result).toEqual({ created: 0, refreshed: 0, skipped: 1 });
+  });
+
+  it("skips when the user edited the workflow (updatedAt beyond epsilon)", async () => {
+    const seededAt = new Date("2026-01-01T00:00:00Z");
+    const updatedAt = new Date(seededAt.getTime() + 60_000); // beyond epsilon
+    const db = makeDb([
+      {
+        id: FIXTURE.id,
+        updatedAt,
+        seededAt,
+        deletedAt: null,
+      },
+    ]);
+
+    const result = await seedAgentGuardPause(
+      db as never,
+      IDENTITY
+    );
+
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(result).toEqual({ created: 0, refreshed: 0, skipped: 1 });
+  });
+});


### PR DESCRIPTION
- Seeder: added scripts/seed/seed-agentguard-pause.ts consuming AGENTGUARD_PAUSE_FIXTURES (idempotent, same pattern as seed-onboarding-workflows.ts), wired into dev-bootstrap.ts, and added the db:seed-agentguard-pause script.
- Product-first tutorial: the doc now walks through building the workflow in the visual builder (no local repo / DB required); removed all repo-path references (scripts/seed/..., pnpm db:seed-...) so the page names only paths that exist for a docs-site reader.
- ABI sync: the SecurityVault contract in the tutorial now matches the embedded ABI exactly — including emergencyWithdraw(bytes32 runId), renounceOwnership(), the whenNotPaused guard on management functions, a non-zero guardian check, and the EmergencyWithdraw event / receive().
- Safe defaults: fixture contractAddress left empty so a reader can't transact against a baked-in live deployment.
- Links: /workflows and /keeper-runs (no /docs prefix). Dropped the hackathon framing from the doc and the fixture; shortened the nav title to "Pause-Protected Vault Starter".