### PR TITLE
fix: classify third-party relay transport failures as external

### DIFF
--- a/lib/errors/classify.ts
+++ b/lib/errors/classify.ts
@@ -19,8 +19,12 @@ export { ExecutionErrorType } from "@/lib/errors/execution-error-type";
  *                    configured the workflow to call (HTTP request / webhook
  *                    transport failures such as timeouts, connection resets, DNS
  *                    failures) where neither the customer's config nor KeeperHub
- *                    is at fault. RPC endpoints are KeeperHub-managed, so their
- *                    failures stay "system", not "external".
+ *                    is at fault. RPC endpoints are KeeperHub-managed by
+ *                    default, so an `RPC failed ...` message stays "system"
+ *                    here; the exception is an endpoint we only point at and do
+ *                    not operate (a private-mempool relay, a customer's own
+ *                    node), which the RPC layer tags at the failure site and
+ *                    the step forwards as an errorClass hint.
  *   - code:          a `PREFIX-NNNN` system error code for system failures, or
  *                    null for user and external failures (which surface their
  *                    raw message).

--- a/lib/errors/classify.ts
+++ b/lib/errors/classify.ts
@@ -19,12 +19,12 @@ export { ExecutionErrorType } from "@/lib/errors/execution-error-type";
  *                    configured the workflow to call (HTTP request / webhook
  *                    transport failures such as timeouts, connection resets, DNS
  *                    failures) where neither the customer's config nor KeeperHub
- *                    is at fault. RPC endpoints are KeeperHub-managed by
- *                    default, so an `RPC failed ...` message stays "system"
- *                    here; the exception is an endpoint we only point at and do
- *                    not operate (a private-mempool relay, a customer's own
- *                    node), which the RPC layer tags at the failure site and
- *                    the step forwards as an errorClass hint.
+ *                    is at fault. RPC endpoints are KeeperHub-managed, so an
+ *                    `RPC failed ...` message stays "system" here; the one
+ *                    exception is the private-mempool relay a node opted into,
+ *                    which we point at but do not operate. The RPC layer tags
+ *                    that at the failure site and the step forwards it as an
+ *                    errorClass hint.
  *   - code:          a `PREFIX-NNNN` system error code for system failures, or
  *                    null for user and external failures (which surface their
  *                    raw message).

--- a/lib/rpc/config-service.ts
+++ b/lib/rpc/config-service.ts
@@ -13,7 +13,7 @@ import {
   userRpcPreferences,
 } from "@/lib/db/schema";
 import { logWarn } from "@/lib/logging";
-import { type ResolvedRpcConfig, RPC_ENDPOINT_ORIGIN } from "./types";
+import type { ResolvedRpcConfig } from "./types";
 
 /**
  * Options for resolveRpcConfig.
@@ -83,10 +83,6 @@ export async function resolveRpcConfig(
           userPref.primaryWssUrl || chain.defaultPrimaryWss || undefined,
         fallbackWssUrl:
           userPref.fallbackWssUrl || chain.defaultFallbackWss || undefined,
-        primaryOrigin: RPC_ENDPOINT_ORIGIN.USER,
-        fallbackOrigin: userPref.fallbackRpcUrl
-          ? RPC_ENDPOINT_ORIGIN.USER
-          : undefined,
         ...chainCapabilities,
         source: "user",
       };
@@ -117,10 +113,6 @@ function buildDefaultConfig(
     fallbackRpcUrl: chain.defaultFallbackRpc || undefined,
     primaryWssUrl: chain.defaultPrimaryWss || undefined,
     fallbackWssUrl: chain.defaultFallbackWss || undefined,
-    primaryOrigin: RPC_ENDPOINT_ORIGIN.PLATFORM,
-    fallbackOrigin: chain.defaultFallbackRpc
-      ? RPC_ENDPOINT_ORIGIN.PLATFORM
-      : undefined,
     ...capabilities,
     source: "default",
   };
@@ -159,11 +151,10 @@ function applyPrivateMempoolSwap(
     ...baseConfig,
     primaryRpcUrl: baseConfig.privateRpcUrl,
     fallbackRpcUrl: strict ? undefined : baseConfig.primaryRpcUrl,
-    // We configure the relay pointer but do not operate the node, so its
-    // transport failures are not ours. Non-strict keeps the pre-swap primary
-    // as fallback, which keeps whatever origin it already had.
-    primaryOrigin: RPC_ENDPOINT_ORIGIN.RELAY,
-    fallbackOrigin: strict ? undefined : baseConfig.primaryOrigin,
+    // Only reached when the swap actually happened: the node asked for the
+    // private mempool and the chain had a relay to route to. We configure that
+    // pointer but do not run the node behind it.
+    primaryIsPrivateRelay: true,
   };
 }
 
@@ -208,10 +199,6 @@ export async function resolveAllRpcConfigs(
           userPref.primaryWssUrl || chain.defaultPrimaryWss || undefined,
         fallbackWssUrl:
           userPref.fallbackWssUrl || chain.defaultFallbackWss || undefined,
-        primaryOrigin: RPC_ENDPOINT_ORIGIN.USER,
-        fallbackOrigin: userPref.fallbackRpcUrl
-          ? RPC_ENDPOINT_ORIGIN.USER
-          : undefined,
         ...capabilities,
         source: "user" as const,
       };
@@ -224,10 +211,6 @@ export async function resolveAllRpcConfigs(
       fallbackRpcUrl: chain.defaultFallbackRpc || undefined,
       primaryWssUrl: chain.defaultPrimaryWss || undefined,
       fallbackWssUrl: chain.defaultFallbackWss || undefined,
-      primaryOrigin: RPC_ENDPOINT_ORIGIN.PLATFORM,
-      fallbackOrigin: chain.defaultFallbackRpc
-        ? RPC_ENDPOINT_ORIGIN.PLATFORM
-        : undefined,
       ...capabilities,
       source: "default" as const,
     };

--- a/lib/rpc/config-service.ts
+++ b/lib/rpc/config-service.ts
@@ -13,7 +13,7 @@ import {
   userRpcPreferences,
 } from "@/lib/db/schema";
 import { logWarn } from "@/lib/logging";
-import type { ResolvedRpcConfig } from "./types";
+import { type ResolvedRpcConfig, RPC_ENDPOINT_ORIGIN } from "./types";
 
 /**
  * Options for resolveRpcConfig.
@@ -83,6 +83,10 @@ export async function resolveRpcConfig(
           userPref.primaryWssUrl || chain.defaultPrimaryWss || undefined,
         fallbackWssUrl:
           userPref.fallbackWssUrl || chain.defaultFallbackWss || undefined,
+        primaryOrigin: RPC_ENDPOINT_ORIGIN.USER,
+        fallbackOrigin: userPref.fallbackRpcUrl
+          ? RPC_ENDPOINT_ORIGIN.USER
+          : undefined,
         ...chainCapabilities,
         source: "user",
       };
@@ -113,6 +117,10 @@ function buildDefaultConfig(
     fallbackRpcUrl: chain.defaultFallbackRpc || undefined,
     primaryWssUrl: chain.defaultPrimaryWss || undefined,
     fallbackWssUrl: chain.defaultFallbackWss || undefined,
+    primaryOrigin: RPC_ENDPOINT_ORIGIN.PLATFORM,
+    fallbackOrigin: chain.defaultFallbackRpc
+      ? RPC_ENDPOINT_ORIGIN.PLATFORM
+      : undefined,
     ...capabilities,
     source: "default",
   };
@@ -151,6 +159,11 @@ function applyPrivateMempoolSwap(
     ...baseConfig,
     primaryRpcUrl: baseConfig.privateRpcUrl,
     fallbackRpcUrl: strict ? undefined : baseConfig.primaryRpcUrl,
+    // We configure the relay pointer but do not operate the node, so its
+    // transport failures are not ours. Non-strict keeps the pre-swap primary
+    // as fallback, which keeps whatever origin it already had.
+    primaryOrigin: RPC_ENDPOINT_ORIGIN.RELAY,
+    fallbackOrigin: strict ? undefined : baseConfig.primaryOrigin,
   };
 }
 
@@ -195,6 +208,10 @@ export async function resolveAllRpcConfigs(
           userPref.primaryWssUrl || chain.defaultPrimaryWss || undefined,
         fallbackWssUrl:
           userPref.fallbackWssUrl || chain.defaultFallbackWss || undefined,
+        primaryOrigin: RPC_ENDPOINT_ORIGIN.USER,
+        fallbackOrigin: userPref.fallbackRpcUrl
+          ? RPC_ENDPOINT_ORIGIN.USER
+          : undefined,
         ...capabilities,
         source: "user" as const,
       };
@@ -207,6 +224,10 @@ export async function resolveAllRpcConfigs(
       fallbackRpcUrl: chain.defaultFallbackRpc || undefined,
       primaryWssUrl: chain.defaultPrimaryWss || undefined,
       fallbackWssUrl: chain.defaultFallbackWss || undefined,
+      primaryOrigin: RPC_ENDPOINT_ORIGIN.PLATFORM,
+      fallbackOrigin: chain.defaultFallbackRpc
+        ? RPC_ENDPOINT_ORIGIN.PLATFORM
+        : undefined,
       ...capabilities,
       source: "default" as const,
     };

--- a/lib/rpc/provider-factory.ts
+++ b/lib/rpc/provider-factory.ts
@@ -145,8 +145,7 @@ export async function getRpcProvider(
     fallbackRpcUrl: config.fallbackRpcUrl,
     chainName: config.chainName,
     chainId,
-    primaryOrigin: config.primaryOrigin,
-    fallbackOrigin: config.fallbackOrigin,
+    primaryIsPrivateRelay: config.primaryIsPrivateRelay,
     metricsCollector,
     onFailoverStateChange: (chain, isUsingFallback, reason) => {
       try {

--- a/lib/rpc/provider-factory.ts
+++ b/lib/rpc/provider-factory.ts
@@ -145,6 +145,8 @@ export async function getRpcProvider(
     fallbackRpcUrl: config.fallbackRpcUrl,
     chainName: config.chainName,
     chainId,
+    primaryOrigin: config.primaryOrigin,
+    fallbackOrigin: config.fallbackOrigin,
     metricsCollector,
     onFailoverStateChange: (chain, isUsingFallback, reason) => {
       try {

--- a/lib/rpc/providers/error-classification.ts
+++ b/lib/rpc/providers/error-classification.ts
@@ -44,6 +44,56 @@ export function isNonRetryableError(error: unknown): boolean {
   return NON_RETRYABLE_ERROR_CODES.has(ethersError.code as string);
 }
 
+export const RPC_CONNECTION_ERROR_PATTERNS: readonly string[] = [
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "fetch failed",
+];
+
+/** Lowest HTTP status that means the endpoint itself failed to serve us. */
+const SERVER_ERROR_STATUS_FLOOR = 500;
+const RATE_LIMIT_STATUS = 429;
+
+/**
+ * Whether an error means we could not get an answer out of the endpoint at all
+ * -- it timed out, refused the connection, did not resolve, rate-limited us, or
+ * answered 5xx. Deliberately excludes anything the endpoint answered
+ * definitively (reverts, insufficient funds, nonce conflicts, malformed
+ * responses): those are the same on every node, so they say nothing about who
+ * operates this one.
+ *
+ * Used to decide whether a failover exhaustion can be attributed to whoever
+ * runs the endpoint. Unrecognised errors return false, so an unknown failure
+ * stays with the platform rather than being blamed on a third party.
+ */
+export function isTransportFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  // RpcProviderManager.withTimeout, which races the operation itself.
+  if (error.message.startsWith("Timeout after ")) {
+    return true;
+  }
+  if (isError(error, "TIMEOUT") || isError(error, "NETWORK_ERROR")) {
+    return true;
+  }
+  if (isError(error, "SERVER_ERROR")) {
+    const status = (
+      error as EthersError & { response?: { statusCode?: number } }
+    ).response?.statusCode;
+    // No status at all means the request never completed a round trip.
+    return (
+      status === undefined ||
+      status === RATE_LIMIT_STATUS ||
+      status >= SERVER_ERROR_STATUS_FLOOR
+    );
+  }
+  return RPC_CONNECTION_ERROR_PATTERNS.some((pattern) =>
+    error.message.includes(pattern)
+  );
+}
+
 /**
  * Type guard for 429 rate-limit responses. Used by RpcProviderManager to
  * extract Retry-After headers.

--- a/lib/rpc/providers/index.ts
+++ b/lib/rpc/providers/index.ts
@@ -2,13 +2,12 @@ import { ethers, isError } from "ethers";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { safeEthersGetUrl } from "../safe-ethers-fetch";
 import { redactAllUrls, scrubRpcUrls } from "../scrub-rpc-urls";
-import { RPC_ENDPOINT_ORIGIN, type RpcEndpointOrigin } from "../types";
 import {
   isNonRetryableError,
   isTransportFailure,
   RPC_CONNECTION_ERROR_PATTERNS,
 } from "./error-classification";
-import { RpcTransportError, transportFaultDomain } from "./transport-error";
+import { RpcRelayTransportError } from "./transport-error";
 
 export {
   isNonRetryableError,
@@ -16,10 +15,7 @@ export {
   NON_RETRYABLE_ERROR_CODES,
   RPC_CONNECTION_ERROR_PATTERNS,
 } from "./error-classification";
-export {
-  RpcTransportError,
-  rpcTransportErrorClass,
-} from "./transport-error";
+export { RpcRelayTransportError, rpcRelayErrorClass } from "./transport-error";
 
 /**
  * Interface for metrics collection - allows dependency injection
@@ -190,10 +186,10 @@ export type RpcProviderConfig = {
   timeoutMs?: number;
   chainName?: string;
   chainId?: number;
-  // Who operates each endpoint. Defaults to platform, so a manager built from
-  // raw URLs keeps attributing its failures to KeeperHub.
-  primaryOrigin?: RpcEndpointOrigin;
-  fallbackOrigin?: RpcEndpointOrigin;
+  // True only when the private-mempool swap put the chain's relay on the
+  // primary. Defaults to false, so a manager built from raw URLs keeps
+  // attributing its failures to KeeperHub.
+  primaryIsPrivateRelay?: boolean;
 };
 
 export type RpcProviderMetrics = {
@@ -215,10 +211,9 @@ export class RpcProviderManager {
   private primaryProvider: ethers.JsonRpcProvider | null = null;
   private fallbackProvider: ethers.JsonRpcProvider | null = null;
   private readonly config: Required<
-    Omit<RpcProviderConfig, "fallbackRpcUrl" | "fallbackOrigin">
+    Omit<RpcProviderConfig, "fallbackRpcUrl">
   > & {
     fallbackRpcUrl?: string;
-    fallbackOrigin?: RpcEndpointOrigin;
   };
   private readonly metrics: RpcProviderMetrics;
   private readonly metricsCollector: RpcMetricsCollector;
@@ -244,10 +239,7 @@ export class RpcProviderManager {
       timeoutMs: config.timeoutMs ?? RpcProviderManager.DEFAULT_TIMEOUT_MS,
       chainName: config.chainName ?? "unknown",
       chainId: config.chainId ?? 1,
-      primaryOrigin: config.primaryOrigin ?? RPC_ENDPOINT_ORIGIN.PLATFORM,
-      fallbackOrigin: config.fallbackRpcUrl
-        ? (config.fallbackOrigin ?? RPC_ENDPOINT_ORIGIN.PLATFORM)
-        : undefined,
+      primaryIsPrivateRelay: config.primaryIsPrivateRelay ?? false,
     };
 
     this.metricsCollector = metricsCollector;
@@ -477,10 +469,11 @@ export class RpcProviderManager {
   /**
    * Build the error for an exhausted failover round.
    *
-   * Carries a fault domain only when every endpoint we burned through failed on
-   * transport AND none of them is ours to operate -- a private-mempool relay or
-   * a customer's own node. Anything else stays a plain Error so the message
-   * classifier keeps deciding, which for RPC means a platform fault.
+   * Becomes a relay error only when the round never touched an endpoint we
+   * operate AND every attempt failed on transport. In practice that is the
+   * strict private-mempool case, where the swap left the relay as the only
+   * endpoint. Anything else stays a plain Error so the message classifier
+   * keeps deciding, which for RPC means a platform fault.
    */
   private failoverError(
     message: string,
@@ -490,18 +483,14 @@ export class RpcProviderManager {
     }[]
   ): Error {
     const redacted = redactAllUrls(message);
-    if (!failures.every((failure) => failure.transport)) {
-      return new Error(redacted);
-    }
-
-    const origins = failures.map((failure) =>
-      failure.endpoint === "primary"
-        ? this.config.primaryOrigin
-        : (this.config.fallbackOrigin ?? RPC_ENDPOINT_ORIGIN.PLATFORM)
+    const allOnTheRelay = failures.every(
+      (failure) =>
+        failure.transport &&
+        failure.endpoint === "primary" &&
+        this.config.primaryIsPrivateRelay
     );
-    const errorClass = transportFaultDomain(origins);
-    return errorClass
-      ? new RpcTransportError(redacted, errorClass)
+    return allOnTheRelay
+      ? new RpcRelayTransportError(redacted)
       : new Error(redacted);
   }
 
@@ -749,8 +738,7 @@ export type CreateRpcProviderManagerOptions = {
   timeoutMs?: number;
   chainName?: string;
   chainId?: number;
-  primaryOrigin?: RpcEndpointOrigin;
-  fallbackOrigin?: RpcEndpointOrigin;
+  primaryIsPrivateRelay?: boolean;
   metricsCollector?: RpcMetricsCollector;
   onFailoverStateChange?: FailoverStateChangeCallback;
 };
@@ -758,9 +746,7 @@ export type CreateRpcProviderManagerOptions = {
 export function createRpcProviderManager(
   options: CreateRpcProviderManagerOptions
 ): RpcProviderManager {
-  // Origins are part of the identity: the same URL reached as a chain default
-  // and as a customer preference are attributed differently on failure.
-  const cacheKey = `${options.primaryRpcUrl}|${options.fallbackRpcUrl || ""}|${options.chainId ?? ""}|${options.primaryOrigin ?? ""}|${options.fallbackOrigin ?? ""}`;
+  const cacheKey = `${options.primaryRpcUrl}|${options.fallbackRpcUrl || ""}|${options.chainId ?? ""}`;
 
   let manager = managerCache.get(cacheKey);
   if (!manager) {
@@ -772,8 +758,7 @@ export function createRpcProviderManager(
         timeoutMs: options.timeoutMs,
         chainName: options.chainName,
         chainId: options.chainId,
-        primaryOrigin: options.primaryOrigin,
-        fallbackOrigin: options.fallbackOrigin,
+        primaryIsPrivateRelay: options.primaryIsPrivateRelay,
       },
       metricsCollector: options.metricsCollector,
       onFailoverStateChange: options.onFailoverStateChange,

--- a/lib/rpc/providers/index.ts
+++ b/lib/rpc/providers/index.ts
@@ -2,12 +2,24 @@ import { ethers, isError } from "ethers";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { safeEthersGetUrl } from "../safe-ethers-fetch";
 import { redactAllUrls, scrubRpcUrls } from "../scrub-rpc-urls";
-import { isNonRetryableError } from "./error-classification";
+import { RPC_ENDPOINT_ORIGIN, type RpcEndpointOrigin } from "../types";
+import {
+  isNonRetryableError,
+  isTransportFailure,
+  RPC_CONNECTION_ERROR_PATTERNS,
+} from "./error-classification";
+import { RpcTransportError, transportFaultDomain } from "./transport-error";
 
 export {
   isNonRetryableError,
+  isTransportFailure,
   NON_RETRYABLE_ERROR_CODES,
+  RPC_CONNECTION_ERROR_PATTERNS,
 } from "./error-classification";
+export {
+  RpcTransportError,
+  rpcTransportErrorClass,
+} from "./transport-error";
 
 /**
  * Interface for metrics collection - allows dependency injection
@@ -143,13 +155,6 @@ export const consoleMetricsCollector: RpcMetricsCollector = {
     ),
 };
 
-export const RPC_CONNECTION_ERROR_PATTERNS: readonly string[] = [
-  "ECONNREFUSED",
-  "ENOTFOUND",
-  "ETIMEDOUT",
-  "fetch failed",
-];
-
 /**
  * Classify an RPC error into a category for metrics tracking.
  * Standalone version for use outside of executeWithFailover
@@ -185,6 +190,10 @@ export type RpcProviderConfig = {
   timeoutMs?: number;
   chainName?: string;
   chainId?: number;
+  // Who operates each endpoint. Defaults to platform, so a manager built from
+  // raw URLs keeps attributing its failures to KeeperHub.
+  primaryOrigin?: RpcEndpointOrigin;
+  fallbackOrigin?: RpcEndpointOrigin;
 };
 
 export type RpcProviderMetrics = {
@@ -206,9 +215,10 @@ export class RpcProviderManager {
   private primaryProvider: ethers.JsonRpcProvider | null = null;
   private fallbackProvider: ethers.JsonRpcProvider | null = null;
   private readonly config: Required<
-    Omit<RpcProviderConfig, "fallbackRpcUrl">
+    Omit<RpcProviderConfig, "fallbackRpcUrl" | "fallbackOrigin">
   > & {
     fallbackRpcUrl?: string;
+    fallbackOrigin?: RpcEndpointOrigin;
   };
   private readonly metrics: RpcProviderMetrics;
   private readonly metricsCollector: RpcMetricsCollector;
@@ -234,6 +244,10 @@ export class RpcProviderManager {
       timeoutMs: config.timeoutMs ?? RpcProviderManager.DEFAULT_TIMEOUT_MS,
       chainName: config.chainName ?? "unknown",
       chainId: config.chainId ?? 1,
+      primaryOrigin: config.primaryOrigin ?? RPC_ENDPOINT_ORIGIN.PLATFORM,
+      fallbackOrigin: config.fallbackRpcUrl
+        ? (config.fallbackOrigin ?? RPC_ENDPOINT_ORIGIN.PLATFORM)
+        : undefined,
     };
 
     this.metricsCollector = metricsCollector;
@@ -376,10 +390,12 @@ export class RpcProviderManager {
         // Thrown messages reach end users via step errors; drop provider
         // URLs entirely (host included). Internal logs above keep the
         // host-visible masked form.
-        throw new Error(
-          redactAllUrls(
-            `RPC failed on both endpoints. Fallback: ${fallbackResult.error}. Primary: ${primaryResult.error}`
-          )
+        throw this.failoverError(
+          `RPC failed on both endpoints. Fallback: ${fallbackResult.error}. Primary: ${primaryResult.error}`,
+          [
+            { endpoint: "fallback", transport: fallbackResult.transport },
+            { endpoint: "primary", transport: primaryResult.transport },
+          ]
         );
       }
     }
@@ -443,16 +459,50 @@ export class RpcProviderManager {
           chain: this.config.chainName,
         }
       );
-      throw new Error(
-        redactAllUrls(
-          `RPC failed on both endpoints. Primary: ${primaryResult.error}. Fallback: ${fallbackResult.error}`
-        )
+      throw this.failoverError(
+        `RPC failed on both endpoints. Primary: ${primaryResult.error}. Fallback: ${fallbackResult.error}`,
+        [
+          { endpoint: "primary", transport: primaryResult.transport },
+          { endpoint: "fallback", transport: fallbackResult.transport },
+        ]
       );
     }
 
-    throw new Error(
-      redactAllUrls(`RPC failed on primary endpoint: ${primaryResult.error}`)
+    throw this.failoverError(
+      `RPC failed on primary endpoint: ${primaryResult.error}`,
+      [{ endpoint: "primary", transport: primaryResult.transport }]
     );
+  }
+
+  /**
+   * Build the error for an exhausted failover round.
+   *
+   * Carries a fault domain only when every endpoint we burned through failed on
+   * transport AND none of them is ours to operate -- a private-mempool relay or
+   * a customer's own node. Anything else stays a plain Error so the message
+   * classifier keeps deciding, which for RPC means a platform fault.
+   */
+  private failoverError(
+    message: string,
+    failures: readonly {
+      endpoint: "primary" | "fallback";
+      transport?: boolean;
+    }[]
+  ): Error {
+    const redacted = redactAllUrls(message);
+    if (!failures.every((failure) => failure.transport)) {
+      return new Error(redacted);
+    }
+
+    const origins = failures.map((failure) =>
+      failure.endpoint === "primary"
+        ? this.config.primaryOrigin
+        : (this.config.fallbackOrigin ?? RPC_ENDPOINT_ORIGIN.PLATFORM)
+    );
+    const errorClass = transportFaultDomain(origins);
+    return errorClass
+      ? new RpcTransportError(redacted, errorClass)
+      : new Error(redacted);
   }
 
   private recordAttempt(
@@ -550,7 +600,13 @@ export class RpcProviderManager {
     providerType: "primary" | "fallback",
     maxRetries: number,
     operationType: RpcOperationType = "read"
-  ): Promise<{ success: boolean; result?: T; error?: string }> {
+  ): Promise<{
+    success: boolean;
+    result?: T;
+    error?: string;
+    /** Whether the last attempt failed on transport rather than on an answer. */
+    transport?: boolean;
+  }> {
     let lastError: Error | undefined;
 
     for (let attempt = 0; attempt < maxRetries; attempt++) {
@@ -609,6 +665,7 @@ export class RpcProviderManager {
       // Ethers v6 inlines info.requestUrl (keyed RPC URL) into Error.message;
       // mask the key before the message reaches thrown errors and logs.
       error: scrubRpcUrls(lastError?.message ?? "") || "Unknown error",
+      transport: isTransportFailure(lastError),
     };
   }
 
@@ -692,6 +749,8 @@ export type CreateRpcProviderManagerOptions = {
   timeoutMs?: number;
   chainName?: string;
   chainId?: number;
+  primaryOrigin?: RpcEndpointOrigin;
+  fallbackOrigin?: RpcEndpointOrigin;
   metricsCollector?: RpcMetricsCollector;
   onFailoverStateChange?: FailoverStateChangeCallback;
 };
@@ -699,7 +758,9 @@ export type CreateRpcProviderManagerOptions = {
 export function createRpcProviderManager(
   options: CreateRpcProviderManagerOptions
 ): RpcProviderManager {
-  const cacheKey = `${options.primaryRpcUrl}|${options.fallbackRpcUrl || ""}|${options.chainId ?? ""}`;
+  // Origins are part of the identity: the same URL reached as a chain default
+  // and as a customer preference are attributed differently on failure.
+  const cacheKey = `${options.primaryRpcUrl}|${options.fallbackRpcUrl || ""}|${options.chainId ?? ""}|${options.primaryOrigin ?? ""}|${options.fallbackOrigin ?? ""}`;
 
   let manager = managerCache.get(cacheKey);
   if (!manager) {
@@ -711,6 +772,8 @@ export function createRpcProviderManager(
         timeoutMs: options.timeoutMs,
         chainName: options.chainName,
         chainId: options.chainId,
+        primaryOrigin: options.primaryOrigin,
+        fallbackOrigin: options.fallbackOrigin,
       },
       metricsCollector: options.metricsCollector,
       onFailoverStateChange: options.onFailoverStateChange,

--- a/lib/rpc/providers/transport-error.ts
+++ b/lib/rpc/providers/transport-error.ts
@@ -1,48 +1,30 @@
 import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
-import { RPC_ENDPOINT_ORIGIN, type RpcEndpointOrigin } from "../types";
 
 /**
- * Failover exhausted on endpoints KeeperHub does not operate, with every
- * attempt ending in a transport failure. `errorClass` names whose fault that
- * is, so the step that catches this can hand the executor an authoritative
- * classification instead of leaving the message classifier to infer one from
- * prose (which reads every `RPC failed ...` string as a platform fault).
+ * Failover exhausted against the chain's private-mempool relay (Flashbots
+ * Protect and friends), with every attempt failing on transport.
+ *
+ * Every other endpoint we route to is one we run: chain defaults point at
+ * env-configured infrastructure, so their failures are ours to answer for and
+ * stay `system`. The relay is a pointer we configure and a node we do not
+ * operate, which makes it a third-party dependency.
+ *
+ * `errorClass` lets the step that catches this hand the executor an
+ * authoritative classification instead of leaving the message classifier to
+ * infer one from prose, which reads every `RPC failed ...` string as a
+ * platform fault.
  */
-export class RpcTransportError extends Error {
-  override readonly name = "RpcTransportError" as const;
-  readonly errorClass: ExecutionErrorType;
-
-  constructor(message: string, errorClass: ExecutionErrorType) {
-    super(message);
-    this.errorClass = errorClass;
-  }
+export class RpcRelayTransportError extends Error {
+  override readonly name = "RpcRelayTransportError" as const;
+  readonly errorClass = ExecutionErrorType.EXTERNAL;
 }
 
 /**
  * The fault domain an RPC failure declares, or undefined for anything that is
- * not a third-party transport failure (the caller keeps its own classification).
+ * not a relay transport failure (the caller keeps its own classification).
  */
-export function rpcTransportErrorClass(
+export function rpcRelayErrorClass(
   error: unknown
 ): ExecutionErrorType | undefined {
-  return error instanceof RpcTransportError ? error.errorClass : undefined;
-}
-
-/**
- * Attribute a transport failure that exhausted every endpoint in `origins`.
- *
- * Undefined when any of them is platform-operated: our own node failing is our
- * problem to answer for, even if a relay failed alongside it. A relay in the
- * mix wins over a customer node because it is the endpoint the routing mode
- * points at.
- */
-export function transportFaultDomain(
-  origins: readonly RpcEndpointOrigin[]
-): ExecutionErrorType | undefined {
-  if (origins.length === 0 || origins.includes(RPC_ENDPOINT_ORIGIN.PLATFORM)) {
-    return;
-  }
-  return origins.includes(RPC_ENDPOINT_ORIGIN.RELAY)
-    ? ExecutionErrorType.EXTERNAL
-    : ExecutionErrorType.USER;
+  return error instanceof RpcRelayTransportError ? error.errorClass : undefined;
 }

--- a/lib/rpc/providers/transport-error.ts
+++ b/lib/rpc/providers/transport-error.ts
@@ -1,0 +1,48 @@
+import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
+import { RPC_ENDPOINT_ORIGIN, type RpcEndpointOrigin } from "../types";
+
+/**
+ * Failover exhausted on endpoints KeeperHub does not operate, with every
+ * attempt ending in a transport failure. `errorClass` names whose fault that
+ * is, so the step that catches this can hand the executor an authoritative
+ * classification instead of leaving the message classifier to infer one from
+ * prose (which reads every `RPC failed ...` string as a platform fault).
+ */
+export class RpcTransportError extends Error {
+  override readonly name = "RpcTransportError" as const;
+  readonly errorClass: ExecutionErrorType;
+
+  constructor(message: string, errorClass: ExecutionErrorType) {
+    super(message);
+    this.errorClass = errorClass;
+  }
+}
+
+/**
+ * The fault domain an RPC failure declares, or undefined for anything that is
+ * not a third-party transport failure (the caller keeps its own classification).
+ */
+export function rpcTransportErrorClass(
+  error: unknown
+): ExecutionErrorType | undefined {
+  return error instanceof RpcTransportError ? error.errorClass : undefined;
+}
+
+/**
+ * Attribute a transport failure that exhausted every endpoint in `origins`.
+ *
+ * Undefined when any of them is platform-operated: our own node failing is our
+ * problem to answer for, even if a relay failed alongside it. A relay in the
+ * mix wins over a customer node because it is the endpoint the routing mode
+ * points at.
+ */
+export function transportFaultDomain(
+  origins: readonly RpcEndpointOrigin[]
+): ExecutionErrorType | undefined {
+  if (origins.length === 0 || origins.includes(RPC_ENDPOINT_ORIGIN.PLATFORM)) {
+    return;
+  }
+  return origins.includes(RPC_ENDPOINT_ORIGIN.RELAY)
+    ? ExecutionErrorType.EXTERNAL
+    : ExecutionErrorType.USER;
+}

--- a/lib/rpc/types.ts
+++ b/lib/rpc/types.ts
@@ -25,11 +25,32 @@ export type ExplorerConfigType = {
   explorerContractPath?: string;
 };
 
+/**
+ * Who operates an RPC endpoint. Transport failures are attributed by origin:
+ * a KeeperHub-operated endpoint failing is a platform fault, a third-party
+ * private-mempool relay failing is an external dependency, and a node the
+ * customer pointed us at is theirs.
+ */
+export const RPC_ENDPOINT_ORIGIN = {
+  /** Chain default: `chain.techops.services`, `lb.drpc.live`, and friends. */
+  PLATFORM: "platform",
+  /** Private-mempool relay from `chains.default_private_rpc_url`. */
+  RELAY: "relay",
+  /** Endpoint from `user_rpc_preferences`. */
+  USER: "user",
+} as const;
+
+export type RpcEndpointOrigin =
+  (typeof RPC_ENDPOINT_ORIGIN)[keyof typeof RPC_ENDPOINT_ORIGIN];
+
 export type ResolvedRpcConfig = {
   chainId: number;
   chainName: string;
   primaryRpcUrl: string;
   fallbackRpcUrl?: string;
+  primaryOrigin: RpcEndpointOrigin;
+  /** Undefined when the config has no fallback endpoint. */
+  fallbackOrigin?: RpcEndpointOrigin;
   primaryWssUrl?: string;
   fallbackWssUrl?: string;
   // KEEP-137: whether the chain supports private mempool routing (Flashbots Protect).

--- a/lib/rpc/types.ts
+++ b/lib/rpc/types.ts
@@ -25,32 +25,19 @@ export type ExplorerConfigType = {
   explorerContractPath?: string;
 };
 
-/**
- * Who operates an RPC endpoint. Transport failures are attributed by origin:
- * a KeeperHub-operated endpoint failing is a platform fault, a third-party
- * private-mempool relay failing is an external dependency, and a node the
- * customer pointed us at is theirs.
- */
-export const RPC_ENDPOINT_ORIGIN = {
-  /** Chain default: `chain.techops.services`, `lb.drpc.live`, and friends. */
-  PLATFORM: "platform",
-  /** Private-mempool relay from `chains.default_private_rpc_url`. */
-  RELAY: "relay",
-  /** Endpoint from `user_rpc_preferences`. */
-  USER: "user",
-} as const;
-
-export type RpcEndpointOrigin =
-  (typeof RPC_ENDPOINT_ORIGIN)[keyof typeof RPC_ENDPOINT_ORIGIN];
-
 export type ResolvedRpcConfig = {
   chainId: number;
   chainName: string;
   primaryRpcUrl: string;
   fallbackRpcUrl?: string;
-  primaryOrigin: RpcEndpointOrigin;
-  /** Undefined when the config has no fallback endpoint. */
-  fallbackOrigin?: RpcEndpointOrigin;
+  /**
+   * True when the private-mempool swap put the chain's relay (Flashbots
+   * Protect and friends, from `chains.default_private_rpc_url`) on the primary.
+   * Every other endpoint we hand out is one we run: chain defaults come from
+   * env-configured infrastructure. The fallback is never the relay -- strict
+   * mode clears it, non-strict keeps the public endpoint the swap replaced.
+   */
+  primaryIsPrivateRelay?: boolean;
   primaryWssUrl?: string;
   fallbackWssUrl?: string;
   // KEEP-137: whether the chain supports private mempool routing (Flashbots Protect).

--- a/plugins/web3/steps/approve-token-core.ts
+++ b/plugins/web3/steps/approve-token-core.ts
@@ -20,6 +20,8 @@ import {
 } from "@/lib/web3/wallet-helpers";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { rpcTransportErrorClass } from "@/lib/rpc/providers";
+import type { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 import { getErrorMessage } from "@/lib/utils";
 import { generateId } from "@/lib/utils/id";
 import {
@@ -103,6 +105,9 @@ export type ApproveTokenResult =
        * the revert payload was empty / unrecognised.
        */
       rejection?: RevertKind;
+      // Authoritative fault domain when the failure site knows it, e.g. a
+      // transport failure against an endpoint KeeperHub does not operate.
+      errorClass?: ExecutionErrorType;
       // Set only when a transaction reached the chain and failed
       // there, so the finalizer can persist a receipt for the failure. Absent
       // on pre-broadcast failures, where no transaction exists.
@@ -219,7 +224,12 @@ export async function approveTokenCore(
         chain_id: String(chainId),
       }
     );
-    return { success: false, error: getErrorMessage(error) };
+    const errorClass = rpcTransportErrorClass(error);
+    return {
+      success: false,
+      error: getErrorMessage(error),
+      ...(errorClass ? { errorClass } : {}),
+    };
   }
 
   // Get wallet address for nonce management
@@ -532,6 +542,7 @@ export async function approveTokenCore(
         }
       );
       const rejection = classifyRevert(error, contract.interface);
+      const errorClass = rpcTransportErrorClass(error);
       return {
         success: false,
         error: formatContractError(
@@ -539,6 +550,7 @@ export async function approveTokenCore(
           contract.interface,
           "Token approval failed"
         ),
+        ...(errorClass ? { errorClass } : {}),
         ...(rejection.kind !== "unknown" ? { rejection } : {}),
         ...(revertedTransactionHash(error)
           ? { transactionHash: revertedTransactionHash(error), chainId }

--- a/plugins/web3/steps/approve-token-core.ts
+++ b/plugins/web3/steps/approve-token-core.ts
@@ -20,7 +20,7 @@ import {
 } from "@/lib/web3/wallet-helpers";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
-import { rpcTransportErrorClass } from "@/lib/rpc/providers";
+import { rpcRelayErrorClass } from "@/lib/rpc/providers";
 import type { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 import { getErrorMessage } from "@/lib/utils";
 import { generateId } from "@/lib/utils/id";
@@ -105,8 +105,8 @@ export type ApproveTokenResult =
        * the revert payload was empty / unrecognised.
        */
       rejection?: RevertKind;
-      // Authoritative fault domain when the failure site knows it, e.g. a
-      // transport failure against an endpoint KeeperHub does not operate.
+      // Authoritative fault domain when the failure site knows it: the
+      // private-mempool relay never answered, and we do not run that node.
       errorClass?: ExecutionErrorType;
       // Set only when a transaction reached the chain and failed
       // there, so the finalizer can persist a receipt for the failure. Absent
@@ -224,7 +224,7 @@ export async function approveTokenCore(
         chain_id: String(chainId),
       }
     );
-    const errorClass = rpcTransportErrorClass(error);
+    const errorClass = rpcRelayErrorClass(error);
     return {
       success: false,
       error: getErrorMessage(error),
@@ -542,7 +542,7 @@ export async function approveTokenCore(
         }
       );
       const rejection = classifyRevert(error, contract.interface);
-      const errorClass = rpcTransportErrorClass(error);
+      const errorClass = rpcRelayErrorClass(error);
       return {
         success: false,
         error: formatContractError(

--- a/plugins/web3/steps/transfer-funds-core.ts
+++ b/plugins/web3/steps/transfer-funds-core.ts
@@ -24,6 +24,8 @@ import {
 } from "@/lib/web3/wallet-helpers";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
+import { rpcTransportErrorClass } from "@/lib/rpc/providers";
+import type { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 import { getErrorMessage } from "@/lib/utils";
 import { generateId } from "@/lib/utils/id";
 import { PublicKey } from "@solana/web3.js";
@@ -100,6 +102,9 @@ export type TransferFundsResult =
       success: false;
       error: string;
       rejection?: RevertKind;
+      // Authoritative fault domain when the failure site knows it, e.g. a
+      // transport failure against an endpoint KeeperHub does not operate.
+      errorClass?: ExecutionErrorType;
       // Set only when a transaction reached the chain and failed
       // there, so the finalizer can persist a receipt for the failure. Absent
       // on pre-broadcast failures, where no transaction exists.
@@ -223,7 +228,12 @@ export async function transferFundsCore(
       error,
       { plugin_name: "web3", action_name: "transfer-funds" }
     );
-    return { success: false, error: getErrorMessage(error) };
+    const errorClass = rpcTransportErrorClass(error);
+    return {
+      success: false,
+      error: getErrorMessage(error),
+      ...(errorClass ? { errorClass } : {}),
+    };
   }
 
   // Get wallet address for nonce management
@@ -486,9 +496,11 @@ export async function transferFundsCore(
         }
       );
       const rejection = classifyRevert(error);
+      const errorClass = rpcTransportErrorClass(error);
       return {
         success: false,
         error: formatContractError(error, undefined, "Transaction failed"),
+        ...(errorClass ? { errorClass } : {}),
         ...(rejection.kind !== "unknown" ? { rejection } : {}),
         ...(revertedTransactionHash(error)
           ? { transactionHash: revertedTransactionHash(error), chainId }

--- a/plugins/web3/steps/transfer-funds-core.ts
+++ b/plugins/web3/steps/transfer-funds-core.ts
@@ -24,7 +24,7 @@ import {
 } from "@/lib/web3/wallet-helpers";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
-import { rpcTransportErrorClass } from "@/lib/rpc/providers";
+import { rpcRelayErrorClass } from "@/lib/rpc/providers";
 import type { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 import { getErrorMessage } from "@/lib/utils";
 import { generateId } from "@/lib/utils/id";
@@ -102,8 +102,8 @@ export type TransferFundsResult =
       success: false;
       error: string;
       rejection?: RevertKind;
-      // Authoritative fault domain when the failure site knows it, e.g. a
-      // transport failure against an endpoint KeeperHub does not operate.
+      // Authoritative fault domain when the failure site knows it: the
+      // private-mempool relay never answered, and we do not run that node.
       errorClass?: ExecutionErrorType;
       // Set only when a transaction reached the chain and failed
       // there, so the finalizer can persist a receipt for the failure. Absent
@@ -228,7 +228,7 @@ export async function transferFundsCore(
       error,
       { plugin_name: "web3", action_name: "transfer-funds" }
     );
-    const errorClass = rpcTransportErrorClass(error);
+    const errorClass = rpcRelayErrorClass(error);
     return {
       success: false,
       error: getErrorMessage(error),
@@ -496,7 +496,7 @@ export async function transferFundsCore(
         }
       );
       const rejection = classifyRevert(error);
-      const errorClass = rpcTransportErrorClass(error);
+      const errorClass = rpcRelayErrorClass(error);
       return {
         success: false,
         error: formatContractError(error, undefined, "Transaction failed"),

--- a/plugins/web3/steps/transfer-token-core.ts
+++ b/plugins/web3/steps/transfer-token-core.ts
@@ -24,7 +24,7 @@ import {
 } from "@/lib/web3/wallet-helpers";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
-import { rpcTransportErrorClass } from "@/lib/rpc/providers";
+import { rpcRelayErrorClass } from "@/lib/rpc/providers";
 import type { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 import { getErrorMessage } from "@/lib/utils";
 import { generateId } from "@/lib/utils/id";
@@ -103,8 +103,8 @@ export type TransferTokenResult =
       success: false;
       error: string;
       rejection?: RevertKind;
-      // Authoritative fault domain when the failure site knows it, e.g. a
-      // transport failure against an endpoint KeeperHub does not operate.
+      // Authoritative fault domain when the failure site knows it: the
+      // private-mempool relay never answered, and we do not run that node.
       errorClass?: ExecutionErrorType;
       // Set only when a transaction reached the chain and failed
       // there, so the finalizer can persist a receipt for the failure. Absent
@@ -327,7 +327,7 @@ export async function transferTokenCore(
         chain_id: String(chainId),
       }
     );
-    const errorClass = rpcTransportErrorClass(error);
+    const errorClass = rpcRelayErrorClass(error);
     return {
       success: false,
       error: getErrorMessage(error),
@@ -645,7 +645,7 @@ export async function transferTokenCore(
         }
       );
       const rejection = classifyRevert(error, contract.interface);
-      const errorClass = rpcTransportErrorClass(error);
+      const errorClass = rpcRelayErrorClass(error);
       return {
         success: false,
         error: formatContractError(

--- a/plugins/web3/steps/transfer-token-core.ts
+++ b/plugins/web3/steps/transfer-token-core.ts
@@ -24,6 +24,8 @@ import {
 } from "@/lib/web3/wallet-helpers";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { rpcTransportErrorClass } from "@/lib/rpc/providers";
+import type { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 import { getErrorMessage } from "@/lib/utils";
 import { generateId } from "@/lib/utils/id";
 import {
@@ -101,6 +103,9 @@ export type TransferTokenResult =
       success: false;
       error: string;
       rejection?: RevertKind;
+      // Authoritative fault domain when the failure site knows it, e.g. a
+      // transport failure against an endpoint KeeperHub does not operate.
+      errorClass?: ExecutionErrorType;
       // Set only when a transaction reached the chain and failed
       // there, so the finalizer can persist a receipt for the failure. Absent
       // on pre-broadcast failures, where no transaction exists.
@@ -322,7 +327,12 @@ export async function transferTokenCore(
         chain_id: String(chainId),
       }
     );
-    return { success: false, error: getErrorMessage(error) };
+    const errorClass = rpcTransportErrorClass(error);
+    return {
+      success: false,
+      error: getErrorMessage(error),
+      ...(errorClass ? { errorClass } : {}),
+    };
   }
 
   // Get wallet address for nonce management
@@ -635,6 +645,7 @@ export async function transferTokenCore(
         }
       );
       const rejection = classifyRevert(error, contract.interface);
+      const errorClass = rpcTransportErrorClass(error);
       return {
         success: false,
         error: formatContractError(
@@ -642,6 +653,7 @@ export async function transferTokenCore(
           contract.interface,
           "Token transfer failed"
         ),
+        ...(errorClass ? { errorClass } : {}),
         ...(rejection.kind !== "unknown" ? { rejection } : {}),
         ...(revertedTransactionHash(error)
           ? { transactionHash: revertedTransactionHash(error), chainId }

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -23,7 +23,7 @@ import {
 } from "@/lib/web3/wallet-helpers";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
-import { rpcTransportErrorClass } from "@/lib/rpc/providers";
+import { rpcRelayErrorClass } from "@/lib/rpc/providers";
 import { findAbiFunction } from "@/lib/abi/utils";
 import { getErrorMessage, resolveFailOnError } from "@/lib/utils";
 import { getAbiFunctionKey } from "@/lib/abi/function-key";
@@ -355,9 +355,10 @@ export async function writeContractCore(
     return {
       success: false,
       error: getErrorMessage(error),
-      // A relay or customer endpoint that never answered is not our platform
-      // failing; everything else here (unknown chain, disabled chain) is.
-      errorClass: rpcTransportErrorClass(error) ?? ExecutionErrorType.SYSTEM,
+      // A private-mempool relay that never answered is not our platform
+      // failing; everything else here (unknown chain, disabled chain, our own
+      // endpoints) is.
+      errorClass: rpcRelayErrorClass(error) ?? ExecutionErrorType.SYSTEM,
     };
   }
 
@@ -667,7 +668,7 @@ export async function writeContractCore(
       );
       const rejection = classifyRevert(error, contractInterface);
       const revertedHash = revertedTransactionHash(error);
-      const errorClass = rpcTransportErrorClass(error);
+      const errorClass = rpcRelayErrorClass(error);
       return {
         success: false,
         error: formatContractError(error, contractInterface),

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -23,6 +23,7 @@ import {
 } from "@/lib/web3/wallet-helpers";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { rpcTransportErrorClass } from "@/lib/rpc/providers";
 import { findAbiFunction } from "@/lib/abi/utils";
 import { getErrorMessage, resolveFailOnError } from "@/lib/utils";
 import { getAbiFunctionKey } from "@/lib/abi/function-key";
@@ -142,14 +143,15 @@ export type WriteContractResult =
  * the workflow continues past a revert/RPC failure instead of aborting. This is the
  * write-contract counterpart to HTTP Request's failOnError.
  *
- * Only failures with no `errorClass` are eligible: those are the ones raised
- * by the actual attempt to send the transaction (signer init, broadcast,
- * on-chain revert). Failures classified USER (bad ABI/args/address) or SYSTEM
- * (org context, wallet, RPC/Web3 Connection resolution) are configuration
- * problems that would recur on every execution, so, mirroring HTTP
- * Request's SSRF/malformed-URL carve-out, they always hard-fail regardless
- * of this flag; softening them would let a broken node config run forever
- * without the author noticing.
+ * Failures raised by the actual attempt to send the transaction (signer init,
+ * broadcast, on-chain revert) are eligible, and so are EXTERNAL ones: a relay
+ * that timed out is exactly the transient dependency failure this toggle
+ * exists to skip past. Failures classified USER (bad ABI/args/address) or
+ * SYSTEM (org context, wallet, RPC/Web3 Connection resolution) are
+ * configuration problems that would recur on every execution, so, mirroring
+ * HTTP Request's SSRF/malformed-URL carve-out, they always hard-fail
+ * regardless of this flag; softening them would let a broken node config run
+ * forever without the author noticing.
  *
  * Must be applied to the writeContractCore result only, AFTER
  * withStepValueCap resolves it, never inside writeContractCore: the
@@ -178,7 +180,10 @@ export function applyFailOnError(
   result: WriteContractResult,
   failOnError: unknown
 ): WriteContractResult {
-  if (result.success || result.errorClass || resolveFailOnError(failOnError)) {
+  if (result.success || resolveFailOnError(failOnError)) {
+    return result;
+  }
+  if (result.errorClass && result.errorClass !== ExecutionErrorType.EXTERNAL) {
     return result;
   }
   return {
@@ -350,7 +355,9 @@ export async function writeContractCore(
     return {
       success: false,
       error: getErrorMessage(error),
-      errorClass: ExecutionErrorType.SYSTEM,
+      // A relay or customer endpoint that never answered is not our platform
+      // failing; everything else here (unknown chain, disabled chain) is.
+      errorClass: rpcTransportErrorClass(error) ?? ExecutionErrorType.SYSTEM,
     };
   }
 
@@ -660,9 +667,11 @@ export async function writeContractCore(
       );
       const rejection = classifyRevert(error, contractInterface);
       const revertedHash = revertedTransactionHash(error);
+      const errorClass = rpcTransportErrorClass(error);
       return {
         success: false,
         error: formatContractError(error, contractInterface),
+        ...(errorClass ? { errorClass } : {}),
         ...(rejection.kind !== "unknown" ? { rejection } : {}),
         ...(revertedHash
           ? { transactionHash: revertedHash, chainId }

--- a/tests/unit/config-service.test.ts
+++ b/tests/unit/config-service.test.ts
@@ -40,6 +40,18 @@ describe("config-service", () => {
     updatedAt: new Date(),
   };
 
+  function mockChainQuery(chain: Record<string, unknown>): void {
+    vi.mocked(db.select).mockImplementation(
+      vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([chain]),
+          }),
+        }),
+      })
+    );
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -65,6 +77,8 @@ describe("config-service", () => {
         fallbackRpcUrl: "https://default-eth-backup.example.com",
         primaryWssUrl: undefined,
         fallbackWssUrl: undefined,
+        primaryOrigin: "platform",
+        fallbackOrigin: "platform",
         usePrivateMempoolRpc: false,
         privateRpcUrl: undefined,
         source: "default",
@@ -107,6 +121,8 @@ describe("config-service", () => {
         fallbackRpcUrl: "https://user-eth-backup.example.com",
         primaryWssUrl: undefined,
         fallbackWssUrl: undefined,
+        primaryOrigin: "user",
+        fallbackOrigin: "user",
         usePrivateMempoolRpc: false,
         privateRpcUrl: undefined,
         source: "user",
@@ -170,6 +186,53 @@ describe("config-service", () => {
       const result = await resolveRpcConfig(1);
 
       expect(result).toBeNull();
+    });
+
+    it("marks the primary as a relay when the private mempool swap applies", async () => {
+      mockChainQuery({
+        ...mockChain,
+        usePrivateMempoolRpc: true,
+        defaultPrivateRpcUrl: "https://rpc.flashbots.example.com",
+      });
+
+      const result = await resolveRpcConfig(1, undefined, {
+        usePrivateMempool: true,
+      });
+
+      expect(result?.primaryRpcUrl).toBe("https://rpc.flashbots.example.com");
+      expect(result?.primaryOrigin).toBe("relay");
+      // Strict by default: no fallback, so nothing platform-operated is left in
+      // the round and a transport failure is attributable to the relay alone.
+      expect(result?.fallbackRpcUrl).toBeUndefined();
+      expect(result?.fallbackOrigin).toBeUndefined();
+    });
+
+    it("keeps the platform origin on the fallback when the swap is not strict", async () => {
+      mockChainQuery({
+        ...mockChain,
+        usePrivateMempoolRpc: true,
+        defaultPrivateRpcUrl: "https://rpc.flashbots.example.com",
+      });
+
+      const result = await resolveRpcConfig(1, undefined, {
+        usePrivateMempool: true,
+        strict: false,
+      });
+
+      expect(result?.primaryOrigin).toBe("relay");
+      expect(result?.fallbackRpcUrl).toBe("https://default-eth.example.com");
+      expect(result?.fallbackOrigin).toBe("platform");
+    });
+
+    it("keeps platform origins when the chain does not support private mempool", async () => {
+      mockChainQuery(mockChain);
+
+      const result = await resolveRpcConfig(1, undefined, {
+        usePrivateMempool: true,
+      });
+
+      expect(result?.primaryRpcUrl).toBe("https://default-eth.example.com");
+      expect(result?.primaryOrigin).toBe("platform");
     });
   });
 

--- a/tests/unit/config-service.test.ts
+++ b/tests/unit/config-service.test.ts
@@ -77,8 +77,6 @@ describe("config-service", () => {
         fallbackRpcUrl: "https://default-eth-backup.example.com",
         primaryWssUrl: undefined,
         fallbackWssUrl: undefined,
-        primaryOrigin: "platform",
-        fallbackOrigin: "platform",
         usePrivateMempoolRpc: false,
         privateRpcUrl: undefined,
         source: "default",
@@ -121,8 +119,6 @@ describe("config-service", () => {
         fallbackRpcUrl: "https://user-eth-backup.example.com",
         primaryWssUrl: undefined,
         fallbackWssUrl: undefined,
-        primaryOrigin: "user",
-        fallbackOrigin: "user",
         usePrivateMempoolRpc: false,
         privateRpcUrl: undefined,
         source: "user",
@@ -188,7 +184,7 @@ describe("config-service", () => {
       expect(result).toBeNull();
     });
 
-    it("marks the primary as a relay when the private mempool swap applies", async () => {
+    it("flags the primary as the private relay when the swap applies", async () => {
       mockChainQuery({
         ...mockChain,
         usePrivateMempoolRpc: true,
@@ -200,14 +196,13 @@ describe("config-service", () => {
       });
 
       expect(result?.primaryRpcUrl).toBe("https://rpc.flashbots.example.com");
-      expect(result?.primaryOrigin).toBe("relay");
-      // Strict by default: no fallback, so nothing platform-operated is left in
-      // the round and a transport failure is attributable to the relay alone.
+      expect(result?.primaryIsPrivateRelay).toBe(true);
+      // Strict by default: no fallback, so the relay is the only endpoint in
+      // the round and a transport failure is attributable to it alone.
       expect(result?.fallbackRpcUrl).toBeUndefined();
-      expect(result?.fallbackOrigin).toBeUndefined();
     });
 
-    it("keeps the platform origin on the fallback when the swap is not strict", async () => {
+    it("keeps our own endpoint as the fallback when the swap is not strict", async () => {
       mockChainQuery({
         ...mockChain,
         usePrivateMempoolRpc: true,
@@ -219,12 +214,11 @@ describe("config-service", () => {
         strict: false,
       });
 
-      expect(result?.primaryOrigin).toBe("relay");
+      expect(result?.primaryIsPrivateRelay).toBe(true);
       expect(result?.fallbackRpcUrl).toBe("https://default-eth.example.com");
-      expect(result?.fallbackOrigin).toBe("platform");
     });
 
-    it("keeps platform origins when the chain does not support private mempool", async () => {
+    it("does not flag the relay when the chain does not support private mempool", async () => {
       mockChainQuery(mockChain);
 
       const result = await resolveRpcConfig(1, undefined, {
@@ -232,7 +226,20 @@ describe("config-service", () => {
       });
 
       expect(result?.primaryRpcUrl).toBe("https://default-eth.example.com");
-      expect(result?.primaryOrigin).toBe("platform");
+      expect(result?.primaryIsPrivateRelay).toBeUndefined();
+    });
+
+    it("does not flag the relay when the node did not ask for the private mempool", async () => {
+      mockChainQuery({
+        ...mockChain,
+        usePrivateMempoolRpc: true,
+        defaultPrivateRpcUrl: "https://rpc.flashbots.example.com",
+      });
+
+      const result = await resolveRpcConfig(1);
+
+      expect(result?.primaryRpcUrl).toBe("https://default-eth.example.com");
+      expect(result?.primaryIsPrivateRelay).toBeUndefined();
     });
   });
 

--- a/tests/unit/rpc-preferences-routes.test.ts
+++ b/tests/unit/rpc-preferences-routes.test.ts
@@ -81,6 +81,7 @@ import {
   resolveRpcConfig,
   setUserRpcPreference,
 } from "@/lib/rpc/config-service";
+import { RPC_ENDPOINT_ORIGIN } from "@/lib/rpc/types";
 
 describe("RPC Preferences API Routes", () => {
   const mockUser = {
@@ -143,6 +144,8 @@ describe("RPC Preferences API Routes", () => {
     chainName: "Ethereum Mainnet",
     primaryRpcUrl: "https://custom-eth.example.com",
     fallbackRpcUrl: "https://custom-eth-backup.example.com",
+    primaryOrigin: RPC_ENDPOINT_ORIGIN.USER,
+    fallbackOrigin: RPC_ENDPOINT_ORIGIN.USER,
     source: "user" as const,
   };
 

--- a/tests/unit/rpc-preferences-routes.test.ts
+++ b/tests/unit/rpc-preferences-routes.test.ts
@@ -81,7 +81,6 @@ import {
   resolveRpcConfig,
   setUserRpcPreference,
 } from "@/lib/rpc/config-service";
-import { RPC_ENDPOINT_ORIGIN } from "@/lib/rpc/types";
 
 describe("RPC Preferences API Routes", () => {
   const mockUser = {
@@ -144,8 +143,6 @@ describe("RPC Preferences API Routes", () => {
     chainName: "Ethereum Mainnet",
     primaryRpcUrl: "https://custom-eth.example.com",
     fallbackRpcUrl: "https://custom-eth-backup.example.com",
-    primaryOrigin: RPC_ENDPOINT_ORIGIN.USER,
-    fallbackOrigin: RPC_ENDPOINT_ORIGIN.USER,
     source: "user" as const,
   };
 

--- a/tests/unit/rpc-provider.test.ts
+++ b/tests/unit/rpc-provider.test.ts
@@ -22,7 +22,9 @@ import {
   noopMetricsCollector,
   type RpcMetricsCollector,
   RpcProviderManager,
+  RpcTransportError,
 } from "@/lib/rpc/providers";
+import { RPC_ENDPOINT_ORIGIN } from "@/lib/rpc/types";
 
 // Mock ethers
 vi.mock("ethers", () => {
@@ -321,6 +323,133 @@ describe("RpcProviderManager", () => {
       await expect(manager.executeWithFailover(mockOperation)).rejects.toThrow(
         "RPC failed on primary endpoint"
       );
+    });
+
+    it("attributes a relay timeout to the third party, not the platform", async () => {
+      const manager = new RpcProviderManager({
+        config: {
+          primaryRpcUrl: "https://rpc.flashbots.example.com",
+          maxRetries: 1,
+          timeoutMs: 100,
+          chainName: "Sepolia",
+          primaryOrigin: RPC_ENDPOINT_ORIGIN.RELAY,
+        },
+        metricsCollector,
+      });
+
+      const mockOperation = vi
+        .fn()
+        .mockRejectedValue(makeEthersError("TIMEOUT", "timeout"));
+
+      await expect(
+        manager.executeWithFailover(mockOperation)
+      ).rejects.toSatisfy((error: unknown) => {
+        expect(error).toBeInstanceOf(RpcTransportError);
+        expect((error as RpcTransportError).errorClass).toBe("external");
+        expect((error as Error).message).toContain(
+          "RPC failed on primary endpoint"
+        );
+        return true;
+      });
+    });
+
+    it("attributes a customer endpoint's timeout to the customer", async () => {
+      const manager = new RpcProviderManager({
+        config: {
+          primaryRpcUrl: "https://their-node.example.com",
+          maxRetries: 1,
+          timeoutMs: 100,
+          chainName: "Ethereum",
+          primaryOrigin: RPC_ENDPOINT_ORIGIN.USER,
+        },
+        metricsCollector,
+      });
+
+      const mockOperation = vi
+        .fn()
+        .mockRejectedValue(new Error("connect ECONNREFUSED 10.0.0.1:8545"));
+
+      await expect(
+        manager.executeWithFailover(mockOperation)
+      ).rejects.toSatisfy((error: unknown) => {
+        expect((error as RpcTransportError).errorClass).toBe("user");
+        return true;
+      });
+    });
+
+    it("leaves a relay failure unattributed when it answered rather than timed out", async () => {
+      const manager = new RpcProviderManager({
+        config: {
+          primaryRpcUrl: "https://rpc.flashbots.example.com",
+          maxRetries: 1,
+          timeoutMs: 100,
+          chainName: "Sepolia",
+          primaryOrigin: RPC_ENDPOINT_ORIGIN.RELAY,
+        },
+        metricsCollector,
+      });
+
+      // Every node answers this identically, so it says nothing about the relay.
+      const mockOperation = vi.fn().mockRejectedValue(makeServerError(400));
+
+      await expect(
+        manager.executeWithFailover(mockOperation)
+      ).rejects.toSatisfy((error: unknown) => {
+        expect(error).not.toBeInstanceOf(RpcTransportError);
+        return true;
+      });
+    });
+
+    it("keeps a platform endpoint's timeout unattributed", async () => {
+      const manager = new RpcProviderManager({
+        config: {
+          primaryRpcUrl: "https://primary.example.com",
+          maxRetries: 1,
+          timeoutMs: 100,
+          chainName: "Ethereum",
+        },
+        metricsCollector,
+      });
+
+      const mockOperation = vi
+        .fn()
+        .mockRejectedValue(makeEthersError("TIMEOUT", "timeout"));
+
+      await expect(
+        manager.executeWithFailover(mockOperation)
+      ).rejects.toSatisfy((error: unknown) => {
+        expect(error).not.toBeInstanceOf(RpcTransportError);
+        return true;
+      });
+    });
+
+    it("keeps the failure ours when a platform fallback went down alongside the relay", async () => {
+      const manager = new RpcProviderManager({
+        config: {
+          primaryRpcUrl: "https://rpc.flashbots.example.com",
+          fallbackRpcUrl: "https://primary.example.com",
+          maxRetries: 1,
+          timeoutMs: 100,
+          chainName: "Sepolia",
+          primaryOrigin: RPC_ENDPOINT_ORIGIN.RELAY,
+          fallbackOrigin: RPC_ENDPOINT_ORIGIN.PLATFORM,
+        },
+        metricsCollector,
+      });
+
+      const mockOperation = vi
+        .fn()
+        .mockRejectedValue(makeEthersError("TIMEOUT", "timeout"));
+
+      await expect(
+        manager.executeWithFailover(mockOperation)
+      ).rejects.toSatisfy((error: unknown) => {
+        expect(error).not.toBeInstanceOf(RpcTransportError);
+        expect((error as Error).message).toContain(
+          "RPC failed on both endpoints"
+        );
+        return true;
+      });
     });
 
     it("should call failover state change callback on failover", async () => {

--- a/tests/unit/rpc-provider.test.ts
+++ b/tests/unit/rpc-provider.test.ts
@@ -22,9 +22,8 @@ import {
   noopMetricsCollector,
   type RpcMetricsCollector,
   RpcProviderManager,
-  RpcTransportError,
+  RpcRelayTransportError,
 } from "@/lib/rpc/providers";
-import { RPC_ENDPOINT_ORIGIN } from "@/lib/rpc/types";
 
 // Mock ethers
 vi.mock("ethers", () => {
@@ -325,14 +324,14 @@ describe("RpcProviderManager", () => {
       );
     });
 
-    it("attributes a relay timeout to the third party, not the platform", async () => {
+    it("attributes a private-mempool relay timeout to the relay, not the platform", async () => {
       const manager = new RpcProviderManager({
         config: {
           primaryRpcUrl: "https://rpc.flashbots.example.com",
           maxRetries: 1,
           timeoutMs: 100,
           chainName: "Sepolia",
-          primaryOrigin: RPC_ENDPOINT_ORIGIN.RELAY,
+          primaryIsPrivateRelay: true,
         },
         metricsCollector,
       });
@@ -344,35 +343,11 @@ describe("RpcProviderManager", () => {
       await expect(
         manager.executeWithFailover(mockOperation)
       ).rejects.toSatisfy((error: unknown) => {
-        expect(error).toBeInstanceOf(RpcTransportError);
-        expect((error as RpcTransportError).errorClass).toBe("external");
+        expect(error).toBeInstanceOf(RpcRelayTransportError);
+        expect((error as RpcRelayTransportError).errorClass).toBe("external");
         expect((error as Error).message).toContain(
           "RPC failed on primary endpoint"
         );
-        return true;
-      });
-    });
-
-    it("attributes a customer endpoint's timeout to the customer", async () => {
-      const manager = new RpcProviderManager({
-        config: {
-          primaryRpcUrl: "https://their-node.example.com",
-          maxRetries: 1,
-          timeoutMs: 100,
-          chainName: "Ethereum",
-          primaryOrigin: RPC_ENDPOINT_ORIGIN.USER,
-        },
-        metricsCollector,
-      });
-
-      const mockOperation = vi
-        .fn()
-        .mockRejectedValue(new Error("connect ECONNREFUSED 10.0.0.1:8545"));
-
-      await expect(
-        manager.executeWithFailover(mockOperation)
-      ).rejects.toSatisfy((error: unknown) => {
-        expect((error as RpcTransportError).errorClass).toBe("user");
         return true;
       });
     });
@@ -384,7 +359,7 @@ describe("RpcProviderManager", () => {
           maxRetries: 1,
           timeoutMs: 100,
           chainName: "Sepolia",
-          primaryOrigin: RPC_ENDPOINT_ORIGIN.RELAY,
+          primaryIsPrivateRelay: true,
         },
         metricsCollector,
       });
@@ -395,12 +370,12 @@ describe("RpcProviderManager", () => {
       await expect(
         manager.executeWithFailover(mockOperation)
       ).rejects.toSatisfy((error: unknown) => {
-        expect(error).not.toBeInstanceOf(RpcTransportError);
+        expect(error).not.toBeInstanceOf(RpcRelayTransportError);
         return true;
       });
     });
 
-    it("keeps a platform endpoint's timeout unattributed", async () => {
+    it("keeps a timeout on our own endpoint unattributed", async () => {
       const manager = new RpcProviderManager({
         config: {
           primaryRpcUrl: "https://primary.example.com",
@@ -418,12 +393,12 @@ describe("RpcProviderManager", () => {
       await expect(
         manager.executeWithFailover(mockOperation)
       ).rejects.toSatisfy((error: unknown) => {
-        expect(error).not.toBeInstanceOf(RpcTransportError);
+        expect(error).not.toBeInstanceOf(RpcRelayTransportError);
         return true;
       });
     });
 
-    it("keeps the failure ours when a platform fallback went down alongside the relay", async () => {
+    it("keeps the failure ours when our fallback went down alongside the relay", async () => {
       const manager = new RpcProviderManager({
         config: {
           primaryRpcUrl: "https://rpc.flashbots.example.com",
@@ -431,8 +406,7 @@ describe("RpcProviderManager", () => {
           maxRetries: 1,
           timeoutMs: 100,
           chainName: "Sepolia",
-          primaryOrigin: RPC_ENDPOINT_ORIGIN.RELAY,
-          fallbackOrigin: RPC_ENDPOINT_ORIGIN.PLATFORM,
+          primaryIsPrivateRelay: true,
         },
         metricsCollector,
       });
@@ -444,7 +418,7 @@ describe("RpcProviderManager", () => {
       await expect(
         manager.executeWithFailover(mockOperation)
       ).rejects.toSatisfy((error: unknown) => {
-        expect(error).not.toBeInstanceOf(RpcTransportError);
+        expect(error).not.toBeInstanceOf(RpcRelayTransportError);
         expect((error as Error).message).toContain(
           "RPC failed on both endpoints"
         );

--- a/tests/unit/write-contract-core.test.ts
+++ b/tests/unit/write-contract-core.test.ts
@@ -186,6 +186,7 @@ vi.mock("@/lib/web3/transaction-manager", () => ({
 import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { RpcTransportError } from "@/lib/rpc/providers/transport-error";
 import { parsePriorityFeeGwei } from "@/lib/web3/gas-defaults";
 // Import mocks for assertion
 import { initializeWalletSigner } from "@/lib/web3/wallet-helpers";
@@ -414,6 +415,33 @@ describe("writeContractCore RPC resolution failure", () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.errorClass).toBe(ExecutionErrorType.SYSTEM);
+    }
+  });
+
+  it("forwards the relay's fault domain when the endpoint we only point at never answered", async () => {
+    vi.mocked(getRpcProvider).mockResolvedValueOnce({
+      resolveActiveRpcUrl: vi
+        .fn()
+        .mockRejectedValue(
+          new RpcTransportError(
+            "RPC failed on primary endpoint: timeout",
+            ExecutionErrorType.EXTERNAL
+          )
+        ),
+    } as unknown as Awaited<ReturnType<typeof getRpcProvider>>);
+
+    const result = await writeContractCore({
+      contractAddress: "0x1234567890123456789012345678901234567890",
+      network: "ethereum",
+      abi: VALID_ABI,
+      abiFunction: "transfer",
+      usePrivateMempool: true,
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errorClass).toBe(ExecutionErrorType.EXTERNAL);
     }
   });
 });

--- a/tests/unit/write-contract-core.test.ts
+++ b/tests/unit/write-contract-core.test.ts
@@ -186,7 +186,7 @@ vi.mock("@/lib/web3/transaction-manager", () => ({
 import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
-import { RpcTransportError } from "@/lib/rpc/providers/transport-error";
+import { RpcRelayTransportError } from "@/lib/rpc/providers/transport-error";
 import { parsePriorityFeeGwei } from "@/lib/web3/gas-defaults";
 // Import mocks for assertion
 import { initializeWalletSigner } from "@/lib/web3/wallet-helpers";
@@ -418,15 +418,12 @@ describe("writeContractCore RPC resolution failure", () => {
     }
   });
 
-  it("forwards the relay's fault domain when the endpoint we only point at never answered", async () => {
+  it("forwards the relay's fault domain when the private-mempool endpoint never answered", async () => {
     vi.mocked(getRpcProvider).mockResolvedValueOnce({
       resolveActiveRpcUrl: vi
         .fn()
         .mockRejectedValue(
-          new RpcTransportError(
-            "RPC failed on primary endpoint: timeout",
-            ExecutionErrorType.EXTERNAL
-          )
+          new RpcRelayTransportError("RPC failed on primary endpoint: timeout")
         ),
     } as unknown as Awaited<ReturnType<typeof getRpcProvider>>);
 

--- a/tests/unit/write-contract-fail-on-error.test.ts
+++ b/tests/unit/write-contract-fail-on-error.test.ts
@@ -311,4 +311,21 @@ describe("applyFailOnError", () => {
 
     expect(applyFailOnError(failure, false)).toEqual(failure);
   });
+
+  it("softens an EXTERNAL-classified relay outage when failOnError is false", () => {
+    const failure: WriteContractResult = {
+      success: false,
+      error: "RPC failed on primary endpoint: timeout",
+      errorClass: ExecutionErrorType.EXTERNAL,
+    };
+
+    // A third-party endpoint being down is transient, unlike the config faults
+    // above, so it is exactly what the toggle exists to continue past.
+    expect(applyFailOnError(failure, false)).toEqual({
+      success: true,
+      error: "RPC failed on primary endpoint: timeout",
+      rejection: undefined,
+    });
+    expect(applyFailOnError(failure, undefined)).toEqual(failure);
+  });
 });


### PR DESCRIPTION
## Problem

The message classifier reads every `RPC failed ...` string as a platform fault,
on the doctrine that RPC endpoints are KeeperHub-managed. That holds for the
endpoints we run: chain defaults point at env-configured infrastructure, and
their failures are ours to answer for.

It does not hold for one case. A node with Private Mempool enabled repoints
primary at the chain's Flashbots relay (`chains.default_private_rpc_url`) and,
in strict mode, clears the fallback. We configure that pointer; we do not
operate the node behind it. So a relay timing out currently pages us as if our
own RPC were degraded, and drives Statuspage.

## Change

`ResolvedRpcConfig` carries `primaryIsPrivateRelay`, set only where the swap
actually happens: the node asked for the private mempool and the chain had a
relay to route to. Nothing else in the resolver sets it, so every endpoint we
run is unaffected.

`executeWithFailover` throws an `RpcRelayTransportError` (fault domain
`external`) only when the exhausted round failed entirely on that relay
primary, with every attempt failing on transport: timeout, connection refused,
DNS, 429, 5xx. The web3 write paths forward it as the step's `errorClass`,
which overrides the message classifier when the execution row is finalized.

Deliberately narrow, in both directions:

- anything the relay answered definitively (reverts, insufficient funds, nonce
  conflicts) is identical on every node and keeps its existing classification,
- a round where one of our own endpoints also failed, which is the non-strict
  swap keeping the public endpoint as fallback, stays `system`.

## Where this applies

One row changes. Everything else keeps the classification it has today.

| Endpoint | Failure | Before | After |
| -- | -- | -- | -- |
| Chain default (env-configured, ours) | transport, primary exhausted | `system` / `C-0001` | unchanged |
| Chain default (ours) | transport, both endpoints exhausted | `system` / `N-0001` | unchanged |
| `user_rpc_preferences` | any | `system` | unchanged |
| **Relay, strict** | **transport: timeout, connection refused, DNS, 429, 5xx** | **`system` / `C-0001`** | **`external`, no code** |
| Relay, non-strict | relay and our fallback both failed | `system` / `N-0001` | unchanged |
| Relay | revert, insufficient funds, nonce conflict | `user` | unchanged |
| Relay | failure inside `populateTransaction` / `signTransaction` | message classifier | unchanged, see Known limit |

## Effect

The changed row moves `error_type` from `system` to `external`, `error_category`
to `external_service`, and clears the `C-0001` code. The execution's
user-facing status stays `error` either way: `C-0001` is the classifier's
default for an unmatched message, which never promoted the row to
`system_error`.

What changes is alert matching. The row stops matching every rule keyed on
`error_type="system"`, including the P2 that drives PagerDuty and Statuspage,
and does not enter the managed-client `error_type="user"` rules.

## Behavior change worth calling out

`applyFailOnError` now softens `EXTERNAL` failures. Without it, tagging the
broadcast path would turn a relay timeout into a hard failure for authors
running `failOnError=false`, which is a regression: a third-party outage is the
transient dependency failure the toggle exists to continue past. `USER` and
`SYSTEM` still always hard-fail, since those are config faults that recur on
every run.

## Known limit

`populateTransaction` / `signTransaction` talk to the endpoint directly,
outside the failover wrapper, so a relay timeout during those still falls to
the message classifier. The reachability probe runs first and catches a down
relay; this only applies to a flaky one.
