### PR TITLE
docs: sync CLI reference from v0.13.2

### DIFF
--- a/docs/cli/commands/kh_read.md
+++ b/docs/cli/commands/kh_read.md
@@ -10,7 +10,9 @@ The function signature should be in Solidity format (e.g. "balanceOf(address)").
 Arguments are positional and must match the function signature types.
 
 Supported argument types: address, uint256, bool, bytes32.
-No auth required; uses public RPC endpoints by default.
+
+No auth required. The RPC endpoint is yours to supply, via --rpc-url, the
+KH_RPC_URL env var, or an rpc.<chain-id> entry in the config file.
 
 ```
 kh read <contract-address> <function-signature> [args...] [flags]

--- a/docs/cli/quickstart.md
+++ b/docs/cli/quickstart.md
@@ -67,7 +67,7 @@ KeeperHub exposes its actions as tools to AI assistants via the [Model Context P
 
 **Recommended: remote HTTP endpoint (no local server required):**
 ```
-claude mcp add --transport http --scope user keeperhub https://app.keeperhub.com/mcp
+claude mcp add --transport http keeperhub https://app.keeperhub.com/mcp
 ```
 
 **Add to Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):


### PR DESCRIPTION
Auto-synced CLI command reference from cli@v0.13.2. Changes generated by go generate ./docs/... and copied to docs/cli/.