### PR TITLE
fix: report success on every check-and-execute dry run

### DIFF
--- a/app/api/execute/check-and-execute/route.ts
+++ b/app/api/execute/check-and-execute/route.ts
@@ -63,12 +63,19 @@ async function resolveAbiFromField(
   }
 }
 
+// Every dry-run response says whether the run itself completed, so a caller
+// never has to read an absent `success` as a failure. `wouldRevert` is not in
+// here on purpose: it is a claim about a specific call, so it is only set on
+// the branches that actually made one.
+const SIMULATION_RAN = { success: true, status: "simulated" } as const;
+
 async function executeConditionalRead(
   action: ActionBody,
   network: string,
   resolvedWriteAbi: string,
   organizationId: string,
-  conditionResult: ConditionResult
+  conditionResult: ConditionResult,
+  simulate: boolean
 ): Promise<NextResponse> {
   const readResult = await readContractCore({
     contractAddress: action.contractAddress,
@@ -86,8 +93,17 @@ async function executeConditionalRead(
     );
   }
 
+  // No `wouldRevert`: nothing was written or estimated here, so the field has
+  // no answer to give about this call.
   return NextResponse.json(
-    { executed: true, conditionResult, result: readResult.result },
+    simulate
+      ? {
+          ...SIMULATION_RAN,
+          executed: true,
+          conditionResult,
+          result: readResult.result,
+        }
+      : { executed: true, conditionResult, result: readResult.result },
     { status: HttpStatus.OK }
   );
 }
@@ -320,8 +336,12 @@ export async function POST(request: Request): Promise<NextResponse> {
   const conditionResult = evaluateCondition(readResult.result, condition);
 
   if (!conditionResult.met) {
+    // No `wouldRevert`: the action was never encoded or estimated, so we have
+    // no evidence either way and will not invent one.
     return NextResponse.json(
-      { executed: false, conditionResult },
+      simulateFlag.simulate
+        ? { ...SIMULATION_RAN, executed: false, conditionResult }
+        : { executed: false, conditionResult },
       { status: HttpStatus.OK }
     );
   }
@@ -365,7 +385,8 @@ export async function POST(request: Request): Promise<NextResponse> {
         network,
         writeAbiResult.abi,
         apiKeyCtx.organizationId,
-        conditionResult
+        conditionResult,
+        simulateFlag.simulate
       ),
       rateLimit
     );

--- a/docs/api/direct-execution.md
+++ b/docs/api/direct-execution.md
@@ -537,6 +537,32 @@ For ERC-20 transfers, `decimals` is optional — when omitted, the simulator loo
 
 `executed` reflects whether the action would have successfully run, so a reverted simulate returns `executed: false`.
 
+#### When no action is simulated
+
+A dry run reaches the action only when the condition is met and the action is a
+write. Two outcomes stop earlier, and both answer `200` with `success: true` and
+`status: "simulated"`, so the run is never mistaken for a failure:
+
+```json
+{
+  "success": true,
+  "status": "simulated",
+  "executed": false,
+  "conditionResult": { "met": false, "...": "..." }
+}
+```
+
+A read-only action answers the same way with `executed: true` and the `result`
+of the read.
+
+Neither carries `wouldRevert`. That field is a statement about a specific call
+that was encoded and estimated, and on these paths no such call was made, so
+there is nothing to report. Read `wouldRevert` only when it is present, and use
+`success` to decide whether the dry run itself completed.
+
+Broadcast responses are unaffected: without `simulate: true` these two outcomes
+return `{ executed, conditionResult }` exactly as before.
+
 ### Known limitation
 
 The `from` address used during simulation is the org's wallet (`getOrganizationWalletAddress`). Organizations that route writes through a Safe will see a simulation that reflects the EOA sending the call, not the Safe. Most config-bug categories (bad ABI, bad args, allowance mismatches) still surface; Safe-routed `msg.sender` semantics do not.

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -146,7 +146,7 @@
       "path": "/api/execute/{executionId}/status",
       "route_file": "app/api/execute/[executionId]/status/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 549
+      "line": 575
     },
     {
       "method": "GET",

--- a/tests/unit/check-and-execute-routing.test.ts
+++ b/tests/unit/check-and-execute-routing.test.ts
@@ -230,3 +230,104 @@ describe("check-and-execute routing", () => {
     expect(mockReadContractCore).toHaveBeenCalledTimes(1);
   });
 });
+
+// A dry run answers with one shape whatever it finds, so a caller cannot
+// mistake an absent `success` for a failed simulation.
+describe("check-and-execute dry-run response shape", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  type DryRun = {
+    success?: boolean;
+    status?: string;
+    wouldRevert?: boolean;
+    executed: boolean;
+  };
+
+  async function postJson(body: Record<string, unknown>): Promise<{
+    status: number;
+    json: DryRun;
+  }> {
+    const res = await POST(createRequest(body));
+    return { status: res.status, json: (await res.json()) as DryRun };
+  }
+
+  it("reports success when the condition is not met", async () => {
+    mockEvaluateCondition.mockReturnValue({
+      met: false,
+      actual: "10",
+      operator: "gt",
+      expected: "50",
+    });
+
+    const { status, json } = await postJson({
+      ...makeBody("nonpayable"),
+      simulate: true,
+    });
+
+    expect(status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.status).toBe("simulated");
+    expect(json.executed).toBe(false);
+    expect(mockWriteContractCore).not.toHaveBeenCalled();
+  });
+
+  it("claims nothing about reverting when no action was simulated", async () => {
+    mockEvaluateCondition.mockReturnValue({
+      met: false,
+      actual: "10",
+      operator: "gt",
+      expected: "50",
+    });
+
+    const { json } = await postJson({
+      ...makeBody("nonpayable"),
+      simulate: true,
+    });
+
+    expect(json).not.toHaveProperty("wouldRevert");
+  });
+
+  it("reports success when the action is read-only", async () => {
+    const { status, json } = await postJson({
+      ...makeBody("view"),
+      simulate: true,
+    });
+
+    expect(status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.status).toBe("simulated");
+    expect(json.executed).toBe(true);
+    expect(json).not.toHaveProperty("wouldRevert");
+    expect(mockWriteContractCore).not.toHaveBeenCalled();
+  });
+
+  it("leaves the broadcast response untouched when the condition is not met", async () => {
+    mockEvaluateCondition.mockReturnValue({
+      met: false,
+      actual: "10",
+      operator: "gt",
+      expected: "50",
+    });
+
+    const { status, json } = await postJson(makeBody("nonpayable"));
+
+    expect(status).toBe(200);
+    expect(json.executed).toBe(false);
+    expect(json).not.toHaveProperty("success");
+    expect(json).not.toHaveProperty("status");
+    expect(json).not.toHaveProperty("wouldRevert");
+  });
+
+  it("leaves the broadcast response untouched for a read-only action", async () => {
+    const { status, json } = await postJson(makeBody("view"));
+
+    expect(status).toBe(200);
+    expect(json.executed).toBe(true);
+    expect(json).not.toHaveProperty("success");
+    expect(json).not.toHaveProperty("status");
+    expect(json).not.toHaveProperty("wouldRevert");
+  });
+});


### PR DESCRIPTION
A `simulate: true` request to `/api/execute/check-and-execute` carried `success` only when the condition was met and the action was a write. Two earlier branches answered `200` with neither `success` nor `status`:

- condition not met (`route.ts:322`)
- action is `view` or `pure` (`route.ts:361`)

Both sit before the simulate branch, so they are shared with the broadcast path.

A client cannot distinguish an absent field from a false one. A dry run that ran perfectly and found the condition untrue is therefore indistinguishable from a failure, and the obvious guard, `if (!result.success || result.wouldRevert)`, rejects it.

## What changed

Both branches now carry `success: true` and `status: "simulated"` when the request asked for a dry run.

Neither reports `wouldRevert`. That field is a claim about a call that was encoded and estimated, and on these paths no such call exists, so answering `false` would assert something never checked. It stays confined to the write simulate path where the simulator produces it.

The two values that were added are facts rather than defaults: `status` mirrors the parsed simulate flag, and `success: true` is only reachable after the earlier failure branches have returned.

Broadcast responses are byte-identical, so this is not a breaking change.

## Tests

Five new cases in the routing suite, including one pinning that `wouldRevert` is absent rather than false, and two pinning that non-simulate responses gained no fields. The 54 tests across the five adjacent simulate suites still pass.

## Note

`pnpm check` reports one formatter error in `tests/unit/billing-execution-limit-core.test.ts`. It reproduces on pristine `staging` with this branch stashed, so it is pre-existing and unrelated.