### PR TITLE
fix: name the cause when a request carries a doubled /api prefix

### DIFF
--- a/app/api/[...slug]/route.ts
+++ b/app/api/[...slug]/route.ts
@@ -19,8 +19,40 @@ import { type NextRequest, NextResponse } from "next/server";
 import { ApiErrorCodes, apiError } from "@/lib/errors/api-envelope";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 
+// Per-route code, kept here rather than in ApiErrorCodes because only this
+// handler raises it.
+const DOUBLED_API_PREFIX = "doubled_api_prefix";
+
+// Every documented path already carries the /api prefix, so a client whose
+// base URL also ends in /api produces /api/api/... . A bare not_found reads
+// as a wrong path or a deleted resource, which sends people looking in the
+// wrong place, so name the cause instead.
+function doubledPrefixResponse(request: NextRequest, pathname: string) {
+  const corrected = pathname.replace("/api/api/", "/api/");
+  logUserError(
+    ErrorCategory.VALIDATION,
+    `[api-doubled-prefix] ${request.method} ${pathname}`,
+    undefined,
+    { method: request.method }
+  );
+  return apiError({
+    status: 404,
+    code: DOUBLED_API_PREFIX,
+    detail: `Route ${request.method} ${pathname} not found. The path is doubled: it contains /api twice.`,
+    hint: `Your base URL already includes /api. Drop it from the base URL, or call ${corrected} instead.`,
+    requestHeaders: request.headers,
+    headers: { "Cache-Control": "no-store" },
+  });
+}
+
 function notFoundResponse(request: NextRequest) {
   const { pathname } = new URL(request.url);
+
+  // Matches the bare /api/api too, which is what a base-URL misconfiguration
+  // produces when the caller asks for the API root.
+  if (pathname === "/api/api" || pathname.startsWith("/api/api/")) {
+    return doubledPrefixResponse(request, pathname);
+  }
   // Emit a structured Loki line so frequently-probed unknown routes stay
   // diagnosable. This is a public surface that bots hammer with random
   // paths; a miss is a client error, not a system fault, so it must not

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -19,6 +19,17 @@ base above exactly as shown. Setting a client's base URL to
 `https://app.keeperhub.com/api` and then appending a documented path produces a
 doubled `/api/api` prefix and a 404.
 
+That particular 404 names itself, so you do not have to guess. It answers with
+`error: "doubled_api_prefix"` and a `hint` carrying the corrected path:
+
+```json
+{
+  "error": "doubled_api_prefix",
+  "detail": "Route GET /api/api/chains not found. The path is doubled: it contains /api twice.",
+  "hint": "Your base URL already includes /api. Drop it from the base URL, or call /api/chains instead."
+}
+```
+
 ## Authentication
 
 API requests require authentication. Two methods are supported, but their accepted scope differs:

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -195,7 +195,7 @@
       "path": "/api/security/audit",
       "route_file": "app/api/security/audit/route.ts",
       "source": "docs/api/index.md",
-      "line": 65
+      "line": 76
     },
     {
       "method": "GET",
@@ -307,7 +307,7 @@
       "path": "/api/workflows/{workflowId}/history",
       "route_file": "app/api/workflows/[workflowId]/history/route.ts",
       "source": "docs/api/index.md",
-      "line": 64
+      "line": 75
     },
     {
       "method": "PATCH",

--- a/tests/unit/api-not-found.test.ts
+++ b/tests/unit/api-not-found.test.ts
@@ -95,3 +95,52 @@ describe("/api/[...slug] catch-all 404", () => {
     expect(body.detail).toBe("Route POST /api/me not found");
   });
 });
+
+// A base URL that already ends in /api produces /api/api/... . That is a
+// configuration mistake with one cause, so it gets its own code rather than
+// being indistinguishable from a wrong path.
+describe("/api/[...slug] doubled prefix", () => {
+  it("names the cause instead of returning a bare not_found", async () => {
+    const response = GET(buildRequest("GET", "/api/api/chains"));
+    expect(response.status).toBe(404);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.error).toBe("doubled_api_prefix");
+    expect(body.detail).toContain("/api twice");
+  });
+
+  it("hints the corrected path with the duplicate segment removed", async () => {
+    const response = GET(buildRequest("GET", "/api/api/chains"));
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.hint).toContain("/api/chains");
+    expect(body.hint).not.toContain("/api/api/chains");
+  });
+
+  it("catches the bare doubled root", async () => {
+    const response = GET(buildRequest("GET", "/api/api"));
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.error).toBe("doubled_api_prefix");
+  });
+
+  it("applies to every verb", async () => {
+    for (const [method, handler] of Object.entries(HANDLERS)) {
+      const response = handler(buildRequest(method, "/api/api/workflows"));
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("doubled_api_prefix");
+    }
+  });
+
+  it("leaves a path that merely contains api elsewhere alone", async () => {
+    const response = GET(buildRequest("GET", "/api/workflows/api/runs"));
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.error).toBe("not_found");
+  });
+
+  it("keeps the canonical envelope fields", async () => {
+    const response = GET(
+      buildRequest("GET", "/api/api/chains", { "x-request-id": "trace-dup-1" })
+    );
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.request_id).toBe("trace-dup-1");
+  });
+});


### PR DESCRIPTION
Every documented path already includes the `/api` prefix, so a client whose base URL also ends in `/api` produces `/api/api/...`. The catch-all answered that with a bare `not_found`, which reads exactly like a wrong path or a deleted resource and sends people looking in the wrong place. Every SDK convention treats the base URL as the API root, so integrators keep configuring it that way.

## What changed

The catch-all recognises the shape and answers with:

```json
{
  "error": "doubled_api_prefix",
  "detail": "Route GET /api/api/chains not found. The path is doubled: it contains /api twice.",
  "hint": "Your base URL already includes /api. Drop it from the base URL, or call /api/chains instead."
}
```

The corrected path in the hint is derived from the request rather than described in prose.

Status stays `404`, since the resource genuinely is not there. Only the diagnosis is sharper.

The code lives beside the route rather than in `ApiErrorCodes`, matching the convention documented on that object that per-route codes stay next to whatever raises them. The log line gets its own `[api-doubled-prefix]` context so frequency is measurable without adding an unbounded metric label.

The bare `/api/api` root is matched too, which is what the same misconfiguration produces when a caller asks for the API root.

## Tests

Six new cases: the code and detail, the derived hint, the bare doubled root, every verb, envelope fields and request-id echo preserved, and one pinning that a path merely containing `api` in a later segment (`/api/workflows/api/runs`) still returns plain `not_found`.

## Note

`pnpm check` reports one formatter error in `tests/unit/billing-execution-limit-core.test.ts`. It reproduces on pristine `staging`, so it is pre-existing and unrelated.