### PR TITLE
docs: advertise the status poll interval hint in the quickstart

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -132,7 +132,10 @@ faucets above, then use this sequence:
 3. Repeat the same call with `simulate` omitted and a new
    `idempotency_key`.
 4. Pass the returned `executionId` to `get_direct_execution_status` and poll
-   until the status is `completed` or `failed`.
+   until the status is `completed` or `failed`. Wait the number of seconds in
+   the `X-Poll-Interval-Hint` response header between polls rather than
+   picking your own interval; a value of `0` means the execution is terminal
+   and you can stop.
 5. Save `transactionLink` from the terminal response as the onchain proof.
 
 Example simulation on Base Sepolia:


### PR DESCRIPTION
`GET /api/execute/{executionId}/status` returns an `X-Poll-Interval-Hint` header, where `0` means the execution is terminal. It removes the fixed-timer guesswork from polling, and it was documented only near the end of the direct-execution reference, which is not where someone writes their first poll loop.

The quickstart's polling step now says to honour it, and what `0` means.

An external integrator singled this header out as good design that is hard to discover, which is the whole problem: you only meet it if you read the reference to the end.