### PR TITLE
fix: charge overage left behind when a subscription ends

### DIFF
--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -662,7 +662,7 @@ app:
           repository: ${ECR_REGISTRY}/keeperhub-prod
           tag: app-${IMAGE_TAG}
           imagePullPolicy: Always
-        schedule: "17 * * * *" # hourly, offset by 17 minutes
+        schedule: "17 1,13 * * *" # twice daily, offset by 17 minutes
         command: ["/bin/sh"]
         args:
           - "/app/deploy/scripts/reaper.sh"

--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -657,6 +657,63 @@ app:
         failedJobsHistoryLimit: 3
         restartPolicy: OnFailure
         backoffLimit: 2
+      - name: overage-scan
+        image:
+          repository: ${ECR_REGISTRY}/keeperhub-prod
+          tag: app-${IMAGE_TAG}
+          imagePullPolicy: Always
+        schedule: "17 * * * *" # hourly, offset by 17 minutes
+        command: ["/bin/sh"]
+        args:
+          - "/app/deploy/scripts/reaper.sh"
+          - "http://keeperhub-common:3000/api/billing/overage"
+          - "POST"
+          - '{"scan":true}'
+        env:
+          INTERNAL_SERVICE_HMAC_SECRET:
+            type: parameterStore
+            name: internal-service-hmac-secret
+            parameter_name: /eks/techops-prod/keeperhub/internal-service-hmac-secret
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "10m"
+          limits:
+            memory: "32Mi"
+            cpu: "10m"
+        concurrencyPolicy: Forbid
+        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 3
+        restartPolicy: OnFailure
+        backoffLimit: 2
+      - name: billing-debt-scan
+        image:
+          repository: ${ECR_REGISTRY}/keeperhub-prod
+          tag: app-${IMAGE_TAG}
+          imagePullPolicy: Always
+        schedule: "23 4 * * *" # daily at 04:23 UTC
+        command: ["/bin/sh"]
+        args:
+          - "/app/deploy/scripts/reaper.sh"
+          - "http://keeperhub-common:3000/api/billing/debt-scan"
+          - "POST"
+        env:
+          INTERNAL_SERVICE_HMAC_SECRET:
+            type: parameterStore
+            name: internal-service-hmac-secret
+            parameter_name: /eks/techops-prod/keeperhub/internal-service-hmac-secret
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "10m"
+          limits:
+            memory: "32Mi"
+            cpu: "10m"
+        concurrencyPolicy: Forbid
+        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 3
+        restartPolicy: OnFailure
+        backoffLimit: 2
       - name: tempo-broadcast-due
         image:
           repository: ${ECR_REGISTRY}/keeperhub-prod

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -659,6 +659,63 @@ app:
         restartPolicy: OnFailure
         backoffLimit: 2
 
+      - name: overage-scan
+        image:
+          repository: ${ECR_REGISTRY}/keeperhub-staging
+          tag: app-${IMAGE_TAG}
+          imagePullPolicy: Always
+        schedule: "17 * * * *" # hourly, offset by 17 minutes
+        command: ["/bin/sh"]
+        args:
+          - "/app/deploy/scripts/reaper.sh"
+          - "http://keeperhub-common:3000/api/billing/overage"
+          - "POST"
+          - '{"scan":true}'
+        env:
+          INTERNAL_SERVICE_HMAC_SECRET:
+            type: parameterStore
+            name: internal-service-hmac-secret
+            parameter_name: /eks/techops-staging/keeperhub/internal-service-hmac-secret
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "10m"
+          limits:
+            memory: "32Mi"
+            cpu: "10m"
+        concurrencyPolicy: Forbid
+        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 3
+        restartPolicy: OnFailure
+        backoffLimit: 2
+      - name: billing-debt-scan
+        image:
+          repository: ${ECR_REGISTRY}/keeperhub-staging
+          tag: app-${IMAGE_TAG}
+          imagePullPolicy: Always
+        schedule: "23 4 * * *" # daily at 04:23 UTC
+        command: ["/bin/sh"]
+        args:
+          - "/app/deploy/scripts/reaper.sh"
+          - "http://keeperhub-common:3000/api/billing/debt-scan"
+          - "POST"
+        env:
+          INTERNAL_SERVICE_HMAC_SECRET:
+            type: parameterStore
+            name: internal-service-hmac-secret
+            parameter_name: /eks/techops-staging/keeperhub/internal-service-hmac-secret
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "10m"
+          limits:
+            memory: "32Mi"
+            cpu: "10m"
+        concurrencyPolicy: Forbid
+        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 3
+        restartPolicy: OnFailure
+        backoffLimit: 2
       - name: tempo-broadcast-due
         image:
           repository: ${ECR_REGISTRY}/keeperhub-staging

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -664,7 +664,7 @@ app:
           repository: ${ECR_REGISTRY}/keeperhub-staging
           tag: app-${IMAGE_TAG}
           imagePullPolicy: Always
-        schedule: "17 * * * *" # hourly, offset by 17 minutes
+        schedule: "17 1,13 * * *" # twice daily, offset by 17 minutes
         command: ["/bin/sh"]
         args:
           - "/app/deploy/scripts/reaper.sh"

--- a/deploy/scripts/reaper.sh
+++ b/deploy/scripts/reaper.sh
@@ -2,6 +2,9 @@
 set -e
 
 URL="$1"
+# Optional, so the GET callers keep passing a URL and nothing else.
+METHOD="${2:-GET}"
+BODY="${3:-}"
 
 if [ -z "$URL" ]; then
   echo '{"error":"missing URL argument"}' >&2
@@ -14,9 +17,8 @@ if [ -z "$INTERNAL_SERVICE_HMAC_SECRET" ]; then
 fi
 
 CALLER="scheduler"
-METHOD="GET"
 TIMESTAMP=$(date +%s)
-BODY_DIGEST=$(printf '' | openssl dgst -sha256 | awk '{print $2}')
+BODY_DIGEST=$(printf '%s' "$BODY" | openssl dgst -sha256 | awk '{print $2}')
 PATHNAME=$(printf '%s' "$URL" | sed 's|https\?://[^/]*||')
 SIGNING_STRING=$(printf '%s\n%s\n%s\n%s\n%s' "$METHOD" "$PATHNAME" "$CALLER" "$BODY_DIGEST" "$TIMESTAMP")
 SIGNATURE=$(printf '%s' "$SIGNING_STRING" | openssl dgst -sha256 -hmac "$INTERNAL_SERVICE_HMAC_SECRET" | awk '{print $2}')
@@ -31,12 +33,25 @@ echo "Environment variables are ready"
 # silently undone. Fail the job on any non-2xx (and on an unparseable status)
 # so Kubernetes records a failed job and the cluster's CronJob-failure alerting
 # can page. Applies to every cron that runs this script, not just the scan.
-RESPONSE=$(curl -sS \
-  -w '\n{"http_code":%{http_code},"time_total":%{time_total}}' \
-  -H "X-KH-Caller: ${CALLER}" \
-  -H "X-KH-Timestamp: ${TIMESTAMP}" \
-  -H "X-KH-Signature: ${SIGNATURE}" \
-  "$URL")
+if [ -n "$BODY" ]; then
+  RESPONSE=$(curl -sS \
+    -w '\n{"http_code":%{http_code},"time_total":%{time_total}}' \
+    -X "$METHOD" \
+    -H "X-KH-Caller: ${CALLER}" \
+    -H "X-KH-Timestamp: ${TIMESTAMP}" \
+    -H "X-KH-Signature: ${SIGNATURE}" \
+    -H "Content-Type: application/json" \
+    --data-raw "$BODY" \
+    "$URL")
+else
+  RESPONSE=$(curl -sS \
+    -w '\n{"http_code":%{http_code},"time_total":%{time_total}}' \
+    -X "$METHOD" \
+    -H "X-KH-Caller: ${CALLER}" \
+    -H "X-KH-Timestamp: ${TIMESTAMP}" \
+    -H "X-KH-Signature: ${SIGNATURE}" \
+    "$URL")
+fi
 
 printf '%s\n' "$RESPONSE"
 

--- a/lib/billing/handle-billing-event.ts
+++ b/lib/billing/handle-billing-event.ts
@@ -14,8 +14,12 @@ import { getMetricsCollector } from "@/lib/metrics";
 import { MetricNames } from "@/lib/metrics/types";
 import { recordAuditEvent } from "@/lib/security/audit-log";
 import { BILLING_ALERTS } from "./constants";
-import { clearAllDebtForOrg, clearDebtForInvoice } from "./execution-debt";
-import { billOverageForOrg } from "./overage";
+import { clearDebtForInvoice } from "./execution-debt";
+import {
+  billOverageForOrg,
+  collectFinalPeriodOverage,
+  collectOutstandingOverage,
+} from "./overage";
 import { type PlanName, parsePlanName } from "./plans";
 import { resolveSubscriptionPlan } from "./plans-server";
 import type { BillingProvider, BillingWebhookEvent } from "./provider";
@@ -222,6 +226,20 @@ async function handleCheckoutCompleted(
     });
 
   console.info(LOG_PREFIX, "Upserted subscription for org:", organizationId);
+
+  // A returning org may have left an unpaid overage invoice behind when it
+  // cancelled. Subscribing again means there is a payment method on file, so
+  // this is the moment to settle it. Never blocks the subscription itself.
+  try {
+    await collectOutstandingOverage(organizationId, provider);
+  } catch (error) {
+    logSystemWarn(
+      ErrorCategory.BILLING,
+      `${LOG_PREFIX} Failed to settle outstanding overage on resubscribe`,
+      error,
+      { org_id: organizationId }
+    );
+  }
 
   const metrics = getMetricsCollector();
   metrics.incrementCounter(MetricNames.BILLING_SUBSCRIPTION_CREATED, {
@@ -462,6 +480,44 @@ async function handleSubscriptionUpdated(
   }
 }
 
+/**
+ * Charge the closing period's overage on a subscription that is ending.
+ *
+ * Never throws. The downgrade has to complete regardless: leaving an org on a
+ * paid plan because a card was declined would hand it a plan it is not paying
+ * for. An uncollected amount stays on the open invoice and is picked up by the
+ * debt scan.
+ */
+async function collectFinalPeriodOverageSafely(
+  current: SubscriptionRow | undefined
+): Promise<void> {
+  if (
+    !(
+      current?.providerCustomerId &&
+      current.currentPeriodStart instanceof Date &&
+      current.currentPeriodEnd instanceof Date
+    )
+  ) {
+    return;
+  }
+
+  try {
+    await collectFinalPeriodOverage(
+      current.organizationId,
+      current.currentPeriodStart,
+      current.currentPeriodEnd,
+      current.providerCustomerId
+    );
+  } catch (error) {
+    logSystemWarn(
+      ErrorCategory.BILLING,
+      `${LOG_PREFIX} Failed to bill the final period on cancellation (will be retried by scan)`,
+      error,
+      { org_id: current.organizationId }
+    );
+  }
+}
+
 async function handleSubscriptionDeleted(
   data: BillingWebhookEvent["data"]
 ): Promise<void> {
@@ -503,11 +559,9 @@ async function handleSubscriptionDeleted(
         )
       );
 
-    // Clear debt even when period is still active -- no further overage
-    // will be billed on a canceled subscription, so debt is moot.
-    if (current) {
-      await clearAllDebtForOrg(current.organizationId);
-    }
+    // Debt is deliberately left in place. The org still owes the amount, and
+    // it is what gates them if they subscribe again. The period is not over
+    // here, so the excess is billed later by the overage scan.
 
     getMetricsCollector().incrementCounter(
       MetricNames.BILLING_SUBSCRIPTION_CANCELED,
@@ -543,6 +597,11 @@ async function handleSubscriptionDeleted(
     "period ended, resetting to free"
   );
 
+  // Before the reset, while the row still carries the paid plan and its limit.
+  // billOverageForOrg reads plan off the row and skips a free one, so this
+  // cannot move below the update.
+  await collectFinalPeriodOverageSafely(current);
+
   await db
     .update(organizationSubscriptions)
     .set({
@@ -561,10 +620,8 @@ async function handleSubscriptionDeleted(
       )
     );
 
-  // Clear any active debt -- it becomes moot when downgrading to free
-  if (current) {
-    await clearAllDebtForOrg(current.organizationId);
-  }
+  // Debt survives the downgrade. Dropping to free does not settle what the org
+  // already ran up, and the record is what lets us collect if they return.
 
   getMetricsCollector().incrementCounter(
     MetricNames.BILLING_SUBSCRIPTION_CANCELED,

--- a/lib/billing/overage.ts
+++ b/lib/billing/overage.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
   organizationSubscriptions,
@@ -217,4 +217,138 @@ export async function billOverageForOrg(
 
     return { billed: false, reason: `provider error: ${message}` };
   }
+}
+
+type FinalPeriodResult =
+  | { collected: true; totalChargeCents: number }
+  // invoiceId is set only when an invoice was raised but not paid, i.e. the
+  // amount is owed rather than there being nothing to bill.
+  | { collected: false; reason: string; invoiceId?: string };
+
+/**
+ * Bill and immediately collect a closing period's overage for an organization
+ * whose subscription is ending.
+ *
+ * The normal path attaches overage to the invoice that closes the period, but a
+ * subscription that ends produces no such invoice, so the excess would never be
+ * charged. This opens a standalone invoice instead, deliberately not tied to
+ * the subscription, so it carries the overage line and nothing else: no plan
+ * fee, no proration.
+ *
+ * A declined card leaves the invoice open rather than raising. The amount stays
+ * owed and the debt scan turns it into an execution-debt record once the grace
+ * period passes.
+ */
+export async function collectFinalPeriodOverage(
+  organizationId: string,
+  periodStart: Date,
+  periodEnd: Date,
+  customerId: string
+): Promise<FinalPeriodResult> {
+  const provider = getBillingProvider();
+
+  const { invoiceId } = await provider.createDraftInvoice(customerId);
+
+  const result = await billOverageForOrg(
+    organizationId,
+    periodStart,
+    periodEnd,
+    { invoiceId }
+  );
+
+  if (!result.billed) {
+    await provider.deleteDraftInvoice(invoiceId);
+    return { collected: false, reason: result.reason };
+  }
+
+  const collection = await provider.finalizeAndCollectInvoice(invoiceId);
+
+  if (!collection.paid) {
+    logSystemWarn(
+      ErrorCategory.BILLING,
+      `${LOG_PREFIX} Final-period invoice was not collected; amount stays owed`,
+      new Error(collection.failureReason ?? "collection failed"),
+      { org_id: organizationId }
+    );
+    return {
+      collected: false,
+      reason: collection.failureReason ?? "collection failed",
+      invoiceId: collection.invoiceId,
+    };
+  }
+
+  return { collected: true, totalChargeCents: result.totalChargeCents };
+}
+
+/**
+ * Settle any overage an organization left unpaid, called when it subscribes
+ * again.
+ *
+ * Cancelling does not clear what was already run up: the invoice stays open and
+ * the debt record stays active. Coming back is the point where a payment method
+ * exists again, so this is where the outstanding amount gets another attempt.
+ * Records already attributed to a paid invoice are skipped.
+ */
+export async function collectOutstandingOverage(
+  organizationId: string,
+  provider: BillingProvider
+): Promise<{ attempted: number; collected: number }> {
+  const rows = await db
+    .select({
+      id: overageBillingRecords.id,
+      providerInvoiceItemId: overageBillingRecords.providerInvoiceItemId,
+    })
+    .from(overageBillingRecords)
+    .where(
+      and(
+        eq(overageBillingRecords.organizationId, organizationId),
+        eq(overageBillingRecords.status, "billed"),
+        isNull(overageBillingRecords.providerInvoiceId)
+      )
+    );
+
+  let attempted = 0;
+  let collected = 0;
+
+  for (const row of rows) {
+    if (!row.providerInvoiceItemId) {
+      continue;
+    }
+
+    try {
+      const invoice = await provider.getInvoiceForItem(
+        row.providerInvoiceItemId
+      );
+      if (!invoice) {
+        continue;
+      }
+
+      if (invoice.paid) {
+        await db
+          .update(overageBillingRecords)
+          .set({ providerInvoiceId: invoice.invoiceId })
+          .where(eq(overageBillingRecords.id, row.id));
+        continue;
+      }
+
+      attempted += 1;
+      const result = await provider.finalizeAndCollectInvoice(
+        invoice.invoiceId
+      );
+      if (result.paid) {
+        collected += 1;
+      }
+    } catch (error) {
+      // One unsettleable record must not stop the rest, nor block the checkout
+      // that triggered this.
+      logSystemWarn(
+        ErrorCategory.BILLING,
+        `${LOG_PREFIX} Could not settle an outstanding overage record`,
+        error,
+        { org_id: organizationId }
+      );
+    }
+  }
+
+  return { attempted, collected };
 }

--- a/lib/billing/overage.ts
+++ b/lib/billing/overage.ts
@@ -19,6 +19,9 @@ import { getBillingProvider } from "./providers";
 
 const LOG_PREFIX = "[Overage Billing]";
 
+// The invoice and the items on it must agree; an invoice cannot mix currencies.
+const BILLING_CURRENCY = "usd";
+
 type OverageResult =
   | { billed: false; reason: string }
   | { billed: true; overageCount: number; totalChargeCents: number };
@@ -171,7 +174,7 @@ export async function billOverageForOrg(
     const itemParams = {
       customerId: sub.providerCustomerId,
       amount: totalChargeCents,
-      currency: "usd",
+      currency: BILLING_CURRENCY,
       description: `Overage: ${overageCount.toLocaleString()} executions above ${limits.maxExecutionsPerMonth.toLocaleString()} limit (${plan} plan)`,
       metadata: {
         organizationId,
@@ -247,7 +250,10 @@ export async function collectFinalPeriodOverage(
 ): Promise<FinalPeriodResult> {
   const provider = getBillingProvider();
 
-  const { invoiceId } = await provider.createDraftInvoice(customerId);
+  const { invoiceId } = await provider.createDraftInvoice(
+    customerId,
+    BILLING_CURRENCY
+  );
 
   const result = await billOverageForOrg(
     organizationId,

--- a/lib/billing/overage.ts
+++ b/lib/billing/overage.ts
@@ -1,8 +1,9 @@
 import "server-only";
 
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, eq, isNotNull, isNull, or, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
+  executionDebt,
   organizationSubscriptions,
   overageBillingRecords,
 } from "@/lib/db/schema";
@@ -32,27 +33,45 @@ type OverageResult =
  * Attaching only works while the invoice is still a draft. If it finalized
  * first the attached call is rejected, and the retry keeps the charge as a
  * pending item on the following invoice rather than dropping it.
+ *
+ * Each attempt carries its own idempotency key, so repeating either one returns
+ * the item it already made rather than a second one. The keys have to differ
+ * because the provider refuses a key replayed with different parameters, and
+ * the two attempts differ by exactly the invoice they attach to.
+ *
+ * The retry runs only when the provider refused the request outright, which
+ * means it created nothing. After a transport failure the item may exist and
+ * only the response was lost, so retrying under the other key would bill twice.
  */
 async function createItemWithFallback(
   provider: BillingProvider,
-  params: Omit<CreateInvoiceItemParams, "invoiceId">,
+  params: Omit<CreateInvoiceItemParams, "invoiceId" | "idempotencyKey">,
   invoiceId: string | undefined,
-  organizationId: string
+  organizationId: string,
+  idempotencyKey: string
 ): Promise<CreateInvoiceItemResult> {
   if (!invoiceId) {
-    return await provider.createInvoiceItem(params);
+    return await provider.createInvoiceItem({ ...params, idempotencyKey });
   }
 
   try {
-    return await provider.createInvoiceItem({ ...params, invoiceId });
+    return await provider.createInvoiceItem({
+      ...params,
+      invoiceId,
+      idempotencyKey: `${idempotencyKey}-inv`,
+    });
   } catch (error) {
+    if (!provider.wasRejectedWithoutCreating(error)) {
+      throw error;
+    }
+
     logSystemWarn(
       ErrorCategory.BILLING,
       `${LOG_PREFIX} Could not attach to the closing invoice, falling back to the next one`,
       error,
       { org_id: organizationId }
     );
-    return await provider.createInvoiceItem(params);
+    return await provider.createInvoiceItem({ ...params, idempotencyKey });
   }
 }
 
@@ -182,17 +201,17 @@ export async function billOverageForOrg(
         periodEnd: periodEnd.toISOString(),
         overageCount: String(overageCount),
       },
-      // Keyed on the record, which the unique index already pins to one
-      // organization and period, so every attempt at this charge presents the
-      // same key and the provider can only ever create one item for it.
-      idempotencyKey: `overage-${record.id}`,
     };
 
+    // Keyed on the record, which the unique index already pins to one
+    // organization and period, so a repeat of any attempt returns the item it
+    // already made instead of creating another.
     const { invoiceItemId } = await createItemWithFallback(
       provider,
       itemParams,
       options?.invoiceId,
-      organizationId
+      organizationId,
+      `overage-${record.id}`
     );
 
     await db
@@ -290,6 +309,38 @@ export async function collectFinalPeriodOverage(
   return { collected: true, totalChargeCents: result.totalChargeCents };
 }
 
+type SettleableRecord = {
+  providerInvoiceItemId: string | null;
+  providerInvoiceId: string | null;
+};
+
+/**
+ * Find the invoice a record was billed onto.
+ *
+ * A stamped record names its invoice directly. An unstamped one has to be
+ * traced through its item, which the provider can no longer resolve once the
+ * item has been consumed into a finalized invoice.
+ */
+async function resolveRecordInvoice(
+  row: SettleableRecord,
+  provider: BillingProvider
+): Promise<{ invoiceId: string; status: string; paid: boolean } | undefined> {
+  if (row.providerInvoiceId) {
+    const status = await provider.getInvoiceStatus(row.providerInvoiceId);
+    return {
+      invoiceId: row.providerInvoiceId,
+      status: status.status,
+      paid: status.paid,
+    };
+  }
+
+  if (!row.providerInvoiceItemId) {
+    return undefined;
+  }
+
+  return await provider.getInvoiceForItem(row.providerInvoiceItemId);
+}
+
 /**
  * Settle any overage an organization left unpaid, called when it subscribes
  * again.
@@ -303,17 +354,32 @@ export async function collectOutstandingOverage(
   organizationId: string,
   provider: BillingProvider
 ): Promise<{ attempted: number; collected: number }> {
+  // Unattributed records are the usual case. A record the debt scan already
+  // stamped is included too: stamping only means the invoice was resolved, not
+  // that it was paid, and skipping those leaves the debt that gates this
+  // organization with no way to ever settle.
   const rows = await db
     .select({
       id: overageBillingRecords.id,
       providerInvoiceItemId: overageBillingRecords.providerInvoiceItemId,
+      providerInvoiceId: overageBillingRecords.providerInvoiceId,
     })
     .from(overageBillingRecords)
+    .leftJoin(
+      executionDebt,
+      and(
+        eq(executionDebt.overageRecordId, overageBillingRecords.id),
+        eq(executionDebt.status, "active")
+      )
+    )
     .where(
       and(
         eq(overageBillingRecords.organizationId, organizationId),
         eq(overageBillingRecords.status, "billed"),
-        isNull(overageBillingRecords.providerInvoiceId)
+        or(
+          isNull(overageBillingRecords.providerInvoiceId),
+          isNotNull(executionDebt.id)
+        )
       )
     );
 
@@ -321,14 +387,8 @@ export async function collectOutstandingOverage(
   let collected = 0;
 
   for (const row of rows) {
-    if (!row.providerInvoiceItemId) {
-      continue;
-    }
-
     try {
-      const invoice = await provider.getInvoiceForItem(
-        row.providerInvoiceItemId
-      );
+      const invoice = await resolveRecordInvoice(row, provider);
       if (!invoice) {
         continue;
       }
@@ -338,6 +398,13 @@ export async function collectOutstandingOverage(
           .update(overageBillingRecords)
           .set({ providerInvoiceId: invoice.invoiceId })
           .where(eq(overageBillingRecords.id, row.id));
+        continue;
+      }
+
+      // A draft is still being assembled by the provider. Finalizing it here
+      // would charge a renewal invoice early, before the lines it is waiting on
+      // are added. Only an already-open invoice is ours to collect.
+      if (invoice.status === "draft") {
         continue;
       }
 

--- a/lib/billing/overage.ts
+++ b/lib/billing/overage.ts
@@ -182,6 +182,10 @@ export async function billOverageForOrg(
         periodEnd: periodEnd.toISOString(),
         overageCount: String(overageCount),
       },
+      // Keyed on the record, which the unique index already pins to one
+      // organization and period, so every attempt at this charge presents the
+      // same key and the provider can only ever create one item for it.
+      idempotencyKey: `overage-${record.id}`,
     };
 
     const { invoiceItemId } = await createItemWithFallback(

--- a/lib/billing/provider.ts
+++ b/lib/billing/provider.ts
@@ -95,6 +95,13 @@ export type CreateInvoiceItemResult = {
   invoiceItemId: string;
 };
 
+export type CollectInvoiceResult = {
+  invoiceId: string;
+  paid: boolean;
+  // Why collection failed, for the log and the debt record. Undefined when paid.
+  failureReason?: string;
+};
+
 export type ProrationPreview = {
   amountDue: number;
   subtotal: number;
@@ -165,4 +172,23 @@ export interface BillingProvider {
   getInvoiceForItem(
     invoiceItemId: string
   ): Promise<{ invoiceId: string; status: string; paid: boolean } | undefined>;
+
+  /**
+   * Open an empty draft invoice for a customer, deliberately not tied to a
+   * subscription so the provider puts no plan or proration lines on it. Items
+   * are attached explicitly via createInvoiceItem, so the invoice bills only
+   * what the caller adds.
+   */
+  createDraftInvoice(customerId: string): Promise<{ invoiceId: string }>;
+
+  /**
+   * Finalize a draft and attempt payment. Resolves with paid: false and a
+   * reason rather than throwing when the charge is declined or no payment
+   * method is on file, since an uncollected invoice is a debt to record and
+   * not an error to retry.
+   */
+  finalizeAndCollectInvoice(invoiceId: string): Promise<CollectInvoiceResult>;
+
+  /** Discard a draft that ended up with nothing to bill. */
+  deleteDraftInvoice(invoiceId: string): Promise<void>;
 }

--- a/lib/billing/provider.ts
+++ b/lib/billing/provider.ts
@@ -178,8 +178,15 @@ export interface BillingProvider {
    * subscription so the provider puts no plan or proration lines on it. Items
    * are attached explicitly via createInvoiceItem, so the invoice bills only
    * what the caller adds.
+   *
+   * `currency` must match the items that will be attached. Left to the
+   * provider it defaults to the account or customer currency, and an invoice
+   * cannot mix currencies, so a mismatch rejects the attach outright.
    */
-  createDraftInvoice(customerId: string): Promise<{ invoiceId: string }>;
+  createDraftInvoice(
+    customerId: string,
+    currency: string
+  ): Promise<{ invoiceId: string }>;
 
   /**
    * Finalize a draft and attempt payment. Resolves with paid: false and a

--- a/lib/billing/provider.ts
+++ b/lib/billing/provider.ts
@@ -202,4 +202,13 @@ export interface BillingProvider {
 
   /** Discard a draft that ended up with nothing to bill. */
   deleteDraftInvoice(invoiceId: string): Promise<void>;
+
+  /**
+   * Whether a create failed because the provider refused the request, meaning
+   * nothing was created and retrying with different parameters is safe.
+   *
+   * A transport failure is the opposite case: the item may well exist, and only
+   * the response was lost. Retrying that would bill twice.
+   */
+  wasRejectedWithoutCreating(error: unknown): boolean;
 }

--- a/lib/billing/provider.ts
+++ b/lib/billing/provider.ts
@@ -89,6 +89,10 @@ export type CreateInvoiceItemParams = {
   // Attach to this specific draft invoice. Without it the item is left pending
   // and the provider only sweeps it into whichever invoice is created next.
   invoiceId?: string;
+  // Makes the create safe to repeat. If the provider created the item but the
+  // response never arrived, replaying the same key returns that item instead of
+  // billing the customer a second time.
+  idempotencyKey?: string;
 };
 
 export type CreateInvoiceItemResult = {

--- a/lib/billing/providers/stripe.ts
+++ b/lib/billing/providers/stripe.ts
@@ -618,12 +618,16 @@ export class StripeBillingProvider implements BillingProvider {
     };
   }
 
-  async createDraftInvoice(customerId: string): Promise<{ invoiceId: string }> {
+  async createDraftInvoice(
+    customerId: string,
+    currency: string
+  ): Promise<{ invoiceId: string }> {
     // No `subscription`, so Stripe adds no plan or proration lines, and
     // pending_invoice_items_behavior "exclude" keeps unrelated pending items
     // off it. The invoice bills exactly what is attached to it afterwards.
     const invoice = await getStripe().invoices.create({
       customer: customerId,
+      currency,
       auto_advance: false,
       collection_method: "charge_automatically",
       pending_invoice_items_behavior: "exclude",

--- a/lib/billing/providers/stripe.ts
+++ b/lib/billing/providers/stripe.ts
@@ -687,6 +687,18 @@ export class StripeBillingProvider implements BillingProvider {
     }
   }
 
+  // A 400 means the request was evaluated and refused, so no object was
+  // created. Transport and rate-limit failures say nothing about whether the
+  // provider acted, so they are deliberately excluded.
+  wasRejectedWithoutCreating(error: unknown): boolean {
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      "type" in error &&
+      (error as { type: unknown }).type === "StripeInvalidRequestError"
+    );
+  }
+
   async deleteDraftInvoice(invoiceId: string): Promise<void> {
     try {
       await getStripe().invoices.del(invoiceId);

--- a/lib/billing/providers/stripe.ts
+++ b/lib/billing/providers/stripe.ts
@@ -4,6 +4,7 @@ import type {
   BillingDetails,
   BillingProvider,
   BillingWebhookEvent,
+  CollectInvoiceResult,
   CreateCheckoutParams,
   CreateCustomerParams,
   CreateInvoiceItemParams,
@@ -615,6 +616,75 @@ export class StripeBillingProvider implements BillingProvider {
       status: invoice.status ?? "draft",
       paid: invoice.status === "paid",
     };
+  }
+
+  async createDraftInvoice(customerId: string): Promise<{ invoiceId: string }> {
+    // No `subscription`, so Stripe adds no plan or proration lines, and
+    // pending_invoice_items_behavior "exclude" keeps unrelated pending items
+    // off it. The invoice bills exactly what is attached to it afterwards.
+    const invoice = await getStripe().invoices.create({
+      customer: customerId,
+      auto_advance: false,
+      collection_method: "charge_automatically",
+      pending_invoice_items_behavior: "exclude",
+    });
+
+    if (!invoice.id) {
+      throw new Error("Stripe did not return an invoice ID");
+    }
+
+    return { invoiceId: invoice.id };
+  }
+
+  async finalizeAndCollectInvoice(
+    invoiceId: string
+  ): Promise<CollectInvoiceResult> {
+    const s = getStripe();
+    const existing = await s.invoices.retrieve(invoiceId);
+
+    if (existing.status === "paid") {
+      return { invoiceId, paid: true };
+    }
+
+    // Only a draft needs finalizing. A retry on an already-open invoice, e.g.
+    // when a returning org settles what it left behind, goes straight to pay.
+    if (existing.status === "draft") {
+      const finalized = await s.invoices.finalizeInvoice(invoiceId);
+      if (finalized.status === "paid") {
+        return { invoiceId, paid: true };
+      }
+    }
+
+    try {
+      const paid = await s.invoices.pay(invoiceId);
+      return paid.status === "paid"
+        ? { invoiceId, paid: true }
+        : {
+            invoiceId,
+            paid: false,
+            failureReason: `invoice status ${paid.status ?? "unknown"}`,
+          };
+    } catch (error: unknown) {
+      // A decline or a missing payment method is an expected outcome here, not
+      // a fault: the invoice stays open and the amount is carried as debt.
+      return {
+        invoiceId,
+        paid: false,
+        failureReason: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  async deleteDraftInvoice(invoiceId: string): Promise<void> {
+    try {
+      await getStripe().invoices.del(invoiceId);
+    } catch (error: unknown) {
+      // Already gone or already finalized; nothing left to discard.
+      if (isStripeNotFound(error)) {
+        return;
+      }
+      throw error;
+    }
   }
 }
 

--- a/lib/billing/providers/stripe.ts
+++ b/lib/billing/providers/stripe.ts
@@ -567,14 +567,22 @@ export class StripeBillingProvider implements BillingProvider {
   async createInvoiceItem(
     params: CreateInvoiceItemParams
   ): Promise<CreateInvoiceItemResult> {
-    const item = await getStripe().invoiceItems.create({
+    const body = {
       customer: params.customerId,
       amount: params.amount,
       currency: params.currency,
       description: params.description,
       metadata: params.metadata,
       ...(params.invoiceId && { invoice: params.invoiceId }),
-    });
+    };
+
+    // Callers without a key keep the original single-argument call.
+    const item = params.idempotencyKey
+      ? await getStripe().invoiceItems.create(body, {
+          idempotencyKey: params.idempotencyKey,
+        })
+      : await getStripe().invoiceItems.create(body);
+
     return { invoiceItemId: item.id };
   }
 

--- a/tests/unit/billing-handle-event.test.ts
+++ b/tests/unit/billing-handle-event.test.ts
@@ -122,6 +122,7 @@ function createMockProvider(
       .fn()
       .mockResolvedValue({ invoiceId: "in_draft", paid: true }),
     deleteDraftInvoice: vi.fn().mockResolvedValue(undefined),
+    wasRejectedWithoutCreating: vi.fn().mockReturnValue(false),
     ...overrides,
   };
 }

--- a/tests/unit/billing-handle-event.test.ts
+++ b/tests/unit/billing-handle-event.test.ts
@@ -14,8 +14,19 @@ const mockBillOverageForOrg = vi
   .fn()
   .mockResolvedValue({ billed: false, reason: "no overage" });
 
+const mockCollectFinalPeriodOverage = vi
+  .fn()
+  .mockResolvedValue({ collected: false, reason: "no overage" });
+const mockCollectOutstandingOverage = vi
+  .fn()
+  .mockResolvedValue({ attempted: 0, collected: 0 });
+
 vi.mock("@/lib/billing/overage", () => ({
   billOverageForOrg: (...args: unknown[]) => mockBillOverageForOrg(...args),
+  collectFinalPeriodOverage: (...args: unknown[]) =>
+    mockCollectFinalPeriodOverage(...args),
+  collectOutstandingOverage: (...args: unknown[]) =>
+    mockCollectOutstandingOverage(...args),
 }));
 
 const mockIncrementCounter = vi.fn();
@@ -106,6 +117,11 @@ function createMockProvider(
     createInvoiceItem: vi.fn(),
     getInvoiceStatus: vi.fn().mockResolvedValue({ status: "paid", paid: true }),
     getInvoiceForItem: vi.fn().mockResolvedValue(undefined),
+    createDraftInvoice: vi.fn().mockResolvedValue({ invoiceId: "in_draft" }),
+    finalizeAndCollectInvoice: vi
+      .fn()
+      .mockResolvedValue({ invoiceId: "in_draft", paid: true }),
+    deleteDraftInvoice: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -126,6 +142,14 @@ beforeEach(() => {
   mockBillOverageForOrg.mockResolvedValue({
     billed: false,
     reason: "no overage",
+  });
+  mockCollectFinalPeriodOverage.mockResolvedValue({
+    collected: false,
+    reason: "no overage",
+  });
+  mockCollectOutstandingOverage.mockResolvedValue({
+    attempted: 0,
+    collected: 0,
   });
 });
 
@@ -196,6 +220,37 @@ describe("handleBillingEvent", () => {
           }),
         })
       );
+    });
+
+    it("settles overage the org left unpaid when it subscribes again", async () => {
+      const provider = createMockProvider();
+
+      await handleBillingEvent(
+        makeEvent("checkout.completed", {
+          organizationId: "org_1",
+          providerSubscriptionId: "sub_1",
+        }),
+        provider
+      );
+
+      expect(mockCollectOutstandingOverage).toHaveBeenCalledWith(
+        "org_1",
+        provider
+      );
+    });
+
+    it("still subscribes when settling the old balance fails", async () => {
+      mockCollectOutstandingOverage.mockRejectedValue(new Error("Stripe down"));
+
+      await handleBillingEvent(
+        makeEvent("checkout.completed", {
+          organizationId: "org_1",
+          providerSubscriptionId: "sub_1",
+        }),
+        createMockProvider()
+      );
+
+      expect(db.insert).toHaveBeenCalled();
     });
 
     it("skips when organizationId is missing", async () => {
@@ -684,7 +739,7 @@ describe("handleBillingEvent", () => {
       expect(setArg.plan).toBeUndefined();
     });
 
-    it("clears all debt when resetting to free", async () => {
+    it("keeps debt when resetting to free", async () => {
       const pastDate = new Date(Date.now() - 86_400_000);
       mockSelectReturning([
         {
@@ -702,10 +757,10 @@ describe("handleBillingEvent", () => {
 
       await handleBillingEvent(event, provider);
 
-      expect(mockClearAllDebtForOrg).toHaveBeenCalledWith("org_1");
+      expect(mockClearAllDebtForOrg).not.toHaveBeenCalled();
     });
 
-    it("clears debt even when period still active", async () => {
+    it("keeps debt when the period is still active", async () => {
       const futureDate = new Date(Date.now() + 86_400_000 * 30);
       mockSelectReturning([
         {
@@ -723,7 +778,107 @@ describe("handleBillingEvent", () => {
 
       await handleBillingEvent(event, provider);
 
-      expect(mockClearAllDebtForOrg).toHaveBeenCalledWith("org_1");
+      expect(mockClearAllDebtForOrg).not.toHaveBeenCalled();
+    });
+
+    it("bills the final period before the row drops to free", async () => {
+      const pastDate = new Date(Date.now() - 86_400_000);
+      const row = {
+        providerSubscriptionId: "sub_1",
+        organizationId: "org_1",
+        providerCustomerId: "cus_1",
+        currentPeriodStart: new Date("2025-01-01"),
+        currentPeriodEnd: pastDate,
+        plan: "pro",
+      };
+      mockSelectReturning([row]);
+
+      await handleBillingEvent(
+        makeEvent("subscription.deleted", { providerSubscriptionId: "sub_1" }),
+        createMockProvider()
+      );
+
+      expect(mockCollectFinalPeriodOverage).toHaveBeenCalledWith(
+        "org_1",
+        row.currentPeriodStart,
+        pastDate,
+        "cus_1"
+      );
+      // Order matters: billing reads the plan off the row, and a free row bills
+      // nothing.
+      const billOrder =
+        mockCollectFinalPeriodOverage.mock.invocationCallOrder[0];
+      const resetOrder = mockSet.mock.invocationCallOrder[0];
+      expect(billOrder).toBeLessThan(resetOrder);
+    });
+
+    it("does not bill while the paid period is still running", async () => {
+      const futureDate = new Date(Date.now() + 86_400_000 * 30);
+      mockSelectReturning([
+        {
+          providerSubscriptionId: "sub_1",
+          organizationId: "org_1",
+          providerCustomerId: "cus_1",
+          currentPeriodStart: new Date("2025-01-01"),
+          currentPeriodEnd: futureDate,
+          plan: "pro",
+        },
+      ]);
+
+      await handleBillingEvent(
+        makeEvent("subscription.deleted", { providerSubscriptionId: "sub_1" }),
+        createMockProvider()
+      );
+
+      expect(mockCollectFinalPeriodOverage).not.toHaveBeenCalled();
+    });
+
+    it("still downgrades when the final charge fails", async () => {
+      const pastDate = new Date(Date.now() - 86_400_000);
+      mockSelectReturning([
+        {
+          providerSubscriptionId: "sub_1",
+          organizationId: "org_1",
+          providerCustomerId: "cus_1",
+          currentPeriodStart: new Date("2025-01-01"),
+          currentPeriodEnd: pastDate,
+          plan: "pro",
+        },
+      ]);
+      mockCollectFinalPeriodOverage.mockRejectedValue(new Error("Stripe down"));
+
+      await handleBillingEvent(
+        makeEvent("subscription.deleted", { providerSubscriptionId: "sub_1" }),
+        createMockProvider()
+      );
+
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({ plan: "free" })
+      );
+    });
+
+    it("skips billing when the org has no customer on file", async () => {
+      const pastDate = new Date(Date.now() - 86_400_000);
+      mockSelectReturning([
+        {
+          providerSubscriptionId: "sub_1",
+          organizationId: "org_1",
+          providerCustomerId: null,
+          currentPeriodStart: new Date("2025-01-01"),
+          currentPeriodEnd: pastDate,
+          plan: "pro",
+        },
+      ]);
+
+      await handleBillingEvent(
+        makeEvent("subscription.deleted", { providerSubscriptionId: "sub_1" }),
+        createMockProvider()
+      );
+
+      expect(mockCollectFinalPeriodOverage).not.toHaveBeenCalled();
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({ plan: "free" })
+      );
     });
 
     it("skips when providerSubscriptionId is missing", async () => {

--- a/tests/unit/billing-overage.test.ts
+++ b/tests/unit/billing-overage.test.ts
@@ -9,6 +9,7 @@ const mockOnConflictDoNothing = vi.fn();
 const mockReturning = vi.fn();
 const mockUpdateSet = vi.fn();
 const mockUpdateWhere = vi.fn();
+const mockSelectWhere = vi.fn();
 
 vi.mock("@/lib/db", () => ({
   db: {
@@ -27,6 +28,11 @@ vi.mock("@/lib/db", () => ({
     update: vi.fn(() => ({
       set: mockUpdateSet,
     })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: (...args: unknown[]) => mockSelectWhere(...args),
+      })),
+    })),
   },
 }));
 
@@ -34,7 +40,11 @@ vi.mock("@/lib/billing/providers", () => ({
   getBillingProvider: vi.fn(),
 }));
 
-import { billOverageForOrg } from "@/lib/billing/overage";
+import {
+  billOverageForOrg,
+  collectFinalPeriodOverage,
+  collectOutstandingOverage,
+} from "@/lib/billing/overage";
 import type { BillingProvider } from "@/lib/billing/provider";
 import { getBillingProvider } from "@/lib/billing/providers";
 import { db } from "@/lib/db";
@@ -65,6 +75,7 @@ beforeEach(() => {
     where: mockUpdateWhere,
   });
   mockUpdateWhere.mockResolvedValue(undefined);
+  mockSelectWhere.mockResolvedValue([]);
 });
 
 describe("billOverageForOrg", () => {
@@ -333,5 +344,184 @@ describe("billOverageForOrg", () => {
     expect(mockCreateInvoiceItem).toHaveBeenCalledWith(
       expect.not.objectContaining({ invoiceId: expect.anything() })
     );
+  });
+});
+
+describe("collectFinalPeriodOverage", () => {
+  function proSubWithOverage(): void {
+    mockFindFirstSub.mockResolvedValue({
+      plan: "pro",
+      tier: "25k",
+      status: "active",
+      providerCustomerId: "cus_123",
+    });
+    mockFindFirstOverage.mockResolvedValue(undefined);
+    mockExecutionCount(26_500);
+    mockReturning.mockResolvedValue([{ id: "rec_1" }]);
+  }
+
+  it("raises a standalone invoice carrying only the overage and collects it", async () => {
+    proSubWithOverage();
+    const createDraftInvoice = vi
+      .fn()
+      .mockResolvedValue({ invoiceId: "in_final" });
+    const finalizeAndCollectInvoice = vi
+      .fn()
+      .mockResolvedValue({ invoiceId: "in_final", paid: true });
+    const deleteDraftInvoice = vi.fn();
+    mockBillingProvider({
+      createDraftInvoice,
+      finalizeAndCollectInvoice,
+      deleteDraftInvoice,
+      createInvoiceItem: vi.fn().mockResolvedValue({ invoiceItemId: "ii_1" }),
+    });
+
+    const result = await collectFinalPeriodOverage(
+      "org_1",
+      periodStart,
+      periodEnd,
+      "cus_123"
+    );
+
+    expect(createDraftInvoice).toHaveBeenCalledWith("cus_123");
+    expect(finalizeAndCollectInvoice).toHaveBeenCalledWith("in_final");
+    expect(deleteDraftInvoice).not.toHaveBeenCalled();
+    expect(result).toEqual({ collected: true, totalChargeCents: 300 });
+  });
+
+  it("discards the draft when there is nothing over the limit", async () => {
+    mockFindFirstSub.mockResolvedValue({
+      plan: "pro",
+      tier: "25k",
+      status: "active",
+      providerCustomerId: "cus_123",
+    });
+    mockFindFirstOverage.mockResolvedValue(undefined);
+    mockExecutionCount(10_000);
+
+    const deleteDraftInvoice = vi.fn();
+    const finalizeAndCollectInvoice = vi.fn();
+    mockBillingProvider({
+      createDraftInvoice: vi.fn().mockResolvedValue({ invoiceId: "in_empty" }),
+      finalizeAndCollectInvoice,
+      deleteDraftInvoice,
+    });
+
+    const result = await collectFinalPeriodOverage(
+      "org_1",
+      periodStart,
+      periodEnd,
+      "cus_123"
+    );
+
+    expect(deleteDraftInvoice).toHaveBeenCalledWith("in_empty");
+    expect(finalizeAndCollectInvoice).not.toHaveBeenCalled();
+    expect(result).toEqual({ collected: false, reason: "no overage" });
+  });
+
+  it("reports the amount as owed when the card is declined", async () => {
+    proSubWithOverage();
+    mockBillingProvider({
+      createDraftInvoice: vi.fn().mockResolvedValue({ invoiceId: "in_final" }),
+      finalizeAndCollectInvoice: vi.fn().mockResolvedValue({
+        invoiceId: "in_final",
+        paid: false,
+        failureReason: "card_declined",
+      }),
+      deleteDraftInvoice: vi.fn(),
+      createInvoiceItem: vi.fn().mockResolvedValue({ invoiceItemId: "ii_1" }),
+    });
+
+    const result = await collectFinalPeriodOverage(
+      "org_1",
+      periodStart,
+      periodEnd,
+      "cus_123"
+    );
+
+    expect(result).toEqual({
+      collected: false,
+      reason: "card_declined",
+      invoiceId: "in_final",
+    });
+  });
+});
+
+describe("collectOutstandingOverage", () => {
+  it("retries an invoice the org left unpaid", async () => {
+    mockSelectWhere.mockResolvedValue([
+      { id: "rec_1", providerInvoiceItemId: "ii_1" },
+    ]);
+    const finalizeAndCollectInvoice = vi
+      .fn()
+      .mockResolvedValue({ invoiceId: "in_1", paid: true });
+    const provider = {
+      getInvoiceForItem: vi
+        .fn()
+        .mockResolvedValue({ invoiceId: "in_1", status: "open", paid: false }),
+      finalizeAndCollectInvoice,
+    } as unknown as BillingProvider;
+
+    const result = await collectOutstandingOverage("org_1", provider);
+
+    expect(finalizeAndCollectInvoice).toHaveBeenCalledWith("in_1");
+    expect(result).toEqual({ attempted: 1, collected: 1 });
+  });
+
+  it("stamps the invoice and does not recharge one already paid", async () => {
+    mockSelectWhere.mockResolvedValue([
+      { id: "rec_1", providerInvoiceItemId: "ii_1" },
+    ]);
+    const finalizeAndCollectInvoice = vi.fn();
+    const provider = {
+      getInvoiceForItem: vi
+        .fn()
+        .mockResolvedValue({ invoiceId: "in_1", status: "paid", paid: true }),
+      finalizeAndCollectInvoice,
+    } as unknown as BillingProvider;
+
+    const result = await collectOutstandingOverage("org_1", provider);
+
+    expect(finalizeAndCollectInvoice).not.toHaveBeenCalled();
+    expect(mockUpdateSet).toHaveBeenCalledWith({ providerInvoiceId: "in_1" });
+    expect(result).toEqual({ attempted: 0, collected: 0 });
+  });
+
+  it("keeps going when one record cannot be settled", async () => {
+    mockSelectWhere.mockResolvedValue([
+      { id: "rec_1", providerInvoiceItemId: "ii_bad" },
+      { id: "rec_2", providerInvoiceItemId: "ii_good" },
+    ]);
+    const provider = {
+      getInvoiceForItem: vi.fn((itemId: string) =>
+        itemId === "ii_bad"
+          ? Promise.reject(new Error("Stripe unavailable"))
+          : Promise.resolve({
+              invoiceId: "in_2",
+              status: "open",
+              paid: false,
+            })
+      ),
+      finalizeAndCollectInvoice: vi
+        .fn()
+        .mockResolvedValue({ invoiceId: "in_2", paid: true }),
+    } as unknown as BillingProvider;
+
+    const result = await collectOutstandingOverage("org_1", provider);
+
+    expect(result).toEqual({ attempted: 1, collected: 1 });
+  });
+
+  it("does nothing when the org owes nothing", async () => {
+    mockSelectWhere.mockResolvedValue([]);
+    const provider = {
+      getInvoiceForItem: vi.fn(),
+      finalizeAndCollectInvoice: vi.fn(),
+    } as unknown as BillingProvider;
+
+    const result = await collectOutstandingOverage("org_1", provider);
+
+    expect(provider.getInvoiceForItem).not.toHaveBeenCalled();
+    expect(result).toEqual({ attempted: 0, collected: 0 });
   });
 });

--- a/tests/unit/billing-overage.test.ts
+++ b/tests/unit/billing-overage.test.ts
@@ -30,6 +30,9 @@ vi.mock("@/lib/db", () => ({
     })),
     select: vi.fn(() => ({
       from: vi.fn(() => ({
+        leftJoin: vi.fn(() => ({
+          where: (...args: unknown[]) => mockSelectWhere(...args),
+        })),
         where: (...args: unknown[]) => mockSelectWhere(...args),
       })),
     })),
@@ -300,7 +303,11 @@ describe("billOverageForOrg", () => {
       .fn()
       .mockRejectedValueOnce(new Error("Invoice is no longer editable"))
       .mockResolvedValueOnce({ invoiceItemId: "ii_pending" });
-    mockBillingProvider({ createInvoiceItem: mockCreateInvoiceItem });
+    mockBillingProvider({
+      createInvoiceItem: mockCreateInvoiceItem,
+      // The provider refused the request outright, so nothing was created.
+      wasRejectedWithoutCreating: vi.fn().mockReturnValue(true),
+    });
 
     const result = await billOverageForOrg("org_1", periodStart, periodEnd, {
       invoiceId: "in_closing",
@@ -321,6 +328,74 @@ describe("billOverageForOrg", () => {
         providerInvoiceItemId: "ii_pending",
       })
     );
+  });
+
+  it("does not retry after a transport failure, which could have created it", async () => {
+    mockFindFirstSub.mockResolvedValue({
+      plan: "pro",
+      tier: "25k",
+      status: "active",
+      providerCustomerId: "cus_123",
+    });
+    mockFindFirstOverage.mockResolvedValue(undefined);
+    mockExecutionCount(26_500);
+    mockReturning.mockResolvedValue([{ id: "rec_1" }]);
+
+    const mockCreateInvoiceItem = vi
+      .fn()
+      .mockRejectedValue(new Error("socket hang up"));
+    mockBillingProvider({
+      createInvoiceItem: mockCreateInvoiceItem,
+      wasRejectedWithoutCreating: vi.fn().mockReturnValue(false),
+    });
+
+    const result = await billOverageForOrg("org_1", periodStart, periodEnd, {
+      invoiceId: "in_closing",
+    });
+
+    // Exactly one attempt: a second under a different key would bill twice if
+    // the first had in fact landed.
+    expect(mockCreateInvoiceItem).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      billed: false,
+      reason: "provider error: socket hang up",
+    });
+  });
+
+  it("gives each attach mode its own idempotency key", async () => {
+    mockFindFirstSub.mockResolvedValue({
+      plan: "pro",
+      tier: "25k",
+      status: "active",
+      providerCustomerId: "cus_123",
+    });
+    mockFindFirstOverage.mockResolvedValue(undefined);
+    mockExecutionCount(26_500);
+    mockReturning.mockResolvedValue([{ id: "rec_1" }]);
+
+    const mockCreateInvoiceItem = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Invoice is no longer editable"))
+      .mockResolvedValueOnce({ invoiceItemId: "ii_pending" });
+    mockBillingProvider({
+      createInvoiceItem: mockCreateInvoiceItem,
+      wasRejectedWithoutCreating: vi.fn().mockReturnValue(true),
+    });
+
+    await billOverageForOrg("org_1", periodStart, periodEnd, {
+      invoiceId: "in_closing",
+    });
+
+    // Replaying a key with different parameters is rejected by the provider, so
+    // the attached and unattached attempts must not share one.
+    const first = mockCreateInvoiceItem.mock.calls[0][0] as {
+      idempotencyKey: string;
+    };
+    const second = mockCreateInvoiceItem.mock.calls[1][0] as {
+      idempotencyKey: string;
+    };
+    expect(first.idempotencyKey).not.toBe(second.idempotencyKey);
+    expect(second.idempotencyKey).toBe("overage-rec_1");
   });
 
   it("leaves the item unattached when no closing invoice is given", async () => {
@@ -478,7 +553,7 @@ describe("collectFinalPeriodOverage", () => {
 describe("collectOutstandingOverage", () => {
   it("retries an invoice the org left unpaid", async () => {
     mockSelectWhere.mockResolvedValue([
-      { id: "rec_1", providerInvoiceItemId: "ii_1" },
+      { id: "rec_1", providerInvoiceItemId: "ii_1", providerInvoiceId: null },
     ]);
     const finalizeAndCollectInvoice = vi
       .fn()
@@ -498,7 +573,7 @@ describe("collectOutstandingOverage", () => {
 
   it("stamps the invoice and does not recharge one already paid", async () => {
     mockSelectWhere.mockResolvedValue([
-      { id: "rec_1", providerInvoiceItemId: "ii_1" },
+      { id: "rec_1", providerInvoiceItemId: "ii_1", providerInvoiceId: null },
     ]);
     const finalizeAndCollectInvoice = vi.fn();
     const provider = {
@@ -517,8 +592,12 @@ describe("collectOutstandingOverage", () => {
 
   it("keeps going when one record cannot be settled", async () => {
     mockSelectWhere.mockResolvedValue([
-      { id: "rec_1", providerInvoiceItemId: "ii_bad" },
-      { id: "rec_2", providerInvoiceItemId: "ii_good" },
+      { id: "rec_1", providerInvoiceItemId: "ii_bad", providerInvoiceId: null },
+      {
+        id: "rec_2",
+        providerInvoiceItemId: "ii_good",
+        providerInvoiceId: null,
+      },
     ]);
     const provider = {
       getInvoiceForItem: vi.fn((itemId: string) =>
@@ -537,6 +616,48 @@ describe("collectOutstandingOverage", () => {
 
     const result = await collectOutstandingOverage("org_1", provider);
 
+    expect(result).toEqual({ attempted: 1, collected: 1 });
+  });
+
+  it("skips a draft invoice rather than finalizing it early", async () => {
+    mockSelectWhere.mockResolvedValue([
+      { id: "rec_1", providerInvoiceItemId: "ii_1", providerInvoiceId: null },
+    ]);
+    const finalizeAndCollectInvoice = vi.fn();
+    const provider = {
+      getInvoiceForItem: vi
+        .fn()
+        .mockResolvedValue({ invoiceId: "in_1", status: "draft", paid: false }),
+      finalizeAndCollectInvoice,
+    } as unknown as BillingProvider;
+
+    const result = await collectOutstandingOverage("org_1", provider);
+
+    expect(finalizeAndCollectInvoice).not.toHaveBeenCalled();
+    expect(result).toEqual({ attempted: 0, collected: 0 });
+  });
+
+  it("settles a record the debt scan already stamped", async () => {
+    mockSelectWhere.mockResolvedValue([
+      { id: "rec_1", providerInvoiceItemId: "ii_1", providerInvoiceId: "in_9" },
+    ]);
+    const getInvoiceForItem = vi.fn();
+    const finalizeAndCollectInvoice = vi
+      .fn()
+      .mockResolvedValue({ invoiceId: "in_9", paid: true });
+    const provider = {
+      getInvoiceStatus: vi
+        .fn()
+        .mockResolvedValue({ status: "open", paid: false }),
+      getInvoiceForItem,
+      finalizeAndCollectInvoice,
+    } as unknown as BillingProvider;
+
+    const result = await collectOutstandingOverage("org_1", provider);
+
+    // Resolved straight from the stamped id, not traced back through the item.
+    expect(getInvoiceForItem).not.toHaveBeenCalled();
+    expect(finalizeAndCollectInvoice).toHaveBeenCalledWith("in_9");
     expect(result).toEqual({ attempted: 1, collected: 1 });
   });
 

--- a/tests/unit/billing-overage.test.ts
+++ b/tests/unit/billing-overage.test.ts
@@ -383,10 +383,38 @@ describe("collectFinalPeriodOverage", () => {
       "cus_123"
     );
 
-    expect(createDraftInvoice).toHaveBeenCalledWith("cus_123");
+    expect(createDraftInvoice).toHaveBeenCalledWith("cus_123", "usd");
     expect(finalizeAndCollectInvoice).toHaveBeenCalledWith("in_final");
     expect(deleteDraftInvoice).not.toHaveBeenCalled();
     expect(result).toEqual({ collected: true, totalChargeCents: 300 });
+  });
+
+  it("opens the draft in the same currency as the item it will carry", async () => {
+    proSubWithOverage();
+    const createDraftInvoice = vi
+      .fn()
+      .mockResolvedValue({ invoiceId: "in_final" });
+    const createInvoiceItem = vi
+      .fn()
+      .mockResolvedValue({ invoiceItemId: "ii_1" });
+    mockBillingProvider({
+      createDraftInvoice,
+      createInvoiceItem,
+      finalizeAndCollectInvoice: vi
+        .fn()
+        .mockResolvedValue({ invoiceId: "in_final", paid: true }),
+      deleteDraftInvoice: vi.fn(),
+    });
+
+    await collectFinalPeriodOverage("org_1", periodStart, periodEnd, "cus_123");
+
+    // An invoice cannot mix currencies, so a draft left on the account default
+    // rejects the attach and the overage silently goes uncharged.
+    const draftCurrency = createDraftInvoice.mock.calls[0][1];
+    const itemCurrency = (
+      createInvoiceItem.mock.calls[0][0] as { currency: string }
+    ).currency;
+    expect(draftCurrency).toBe(itemCurrency);
   });
 
   it("discards the draft when there is nothing over the limit", async () => {


### PR DESCRIPTION
An organization that exceeded its included executions and then cancelled was never billed for the excess, on any plan.

Overage is billed from two triggers: a renewal invoice being drafted, or the period rolling. A subscription that ends produces neither, and the cancellation handler never billed. The two scan endpoints written as the safety net for exactly this had no caller in any repo, so they had never run. Cancellation also cleared the organization's outstanding execution debt on the way out, discarding the record of what was owed along with the means to collect it.

## Changes

**Bill the closing period on cancellation.** The subscription-deleted handler now bills and collects before the row drops to free, since the plan on the row is what decides whether there is anything to bill.

**Charge the overage and nothing else.** The invoice is opened with no subscription attached and `pending_invoice_items_behavior: "exclude"`, then the overage item is attached explicitly. No plan fee, no proration, no unrelated pending items. Proration of the plan stays with the provider, which owns the subscription and has already taken payment for the period in advance.

**Debt survives cancellation.** Both `clearAllDebtForOrg` calls are removed. Resubscribing settles whatever was left open, which is the point at which a payment method exists again.

**A declined card is an outcome, not a failure.** Collection returns a reason rather than throwing; the invoice stays open, the amount stays owed, and the downgrade still completes. Leaving an organization on a paid plan because its card bounced would hand it a plan nobody is paying for.

**Both scans are now scheduled** in staging and prod, hourly for the overage scan and daily for the debt scan. `reaper.sh` takes an optional method and body to drive the POST endpoints; existing GET callers pass a URL alone and are unaffected. Its HMAC signature was checked against the server implementation for both an empty body and a JSON body.