### PR TITLE
docs: sync CLI reference from v0.14.0

### DIFF
--- a/docs/cli/commands/kh_doctor.md
+++ b/docs/cli/commands/kh_doctor.md
@@ -5,8 +5,13 @@ Check CLI health
 ### Synopsis
 
 Run diagnostic checks against your KeeperHub configuration and API
-connectivity. Checks auth validity, API reachability, wallet status,
-spend cap, chain availability, and CLI version.
+connectivity. Checks auth validity, API reachability, organization wallet
+status, agentic wallet status and credit, spend cap, chain availability,
+and CLI version.
+
+The agentic wallet check signs its request with the HMAC secret in
+~/.keeperhub/wallet.json, so it reports only the wallet held on this machine.
+The secret is never printed.
 
 See also: kh auth status, kh version
 

--- a/docs/cli/quickstart.md
+++ b/docs/cli/quickstart.md
@@ -67,7 +67,7 @@ KeeperHub exposes its actions as tools to AI assistants via the [Model Context P
 
 **Recommended: remote HTTP endpoint (no local server required):**
 ```
-claude mcp add --transport http keeperhub https://app.keeperhub.com/mcp
+claude mcp add --transport http --scope user keeperhub https://app.keeperhub.com/mcp
 ```
 
 **Add to Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):


### PR DESCRIPTION
Auto-synced CLI command reference from cli@v0.14.0. Changes generated by go generate ./docs/... and copied to docs/cli/.