### PR TITLE
docs: correct the trigger type in the write-contract workflow example

### DIFF
--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -131,7 +131,7 @@ POST /api/workflows/create
 
 `name`, `nodes`, and `edges` are required. `description`, `projectId`, `tagId`, and `enabled` are optional. `projectId` assigns the workflow to a [project](/api/projects); `tagId` assigns it to an organization tag for categorization; `enabled` (boolean) controls whether the workflow is active on creation.
 
-### Generic web3 write-contract example (HTTP trigger)
+### Generic web3 write-contract example (Manual trigger)
 
 Named-protocol actions (`aave-v3/supply`, etc.) hide most of the plumbing behind protocol-aware config keys. When you want to call an arbitrary contract that isn't in the [plugin catalog](/plugins/web3), use the generic `web3/write-contract` action. The trap is that the UI labels ("Function", "Function Arguments") don't line up 1:1 with the API field names, and `functionArgs` is a **JSON-encoded array string**, not a raw array. The full config shape:
 
@@ -143,8 +143,8 @@ Named-protocol actions (`aave-v3/supply`, etc.) hide most of the plumbing behind
       "id": "trigger-1",
       "type": "trigger",
       "data": {
-        "label": "HTTP",
-        "config": { "triggerType": "HTTP", "httpMethod": "POST" }
+        "label": "Manual",
+        "config": { "triggerType": "Manual" }
       }
     },
     {
@@ -159,7 +159,7 @@ Named-protocol actions (`aave-v3/supply`, etc.) hide most of the plumbing behind
           "contractAddress": "0x599869cef2e4c52e2c9074caaf8f9fb0cb191776",
           "abi": "[{\"type\":\"function\",\"name\":\"release\",\"stateMutability\":\"nonpayable\",\"inputs\":[{\"name\":\"depositId\",\"type\":\"bytes32\"}],\"outputs\":[]}]",
           "abiFunction": "release",
-          "functionArgs": "[\"{{@trigger-1:HTTP.depositId}}\"]"
+          "functionArgs": "[\"{{@trigger-1:Manual.depositId}}\"]"
         }
       }
     }
@@ -181,7 +181,7 @@ Field-name gotchas the strict validator will reject:
 
 A warning on `functionName` and `args`: the save-time validator accepts them, because workflows persisted before a field rename still carry that shape and have to stay re-savable. The runtime does not translate them. A workflow that uses `functionName` will therefore save without complaint and then fail at execution with ``Missing `abiFunction` in the step config``. Always send `abiFunction` and `functionArgs`.
 
-Trigger data reference from a downstream action uses the [stored templating format](/workflows/templating): `{{@<nodeId>:<Label>.<field>}}`. For an HTTP trigger, top-level fields on the request body are spread into the trigger's output, so `{"input": {"depositId": "0x…"}}` sent to [`POST /api/workflows/{id}/execute`](#execute-workflow) is reachable at `{{@trigger-1:HTTP.depositId}}`.
+Trigger data reference from a downstream action uses the [stored templating format](/workflows/templating): `{{@<nodeId>:<Label>.<field>}}`. Fields on the `input` object are spread into the trigger's output, so `{"input": {"depositId": "0x…"}}` sent to [`POST /api/workflows/{id}/execute`](#execute-workflow) is reachable at `{{@trigger-1:Manual.depositId}}`. Valid `triggerType` values are `Manual`, `Schedule`, `Webhook`, `Event`, `Block`, and `Transfer`; a `Webhook` trigger receives the same treatment on its own `POST /api/workflows/{id}/webhook` URL.
 
 ### Response
 

--- a/docs/plugins/web3.md
+++ b/docs/plugins/web3.md
@@ -479,7 +479,7 @@ If you're building this action via the [Workflows API](/api/workflows) rather th
 | Web3 Connection | `web3Connection` | Sender routing: `"default"` (org policy), `"eoa"` (force the Turnkey EOA), or `"safe:<safeWalletId>"`. The signing wallet is your org's Turnkey wallet, resolved automatically. |
 | Network | `network` | numeric chain id as a string (e.g. `"11155111"`) |
 
-See the [generic web3 write-contract example](/api/workflows#generic-web3-write-contract-example-http-trigger) in the Workflows API docs for a full working request body.
+See the [generic web3 write-contract example](/api/workflows#generic-web3-write-contract-example-manual-trigger) in the Workflows API docs for a full working request body.
 
 ---
 

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -507,6 +507,13 @@
     },
     {
       "method": "POST",
+      "path": "/api/workflows/{id}/webhook",
+      "route_file": "app/api/workflows/[workflowId]/webhook/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 184
+    },
+    {
+      "method": "POST",
       "path": "/api/workflows/{workflowId}/claim",
       "route_file": "app/api/workflows/[workflowId]/claim/route.ts",
       "source": "docs/api/workflows.md",


### PR DESCRIPTION
## Problem

The generic web3 write-contract example in the Workflows API docs shipped an invalid trigger config:

```json
"config": { "triggerType": "HTTP", "httpMethod": "POST" }
```

`HTTP` is not a valid trigger type. The six valid values are `Manual`, `Schedule`, `Webhook`, `Event`, `Block`, and `Transfer` (`lib/workflow/store.ts`). `httpMethod` is an HTTP Request *action* field (`lib/workflow/nodes/http-request/perform.ts`), not a trigger field.

Anyone copy-pasting the block, which the section explicitly presents as "the full config shape", got a workflow the strict validator rejects. It also contradicted the note earlier on the same page stating that trigger nodes use `config.triggerType` set to the Pascal-case trigger name.

## Fix

Switched the example to the `Manual` trigger. That matches the surrounding text, which describes invoking the workflow through `POST /api/workflows/{id}/execute` with an `input` object. `triggerInput` is spread into the trigger's output for any trigger type (`lib/workflow/executor/executor.workflow.ts`), so the templating narrative holds unchanged.

- Heading and node label updated to `Manual`
- `httpMethod` dropped from the trigger config
- Template references updated to `{{@trigger-1:Manual.depositId}}`
- Added the list of valid `triggerType` values, plus a pointer that a `Webhook` trigger gets the same input treatment on its own `/webhook` URL
- Updated the cross-link anchor on the web3 plugin page to follow the renamed heading
- `specs/api-coverage.json` regenerated, picking up the new `/api/workflows/{id}/webhook` mention

`scripts/check-api-docs-routes.ts` reports no docs-vs-code drift.