### PR TITLE
docs: add Agent Quick Start for programmatic workflow execution

### DIFF
--- a/docs/getting-started/_meta.ts
+++ b/docs/getting-started/_meta.ts
@@ -1,3 +1,4 @@
 export default {
   quickstart: "Quick Start Guide",
+  "agent-quickstart": "Agent Quick Start",
 };

--- a/docs/getting-started/agent-quickstart.md
+++ b/docs/getting-started/agent-quickstart.md
@@ -30,7 +30,7 @@ This page covers **Workflow Execution** — the more common pattern for an agent
 
 Profile icon → **Wallet**. Top up with ETH on whichever network your workflow targets.
 
-> **Gas sponsorship covers Mainnet Ethereum only.** If you're testing on Sepolia or any other testnet, the wallet needs its own funded balance regardless of sponsorship — this trips people up specifically because it's easy to test on a testnet first and assume sponsorship applies there too.
+> **Gas sponsorship pays the transaction fee, not the value your transaction moves.** On supported networks KeeperHub can cover the gas fee so a workflow runs from a wallet holding no native token — but a workflow that sends 0.1 ETH still needs 0.1 ETH in the wallet, and an ERC-20 transfer still needs the token balance. Sponsorship also requires the sender to be the wallet itself rather than a Safe, the transaction to use the public mempool, and your organization to have gas credits left for the period. See [Gas Management](/wallet-management/gas) for the supported networks and the full set of conditions.
 
 ## 3. Trigger the workflow
 
@@ -88,7 +88,3 @@ That's the full loop. See the [full API reference](/api) for execution history, 
 - **A key that "looks" set but isn't.** If you're validating config before running (recommended), check for placeholder patterns explicitly — an all-zeros private key (`0x000...0`) or a literal `your_key_here` string will pass a naive `if (key)` truthiness check and fail later with a confusing signing error instead of a clear "not configured" message.
 - **404 on execute.** Usually means the workflow ID is wrong or belongs to a different organization than the API key.
 - **Execution stuck in `pending`.** Check the wallet's balance on the target network first — see the gas sponsorship note above.
-
-## Runnable example
-
-A minimal, complete version of this flow (trigger → poll → confirm, with proper env validation) is available as a standalone template: [keeperhub-agent-quickstart](https://github.com/chriswilton971-sudo/keeperhub-agent-quickstart).

--- a/docs/getting-started/agent-quickstart.md
+++ b/docs/getting-started/agent-quickstart.md
@@ -1,0 +1,94 @@
+---
+title: Agent Quick Start (Programmatic)
+description: Trigger a KeeperHub workflow and get a transaction hash back, entirely from code — no dashboard clicking required.
+---
+
+# Agent Quick Start
+
+The [Quick Start Guide](/getting-started/quickstart) walks through building a workflow by hand in the visual canvas. This page is for the other half of KeeperHub's users: an agent, or a backend service acting on one, that needs to **trigger an existing workflow from code** and **read the result back programmatically**.
+
+If you haven't built a workflow yet, do that first — this page covers *execution*, not *authoring*. The fastest way to author one is still the canvas in the [Quick Start Guide](/getting-started/quickstart), or describe it to the **Ask AI...** assistant on the canvas.
+
+## Which execution path do you want?
+
+KeeperHub has two ways to get a transaction onchain. Pick based on what you're building:
+
+| | Direct Execution | Workflow Execution |
+|---|---|---|
+| **Use when** | One-off contract call or transfer, no branching logic | Multi-step logic, conditions, or a workflow you'll reuse across triggers |
+| **Setup** | No workflow object needed | Requires a workflow created in advance (dashboard or API) |
+| **CLI** | `kh execute contract-call`, `kh execute transfer` | N/A — API only |
+| **API** | `POST /api/execute/contract-call` | `POST /api/workflows/{id}/execute` |
+
+This page covers **Workflow Execution** — the more common pattern for an agent that already has a workflow and needs to trigger it as one step in a larger decision loop.
+
+## 1. Get an API key
+
+`app.keeperhub.com` → Settings → API Keys. A wallet is auto-provisioned for your organization on signup — no separate wallet setup needed.
+
+## 2. Fund the wallet if your workflow spends gas
+
+Profile icon → **Wallet**. Top up with ETH on whichever network your workflow targets.
+
+> **Gas sponsorship covers Mainnet Ethereum only.** If you're testing on Sepolia or any other testnet, the wallet needs its own funded balance regardless of sponsorship — this trips people up specifically because it's easy to test on a testnet first and assume sponsorship applies there too.
+
+## 3. Trigger the workflow
+
+```bash
+curl -X POST https://app.keeperhub.com/api/workflows/{workflowId}/execute \
+  -H "Authorization: Bearer $KEEPERHUB_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+```js
+const res = await fetch(`https://app.keeperhub.com/api/workflows/${workflowId}/execute`, {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${process.env.KEEPERHUB_API_KEY}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({}),
+});
+const { executionId } = await res.json();
+```
+
+This only returns `{ executionId, status: "running" }` — no transaction hash yet. That comes from the next step.
+
+## 4. Wait for it to finish
+
+```js
+async function waitForExecution(executionId) {
+  const res = await fetch(
+    `https://app.keeperhub.com/api/workflows/executions/${executionId}/wait?timeoutMs=55000`,
+    { headers: { Authorization: `Bearer ${process.env.KEEPERHUB_API_KEY}` } }
+  );
+  const data = await res.json();
+  if (data.status === "error") throw new Error(data.error);
+  if (!data.completed) throw new Error("Didn't finish within the wait window");
+  return data;
+}
+```
+
+`/wait` blocks server-side until the execution reaches a terminal state, so you don't need to write your own poll loop. If you'd rather poll yourself (e.g. to show incremental progress), `GET /api/workflows/executions/{id}/status` is the non-blocking equivalent — same response shape, returns immediately with the current status.
+
+## 5. Read the result
+
+A successful execution includes the transaction hash of any onchain write the workflow performed:
+
+```js
+const result = await waitForExecution(executionId);
+console.log(result.transactionHashes[0].hash);
+```
+
+That's the full loop. See the [full API reference](/api) for execution history, error shapes, and the executions list endpoint.
+
+## Common issues
+
+- **A key that "looks" set but isn't.** If you're validating config before running (recommended), check for placeholder patterns explicitly — an all-zeros private key (`0x000...0`) or a literal `your_key_here` string will pass a naive `if (key)` truthiness check and fail later with a confusing signing error instead of a clear "not configured" message.
+- **404 on execute.** Usually means the workflow ID is wrong or belongs to a different organization than the API key.
+- **Execution stuck in `pending`.** Check the wallet's balance on the target network first — see the gas sponsorship note above.
+
+## Runnable example
+
+A minimal, complete version of this flow (trigger → poll → confirm, with proper env validation) is available as a standalone template: [keeperhub-agent-quickstart](https://github.com/chriswilton971-sudo/keeperhub-agent-quickstart).

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -88,4 +88,5 @@ Example prompts:
 
 - Explore the **Hub** to discover and import workflow templates from the community
 - Learn more about [building workflows](/workflows/creating) for more complex automation patterns
+- Building an agent or backend service instead of clicking through the canvas? See the [Agent Quick Start](/getting-started/agent-quickstart) for triggering workflows and reading results entirely from code
 - Review [Security Best Practices](/practices/security) before deploying to Mainnet


### PR DESCRIPTION
## What

Adds `docs/getting-started/agent-quickstart.md` — a companion to the existing Quick Start Guide, covering the programmatic/agent path (trigger a workflow via API, poll for completion, read back a tx hash) instead of the visual canvas walkthrough.

Also adds one link to it from the existing quickstart's "What's Next" section.

## Why

The current Quick Start Guide is excellent for building a workflow by hand in the canvas, but doesn't cover triggering an *existing* workflow from code — which is the entry point most agent/backend integrations actually need. Built this while integrating KeeperHub into an onchain-agent hackathon project and had to piece the programmatic path together from the CLI reference and API index separately; this doc is the version I wish had existed on day one.

Also documents two specific gotchas that cost real debugging time:
- Direct Execution vs. Workflow Execution have no "which one do I want" signpost anywhere
- Gas sponsorship is Mainnet-only, which is easy to assume covers testnets during initial development

## Testing

Docs-only change — no app code touched. Verified every API path and response shape (`POST /api/workflows/{id}/execute`, `GET /api/workflows/executions/{id}/wait`, `GET /api/workflows/executions/{id}/status`) directly against `docs.keeperhub.com/api/workflows` and `/api/executions` rather than assuming — an earlier draft of this doc had a wrong endpoint shape that I caught and fixed before opening this.

## Not included

Didn't touch anything about Direct Execution's own docs, `kh doctor`, or the CLI reference — flagged a possible `kh doctor` improvement (checking for all-zeros placeholder private keys specifically) in a separate teardown writeup rather than bundling an unrelated CLI change into a docs-only PR.

## Submitted for

[Best Onboarding UX Improvement bounty](https://dorahacks.io/hackathon/agents-onchain/detail) — [KeeperHub Agents Onchain Hackathon](https://dorahacks.io/hackathon/agents-onchain/detail), by **[The Abuja Algorithmic Defenders (TAAD)](https://x.com/taadengineers?s=11)**: [armstrongmonday](https://github.com/armstrongmonday), [chriswilton971-sudo](https://github.com/chriswilton971-sudo), [danielnweze54-cyber](https://github.com/danielnweze54-cyber). Team page: [DoraHacks](https://dorahacks.io/navi?to=%2Fhome).

Companion submissions: [onboarding teardown](https://github.com/chriswilton971-sudo/Proof_of_dev/blob/main/docs/keeperhub-onboarding-teardown.md) and [keeperhub-agent-quickstart](https://github.com/chriswilton971-sudo/keeperhub-agent-quickstart) (standalone starter template implementing the same trigger → wait → confirm flow documented here).
