### PR TITLE
docs: align README Node.js version with .node-version and Docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Restart Claude Code after setup. [Plugin source code](https://github.com/KeeperH
 
 ### Prerequisites
 
-- Node.js 22 (Next.js 16 requires `>=20.9.0`; Node 18 will not work)
+- Node.js 24 (see `.node-version`; every Docker stage builds on `node:24-alpine`)
 - pnpm package manager
 - PostgreSQL 16 (only for "Local Development" mode below; Docker and Hybrid modes start their own Postgres in a container)
 - Docker Engine with the Compose plugin (only for Docker and Hybrid modes)


### PR DESCRIPTION
## What

`README.md:66` asks for Node.js 22. Everything else in the repo says 24.

| Source | Version |
|---|---|
| `README.md:66` | **22** |
| `.node-version` | 24 |
| `CONTRIBUTING.md:17` | Node.js 24+ |
| `Dockerfile` | `node:24-alpine` — all 10 stages (`deps`, `dev`, `source`, `migrator`, `scheduler-deps`, `scheduler-base`, `workflow-runner`, `executor`, `runner`, `metrics-collector`) |

The README is the odd one out, and it is the first file a new contributor reads. This changes that one line to 24 and points at `.node-version` as the source of truth, so the three docs can't drift apart again independently.

## How I ran into it

I came to the repo during the hackathon and followed the README to set up, then read `CONTRIBUTING.md` — two different answers inside the same setup pass. `.node-version` and the Dockerfile settle it: 24 is what CI and production actually run.

Worth noting for whoever picks this up: `pnpm install` **does** succeed on Node 22, because there is no `engines` field to stop you. The mismatch never fails loudly. It just quietly leaves a new contributor on a runtime nothing in CI or production uses, which is the kind of difference that surfaces much later and much less obviously.

## Separate observation — not changed here

Two workflows still pin Node 22 while every Docker stage is on 24:

- `.github/workflows/docs-sync.yml:381` — `node-version: '22'`
- `.github/workflows/pin-agent-card.yml:33` — `node-version: 22`

Left untouched since they may well be deliberate, but flagging them in case they should track `.node-version` too.

## Checks

Docs-only, single line, no code paths touched, so `pnpm check` and `pnpm type-check` are unaffected by this change.
