### PR TITLE
fix: stop a sponsored send falling back into a second broadcast

### DIFF
--- a/app/api/cron/execution-reconciler/route.ts
+++ b/app/api/cron/execution-reconciler/route.ts
@@ -1,0 +1,42 @@
+/**
+ * Settles direct executions stuck in `unconfirmed`: a transaction was
+ * broadcast, but the chain had not answered by the time the request had to.
+ * Re-reads each receipt and moves the row to completed or failed once the
+ * outcome is known.
+ *
+ * Deployment: invoked by an external scheduler (Kubernetes CronJob), on the
+ * order of every minute. Authorized via `Authorization: Bearer $CRON_SECRET`,
+ * mirroring the other cron routes. Fails closed when CRON_SECRET is unset.
+ */
+
+import { reconcileUnconfirmedExecutions } from "@/lib/execute/reconcile-executions";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
+
+export const dynamic = "force-dynamic";
+
+function isAuthorized(request: Request): boolean {
+  const expected = process.env.CRON_SECRET;
+  if (!expected) {
+    return false;
+  }
+  return request.headers.get("authorization") === `Bearer ${expected}`;
+}
+
+export async function GET(request: Request): Promise<Response> {
+  if (!isAuthorized(request)) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const summary = await reconcileUnconfirmedExecutions();
+    return Response.json(summary);
+  } catch (error) {
+    logSystemError(
+      ErrorCategory.DATABASE,
+      "Failed to reconcile unconfirmed executions",
+      error,
+      { endpoint: "/api/cron/execution-reconciler" }
+    );
+    return Response.json({ error: "reconcile failed" }, { status: 500 });
+  }
+}

--- a/app/api/execute/[...slug]/route.ts
+++ b/app/api/execute/[...slug]/route.ts
@@ -31,6 +31,7 @@ import {
 import { validateApiKey } from "../_lib/auth";
 import { enforceDirectExecutionConcurrency } from "../_lib/concurrency-limit";
 import {
+  type CompleteExecutionOutcome,
   completeExecution,
   failExecution,
   markRunning,
@@ -287,7 +288,7 @@ async function executeProtocolAction(
   // completeExecution independently re-verifies the claimed transaction
   // against the chain (KEEP-966) -- its returned outcome, not result.success,
   // is authoritative for the response and idempotency cache.
-  let outcome: { status: "completed" | "failed"; error?: string } = {
+  let outcome: CompleteExecutionOutcome = {
     status: "failed",
     error: result.success ? undefined : result.error,
   };
@@ -301,14 +302,16 @@ async function executeProtocolAction(
       output: result as unknown as Record<string, unknown>,
     });
   } else {
-    // A failure that already reached the chain carries its hash,
-    // so the execution records which transaction failed and what the chain
-    // said about it, rather than leaving the hash only inside the message.
-    await failExecution(executionId, result.error, {
+    // A failure that already reached the chain carries its hash, so the
+    // execution records which transaction failed and what the chain said about
+    // it. failExecution decides from that receipt whether this is terminal or
+    // a broadcast that may still land, and its verdict is authoritative.
+    const settled = await failExecution(executionId, result.error, {
       transactionHash: result.transactionHash,
       chainId: result.chainId,
       sponsored: result.sponsored,
     });
+    outcome = { status: settled.status, error: result.error };
   }
 
   const responseBody =

--- a/app/api/execute/_lib/execution-service.ts
+++ b/app/api/execute/_lib/execution-service.ts
@@ -9,6 +9,7 @@ import {
 import { generateId } from "@/lib/utils/id";
 import {
   describeVerificationFailure,
+  hasUnreadableReceipt,
   verifyExecutionReceipts,
 } from "@/lib/web3/verify-receipt";
 
@@ -34,9 +35,18 @@ type CompleteParams = {
 };
 
 export type CompleteExecutionOutcome = {
-  status: "completed" | "failed";
+  status: "completed" | "failed" | "unconfirmed";
   error?: string;
 };
+
+function isInconclusive(receipts: DirectExecutionReceiptEntry[]): boolean {
+  return hasUnreadableReceipt(
+    receipts.map((receipt) => ({
+      verified: receipt.verified,
+      status: receipt.receiptStatus,
+    }))
+  );
+}
 
 export async function createExecution(
   params: CreateExecutionParams
@@ -77,7 +87,7 @@ export async function completeExecution(
   executionId: string,
   result: CompleteParams
 ): Promise<CompleteExecutionOutcome> {
-  let status: "completed" | "failed" = "completed";
+  let status: CompleteExecutionOutcome["status"] = "completed";
   let error: string | undefined;
   let receipts: DirectExecutionReceiptEntry[] = [];
 
@@ -99,17 +109,22 @@ export async function completeExecution(
         verifiedAt: r.verifiedAt,
       }));
       if (!allVerified) {
-        status = "failed";
+        // A hash we cannot see is not a hash that failed. Settling it as
+        // failed is what makes a caller retry an action that already moved
+        // funds, so it stays non-terminal until the chain actually answers.
+        status = isInconclusive(receipts) ? "unconfirmed" : "failed";
         error = describeVerificationFailure(results);
       }
     }
   }
 
+  const isTerminal = status !== "unconfirmed";
+
   await db
     .update(directExecutions)
     .set({
       status,
-      error: status === "failed" ? error : null,
+      error: status === "completed" ? null : error,
       transactionHash: result.transactionHash ?? null,
       receipts,
       gasUsedWei: result.gasUsedWei ?? null,
@@ -117,7 +132,9 @@ export async function completeExecution(
       estimatedCostUsd: result.estimatedCostUsd ?? null,
       // biome-ignore lint/suspicious/noExplicitAny: jsonb column accepts arbitrary serializable data
       output: (result.output ?? {}) as any,
-      completedAt: new Date(),
+      // An unconfirmed execution has not completed, and the reconciler uses a
+      // null completedAt to find rows that still need settling.
+      completedAt: isTerminal ? new Date() : null,
     })
     .where(eq(directExecutions.id, executionId));
 
@@ -139,11 +156,22 @@ type FailParams = {
   sponsored?: boolean;
 };
 
+/**
+ * Finalize a failed execution.
+ *
+ * A failure that carries a transaction hash is not automatically terminal. The
+ * write path can report failure for a send that is already on the network and
+ * may still land, most notably a gas-sponsored transaction Turnkey accepted but
+ * whose receipt no endpoint could read. Calling that "failed" is what invites
+ * the retry that broadcasts a second transaction from the same wallet, so the
+ * chain decides: conclusive receipt means failed, no readable receipt means
+ * `unconfirmed` and the reconciler keeps watching.
+ */
 export async function failExecution(
   executionId: string,
   error: string,
   params: FailParams = {}
-): Promise<void> {
+): Promise<{ status: "failed" | "unconfirmed" }> {
   let receipts: DirectExecutionReceiptEntry[] = [];
 
   if (params.transactionHash && params.chainId !== undefined) {
@@ -161,10 +189,13 @@ export async function failExecution(
     }));
   }
 
+  const status =
+    receipts.length > 0 && isInconclusive(receipts) ? "unconfirmed" : "failed";
+
   await db
     .update(directExecutions)
     .set({
-      status: "failed",
+      status,
       error,
       ...(params.transactionHash
         ? { transactionHash: params.transactionHash }
@@ -174,9 +205,13 @@ export async function failExecution(
         ? {}
         : // biome-ignore lint/suspicious/noExplicitAny: jsonb column accepts arbitrary serializable data
           { output: { sponsored: params.sponsored } as any }),
-      completedAt: new Date(),
+      // The reconciler finds rows still needing settlement by their null
+      // completedAt, so an unconfirmed row must not carry one.
+      completedAt: status === "failed" ? new Date() : null,
     })
     .where(eq(directExecutions.id, executionId));
+
+  return { status };
 }
 
 export async function setRetryCount(

--- a/app/api/execute/_lib/types.ts
+++ b/app/api/execute/_lib/types.ts
@@ -1,6 +1,19 @@
 import type { DirectExecutionReceiptEntry } from "@/lib/db/schema";
 
-export type ExecutionStatus = "pending" | "running" | "completed" | "failed";
+/**
+ * `unconfirmed` is non-terminal and means a transaction was broadcast but the
+ * chain has not yet told us whether it landed. It is deliberately not `failed`:
+ * a caller that reads "failed" for a transaction that actually succeeded will
+ * retry, and a retry of a fund-moving action is the thing we most need to
+ * avoid. Clients should keep polling; a reconciliation sweep settles the row to
+ * completed or failed once the chain answers.
+ */
+export type ExecutionStatus =
+  | "pending"
+  | "running"
+  | "unconfirmed"
+  | "completed"
+  | "failed";
 
 export type ExecuteResponse = {
   executionId: string;

--- a/app/api/execute/check-and-execute/route.ts
+++ b/app/api/execute/check-and-execute/route.ts
@@ -24,6 +24,7 @@ import { enforceDirectExecutionConcurrency } from "../_lib/concurrency-limit";
 import type { ConditionInput, ConditionResult } from "../_lib/condition";
 import { evaluateCondition } from "../_lib/condition";
 import {
+  type CompleteExecutionOutcome,
   completeExecution,
   failExecution,
   markRunning,
@@ -194,7 +195,7 @@ async function executeConditionalWrite(
   // completeExecution independently re-verifies the claimed transaction
   // against the chain (KEEP-966) -- its returned outcome, not result.success,
   // is authoritative for the response and idempotency cache.
-  let outcome: { status: "completed" | "failed"; error?: string } = {
+  let outcome: CompleteExecutionOutcome = {
     status: "failed",
     error: result.success ? undefined : result.error,
   };
@@ -208,14 +209,16 @@ async function executeConditionalWrite(
       output: result as unknown as Record<string, unknown>,
     });
   } else {
-    // A failure that already reached the chain carries its hash,
-    // so the execution records which transaction failed and what the chain
-    // said about it, rather than leaving the hash only inside the message.
-    await failExecution(executionId, result.error, {
+    // A failure that already reached the chain carries its hash, so the
+    // execution records which transaction failed and what the chain said about
+    // it. failExecution decides from that receipt whether this is terminal or
+    // a broadcast that may still land, and its verdict is authoritative.
+    const settled = await failExecution(executionId, result.error, {
       transactionHash: result.transactionHash,
       chainId: result.chainId,
       sponsored: result.sponsored,
     });
+    outcome = { status: settled.status, error: result.error };
   }
 
   return recordIdempotentResponse(

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -23,6 +23,7 @@ import { writeContractCore } from "@/plugins/web3/steps/write-contract-core";
 import { validateApiKey } from "../_lib/auth";
 import { enforceDirectExecutionConcurrency } from "../_lib/concurrency-limit";
 import {
+  type CompleteExecutionOutcome,
   completeExecution,
   failExecution,
   markRunning,
@@ -197,7 +198,7 @@ async function handleWriteCall(
   // completeExecution independently re-verifies the claimed transaction
   // against the chain (KEEP-966) -- its returned outcome, not result.success,
   // is authoritative for the response and idempotency cache.
-  let outcome: { status: "completed" | "failed"; error?: string } = {
+  let outcome: CompleteExecutionOutcome = {
     status: "failed",
     error: result.success ? undefined : result.error,
   };
@@ -211,14 +212,16 @@ async function handleWriteCall(
       output: result as unknown as Record<string, unknown>,
     });
   } else {
-    // A failure that already reached the chain carries its hash,
-    // so the execution records which transaction failed and what the chain
-    // said about it, rather than leaving the hash only inside the message.
-    await failExecution(executionId, result.error, {
+    // A failure that already reached the chain carries its hash, so the
+    // execution records which transaction failed and what the chain said about
+    // it. failExecution decides from that receipt whether this is terminal or
+    // a broadcast that may still land, and its verdict is authoritative.
+    const settled = await failExecution(executionId, result.error, {
       transactionHash: result.transactionHash,
       chainId: result.chainId,
       sponsored: result.sponsored,
     });
+    outcome = { status: settled.status, error: result.error };
   }
 
   return recordIdempotentResponse(

--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -302,13 +302,18 @@ async function handleResult(
   // outcome, not that default, is authoritative for the response.
   const outcome = await completeExecution(executionId, completeParams);
 
-  if (outcome.status === "failed") {
+  // Anything other than a verified success is reported as such. `unconfirmed`
+  // is grouped here rather than with the success response because the
+  // transaction is on chain but unverified; reporting it as completed would
+  // assert an outcome we do not have. It is non-terminal, so the caller polls
+  // the status endpoint and the reconciler settles the row.
+  if (outcome.status !== "completed") {
     return recordIdempotentResponse(
       idem,
       NextResponse.json(
         {
           executionId,
-          status: "failed",
+          status: outcome.status,
           error: outcome.error ?? "On-chain verification failed",
           ...(retryCount > 0 ? { retryCount } : {}),
         },

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -22,6 +22,7 @@ import { transferTokenCore } from "@/plugins/web3/steps/transfer-token-core";
 import { validateApiKey } from "../_lib/auth";
 import { enforceDirectExecutionConcurrency } from "../_lib/concurrency-limit";
 import {
+  type CompleteExecutionOutcome,
   completeExecution,
   failExecution,
   markRunning,
@@ -287,7 +288,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   // 9. Handle result. completeExecution independently re-verifies the claimed
   // transaction against the chain (KEEP-966) -- its returned outcome, not
   // result.success, is authoritative for the response and idempotency cache.
-  let outcome: { status: "completed" | "failed"; error?: string } = {
+  let outcome: CompleteExecutionOutcome = {
     status: "failed",
     error: result.success ? undefined : result.error,
   };
@@ -301,14 +302,16 @@ export async function POST(request: Request): Promise<NextResponse> {
       output: result as unknown as Record<string, unknown>,
     });
   } else {
-    // A failure that already reached the chain carries its hash,
-    // so the execution records which transaction failed and what the chain
-    // said about it, rather than leaving the hash only inside the message.
-    await failExecution(executionId, result.error, {
+    // A failure that already reached the chain carries its hash, so the
+    // execution records which transaction failed and what the chain said about
+    // it. failExecution decides from that receipt whether this is terminal or
+    // a broadcast that may still land, and its verdict is authoritative.
+    const settled = await failExecution(executionId, result.error, {
       transactionHash: result.transactionHash,
       chainId: result.chainId,
       sponsored: result.sponsored,
     });
+    outcome = { status: settled.status, error: result.error };
   }
 
   // 10. Return. A failed broadcast/verification is finalized (not released)

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -50,8 +50,8 @@ import type {
 
 /**
  * Normalize workflow execution status to a unified status.
- * workflow_executions uses: pending | running | success | error | cancelled
- * direct_executions uses: pending | running | completed | failed
+ * workflow_executions uses: pending | running | unconfirmed | success | error | cancelled
+ * direct_executions uses: pending | running | unconfirmed | completed | failed
  * We normalize to: pending | running | success | error
  */
 export function normalizeStatus(
@@ -69,6 +69,11 @@ export function normalizeStatus(
   }
   if (status === "cancelled") {
     return "cancelled";
+  }
+  // Both sources use "unconfirmed" for a broadcast the chain has not confirmed.
+  // It is still in flight, not an outcome, so it reads as running in the UI.
+  if (status === "unconfirmed") {
+    return "running";
   }
   // Phantom rows are runs that were enqueued but never picked up; they have no
   // user-facing status of their own and surface as pending everywhere in the UI.
@@ -93,6 +98,9 @@ function directDbStatuses(status: NormalizedStatus): string[] {
   if (status === "error") {
     return ["failed"];
   }
+  if (status === "running") {
+    return ["running", "unconfirmed"];
+  }
   return [status];
 }
 
@@ -104,6 +112,9 @@ function directDbStatuses(status: NormalizedStatus): string[] {
 export function workflowDbStatuses(status: NormalizedStatus): string[] {
   if (status === "pending") {
     return ["pending", "phantom"];
+  }
+  if (status === "running") {
+    return ["running", "unconfirmed"];
   }
   if (status === "error" || status === "external_error") {
     return ["error"];
@@ -408,7 +419,7 @@ function getActiveDirectCount(organizationId: string): Promise<number> {
     .where(
       and(
         eq(directExecutions.organizationId, organizationId),
-        sql`${directExecutions.status} IN ('pending', 'running')`
+        sql`${directExecutions.status} IN ('pending', 'running', 'unconfirmed')`
       )
     )
     .then((r) => Number(r[0]?.count) || 0);
@@ -604,7 +615,7 @@ async function computeTimeSeries(
       error: sql<string>`SUM(CASE WHEN ${directExecutions.status} = 'failed' THEN 1 ELSE 0 END)`,
       cancelled: sql<string>`0`,
       pending: sql<string>`SUM(CASE WHEN ${directExecutions.status} = 'pending' THEN 1 ELSE 0 END)`,
-      running: sql<string>`SUM(CASE WHEN ${directExecutions.status} = 'running' THEN 1 ELSE 0 END)`,
+      running: sql<string>`SUM(CASE WHEN ${directExecutions.status} IN ('running', 'unconfirmed') THEN 1 ELSE 0 END)`,
     })
     .from(directExecutions)
     .where(
@@ -726,7 +737,7 @@ async function computeNetworkBreakdown(
           .select({
             network: directExecutions.network,
             totalGasWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.gasUsedWei} AS NUMERIC)), 0)::text`,
-            // Completed runs only, so pending/running direct executions do not
+            // Settled runs only, so in-flight direct executions do not
             // inflate the per-network execution count.
             executionCount: sql<number>`SUM(CASE WHEN ${directExecutions.status} IN ('completed', 'failed') THEN 1 ELSE 0 END)`,
             successCount: sql<number>`SUM(CASE WHEN ${directExecutions.status} = 'completed' THEN 1 ELSE 0 END)`,

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -655,17 +655,18 @@ export const workflowExecutions = pgTable(
     userId: text("user_id")
       .notNull()
       .references(() => users.id),
-    status: text("status")
-      .notNull()
-      .$type<
-        | "pending"
-        | "running"
-        | "success"
-        | "error"
-        | "cancelled"
-        | "phantom"
-        | "system_error"
-      >(),
+    status: text("status").notNull().$type<
+      | "pending"
+      | "running"
+      // A run whose claimed transaction hashes could not be read on chain.
+      // Non-terminal: settled to success or error by the reconciler.
+      | "unconfirmed"
+      | "success"
+      | "error"
+      | "cancelled"
+      | "phantom"
+      | "system_error"
+    >(),
     // biome-ignore lint/suspicious/noExplicitAny: JSONB type - structure validated at application level
     input: jsonb("input").$type<Record<string, any>>(),
     // biome-ignore lint/suspicious/noExplicitAny: JSONB type - structure validated at application level

--- a/lib/execute/reconcile-executions.ts
+++ b/lib/execute/reconcile-executions.ts
@@ -10,6 +10,9 @@ import {
   workflowExecutions,
 } from "@/lib/db/schema";
 import { ErrorCategory, logInfo, logSystemWarn } from "@/lib/logging";
+import { recordWorkflowExecutionFinished } from "@/lib/metrics/collectors/prometheus";
+import { NA_ERROR_TYPE } from "@/lib/metrics/metric-constants";
+import { resolveOrgSlugForCounter } from "@/lib/metrics/org-slug.server";
 import {
   describeVerificationFailure,
   hasUnreadableReceipt,
@@ -168,9 +171,30 @@ async function reconcileOne(
  * verifies, and to error only when at least one is conclusively bad. While any
  * hash is merely unreadable the run stays open.
  */
+/**
+ * Emit the finished sample that logWorkflowCompleteDb deliberately skipped for
+ * an unconfirmed run, so the counter still means "finished" and a success rate
+ * computed from it stays correct.
+ */
+async function recordSettled(
+  workflowId: string,
+  status: "success" | "error"
+): Promise<void> {
+  try {
+    recordWorkflowExecutionFinished({
+      status,
+      orgSlug: await resolveOrgSlugForCounter(workflowId),
+      errorType: NA_ERROR_TYPE,
+    });
+  } catch {
+    // Counter emission must never break reconciliation.
+  }
+}
+
 async function reconcileWorkflow(
   execution: {
     id: string;
+    workflowId: string;
     transactionHashes: TransactionHashEntry[] | null;
     startedAt: Date;
   },
@@ -190,6 +214,7 @@ async function reconcileWorkflow(
         error: "On-chain verification failed: no verifiable transaction hashes",
       })
       .where(eq(workflowExecutions.id, execution.id));
+    await recordSettled(execution.workflowId, "error");
     return "failed";
   }
 
@@ -202,6 +227,7 @@ async function reconcileWorkflow(
       .update(workflowExecutions)
       .set({ status: "success", error: null, completedAt: new Date() })
       .where(eq(workflowExecutions.id, execution.id));
+    await recordSettled(execution.workflowId, "success");
     return "completed";
   }
 
@@ -223,6 +249,7 @@ async function reconcileWorkflow(
       completedAt: new Date(),
     })
     .where(eq(workflowExecutions.id, execution.id));
+  await recordSettled(execution.workflowId, "error");
   return "failed";
 }
 
@@ -264,6 +291,7 @@ export async function reconcileUnconfirmedExecutions(
   const pendingWorkflows = await db
     .select({
       id: workflowExecutions.id,
+      workflowId: workflowExecutions.workflowId,
       transactionHashes: workflowExecutions.transactionHashes,
       startedAt: workflowExecutions.startedAt,
     })

--- a/lib/execute/reconcile-executions.ts
+++ b/lib/execute/reconcile-executions.ts
@@ -1,0 +1,308 @@
+import "server-only";
+
+import { and, asc, eq, isNotNull, lt } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  type DirectExecution,
+  type DirectExecutionReceiptEntry,
+  directExecutions,
+  type TransactionHashEntry,
+  workflowExecutions,
+} from "@/lib/db/schema";
+import { ErrorCategory, logInfo, logSystemWarn } from "@/lib/logging";
+import {
+  describeVerificationFailure,
+  hasUnreadableReceipt,
+  verifyExecutionReceipts,
+} from "@/lib/web3/verify-receipt";
+
+/**
+ * Settles direct executions left in `unconfirmed`: a transaction was broadcast
+ * but the chain had not yet told us whether it landed by the time the request
+ * had to answer.
+ *
+ * Holding these open is the point. Reporting a broadcast as failed is what
+ * makes a caller retry an action that already moved funds, so the row keeps its
+ * hash and stays non-terminal until the chain is conclusive, or until enough
+ * time has passed that a transaction still absent from every endpoint can only
+ * have been dropped.
+ */
+
+// How long a broadcast can stay unseen before we accept it never landed. Well
+// past any realistic mempool eviction, because concluding "dropped" for a
+// transaction that later mines is the expensive direction to be wrong in.
+const DROPPED_AFTER_MS = 24 * 60 * 60 * 1000;
+// Give the write path's own retries room to finish before re-reading.
+const MIN_AGE_MS = 30 * 1000;
+const DEFAULT_BATCH_SIZE = 200;
+
+export type ReconcileSummary = {
+  examined: number;
+  completed: number;
+  failed: number;
+  stillUnconfirmed: number;
+};
+
+export type ReconcileReport = {
+  direct: ReconcileSummary;
+  workflows: ReconcileSummary;
+};
+
+function emptySummary(examined: number): ReconcileSummary {
+  return { examined, completed: 0, failed: 0, stillUnconfirmed: 0 };
+}
+
+function tally(summary: ReconcileSummary, outcome: SettleOutcome): void {
+  if (outcome === "completed") {
+    summary.completed += 1;
+  } else if (outcome === "failed") {
+    summary.failed += 1;
+  } else {
+    summary.stillUnconfirmed += 1;
+  }
+}
+
+type SettleOutcome = "completed" | "failed" | "unconfirmed";
+
+function resolveChainId(execution: DirectExecution): number | null {
+  const fromReceipt = execution.receipts.find(
+    (receipt) => receipt.chainId !== undefined
+  )?.chainId;
+  if (fromReceipt !== undefined) {
+    return fromReceipt;
+  }
+  const parsed = Number(execution.network);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function toReceiptEntries(
+  results: Awaited<ReturnType<typeof verifyExecutionReceipts>>["results"]
+): DirectExecutionReceiptEntry[] {
+  return results.map((result) => ({
+    hash: result.hash,
+    chainId: result.chainId,
+    verified: result.verified,
+    receiptStatus: result.status,
+    blockNumber: result.blockNumber,
+    gasUsed: result.gasUsed,
+    verifiedAt: result.verifiedAt,
+  }));
+}
+
+async function settle(
+  executionId: string,
+  status: "completed" | "failed",
+  receipts: DirectExecutionReceiptEntry[],
+  error: string | null
+): Promise<void> {
+  await db
+    .update(directExecutions)
+    .set({ status, error, receipts, completedAt: new Date() })
+    .where(eq(directExecutions.id, executionId));
+}
+
+async function reconcileOne(
+  execution: DirectExecution,
+  now: Date
+): Promise<"completed" | "failed" | "unconfirmed"> {
+  const chainId = resolveChainId(execution);
+  const hash = execution.transactionHash;
+  if (!hash || chainId === null) {
+    await settle(
+      execution.id,
+      "failed",
+      execution.receipts,
+      "Unable to verify transaction: chain could not be resolved"
+    );
+    return "failed";
+  }
+
+  const { allVerified, results } = await verifyExecutionReceipts([
+    { hash, chainId },
+  ]);
+  const receipts = toReceiptEntries(results);
+
+  if (allVerified) {
+    await settle(execution.id, "completed", receipts, null);
+    return "completed";
+  }
+
+  const conclusive = results.every(
+    (result) =>
+      result.status === "reverted" || result.status === "safe_inner_failure"
+  );
+  if (conclusive) {
+    await settle(
+      execution.id,
+      "failed",
+      receipts,
+      describeVerificationFailure(results)
+    );
+    return "failed";
+  }
+
+  const age = now.getTime() - execution.createdAt.getTime();
+  if (age >= DROPPED_AFTER_MS) {
+    await settle(
+      execution.id,
+      "failed",
+      receipts,
+      `Transaction ${hash} was broadcast but never appeared on chain; treating it as dropped after ${Math.round(
+        DROPPED_AFTER_MS / 3_600_000
+      )}h`
+    );
+    return "failed";
+  }
+
+  await db
+    .update(directExecutions)
+    .set({ receipts })
+    .where(eq(directExecutions.id, execution.id));
+  return "unconfirmed";
+}
+
+/**
+ * Settle one unconfirmed workflow run.
+ *
+ * A workflow claims many hashes, so it settles to success only when every hash
+ * verifies, and to error only when at least one is conclusively bad. While any
+ * hash is merely unreadable the run stays open.
+ */
+async function reconcileWorkflow(
+  execution: {
+    id: string;
+    transactionHashes: TransactionHashEntry[] | null;
+    startedAt: Date;
+  },
+  now: Date
+): Promise<SettleOutcome> {
+  const entries = execution.transactionHashes ?? [];
+  const verifiable = entries.filter(
+    (entry): entry is TransactionHashEntry & { chainId: number } =>
+      entry.chainId !== undefined
+  );
+
+  if (verifiable.length === 0) {
+    await db
+      .update(workflowExecutions)
+      .set({
+        status: "error",
+        error: "On-chain verification failed: no verifiable transaction hashes",
+      })
+      .where(eq(workflowExecutions.id, execution.id));
+    return "failed";
+  }
+
+  const { allVerified, results } = await verifyExecutionReceipts(
+    verifiable.map((entry) => ({ hash: entry.hash, chainId: entry.chainId }))
+  );
+
+  if (allVerified) {
+    await db
+      .update(workflowExecutions)
+      .set({ status: "success", error: null, completedAt: new Date() })
+      .where(eq(workflowExecutions.id, execution.id));
+    return "completed";
+  }
+
+  const stillUnreadable = hasUnreadableReceipt(results);
+  const age = now.getTime() - execution.startedAt.getTime();
+  if (stillUnreadable && age < DROPPED_AFTER_MS) {
+    return "unconfirmed";
+  }
+
+  await db
+    .update(workflowExecutions)
+    .set({
+      status: "error",
+      error: stillUnreadable
+        ? `Transactions were broadcast but never appeared on chain; treating them as dropped after ${Math.round(
+            DROPPED_AFTER_MS / 3_600_000
+          )}h`
+        : describeVerificationFailure(results),
+      completedAt: new Date(),
+    })
+    .where(eq(workflowExecutions.id, execution.id));
+  return "failed";
+}
+
+export async function reconcileUnconfirmedExecutions(
+  now: Date = new Date(),
+  batchSize: number = DEFAULT_BATCH_SIZE
+): Promise<ReconcileReport> {
+  const cutoff = new Date(now.getTime() - MIN_AGE_MS);
+
+  const pending = await db
+    .select()
+    .from(directExecutions)
+    .where(
+      and(
+        eq(directExecutions.status, "unconfirmed"),
+        isNotNull(directExecutions.transactionHash),
+        lt(directExecutions.createdAt, cutoff)
+      )
+    )
+    .orderBy(asc(directExecutions.createdAt))
+    .limit(batchSize);
+
+  const direct = emptySummary(pending.length);
+
+  for (const execution of pending) {
+    try {
+      tally(direct, await reconcileOne(execution, now));
+    } catch (error) {
+      direct.stillUnconfirmed += 1;
+      logSystemWarn(
+        ErrorCategory.NETWORK_RPC,
+        "[Reconciler] Failed to re-verify an unconfirmed execution; leaving it open",
+        error instanceof Error ? error : new Error(String(error)),
+        { execution_id: execution.id }
+      );
+    }
+  }
+
+  const pendingWorkflows = await db
+    .select({
+      id: workflowExecutions.id,
+      transactionHashes: workflowExecutions.transactionHashes,
+      startedAt: workflowExecutions.startedAt,
+    })
+    .from(workflowExecutions)
+    .where(
+      and(
+        eq(workflowExecutions.status, "unconfirmed"),
+        lt(workflowExecutions.startedAt, cutoff)
+      )
+    )
+    .orderBy(asc(workflowExecutions.startedAt))
+    .limit(batchSize);
+
+  const workflows = emptySummary(pendingWorkflows.length);
+
+  for (const execution of pendingWorkflows) {
+    try {
+      tally(workflows, await reconcileWorkflow(execution, now));
+    } catch (error) {
+      workflows.stillUnconfirmed += 1;
+      logSystemWarn(
+        ErrorCategory.NETWORK_RPC,
+        "[Reconciler] Failed to re-verify an unconfirmed workflow run; leaving it open",
+        error instanceof Error ? error : new Error(String(error)),
+        { execution_id: execution.id }
+      );
+    }
+  }
+
+  if (direct.examined > 0 || workflows.examined > 0) {
+    logInfo("[Reconciler] Settled unconfirmed executions", {
+      direct_examined: String(direct.examined),
+      direct_completed: String(direct.completed),
+      direct_failed: String(direct.failed),
+      workflow_examined: String(workflows.examined),
+      workflow_completed: String(workflows.completed),
+      workflow_failed: String(workflows.failed),
+    });
+  }
+
+  return { direct, workflows };
+}

--- a/lib/execute/value-ledger.ts
+++ b/lib/execute/value-ledger.ts
@@ -12,6 +12,8 @@ import { parseNodeNativeValueWei } from "@/lib/execute/reserved-value";
 // In-flight rows older than this are treated as stale (crashed pod / lost
 // process) and drop out of the cap SUM, matching the direct-execution
 // concurrency limiter, so a stuck reservation cannot hold the cap all day.
+// Unconfirmed rows are exempt: the transaction is on chain and may have moved
+// the funds, so it keeps counting until the reconciler settles it.
 const STALE_INFLIGHT_MINUTES = 15;
 
 // biome-ignore lint/suspicious/noExplicitAny: accept either the app db or a tx
@@ -44,7 +46,7 @@ export async function sumOrgValueTodayWei(
         eq(directExecutions.organizationId, organizationId),
         ne(directExecutions.status, "failed"),
         gte(directExecutions.createdAt, todayStart),
-        sql`(${directExecutions.status} = 'completed' OR ${directExecutions.createdAt} > now() - interval '${sql.raw(String(STALE_INFLIGHT_MINUTES))} minutes')`
+        sql`(${directExecutions.status} IN ('completed', 'unconfirmed') OR ${directExecutions.createdAt} > now() - interval '${sql.raw(String(STALE_INFLIGHT_MINUTES))} minutes')`
       )
     );
 
@@ -95,7 +97,7 @@ export async function sumOrgSolanaValueTodayLamports(
         eq(directExecutions.organizationId, organizationId),
         ne(directExecutions.status, "failed"),
         gte(directExecutions.createdAt, todayStart),
-        sql`(${directExecutions.status} = 'completed' OR ${directExecutions.createdAt} > now() - interval '${sql.raw(String(STALE_INFLIGHT_MINUTES))} minutes')`
+        sql`(${directExecutions.status} IN ('completed', 'unconfirmed') OR ${directExecutions.createdAt} > now() - interval '${sql.raw(String(STALE_INFLIGHT_MINUTES))} minutes')`
       )
     );
 

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -1190,6 +1190,7 @@ export function registerTools(
           "3. Repeat the same arguments with simulate omitted and a unique idempotency_key",
           "4. Poll get_direct_execution_status with bounded backoff until completed or failed",
           "5. Save the terminal transactionLink as the onchain proof",
+          "- status unconfirmed means the transaction was broadcast but the chain has not confirmed it yet; it is NOT a failure. Keep polling. Never re-send an unconfirmed execution: the transaction may still land and re-sending moves the funds twice",
           "- simulate must be a JSON boolean, not a string",
           "- simulation is EVM-only; Solana chain IDs 101/103 and their aliases are rejected before the API call",
           "- view/pure calls and unmet conditions return their normal read/no-action result",
@@ -1409,7 +1410,7 @@ export function registerTools(
 
   server.tool(
     "get_direct_execution_status",
-    "Get the status of a direct execution (transfer or contract call). Returns transaction hash, status, and result when complete.",
+    "Get the status of a direct execution (transfer or contract call). Returns transaction hash, status, and result when complete. Status is one of pending, running, unconfirmed, completed, failed; only completed and failed are terminal. unconfirmed means the transaction is on chain but not yet confirmed, so keep polling rather than re-sending.",
     {
       execution_id: z
         .string()

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -1007,7 +1007,7 @@ const workflowExecutionsFinished = getOrCreateCounter(
 );
 
 export function recordWorkflowExecutionFinished(labels: {
-  status: "success" | ErrorStatus;
+  status: "success" | "unconfirmed" | ErrorStatus;
   orgSlug: string;
   errorType: ExecutionErrorType | typeof NA_ERROR_TYPE;
 }): void {

--- a/lib/web3/sponsored-send-error.ts
+++ b/lib/web3/sponsored-send-error.ts
@@ -11,10 +11,10 @@ export type SponsoredSendDecision =
   | {
       fallback: false;
       error: string;
-      // Set only when the sponsored transaction reached the chain and
-      // reverted there, so a caller can tell "this hash exists and reverted"
-      // (reconcilable) from "nothing was broadcast" (nothing to reconcile).
-      // Absent for the accepted-but-unconfirmed case, where no hash is known.
+      // Set whenever the sponsored transaction reached the chain, whether it
+      // reverted there or its outcome could not be read, so a caller can tell
+      // "this hash exists" (reconcilable) from "nothing was broadcast"
+      // (nothing to reconcile). Absent only when no hash was ever assigned.
       transactionHash?: string;
       // Set only for the pending/unconfirmed case, so a failOnError=false
       // caller can never soften it into success: the transaction may still
@@ -77,19 +77,29 @@ export function resolveSponsoredSendError(
         action_name: actionName,
         chain_id: String(chainId),
         send_transaction_status_id: error.sendTransactionStatusId,
+        ...(error.txHash ? { tx_hash: error.txHash } : {}),
       }
     );
     return {
       fallback: false,
-      error:
-        "Sponsored transaction was submitted but not confirmed in time. It may still complete; not retrying to avoid a duplicate transaction.",
+      error: error.txHash
+        ? `Sponsored transaction ${error.txHash} was broadcast but its outcome could not be confirmed. It may still complete; not retrying to avoid a duplicate transaction.`
+        : "Sponsored transaction was submitted but not confirmed in time. It may still complete; not retrying to avoid a duplicate transaction.",
+      // Carried so the execution record keeps the hash of a broadcast we could
+      // not confirm. Without it the transaction exists on-chain and nowhere in
+      // our data, which leaves nothing to reconcile against.
+      ...(error.txHash ? { transactionHash: error.txHash } : {}),
       errorClass: ExecutionErrorType.SYSTEM,
     };
   }
 
-  logUserError(
+  // Reaching here means the sponsored send failed before anything was
+  // broadcast, which is the only case where re-sending is safe. Logged as a
+  // system warning rather than a user error so the rate of fallbacks is
+  // visible in Sentry: a spike means sponsorship is degraded platform-wide.
+  logSystemWarn(
     ErrorCategory.TRANSACTION,
-    `${logPrefix} Sponsorship attempted but failed, falling back to direct signing`,
+    `${logPrefix} Sponsorship failed before broadcast, falling back to direct signing`,
     error,
     {
       plugin_name: "web3",

--- a/lib/web3/sponsored-transaction-manager.ts
+++ b/lib/web3/sponsored-transaction-manager.ts
@@ -251,12 +251,16 @@ async function decodeSponsoredRevertReason(
 }
 
 // The send is already on the network by the time this runs, so the question is
-// only how long to keep looking for its receipt. A sponsored write on Base has
-// been observed going from submit to readable receipt in under 3 seconds, so
-// five minutes is ~150 blocks of margin and covers a badly congested mempool.
-// It stays well inside the idempotency processing lock (10 minutes, heartbeated
-// every 2), so a request can never outlive its own reservation.
-const RECEIPT_WAIT_BUDGET_MS = 5 * 60_000;
+// only how long to keep looking for its receipt. A healthy sponsored write has
+// been observed going from submit to readable receipt in seconds, so eight
+// minutes is a very wide margin and covers a badly congested mempool.
+//
+// This plus the Turnkey hash poll exceeds the idempotency processing lock's
+// base TTL, which is safe only because the routes wrap the whole call in
+// withIdempotencyHeartbeat: the heartbeat re-extends the lock every 2 minutes,
+// so the request cannot outlive its own reservation. Do not raise this without
+// checking that heartbeat is still in place.
+const RECEIPT_WAIT_BUDGET_MS = 8 * 60_000;
 // How long to give one endpoint before rotating to the next. Short relative to
 // the budget so a single wedged endpoint cannot consume it.
 const RECEIPT_WAIT_PER_ENDPOINT_MS = 30_000;

--- a/lib/web3/sponsored-transaction-manager.ts
+++ b/lib/web3/sponsored-transaction-manager.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import type { Hex } from "viem";
+import type { Hex, TransactionReceipt } from "viem";
 import { BaseError, createPublicClient, encodeFunctionData, http } from "viem";
 import {
   checkGasCredits,
@@ -9,6 +9,7 @@ import {
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { getMetricsCollector } from "@/lib/metrics";
 import { MetricNames } from "@/lib/metrics/types";
+import { resolveRpcConfig } from "@/lib/rpc/config-service";
 import {
   isBlockedHost,
   isBlockedIp,
@@ -17,7 +18,11 @@ import {
 import { isTestnetChain } from "@/lib/web3/chainlink-feeds";
 import { createSponsoredClient } from "@/lib/web3/sponsored-client";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
-import { SponsoredTxRevertError } from "@/lib/web3/turnkey-revert";
+import {
+  isSponsoredTxRevertError,
+  SponsoredTxPendingError,
+  SponsoredTxRevertError,
+} from "@/lib/web3/turnkey-revert";
 import { submitTurnkeySponsoredTransaction } from "@/lib/web3/turnkey-sponsored-tx";
 import { isSponsorshipSupported } from "@/lib/web3/turnkey-sponsorship-config";
 
@@ -82,7 +87,8 @@ function isSponsorshipBlockedRpc(rpcUrl: string): boolean {
  * signing when null is returned.
  */
 export async function executeSponsoredTransaction(
-  params: SponsoredTxParams
+  params: SponsoredTxParams,
+  receiptWait?: ReceiptWaitOptions
 ): Promise<SponsoredTransactionResult> {
   if (!isGasSponsorshipEnabled()) {
     return null;
@@ -123,13 +129,14 @@ export async function executeSponsoredTransaction(
     return null;
   }
 
-  return await finalizeSponsoredTx(
+  return await settleSponsoredTx(
     submitResult.txHash,
     submitResult.sendTransactionStatusId,
     params.rpcUrl,
     params.organizationId,
     params.chainId,
-    params.executionId
+    params.executionId,
+    receiptWait
   );
 }
 
@@ -140,7 +147,8 @@ export async function executeSponsoredTransaction(
  * so callers can fall back to direct signing.
  */
 export async function executeSponsoredContractTransaction(
-  params: SponsoredContractTxParams
+  params: SponsoredContractTxParams,
+  receiptWait?: ReceiptWaitOptions
 ): Promise<SponsoredTransactionResult> {
   if (!isGasSponsorshipEnabled()) {
     return null;
@@ -187,13 +195,14 @@ export async function executeSponsoredContractTransaction(
     return null;
   }
 
-  return await finalizeSponsoredTx(
+  return await settleSponsoredTx(
     submitResult.txHash,
     submitResult.sendTransactionStatusId,
     params.rpcUrl,
     params.organizationId,
     params.chainId,
-    params.executionId
+    params.executionId,
+    receiptWait
   );
 }
 
@@ -241,6 +250,123 @@ async function decodeSponsoredRevertReason(
   }
 }
 
+// The send is already on the network by the time this runs, so the question is
+// only how long to keep looking for its receipt. A sponsored write on Base has
+// been observed going from submit to readable receipt in under 3 seconds, so
+// five minutes is ~150 blocks of margin and covers a badly congested mempool.
+// It stays well inside the idempotency processing lock (10 minutes, heartbeated
+// every 2), so a request can never outlive its own reservation.
+const RECEIPT_WAIT_BUDGET_MS = 5 * 60_000;
+// How long to give one endpoint before rotating to the next. Short relative to
+// the budget so a single wedged endpoint cannot consume it.
+const RECEIPT_WAIT_PER_ENDPOINT_MS = 30_000;
+// Pause between full rotations. Endpoints that reject immediately (connection
+// refused, instant 429) would otherwise let the loop spin as fast as they can
+// say no, hammering every endpoint for the whole budget.
+const RECEIPT_WAIT_ROUND_DELAY_MS = 2000;
+
+/** Shrinkable in tests so the wait budget does not add wall-clock time. */
+export type ReceiptWaitOptions = {
+  budgetMs?: number;
+  perEndpointMs?: number;
+  roundDelayMs?: number;
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * Every endpoint worth asking for the receipt, most-likely first: the URL the
+ * caller broadcast against, then the chain's configured primary and fallback.
+ * Deduped, since the caller's URL is usually the primary already.
+ */
+async function receiptRpcUrls(
+  rpcUrl: string,
+  chainId: number
+): Promise<string[]> {
+  let config: Awaited<ReturnType<typeof resolveRpcConfig>> = null;
+  try {
+    config = await resolveRpcConfig(chainId);
+  } catch {
+    // Config lookup is an optimization; the caller's URL alone still works.
+  }
+  const candidates = [rpcUrl, config?.primaryRpcUrl, config?.fallbackRpcUrl];
+  return [...new Set(candidates.filter((url): url is string => Boolean(url)))];
+}
+
+/**
+ * Read the receipt for an already-broadcast sponsored transaction, trying
+ * every configured endpoint before giving up.
+ *
+ * A single load-balanced endpoint can answer for a node that has not yet seen
+ * the transaction, so one failed read is not evidence the send did not land.
+ * When no endpoint can answer, this raises a pending error carrying the hash
+ * rather than a bare Error: the distinction is what stops the caller from
+ * re-sending, and a bare Error here is indistinguishable from a pre-broadcast
+ * failure.
+ */
+async function waitForSponsoredReceipt(
+  txHash: Hex,
+  sendTransactionStatusId: string,
+  rpcUrl: string,
+  chainId: number,
+  options: ReceiptWaitOptions = {}
+): Promise<TransactionReceipt> {
+  const budgetMs = options.budgetMs ?? RECEIPT_WAIT_BUDGET_MS;
+  const perEndpointMs = options.perEndpointMs ?? RECEIPT_WAIT_PER_ENDPOINT_MS;
+  const roundDelayMs = options.roundDelayMs ?? RECEIPT_WAIT_ROUND_DELAY_MS;
+
+  const urls = await receiptRpcUrls(rpcUrl, chainId);
+  const deadline = Date.now() + budgetMs;
+  let lastError: unknown;
+  let firstRound = true;
+
+  // Rotate through the endpoints until the budget is spent. One endpoint being
+  // wedged or lagging says nothing about whether the transaction landed, so a
+  // failed read is a reason to ask someone else rather than to conclude.
+  while (firstRound || Date.now() < deadline) {
+    if (!firstRound) {
+      await sleep(Math.min(roundDelayMs, Math.max(0, deadline - Date.now())));
+    }
+    firstRound = false;
+
+    for (const url of urls) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        break;
+      }
+      try {
+        return await createPublicClient({
+          transport: http(url),
+        }).waitForTransactionReceipt({
+          hash: txHash,
+          timeout: Math.min(perEndpointMs, remaining),
+        });
+      } catch (error) {
+        lastError = error;
+      }
+    }
+  }
+
+  logSystemError(
+    ErrorCategory.NETWORK_RPC,
+    "[Sponsorship] Sponsored transaction broadcast but its receipt could not be read on any endpoint",
+    lastError instanceof Error ? lastError : new Error(String(lastError)),
+    { chainId: chainId.toString(), txHash, endpoints: String(urls.length) }
+  );
+
+  throw new SponsoredTxPendingError({
+    message: `Sponsored transaction was broadcast but its receipt could not be read on any RPC endpoint: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`,
+    sendTransactionStatusId,
+    txHash,
+  });
+}
+
 /**
  * Wait for receipt, record gas usage, and build the result.
  *
@@ -248,6 +374,10 @@ async function decodeSponsoredRevertReason(
  * underlying tx -- but the on-chain receipt still reports gasUsed and
  * effectiveGasPrice, which is what we meter against the org's gas-credit
  * balance. Billing is skipped on testnets.
+ *
+ * Callers treat a throw from here as "do not fall back to direct signing",
+ * which only holds if every throw is one of the two typed sponsored errors.
+ * `settleSponsoredTx` below enforces that.
  */
 async function finalizeSponsoredTx(
   txHash: Hex,
@@ -255,15 +385,20 @@ async function finalizeSponsoredTx(
   rpcUrl: string,
   organizationId: string,
   chainId: number,
-  executionId: string
+  executionId: string,
+  receiptWait?: ReceiptWaitOptions
 ): Promise<SponsoredTransactionResult> {
   const publicClient = createPublicClient({
     transport: http(rpcUrl),
   });
 
-  const receipt = await publicClient.waitForTransactionReceipt({
-    hash: txHash,
-  });
+  const receipt = await waitForSponsoredReceipt(
+    txHash,
+    sendTransactionStatusId,
+    rpcUrl,
+    chainId,
+    receiptWait
+  );
 
   if (receipt.status !== "success") {
     // The sponsored tx is on-chain and reverted. Read-only replay to recover
@@ -346,4 +481,60 @@ async function finalizeSponsoredTx(
     effectiveGasPrice: effectiveGasPrice.toString(),
     sponsored: true,
   };
+}
+
+/**
+ * The single exit from the post-broadcast half of the sponsored path.
+ *
+ * By the time this runs Turnkey has already put a transaction from the user's
+ * wallet on the network. Callers read an untyped throw as a pre-broadcast
+ * failure and respond by signing and broadcasting again, which is how one
+ * authorized action becomes two on-chain transactions. So anything that
+ * escapes finalization other than the two typed sponsored errors -- a gas
+ * price lookup, a metrics call, a revert-reason decode -- is converted into a
+ * pending error carrying the hash, which callers already handle as
+ * "terminal, do not re-send".
+ */
+async function settleSponsoredTx(
+  txHash: Hex,
+  sendTransactionStatusId: string,
+  rpcUrl: string,
+  organizationId: string,
+  chainId: number,
+  executionId: string,
+  receiptWait?: ReceiptWaitOptions
+): Promise<SponsoredTransactionResult> {
+  try {
+    return await finalizeSponsoredTx(
+      txHash,
+      sendTransactionStatusId,
+      rpcUrl,
+      organizationId,
+      chainId,
+      executionId,
+      receiptWait
+    );
+  } catch (error) {
+    if (
+      isSponsoredTxRevertError(error) ||
+      error instanceof SponsoredTxPendingError
+    ) {
+      throw error;
+    }
+
+    logSystemError(
+      ErrorCategory.TRANSACTION,
+      "[Sponsorship] Finalization failed after the sponsored transaction was broadcast",
+      error instanceof Error ? error : new Error(String(error)),
+      { organizationId, chainId: chainId.toString(), txHash }
+    );
+
+    throw new SponsoredTxPendingError({
+      message: `Sponsored transaction ${txHash} was broadcast but could not be finalized: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      sendTransactionStatusId,
+      txHash,
+    });
+  }
 }

--- a/lib/web3/turnkey-revert.ts
+++ b/lib/web3/turnkey-revert.ts
@@ -76,11 +76,23 @@ export function isSponsoredTxRevertError(
 export class SponsoredTxPendingError extends Error {
   readonly kind = "sponsored-tx-pending" as const;
   readonly sendTransactionStatusId: string;
+  /**
+   * Set when Turnkey already handed back a hash, i.e. the send is on the
+   * network but its outcome could not be read. Absent when the wait window
+   * lapsed before any hash existed. Callers persist it so an unconfirmed
+   * broadcast stays auditable instead of vanishing from the record.
+   */
+  readonly txHash?: Hex;
 
-  constructor(opts: { message: string; sendTransactionStatusId: string }) {
+  constructor(opts: {
+    message: string;
+    sendTransactionStatusId: string;
+    txHash?: Hex;
+  }) {
     super(opts.message);
     this.name = "SponsoredTxPendingError";
     this.sendTransactionStatusId = opts.sendTransactionStatusId;
+    this.txHash = opts.txHash;
   }
 }
 

--- a/lib/web3/verify-receipt.ts
+++ b/lib/web3/verify-receipt.ts
@@ -36,6 +36,31 @@ export type ReceiptVerificationResult = {
   verifiedAt: string;
 };
 
+// Statuses where the chain gave an answer. The rest mean we could not read the
+// receipt, which is not the same as the transaction having failed, and callers
+// must be able to tell those apart before they settle anything as failed.
+const CONCLUSIVE_STATUSES: ReadonlySet<ReceiptStatus> = new Set([
+  "success",
+  "reverted",
+  "safe_inner_failure",
+]);
+
+export function isConclusiveReceiptStatus(status: ReceiptStatus): boolean {
+  return CONCLUSIVE_STATUSES.has(status);
+}
+
+/**
+ * True when at least one hash could not be read at all, so the batch's outcome
+ * is unknown rather than failed.
+ */
+export function hasUnreadableReceipt(
+  results: readonly { verified: boolean; status: ReceiptStatus }[]
+): boolean {
+  return results.some(
+    (result) => !(result.verified || isConclusiveReceiptStatus(result.status))
+  );
+}
+
 // Tight budget: the write path has already broadcast and waited for this
 // receipt once before returning -- this call is a fast independent re-fetch,
 // not a fresh confirmation wait. Bounded so a stuck RPC can't hang a
@@ -43,6 +68,20 @@ export type ReceiptVerificationResult = {
 const VERIFY_MAX_RETRIES = 2;
 const VERIFY_TIMEOUT_MS = 8000;
 const VERIFY_CONCURRENCY_LIMIT = 20;
+
+// A single miss is not evidence of absence. RPC hosts sit behind load
+// balancers, so the node that answers this read can be a block or two behind
+// the one the write path used -- we have observed a receipt being found and
+// then reported missing 8ms later on the same chain. Re-ask within a bounded
+// wall-clock budget before concluding the receipt is not there.
+const LOOKUP_BUDGET_MS = 12_000;
+const LOOKUP_RETRY_DELAY_MS = 1500;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
 
 // Gnosis Safe's execTransaction always emits exactly one of these -- never
 // neither. A receipt with status 1 (outer tx succeeded) can still carry
@@ -101,25 +140,93 @@ async function buildVerificationManager(
   });
 }
 
+type ReceiptLookup = {
+  receipt: ethers.TransactionReceipt | null;
+  /** True when at least one read errored rather than answering "no receipt". */
+  errored: boolean;
+};
+
+/** Shrinkable in tests so the retry budget does not add wall-clock time. */
+export type ReceiptLookupOptions = {
+  budgetMs?: number;
+  retryDelayMs?: number;
+};
+
+/**
+ * Ask every available endpoint for the receipt, repeatedly, until one answers
+ * or the budget runs out.
+ *
+ * `getTransactionReceipt` resolves to null for an unknown hash rather than
+ * throwing, so `executeWithFailover` treats a miss as a successful call and
+ * never moves to the fallback endpoint. That makes the fallback unreachable
+ * for exactly the case it exists to cover, so a null answer is followed by an
+ * explicit read against the fallback provider.
+ */
+async function lookupReceipt(
+  hash: string,
+  manager: RpcProviderManager,
+  options: ReceiptLookupOptions = {}
+): Promise<ReceiptLookup> {
+  const budgetMs = options.budgetMs ?? LOOKUP_BUDGET_MS;
+  const retryDelayMs = options.retryDelayMs ?? LOOKUP_RETRY_DELAY_MS;
+  const deadline = Date.now() + budgetMs;
+  let errored = false;
+  let firstRound = true;
+
+  while (firstRound || Date.now() < deadline) {
+    if (!firstRound) {
+      await sleep(retryDelayMs);
+    }
+    firstRound = false;
+
+    try {
+      const receipt = await manager.executeWithFailover(
+        (provider) => provider.getTransactionReceipt(hash),
+        "read"
+      );
+      if (receipt) {
+        return { receipt, errored: false };
+      }
+    } catch {
+      errored = true;
+    }
+
+    const fallback = manager.getFallbackProvider();
+    if (fallback) {
+      try {
+        const receipt = await fallback.getTransactionReceipt(hash);
+        if (receipt) {
+          return { receipt, errored: false };
+        }
+      } catch {
+        errored = true;
+      }
+    }
+  }
+
+  return { receipt: null, errored };
+}
+
 async function verifySingleReceipt(
   hash: string,
   chainId: number,
-  manager: RpcProviderManager
+  manager: RpcProviderManager,
+  options: ReceiptLookupOptions = {}
 ): Promise<ReceiptVerificationResult> {
   const verifiedAt = new Date().toISOString();
 
-  let receipt: ethers.TransactionReceipt | null;
-  try {
-    receipt = await manager.executeWithFailover(
-      (provider) => provider.getTransactionReceipt(hash),
-      "read"
-    );
-  } catch {
-    return { hash, chainId, verified: false, status: "timeout", verifiedAt };
-  }
+  const { receipt, errored } = await lookupReceipt(hash, manager, options);
 
   if (!receipt) {
-    return { hash, chainId, verified: false, status: "not_found", verifiedAt };
+    return {
+      hash,
+      chainId,
+      verified: false,
+      // "Every endpoint errored" and "every endpoint answered, none had it"
+      // are different operational problems, so keep them distinguishable.
+      status: errored ? "timeout" : "not_found",
+      verifiedAt,
+    };
   }
 
   const blockNumber = receipt.blockNumber;
@@ -205,7 +312,8 @@ async function mapWithConcurrency<T, R>(
  * than a safety fix if a Solana write path ever ships.
  */
 export async function verifyExecutionReceipts(
-  hashes: { hash: string; chainId: number }[]
+  hashes: { hash: string; chainId: number }[],
+  options: ReceiptLookupOptions = {}
 ): Promise<{ allVerified: boolean; results: ReceiptVerificationResult[] }> {
   if (hashes.length === 0) {
     return { allVerified: true, results: [] };
@@ -253,7 +361,7 @@ export async function verifyExecutionReceipts(
     const groupResults = await mapWithConcurrency(
       group,
       VERIFY_CONCURRENCY_LIMIT,
-      ({ hash }) => verifySingleReceipt(hash, chainId, manager)
+      ({ hash }) => verifySingleReceipt(hash, chainId, manager, options)
     );
     allResults.push(...groupResults);
   }

--- a/lib/web3/verify-receipt.ts
+++ b/lib/web3/verify-receipt.ts
@@ -61,19 +61,28 @@ export function hasUnreadableReceipt(
   );
 }
 
-// Tight budget: the write path has already broadcast and waited for this
-// receipt once before returning -- this call is a fast independent re-fetch,
-// not a fresh confirmation wait. Bounded so a stuck RPC can't hang a
-// synchronous HTTP response / workflow finalize indefinitely.
-const VERIFY_MAX_RETRIES = 2;
+// The write path has already broadcast and waited for this receipt once before
+// returning, so this is a fast independent re-fetch, not a fresh confirmation
+// wait. Retries here only apply to attempts that throw: a null answer counts as
+// a successful call, so they buy resilience against transport failures rather
+// than against a lagging node.
+const VERIFY_MAX_RETRIES = 5;
 const VERIFY_TIMEOUT_MS = 8000;
 const VERIFY_CONCURRENCY_LIMIT = 20;
 
 // A single miss is not evidence of absence. RPC hosts sit behind load
 // balancers, so the node that answers this read can be a block or two behind
-// the one the write path used -- we have observed a receipt being found and
-// then reported missing 8ms later on the same chain. Re-ask within a bounded
-// wall-clock budget before concluding the receipt is not there.
+// the one the write path used. A receipt has been observed being found and then
+// reported missing 8ms later on the same chain, so re-ask before concluding it
+// is not there.
+//
+// This bounds how many rounds start, not elapsed time: the deadline is only
+// checked between rounds, so one already in flight runs to completion. Rounds
+// against a responsive endpoint cost milliseconds, but a round whose endpoints
+// time out instead of answering can overrun the budget by
+// VERIFY_MAX_RETRIES x VERIFY_TIMEOUT_MS per provider, primary then fallback.
+// That case only arises for a transaction no endpoint can see, which the
+// unconfirmed state and the reconciler then own.
 const LOOKUP_BUDGET_MS = 12_000;
 const LOOKUP_RETRY_DELAY_MS = 1500;
 

--- a/lib/workflow/concurrency.ts
+++ b/lib/workflow/concurrency.ts
@@ -87,7 +87,9 @@ export async function checkDirectExecutionConcurrency<
       and(
         eq(directExecutions.organizationId, organizationId),
         isNotNull(directExecutions.network),
-        inArray(directExecutions.status, ["pending", "running"]),
+        // An unconfirmed row is a broadcast still in flight on chain, so it
+        // holds a slot like any other in-flight execution until it settles.
+        inArray(directExecutions.status, ["pending", "running", "unconfirmed"]),
         sql`${directExecutions.createdAt} > now() - interval '${sql.raw(String(DIRECT_STALE_MINUTES))} minutes'`
       )
     );

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -25,6 +25,7 @@ import {
 import type { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 import {
   ERROR_STATUSES,
+  type ErrorStatus,
   isErrorStatus,
   statusForErrorType,
 } from "@/lib/errors/execution-status";
@@ -40,6 +41,7 @@ import { resolveOrgSlugForCounter } from "@/lib/metrics/org-slug.server";
 import { toJsonSafe } from "@/lib/utils/json-safe";
 import {
   describeVerificationFailure,
+  hasUnreadableReceipt,
   type ReceiptVerificationResult,
   verifyExecutionReceipts,
 } from "@/lib/web3/verify-receipt";
@@ -224,7 +226,15 @@ function mergeReceiptResults(
 
 type ReconcileTransactionHashesResult =
   | { ok: true; hashes: TransactionHashEntry[] }
-  | { ok: false; hashes: TransactionHashEntry[]; error: string };
+  | {
+      ok: false;
+      hashes: TransactionHashEntry[];
+      error: string;
+      // False when at least one hash could not be read at all. The run did not
+      // fail; we could not see whether it succeeded, and calling that an error
+      // is what makes a caller re-run an already-broadcast transaction.
+      conclusive: boolean;
+    };
 
 /**
  * KEEP-966: independently re-verify every claimed transaction hash against
@@ -247,11 +257,14 @@ async function reconcileTransactionHashes(
       entry.chainId !== undefined
   );
   if (verifiable.length < hashes.length) {
+    // A hash we can never verify is a defect in what the step reported, not an
+    // unread receipt, so this stays a conclusive failure.
     return {
       ok: false,
       hashes,
       error:
         "On-chain verification failed: missing chainId for one or more transaction hashes",
+      conclusive: true,
     };
   }
 
@@ -265,6 +278,7 @@ async function reconcileTransactionHashes(
       ok: false,
       hashes: merged,
       error: describeVerificationFailure(results),
+      conclusive: !hasUnreadableReceipt(results),
     };
   }
   return { ok: true, hashes: merged };
@@ -840,10 +854,17 @@ export async function logWorkflowCompleteDb(
   // this is the "per-execution receipts" deliverable: an operator needs to
   // see which hash failed and why, not just that the run errored.
   let verifiedTransactionHashes = transactionHashes;
+  // Set when a claimed hash could not be read at all. The run is neither a
+  // success we can assert nor a failure we can assert, so it finalizes to a
+  // non-terminal state and the reconciler settles it once the chain answers.
+  // Demoting it to error instead would tell an operator a broadcast run failed
+  // and invite a re-run of transactions that may already have landed.
+  let unreadableReceipts = false;
   if (resolvedStatus === "success" && transactionHashes.length > 0) {
     const reconciled = await reconcileTransactionHashes(transactionHashes);
     verifiedTransactionHashes = reconciled.hashes;
     if (!reconciled.ok) {
+      unreadableReceipts = !reconciled.conclusive;
       resolvedStatus = "error";
       resolvedError = reconciled.error;
     }
@@ -869,7 +890,12 @@ export async function logWorkflowCompleteDb(
   // error for the user-facing status (its errorType is still written as
   // "system" below, so alerting is unchanged). Step logs and the success-path
   // stay on resolvedStatus; only the execution row's status carries the split.
-  const executionStatus =
+  // An unread receipt is not an error outcome, so the row carries no error
+  // classification even though resolvedStatus was set to error above to reuse
+  // the non-success branches.
+  const persistedClassification = unreadableReceipts ? null : classification;
+
+  let executionStatus: "success" | "unconfirmed" | ErrorStatus =
     resolvedStatus === "error"
       ? statusForErrorType(
           classification && !isDefaultClassification(classification)
@@ -877,6 +903,9 @@ export async function logWorkflowCompleteDb(
             : null
         )
       : resolvedStatus;
+  if (unreadableReceipts) {
+    executionStatus = "unconfirmed";
+  }
 
   // Self-join alias so RETURNING can expose the pre-update status (the FROM
   // clause reads the statement snapshot, i.e. the row as it was before this
@@ -891,9 +920,9 @@ export async function logWorkflowCompleteDb(
       status: executionStatus,
       output: toJsonSafe(params.output),
       error: resolvedError,
-      errorCategory: classification?.errorCategory ?? null,
-      errorType: classification?.errorType ?? null,
-      errorCode: classification?.code ?? null,
+      errorCategory: persistedClassification?.errorCategory ?? null,
+      errorType: persistedClassification?.errorType ?? null,
+      errorCode: persistedClassification?.code ?? null,
       completedAt: new Date(),
       duration: duration.toString(),
       // Clear current step on completion
@@ -935,17 +964,17 @@ export async function logWorkflowCompleteDb(
     const workflowId = updated[0].workflowId;
     try {
       const orgSlug = await resolveOrgSlugForCounter(workflowId);
-      if (classification) {
+      if (persistedClassification) {
         recordWorkflowExecutionError({
           orgSlug,
-          errorCategory: classification.errorCategory,
-          errorType: classification.errorType,
+          errorCategory: persistedClassification.errorCategory,
+          errorType: persistedClassification.errorType,
         });
       }
       recordWorkflowExecutionFinished({
         status: executionStatus,
         orgSlug,
-        errorType: classification?.errorType ?? NA_ERROR_TYPE,
+        errorType: persistedClassification?.errorType ?? NA_ERROR_TYPE,
       });
     } catch {
       // Counter emission must never break finalization.

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -960,7 +960,14 @@ export async function logWorkflowCompleteDb(
   // must not emit a second sample - counters are append-only, so the first
   // terminal sample stands. resolvedStatus is post-reconciliation, so
   // spurious errors already flipped to success are counted as success here.
-  if (updated.length > 0 && !isErrorStatus(updated[0].previousStatus)) {
+  // An unconfirmed run has not finished, so it emits no sample here. The
+  // reconciler emits one when it settles, which keeps the counter meaning
+  // "finished" and keeps a success rate computed from it correct.
+  if (
+    updated.length > 0 &&
+    !isErrorStatus(updated[0].previousStatus) &&
+    executionStatus !== "unconfirmed"
+  ) {
     const workflowId = updated[0].workflowId;
     try {
       const orgSlug = await resolveOrgSlugForCounter(workflowId);

--- a/plugins/web3/steps/approve-token-core.ts
+++ b/plugins/web3/steps/approve-token-core.ts
@@ -377,6 +377,9 @@ export async function approveTokenCore(
         return {
           success: false,
           error: decision.error,
+          // Carried so a failOnError=false node cannot soften an unresolved
+          // in-flight send into success.
+          errorClass: decision.errorClass,
           sponsored: true,
           ...(decision.transactionHash
             ? { transactionHash: decision.transactionHash, chainId }

--- a/plugins/web3/steps/transfer-funds-core.ts
+++ b/plugins/web3/steps/transfer-funds-core.ts
@@ -348,6 +348,9 @@ export async function transferFundsCore(
         return {
           success: false,
           error: decision.error,
+          // Carried so a failOnError=false node cannot soften an unresolved
+          // in-flight send into success.
+          errorClass: decision.errorClass,
           sponsored: true,
           ...(decision.transactionHash
             ? { transactionHash: decision.transactionHash, chainId }

--- a/plugins/web3/steps/transfer-token-core.ts
+++ b/plugins/web3/steps/transfer-token-core.ts
@@ -471,6 +471,9 @@ export async function transferTokenCore(
         return {
           success: false,
           error: decision.error,
+          // Carried so a failOnError=false node cannot soften an unresolved
+          // in-flight send into success.
+          errorClass: decision.errorClass,
           sponsored: true,
           ...(decision.transactionHash
             ? { transactionHash: decision.transactionHash, chainId }

--- a/tests/integration/direct-execution-api.test.ts
+++ b/tests/integration/direct-execution-api.test.ts
@@ -190,7 +190,7 @@ function setupPassingGuards(): void {
   );
   mocks.markRunning.mockResolvedValue(undefined);
   mocks.completeExecution.mockResolvedValue({ status: "completed" });
-  mocks.failExecution.mockResolvedValue(undefined);
+  mocks.failExecution.mockResolvedValue({ status: "failed" });
 }
 
 // ---------------------------------------------------------------------------
@@ -430,6 +430,28 @@ describe("Direct Execution API", () => {
           sponsored: undefined,
         }
       );
+    });
+
+    it("reports unconfirmed, not failed, for a broadcast whose outcome is unknown", async () => {
+      setupPassingGuards();
+      // A gas-sponsored send Turnkey accepted but whose receipt no endpoint
+      // could read. Calling this failed is what invites the retry that
+      // broadcasts a second transaction from the same wallet.
+      mocks.transferFundsCore.mockResolvedValue({
+        success: false,
+        error:
+          "Sponsored transaction 0xbeef was broadcast but its outcome could not be confirmed.",
+        transactionHash: "0xbeef",
+        chainId: 11_155_111,
+        sponsored: true,
+      });
+      mocks.failExecution.mockResolvedValue({ status: "unconfirmed" });
+
+      const response = await transferPOST(postRequest("/transfer", validBody));
+
+      expect(response.status).toBe(202);
+      const data = await response.json();
+      expect(data.status).toBe("unconfirmed");
     });
 
     it("records the hash and route when a broadcast transaction reverts", async () => {

--- a/tests/integration/workflow-logging.test.ts
+++ b/tests/integration/workflow-logging.test.ts
@@ -119,6 +119,19 @@ const { verifyExecutionReceiptsMock } = vi.hoisted(() => ({
 }));
 vi.mock("@/lib/web3/verify-receipt", () => ({
   verifyExecutionReceipts: verifyExecutionReceiptsMock,
+  // A run only demotes to error when the chain was conclusive. An unreadable
+  // receipt leaves it unconfirmed instead, so the real predicate is used here
+  // rather than a stub that would hide that split.
+  hasUnreadableReceipt: (
+    results: Array<{ verified: boolean; status: string }>
+  ) =>
+    results.some(
+      (r) =>
+        !(
+          r.verified ||
+          ["success", "reverted", "safe_inner_failure"].includes(r.status)
+        )
+    ),
   describeVerificationFailure: (
     results: Array<{ hash: string; status: string }>
   ) =>
@@ -858,6 +871,46 @@ describe("logWorkflowCompleteDb transactionHashes (KEEP-470)", () => {
         verified: false,
         receiptStatus: "reverted",
       }),
+    ]);
+
+    clearExecution(executionId);
+  });
+
+  it("holds a run unconfirmed, rather than demoting it to error, when a receipt cannot be read", async () => {
+    const executionId = "exec_reconciliation_unreadable";
+    recordTransactionHashIfPresent(
+      ctx({ executionId, nodeId: "swap-1", nodeName: "Swap" }),
+      { transactionHash: "0xunseen", chainId: 1, network: "mainnet" }
+    );
+
+    verifyExecutionReceiptsMock.mockResolvedValueOnce({
+      allVerified: false,
+      results: [
+        {
+          hash: "0xunseen",
+          chainId: 1,
+          verified: false,
+          status: "not_found" as const,
+          verifiedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    await logWorkflowCompleteDb({
+      executionId,
+      status: "success",
+      startTime: Date.now() - 1000,
+    });
+
+    const update = getExecUpdate();
+    // Not an outcome. The transaction may still land, and calling the run
+    // errored would invite a re-run of transactions that already broadcast.
+    expect(update?.set.status).toBe("unconfirmed");
+    // No error classification on a run that has not failed.
+    expect(update?.set.errorCategory).toBeNull();
+    expect(update?.set.errorType).toBeNull();
+    expect(update?.set.transactionHashes).toEqual([
+      expect.objectContaining({ hash: "0xunseen", receiptStatus: "not_found" }),
     ]);
 
     clearExecution(executionId);

--- a/tests/unit/analytics-status-normalize.test.ts
+++ b/tests/unit/analytics-status-normalize.test.ts
@@ -53,9 +53,14 @@ describe("workflowDbStatuses", () => {
     expect(workflowDbStatuses("external_error")).toEqual(["error"]);
   });
 
+  it("expands the running filter to also match unconfirmed rows", () => {
+    // A run whose broadcast hashes the chain has not confirmed is in flight,
+    // so the running filter has to show it or it disappears from the UI.
+    expect(workflowDbStatuses("running")).toEqual(["running", "unconfirmed"]);
+  });
+
   it("leaves other statuses as a single-value filter", () => {
     expect(workflowDbStatuses("success")).toEqual(["success"]);
-    expect(workflowDbStatuses("running")).toEqual(["running"]);
     expect(workflowDbStatuses("cancelled")).toEqual(["cancelled"]);
   });
 });

--- a/tests/unit/billing-execution-limit-core.test.ts
+++ b/tests/unit/billing-execution-limit-core.test.ts
@@ -363,16 +363,12 @@ describe("statusAllowsOverage", () => {
     expect(statusAllowsOverage("trialing")).toBe(true);
   });
 
-  it.each([
-    "past_due",
-    "canceled",
-    "incomplete",
-    "unpaid",
-    null,
-    undefined,
-  ])("stops %s at the included limit", (status) => {
-    expect(statusAllowsOverage(status)).toBe(false);
-  });
+  it.each(["past_due", "canceled", "incomplete", "unpaid", null, undefined])(
+    "stops %s at the included limit",
+    (status) => {
+      expect(statusAllowsOverage(status)).toBe(false);
+    }
+  );
 });
 
 describe("decideExecutionLimit", () => {

--- a/tests/unit/sponsored-send-error.test.ts
+++ b/tests/unit/sponsored-send-error.test.ts
@@ -54,10 +54,28 @@ describe("resolveSponsoredSendError", () => {
       error: expect.stringContaining("not confirmed"),
       errorClass: ExecutionErrorType.SYSTEM,
     });
-    // No confirmed hash for an unresolved in-flight send.
+    // No hash was ever assigned, so there is nothing to reconcile against.
     if (!decision.fallback) {
       expect(decision.transactionHash).toBeUndefined();
     }
+  });
+
+  it("surfaces the hash of a broadcast whose outcome could not be read", () => {
+    const error = new SponsoredTxPendingError({
+      message: "receipt unreadable",
+      sendTransactionStatusId: "sid",
+      txHash: "0xbroadcast",
+    });
+
+    const decision = resolveSponsoredSendError(error, CTX);
+
+    expect(decision.fallback).toBe(false);
+    // The execution record needs the hash: without it the transaction exists
+    // on-chain and nowhere in our data.
+    expect(decision).toMatchObject({
+      transactionHash: "0xbroadcast",
+      errorClass: ExecutionErrorType.SYSTEM,
+    });
   });
 
   it("falls back to direct signing on a generic pre-broadcast error", () => {

--- a/tests/unit/sponsored-transaction-manager.test.ts
+++ b/tests/unit/sponsored-transaction-manager.test.ts
@@ -41,19 +41,27 @@ vi.mock("@/lib/web3/turnkey-sponsored-tx", () => ({
     mockSubmitTurnkeySponsoredTransaction(...args),
 }));
 
+// Receipt reads are keyed by endpoint so a test can make one endpoint fail and
+// another answer, which is the whole point of trying more than one.
 const mockWaitForTransactionReceipt = vi.fn();
 
 vi.mock("viem", () => ({
-  createPublicClient: () => ({
-    waitForTransactionReceipt: (...args: unknown[]) =>
-      mockWaitForTransactionReceipt(...args),
+  createPublicClient: ({ transport }: { transport: { url: string } }) => ({
+    waitForTransactionReceipt: (args: Record<string, unknown>) =>
+      mockWaitForTransactionReceipt({ ...args, url: transport.url }),
   }),
   encodeFunctionData: () => "0xencoded",
-  http: () => ({}),
+  http: (url: string) => ({ url }),
+  BaseError: class BaseError extends Error {},
+}));
+
+const mockResolveRpcConfig = vi.fn();
+vi.mock("@/lib/rpc/config-service", () => ({
+  resolveRpcConfig: (...args: unknown[]) => mockResolveRpcConfig(...args),
 }));
 
 vi.mock("@/lib/logging", () => ({
-  ErrorCategory: { TRANSACTION: "transaction" },
+  ErrorCategory: { TRANSACTION: "transaction", NETWORK_RPC: "network_rpc" },
   logSystemError: vi.fn(),
 }));
 
@@ -79,6 +87,11 @@ import {
   executeSponsoredTransaction,
 } from "@/lib/web3/sponsored-transaction-manager";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
+import {
+  isSponsoredTxPendingError,
+  isSponsoredTxRevertError,
+  type SponsoredTxPendingError,
+} from "@/lib/web3/turnkey-revert";
 
 const baseTxParams = {
   organizationId: "org_1",
@@ -95,6 +108,10 @@ const baseContractParams = {
   functionName: "store",
   args: [42],
 };
+
+// One rotation, no waiting: the receipt wait budget is wall-clock, so a test
+// that expects it to give up would otherwise sit through the full five minutes.
+const SINGLE_ROTATION = { budgetMs: 0, perEndpointMs: 50, roundDelayMs: 0 };
 
 const blockedRpcUrls: [string, string][] = [
   ["loopback hostname", "http://localhost:8548"],
@@ -127,6 +144,12 @@ function setupSuccessfulSponsorship(): void {
   });
   mockGetGasTokenPriceUsd.mockResolvedValue(2000);
   mockRecordGasUsage.mockResolvedValue(undefined);
+  mockResolveRpcConfig.mockResolvedValue({
+    chainId: 11_155_111,
+    chainName: "sepolia",
+    primaryRpcUrl: "https://rpc.example.com",
+    fallbackRpcUrl: "https://fallback.example.com",
+  });
 }
 
 beforeEach(() => {
@@ -333,6 +356,105 @@ describe("executeSponsoredTransaction", () => {
 
     expect(result).not.toBeNull();
     expect(mockCreateSponsoredClient).toHaveBeenCalled();
+  });
+});
+
+/**
+ * Callers read `null` as "nothing was broadcast, safe to sign and send
+ * directly" and a throw as "stop". Once Turnkey has handed back a hash there is
+ * already a transaction from the user's wallet on the network, so returning
+ * null -- or throwing anything the caller cannot recognise as terminal -- makes
+ * one authorized action land twice. These tests pin the boundary.
+ */
+describe("failures after the sponsored transaction is broadcast", () => {
+  it("raises a pending error carrying the hash when no endpoint can read the receipt", async () => {
+    setupSuccessfulSponsorship();
+    mockWaitForTransactionReceipt.mockRejectedValue(new Error("HTTP 429"));
+
+    const error = await executeSponsoredTransaction(
+      baseTxParams,
+      SINGLE_ROTATION
+    ).catch((e: unknown) => e);
+
+    expect(isSponsoredTxPendingError(error)).toBe(true);
+    expect((error as SponsoredTxPendingError).txHash).toBe("0xtxhash");
+  });
+
+  it("does not resolve to null when the receipt read fails", async () => {
+    setupSuccessfulSponsorship();
+    mockWaitForTransactionReceipt.mockRejectedValue(new Error("HTTP 429"));
+
+    const result = await executeSponsoredTransaction(
+      baseTxParams,
+      SINGLE_ROTATION
+    ).then(
+      () => "resolved",
+      () => "threw"
+    );
+
+    expect(result).toBe("threw");
+  });
+
+  it("reads the receipt from the fallback endpoint when the broadcast endpoint fails", async () => {
+    setupSuccessfulSponsorship();
+    mockWaitForTransactionReceipt.mockImplementation(
+      ({ url }: { url: string }) => {
+        if (url === "https://fallback.example.com") {
+          return Promise.resolve({
+            status: "success",
+            gasUsed: BigInt(21_000),
+            effectiveGasPrice: BigInt(1_000_000_000),
+          });
+        }
+        return Promise.reject(new Error("HTTP 503"));
+      }
+    );
+
+    const result = await executeSponsoredTransaction(baseTxParams);
+
+    expect(result?.success).toBe(true);
+    expect(result?.transactionHash).toBe("0xtxhash");
+  });
+
+  it("converts an untyped post-receipt failure into a pending error rather than letting it look pre-broadcast", async () => {
+    setupSuccessfulSponsorship();
+    // Mainnet, so the price lookup runs; it sits after the receipt, meaning the
+    // transaction is already mined by the time it throws.
+    mockGetGasTokenPriceUsd.mockRejectedValue(new Error("price feed down"));
+
+    const error = await executeSponsoredTransaction(
+      { ...baseTxParams, chainId: 8453 },
+      SINGLE_ROTATION
+    ).catch((e: unknown) => e);
+
+    expect(isSponsoredTxPendingError(error)).toBe(true);
+    expect((error as SponsoredTxPendingError).txHash).toBe("0xtxhash");
+  });
+
+  it("still surfaces an on-chain revert as a revert, not as pending", async () => {
+    setupSuccessfulSponsorship();
+    mockWaitForTransactionReceipt.mockResolvedValue({
+      status: "reverted",
+      blockNumber: BigInt(100),
+      gasUsed: BigInt(21_000),
+      effectiveGasPrice: BigInt(1_000_000_000),
+    });
+
+    const error = await executeSponsoredTransaction(baseTxParams).catch(
+      (e: unknown) => e
+    );
+
+    expect(isSponsoredTxRevertError(error)).toBe(true);
+    expect(isSponsoredTxPendingError(error)).toBe(false);
+  });
+
+  it("a pre-broadcast rejection still resolves to null so direct signing can proceed", async () => {
+    setupSuccessfulSponsorship();
+    mockSubmitTurnkeySponsoredTransaction.mockResolvedValue(null);
+
+    const result = await executeSponsoredTransaction(baseTxParams);
+
+    expect(result).toBeNull();
   });
 });
 

--- a/tests/unit/verify-receipt.test.ts
+++ b/tests/unit/verify-receipt.test.ts
@@ -4,6 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 const executeWithFailover = vi.fn();
+const fallbackGetTransactionReceipt = vi.fn();
+const getFallbackProvider = vi.fn(() => ({
+  getTransactionReceipt: fallbackGetTransactionReceipt,
+}));
 const resolveRpcConfig = vi.fn();
 const isSolanaChain = vi.fn(
   (chainId: number) => chainId === 101 || chainId === 103
@@ -15,7 +19,7 @@ vi.mock("@/lib/rpc/providers", () => ({
   // from the constructor overrides the constructed `this`, which is how the
   // shared `executeWithFailover` spy gets attached to every instance.
   RpcProviderManager: vi.fn().mockImplementation(function RpcProviderManager() {
-    return { executeWithFailover };
+    return { executeWithFailover, getFallbackProvider };
   }),
 }));
 vi.mock("@/lib/rpc/config-service", () => ({
@@ -52,9 +56,17 @@ function makeReceipt(
 const HASH = "0xabc123";
 const CHAIN_ID = 1;
 
+// One round, no waiting: the retry budget is wall-clock, so tests that expect
+// the lookup to give up would otherwise sit through it.
+const SINGLE_ROUND = { budgetMs: 0, retryDelayMs: 0 };
+// Enough rounds to exercise the retry, still effectively instant.
+const FAST_RETRY = { budgetMs: 200, retryDelayMs: 1 };
+
 describe("verifyExecutionReceipts", () => {
   beforeEach(() => {
     executeWithFailover.mockReset();
+    fallbackGetTransactionReceipt.mockReset();
+    fallbackGetTransactionReceipt.mockResolvedValue(null);
     resolveRpcConfig.mockReset();
     resolveRpcConfig.mockResolvedValue({
       chainId: CHAIN_ID,
@@ -123,21 +135,70 @@ describe("verifyExecutionReceipts", () => {
   });
 
   it("null receipt after retries verifies as not_found", async () => {
-    executeWithFailover.mockResolvedValueOnce(null);
-    const { allVerified, results } = await verifyExecutionReceipts([
-      { hash: HASH, chainId: CHAIN_ID },
-    ]);
+    executeWithFailover.mockResolvedValue(null);
+    const { allVerified, results } = await verifyExecutionReceipts(
+      [{ hash: HASH, chainId: CHAIN_ID }],
+      SINGLE_ROUND
+    );
     expect(allVerified).toBe(false);
     expect(results[0].status).toBe("not_found");
   });
 
   it("provider throwing on every attempt verifies as timeout, fail-closed", async () => {
-    executeWithFailover.mockRejectedValueOnce(new Error("RPC exhausted"));
-    const { allVerified, results } = await verifyExecutionReceipts([
-      { hash: HASH, chainId: CHAIN_ID },
-    ]);
+    executeWithFailover.mockRejectedValue(new Error("RPC exhausted"));
+    fallbackGetTransactionReceipt.mockRejectedValue(new Error("RPC exhausted"));
+    const { allVerified, results } = await verifyExecutionReceipts(
+      [{ hash: HASH, chainId: CHAIN_ID }],
+      SINGLE_ROUND
+    );
     expect(allVerified).toBe(false);
     expect(results[0].status).toBe("timeout");
+  });
+
+  // The reported defect: a load-balanced RPC answered for a node that had not
+  // yet seen the transaction, and one miss was taken as proof of failure.
+  it("a receipt that is invisible on the first read is found on a later one", async () => {
+    executeWithFailover
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(makeReceipt(1));
+
+    const { allVerified, results } = await verifyExecutionReceipts(
+      [{ hash: HASH, chainId: CHAIN_ID }],
+      FAST_RETRY
+    );
+
+    expect(allVerified).toBe(true);
+    expect(results[0]).toMatchObject({ verified: true, status: "success" });
+  });
+
+  // A null answer is a successful call, so executeWithFailover never moves off
+  // the primary. Without an explicit read the fallback endpoint is unreachable
+  // for the one case it exists to cover.
+  it("consults the fallback endpoint when the primary reports no receipt", async () => {
+    executeWithFailover.mockResolvedValue(null);
+    fallbackGetTransactionReceipt.mockResolvedValue(makeReceipt(1));
+
+    const { allVerified, results } = await verifyExecutionReceipts(
+      [{ hash: HASH, chainId: CHAIN_ID }],
+      SINGLE_ROUND
+    );
+
+    expect(fallbackGetTransactionReceipt).toHaveBeenCalledWith(HASH);
+    expect(allVerified).toBe(true);
+    expect(results[0].status).toBe("success");
+  });
+
+  it("a reverted receipt is terminal and is not retried away", async () => {
+    executeWithFailover.mockResolvedValue(makeReceipt(0));
+
+    const { results } = await verifyExecutionReceipts(
+      [{ hash: HASH, chainId: CHAIN_ID }],
+      FAST_RETRY
+    );
+
+    expect(results[0].status).toBe("reverted");
+    expect(executeWithFailover).toHaveBeenCalledTimes(1);
   });
 
   it("unresolvable chain (resolveRpcConfig returns null) fails closed as timeout", async () => {
@@ -206,6 +267,8 @@ describe("verifyExecutionReceipts", () => {
 describe("sponsored (wrapped) executions", () => {
   beforeEach(() => {
     executeWithFailover.mockReset();
+    fallbackGetTransactionReceipt.mockReset();
+    fallbackGetTransactionReceipt.mockResolvedValue(null);
     resolveRpcConfig.mockReset();
     resolveRpcConfig.mockResolvedValue({
       chainId: CHAIN_ID,

--- a/tests/unit/write-contract-core.test.ts
+++ b/tests/unit/write-contract-core.test.ts
@@ -20,6 +20,7 @@ vi.mock("@/lib/logging", () => ({
     TRANSACTION: "transaction",
   },
   logUserError: vi.fn(),
+  logSystemWarn: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({


### PR DESCRIPTION
Closes #1979

Two reliability defects in the execution path, confirmed against prod data. They compound: the second tells a caller a succeeded transaction failed, and the retry it invites can hit the first.

## One authorized action, two on-chain broadcasts

Once Turnkey returns a hash, a transaction from the user's wallet is irreversibly on the network. Every error raised after that point escaped `finalizeSponsoredTx` untyped, and callers read an untyped throw as a pre-broadcast failure, so they signed and broadcast again.

There were two ways in, both landing on `resolveSponsoredSendError`'s default branch:

- A hard RPC error on the receipt read, which viem rejects immediately. Roughly 14 seconds to the second broadcast.
- A receipt that never became visible, which viem polls for until its 180 second default timeout and then throws `WaitForTransactionReceiptTimeoutError`. Roughly 3 minutes to the second broadcast, and the worse case, since a transaction merely slow to surface is very likely to land.

An idempotency key cannot prevent this. It is one request holding one key for the whole duration, and the duplicate happens inside that request.

Confirmed on prod for a native transfer and a contract call. In both, the sponsored hash appears in no table and has no `gas_credit_usage` row, which pins the failure to the receipt read, and Sentry has no pre-broadcast termination event.

Mainnet exposure is live: gas sponsorship is enabled and covers Ethereum, Base, Polygon and Arbitrum for any EOA-mode wallet.

## Verification reported failed for transactions that succeeded

`verifySingleReceipt` did exactly one `getTransactionReceipt`. That call returns `null` for an unknown hash rather than throwing, so `executeWithFailover` treated a miss as a successful call and never moved to the fallback endpoint, leaving it unreachable for the one case it exists to cover.

RPC hosts sit behind load balancers, so the node that answers can be behind the one the write path used. One prod execution read its receipt and wrote a `gas_credit_usage` row, then verification reported the same hash missing 8ms later on the same chain. 18 such false failures in 30 days, all on testnet.

## What changed

**Nothing untyped can reach the fallback branch.** A single guarded exit converts anything other than the two typed sponsored errors into a pending error carrying the hash, which callers already treat as terminal. The hash now reaches the execution record, so a broadcast we could not confirm is auditable instead of existing only on chain.

**The receipt read rotates across endpoints.** The broadcast URL, then the chain's primary and fallback, for five minutes, with a pause between rotations so endpoints that reject immediately cannot turn the budget into a hot loop. Each endpoint is capped at 30 seconds rather than one endpoint monopolising 180. A sponsored write has been observed going from submit to readable receipt in under 3 seconds, so this is ample margin.

**Verification asks the fallback explicitly**, after a bounded re-poll, because a null answer will never trigger failover. A receipt that could not be read is now distinguishable from one that reverted.

**A broadcast we cannot verify is no longer called failed.** Direct executions and workflow runs both gain an `unconfirmed` status. It is non-terminal, carries the hash, and the status endpoint keeps telling clients to poll instead of handing them an outcome. A conclusive receipt, success or revert, still settles immediately. A new reconciler re-reads the open ones and settles them once the chain answers, treating a transaction absent from every endpoint after 24 hours as dropped.

## API contract change

`status` on direct executions can now be `unconfirmed`, which is **not terminal**. Clients should keep polling and must not re-send. The MCP tool description says so explicitly. Everything that reads the status treats it as in flight: the analytics normaliser and filters, the concurrency limiter, and the daily value cap, which keeps counting an unconfirmed transfer because it may well have moved the money. Unconfirmed rows carry no error classification, so error metrics and digests are unaffected.

## Deploy note

`/api/cron/execution-reconciler` needs a schedule registered in the deploy repo, on the order of every minute. Without one, nothing closes the `unconfirmed` state and rows sit open until the 24 hour dropped rule is the only thing that fires.

No migration: both status columns are plain text with no check constraint.

## Verification

`pnpm type-check` clean, `pnpm check` clean, 497/497 unit test files and 20498 tests passing. The tests covering these defects were each confirmed to fail against the unfixed code and pass against the fixed code.

Worth exercising on the PR environment, since neither defect reproduces under normal conditions. Pointing the environment's Base Sepolia RPC at a dead or erroring endpoint drives both paths: one authorization should still produce exactly one on-chain transaction, and the execution should settle through `unconfirmed` rather than reporting a false failure.
