### PR TITLE
docs: clarify private mempool capability

### DIFF
--- a/docs/api/chains.md
+++ b/docs/api/chains.md
@@ -76,9 +76,32 @@ Returns a bare JSON array of chain objects. The response is not wrapped in a `da
 | `explorerApiType` | string \| null | Explorer API family (e.g. `etherscan`, `blockscout`) |
 | `isTestnet` | boolean | Whether this chain is a testnet |
 | `isEnabled` | boolean | Whether the chain is currently available for workflow execution |
-| `usePrivateMempoolRpc` | boolean | Whether KeeperHub routes transactions through a private mempool (Flashbots Protect) by default |
+| `usePrivateMempoolRpc` | boolean | Whether this chain offers a configured private-mempool RPC capability (Flashbots Protect). This does not enable private routing by default. |
 
 RPC endpoint URLs (`defaultPrimaryRpc`, `defaultFallbackRpc`) are not returned by this endpoint. They may embed provider API keys and are read server-side only; client code should use the user-configurable RPC preferences API instead.
+
+### Private Mempool Capability
+
+`usePrivateMempoolRpc` describes a chain capability, not the route used by a
+specific transaction. A `true` value makes the chain's `(Flashbots)` variant
+available on supported workflow write actions. Selecting that variant stores
+`usePrivateMempool: true` in the action configuration. Programmatic workflow
+definitions can set the same field directly.
+
+Private routing is strict by default: when the private RPC is available, its
+public fallback is removed. Set `strict: false` only when falling back to the
+public mempool is acceptable. If a stored action requests private routing after
+the chain capability is removed, execution proceeds through the public RPC and
+logs a warning.
+
+Private-mempool writes are not gas sponsored because Turnkey sponsorship uses
+its own broadcast path. The direct-execution API and MCP execute tools do not
+currently expose the workflow action's `usePrivateMempool` or `strict` fields.
+
+Neither this chain capability nor a saved workflow setting confirms that a
+specific transaction used a private route. Current execution outputs do not
+include a public/private route field, so describe the route as requested unless
+you have separate relay evidence.
 
 ### Chain Types
 
@@ -143,4 +166,3 @@ Fetches the ABI for a verified contract from the block explorer. The `{chainId}`
   "explorerUrl": "https://etherscan.io"
 }
 ```
-

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -139,7 +139,7 @@
       "path": "/api/chains/{chainId}/abi",
       "route_file": "app/api/chains/[chainId]/abi/route.ts",
       "source": "docs/api/chains.md",
-      "line": 119
+      "line": 142
     },
     {
       "method": "GET",


### PR DESCRIPTION
## Why

`GET /api/chains` currently describes `usePrivateMempoolRpc` as if KeeperHub
routes transactions privately by default. In the implementation, it is a chain
capability flag. Workflow write actions opt in separately with
`usePrivateMempool: true`.

That distinction matters for builders making security claims. Capability,
requested routing, fallback behavior, and proof of the route used are separate
facts.

This gap surfaced while building
[LegacyKeeper](https://github.com/ajanaku1/legacy-keeper) and is documented in
its [KeeperHub onboarding teardown](https://github.com/ajanaku1/legacy-keeper/blob/main/reports/keeperhub-onboarding-teardown.md).

## What changed

- Correct the `usePrivateMempoolRpc` field description.
- Explain how UI and programmatic workflows request private routing.
- Document strict mode and the public fallback behavior.
- Record that private-mempool writes are not gas sponsored.
- Clarify that direct-execution and MCP execute tools do not expose the
  workflow-only routing fields.
- Separate a configured/requested private route from evidence that a specific
  transaction used it.
- Regenerate the API coverage line reference.

## Source checks

The wording follows the current behavior in:

- `lib/rpc/config-service.ts`
- `components/workflow/config/chain-select-field.tsx`
- `plugins/web3/steps/write-contract-core.ts`
- `app/api/execute/`
- `lib/mcp/tools.ts`

## Verification

- `pnpm check:api-docs` - passes; no docs-versus-code drift
- `pnpm discover-plugins && pnpm type-check` - passes
- `pnpm check` - Biome reports 0 errors and 81 existing warnings across the
  repository; Ultracite 6.5.1 then reports that it cannot parse Biome's JSON
  output
- `git diff --check` - passes

Documentation only; no runtime behavior changes.
