### PR TITLE
docs: sync CLI reference from v0.14.1

### DIFF
--- a/docs/cli/commands/kh_auth.md
+++ b/docs/cli/commands/kh_auth.md
@@ -5,7 +5,7 @@ Authenticate with KeeperHub
 ### Examples
 
 ```
-  # Log in via browser
+  # Log in (device code flow — prints a URL and code to confirm in a browser)
   kh auth login
 
   # Check current auth status

--- a/docs/cli/commands/kh_auth_login.md
+++ b/docs/cli/commands/kh_auth_login.md
@@ -5,7 +5,9 @@ Log in to KeeperHub
 ### Synopsis
 
 Authenticate with KeeperHub using the device code flow.
-Prints a URL and a one-time code; open the URL in a browser to confirm it.
+Prints a URL and a one-time code. Open the URL in any browser (the browser
+does not open automatically — copy the URL from the terminal) and enter the
+code to complete sign-in. Codes expire after 15 minutes.
 Use --with-token to read an API key from stdin for non-interactive automation.
 
 See also: kh auth status, kh auth logout

--- a/docs/cli/commands/kh_wallet.md
+++ b/docs/cli/commands/kh_wallet.md
@@ -10,12 +10,14 @@ Creator wallet (REST):
   kh w balance    show creator-wallet on-chain balances via KeeperHub REST API
   kh w tokens     list supported tokens
 
-Agentic wallet (thin wrappers around npx @keeperhub/wallet):
+Agentic wallet (thin wrappers around npx -p @keeperhub/wallet keeperhub-wallet):
   kh w add        provision a new agentic wallet (no account required)
   kh w info       print agentic subOrgId + walletAddress
   kh w fund       print Coinbase Onramp URL + Tempo deposit address
   kh w link       link agentic wallet to a KeeperHub account (needs KH_SESSION_COOKIE)
   kh w feedback   submit ERC-8004 feedback for a workflow execution this wallet paid for
+
+Prerequisite for agentic subcommands: Node.js (v18+) and npx must be on your PATH.
 
 ### Examples
 
@@ -26,8 +28,8 @@ Agentic wallet (thin wrappers around npx @keeperhub/wallet):
   # Provision an agentic wallet (npx wrapper):
   kh w add
 
-  # Check balance on the agentic wallet:
-  npx @keeperhub/wallet balance
+  # Check balance on the agentic wallet directly:
+  npx -p @keeperhub/wallet keeperhub-wallet balance
 ```
 
 ### Options

--- a/docs/cli/commands/kh_wallet_add.md
+++ b/docs/cli/commands/kh_wallet_add.md
@@ -6,7 +6,7 @@ Provision a new agentic wallet (no KeeperHub account required)
 
 Provision a new agentic wallet by calling POST /api/agentic-wallet/provision.
 
-This is a thin wrapper around `npx @keeperhub/wallet add` -- the npm package is the
+This is a thin wrapper around `npx -p @keeperhub/wallet keeperhub-wallet add` -- the npm package is the
 canonical tool. Writes {subOrgId, walletAddress, hmacSecret} to ~/.keeperhub/wallet.json
 (chmod 0o600) and prints subOrgId + walletAddress (hmacSecret is NEVER printed).
 

--- a/docs/cli/commands/kh_wallet_feedback.md
+++ b/docs/cli/commands/kh_wallet_feedback.md
@@ -9,7 +9,7 @@ wallet paid for. Signs giveFeedback() via Turnkey and broadcasts on Ethereum
 mainnet via the KeeperHub server proxy. Caller wallet pays gas natively
 (~$0.05-2 per call at typical mainnet gas).
 
-Thin wrapper around `npx @keeperhub/wallet feedback`. Defaults to rating
+Thin wrapper around `npx -p @keeperhub/wallet keeperhub-wallet feedback`. Defaults to rating
 KeeperHub's own ERC-8004 agent (id 31875 on Ethereum); use --agent-id to rate
 any other agent.
 

--- a/docs/cli/commands/kh_wallet_fund.md
+++ b/docs/cli/commands/kh_wallet_fund.md
@@ -6,7 +6,7 @@ Print Coinbase Onramp URL (Base USDC) and Tempo deposit address for the agentic 
 
 Print a Coinbase Onramp URL for Base USDC funding plus the Tempo deposit address.
 
-Thin wrapper around `npx @keeperhub/wallet fund`. No HTTP calls, no browser launch --
+Thin wrapper around `npx -p @keeperhub/wallet keeperhub-wallet fund`. No HTTP calls, no browser launch --
 prints copy-paste instructions only.
 
 ```

--- a/docs/cli/commands/kh_wallet_info.md
+++ b/docs/cli/commands/kh_wallet_info.md
@@ -6,7 +6,7 @@ Print subOrgId and walletAddress from local agentic wallet config
 
 Print subOrgId and walletAddress from ~/.keeperhub/wallet.json.
 
-Thin wrapper around `npx @keeperhub/wallet info`. Exits non-zero if the config is missing.
+Thin wrapper around `npx -p @keeperhub/wallet keeperhub-wallet info`. Exits non-zero if the config is missing.
 
 ```
 kh wallet info [flags]

--- a/docs/cli/commands/kh_wallet_link.md
+++ b/docs/cli/commands/kh_wallet_link.md
@@ -6,7 +6,7 @@ Link the agentic wallet to a KeeperHub account (requires KH_SESSION_COOKIE)
 
 Link the current agentic wallet to your KeeperHub account by calling POST /api/agentic-wallet/link.
 
-Thin wrapper around `npx @keeperhub/wallet link`. Requires the KH_SESSION_COOKIE env var
+Thin wrapper around `npx -p @keeperhub/wallet keeperhub-wallet link`. Requires the KH_SESSION_COOKIE env var
 set to a valid kh session cookie (sign in at app.keeperhub.com, copy the session cookie, export it).
 
 This command does not launch a browser session handshake; the env-var contract matches the npm CLI.

--- a/docs/cli/quickstart.md
+++ b/docs/cli/quickstart.md
@@ -7,10 +7,23 @@ description: "KeeperHub CLI Quickstart"
 
 ## Install
 
-**Homebrew (macOS/Linux):**
+**Homebrew (macOS/Linux with Homebrew):**
 ```
 brew install keeperhub/tap/kh
 ```
+
+**Linux (no Homebrew / headless):**
+```bash
+mkdir -p ~/.local/bin && cd "$(mktemp -d)"
+curl -fsSL https://api.github.com/repos/keeperhub/cli/releases/latest \
+  | grep browser_download_url | cut -d '"' -f 4 \
+  | grep -E 'linux_amd64\.tar\.gz|checksums\.txt' \
+  | xargs -n1 curl -fsSLO
+sha256sum --ignore-missing -c checksums.txt
+tar -xzf kh_*_linux_amd64.tar.gz -C ~/.local/bin kh
+```
+Replace `linux_amd64` with `linux_arm64` on ARM. Ensure `~/.local/bin` is on your `PATH`.
+The unauthenticated GitHub API is rate-limited to 60 requests per hour per IP; if you hit that limit, download directly from [GitHub Releases](https://github.com/keeperhub/cli/releases).
 
 **Go install:**
 ```
@@ -25,7 +38,7 @@ go install github.com/keeperhub/cli/cmd/kh@latest
 kh auth login
 ```
 
-This opens a browser window to authenticate. Your token is stored in the OS keyring.
+This uses the **device code flow**: it prints a URL and a short code. Open the URL in any browser (including on a different machine) and enter the code to complete sign-in. On headless or remote boxes the browser will not open automatically — copy the URL from the terminal. Codes expire after 15 minutes; re-run `kh auth login` if yours expires. Your token is stored in the OS keyring.
 
 To authenticate non-interactively (CI/CD), set `KH_API_KEY` instead.
 


### PR DESCRIPTION
Auto-synced CLI command reference from cli@v0.14.1. Changes generated by go generate ./docs/... and copied to docs/cli/.