### PR TITLE
docs: llms.txt omits Safe smart accounts and agentic wallet custody

### DIFF
--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -55,7 +55,7 @@ This site. Canonical reference for concepts, node configuration, plugins, API, C
 - [Marketplace](https://docs.keeperhub.com/workflows/marketplace): Listing and monetising workflows
 - [Hub](https://docs.keeperhub.com/workflows/hub): Discover and import community workflows
 - [Keeper Runs](https://docs.keeperhub.com/keeper-runs): Execution status, logs, performance, troubleshooting
-- [Wallet Management](https://docs.keeperhub.com/wallet-management): Turnkey wallets, gas and sponsorship, address book
+- [Wallet Management](https://docs.keeperhub.com/wallet-management): Turnkey wallets, Safe smart accounts, gas and sponsorship, address book
 - [Notifications](https://docs.keeperhub.com/notifications): Connections and message templates
 - [Best Practices](https://docs.keeperhub.com/practices): Security and reliability
 - [Users and Organizations](https://docs.keeperhub.com/users-teams-orgs): Team and org model
@@ -70,7 +70,7 @@ This site. Canonical reference for concepts, node configuration, plugins, API, C
 - [MCP Server](https://docs.keeperhub.com/agent/mcp-server): OAuth-authenticated MCP server exposing workflow catalog, schema introspection, and execution
 - [MCP Trigger Inputs](https://docs.keeperhub.com/agent/mcp-trigger-inputs): Input schema per trigger type
 - [Claude Code Plugin](https://docs.keeperhub.com/agent/claude-code-plugin): Marketplace install and skill set
-- [Agentic Wallets](https://docs.keeperhub.com/agent/agentic-wallet): x402 and MPP wallets so an agent can pay for workflows
+- [Agentic Wallets](https://docs.keeperhub.com/agent/agentic-wallet): x402 and MPP wallets so an agent can pay for workflows, custody server-side in a per-wallet Turnkey sub-organisation
 
 ## Plugins
 


### PR DESCRIPTION
Rebased onto `staging` and reduced to what its lines are still missing. The Para
references this originally corrected are gone, so that premise is void and the
diff no longer touches it.

Two lines remain, both grounded in the page each one links to.

`Wallet Management` links a page whose index has two sections, `Turnkey` and
`Safe Smart Accounts` (`docs/wallet-management/index.md:12,16`). The line named
only Turnkey, so the file advertised half of what the page documents.

`Agentic Wallets` said what the page is for and not how custody works. The page
states it in one clause: "Custody is server-side in a per-wallet Turnkey
sub-organisation" (`docs/agent/agentic-wallet.md:14`). Both facts fit on the
line together, so the entry now carries the purpose and the custody model.

Everything else from the first version is dropped. `staging`'s own wording is
kept verbatim where it already exists, including `gas and sponsorship` and the
`/agent/*` URLs from the restructure.

One note on the review: the line numbers have moved again since it was written.
The two lines are now 58 and 73, not 52 and 66.