### PR TITLE
fix: stop rounding sub-cent marketplace prices to whole cents

### DIFF
--- a/lib/payments/x402/payment-gate.ts
+++ b/lib/payments/x402/payment-gate.ts
@@ -43,7 +43,15 @@ export function buildPaymentConfig(
   workflow: CallRouteWorkflow,
   creatorWalletAddress: string
 ): RouteConfig {
-  const price = Number(workflow.priceUsdcPerCall);
+  // Passed through at the precision it was stored with. `toFixed(2)` rounded
+  // every sub-cent listing to whole cents, while buildPaymentRequired() in
+  // ../router.ts advertises the true amount at USDC's six decimals -- so a
+  // workflow listed at $0.005 quoted 5000 in its 402 and then demanded 10000 at
+  // the gate. The caller signs the advertised amount, the gate finds no
+  // requirement matching it, and every payment fails with "No matching payment
+  // requirements". @x402/evm parsePrice() resolves "$0.005" to 5000 correctly,
+  // so nothing downstream needed the rounding.
+  const price = workflow.priceUsdcPerCall ?? "0";
   const publicHost =
     process.env.NEXT_PUBLIC_APP_URL ?? "https://app.keeperhub.com";
   return {
@@ -51,7 +59,7 @@ export function buildPaymentConfig(
       scheme: "exact",
       network: "eip155:8453",
       payTo: creatorWalletAddress,
-      price: `$${price.toFixed(2)}`,
+      price: `$${price}`,
       // extra.name and extra.version are required by @x402/evm verifyEIP3009 to
       // reconstruct the EIP-712 domain. Without these fields the CDP facilitator
       // throws "EIP-712 domain parameters (name, version) are required" and the

--- a/tests/unit/build-payment-config-extra-domain.test.ts
+++ b/tests/unit/build-payment-config-extra-domain.test.ts
@@ -30,3 +30,42 @@ describe("buildPaymentConfig extra domain fields", () => {
     ).toBe("2");
   });
 });
+
+describe("buildPaymentConfig price precision", () => {
+  const configFor = (priceUsdcPerCall: string) =>
+    buildPaymentConfig(
+      { ...mockWorkflow, priceUsdcPerCall } as Parameters<
+        typeof buildPaymentConfig
+      >[0],
+      "0x1234000000000000000000000000000000005678"
+    ).accepts as unknown as Record<string, unknown>;
+
+  it("keeps a sub-cent price at the precision it was listed with", () => {
+    // Rounding to cents made the gate demand a different amount than the 402
+    // advertised, so the payer's signed authorization matched no requirement
+    // and every payment failed. The docs recommend pricing from $0.001.
+    expect(configFor("0.005").price).toBe("$0.005");
+  });
+
+  it("keeps the smallest documented price out of zero", () => {
+    expect(configFor("0.001").price).toBe("$0.001");
+  });
+
+  it("still passes through prices that are whole cents", () => {
+    expect(configFor("1.00").price).toBe("$1.00");
+    expect(configFor("0.05").price).toBe("$0.05");
+  });
+
+  it("falls back to zero when a listing has no price", () => {
+    expect(
+      (
+        buildPaymentConfig(
+          { ...mockWorkflow, priceUsdcPerCall: null } as unknown as Parameters<
+            typeof buildPaymentConfig
+          >[0],
+          "0x1234000000000000000000000000000000005678"
+        ).accepts as unknown as Record<string, unknown>
+      ).price
+    ).toBe("$0");
+  });
+});


### PR DESCRIPTION
## Problem

Two code paths derive the price of a listed workflow, and they disagree.

**Advertised** — `buildPaymentRequired()` in `lib/payments/router.ts`, which
produces the 402 body that x402scan and agent clients read:

```ts
const amountSmallestUnit = String(Math.round(Number(price) * 10 ** USDC_DECIMALS));
```

**Enforced** — `buildPaymentConfig()` in `lib/payments/x402/payment-gate.ts`,
which builds the requirements `withX402` gates on:

```ts
price: `$${price.toFixed(2)}`
```

For any price that is not a whole number of cents the two produce different
amounts, and the gate wins.

A workflow listed at **$0.005**:

1. Its 402 advertises `amount: "5000"`.
2. The caller signs an EIP-3009 authorization for 5000 — the amount it was
   quoted.
3. The gate builds requirements for `$0.01` and finds nothing matching.
4. The response is another 402, `error: "No matching payment requirements"`.

The listing looks healthy, discovery works, the challenge is well-formed, and
every payment fails with an error that points at the caller. At **$0.001** the
price rounds to `$0.00`.

The [Marketplace docs](https://docs.keeperhub.com/workflows/marketplace#price)
say "Most utility workflows on the Marketplace price between `$0.001` and
`$0.10` per call", so most of the documented range cannot be paid for.

## Change

Pass the price through at the precision it was stored with. `priceUsdcPerCall`
is already a `string` from Drizzle, so the `Number()` round-trip was what lost
it.

`@x402/evm`'s `parsePrice` handles sub-cent dollar strings correctly — verified
against the installed version:

```
"$0.01"  -> 10000
"$0.005" ->  5000
"$0.001" ->  1000
```

so nothing downstream relied on the rounding.

## Verification

Extended `tests/unit/build-payment-config-extra-domain.test.ts`. The three new
precision assertions fail on `staging`:

```
expected '$0.01' to be '$0.005'
expected '$0.00' to be '$0.001'
expected '$0.00' to be '$0'
```

and pass with this change. `build-payment-config-extra-domain`,
`payment-router` and `x402-call-route` together: 50 tests pass.

End to end, against production: a workflow listed at `$0.005` could not be paid
for. Repriced to `$0.01` — the nearest value the rounding preserves — the same
client settled immediately:

- USDC transfer [`0x8cd8d6ac…`](https://basescan.org/tx/0x8cd8d6ac5dae125e5f3cf039db1ffb7f6b7dafa44243396d00e30074a93a51f9) on Base
- payer balance 1.08 → 1.07 USDC, gas paid by the facilitator

## Context

Found while publishing a workflow from an incident-detection agent to the
Marketplace and paying for it from another agent.
