### PR TITLE
fix: chain-id validation should skip template references

### DIFF
--- a/lib/mcp/validate-workflow-web3.ts
+++ b/lib/mcp/validate-workflow-web3.ts
@@ -50,10 +50,26 @@ export function chainExists(
     // A network supplied by the caller arrives as a template reference and is
     // resolved at execution time, so there is no chain id to check statically.
     // The address checks below already skip these for the same reason; without
-    // the same guard here, every marketplace workflow that takes its chain from
-    // the trigger — which is what the Marketplace docs tell you to do — reports
-    // unknown-chain-id while executing correctly.
-    if (isTemplateReference(network)) {
+    // the same guard here, a workflow that takes its chain from the trigger
+    // reports unknown-chain-id while executing correctly.
+    //
+    // Two limits on the skip, both cases where a template is wrong rather than
+    // unresolvable:
+    //
+    // - Trigger nodes are excluded. Nothing resolves a trigger's own network:
+    //   the event listener does Number(config.network) and skips the workflow
+    //   when it does not parse (workflow-mapper.ts), so a templated trigger
+    //   network never registers a listener and the workflow silently never
+    //   fires. This error is the only static signal that says why.
+    // - The reference must be the whole value. A chain id is substituted
+    //   entire, never built from a fragment, so "1{{@a:B.c}}" is a mistake
+    //   that would otherwise resolve into a chain the author never chose.
+    //   Address fields can afford the looser check because readContractCore
+    //   re-checks the resolved value with ethers.isAddress; network has no
+    //   such re-check.
+    const isTriggerNode =
+      readStringConfig(rawNode as NodeLike, "triggerType") !== null;
+    if (!isTriggerNode && isWholeTemplateReference(network)) {
       continue;
     }
     const parsed = Number(network);
@@ -144,6 +160,27 @@ const TEMPLATE_REFERENCE_RE = /\{\{.*?\}\}/;
 
 export function isTemplateReference(value: string): boolean {
   return TEMPLATE_REFERENCE_RE.test(value);
+}
+
+/**
+ * True when the value is a single template reference and nothing else.
+ *
+ * Stricter than isTemplateReference, which matches a `{{...}}` anywhere in the
+ * value. That is right for an address, whose resolved value is re-checked with
+ * ethers.isAddress before use, and wrong for a chain id, which is substituted
+ * whole and never re-validated: "1{{@a:B.c}}" would skip the check and then
+ * resolve into a chain the author never chose.
+ *
+ * An empty or whitespace-only body is not a reference any resolver in the repo
+ * recognises, and neither is a body containing further braces.
+ */
+export function isWholeTemplateReference(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{{") || !trimmed.endsWith("}}")) {
+    return false;
+  }
+  const body = trimmed.slice(2, -2);
+  return body.trim().length > 0 && !/[{}]/.test(body);
 }
 
 function readStringConfig(node: NodeLike, key: string): string | null {

--- a/lib/mcp/validate-workflow-web3.ts
+++ b/lib/mcp/validate-workflow-web3.ts
@@ -18,6 +18,7 @@ type Web3Issue = {
 type NodeLike = {
   id?: unknown;
   data?: {
+    type?: unknown;
     config?: Record<string, unknown>;
   } | null;
 };
@@ -49,25 +50,18 @@ export function chainExists(
     }
     // A network supplied by the caller arrives as a template reference and is
     // resolved at execution time, so there is no chain id to check statically.
-    // The address checks below already skip these for the same reason; without
-    // the same guard here, a workflow that takes its chain from the trigger
-    // reports unknown-chain-id while executing correctly.
-    //
     // Two limits on the skip, both cases where a template is wrong rather than
-    // unresolvable:
+    // unresolvable: a trigger's own network is never resolved by anything, and
+    // the reference has to be the whole value.
     //
-    // - Trigger nodes are excluded. Nothing resolves a trigger's own network:
-    //   the event listener does Number(config.network) and skips the workflow
-    //   when it does not parse (workflow-mapper.ts), so a templated trigger
-    //   network never registers a listener and the workflow silently never
-    //   fires. This error is the only static signal that says why.
-    // - The reference must be the whole value. A chain id is substituted
-    //   entire, never built from a fragment, so "1{{@a:B.c}}" is a mistake
-    //   that would otherwise resolve into a chain the author never chose.
-    //   Address fields can afford the looser check because readContractCore
-    //   re-checks the resolved value with ethers.isAddress; network has no
-    //   such re-check.
+    // A trigger is identified the same way this module's caller identifies one
+    // — by data.type — and not by the presence of triggerType, which
+    // sanitize-nodes only injects for Schedule nodes. A trigger imported
+    // without it would otherwise be read as an action, take the skip, and
+    // validate clean while the event listener drops the workflow for a
+    // non-numeric chain id and it never fires.
     const isTriggerNode =
+      (rawNode as NodeLike)?.data?.type === "trigger" ||
       readStringConfig(rawNode as NodeLike, "triggerType") !== null;
     if (!isTriggerNode && isWholeTemplateReference(network)) {
       continue;
@@ -172,7 +166,11 @@ export function isTemplateReference(value: string): boolean {
  * resolve into a chain the author never chose.
  *
  * An empty or whitespace-only body is not a reference any resolver in the repo
- * recognises, and neither is a body containing further braces.
+ * recognises. A closing brace inside the body is not either: TEMPLATE_PATTERN
+ * in lib/utils/template.ts is /\{\{([^}]+)\}\}/g, so the body it accepts may
+ * contain "{" but never "}". Rejecting "{" here would flag "{{a{b}}", which
+ * resolves at execution time — exactly the false positive this skip exists to
+ * remove.
  */
 export function isWholeTemplateReference(value: string): boolean {
   const trimmed = value.trim();
@@ -180,7 +178,7 @@ export function isWholeTemplateReference(value: string): boolean {
     return false;
   }
   const body = trimmed.slice(2, -2);
-  return body.trim().length > 0 && !/[{}]/.test(body);
+  return body.trim().length > 0 && !body.includes("}");
 }
 
 function readStringConfig(node: NodeLike, key: string): string | null {

--- a/lib/mcp/validate-workflow-web3.ts
+++ b/lib/mcp/validate-workflow-web3.ts
@@ -174,7 +174,7 @@ export function isTemplateReference(value: string): boolean {
  */
 export function isWholeTemplateReference(value: string): boolean {
   const trimmed = value.trim();
-  if (!trimmed.startsWith("{{") || !trimmed.endsWith("}}")) {
+  if (!(trimmed.startsWith("{{") && trimmed.endsWith("}}"))) {
     return false;
   }
   const body = trimmed.slice(2, -2);

--- a/lib/mcp/validate-workflow-web3.ts
+++ b/lib/mcp/validate-workflow-web3.ts
@@ -47,6 +47,15 @@ export function chainExists(
     if (network === null) {
       continue;
     }
+    // A network supplied by the caller arrives as a template reference and is
+    // resolved at execution time, so there is no chain id to check statically.
+    // The address checks below already skip these for the same reason; without
+    // the same guard here, every marketplace workflow that takes its chain from
+    // the trigger — which is what the Marketplace docs tell you to do — reports
+    // unknown-chain-id while executing correctly.
+    if (isTemplateReference(network)) {
+      continue;
+    }
     const parsed = Number(network);
     if (!Number.isInteger(parsed) || parsed <= 0) {
       issues.push({

--- a/tests/unit/validate-workflow-web3.test.ts
+++ b/tests/unit/validate-workflow-web3.test.ts
@@ -64,7 +64,10 @@ describe("validateWorkflow — unknown-chain-id (VALID-05)", () => {
   it.each([
     ["an unclosed template", "{{ not closed"],
     ["an empty template body", "{{}}"],
-    ["a template that is only part of the value", "1{{@trigger-1:Manual.network}}"],
+    [
+      "a template that is only part of the value",
+      "1{{@trigger-1:Manual.network}}",
+    ],
   ])("still errors on %s", (_label, network) => {
     // The skip covers a value that is entirely one reference.
     const wf = makeWorkflow({

--- a/tests/unit/validate-workflow-web3.test.ts
+++ b/tests/unit/validate-workflow-web3.test.ts
@@ -66,10 +66,7 @@ describe("validateWorkflow — unknown-chain-id (VALID-05)", () => {
     ["an empty template body", "{{}}"],
     ["a template that is only part of the value", "1{{@trigger-1:Manual.network}}"],
   ])("still errors on %s", (_label, network) => {
-    // The skip covers a value that is entirely one reference. A chain id is
-    // substituted whole and never re-validated after resolution, so a fragment
-    // would resolve into a chain nobody chose, and an empty body resolves to
-    // nothing at all.
+    // The skip covers a value that is entirely one reference.
     const wf = makeWorkflow({
       nodes: [triggerNode(), actionNode("a1", { network })],
       edges: [edge("e1", "trigger-1", "a1")],
@@ -84,7 +81,7 @@ describe("validateWorkflow — unknown-chain-id (VALID-05)", () => {
   it("still errors on a templated network on the trigger itself", () => {
     // Nothing resolves a trigger's own network. The event listener parses it
     // with Number() and skips the workflow when that fails, so a templated
-    // trigger network registers no listener and the workflow never fires --
+    // trigger network registers no listener and the workflow never fires -
     // and this error is the only static signal that says why.
     const wf = makeWorkflow({
       nodes: [
@@ -109,6 +106,48 @@ describe("validateWorkflow — unknown-chain-id (VALID-05)", () => {
         (e) => e.code === "unknown-chain-id"
       )
     ).toBeDefined();
+  });
+
+  it("still errors on a trigger that carries no triggerType", () => {
+    // sanitize-nodes only injects triggerType for Schedule nodes, so a trigger
+    // created or imported without one keeps its trigger identity through
+    // data.type alone. Reading it as an action would take the skip and report
+    // clean on the one node whose network nothing resolves.
+    const wf = makeWorkflow({
+      nodes: [
+        {
+          id: "trigger-1",
+          type: "trigger",
+          data: {
+            label: "Trigger",
+            type: "trigger",
+            config: { network: "{{@x:Y.chainId}}" },
+          },
+        },
+        actionNode("a1", { network: "1" }),
+      ],
+      edges: [edge("e1", "trigger-1", "a1")],
+    });
+    expect(
+      validateWorkflow(wf, { chainIds: new Set([1, 8453]) }).errors.find(
+        (e) => e.code === "unknown-chain-id"
+      )
+    ).toBeDefined();
+  });
+
+  it("skips a reference whose body contains an opening brace", () => {
+    // TEMPLATE_PATTERN is /\{\{([^}]+)\}\}/g, so "{{a{b}}" resolves at
+    // execution time. Rejecting it here would be the false positive this skip
+    // exists to remove.
+    const wf = makeWorkflow({
+      nodes: [triggerNode(), actionNode("a1", { network: "{{a{b}}" })],
+      edges: [edge("e1", "trigger-1", "a1")],
+    });
+    expect(
+      validateWorkflow(wf, { chainIds: new Set([1, 8453]) }).errors.find(
+        (e) => e.code === "unknown-chain-id"
+      )
+    ).toBeUndefined();
   });
 
   it("errors when network value is a non-numeric string", () => {

--- a/tests/unit/validate-workflow-web3.test.ts
+++ b/tests/unit/validate-workflow-web3.test.ts
@@ -43,6 +43,36 @@ describe("validateWorkflow — unknown-chain-id (VALID-05)", () => {
     expect(err?.message).toContain("9999");
   });
 
+  it("skips a network supplied by a template reference", () => {
+    // A marketplace workflow takes its chain from the caller, which the
+    // Marketplace docs explicitly instruct. The value is a template resolved at
+    // execution time, so there is no chain id to check statically — the address
+    // checks in this module already skip these for the same reason.
+    const wf = makeWorkflow({
+      nodes: [
+        triggerNode(),
+        actionNode("a1", { network: "{{@trigger-1:Manual.network}}" }),
+      ],
+      edges: [edge("e1", "trigger-1", "a1")],
+    });
+    const result = validateWorkflow(wf, { chainIds: new Set([1, 8453]) });
+    expect(
+      result.errors.find((e) => e.code === "unknown-chain-id")
+    ).toBeUndefined();
+  });
+
+  it("still errors on a non-numeric network that is not a template", () => {
+    const wf = makeWorkflow({
+      nodes: [triggerNode(), actionNode("a1", { network: "{{ not closed" })],
+      edges: [edge("e1", "trigger-1", "a1")],
+    });
+    expect(
+      validateWorkflow(wf, { chainIds: new Set([1, 8453]) }).errors.find(
+        (e) => e.code === "unknown-chain-id"
+      )
+    ).toBeDefined();
+  });
+
   it("errors when network value is a non-numeric string", () => {
     const wf = makeWorkflow({
       nodes: [triggerNode(), actionNode("a1", { network: "abc" })],

--- a/tests/unit/validate-workflow-web3.test.ts
+++ b/tests/unit/validate-workflow-web3.test.ts
@@ -61,9 +61,47 @@ describe("validateWorkflow — unknown-chain-id (VALID-05)", () => {
     ).toBeUndefined();
   });
 
-  it("still errors on a non-numeric network that is not a template", () => {
+  it.each([
+    ["an unclosed template", "{{ not closed"],
+    ["an empty template body", "{{}}"],
+    ["a template that is only part of the value", "1{{@trigger-1:Manual.network}}"],
+  ])("still errors on %s", (_label, network) => {
+    // The skip covers a value that is entirely one reference. A chain id is
+    // substituted whole and never re-validated after resolution, so a fragment
+    // would resolve into a chain nobody chose, and an empty body resolves to
+    // nothing at all.
     const wf = makeWorkflow({
-      nodes: [triggerNode(), actionNode("a1", { network: "{{ not closed" })],
+      nodes: [triggerNode(), actionNode("a1", { network })],
+      edges: [edge("e1", "trigger-1", "a1")],
+    });
+    expect(
+      validateWorkflow(wf, { chainIds: new Set([1, 8453]) }).errors.find(
+        (e) => e.code === "unknown-chain-id"
+      )
+    ).toBeDefined();
+  });
+
+  it("still errors on a templated network on the trigger itself", () => {
+    // Nothing resolves a trigger's own network. The event listener parses it
+    // with Number() and skips the workflow when that fails, so a templated
+    // trigger network registers no listener and the workflow never fires --
+    // and this error is the only static signal that says why.
+    const wf = makeWorkflow({
+      nodes: [
+        {
+          id: "trigger-1",
+          type: "trigger",
+          data: {
+            label: "Trigger",
+            type: "trigger",
+            config: {
+              triggerType: "Event",
+              network: "{{@trigger-1:Event.chainId}}",
+            },
+          },
+        },
+        actionNode("a1", { network: "1" }),
+      ],
       edges: [edge("e1", "trigger-1", "a1")],
     });
     expect(


### PR DESCRIPTION
## Problem

`chainExists()` in `lib/mcp/validate-workflow-web3.ts` runs `Number()` on the
raw `network` config value. When that value is a template reference — resolved
at execution time, not save time — the check reports:

```
unknown-chain-id: nodes[1].config.network "{{@trigger-1:Manual.network}}"
                  is not a numeric chain ID string
```

The two address checks in the same module already guard against this with
`isTemplateReference`, and the helper's own comment states the rule:

> These are not literal addresses, so the `ethers.isAddress` format check must
> skip them rather than report a false invalid-token-address.

The chain check simply missed it.

## Why it matters

It lands on marketplace workflows specifically. [Before you
list](https://docs.keeperhub.com/workflows/marketplace#before-you-list) says:

> **Inputs come from the trigger, not from hardcoded values.** Anything
> caller-supplied (a wallet address, a token, an amount) has to flow in through
> the Manual trigger.

So a workflow that takes its chain from the caller is doing exactly what the
docs instruct, and `validate_workflow` then calls it invalid.

Observed on a live listing. Two workflows in the same org, identical but for
this field:

| Workflow | `network` | `validate_workflow` |
| --- | --- | --- |
| `signer-gas-runway` | `{{@trigger-1:Manual.network}}` | **invalid** — unknown-chain-id |
| internal responder | `"11155111"` | valid |

`signer-gas-runway` is listed, executes correctly, and has settled a real x402
payment ([USDC transfer on Base](https://basescan.org/tx/0x8cd8d6ac5dae125e5f3cf039db1ffb7f6b7dafa44243396d00e30074a93a51f9)). The verdict is a false positive.

## Change

Skip the chain check when the value is a template reference, using the existing
`isTemplateReference` helper — the same guard, in the same module, for the same
reason.

## Verification

`tests/unit/validate-workflow-web3.test.ts`:

- a templated `network` produces no `unknown-chain-id`
- a malformed, non-template string still does, so the check is not simply
  weakened

The first fails on `staging` (`expected { code: 'unknown-chain-id' } to be
undefined`) and passes with this change. The four validate-workflow suites
together: 89 tests pass.

## Context

Found while wiring KeeperHub's MCP server into an incident-remediation agent to
validate its workflows before running them. Because of this, we had to treat the
verdict as advisory rather than blocking — a correct workflow failing validation
is worse than no validation, since it trains callers to ignore it.
