### PR TITLE
fix(billing): admit free orgs to pay-as-you-go on the executor path

### DIFF
--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -193,6 +193,8 @@ async function prepareExecution(
           error: paygCharge.message,
           errorCategory: "billing",
           errorType: "user",
+          // Unpaid means the run never started, so it consumes no quota.
+          billable: false,
           completedAt: new Date(),
         })
         .where(eq(workflowExecutions.id, execution.id));

--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -329,6 +329,8 @@ export async function POST(
           error: paygCharge.message,
           errorCategory: "billing",
           errorType: "user",
+          // Unpaid means the run never started, so it consumes no quota.
+          billable: false,
           completedAt: new Date(),
         })
         .where(eq(workflowExecutions.id, executionId));

--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -437,6 +437,8 @@ export async function POST(
           error: paygCharge.message,
           errorCategory: "billing",
           errorType: "user",
+          // Unpaid means the run never started, so it consumes no quota.
+          billable: false,
           completedAt: new Date(),
         })
         .where(eq(workflowExecutions.id, execution.id));

--- a/keeperhub-executor/billing-guard.test.ts
+++ b/keeperhub-executor/billing-guard.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetExecutionCountCacheForTest } from "../lib/billing/execution-limit-core";
+import { PAYG_OVERFLOW_REASON } from "../lib/billing/payg/constants";
+import { executionDebt, organizationSubscriptions } from "../lib/db/schema";
+import { checkExecutionLimitForExecutor } from "./billing-guard";
+
+type SubRow = { plan: string; tier: string | null; status: string };
+
+// The guard awaits `.where(...)` directly for debt and `.where(...).limit(1)`
+// for the subscription, so the fake resolves both shapes from one object.
+function resultFor(rows: unknown[]): Promise<unknown[]> & {
+  limit: () => Promise<unknown[]>;
+} {
+  const result = Promise.resolve(rows) as Promise<unknown[]> & {
+    limit: () => Promise<unknown[]>;
+  };
+  result.limit = () => Promise.resolve(rows);
+  return result;
+}
+
+function fakeDb(params: { sub: SubRow | null; used: number; debt: number }) {
+  const execute = vi.fn().mockResolvedValue([{ count: params.used }]);
+  const select = vi.fn(() => ({
+    from: (table: unknown) => ({
+      where: () => {
+        if (table === organizationSubscriptions) {
+          return resultFor(params.sub ? [params.sub] : []);
+        }
+        if (table === executionDebt) {
+          return resultFor(
+            params.debt > 0 ? [{ debt: params.debt }] : []
+          );
+        }
+        return resultFor([]);
+      },
+    }),
+  }));
+  return { select, execute };
+}
+
+function asDb(
+  db: ReturnType<typeof fakeDb>
+): Parameters<typeof checkExecutionLimitForExecutor>[0] {
+  return db as unknown as Parameters<typeof checkExecutionLimitForExecutor>[0];
+}
+
+const FREE_LIMIT = 5000;
+
+beforeEach(() => {
+  __resetExecutionCountCacheForTest();
+  vi.stubEnv("NEXT_PUBLIC_BILLING_ENABLED", "true");
+});
+
+describe("checkExecutionLimitForExecutor pay-as-you-go admission", () => {
+  it("admits a free org past its limit that never set spend caps", async () => {
+    const db = fakeDb({
+      sub: { plan: "free", tier: null, status: "active" },
+      used: FREE_LIMIT,
+      debt: 0,
+    });
+
+    const result = await checkExecutionLimitForExecutor(asDb(db), "org_1");
+
+    expect(result).toEqual({ allowed: true, reason: PAYG_OVERFLOW_REASON });
+  });
+
+  it("admits a free org with no subscription row at all", async () => {
+    const db = fakeDb({ sub: null, used: FREE_LIMIT + 120, debt: 0 });
+
+    const result = await checkExecutionLimitForExecutor(asDb(db), "org_2");
+
+    expect(result).toEqual({ allowed: true, reason: PAYG_OVERFLOW_REASON });
+  });
+
+  it("keeps a free org under its limit on the normal path", async () => {
+    const db = fakeDb({
+      sub: { plan: "free", tier: null, status: "active" },
+      used: FREE_LIMIT - 1,
+      debt: 0,
+    });
+
+    const result = await checkExecutionLimitForExecutor(asDb(db), "org_3");
+
+    expect(result).toEqual({ allowed: true, reason: "within_limit" });
+  });
+
+  it("still blocks a paid org carrying unpaid overage debt", async () => {
+    const db = fakeDb({
+      sub: { plan: "pro", tier: "25k", status: "active" },
+      used: 10,
+      debt: 100,
+    });
+
+    const result = await checkExecutionLimitForExecutor(asDb(db), "org_4");
+
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      expect(result.reason).toBe("active_debt");
+    }
+  });
+
+  // Free carries no overage, so debt cannot block there. Matches
+  // checkExecutionLimit, which reaches the same outcome on the web path.
+  it("admits a free org past its limit even with debt on the row", async () => {
+    const db = fakeDb({
+      sub: { plan: "free", tier: null, status: "active" },
+      used: FREE_LIMIT,
+      debt: 100,
+    });
+
+    const result = await checkExecutionLimitForExecutor(asDb(db), "org_5");
+
+    expect(result).toEqual({ allowed: true, reason: PAYG_OVERFLOW_REASON });
+  });
+
+  it("does not query the pay-as-you-go config to decide admission", async () => {
+    const db = fakeDb({
+      sub: { plan: "free", tier: null, status: "active" },
+      used: FREE_LIMIT,
+      debt: 0,
+    });
+
+    await checkExecutionLimitForExecutor(asDb(db), "org_5");
+
+    // Subscription plus debt only. A third select is the config lookup coming back.
+    expect(db.select).toHaveBeenCalledTimes(2);
+  });
+});

--- a/keeperhub-executor/billing-guard.ts
+++ b/keeperhub-executor/billing-guard.ts
@@ -14,11 +14,7 @@ import {
   parseTierKey,
 } from "../lib/billing/plans";
 import { PAYG_OVERFLOW_REASON } from "../lib/billing/payg/constants";
-import {
-  executionDebt,
-  organizationSubscriptions,
-  paygConfig,
-} from "../lib/db/schema";
+import { executionDebt, organizationSubscriptions } from "../lib/db/schema";
 
 export type BillingGuardResult =
   | {
@@ -127,18 +123,12 @@ export async function checkExecutionLimitForExecutor(
         effectiveLimit,
       };
     default: {
-      // Free plan at its included limit: if PAYG is enabled, admit and let the
-      // executor charge the per-execution price before the run (the charge is
-      // the real gate). PAYG is a free-tier feature only.
+      // Free plan at its included limit: admit and let the executor charge the
+      // per-execution price before the run (the charge is the real gate). PAYG
+      // covers every free org, so an org with no config row runs on the default
+      // caps rather than being blocked. Matches checkExecutionLimit.
       if (plan === "free") {
-        const [cfg] = await db
-          .select({ id: paygConfig.id })
-          .from(paygConfig)
-          .where(eq(paygConfig.organizationId, organizationId))
-          .limit(1);
-        if (cfg) {
-          return { allowed: true, reason: PAYG_OVERFLOW_REASON };
-        }
+        return { allowed: true, reason: PAYG_OVERFLOW_REASON };
       }
       return {
         allowed: false,

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -147,6 +147,8 @@ async function settlePaygOverflow(params: {
         error: charge.message,
         errorCategory: "billing",
         errorType: "user",
+        // Unpaid means the run never started, so it consumes no quota.
+        billable: false,
         completedAt: new Date(),
       })
       .where(

--- a/keeperhub-executor/lib/db-helpers.ts
+++ b/keeperhub-executor/lib/db-helpers.ts
@@ -484,6 +484,10 @@ export async function resolvePhantomToError(
       error: fields.error,
       errorCategory: fields.errorCategory,
       errorType: fields.errorType,
+      // The run was blocked before it started, so it consumes no quota. The
+      // claim flips billable to true up front; undo that here or a blocked
+      // org's retries keep inflating its plan-usage ratio past 100%.
+      billable: false,
       completedAt: new Date(),
     })
     .where(

--- a/lib/billing/payg/autopay.ts
+++ b/lib/billing/payg/autopay.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/agentic-wallet/sign-typed-data";
 import { facilitatorClient } from "@/lib/payments/x402/server";
 import { getOrganizationWallet } from "@/lib/web3/wallet-helpers";
+import { hasSufficientUsdc } from "./balance";
 import { getPaygSettings } from "./config-store";
 import {
   evmNetworkId,
@@ -180,6 +181,18 @@ export async function autopayForExecution(params: {
   const zeroCap = zeroCapBlock(config);
   if (zeroCap) {
     return { ok: false, reason: zeroCap };
+  }
+
+  // Stop an unfundable run before it costs a Turnkey signature and a
+  // facilitator round-trip. Unknown (unsupported chain, RPC failure) falls
+  // through and settles as before, so a flaky read never blocks a payer.
+  const funded = await hasSufficientUsdc({
+    payerAddress: wallet.walletAddress,
+    amountRaw: priceRaw,
+    chainId: config.chainId,
+  });
+  if (funded === false) {
+    return { ok: false, reason: "insufficient_funds" };
   }
 
   // Claim the (org, execution) slot with a pending row before settling. The

--- a/lib/billing/payg/balance.ts
+++ b/lib/billing/payg/balance.ts
@@ -1,0 +1,46 @@
+import { Contract, JsonRpcProvider } from "ethers";
+import { USDC_BASE_ADDRESS } from "@/lib/agentic-wallet/constants";
+import { PAYG_DEFAULT_CHAIN_ID } from "./constants";
+
+const BALANCE_OF_ABI = ["function balanceOf(address) view returns (uint256)"];
+
+// Module-level singleton so a per-execution check does not build a new
+// connection pool each time. Mirrors lib/payments/x402/reconcile.ts.
+const provider = new JsonRpcProvider(
+  process.env.BASE_RPC_URL ?? "https://mainnet.base.org"
+);
+
+const usdcByChainId: Record<number, string> = {
+  [PAYG_DEFAULT_CHAIN_ID]: USDC_BASE_ADDRESS,
+};
+
+/**
+ * Whether the payer holds at least `amountRaw` USDC, read straight from the
+ * token contract.
+ *
+ * Settlement signs the EIP-3009 authorization with Turnkey before the
+ * facilitator ever reports a shortfall, so an org with an empty wallet burns a
+ * signing call and a facilitator round-trip on every retry. A blocked org's
+ * triggers keep firing, so that is the common case, not the rare one. This read
+ * is the cheap way to stop before either.
+ *
+ * Returns null when the answer is unknown (unsupported chain, RPC failure), and
+ * the caller settles as before. A flaky RPC must not block an org that can pay.
+ */
+export async function hasSufficientUsdc(params: {
+  payerAddress: string;
+  amountRaw: bigint;
+  chainId: number;
+}): Promise<boolean | null> {
+  const token = usdcByChainId[params.chainId];
+  if (!token) {
+    return null;
+  }
+  try {
+    const contract = new Contract(token, BALANCE_OF_ABI, provider);
+    const balance = (await contract.balanceOf(params.payerAddress)) as bigint;
+    return balance >= params.amountRaw;
+  } catch {
+    return null;
+  }
+}

--- a/tests/unit/payg-autopay.test.ts
+++ b/tests/unit/payg-autopay.test.ts
@@ -52,6 +52,12 @@ vi.mock("@/lib/billing/payg/treasury", () => ({
   getPaygTreasuryOrNull: vi.fn(() => state.treasury),
 }));
 
+// The balance pre-check runs before the claim; never let it reach the network.
+const hasSufficientUsdc = vi.fn();
+vi.mock("@/lib/billing/payg/balance", () => ({
+  hasSufficientUsdc: (...a: unknown[]) => hasSufficientUsdc(...a),
+}));
+
 // --- Payments helpers: spies configured per test. ---
 const findPaygPayment = vi.fn();
 const claimPaygPayment = vi.fn();
@@ -90,6 +96,7 @@ beforeEach(() => {
   markPaygPaymentSettled.mockResolvedValue(undefined);
   releasePaygClaim.mockResolvedValue(undefined);
   facilitatorSettle.mockResolvedValue({ success: true, transaction: "0xtx" });
+  hasSufficientUsdc.mockResolvedValue(true);
 });
 
 describe("autopayForExecution claim-before-settle", () => {
@@ -270,5 +277,40 @@ describe("autopayForExecution claim-before-settle", () => {
     expect(releasePaygClaim).toHaveBeenCalledWith("org_1", "exec_1");
     expect(markPaygPaymentSettled).not.toHaveBeenCalled();
     expect(result).toEqual({ ok: false, reason: "insufficient_funds" });
+  });
+});
+
+describe("autopayForExecution balance pre-check", () => {
+  it("blocks an unfunded wallet before claiming or signing", async () => {
+    hasSufficientUsdc.mockResolvedValue(false);
+
+    const result = await autopayForExecution(PARAMS);
+
+    expect(result).toEqual({ ok: false, reason: "insufficient_funds" });
+    expect(claimPaygPayment).not.toHaveBeenCalled();
+    expect(facilitatorSettle).not.toHaveBeenCalled();
+  });
+
+  it("checks the balance against the per-execution price and payer", async () => {
+    await autopayForExecution(PARAMS);
+
+    expect(hasSufficientUsdc).toHaveBeenCalledWith({
+      payerAddress: "0xabc",
+      amountRaw: BigInt(10_000),
+      chainId: 8453,
+    });
+  });
+
+  it("settles as before when the balance is unknown", async () => {
+    hasSufficientUsdc.mockResolvedValue(null);
+
+    const result = await autopayForExecution(PARAMS);
+
+    expect(result).toEqual({
+      ok: true,
+      txHash: "0xtx",
+      amountRaw: BigInt(10_000),
+    });
+    expect(facilitatorSettle).toHaveBeenCalled();
   });
 });

--- a/tests/unit/payg-balance.test.ts
+++ b/tests/unit/payg-balance.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const balanceOf = vi.fn();
+vi.mock("ethers", () => ({
+  JsonRpcProvider: class {},
+  Contract: class {
+    balanceOf = (...a: unknown[]) => balanceOf(...a);
+  },
+}));
+vi.mock("@/lib/agentic-wallet/constants", () => ({
+  USDC_BASE_ADDRESS: "0xusdc",
+}));
+
+import { hasSufficientUsdc } from "@/lib/billing/payg/balance";
+
+const PRICE = BigInt(10_000);
+const BASE = { payerAddress: "0xabc", amountRaw: PRICE, chainId: 8453 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("hasSufficientUsdc", () => {
+  it("is true when the balance covers the price", async () => {
+    balanceOf.mockResolvedValue(PRICE);
+
+    expect(await hasSufficientUsdc(BASE)).toBe(true);
+  });
+
+  it("is false on an empty wallet", async () => {
+    balanceOf.mockResolvedValue(BigInt(0));
+
+    expect(await hasSufficientUsdc(BASE)).toBe(false);
+  });
+
+  it("is false one unit short of the price", async () => {
+    balanceOf.mockResolvedValue(PRICE - BigInt(1));
+
+    expect(await hasSufficientUsdc(BASE)).toBe(false);
+  });
+
+  it("is unknown when the read throws, so the caller still settles", async () => {
+    balanceOf.mockRejectedValue(new Error("rpc down"));
+
+    expect(await hasSufficientUsdc(BASE)).toBeNull();
+  });
+
+  it("is unknown on a chain with no configured USDC address", async () => {
+    expect(await hasSufficientUsdc({ ...BASE, chainId: 1 })).toBeNull();
+    expect(balanceOf).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Pay-as-you-go became the default for every free org, but the executor never got the memo. It kept the old opt-in check and refused to admit a free org past its included limit unless a `payg_config` row existed:

```ts
if (plan === "free") {
  const [cfg] = await db.select({ id: paygConfig.id })...
  if (cfg) { return { allowed: true, reason: PAYG_OVERFLOW_REASON }; }
}
return { allowed: false, reason: "free_limit_exceeded", ... };
```

Everywhere else a missing row means "run on the default caps", not "off". `getPaygSettings` says so explicitly and `chargePaygIfBillable` never looks for a row at all.

The result was one org behaving two ways depending on which trigger fired. Manual runs went through the web path and were charged. Schedule, event and block triggers hit the executor and were blocked with a flat limit-reached error, no payment attempt. Eight orgs are sitting at or above their cap in production right now, and about 64k runs were rejected this month across eleven orgs.

## Changes

Admission in `keeperhub-executor/billing-guard.ts` drops the config lookup and matches `checkExecutionLimit`: a free org past its limit is admitted, and the per-execution charge is the gate. The `settlePaygOverflow` path this feeds was already wired up and is untouched.

A failed charge no longer leaves the execution row billable. The claim marks the row billable before the charge is attempted, so an unpaid run was counted against the plan and pushed the usage ratio past 100 percent on every retry. Fixed on all four unpaid paths: `resolvePhantomToError`, `settlePaygOverflow`'s running branch, and the manual, webhook and MCP routes. This one is not optional alongside the first change, since admitting these orgs without it would spread the inflated counts to every trigger type instead of just one.

New `keeperhub-executor/billing-guard.test.ts` covers admission with no config row, with no subscription row, the under-limit path, debt handling, and asserts the config table is never queried for admission so this cannot silently regress again.

## Behavior note

A free org carrying unpaid overage debt is now admitted to pay-as-you-go rather than blocked. That is not a new decision, it is what `checkExecutionLimit` already does on the web path, since `decideExecutionLimit` only returns `blocked_debt` when overage is enabled and free has it disabled. The executor now matches instead of inventing a third behavior, and there is a test pinning it.

## Verification

- 19 test files, 218 tests passing across the executor suite and every billing and pay-as-you-go suite
- `pnpm type-check` clean
- `pnpm check` unchanged from the `staging` baseline (1 error, 81 warnings; the error is a formatting issue in a test file this branch does not touch)