### PR TITLE
fix: point earnings help links at the marketplace docs page

### DIFF
--- a/components/earnings/earnings-kpi-cards.tsx
+++ b/components/earnings/earnings-kpi-cards.tsx
@@ -120,7 +120,7 @@ export function EarningsKpiCards(): ReactNode {
     <div className="space-y-4">
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <KpiCard
-          helpHref="https://docs.keeperhub.com/workflows/paid-workflows"
+          helpHref="https://docs.keeperhub.com/workflows/marketplace#receiving-revenue-on-two-chains"
           helpTitle="How dual-chain revenue works"
           icon={<DollarSign className="size-5" />}
           iconClassName="bg-green-500/10 text-green-600 dark:text-green-400"
@@ -129,7 +129,7 @@ export function EarningsKpiCards(): ReactNode {
           value={totalGrossRevenue}
         />
         <KpiCard
-          helpHref="https://docs.keeperhub.com/workflows/paid-workflows"
+          helpHref="https://docs.keeperhub.com/workflows/marketplace#earnings"
           helpTitle="How creator earnings are calculated"
           icon={<TrendingUp className="size-5" />}
           iconClassName="bg-keeperhub-green/10 text-keeperhub-green-dark"

--- a/lib/earnings/queries.ts
+++ b/lib/earnings/queries.ts
@@ -188,7 +188,7 @@ export async function getEarningsSummary(
   const totalInvocations = orgTotals?.invocationCount ?? 0;
 
   // Per-chain breakdown so creators see Base (x402/USDC) vs Tempo (MPP/USDC.e)
-  // split instead of just an aggregate. See docs/workflows/paid-workflows.md.
+  // split instead of just an aggregate. See docs/workflows/marketplace.md.
   const perChainRows = await db
     .select({
       chain: workflowPayments.chain,


### PR DESCRIPTION
## The bug

Both KPI card help links on the Earnings page point at `docs.keeperhub.com/workflows/paid-workflows`. That page has never existed - `paid-workflows` was the predecessor filename for what shipped as `workflows/marketplace.md`. The URL 404s, so the two affordances that explain revenue and earnings lead nowhere.

`lib/earnings/queries.ts` carries the same stale path in a comment.

## The fix

Repoint, rather than add a page. Everything both help titles promise is already in `workflows/marketplace.md`:

- `## Earnings` states the 30% platform fee / 70% creator split and the per-network breakdown
- `### Receiving revenue on two chains` explains the Base (x402/USDC) vs Tempo (MPP/USDC.e) split, including that a zero balance on one chain is not a problem

Writing a `paid-workflows.md` would duplicate a 220-line page that already answers the question.

Each link goes to its specific anchor rather than the page top, so the help affordance lands on the relevant section:

| Help title | Destination |
|---|---|
| How dual-chain revenue works | `workflows/marketplace#receiving-revenue-on-two-chains` |
| How creator earnings are calculated | `workflows/marketplace#earnings` |

## Verification

Built the docs-site image and curled the running container rather than guessing at slug generation:

| URL | Result |
|---|---|
| `/workflows/paid-workflows` | **404** - confirms the bug |
| `/workflows/marketplace` | 200 |
| `#receiving-revenue-on-two-chains` | anchor id present in rendered HTML |
| `#earnings` | anchor id present in rendered HTML |

## Notes

- Three lines, all string content. No type or lint surface; the longer attribute line is unremarkable in a file that already has lines at 105 and 148 chars.
- **No ordering dependency on #1998.** That PR touches `marketplace.md` only to rewrite an `/ai-tools/` link to `/agent/`; the headings these anchors resolve against are untouched, so this works whichever merges first.
- No docs-site redirect added for the old URL. The page never shipped, so nothing external can link to it - the only two references were this component and `llms.txt`, which #1998 fixes.