### PR TITLE
fix: skip merge-deleted docs in edit-link gate

### DIFF
--- a/.github/workflows/pr-docs-site-build.yaml
+++ b/.github/workflows/pr-docs-site-build.yaml
@@ -41,7 +41,8 @@ jobs:
   # receiving docs. So "does the branch exist" would have passed throughout the
   # outage and is not the property worth asserting. What matters is whether the
   # configured branch actually carries the docs the links point into, which is
-  # checked here by resolving the base branch's docs paths against it.
+  # checked here by resolving the base branch's docs paths - minus the ones
+  # this merge deletes - against it.
   #
   # Uses git rather than the contents API: no rate limit, no token, and one
   # fetch instead of one request per page.
@@ -90,6 +91,13 @@ jobs:
           missing=0
           checked=0
           while read -r file; do
+            # `actions/checkout` checks out refs/pull/N/merge, so the working
+            # tree is the post-merge result. Files this merge deletes are never
+            # deployed and their edit links never render, so they are not the
+            # configured branch's job to carry. Without this skip, a docs
+            # restructure on the configured branch fails every release PR into
+            # prod - including the one that would bring prod back in line.
+            [ -f "$file" ] || continue
             checked=$((checked + 1))
             if ! git cat-file -e "refs/remotes/editlink/configured:$file" 2>/dev/null; then
               missing=$((missing + 1))


### PR DESCRIPTION
## Problem

`edit-link-target` fails on PR #1989 (`release: To Prod`) with `'staging' is missing 17 of 190 docs files - those edit links 404`. It is the only failing check, and it blocks the release.

## Root cause

The gate enumerates the docs tree of the **PR base branch** and asserts every file exists on the branch named in `docsRepositoryBase` (`staging`).

- On a `feature -> staging` PR, base equals the configured branch, so the loop compares staging against staging - a tautology that always passes.
- On a `staging -> prod` release PR, base is `prod`, so the loop asks "does staging still contain every docs file prod has". Commit d77ad767e (`docs: consolidate getting-started into four interface paths`) deleted 17 docs files on staging - `docs/ai-tools/*`, `docs/intro/*`, and three `quickstart.md` files. Prod still carries them because it has not received that commit, which is exactly what the release PR delivers.

The file list is taken from the pre-merge base tree, so it includes pages the merge deletes and which are therefore never deployed. The result is a deadlock: the gate blocks the release, and only the release can bring prod back in line.

The condition it reports is real - the live prod docs site currently renders 17 pages whose "Edit this page" links 404 against staging - but merging the release is the fix, not the cause.

## Change

`actions/checkout` resolves `refs/pull/N/merge` on `pull_request`, so the working tree is the post-merge result. One guard in the loop skips files the merge deletes:

```
[ -f "$file" ] || continue
```

## Verification

The step was extracted from the YAML and run verbatim against a real checkout of #1989's merge commit `39aad8268`, the same commit CI failed on.

| Case | Before | After |
|---|---|---|
| #1989, `GITHUB_BASE_REF=prod` | 17 of 190 missing, exit 1 | 173 checked, 0 missing, exit 0 |
| `docsRepositoryBase` pointed at stale `main`, release shape | fail | fail, 173 of 173 missing |
| `docsRepositoryBase` pointed at stale `main`, feature shape | fail | fail, 187 of 187 missing |
| #1992 (`feature -> staging`, renames and deletes docs) | pass | pass |

The gate keeps its teeth on both PR shapes: the original stale-branch failure it was written for is still caught. YAML parses and `bash -n` passes on the run block.

## Sequencing

This has to land on `staging` first. `pull_request` runs use the workflow definition from the merge ref, so #1989's gate re-runs against the fixed version once this merges.

## Follow-up worth a separate decision

On `feature -> staging` PRs - the large majority - the file-by-file loop cannot fail as long as `docsRepositoryBase` names the base branch. The comparison only does real work on release PRs. A wrong branch name is still caught everywhere, so this is defensible, but the gate is weaker on routine PRs than its comment implies. Not changed here; it is a design decision rather than a CI fix.
