### PR TITLE
docs: KEEP-1132 require an accepted issue before a pull request

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,9 +5,13 @@ body:
   - type: markdown
     attributes:
       value: |
-        A reproduction settles a bug report faster than any amount of description.
-        If you already know the fix, say so at the bottom - but wait for the
-        `accepted` label before writing it. See [ISSUES.md](https://github.com/KeeperHub/keeperhub/blob/staging/ISSUES.md).
+        Every issue carries three things: a **reason** it matters, a **scope**
+        it is bounded to, and a **plan** for what happens next. All three are
+        required. The plan is your proposal - triage may replace it, and will
+        say so in a comment before accepting.
+
+        Wait for the `accepted` label before writing code. See
+        [ISSUES.md](https://github.com/KeeperHub/keeperhub/blob/staging/ISSUES.md).
 
   - type: checkboxes
     id: preflight
@@ -18,17 +22,21 @@ body:
           required: true
         - label: I confirmed it still happens on the current `staging`, not only on an older checkout.
           required: true
+        - label: This is one problem, not several. (Several means several issues.)
+          required: true
         - label: This is not a security vulnerability (those go through private reporting).
           required: true
 
   - type: textarea
     id: reproduction
     attributes:
-      label: Reproduction
+      label: "Reason: reproduction"
       description: >-
-        The exact steps, request, or workflow. Include the endpoint and body for
-        an API call, the command for the CLI, or the click path for the UI.
-        Redact keys and addresses you do not want public.
+        The exact steps, request, or workflow, as something someone else can
+        run. A runnable repro is what turns "is this real" into a two-minute
+        question instead of a conversation. Redact keys and addresses you do
+        not want public.
+      render: shell
       placeholder: |
         curl -X POST https://app.keeperhub.com/api/execute/transfer \
           -H "Authorization: Bearer kh_..." \
@@ -39,20 +47,32 @@ body:
   - type: textarea
     id: actual
     attributes:
-      label: What happened
-      description: >-
-        The response body, error message, stack trace, or screenshot. Paste the
-        text rather than a screenshot of text where you can.
+      label: "Reason: what happened"
+      description: The response body, error, stack trace, or screenshot. Paste text rather than a picture of text.
     validations:
       required: true
 
   - type: textarea
     id: expected
     attributes:
-      label: What you expected instead
+      label: "Reason: what you expected, and what told you to expect it"
       description: >-
-        If a documentation page or an error message told you to expect something
-        else, link it. That link is often the fastest route to a fix.
+        Name the source of the expectation - a docs page, an error message, a
+        type, a function name, a schema. This field settles more issues than any
+        other: if the source says something different from the code, we know
+        immediately which of the two is wrong. If nothing told you, say that.
+    validations:
+      required: true
+
+  - type: textarea
+    id: cost
+    attributes:
+      label: "Reason: what it costs"
+      description: >-
+        What goes wrong for a real user or agent that hits this. Lost time,
+        wrong data, a silent failure, funds moved that should not have been.
+        This is what orders the queue - "it is wrong" does not distinguish a
+        typo from a transaction broadcast by mistake.
     validations:
       required: true
 
@@ -72,20 +92,42 @@ body:
     id: version
     attributes:
       label: Version or commit
-      description: >-
-        The `staging` commit you reproduced on, the `kh` version (`kh version`),
-        or the date and time of the production request.
+      description: The `staging` commit you reproduced on, the `kh` version, or the time of the production request.
     validations:
       required: true
 
   - type: textarea
     id: scope
     attributes:
-      label: Proposed fix and its scope
+      label: "Scope: what this covers, and what it does not"
       description: >-
-        Optional, and the problem above matters more. If you do have a fix in
-        mind, say which files or subsystems it touches and - explicitly - what
-        it does not touch. If it splits into parts that could each ship alone,
-        say so; those are separate issues.
+        The surfaces you believe are affected, and the ones you checked and
+        found fine. If the same fault might exist on sibling routes or commands,
+        say which - a fix applied to one route and not its three siblings is a
+        recurring failure here. Then confirm this is one problem: if any part
+        could be fixed and shipped while another stays broken, those are
+        separate issues.
+      placeholder: >-
+        Affects POST /api/execute/{protocol}/{action}. Checked
+        /api/execute/contract-call and /api/execute/transfer - both fine.
+        Did not check check-and-execute.
     validations:
-      required: false
+      required: true
+
+  - type: textarea
+    id: plan
+    attributes:
+      label: "Plan: what should happen next"
+      description: >-
+        Your proposal, which triage may replace. If you know the fix, describe
+        it and say whether it changes anything a caller depends on - a response
+        shape, a unit, a status code, a default. If you do not know the fix,
+        that is a valid plan: say what you would need to determine to choose
+        one. What is not valid is leaving this blank.
+      placeholder: >-
+        Either reject `simulate` on this route with a 400 naming the supported
+        routes, or implement it as contract-call does. The first is smaller and
+        removes the trap; the second is what an agent expects. Changes no
+        existing successful response.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: Bug report
+description: Something behaves differently from how it is documented or intended.
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A reproduction settles a bug report faster than any amount of description.
+        If you already know the fix, say so at the bottom - but wait for the
+        `accepted` label before writing it. See [ISSUES.md](https://github.com/KeeperHub/keeperhub/blob/staging/ISSUES.md).
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before filing
+      options:
+        - label: I searched open and closed issues for this behaviour.
+          required: true
+        - label: I confirmed it still happens on the current `staging`, not only on an older checkout.
+          required: true
+        - label: This is not a security vulnerability (those go through private reporting).
+          required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: >-
+        The exact steps, request, or workflow. Include the endpoint and body for
+        an API call, the command for the CLI, or the click path for the UI.
+        Redact keys and addresses you do not want public.
+      placeholder: |
+        curl -X POST https://app.keeperhub.com/api/execute/transfer \
+          -H "Authorization: Bearer kh_..." \
+          -d '{"chainId": 11155111, "recipientAddress": "0x...", "amount": "0.1"}'
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What happened
+      description: >-
+        The response body, error message, stack trace, or screenshot. Paste the
+        text rather than a screenshot of text where you can.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected instead
+      description: >-
+        If a documentation page or an error message told you to expect something
+        else, link it. That link is often the fastest route to a fix.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Where you saw it
+      options:
+        - Production (app.keeperhub.com)
+        - Staging
+        - Local development
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      description: >-
+        The `staging` commit you reproduced on, the `kh` version (`kh version`),
+        or the date and time of the production request.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Proposed fix and its scope
+      description: >-
+        Optional, and the problem above matters more. If you do have a fix in
+        mind, say which files or subsystems it touches and - explicitly - what
+        it does not touch. If it splits into parts that could each ship alone,
+        say so; those are separate issues.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/change_request.yml
+++ b/.github/ISSUE_TEMPLATE/change_request.yml
@@ -5,9 +5,13 @@ body:
   - type: markdown
     attributes:
       value: |
+        Every issue carries three things: a **reason** it matters, a **scope**
+        it is bounded to, and a **plan** for what happens next. All three are
+        required. The plan is your proposal - triage may replace it, and will
+        say so in a comment before accepting.
+
         Lead with what you are trying to do, not with what to build. The problem
-        is stable and the solution is negotiable - we may already know a cheaper
-        one, or a reason the obvious one does not work here.
+        is stable; the solution is negotiable, and we may know a cheaper one.
 
         Wait for the `accepted` label before writing code. See
         [ISSUES.md](https://github.com/KeeperHub/keeperhub/blob/staging/ISSUES.md).
@@ -21,62 +25,81 @@ body:
           required: true
         - label: I checked the docs and the current behaviour on `staging`.
           required: true
+        - label: This is one change, not several. (Several means several issues.)
+          required: true
 
   - type: textarea
     id: problem
     attributes:
-      label: What you cannot do today
+      label: "Reason: what you cannot do today"
       description: >-
-        The concrete task that is blocked or awkward, and what you currently do
-        instead. Real usage beats a hypothetical - if this came out of building
+        The concrete task that is blocked or awkward, and what you do instead.
+        Real usage beats a hypothetical - if this came out of building
         something, describe that.
     validations:
       required: true
 
   - type: textarea
-    id: proposal
+    id: cost
     attributes:
-      label: What you propose
+      label: "Reason: what the workaround costs"
       description: >-
-        The change as you would build it. Include the API or UI shape if it has
-        one, and say what happens to existing callers.
+        If a workaround exists, what it costs you - time, reliability, an
+        invariant you cannot hold. That cost is the size of the problem, and it
+        is what this gets weighed against. If there is no workaround at all, say
+        so.
     validations:
       required: true
 
   - type: textarea
     id: scope
     attributes:
-      label: Scope
+      label: "Scope: what this touches, and what it does not"
       description: >-
-        What this touches, and explicitly what it does not. Then apply the split
-        test: can each piece of this ship, deploy, and be correct with the other
-        pieces reverted? If yes, they are separate issues - list them and file
-        the rest separately.
+        The surfaces this changes and the ones it deliberately leaves alone.
+        Then confirm it is one change: if any part could ship, deploy, and be
+        correct with another part reverted, those are separate issues - list
+        them and file the rest separately.
+    validations:
+      required: true
+
+  - type: textarea
+    id: plan
+    attributes:
+      label: "Plan: what you propose"
+      description: >-
+        The change as you would build it, including the API or UI shape and what
+        happens to existing callers. Triage may replace this with a different
+        approach and will say so before accepting. If you are proposing the
+        problem rather than a solution, say what you would need to determine to
+        choose one.
     validations:
       required: true
 
   - type: textarea
     id: alternatives
     attributes:
-      label: Alternatives you considered
+      label: "Plan: alternatives you considered"
       description: >-
-        Including doing nothing. If there is a workaround that already works,
-        say what it costs you - that is what tells us the size of the problem.
+        Including doing nothing, and including approaches you rejected and why.
+        A rejected alternative with a reason is often the most useful thing in
+        the issue - it stops triage re-deriving it.
     validations:
       required: false
 
   - type: checkboxes
     id: breaking
     attributes:
-      label: Compatibility
+      label: "Scope: compatibility"
+      description: Tick anything the plan above would touch. Each one turns this into a decision rather than a fix.
       options:
-        - label: This changes an existing response shape, status code, CLI flag, or default.
+        - label: Changes an existing response shape, status code, CLI flag, or default.
           required: false
-        - label: This adds, removes, or upgrades a dependency.
+        - label: Adds, removes, or upgrades a dependency.
           required: false
-        - label: This changes database schema or requires a migration.
+        - label: Changes database schema or requires a migration.
           required: false
-        - label: This touches authentication, permissions, validation, or spend limits.
+        - label: Touches authentication, permissions, validation, or spend limits.
           required: false
-        - label: This changes pricing, plan limits, or anything a user is charged.
+        - label: Changes pricing, plan limits, or anything a user is charged.
           required: false

--- a/.github/ISSUE_TEMPLATE/change_request.yml
+++ b/.github/ISSUE_TEMPLATE/change_request.yml
@@ -1,0 +1,82 @@
+name: Behaviour change or new feature
+description: Propose something KeeperHub should do that it does not do today.
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Lead with what you are trying to do, not with what to build. The problem
+        is stable and the solution is negotiable - we may already know a cheaper
+        one, or a reason the obvious one does not work here.
+
+        Wait for the `accepted` label before writing code. See
+        [ISSUES.md](https://github.com/KeeperHub/keeperhub/blob/staging/ISSUES.md).
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before filing
+      options:
+        - label: I searched open and closed issues for this proposal.
+          required: true
+        - label: I checked the docs and the current behaviour on `staging`.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What you cannot do today
+      description: >-
+        The concrete task that is blocked or awkward, and what you currently do
+        instead. Real usage beats a hypothetical - if this came out of building
+        something, describe that.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you propose
+      description: >-
+        The change as you would build it. Include the API or UI shape if it has
+        one, and say what happens to existing callers.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: >-
+        What this touches, and explicitly what it does not. Then apply the split
+        test: can each piece of this ship, deploy, and be correct with the other
+        pieces reverted? If yes, they are separate issues - list them and file
+        the rest separately.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+      description: >-
+        Including doing nothing. If there is a workaround that already works,
+        say what it costs you - that is what tells us the size of the problem.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: breaking
+    attributes:
+      label: Compatibility
+      options:
+        - label: This changes an existing response shape, status code, CLI flag, or default.
+          required: false
+        - label: This adds, removes, or upgrades a dependency.
+          required: false
+        - label: This changes database schema or requires a migration.
+          required: false
+        - label: This touches authentication, permissions, validation, or spend limits.
+          required: false
+        - label: This changes pricing, plan limits, or anything a user is charged.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/KeeperHub/keeperhub/security
+    about: Report privately. Never in a public issue or pull request.
+  - name: Product and API documentation
+    url: https://docs.keeperhub.com
+    about: Check the docs before filing - the behaviour may be intentional and described.
+  - name: Contribution policy
+    url: https://github.com/KeeperHub/keeperhub/blob/staging/ISSUES.md
+    about: What needs an issue, what does not, and what happens after you file one.

--- a/.github/ISSUE_TEMPLATE/docs_issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs_issue.yml
@@ -1,0 +1,52 @@
+name: Documentation problem
+description: A docs page is wrong, missing, or contradicts the code.
+labels: ["documentation", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **You may not need this form.** A typo, a broken link, or a statement
+        that simply needs to match code which already behaves that way can go
+        straight to a pull request titled `docs: ...` - no issue required.
+
+        Use this form when the docs and the code genuinely disagree and it is
+        not obvious which one should change, or when a page is missing entirely.
+
+  - type: input
+    id: page
+    attributes:
+      label: Page
+      description: The URL on docs.keeperhub.com, or the path under `docs/`.
+      placeholder: https://docs.keeperhub.com/api/direct-execution
+    validations:
+      required: true
+
+  - type: textarea
+    id: claim
+    attributes:
+      label: What the page says
+      description: Quote the sentence or block, with the line number if you have it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reality
+    attributes:
+      label: What the code does
+      description: >-
+        The file and line that settles it, or the request and response showing
+        the real behaviour. This is the part that makes the issue answerable in
+        one pass - a docs claim is only wrong relative to some code.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: which
+    attributes:
+      label: Which one is wrong
+      options:
+        - The docs - the code is behaving correctly
+        - The code - the docs describe the intended behaviour
+        - Not sure
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/docs_issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs_issue.yml
@@ -24,7 +24,7 @@ body:
   - type: textarea
     id: claim
     attributes:
-      label: What the page says
+      label: "Reason: what the page says"
       description: Quote the sentence or block, with the line number if you have it.
     validations:
       required: true
@@ -32,21 +32,43 @@ body:
   - type: textarea
     id: reality
     attributes:
-      label: What the code does
+      label: "Reason: what the code does"
       description: >-
         The file and line that settles it, or the request and response showing
-        the real behaviour. This is the part that makes the issue answerable in
-        one pass - a docs claim is only wrong relative to some code.
+        the real behaviour. A docs claim is only wrong relative to some code, so
+        this is the field that makes the issue answerable in one pass.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: "Scope: where else this appears"
+      description: >-
+        The same claim often appears on several pages, in a tool description, in
+        an error message, and in a type. List the ones you found, and say where
+        you looked and found it correct. Fixing one page and leaving four is the
+        common failure here.
     validations:
       required: true
 
   - type: dropdown
-    id: which
+    id: plan
     attributes:
-      label: Which one is wrong
+      label: "Plan: which one changes"
       options:
         - The docs - the code is behaving correctly
         - The code - the docs describe the intended behaviour
-        - Not sure
+        - Not sure, needs a maintainer to decide
+    validations:
+      required: true
+
+  - type: textarea
+    id: plan_detail
+    attributes:
+      label: "Plan: the correction"
+      description: >-
+        What the page should say instead, or what the code should do. If you
+        picked "not sure" above, say what would settle it.
     validations:
       required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,52 @@
+<!--
+Title format:  <type>: #<issue> <description>
+    fix: #1978 return 403 with a body on public /api/chains
+    feat(cli): #2014 add --require-verified to execute status
+
+The issue must carry the `accepted` label before you open this. See ISSUES.md.
+Exempt: docs / chore / style changes from the "no issue required" list.
+-->
+
+## Issue
+
+Closes #
+
+<!-- If this needs no issue, say which exemption applies and delete the line above. -->
+
+## What this changes
+
+<!--
+What the diff does and why. The diff already shows how.
+Name anything a reader would not predict from the title: touched CI or config,
+a new dependency, a changed default, an altered auth or validation path.
+-->
+
+## Scope
+
+<!--
+Confirm this is one change: could any part of it ship, deploy, and be correct
+with the rest reverted? If yes, split it. If the parts are interdependent, say
+why in one line - "the migration cannot deploy without the backfill".
+-->
+
+## How it was verified
+
+<!--
+Tests added or updated, and what they would catch. Commands you ran.
+For a bug fix, the test that fails without the fix.
+-->
+
+## Screenshots
+
+<!--
+Required for anything that renders. Before and after, each state the change
+touches (empty, loading, error), and both themes if colour or contrast moved.
+Delete this section if the change renders nothing.
+-->
+
+---
+
+- [ ] Targets `staging`
+- [ ] Title carries the issue number, or an exemption applies
+- [ ] `pnpm check` and `pnpm type-check` pass
+- [ ] No secrets, `.env` files, or credentials committed

--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -1,0 +1,105 @@
+name: PR Issue Link
+
+# Runs on pull_request_target so it also runs on fork pull requests, which are
+# the ones this gate exists for. Fork runs of `pull_request` need per-run
+# maintainer approval, which would leave the gate silent exactly where it is
+# needed.
+#
+# SAFETY: pull_request_target runs with the base repository's token. This job
+# therefore never checks out, builds, or executes pull request code. It reads
+# the title, the labels, and the referenced issue through the API and nothing
+# else. Do not add a checkout step to this file.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, labeled, unlabeled]
+    branches:
+      - staging
+      - prod
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  check-issue-link:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require an accepted issue in the PR title
+        env:
+          # Untrusted input. Passed through the environment and never
+          # interpolated into the script body.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          EXEMPT_LABEL: no-issue-required
+          ACCEPTED_LABEL: accepted
+          # Types that never require an issue. Keep in step with the
+          # "not required" list in ISSUES.md.
+          EXEMPT_TYPES: docs chore style
+        run: |
+          set -euo pipefail
+
+          fail() {
+            echo "----------------------------------------------"
+            echo "  ERROR: $1"
+            echo "----------------------------------------------"
+            echo ""
+            echo "  Got title: $PR_TITLE"
+            echo ""
+            echo "  KeeperHub takes issues before pull requests. Open an issue,"
+            echo "  wait for a maintainer to apply the '$ACCEPTED_LABEL' label,"
+            echo "  then reference it in this PR's title:"
+            echo ""
+            echo "    fix: #1978 return 403 with a body on public /api/chains"
+            echo "    feat(cli): #2014 add --require-verified to execute status"
+            echo ""
+            echo "  No issue needed for typos, broken links, formatting, or docs"
+            echo "  corrected to match existing behaviour. Retitle as one of:"
+            echo "    $EXEMPT_TYPES"
+            echo ""
+            echo "  Full policy: https://github.com/$REPO/blob/staging/ISSUES.md"
+            echo ""
+            echo "  Already labelled '$ACCEPTED_LABEL'? This check does not rerun"
+            echo "  by itself when the issue changes - re-run the job, or edit"
+            echo "  the PR title to retrigger it."
+            exit 1
+          }
+
+          if printf '%s' "$PR_LABELS" | grep -qF "\"$EXEMPT_LABEL\""; then
+            echo "Exempt: pull request carries the '$EXEMPT_LABEL' label."
+            exit 0
+          fi
+
+          pr_type=$(printf '%s' "$PR_TITLE" | sed -nE 's/^([a-zA-Z]+)(\([^)]*\))?!?:.*/\1/p' | tr '[:upper:]' '[:lower:]')
+          for exempt in $EXEMPT_TYPES; do
+            if [ "$pr_type" = "$exempt" ]; then
+              echo "Exempt: '$pr_type' changes do not require an issue."
+              exit 0
+            fi
+          done
+
+          issue_number=$(printf '%s' "$PR_TITLE" | grep -oE '#[0-9]+' | head -n1 | tr -d '#')
+          if [ -z "$issue_number" ]; then
+            fail "PR title carries no issue reference."
+          fi
+
+          if ! issue_json=$(gh api "repos/$REPO/issues/$issue_number" 2>/dev/null); then
+            fail "#$issue_number does not resolve to an issue in $REPO."
+          fi
+
+          if printf '%s' "$issue_json" | jq -e '.pull_request' >/dev/null 2>&1; then
+            fail "#$issue_number is a pull request, not an issue."
+          fi
+
+          if ! printf '%s' "$issue_json" | jq -e --arg l "$ACCEPTED_LABEL" \
+            '.labels | map(.name) | index($l)' >/dev/null 2>&1; then
+            state=$(printf '%s' "$issue_json" | jq -r '.state')
+            labels=$(printf '%s' "$issue_json" | jq -r '[.labels[].name] | join(", ")')
+            fail "#$issue_number is not marked '$ACCEPTED_LABEL' (state: $state; labels: ${labels:-none})."
+          fi
+
+          echo "PR title references accepted issue #$issue_number."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,16 @@
 # Contributing to KeeperHub
 
-Internal contribution guide for the KeeperHub workflow automation platform.
+Contribution guide for the KeeperHub workflow automation platform.
+
+## Start with an issue
+
+Anything that changes behaviour needs an issue first, accepted by a maintainer,
+before the pull request. **[ISSUES.md](ISSUES.md) is the policy** - what needs an
+issue, what goes straight to a pull request, and what happens after you file one.
+
+The short version: open an issue, wait for the `accepted` label, then reference
+it in your pull request title (`fix: #1978 description`). Typos, broken links,
+formatting, and docs corrected to match existing behaviour skip all of that.
 
 ## Table of Contents
 
@@ -96,6 +106,8 @@ make hybrid-down      # Teardown
 
 ### Before Submitting
 
+- The backing issue carries the `accepted` label, or the change is on the
+  no-issue-required list in [ISSUES.md](ISSUES.md)
 - All tests pass
 - Code passes lint (`pnpm check`) and type check (`pnpm type-check`)
 - Changes are tested thoroughly
@@ -103,10 +115,11 @@ make hybrid-down      # Teardown
 
 ### PR Guidelines
 
-1. **Title**: Must follow conventional commit format (`feat: description` or `feat(scope): description`). This is enforced by the `pr-title-check` workflow
+1. **Title**: Conventional commit format carrying the reference, `<type>: #<issue> <description>` or `<type>(scope): #<issue> <description>`. Internal work uses its Linear code in the same position (`feat: KEEP-1234 description`); outside contributions use the GitHub issue number (`fix: #1978 description`). Enforced by the `pr-title-check` and `pr-issue-link` workflows
 2. **Base branch**: Always target `staging`
 3. **Description**: Explain what and why, not just how
-4. **Screenshots**: Include for UI changes
+4. **Scope**: One change per pull request. If a part of it could ship and be correct with the rest reverted, split it
+5. **Screenshots**: Include for UI changes - before and after, and each state the change touches
 
 ### Deploy Verification
 

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -41,39 +41,72 @@ any code is written.
 If you are unsure, open the issue. A wrong guess in that direction costs you a
 day; the other direction can cost you the whole change.
 
+## Reason, scope, plan
+
+Every issue carries three things. An issue missing any of them cannot be
+answered, only discussed, and discussion is what this policy exists to replace.
+
+**Reason** - why this matters, in evidence rather than assertion. For a bug that
+is a runnable reproduction, what happened, what you expected, *what told you to
+expect it*, and what it costs someone who hits it. For a change it is the task
+you cannot accomplish and what the workaround costs.
+
+The "what told you to expect it" part settles more issues than anything else. An
+expectation comes from somewhere - a docs page, an error message, a type, a
+function name. Naming that source tells us immediately whether the code is wrong
+or the source is, and those have completely different fixes.
+
+**Scope** - what this covers and, explicitly, what it does not. Which surfaces
+you checked and found fine. Whether the same fault plausibly exists on sibling
+routes or commands. A fix applied to one route and not its three siblings is a
+recurring failure here, and scope is where it gets caught.
+
+Scope is also where you confirm this is *one* issue. If any part could be fixed
+and shipped while another part stays broken, those are separate issues. See
+[Should this be one change](#should-this-be-one-change).
+
+**Plan** - what should happen next. This is your proposal, not a commitment we
+have made, and triage may replace it.
+
+A plan does not require knowing the fix. If you cannot see the codebase, *"I do
+not know the fix; here is what I would need to determine to choose one"* is a
+complete and useful plan. What is not acceptable is leaving it blank: a problem
+with no proposed next step puts the entire cost of thinking on whoever reads it,
+which is exactly the load this policy is meant to move upstream.
+
+What a plan buys you is a check nothing else provides. A proposal stated out
+loud can be tested against the actual contract before any code exists - and a
+well-evidenced issue can still carry a wrong plan. One report here correctly
+observed that `parseNativeValueWei` parses with `ethers.parseEther`, and
+proposed denominating `value` in wei. The observation was right; the plan would
+have silently changed every existing caller's amount by a factor of 1e18,
+because the API's documented unit is ether and the misleading thing is the
+internal function name. That was caught by reading the plan. Unwritten, it would
+have been caught by reading the pull request.
+
 ## What happens to your issue
 
 | Label | Meaning |
 |---|---|
 | `needs-triage` | Received, not yet read. Applied automatically. |
-| `accepted` | The problem is real and the proposed approach is sound and correctly scoped. Write the pull request. |
-| `needs-discussion` | Real, but the approach or the scope is not settled. Do not start yet. |
+| `confirmed` | Someone reproduced it. Says nothing yet about whether we will fix it. |
+| `accepted` | Reason, scope and plan all stand. Write the pull request. |
+| `needs-discussion` | Real, but the scope or the plan is not settled. Do not start yet. |
 | `wontfix` / `duplicate` / `invalid` | Closed, with the reason in a comment. |
 
 **`accepted` is the signal to start.** It is what the pull request gate checks
-for. Nothing else on the issue means "go".
+for. Nothing else on the issue means "go" - `confirmed` in particular does not,
+because reproducing something is not the same as deciding to change it.
+
+**`accepted` accepts a specific plan.** If triage takes your reason and scope but
+replaces your plan, it says so in a comment before applying the label, and that
+comment is the plan. Build against it, not against the one you filed. An
+`accepted` label with no comment means your plan as written was accepted as
+written.
 
 We aim to triage within two working days. If an issue has sat longer than that,
 comment on it - that is not nagging, it is the correct response, and it is the
 fastest way to get it moving.
-
-## What makes an issue answerable
-
-The issue forms ask for these. They exist so we can answer in one pass instead
-of three.
-
-**For a bug**, the thing that settles it is a reproduction: the exact request or
-steps, what happened, what you expected, and on which environment. A stack
-trace, a request id, or a failing response body is worth more than a paragraph
-of description.
-
-**For a change in behaviour**, tell us what you want to do that you currently
-cannot, before telling us what to build. The problem is stable; the solution is
-negotiable, and we may know a cheaper one.
-
-**Scope it.** Name what the change touches and, explicitly, what it does not. If
-you find yourself listing two things joined by "and", that is usually two
-issues. See [Should this be one change](#should-this-be-one-change).
 
 **Check it is still there.** `staging` moves quickly. Confirm the behaviour on
 the current default branch before filing, and say which commit you checked.

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -84,6 +84,20 @@ because the API's documented unit is ether and the misleading thing is the
 internal function name. That was caught by reading the plan. Unwritten, it would
 have been caught by reading the pull request.
 
+### Already filed an issue
+
+Nothing here applies retroactively. Issues filed before this page existed are
+triaged on what they contain, and you will never be asked to resubmit one to
+match a template that did not exist when you wrote it.
+
+More generally, and for new issues too: **you will not be asked to restate
+something you have already said.** If triage needs one more fact, it asks for
+that fact, on your issue. The forms exist so we can answer in one pass, not as a
+standard you have to be measured against.
+
+If an issue turns out to hold several problems, we split it and credit you on
+each part. Finding several problems is the work; refiling them is not.
+
 ## What happens to your issue
 
 | Label | Meaning |

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,142 @@
+# Issues before pull requests
+
+Open an issue before you write code. We answer it, and once the problem and the
+shape of the fix are agreed, the pull request is a short step rather than a
+negotiation.
+
+This is not paperwork. Every item below is something that has cost a real
+contributor real work on this repo:
+
+- A pull request corrected two lines that `staging` had already corrected, by
+  another route, days earlier. The whole change was dead on arrival.
+- A pull request reversed a decision recorded in a comment in the code, for
+  good reasons the author had no way to know were already weighed.
+- A pull request bundled two unrelated fixes, so the simple one waited on the
+  hard one.
+
+None of those are review problems. They are all answerable in a sentence before
+any code is written.
+
+## When an issue is required
+
+**Required** for anything that changes behaviour:
+
+- Application, API, or CLI behaviour, including response shapes and status codes
+- Database schema or migrations
+- Authentication, permissions, validation, or rate limiting
+- Dependencies added, removed, or upgraded
+- CI, build, deployment, or environment configuration
+- Pricing, limits, plans, or anything a user is charged for
+- New features and new abstractions
+
+**Not required** - open a pull request directly:
+
+- Typos, broken links, and formatting
+- Documentation that corrects a statement to match code that already behaves
+  that way
+- Comment and error-message wording
+- Declaring a dependency the code already imports, at the version already
+  resolved
+
+If you are unsure, open the issue. A wrong guess in that direction costs you a
+day; the other direction can cost you the whole change.
+
+## What happens to your issue
+
+| Label | Meaning |
+|---|---|
+| `needs-triage` | Received, not yet read. Applied automatically. |
+| `accepted` | The problem is real and the proposed approach is sound and correctly scoped. Write the pull request. |
+| `needs-discussion` | Real, but the approach or the scope is not settled. Do not start yet. |
+| `wontfix` / `duplicate` / `invalid` | Closed, with the reason in a comment. |
+
+**`accepted` is the signal to start.** It is what the pull request gate checks
+for. Nothing else on the issue means "go".
+
+We aim to triage within two working days. If an issue has sat longer than that,
+comment on it - that is not nagging, it is the correct response, and it is the
+fastest way to get it moving.
+
+## What makes an issue answerable
+
+The issue forms ask for these. They exist so we can answer in one pass instead
+of three.
+
+**For a bug**, the thing that settles it is a reproduction: the exact request or
+steps, what happened, what you expected, and on which environment. A stack
+trace, a request id, or a failing response body is worth more than a paragraph
+of description.
+
+**For a change in behaviour**, tell us what you want to do that you currently
+cannot, before telling us what to build. The problem is stable; the solution is
+negotiable, and we may know a cheaper one.
+
+**Scope it.** Name what the change touches and, explicitly, what it does not. If
+you find yourself listing two things joined by "and", that is usually two
+issues. See [Should this be one change](#should-this-be-one-change).
+
+**Check it is still there.** `staging` moves quickly. Confirm the behaviour on
+the current default branch before filing, and say which commit you checked.
+
+## Should this be one change
+
+Apply this to each seam you can see in what you are proposing:
+
+> Can piece A ship, deploy, and be correct with piece B absent or reverted?
+
+If yes for every pair, they are separate issues and separate pull requests, no
+matter how small. If any piece is only correct in the presence of another - a
+schema migration and the backfill that depends on it, an interface change and
+all its callers - they are one unit, no matter how large.
+
+Diff size is not the test. A large, genuinely coupled change is one pull
+request. Two small independent fixes are two.
+
+## Opening the pull request
+
+Once your issue carries `accepted`:
+
+1. **Reference the issue in the pull request title**, after the conventional
+   commit type:
+
+   ```
+   fix: #1978 return 403 with a body on public /api/chains
+   feat(cli): #2014 add --require-verified to execute status
+   ```
+
+   This mirrors the internal `fix: KEEP-1234 description` convention. The
+   `pr-title-check` workflow already accepts this shape; a separate check
+   resolves the issue number and confirms the issue carries `accepted`.
+
+2. Fill in the pull request template. The description explains what and why -
+   the diff already shows how.
+
+3. Target `staging`.
+
+Pull requests that need no issue (the list above) are exempt from the check
+automatically when their type is `docs`, `chore`, or `style`. Anything else
+without a reference is failed by CI with instructions. A maintainer can apply
+`no-issue-required` to exempt a pull request the rules did not anticipate.
+
+## Continuing an existing issue
+
+Someone may have filed it already. Search open **and** closed issues first - a
+closed one often carries the reason, and reopening that thread with new evidence
+is more useful than a fresh report.
+
+If an issue is `accepted` and unclaimed, say you are taking it before you start,
+so two people do not build the same thing.
+
+## Security
+
+Do not open an issue for a vulnerability, and do not open a pull request that
+fixes one in public. Use [GitHub Private Vulnerability
+Reporting](https://github.com/KeeperHub/keeperhub/security) or the email address
+in [.github/SECURITY.md](.github/SECURITY.md), which also states what is in and
+out of scope.
+
+## Related
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) - setup, workflow, testing, plugin
+  development
+- [docs.keeperhub.com](https://docs.keeperhub.com) - product and API reference


### PR DESCRIPTION
Anything that changes behaviour needs an issue a maintainer has marked `accepted` before the pull request, referenced in the PR title after the conventional-commit type. Typos, broken links, formatting, and docs corrected to match existing behaviour go straight to a pull request as they do today.

## Why

Three things from the last sweep, each answerable in a sentence before any code was written:

- **#1987** corrected two lines that `staging` had already corrected by another route, days earlier. The whole change was dead on arrival, and the contributor had no way to know.
- **#1997** reverses a decision recorded in `lib/workflow/soft-delete.ts:10-12` ("the owner-facing workflow list is the deliberate exception"), for good reasons the author could not have known were already weighed.
- **#1996** bundles a pnpm-resolution fix with an unrelated browser-readiness handshake, so the simple half waits on the hard one.

Contributors are already filing issues - 16 of the 17 open ones are from outside - but zero of the 12 open contributor PRs reference an issue. The two queues never meet.

## What is here

- `ISSUES.md` - the policy. What needs an issue, what does not, and what happens after you file.
- `.github/ISSUE_TEMPLATE/` - bug, behaviour change, and docs forms; free-text issues off.
- `.github/PULL_REQUEST_TEMPLATE.md` - with the issue reference and the split test.
- `.github/workflows/pr-issue-link.yml` - the gate.
- `CONTRIBUTING.md` - points at `ISSUES.md`, and the title format now carries the reference.

### Reason, scope, plan

Every issue carries three parts, all required.

**Reason** is evidence: a runnable reproduction, what happened, what you expected, **what told you to expect it**, and what it costs someone who hits it. That fourth field settles the most - an expectation comes from a docs page, an error, a type, or a function name, and naming the source says immediately whether the code is wrong or the source is.

**Scope** is what is covered, what is not, and which sibling surfaces were checked. Partial fixes are a recurring pattern here.

**Plan** is the filer's proposal, and is now required rather than optional. If triage replaces it, triage says so in a comment before applying `accepted`, and that comment becomes the plan. "I do not know the fix; here is what I would need to determine" is valid. Blank is not.

A written plan is checkable before code exists. Issue #1928 correctly observed that `parseNativeValueWei` parses with `ethers.parseEther`, then proposed denominating `value` in wei - which would have changed every existing caller's amount by 1e18, because `docs/api/direct-execution.md:354` documents the unit as ether and the misleading thing is the internal function name. Reading the plan caught that in about ninety seconds. Unwritten, the pull request would have.

### The title format already passes `pr-title-check`

Its regex is `^(feat|fix|...)(\([^)]*\))?[!]?:[[:space:]].+`, so `fix: #1978 description` validates today. Outside contributions put the issue number exactly where internal work puts its Linear code.

### The gate

`pr-issue-link.yml` passes on an `accepted` issue reference, on a `docs` / `chore` / `style` type, or on a `no-issue-required` label. It fails on missing, unaccepted, not-an-issue, and unresolved, each with the format and a link in the failure output.

It runs on `pull_request_target` deliberately: fork runs of `pull_request` need per-run approval, so the gate would be silent on exactly the pull requests it exists for - nine of ten open fork PRs currently have zero check runs. It reads the title, the labels, and the referenced issue through the API, never checks out or executes PR code, and there is a comment in the file saying not to add a checkout step.

Tested against 17 cases before commit, including four command-injection attempts through the PR title. The title is untrusted input, passed through the environment and never interpolated into the script.

## Nothing applies retroactively

The 12 open contributor PRs are grandfathered by machine: `queue.sh` reports `issue_state: grandfathered` until `POLICY_START` is set, so nobody is asked for an issue on work already in flight.

Existing issues are grandfathered by rule, which is weaker and so is written down in both `ISSUES.md` and the triage guidance: no filer is asked to resubmit through a form that did not exist when they filed, or to restate something already in their issue. Scoring the 17 open issues against the standard found 12 already clearing the reason bar, and nine were triaged to a verdict with no further input from the filer.

Compound issues get split by us, with the reporter credited on each part.

## Before this is useful

Three labels have to exist, or every non-exempt PR fails the gate:

```bash
gh label create "accepted" --repo KeeperHub/keeperhub --color 0e8a16 \
  --description "Reason, scope and plan all stand - a PR for this is welcome"
gh label create "confirmed" --repo KeeperHub/keeperhub --color 0e8a16 \
  --description "Reproduced. Says nothing about whether we will fix it"
gh label create "needs-triage" --repo KeeperHub/keeperhub --color ededed \
  --description "Filed, not yet read by a maintainer"
gh label create "needs-discussion" --repo KeeperHub/keeperhub --color FBCA04 \
  --description "Real, but the scope or the plan is not settled"
gh label create "no-issue-required" --repo KeeperHub/keeperhub --color ededed \
  --description "PR exempt from the issue-first gate"
```

Then set `--policy-start` on the sweep to this PR's merge date, and clear the existing 17-issue backlog before turning the gate on. A contributor hitting a red check that says "wait for `accepted`" against a queue that has not moved in a week is the failure this is meant to prevent.

## Out of scope, filed separately

`decision-label-check.yml` blocks merge on a label named `decision`. That label was renamed to `decision-needed` on 2026-08-05 and no label named `decision` exists in the repo, so the gate cannot fire - PRs #1993 and #1997 both carry an unanswered decision and nothing blocks either. It also triggers on `pull_request`, so it would not run on fork PRs regardless. Two one-line fixes, deliberately not bundled here.

This PR is `docs`-typed, so it is exempt from its own gate.
