### PR TITLE
feat(self-hosted): make the app installable without depending on KeeperHub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -247,3 +247,42 @@ ZERION_API_KEY=
 # Max in-flight direct executions (pending+running) before the execute write
 # routes return 429. Defaults to 100.
 # MAX_CONCURRENT_DIRECT_EXECUTIONS=100
+
+# --- Self-hosting seams -----------------------------------------------------
+# Every variable below defaults to the value the code carried before it existed,
+# so leaving the whole block unset changes nothing. They exist so a deployment
+# KeeperHub does not run can point at its own services, or stop talking to a
+# third party it did not choose. deploy/keeperhub-stack/self-hosted/DEPENDENCIES.md
+# lists what each one actually contacts.
+
+# Turns the signup captcha off. Without it the only way to boot without
+# TURNSTILE_SECRET_KEY is CI=true, which also changes unrelated behaviour.
+# Leaves /sign-up/email open to automated signups, so it logs a warning at boot.
+# TURNSTILE_ENFORCE=true wins over it.
+TURNSTILE_DISABLED=
+
+# Set to "false" to stop resolving sign-in locations. The provider chain is
+# keyless, so a deployment that configures nothing still sends every signing-in
+# user's IP to ipapi.co, then ipwho.is, then freeipapi.com. Sessions simply show
+# no location when this is off. Any other value, including unset, means on.
+GEOIP_ENABLED=
+
+# Where transactional mail is posted. Anything accepting SendGrid's v3
+# mail/send request shape works, so this can point at a self-hosted relay.
+SENDGRID_API_URL=
+
+# Turnkey API endpoint, for a Turnkey-compatible service of your own.
+TURNKEY_API_BASE_URL=
+
+# Logo shown in transactional email. The default lives in KeeperHub's public
+# repository, so the recipient's mail client tells GitHub when they open the
+# message. Set empty to send no logo at all.
+EMAIL_LOGO_URL=
+
+# Base URL for the /llms.txt redirect. Set empty to drop the redirect instead of
+# sending your users to KeeperHub's docs. Read at build time.
+DOCS_BASE_URL=
+
+# The `resource` signed into pay-as-you-go x402 payment payloads. Only relevant
+# when billing is enabled.
+PAYG_RESOURCE_URL=

--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,26 @@ ADDITIONAL_TRUSTED_ORIGINS=
 # OpenAI API key for workflow orchestration
 export OPENAI_API_KEY=""
 
+
+# Identity this deployment publishes to agent registries, reputation scorers and
+# OAuth clients, via the .well-known routes (lib/agent-identity.ts). Every value
+# defaults to KeeperHub's own, so leaving these unset changes nothing.
+#
+# Renaming the agent without also supplying AGENT_ID withholds the on-chain
+# registration rather than republishing KeeperHub's under the new name - a
+# reputation reader would believe it. Set the whole group or none of it.
+AGENT_NAME=
+AGENT_DESCRIPTION=
+AGENT_ID=
+AGENT_REGISTRY_ADDRESS=
+AGENT_REGISTRY_CHAIN=
+AGENT_REGISTRY_CHAIN_ID=
+
+# Status page script embedded in the app shell. Absent by default, so a
+# deployment that runs no status page makes no request for one. Our own
+# environments set it in their Helm values.
+STATUS_EMBED_SRC=
+
 # Oldest `kh` CLI release this deployment considers supported. Advertised to
 # every CLI response via the KH-Minimum-CLI-Version header (lib/cli-version.ts);
 # older builds print an upgrade warning. Defaults to 0.11.1 if unset.

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,16 @@ MCP_SESSION_SECRET=
 # better-auth callback URL (matches the dev server)
 BETTER_AUTH_URL=http://localhost:3000
 
+# Extra origins trusted for cookie-authenticated writes, comma-separated, on
+# top of localhost and *.keeperhub.com (lib/trusted-origins.ts). Needed only by
+# a deployment served on a domain we do not own: without it every save returns
+# 403 with "[csrf] blocked: untrusted origin" while the UI still loads and
+# reads. Same wildcard syntax as the built-in entries, one leading "*." allowed
+# in the host. Entries without a scheme, with a wildcard scheme or host, or
+# carrying a path are ignored, because they would trust far more than intended.
+#   ADDITIONAL_TRUSTED_ORIGINS=https://keeperhub.acme.example,https://*.acme.internal
+ADDITIONAL_TRUSTED_ORIGINS=
+
 # =============================================================================
 # Feature-specific (only needed when you exercise that feature)
 # =============================================================================

--- a/.github/workflows/maintainability.yml
+++ b/.github/workflows/maintainability.yml
@@ -2,7 +2,17 @@ name: Maintainability
 
 on:
   pull_request:
-    branches: [staging]
+    branches:
+      - staging
+      # The self-hosted milestone integrates on its own gate branch, so its pull
+      # requests never target staging and none of the checks below ran on any of
+      # them. Left alone, every one of these jobs would fire for the first time
+      # on the single large pull request that takes the whole milestone to
+      # staging. Listing the gate branch runs them per merge instead.
+      #
+      # Temporary. Delete this entry when the gate branch merges and is deleted;
+      # a filter naming a branch that no longer exists is silent dead config.
+      - KEEP-1114-gate-m0-aws-free-install
 
 permissions:
   contents: read

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -142,6 +142,32 @@ jobs:
             exit 1
           fi
 
+      - name: Forbid KeeperHub-operated hosts in RPC and chain defaults
+        # A deployment that configures no RPCs falls through to the defaults in
+        # lib/rpc/, and scripts/seed/ writes those into the chains table on
+        # every deploy. An endpoint we operate in either place would silently
+        # and durably route that deployment's chain traffic - addresses,
+        # contracts, transaction payloads - through our infrastructure.
+        #
+        # tests/unit/rpc-config.test.ts asserts the same rule over the exported
+        # table, which catches real values; this catches a literal anywhere in
+        # those directories, including one that never reaches the export.
+        # Comments are matched too, on purpose: a commented-out endpoint is an
+        # invitation to paste it back.
+        # Uses git grep on the checked-out tree; no user input is interpolated.
+        run: |
+          MATCHES=$(git grep -nE 'https?://[^"'"'"'`[:space:]]*(techops\.services|keeperhub\.com)' -- \
+            'lib/rpc/' \
+            'scripts/seed/' \
+            ':!*.test.ts' \
+            ':!*.md' \
+            || true)
+          if [ -n "$MATCHES" ]; then
+            echo "::error::A KeeperHub-operated host is used as an RPC or chain default. Use a third-party public endpoint; deployments that configure nothing inherit these, and the chain seeder makes them durable."
+            echo "$MATCHES"
+            exit 1
+          fi
+
       - name: Check public API docs match route files
         # Parses every documented (METHOD /api/...) entry in docs/api/*.md
         # and asserts the corresponding app/api/<path>/route.ts exists and

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,18 @@
 # Multi-stage Dockerfile for Next.js application
 # Stage 1: Dependencies
 FROM node:24-alpine AS deps
+# CA bundle for TLS to Amazon RDS. Only a deployment whose database is RDS
+# needs it, so the URL is a build arg and an empty value skips the download -
+# a build for a cluster-local or self-managed Postgres then needs no AWS host
+# at all. The file is still created either way because the migrator stage
+# copies it unconditionally.
+ARG RDS_CA_BUNDLE_URL=https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
 RUN apk add --no-cache libc6-compat && \
-    wget -q -O /etc/ssl/certs/rds-combined-ca-bundle.pem \
-      https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
+    if [ -n "$RDS_CA_BUNDLE_URL" ]; then \
+      wget -q -O /etc/ssl/certs/rds-combined-ca-bundle.pem "$RDS_CA_BUNDLE_URL"; \
+    else \
+      : > /etc/ssl/certs/rds-combined-ca-bundle.pem; \
+    fi
 WORKDIR /app
 
 # Install pnpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,6 +98,18 @@ ENV NEXT_PUBLIC_TURNSTILE_SITE_KEY=$NEXT_PUBLIC_TURNSTILE_SITE_KEY
 # so this stage is cache-deterministic across commits (see sentry-upload stage).
 ARG NEXT_PUBLIC_SENTRY_DSN
 ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
+
+# Where /llms.txt redirects. next.config.ts compiles redirects into
+# routes-manifest.json, so this is a build-time value and a runtime env var
+# cannot change it.
+#
+# The default is the current destination, on purpose. An empty value drops the
+# redirect entirely, so a bare `ARG DOCS_BASE_URL` would hand every build an
+# empty string and silently remove it from production. Build with
+# `--build-arg DOCS_BASE_URL=` to opt out; that is what the self-hosted harness
+# does, so an install does not redirect its users to a host KeeperHub runs.
+ARG DOCS_BASE_URL=https://docs.keeperhub.com
+ENV DOCS_BASE_URL=$DOCS_BASE_URL
 ENV CI=true
 
 # KEEP-237: Gate admin test routes at build time. Set to "true" for

--- a/app/.well-known/agent-card.json/route.ts
+++ b/app/.well-known/agent-card.json/route.ts
@@ -2,27 +2,23 @@
 // agent registry as the "A2A" service so 8004scan can discover capabilities
 // without an MCP handshake.
 
-const TRAILING_SLASH = /\/$/;
-
-function deriveBaseUrl(request: Request): string {
-  const envUrl = process.env.NEXT_PUBLIC_APP_URL ?? process.env.BETTER_AUTH_URL;
-  if (envUrl) {
-    return envUrl.replace(TRAILING_SLASH, "");
-  }
-  const url = new URL(request.url);
-  return `${url.protocol}//${url.host}`;
-}
+import {
+  agentDescription,
+  agentName,
+  deriveBaseUrl,
+} from "@/lib/agent-identity";
 
 export function GET(request: Request): Response {
   const baseUrl = deriveBaseUrl(request);
   const card = {
-    name: "KeeperHub",
-    description:
-      "Execution layer for AI agents operating onchain. Discover and call DeFi workflows via MCP and ERC-8004, pay per execution in USDC over x402 on Base or MPP on Tempo. Managed DeFi 24/7 with onchain audit trail.",
+    name: agentName(),
+    description: agentDescription(
+      "Execution layer for AI agents operating onchain. Discover and call DeFi workflows via MCP and ERC-8004, pay per execution in USDC over x402 on Base or MPP on Tempo. Managed DeFi 24/7 with onchain audit trail."
+    ),
     url: baseUrl,
     version: "1.0.0",
     provider: {
-      organization: "KeeperHub",
+      organization: agentName(),
       url: baseUrl,
     },
     capabilities: {

--- a/app/.well-known/erc8004.json/route.ts
+++ b/app/.well-known/erc8004.json/route.ts
@@ -8,28 +8,37 @@
 // already exists (mcp.json route lines 76-81); only the well-known wrapper
 // was missing.
 
-const TRAILING_SLASH = /\/$/;
-
-function deriveBaseUrl(request: Request): string {
-  const envUrl = process.env.NEXT_PUBLIC_APP_URL ?? process.env.BETTER_AUTH_URL;
-  if (envUrl) {
-    return envUrl.replace(TRAILING_SLASH, "");
-  }
-  const url = new URL(request.url);
-  return `${url.protocol}//${url.host}`;
-}
+import {
+  agentDescription,
+  agentName,
+  deriveBaseUrl,
+  onChainIdentity,
+} from "@/lib/agent-identity";
 
 export function GET(request: Request): Response {
+  const onChain = onChainIdentity();
+
+  // This document IS an on-chain registration - there is no version of it
+  // without one. A deployment that renamed the agent but registered no agent of
+  // its own has nothing true to publish here, and republishing ours under their
+  // name would point reputation readers at the wrong host while looking
+  // entirely plausible. 404 is the honest answer; the endpoint returned exactly
+  // that before the registration existed.
+  if (!onChain) {
+    return new Response(null, { status: 404 });
+  }
+
   const baseUrl = deriveBaseUrl(request);
   const card = {
     schema_version: "1",
-    name: "KeeperHub",
-    description:
-      "Execution layer for AI agents operating onchain. ERC-8004 agent identity for KeeperHub workflows.",
-    agent_id: 31_875,
-    chain: "ethereum",
-    chain_id: 1,
-    registry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+    name: agentName(),
+    description: agentDescription(
+      "Execution layer for AI agents operating onchain. ERC-8004 agent identity for KeeperHub workflows."
+    ),
+    agent_id: onChain.agentId,
+    chain: onChain.chain,
+    chain_id: onChain.chainId,
+    registry: onChain.registry,
     cards: {
       mcp: `${baseUrl}/.well-known/mcp.json`,
       a2a: `${baseUrl}/.well-known/agent-card.json`,
@@ -42,8 +51,8 @@ export function GET(request: Request): Response {
       type: "erc-8004",
       // Feedback writes flow through the agentic-wallet path; consumers
       // read directly from the on-chain registry.
-      registry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
-      chain_id: 1,
+      registry: onChain.registry,
+      chain_id: onChain.chainId,
     },
   };
 

--- a/app/.well-known/mcp.json/route.ts
+++ b/app/.well-known/mcp.json/route.ts
@@ -5,24 +5,24 @@
 // authenticated, org-scoped surface is advertised separately under
 // `authenticatedEndpoint` (OAuth-gated /mcp).
 
+import {
+  agentDescription,
+  agentName,
+  deriveBaseUrl,
+  onChainIdentity,
+} from "@/lib/agent-identity";
 import { getAuthenticatedToolsForDiscovery } from "@/lib/mcp/mcp-tool-catalog";
 import { PUBLIC_TOOLS } from "@/lib/mcp/oauth-scopes";
 
-const TRAILING_SLASH = /\/$/;
-
-function deriveBaseUrl(request: Request): string {
-  const envUrl = process.env.NEXT_PUBLIC_APP_URL ?? process.env.BETTER_AUTH_URL;
-  if (envUrl) {
-    return envUrl.replace(TRAILING_SLASH, "");
-  }
-  const url = new URL(request.url);
-  return `${url.protocol}//${url.host}`;
-}
+// Server names are slugs, so a configured display name has to be reduced to
+// one. Matches the shape of the previous hardcoded "keeperhub".
+const NON_SLUG_CHARS = /[^a-z0-9]+/g;
 
 const TOOLS = getAuthenticatedToolsForDiscovery();
 
 export function GET(request: Request): Response {
   const baseUrl = deriveBaseUrl(request);
+  const onChain = onChainIdentity();
   const card = {
     $schema:
       "https://static.modelcontextprotocol.io/schemas/mcp-server-card/v1.json",
@@ -30,12 +30,13 @@ export function GET(request: Request): Response {
     version: "1.0.0",
     protocolVersion: "2025-06-18",
     serverInfo: {
-      name: "keeperhub",
-      title: "KeeperHub",
+      name: agentName().toLowerCase().replace(NON_SLUG_CHARS, "-"),
+      title: agentName(),
       version: "1.0.0",
     },
-    description:
-      "Web3 workflow automation platform. Build and deploy on-chain automations through a visual builder. Workflows are callable by AI agents via MCP and x402 micropayments.",
+    description: agentDescription(
+      "Web3 workflow automation platform. Build and deploy on-chain automations through a visual builder. Workflows are callable by AI agents via MCP and x402 micropayments."
+    ),
     iconUrl: `${baseUrl}/keeperhub_logo.png`,
     endpoint: `${baseUrl}/mcp/public`,
     transport: {
@@ -63,12 +64,19 @@ export function GET(request: Request): Response {
         resource_metadata: `${baseUrl}/.well-known/oauth-protected-resource`,
       },
     },
-    erc8004: {
-      agent_id: 31_875,
-      chain: "ethereum",
-      chain_id: 1,
-      registry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
-    },
+    // Omitted entirely when there is no registration this deployment can
+    // truthfully claim - see onChainIdentity(). Republishing ours under another
+    // name would send reputation readers to the wrong host.
+    ...(onChain
+      ? {
+          erc8004: {
+            agent_id: onChain.agentId,
+            chain: onChain.chain,
+            chain_id: onChain.chainId,
+            registry: onChain.registry,
+          },
+        }
+      : {}),
   };
 
   return Response.json(card, {

--- a/app/.well-known/oauth-protected-resource/route.ts
+++ b/app/.well-known/oauth-protected-resource/route.ts
@@ -6,16 +6,7 @@ import {
 
 export const dynamic = "force-dynamic";
 
-const TRAILING_SLASH = /\/$/;
-
-function deriveBaseUrl(request: Request): string {
-  const envUrl = process.env.NEXT_PUBLIC_APP_URL ?? process.env.BETTER_AUTH_URL;
-  if (envUrl) {
-    return envUrl.replace(TRAILING_SLASH, "");
-  }
-  const url = new URL(request.url);
-  return `${url.protocol}//${url.host}`;
-}
+import { agentName, deriveBaseUrl } from "@/lib/agent-identity";
 
 // RFC 9728 Protected Resource Metadata. Claude Desktop and other strict
 // MCP clients discover the authorization server via this document after
@@ -32,7 +23,7 @@ export function GET(request: Request): Response {
     authorization_servers: [baseUrl],
     scopes_supported: [SCOPE_MCP_READ, SCOPE_MCP_WRITE, SCOPE_MCP_ADMIN],
     bearer_methods_supported: ["header"],
-    resource_name: "KeeperHub",
+    resource_name: agentName(),
     resource_documentation: `${baseUrl}/mcp`,
   };
   return Response.json(metadata);

--- a/app/api/agent-registry/route.ts
+++ b/app/api/agent-registry/route.ts
@@ -1,5 +1,11 @@
 import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
+import {
+  agentDescription,
+  agentName,
+  DEFAULT_AGENT_NAME,
+  deriveBaseUrl,
+} from "@/lib/agent-identity";
 import { db } from "@/lib/db";
 import { agentRegistrations } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
@@ -12,7 +18,13 @@ import { getAuthenticatedToolsForDiscovery } from "@/lib/mcp/mcp-tool-catalog";
 const MAINNET_CHAIN_ID = 1;
 const IDENTITY_REGISTRY_ADDRESS = "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432";
 
-export async function GET(_request: Request): Promise<NextResponse> {
+export async function GET(request: Request): Promise<NextResponse> {
+  const baseUrl = deriveBaseUrl(request);
+  // The ENS name and agent wallet are KeeperHub's own and have no configurable
+  // equivalent, so they are published only by a deployment that has not renamed
+  // itself. Same reasoning as the on-chain block elsewhere: a card carrying our
+  // wallet under someone else's name is worse than one without it.
+  const isKeeperHub = agentName() === DEFAULT_AGENT_NAME;
   try {
     const rows = await db
       .select()
@@ -28,32 +40,37 @@ export async function GET(_request: Request): Promise<NextResponse> {
 
     const registrationJson = {
       type: "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
-      name: "KeeperHub",
-      description:
-        "Web3 workflow automation platform. Build and deploy on-chain automations through a visual builder. Workflows are callable by AI agents via MCP.",
-      image: "https://app.keeperhub.com/keeperhub_logo.png",
+      name: agentName(),
+      description: agentDescription(
+        "Web3 workflow automation platform. Build and deploy on-chain automations through a visual builder. Workflows are callable by AI agents via MCP."
+      ),
+      image: `${baseUrl}/keeperhub_logo.png`,
       services: [
         {
           name: "MCP",
-          endpoint: "https://app.keeperhub.com/.well-known/mcp.json",
+          endpoint: `${baseUrl}/.well-known/mcp.json`,
           version: "2025-06-18",
           mcpTools: getAuthenticatedToolsForDiscovery(),
         },
         {
           name: "A2A",
-          endpoint: "https://app.keeperhub.com/.well-known/agent-card.json",
+          endpoint: `${baseUrl}/.well-known/agent-card.json`,
           version: "0.3.0",
         },
         {
           name: "workflows",
-          endpoint: "https://app.keeperhub.com/api/mcp/workflows",
+          endpoint: `${baseUrl}/api/mcp/workflows`,
         },
-        { name: "web", endpoint: "https://app.keeperhub.com" },
-        { name: "ens", endpoint: "keeperhub.eth" },
-        {
-          name: "agentWallet",
-          endpoint: "eip155:1:0xaa70faa583c0889164cfd9b45aa075f6c4388fee",
-        },
+        { name: "web", endpoint: baseUrl },
+        ...(isKeeperHub
+          ? [
+              { name: "ens", endpoint: "keeperhub.eth" },
+              {
+                name: "agentWallet",
+                endpoint: "eip155:1:0xaa70faa583c0889164cfd9b45aa075f6c4388fee",
+              },
+            ]
+          : []),
       ],
       supportedTrust: ["reputation"],
       x402Support: true,

--- a/app/api/og/generate-og.tsx
+++ b/app/api/og/generate-og.tsx
@@ -10,6 +10,22 @@ import { workflows } from "@/lib/db/schema";
 // Font loading (Anek Latin, bundled locally)
 // ---------------------------------------------------------------------------
 
+// The host printed as a watermark on every generated card. Derived from the
+// deployment's own URL so a deployment KeeperHub does not run does not stamp
+// our domain onto its social previews. Server-only module, so this is a runtime
+// read; unset reproduces the literal both sites carried.
+const OG_WATERMARK_HOST = (() => {
+  const configured = process.env.NEXT_PUBLIC_APP_URL;
+  if (!configured) {
+    return "app.keeperhub.com";
+  }
+  try {
+    return new URL(configured).host;
+  } catch {
+    return "app.keeperhub.com";
+  }
+})();
+
 const fontsDir = join(process.cwd(), "app/api/og/fonts");
 
 const fontRegularPromise = readFile(
@@ -334,7 +350,7 @@ export function generateDefaultOGImage(): Promise<ImageResponse> {
           color: "rgba(255,255,255,0.3)",
         }}
       >
-        app.keeperhub.com
+        {OG_WATERMARK_HOST}
       </div>
     </OGBase>,
     86_400
@@ -1015,7 +1031,7 @@ function Header(): React.JSX.Element {
           color: "rgba(255,255,255,0.3)",
         }}
       >
-        app.keeperhub.com
+        {OG_WATERMARK_HOST}
       </div>
     </div>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -82,6 +82,11 @@ export const viewport: Viewport = {
 const ROOT_DEV_BFCACHE_RELOAD =
   "if(typeof window!=='undefined'&&typeof performance!=='undefined'){var n=performance.getEntriesByType('navigation')[0];if(n&&n.type==='back_forward'){window.location.reload();}}";
 
+// Absent unless a deployment names a status page to embed. KeeperHub's own
+// environments set it in their Helm values; every other deployment gets no
+// third-party script and no outbound request.
+const STATUS_EMBED_SRC = process.env.STATUS_EMBED_SRC;
+
 // Width values MUST match COLLAPSED_WIDTH (60) and EXPANDED_WIDTH (200)
 // in components/navigation-sidebar.tsx. DEFAULT_STATE.sidebar=true in
 // lib/hooks/use-persisted-nav-state.ts means new users default to
@@ -144,10 +149,18 @@ const RootLayout = async ({ children }: RootLayoutProps) => {
             {ROOT_DEV_BFCACHE_RELOAD}
           </Script>
         )}
-        <Script
-          src="https://status.keeperhub.com/embed/script.js"
-          strategy="lazyOnload"
-        />
+        {/*
+          The status widget, loaded only where one is configured.
+
+          It used to be unconditional, which meant every page load of every
+          deployment fetched a script from a host KeeperHub operates - including
+          deployments run by someone else, whose users then beaconed us on every
+          visit. Read at runtime rather than through a NEXT_PUBLIC_ variable so a
+          deployment running a prebuilt image can change it without rebuilding.
+        */}
+        {STATUS_EMBED_SRC && (
+          <Script src={STATUS_EMBED_SRC} strategy="lazyOnload" />
+        )}
       </body>
     </html>
   );

--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -183,6 +183,12 @@ app:
 
   env:
     <<: *shared_env
+    # Status page embedded in the app shell. The application renders the
+    # script only when this is set, so a deployment that does not run a status
+    # page - which is any deployment but ours - makes no request for it.
+    STATUS_EMBED_SRC:
+      type: kv
+      value: "https://status.keeperhub.com/embed/script.js"
     LOG_LEVEL:
       type: kv
       value: "info"

--- a/deploy/keeperhub-stack/self-hosted/DEPENDENCIES.md
+++ b/deploy/keeperhub-stack/self-hosted/DEPENDENCIES.md
@@ -1,0 +1,157 @@
+# What KeeperHub talks to
+
+This lists every network destination a KeeperHub install reaches, so you can decide what to
+allow. It is a description of the software, not a policy: your network is yours to configure.
+
+Read it in four parts, because the answer differs by phase. Building the images reaches one set
+of hosts, installing reaches another, and the running product reaches a third. A fourth set is
+reached only because one of your users configured a workflow step that does so.
+
+Wherever something can be switched off or pointed elsewhere, the exact variable is named. Where
+it cannot, this says so instead of leaving it out.
+
+## The short version
+
+KeeperHub operates almost nothing you depend on. In the whole install path there is exactly one
+host we run:
+
+| What | Host | Avoidable |
+| --- | --- | --- |
+| The Helm chart repository | `techops-services.github.io`, `github.com` | Yes. Set `CHART_REPO_URL` to a mirror, or `CHART_DIR` to install from a local copy |
+
+There is no license server, no update check, no usage reporting, and no telemetry. No analytics
+SDK is present among the project's 110 dependencies, and no analytics host appears in the source.
+`better-auth` bundles a telemetry module, but it stays inert unless you set both
+`BETTER_AUTH_TELEMETRY_ENDPOINT` and `BETTER_AUTH_TELEMETRY=true`, and the app sets neither.
+
+Everything else in this document is third-party infrastructure that you configure and pay for, or
+public blockchain endpoints.
+
+## 1. Building the images
+
+You only need this section if you build from source. The chart requires you to supply
+`global.image.repository`, and there is no default, so building your own is the normal path.
+
+| Host | Why | Avoidable |
+| --- | --- | --- |
+| `registry.npmjs.org` | package install | Point npm at your own mirror |
+| Docker Hub | `node:24-alpine` base image | Retag through your own registry |
+| `gcr.io` | distroless base for the sandbox image only | Same |
+| `dl-cdn.alpinelinux.org` | Alpine packages | Alpine mirror |
+| `fonts.googleapis.com`, `fonts.gstatic.com` | `next/font/google` fetches at build, then self-hosts the result. An offline build fails here | No, without changing the font setup |
+| `truststore.pki.rds.amazonaws.com` | CA bundle for TLS to Amazon RDS | Yes. Build with `--build-arg RDS_CA_BUNDLE_URL=` to skip it. Only an RDS database needs it |
+| `downloads.sentry-cdn.com` | `@sentry/cli` downloads a binary in its postinstall | Not without dropping the dev dependency |
+| `sentry.io` | source-map upload | Already skipped unless `SENTRY_AUTH_TOKEN` is set |
+
+### Values baked into the image
+
+Next.js compiles `NEXT_PUBLIC_*` variables into the JavaScript it produces, so they are fixed
+when the image is built and cannot be changed by configuration afterwards. Four of them identify
+a specific KeeperHub account:
+
+- `NEXT_PUBLIC_TURNSTILE_SITE_KEY`
+- `NEXT_PUBLIC_GITHUB_CLIENT_ID`
+- `NEXT_PUBLIC_GOOGLE_CLIENT_ID`
+- `NEXT_PUBLIC_SENTRY_DSN`
+
+Build with your own values, or with none. If you ever receive a prebuilt KeeperHub image, check
+these first: a Sentry DSN baked in that way sends your users' browser errors to whoever owns it,
+and because the app proxies those events through its own `/monitoring` path, the request leaves
+from your server rather than from the browser.
+
+## 2. Installing
+
+| Host | Why | Required |
+| --- | --- | --- |
+| `techops-services.github.io` and `github.com` | the Helm chart and its tarball | Only if you install from our repository. `CHART_REPO_URL` repoints it, `CHART_DIR` skips it |
+| `raw.githubusercontent.com` | the CloudNativePG operator manifest, which you apply yourself | Only when the database is bundled. Not needed with `DB_MODE=byo` |
+| `ghcr.io` | `cloudnative-pg/postgresql`, the bundled database image | Only with the bundled database |
+| Docker Hub | `softwaremill/elasticmq-native`, the bundled queue | Only with the bundled queue |
+| your own registry | the five KeeperHub images | Always. You choose the host |
+
+The install itself contacts nothing else. Database migration and chain seeding run entirely
+against your database: the seed scripts import only a Postgres driver and local modules, and make
+no network calls. They do write third-party endpoint addresses into your `chains` table, which the
+running product later calls - see the RPC entry below.
+
+The chart assumes an ingress controller and, for TLS, a cert-manager `ClusterIssuer`. It does not
+install either. It does not use External Secrets, and needs no AWS credentials.
+
+## 3. What the running product contacts
+
+### Needed for the product to work
+
+| Service | Host | What it carries | Configuration |
+| --- | --- | --- | --- |
+| Blockchain RPC | ~17 public endpoints, e.g. `ethereum-rpc.publicnode.com`, `mainnet.base.org`, `api.mainnet-beta.solana.com` | wallet and contract addresses, calldata, signed transactions | `CHAIN_RPC_CONFIG`, or per-chain `CHAIN_<NAME>_PRIMARY_RPC`. None of the defaults is a host KeeperHub operates, and a test enforces that |
+| Queue | `sqs.<region>.amazonaws.com` | workflow and execution ids, trigger payloads | Set `AWS_ENDPOINT_URL` to use the bundled in-cluster queue instead, which is what the bundled mode does |
+| Cloudflare Turnstile | `challenges.cloudflare.com` | a captcha token and the client IP, on signup | See below |
+| Email delivery | `api.sendgrid.com` | recipient address, signup codes, invite links | `SENDGRID_API_URL` points at any relay accepting SendGrid's v3 `mail/send` shape |
+| Wallet signing | `api.turnkey.com` | wallet addresses and the payloads to be signed | `TURNKEY_API_BASE_URL`. Only used when wallets are configured |
+
+**About Turnstile.** The server refuses to start without `TURNSTILE_SECRET_KEY`. That check runs
+against a value compiled into the build, so declaring the environment non-production does not
+avoid it. If you cannot use Cloudflare, set `TURNSTILE_DISABLED=true`. That is a real decision:
+your signup endpoint then accepts automated requests, and the server logs a warning at every boot
+saying so. Cloudflare publishes always-pass test keys, but those still contact Cloudflare on every
+signup while verifying nothing, so the opt-out is usually the better answer.
+
+### Optional, and how to stop each
+
+| Service | Host | When | Off by |
+| --- | --- | --- | --- |
+| Location lookup | `ipapi.co`, `ipwho.is`, `freeipapi.com`, `ipinfo.io` | every sign-in | `GEOIP_ENABLED=false`. **Read this one.** These providers need no credential, so configuring nothing does not mean sending nothing - by default every signing-in user's IP address goes to them. Sessions show no location when it is off |
+| Error reporting | whichever host your Sentry DSN names | any error | leave `SENTRY_DSN` and `NEXT_PUBLIC_SENTRY_DSN` unset. Note it reports personal data when enabled |
+| Status page script | whatever you point it at | every page load | `STATUS_EMBED_SRC`, already unset by default |
+| Marketing list | `connect.mailerlite.com` | every signup, sending the user's email | leave `MAILERLITE_API_KEY` unset. The group ids are KeeperHub's own, so this is not useful to you as-is |
+| Signup notifications | `discord.com` | every signup, sending name and email | leave `DISCORD_WEBHOOK_SIGNUPS` unset |
+| Billing | `api.stripe.com` | organisation billing details | leave `STRIPE_SECRET_KEY` unset |
+| Paid workflows | `api.cdp.coinbase.com`, `rpc.tempo.xyz` | payer address, amount, signed authorisation | leave `X402_FACILITATOR_URL` and `MPP_SECRET_KEY` unset. `X402_FACILITATOR_URL` also accepts your own facilitator |
+| AI workflow generation | `api.openai.com`, `api.anthropic.com`, or `ai-gateway.vercel.sh` | the user's prompt and their workflow graph | off unless `NEXT_PUBLIC_AI_PROMPT_ENABLED=true` |
+| Contract ABI lookup | `api.etherscan.io`, Blockscout instances | contract addresses you inspect in the editor | endpoints come from your `explorer_configs` table, so edit the rows |
+| Feedback | whatever you point it at | user submits feedback | `FEEDBACK_SERVICE_URL`, unset by default |
+| Sign-in with GitHub or Google | `github.com`, `accounts.google.com` | OAuth exchange | leave the client id and secret unset |
+| Token logos, email logo | `raw.githubusercontent.com` | rendering a token list; opening an email | `EMAIL_LOGO_URL` for the email one - set it empty to send no logo. Token logo addresses live in your database |
+| Docs redirect | `docs.keeperhub.com` | someone requests `/llms.txt` | `DOCS_BASE_URL`, empty to drop the redirect. Build-time |
+
+### Only because a user configured it
+
+Workflow steps reach whatever the person who built the workflow told them to. That includes
+arbitrary URLs through the Webhook and HTTP Request steps and the Code step, and fixed services
+such as Discord, Telegram, Slack, SendGrid, Hyperliquid, Safe and Blockscout when a user adds
+those steps with their own credentials.
+
+Which of these exist at all is controlled by `plugins/plugin-allowlist.json`, applied when the
+image is built. Trim it to the set you want to offer. Outbound URLs from the generic steps are
+checked against private address ranges before the request is made.
+
+## 4. What still says KeeperHub
+
+Some things are deliberately left as constants, and you should know about them rather than
+discover them.
+
+- The support address in the help dialog, and the community and documentation links, are
+  KeeperHub's. They are read by browser code, so making them configurable would mean baking them
+  into the image at build time, which does not help anyone running a prebuilt image. A seam that
+  cannot be used is worse than an honest constant.
+- Wallet-only accounts get a synthetic address at `wallet.keeperhub.com`. It never receives mail
+  and exists only as a marker. It is not configurable because the same check runs in the browser
+  and on the server, and a value that differed between them would make the two disagree about
+  which accounts are wallet accounts.
+- Some API error messages point at `docs.keeperhub.com` for the request format.
+
+## Known limitations
+
+- **No sandbox is deployed.** The Code step needs one and fails with a connection error without
+  it. Everything else works.
+- **Signup needs working email.** Verification codes, invitations, password resets and MFA
+  step-up all go through the mail path, so an install with no mail relay cannot complete a signup.
+
+## About this document
+
+Written against this branch by reading the source. Counts here come from reading the matches, not
+from counting search hits. `keeperhub-metrics-collector/` is not covered; it is disabled in this
+profile.
+
+If you find something reaching a host that is not listed, that is a bug in this document. Please
+report it.

--- a/deploy/keeperhub-stack/self-hosted/DEPENDENCIES.md
+++ b/deploy/keeperhub-stack/self-hosted/DEPENDENCIES.md
@@ -112,7 +112,7 @@ signup while verifying nothing, so the opt-out is usually the better answer.
 | Feedback | whatever you point it at | user submits feedback | `FEEDBACK_SERVICE_URL`, unset by default |
 | Sign-in with GitHub or Google | `github.com`, `accounts.google.com` | OAuth exchange | leave the client id and secret unset |
 | Token logos, email logo | `raw.githubusercontent.com` | rendering a token list; opening an email | `EMAIL_LOGO_URL` for the email one - set it empty to send no logo. Token logo addresses live in your database |
-| Docs redirect | `docs.keeperhub.com` | someone requests `/llms.txt` | `DOCS_BASE_URL`, empty to drop the redirect. Build-time |
+| Docs redirect | `docs.keeperhub.com` | someone requests `/llms.txt` | **Already off** in an image built by the self-hosted harness, which passes `DOCS_BASE_URL=` so the redirect is not compiled in. Build a different image and you inherit it: `next.config.ts` bakes redirects into the build, so no Helm value can remove it afterwards |
 
 ### Only because a user configured it
 

--- a/deploy/keeperhub-stack/self-hosted/README.md
+++ b/deploy/keeperhub-stack/self-hosted/README.md
@@ -329,17 +329,19 @@ once in the node. Budget tens of minutes and around 25GB.
 These are properties of the shipped application, not of this profile. Each is
 tracked separately.
 
-**The app only runs on a `*.keeperhub.com` hostname.** `lib/trusted-origins.ts`
-hardcodes the trusted-origin list to `http://localhost:*`, `http://127.0.0.1:*`
-and `https://*.keeperhub.com`, with no environment variable to extend it. That
-list backs the CSRF guard in `proxy.ts` and better-auth, so on any other
-hostname every cookie-authenticated POST/PATCH/PUT/DELETE is rejected. The UI
-loads and reads fine, so it looks like the app works until you try to save:
-enabling a workflow returns "Failed to update workflow state" and the only trace
-is `[csrf] blocked: untrusted origin` in the app log. `values.minikube.yaml` sets `appHost` to
-`selfhosted.keeperhub.com` to stay inside the trusted suffix; the base profile has
-no default, because **a client cannot use one** - they do not own the domain. Making trusted origins configurable is a
-prerequisite for any client install (KEEP-1110).
+**Any hostname works, provided the origin is trusted.** `lib/trusted-origins.ts`
+ships a fixed list covering `http://localhost:*`, `http://127.0.0.1:*` and
+`https://*.keeperhub.com`, and that list backs the CSRF guard in `proxy.ts` and
+`lib/middleware/auth-helpers.ts`. An origin outside it has every
+cookie-authenticated POST/PATCH/PUT/DELETE rejected while the UI still loads and
+reads, so it looks like the app works until you try to save: enabling a workflow
+returns "Failed to update workflow state" and the only trace is
+`[csrf] blocked: untrusted origin` in the app log.
+
+This profile sets `ADDITIONAL_TRUSTED_ORIGINS` from `global.appHost`, so your own
+domain is trusted without further configuration. Set it yourself only if the app
+is reached on more origins than that one - a vanity domain, or a separate
+hostname for an internal network.
 
 **There is no email.** `lib/email.ts` posts to SendGrid's HTTP API, so there is
 no SMTP setting and no local mail-catcher option. Without `SENDGRID_API_KEY`,

--- a/deploy/keeperhub-stack/self-hosted/README.md
+++ b/deploy/keeperhub-stack/self-hosted/README.md
@@ -1,7 +1,12 @@
 # Self-hosted KeeperHub
 
-Installs KeeperHub into a Kubernetes cluster you own, with no AWS account and no
-dependency on any KeeperHub-operated service.
+Installs KeeperHub into a Kubernetes cluster you own, with no AWS account.
+
+The running product depends on no service KeeperHub operates. The install itself
+reaches exactly one, the Helm chart repository, and `CHART_REPO_URL` or
+`CHART_DIR` avoids that too. [DEPENDENCIES.md](DEPENDENCIES.md) lists every host
+the build, the install and the running product contact, what each one is for,
+and how to switch it off or point it elsewhere.
 
 A peer of `../staging/` and `../prod/`: the same `keeperhub-stack` umbrella chart,
 the same structure, different values. Diff `values.yaml` against
@@ -12,6 +17,7 @@ while it stays structurally identical to what staging and production run.
 
 | Path | What it is |
 | --- | --- |
+| `DEPENDENCIES.md` | every external host the build, install and running product reach, and how to turn each off |
 | `values.yaml` | chart values common to every install, and the `global:` block you set |
 | `values.db-{bundled,byo}.yaml`, `values.queue-{bundled,byo}.yaml` | the parts that differ per mode, merged over `values.yaml` |
 | `values.queue-byo-endpoint.yaml` | merged only when `QUEUE_MODE=byo` and `AWS_ENDPOINT_URL` is set |

--- a/deploy/keeperhub-stack/self-hosted/config.sh
+++ b/deploy/keeperhub-stack/self-hosted/config.sh
@@ -54,17 +54,15 @@ IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-}"
 
 # The hostname the app is served on, and how it is exposed.
 #
-# One caveat that applies to every hostname outside *.keeperhub.com:
-# lib/trusted-origins.ts hardcodes the trusted-origin list to http://localhost:*,
-# http://127.0.0.1:* and https://*.keeperhub.com, with no environment variable to
-# extend it. That list backs the CSRF guard in proxy.ts and better-auth, so on
-# any other hostname every cookie-authenticated POST/PATCH/PUT/DELETE is
-# rejected. The UI still loads and reads fine, so it looks like the app works
-# until you try to save: enabling a workflow returns "Failed to update workflow
-# state" and the only trace is "[csrf] blocked: untrusted origin" in the app log.
+# Any hostname works. The application ships a fixed trusted-origin list
+# (lib/trusted-origins.ts) covering localhost and *.keeperhub.com, which backs
+# the CSRF guard; the profile extends it with this host through
+# ADDITIONAL_TRUSTED_ORIGINS so a client domain is trusted out of the box.
 #
-# Making the trusted origins configurable is a prerequisite for any client
-# domain, and is tracked separately.
+# Worth knowing because the failure mode is quiet: an untrusted origin still
+# loads and reads, and only writes fail, with 403 and "[csrf] blocked:
+# untrusted origin" in the app log. If you serve the app on more origins than
+# APP_HOST, add them to ADDITIONAL_TRUSTED_ORIGINS yourself.
 APP_HOST="${APP_HOST:-}"
 INGRESS_CLASS="${INGRESS_CLASS:-}"
 TLS_ISSUER="${TLS_ISSUER:-}"

--- a/deploy/keeperhub-stack/self-hosted/config.sh
+++ b/deploy/keeperhub-stack/self-hosted/config.sh
@@ -32,9 +32,13 @@ KUBE_CONTEXT="${KUBE_CONTEXT:-}"
 NAMESPACE="${NAMESPACE:-keeperhub}"
 RELEASE="${RELEASE:-keeperhub}"
 
-CHART_REPO_NAME="techops-services"
-CHART_REPO_URL="https://techops-services.github.io/helm-charts"
-CHART_NAME="techops-services/keeperhub-stack"
+# The chart repository. This is the only host the install reaches that
+# KeeperHub operates, so it is overridable for an installer who mirrors the
+# chart rather than pulling it from us. CHART_DIR below bypasses the repository
+# entirely and installs from a local directory.
+CHART_REPO_NAME="${CHART_REPO_NAME:-techops-services}"
+CHART_REPO_URL="${CHART_REPO_URL:-https://techops-services.github.io/helm-charts}"
+CHART_NAME="${CHART_NAME:-${CHART_REPO_NAME}/keeperhub-stack}"
 CHART_VERSION="${CHART_VERSION:-0.5.0}"
 # Point at a working-tree chart instead of the published one, for developing
 # chart changes alongside this profile: CHART_DIR=../../../helm-charts/charts/keeperhub-stack

--- a/deploy/keeperhub-stack/self-hosted/test-harness/bootstrap-cluster.sh
+++ b/deploy/keeperhub-stack/self-hosted/test-harness/bootstrap-cluster.sh
@@ -100,6 +100,18 @@ create_cluster() {
         --memory="${MIN_MEMORY_GB}g" --cpus="$MIN_CPU_CORES" \
         --disk-size="${MIN_DISK_GB}g" --kubernetes-version=stable
     kubectl --context "$KUBE_CONTEXT" wait --for=condition=Ready nodes --all --timeout=300s
+    # `kubectl wait` on a label selector exits immediately with "no matching
+    # resources found" when nothing matches yet, rather than waiting for the
+    # pods to appear. On a fresh cluster the node goes Ready a moment before the
+    # calico DaemonSet has produced any, so wait for the DaemonSet to exist and
+    # roll out first, then wait on readiness.
+    local waited=0
+    until cni_present; do
+        [ "$waited" -ge 120 ] && { echo "  calico DaemonSet never appeared" >&2; return 1; }
+        sleep 3
+        waited=$((waited + 3))
+    done
+    kubectl --context "$KUBE_CONTEXT" rollout status daemonset/calico-node -n kube-system --timeout=300s
     kubectl --context "$KUBE_CONTEXT" wait --for=condition=Ready pods -l k8s-app=calico-node -n kube-system --timeout=300s
 }
 

--- a/deploy/keeperhub-stack/self-hosted/test-harness/build-images.sh
+++ b/deploy/keeperhub-stack/self-hosted/test-harness/build-images.sh
@@ -64,6 +64,11 @@ if [ "$SKIP_BUILD" = false ]; then
     # buildx merges list fields across -f files and an empty-list assignment does
     # not clear an inherited value. The root file's cache refs point at
     # ${ECR_REGISTRY}, which resolves to "/:cache" here and is not a valid ref.
+    # These three are a command prefix: they enter docker's environment, where
+    # bake reads them as HCL variables. shellcheck loses track of that across
+    # the line continuations and reports them unused, which fails the
+    # --severity=warning gate in maintainability.yml.
+    # shellcheck disable=SC2034
     NEXT_PUBLIC_TURNSTILE_SITE_KEY="$TURNSTILE_SITE_KEY" \
     IMAGE_TAG="$IMAGE_TAG" \
     LOCAL_IMAGE_REPO="$IMAGE_REPO" \

--- a/deploy/keeperhub-stack/self-hosted/test-harness/build-images.sh
+++ b/deploy/keeperhub-stack/self-hosted/test-harness/build-images.sh
@@ -67,10 +67,16 @@ if [ "$SKIP_BUILD" = false ]; then
     NEXT_PUBLIC_TURNSTILE_SITE_KEY="$TURNSTILE_SITE_KEY" \
     IMAGE_TAG="$IMAGE_TAG" \
     LOCAL_IMAGE_REPO="$IMAGE_REPO" \
+    # DOCS_BASE_URL is emptied so the image does not redirect /llms.txt to
+    # docs.keeperhub.com. next.config.ts bakes redirects into the build, so this
+    # cannot be a Helm value - it has to be decided here. Set on every target
+    # rather than just app: the four that run `next build` share one builder
+    # stage and BuildKit only deduplicates it while their args match.
     docker buildx bake \
         -f docker-bake.hcl \
         -f "$SCRIPT_DIR/docker-bake.hcl" \
         --set "*.cache-from=" --set "*.cache-to=" \
+        --set "*.args.DOCS_BASE_URL=" \
         local
 fi
 

--- a/deploy/keeperhub-stack/self-hosted/values.yaml
+++ b/deploy/keeperhub-stack/self-hosted/values.yaml
@@ -161,9 +161,10 @@ app:
       value: '{{ .Values.global.awsRegion }}'
     # Set for the same reason staging sets them. The Code plugin throws at
     # module load when NODE_ENV is "production" unless both are present, and the
-    # plugin registry imports it eagerly. NODE_ENV is "development" here, so the
-    # guard cannot fire today, but leaving these unset would turn any future
-    # NODE_ENV change into a crash on import rather than a config error.
+    # plugin registry imports it eagerly. Both are required, not precautionary:
+    # Next.js inlines process.env.NODE_ENV at build time, so the compiled app
+    # takes the "production" branch whatever NODE_ENV says at runtime. See the
+    # NODE_ENV entry below for the same trap in lib/auth.ts.
     SANDBOX_BACKEND:
       type: kv
       value: "remote"

--- a/deploy/keeperhub-stack/self-hosted/values.yaml
+++ b/deploy/keeperhub-stack/self-hosted/values.yaml
@@ -357,6 +357,17 @@ app:
     BETTER_AUTH_URL:
       type: template
       value: 'https://{{ required "set global.appHost - the hostname the application is served on" .Values.global.appHost }}'
+    # Trusts this install's own hostname for cookie-authenticated writes.
+    #
+    # The application ships a fixed trusted-origin list covering localhost and
+    # *.keeperhub.com. Without this entry a client domain loads and reads fine
+    # and then fails every save with 403 and "[csrf] blocked: untrusted origin"
+    # in the app log - which looks like the app is broken rather than
+    # unconfigured. Set from the same value as the URLs above so the three
+    # cannot disagree.
+    ADDITIONAL_TRUSTED_ORIGINS:
+      type: template
+      value: 'https://{{ required "set global.appHost - the hostname the application is served on" .Values.global.appHost }}'
     # Nothing is gated in a self-hosted install; this short-circuits both the
     # execution guard and the feature route-guard.
     NEXT_PUBLIC_BILLING_ENABLED:

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -184,6 +184,12 @@ app:
 
   env:
     <<: *shared_env
+    # Status page embedded in the app shell. The application renders the
+    # script only when this is set, so a deployment that does not run a status
+    # page - which is any deployment but ours - makes no request for it.
+    STATUS_EMBED_SRC:
+      type: kv
+      value: "https://status.keeperhub.com/embed/script.js"
     LOG_LEVEL:
       type: kv
       value: "info"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -18,6 +18,12 @@ variable "NEXT_PUBLIC_SCAN_ENABLED" { default = "" }
 variable "NEXT_PUBLIC_TURNSTILE_SITE_KEY" { default = "" }
 variable "ENVIRONMENT_TAG" { default = "" }
 variable "NEXT_PUBLIC_SENTRY_DSN" { default = "" }
+# The /llms.txt redirect destination, baked by next.config.ts at build time.
+# Defaults to today's value so a build that says nothing keeps production
+# behaviour; an empty value drops the redirect. See the ARG in Dockerfile.
+# Deliberately NOT plumbed through build-images.yml: a workflow passing an unset
+# repository variable would send "" and quietly remove the redirect from prod.
+variable "DOCS_BASE_URL" { default = "https://docs.keeperhub.com" }
 variable "SENTRY_ORG" { default = "" }
 variable "SENTRY_PROJECT" { default = "" }
 variable "SENTRY_AUTH_TOKEN" { default = "" }
@@ -73,6 +79,7 @@ target "app" {
     NEXT_PUBLIC_SCAN_ENABLED = NEXT_PUBLIC_SCAN_ENABLED
     NEXT_PUBLIC_TURNSTILE_SITE_KEY = NEXT_PUBLIC_TURNSTILE_SITE_KEY
     NEXT_PUBLIC_SENTRY_DSN       = NEXT_PUBLIC_SENTRY_DSN
+    DOCS_BASE_URL                = DOCS_BASE_URL
     INCLUDE_TEST_ENDPOINTS       = INCLUDE_TEST_ENDPOINTS
   }
   tags = ECR_REGISTRY != "" ? compact([
@@ -99,6 +106,7 @@ target "sentry-upload" {
     NEXT_PUBLIC_SCAN_ENABLED = NEXT_PUBLIC_SCAN_ENABLED
     NEXT_PUBLIC_TURNSTILE_SITE_KEY = NEXT_PUBLIC_TURNSTILE_SITE_KEY
     NEXT_PUBLIC_SENTRY_DSN       = NEXT_PUBLIC_SENTRY_DSN
+    DOCS_BASE_URL                = DOCS_BASE_URL
     INCLUDE_TEST_ENDPOINTS       = INCLUDE_TEST_ENDPOINTS
     SENTRY_ORG                   = SENTRY_ORG
     SENTRY_PROJECT               = SENTRY_PROJECT
@@ -140,6 +148,7 @@ target "workflow-runner" {
     NEXT_PUBLIC_SCAN_ENABLED = NEXT_PUBLIC_SCAN_ENABLED
     NEXT_PUBLIC_TURNSTILE_SITE_KEY = NEXT_PUBLIC_TURNSTILE_SITE_KEY
     NEXT_PUBLIC_SENTRY_DSN       = NEXT_PUBLIC_SENTRY_DSN
+    DOCS_BASE_URL                = DOCS_BASE_URL
     INCLUDE_TEST_ENDPOINTS       = INCLUDE_TEST_ENDPOINTS
   }
   tags = compact([
@@ -234,6 +243,7 @@ target "executor" {
     NEXT_PUBLIC_SCAN_ENABLED = NEXT_PUBLIC_SCAN_ENABLED
     NEXT_PUBLIC_TURNSTILE_SITE_KEY = NEXT_PUBLIC_TURNSTILE_SITE_KEY
     NEXT_PUBLIC_SENTRY_DSN       = NEXT_PUBLIC_SENTRY_DSN
+    DOCS_BASE_URL                = DOCS_BASE_URL
     INCLUDE_TEST_ENDPOINTS       = INCLUDE_TEST_ENDPOINTS
   }
   tags = compact([

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,7 +260,11 @@ services:
     hostname: sandbox
     restart: unless-stopped
     ports:
-      - "8787:8787"
+      # Loopback only. This published the sandbox on every host interface, so
+      # any machine on the LAN could reach /run and execute code on a
+      # developer's box. In-cluster the NetworkPolicy restricts ingress to the
+      # keeperhub namespace; compose has no such control.
+      - "127.0.0.1:8787:8787"
     environment:
       NODE_ENV: production
       SANDBOX_PORT: "8787"

--- a/lib/agent-identity.ts
+++ b/lib/agent-identity.ts
@@ -1,0 +1,107 @@
+/**
+ * Who this deployment says it is.
+ *
+ * The `.well-known` routes publish an identity to agent registries, reputation
+ * scorers and OAuth clients. Every value was hardcoded, so a deployment run by
+ * someone else announced itself as KeeperHub - and, worse than a wrong name,
+ * republished KeeperHub's registered on-chain agent, pointing third-party
+ * scorers at the wrong host.
+ *
+ * Every default below is the value that was hardcoded before, so a deployment
+ * that configures nothing produces byte-identical output.
+ *
+ * Server-only on purpose. A NEXT_PUBLIC_ variable is inlined at build time, and
+ * a deployment running a prebuilt image could not change it without rebuilding.
+ */
+
+const TRAILING_SLASH = /\/$/;
+
+export const DEFAULT_AGENT_NAME = "KeeperHub";
+
+/** KeeperHub's own ERC-8004 registration. See the coherence guard below. */
+const DEFAULT_AGENT_ID = 31_875;
+const DEFAULT_REGISTRY = "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432";
+const DEFAULT_REGISTRY_CHAIN = "ethereum";
+const DEFAULT_REGISTRY_CHAIN_ID = 1;
+
+export type OnChainAgentIdentity = {
+  agentId: number;
+  chain: string;
+  chainId: number;
+  registry: string;
+};
+
+export type AgentIdentity = {
+  name: string;
+  /** Present only when it can be published truthfully. See onChainIdentity(). */
+  onChain: OnChainAgentIdentity | null;
+};
+
+/**
+ * The origin this deployment is reached on.
+ *
+ * Lifted from the four `.well-known` routes that each carried an identical
+ * copy. Falls back to the request host so a deployment that sets neither
+ * variable still advertises something reachable rather than a KeeperHub URL.
+ */
+export function deriveBaseUrl(request: Request): string {
+  const envUrl = process.env.NEXT_PUBLIC_APP_URL ?? process.env.BETTER_AUTH_URL;
+  if (envUrl) {
+    return envUrl.replace(TRAILING_SLASH, "");
+  }
+  const url = new URL(request.url);
+  return `${url.protocol}//${url.host}`;
+}
+
+export function agentName(): string {
+  return process.env.AGENT_NAME?.trim() || DEFAULT_AGENT_NAME;
+}
+
+export function agentDescription(fallback: string): string {
+  return process.env.AGENT_DESCRIPTION?.trim() || fallback;
+}
+
+function parsePositiveInt(raw: string | undefined): number | null {
+  if (!raw) {
+    return null;
+  }
+  const parsed = Number.parseInt(raw.trim(), 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+/**
+ * The on-chain agent registration, or null when there is nothing truthful to
+ * publish.
+ *
+ * The coherence guard is the point of this function. An operator who renames
+ * the agent has declared "this is not KeeperHub", and an install in that state
+ * has nothing true to say about KeeperHub's registration - but leaving the
+ * default in place would publish exactly that: a plausible-looking card
+ * carrying our agent id under their name, which is worse than publishing
+ * nothing because a reputation scorer would believe it.
+ *
+ * So the registration is published only when it is internally consistent:
+ * either nothing is customised (KeeperHub's own deployment), or the operator
+ * supplied their own agent id to go with their own name.
+ */
+export function onChainIdentity(): OnChainAgentIdentity | null {
+  const configuredId = parsePositiveInt(process.env.AGENT_ID);
+  const renamed = agentName() !== DEFAULT_AGENT_NAME;
+
+  if (renamed && configuredId === null) {
+    return null;
+  }
+
+  return {
+    agentId: configuredId ?? DEFAULT_AGENT_ID,
+    chain: process.env.AGENT_REGISTRY_CHAIN?.trim() || DEFAULT_REGISTRY_CHAIN,
+    chainId:
+      parsePositiveInt(process.env.AGENT_REGISTRY_CHAIN_ID) ??
+      DEFAULT_REGISTRY_CHAIN_ID,
+    registry: process.env.AGENT_REGISTRY_ADDRESS?.trim() || DEFAULT_REGISTRY,
+  };
+}
+
+export function agentIdentity(): AgentIdentity {
+  return { name: agentName(), onChain: onChainIdentity() };
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -169,6 +169,24 @@ function getBaseURL() {
 const SIGNUP_CAPTCHA_ENDPOINT = "/sign-up/email";
 const captchaSecretKey = process.env.TURNSTILE_SECRET_KEY;
 const captchaForceEnabled = process.env.TURNSTILE_ENFORCE === "true";
+// start custom keeperhub code //
+/**
+ * Deliberate opt-out of the captcha, for a deployment that cannot use
+ * Cloudflare.
+ *
+ * Without this the only way to boot without TURNSTILE_SECRET_KEY is CI=true,
+ * which also disables unrelated behaviour and misdescribes the environment. The
+ * other workaround, Cloudflare's always-pass test key pair, is worse than it
+ * looks: signup still calls challenges.cloudflare.com twice and the captcha
+ * verifies nothing, so the deployment carries the dependency without the
+ * protection.
+ *
+ * TURNSTILE_ENFORCE wins over this, so a deployment that has explicitly asked
+ * for the captcha cannot lose it by also setting this.
+ */
+const captchaDisabled =
+  !captchaForceEnabled && process.env.TURNSTILE_DISABLED === "true";
+// end keeperhub code //
 const captchaSkippedForTests =
   process.env.CI === "true" ||
   process.env.NODE_ENV === "test" ||
@@ -186,8 +204,13 @@ const captchaSkippedForTests =
 // but no runtime secrets injected, so skip the assertion during that phase to
 // avoid crashing the build. The assertion still fires at server boot
 // (phase-production-server) of any environment that actually enforces captcha.
+// start custom keeperhub code //
+// The two reasons the captcha plugin is left out: the test-mode skips above, or
+// a deployment that explicitly opted out because it cannot use Cloudflare.
+const captchaOmitted = captchaSkippedForTests || captchaDisabled;
+// end keeperhub code //
 const captchaRequired =
-  !captchaSkippedForTests &&
+  !captchaOmitted &&
   (process.env.NODE_ENV === "production" || captchaForceEnabled) &&
   process.env.NEXT_PHASE !== "phase-production-build";
 if (captchaRequired && !captchaSecretKey) {
@@ -195,6 +218,16 @@ if (captchaRequired && !captchaSecretKey) {
     "TURNSTILE_SECRET_KEY is required in production (or when TURNSTILE_ENFORCE=true) - refusing to expose /sign-up/email without captcha verification"
   );
 }
+// start custom keeperhub code //
+// Say it out loud once at boot. Turning the captcha off leaves /sign-up/email
+// open to automated signups, and an operator who inherited this configuration
+// should find out from the log rather than from the account table.
+if (captchaDisabled && process.env.NEXT_PHASE !== "phase-production-build") {
+  logWarn(
+    "[Auth] TURNSTILE_DISABLED=true - signup captcha is off and /sign-up/email accepts automated requests"
+  );
+}
+// end keeperhub code //
 
 // Wrap the captcha plugin's onRequest so trusted load-test / e2e traffic can
 // skip the Turnstile check on signup. A real challenge cannot be solved
@@ -222,8 +255,10 @@ function buildTurnstilePlugin(secretKey: string): ReturnType<typeof captcha> {
   };
 }
 
+// captchaOmitted covers the opt-out too, so a deployment that opted out but
+// still has a secret key lying around in its config makes no Cloudflare request.
 const captchaPlugins =
-  !captchaSkippedForTests && captchaSecretKey
+  !captchaOmitted && captchaSecretKey
     ? [buildTurnstilePlugin(captchaSecretKey)]
     : [];
 

--- a/lib/auth/wallet-constants.ts
+++ b/lib/auth/wallet-constants.ts
@@ -2,6 +2,15 @@
 // users have no real inbox, so Better Auth's SIWE plugin mints
 // `<address>@<domain>`. The suffix is the marker the proxy and the
 // auth hooks use to recognize a wallet account without a dedicated column.
+//
+// Deliberately not configurable, though it does put a keeperhub.com suffix in
+// every deployment's user rows. This module is imported by client components
+// (manage-orgs-modal, api-keys-overlay, broadcast-overlay) as well as by server
+// routes, so a non-NEXT_PUBLIC_ read would resolve to the configured value on
+// the server and to the default in the browser. isWalletEmail matches on the
+// suffix, so the two sides would disagree about which accounts are wallet
+// accounts. The address is synthetic and never receives mail; see
+// DEPENDENCIES.md.
 export const WALLET_EMAIL_DOMAIN = "wallet.keeperhub.com";
 
 export function isWalletEmail(email: string | null | undefined): boolean {

--- a/lib/billing/payg/constants.ts
+++ b/lib/billing/payg/constants.ts
@@ -33,7 +33,18 @@ export const PAYG_OVERFLOW_REASON = "payg_overflow";
 export const X402_EXACT_SCHEME = "exact";
 export const USDC_EIP712_NAME = "USD Coin";
 export const USDC_EIP712_VERSION = "2";
-export const PAYG_RESOURCE_URL = "https://keeperhub.com/payg";
+/**
+ * The `resource` a pay-as-you-go x402 payment is signed against
+ * (`lib/billing/payg/autopay.ts`), so it ends up inside the payload the payer
+ * authorises.
+ *
+ * Deliberately an explicit variable rather than something derived from
+ * NEXT_PUBLIC_APP_URL: this is the apex domain, not the `app.` host, so
+ * deriving it would change the value production already signs. Unset keeps that
+ * value byte for byte.
+ */
+export const PAYG_RESOURCE_URL =
+  process.env.PAYG_RESOURCE_URL || "https://keeperhub.com/payg";
 
 /** CAIP-2 network id for an EVM chain (e.g. `eip155:8453`). */
 export function evmNetworkId(chainId: number): string {

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -14,7 +14,34 @@ import {
 
 const isTestEnv = !!process.env.CI || process.env.NODE_ENV === "test";
 
-const SENDGRID_API_URL = "https://api.sendgrid.com/v3/mail/send";
+// start custom keeperhub code //
+/**
+ * Where the mail send is posted.
+ *
+ * Transactional mail carries signup OTPs, invites, password resets and MFA
+ * step-up codes, so a deployment that cannot reach SendGrid cannot complete a
+ * signup. Overriding this lets an operator point at their own relay - anything
+ * that accepts SendGrid's v3 mail/send request shape - instead of patching the
+ * source. Unset keeps the value this constant has always had.
+ */
+const SENDGRID_API_URL =
+  process.env.SENDGRID_API_URL || "https://api.sendgrid.com/v3/mail/send";
+
+/**
+ * Logo shown at the top of transactional email.
+ *
+ * The recipient's mail client fetches this when the message is opened, so the
+ * host learns their IP address and roughly when they read it. The default sits
+ * in KeeperHub's own public repository, which means a deployment KeeperHub does
+ * not run still shows our logo and still reports its users to GitHub.
+ *
+ * Point it at your own asset, or set it empty to send no logo at all - the
+ * templates omit the image entirely rather than rendering a broken one.
+ */
+const EMAIL_LOGO_URL =
+  process.env.EMAIL_LOGO_URL ??
+  "https://raw.githubusercontent.com/KeeperHub/keeperhub/staging/public/keeperhub_logo_email.png";
+// end keeperhub code //
 
 // Cap the outbound SendGrid call so a stalled connection surfaces as a
 // failed send (returns false) instead of hanging the request that's
@@ -178,8 +205,7 @@ export async function sendVerificationOTP(
 ): Promise<boolean> {
   const { email, otp, type } = data;
 
-  const logoUrl =
-    "https://raw.githubusercontent.com/KeeperHub/keeperhub/staging/public/keeperhub_logo_email.png";
+  const logoUrl = EMAIL_LOGO_URL;
 
   const subjectMap = {
     "sign-in": "Your KeeperHub sign-in code",
@@ -233,7 +259,7 @@ KeeperHub - Blockchain Workflow Automation
 </head>
 <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
   <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 30px; border-radius: 12px 12px 0 0; text-align: center;">
-    <img src="${logoUrl}" alt="KeeperHub" style="max-width: 200px; height: auto;" />
+    ${logoUrl ? `<img src="${logoUrl}" alt="KeeperHub" style="max-width: 200px; height: auto;" />` : ""}
   </div>
 
   <div style="background: #ffffff; padding: 30px; border: 1px solid #e5e5e5; border-top: none; border-radius: 0 0 12px 12px;">
@@ -299,8 +325,7 @@ export async function sendOAuthPasswordResetEmail(
 ): Promise<boolean> {
   const { email, providerName } = data;
 
-  const logoUrl =
-    "https://raw.githubusercontent.com/KeeperHub/keeperhub/staging/public/keeperhub_logo_email.png";
+  const logoUrl = EMAIL_LOGO_URL;
 
   const subject = "Password Reset Request - KeeperHub";
 
@@ -328,7 +353,7 @@ KeeperHub - Blockchain Workflow Automation
 </head>
 <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
   <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 30px; border-radius: 12px 12px 0 0; text-align: center;">
-    <img src="${logoUrl}" alt="KeeperHub" style="max-width: 200px; height: auto;" />
+    ${logoUrl ? `<img src="${logoUrl}" alt="KeeperHub" style="max-width: 200px; height: auto;" />` : ""}
   </div>
 
   <div style="background: #ffffff; padding: 30px; border: 1px solid #e5e5e5; border-top: none; border-radius: 0 0 12px 12px;">
@@ -389,8 +414,7 @@ export async function sendInvitationEmail(
   const { inviteeEmail, inviterName, organizationName, role, inviteLink } =
     data;
 
-  const logoUrl =
-    "https://raw.githubusercontent.com/KeeperHub/keeperhub/staging/public/keeperhub_logo_email.png";
+  const logoUrl = EMAIL_LOGO_URL;
 
   const subject = `You've been invited to join ${organizationName} on KeeperHub`;
 
@@ -420,7 +444,7 @@ KeeperHub - Blockchain Workflow Automation
 </head>
 <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
   <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 30px; border-radius: 12px 12px 0 0; text-align: center;">
-    <img src="${logoUrl}" alt="KeeperHub" style="max-width: 200px; height: auto;" />
+    ${logoUrl ? `<img src="${logoUrl}" alt="KeeperHub" style="max-width: 200px; height: auto;" />` : ""}
   </div>
 
   <div style="background: #ffffff; padding: 30px; border: 1px solid #e5e5e5; border-top: none; border-radius: 0 0 12px 12px;">
@@ -496,8 +520,7 @@ export async function sendNewDeviceEmail(
 ): Promise<boolean> {
   const { email, ip, country, device, when } = data;
 
-  const logoUrl =
-    "https://raw.githubusercontent.com/KeeperHub/keeperhub/staging/public/keeperhub_logo_email.png";
+  const logoUrl = EMAIL_LOGO_URL;
 
   const subject = "New device signed in to your KeeperHub account";
 
@@ -528,7 +551,7 @@ KeeperHub - Blockchain Workflow Automation
 </head>
 <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
   <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 30px; border-radius: 12px 12px 0 0; text-align: center;">
-    <img src="${logoUrl}" alt="KeeperHub" style="max-width: 200px; height: auto;" />
+    ${logoUrl ? `<img src="${logoUrl}" alt="KeeperHub" style="max-width: 200px; height: auto;" />` : ""}
   </div>
 
   <div style="background: #ffffff; padding: 30px; border: 1px solid #e5e5e5; border-top: none; border-radius: 0 0 12px 12px;">
@@ -736,8 +759,7 @@ export async function sendWorkflowExecutionDigestEmail(
     stats.total === 1 ? "" : "s"
   }, ${stats.error} failed (last ${period})`;
 
-  const logoUrl =
-    "https://raw.githubusercontent.com/KeeperHub/keeperhub/staging/public/keeperhub_logo_email.png";
+  const logoUrl = EMAIL_LOGO_URL;
 
   const workflowUrl = (id: string): string =>
     `${appUrl}/workflows/${encodeURIComponent(id)}`;
@@ -879,7 +901,7 @@ ${socialText}
 <head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
 <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
   <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 30px; border-radius: 12px 12px 0 0; text-align: center;">
-    <img src="${logoUrl}" alt="KeeperHub" style="max-width: 200px; height: auto;" />
+    ${logoUrl ? `<img src="${logoUrl}" alt="KeeperHub" style="max-width: 200px; height: auto;" />` : ""}
   </div>
   <div style="background: #ffffff; padding: 30px; border: 1px solid #e5e5e5; border-top: none; border-radius: 0 0 12px 12px; text-align: center;">
     <div style="margin:0 0 14px;">
@@ -949,8 +971,7 @@ export async function sendApiKeyChangeEmail(
 ): Promise<boolean> {
   const { email, action, tokenName, keyPrefix, when } = data;
 
-  const logoUrl =
-    "https://raw.githubusercontent.com/KeeperHub/keeperhub/staging/public/keeperhub_logo_email.png";
+  const logoUrl = EMAIL_LOGO_URL;
 
   const created = action === "created";
   const subject = created
@@ -987,7 +1008,7 @@ KeeperHub - Blockchain Workflow Automation
 </head>
 <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
   <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 30px; border-radius: 12px 12px 0 0; text-align: center;">
-    <img src="${logoUrl}" alt="KeeperHub" style="max-width: 200px; height: auto;" />
+    ${logoUrl ? `<img src="${logoUrl}" alt="KeeperHub" style="max-width: 200px; height: auto;" />` : ""}
   </div>
 
   <div style="background: #ffffff; padding: 30px; border: 1px solid #e5e5e5; border-top: none; border-radius: 0 0 12px 12px;">
@@ -1066,8 +1087,7 @@ export async function sendSecurityAlertEmail(
   data: SecurityAlertData
 ): Promise<boolean> {
   const { email, actionPhrase, actorLabel, when, resourceType } = data;
-  const logoUrl =
-    "https://raw.githubusercontent.com/KeeperHub/keeperhub/staging/public/keeperhub_logo_email.png";
+  const logoUrl = EMAIL_LOGO_URL;
   const whenFormatted = when.toUTCString();
   const summary = `${actorLabel} ${actionPhrase}`;
   const subject = "Security alert: a high-risk action on your organization";
@@ -1095,7 +1115,7 @@ KeeperHub - Blockchain Workflow Automation
 </head>
 <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
   <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 30px; border-radius: 12px 12px 0 0; text-align: center;">
-    <img src="${logoUrl}" alt="KeeperHub" style="max-width: 200px; height: auto;" />
+    ${logoUrl ? `<img src="${logoUrl}" alt="KeeperHub" style="max-width: 200px; height: auto;" />` : ""}
   </div>
 
   <div style="background: #ffffff; padding: 30px; border: 1px solid #e5e5e5; border-top: none; border-radius: 0 0 12px 12px;">
@@ -1163,8 +1183,7 @@ export async function sendAccountDeactivatedEmail(
 ): Promise<boolean> {
   const { email, name } = data;
 
-  const logoUrl =
-    "https://raw.githubusercontent.com/KeeperHub/keeperhub/staging/public/keeperhub_logo_email.png";
+  const logoUrl = EMAIL_LOGO_URL;
 
   const subject = "Your KeeperHub account access has been suspended";
 
@@ -1206,7 +1225,7 @@ ${socialText}
 </head>
 <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
   <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 30px; border-radius: 12px 12px 0 0; text-align: center;">
-    <img src="${logoUrl}" alt="KeeperHub" style="max-width: 200px; height: auto;" />
+    ${logoUrl ? `<img src="${logoUrl}" alt="KeeperHub" style="max-width: 200px; height: auto;" />` : ""}
   </div>
 
   <div style="background: #ffffff; padding: 30px; border: 1px solid #e5e5e5; border-top: none; border-radius: 0 0 12px 12px;">

--- a/lib/rpc/rpc-config.ts
+++ b/lib/rpc/rpc-config.ts
@@ -27,9 +27,18 @@ import { ErrorCategory, logSystemError, logWarn } from "@/lib/logging";
 /**
  * Public RPC defaults (no API keys required)
  * These are used as last resort when no config is provided
+ *
+ * Every entry must be a third-party endpoint. A deployment that reaches this
+ * table has configured nothing, so anything we operate here would silently
+ * route that deployment's chain traffic - addresses, contracts, transaction
+ * payloads - through our infrastructure. It is also durable: seed-chains.ts
+ * writes these into the chains table, and re-seeds on every deploy.
+ *
+ * tests/unit/rpc-config.test.ts asserts this over the whole table, so a new
+ * entry pointing at us fails there rather than in someone else's install.
  */
 export const PUBLIC_RPCS = {
-  ETH_MAINNET: "https://chain.techops.services/eth-mainnet",
+  ETH_MAINNET: "https://ethereum-rpc.publicnode.com",
   ETH_MAINNET_FALLBACK: "https://1rpc.io/eth",
   SEPOLIA: "https://ethereum-sepolia-rpc.publicnode.com",
   BASE_MAINNET: "https://mainnet.base.org",

--- a/lib/security/resolve-country.ts
+++ b/lib/security/resolve-country.ts
@@ -14,6 +14,10 @@
  * providers (ipapi.co, ipwho.is, freeipapi) still answer, so a missing
  * IPINFO_TOKEN / IPAPI_KEY degrades quota, not availability.
  *
+ * Because those providers need no credential, a deployment that configures
+ * nothing still sends every user's IP to them. Set GEOIP_ENABLED=false to stop
+ * that; every caller then sees NULL_LOCATION and simply shows no location.
+ *
  * Results are kept in a 24h in-memory cache keyed on IP, since session
  * creation only needs the resolve once and IPs don't change location.
  * Concurrent lookups for the same IP coalesce onto one chain walk.
@@ -90,9 +94,35 @@ async function resolveViaChain(ip: string): Promise<ResolvedLocation> {
   return NULL_LOCATION;
 }
 
+// start custom keeperhub code //
+/**
+ * Whether to resolve locations at all.
+ *
+ * Every provider in the chain is a third-party service, and the keyless ones
+ * answer without any credential, so a deployment that configures nothing still
+ * sends each signing-in user's IP address to ipapi.co, then ipwho.is, then
+ * freeipapi.com. A deployment that does not want that had no way to stop it.
+ *
+ * The polarity is deliberately the opposite of the NEXT_PUBLIC_*_ENABLED flags
+ * elsewhere. Those default off and read `=== "true"`; this one must default on
+ * so that leaving it unset reproduces today's behaviour exactly.
+ *
+ * Read per call rather than at module load so it can be flipped without a
+ * restart, and checked before the cache so a flip takes effect at once.
+ */
+function geoIpEnabled(): boolean {
+  return process.env.GEOIP_ENABLED !== "false";
+}
+// end keeperhub code //
+
 export async function resolveLocationFromIp(
   ip: string | null
 ): Promise<ResolvedLocation> {
+  // start custom keeperhub code //
+  if (!geoIpEnabled()) {
+    return NULL_LOCATION;
+  }
+  // end keeperhub code //
   if (!ip) {
     return NULL_LOCATION;
   }

--- a/lib/social-links.ts
+++ b/lib/social-links.ts
@@ -20,7 +20,16 @@ export type SocialLink = {
   brand: SocialBrand;
 };
 
-/** Address users can email for support. */
+/**
+ * Address users can email for support.
+ *
+ * Deliberately not configurable. The only consumer,
+ * `components/support/contact-support-dialog.tsx`, is a client component, so a
+ * NEXT_PUBLIC_ read here would be inlined at build time and a deployment
+ * running a prebuilt image could never change it. A seam that cannot be used
+ * is worse than an honest constant: see DEPENDENCIES.md, which lists this and
+ * the links below among the things a deployment still shows KeeperHub for.
+ */
 export const SUPPORT_EMAIL = "human@keeperhub.com";
 
 /** Community + resource links, ordered most-direct-help first. */

--- a/lib/trusted-origins.ts
+++ b/lib/trusted-origins.ts
@@ -22,6 +22,74 @@ const DEV_HTTPS_ORIGINS: readonly string[] =
     ? ["https://localhost:*", "https://127.0.0.1:*"]
     : [];
 
+// start custom keeperhub code //
+/**
+ * Extra origins for a deployment served on a domain we do not own.
+ *
+ * The list below is fixed at build time, so an install on a client domain has
+ * every cookie-authenticated write rejected: the UI loads and reads fine, then
+ * saving returns 403 with `[csrf] blocked: untrusted origin` and nothing else.
+ * This is the seam that makes such a deployment possible.
+ *
+ * Comma-separated, same wildcard syntax as the entries below, e.g.
+ *   ADDITIONAL_TRUSTED_ORIGINS=https://keeperhub.acme.example,https://*.acme.internal
+ *
+ * Unset yields exactly the list this file had before the variable existed, so
+ * production is unaffected.
+ *
+ * Deliberately NOT prefixed NEXT_PUBLIC_. Next inlines those into the server
+ * bundle too whenever they are set at build time, which would bake the
+ * builder's value into every image built from this tree.
+ */
+function parseAdditionalOrigins(raw: string | undefined): readonly string[] {
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0 && isSafeOriginPattern(entry));
+}
+
+/**
+ * Rejects patterns that would trust far more than the operator intended.
+ *
+ * `compilePattern` below maps `*` to `[^/\\]*`, which matches `.` and `:` as
+ * well as ordinary characters. So `https://*` matches every https origin on the
+ * internet, and `*` matches every origin of any scheme - either would turn the
+ * CSRF guard off while looking like configuration. A wildcard is still allowed
+ * in the host, which is what makes `https://*.acme.internal` work.
+ */
+function isSafeOriginPattern(pattern: string): boolean {
+  const separator = pattern.indexOf("://");
+  if (separator <= 0) {
+    return false;
+  }
+
+  const scheme = pattern.slice(0, separator);
+  if (scheme !== "http" && scheme !== "https") {
+    return false;
+  }
+
+  // A path would never match anyway - callers compare against a bare origin
+  // from `new URL(value).origin` - so its presence means the entry is wrong.
+  const host = pattern.slice(separator + 3);
+  if (host.length === 0 || host.includes("/")) {
+    return false;
+  }
+
+  // One leading `*.` is the only wildcard worth supporting: it is what makes
+  // `https://*.acme.internal` work. The part it qualifies must be a literal
+  // suffix, so `https://*.`, `https://*.*` and a bare `https://*` are all out.
+  const suffix = host.startsWith("*.") ? host.slice(2) : host;
+  return suffix.length > 0 && !suffix.includes("*");
+}
+
+const ADDITIONAL_TRUSTED_ORIGINS: readonly string[] = parseAdditionalOrigins(
+  process.env.ADDITIONAL_TRUSTED_ORIGINS
+);
+// end keeperhub code //
+
 export const TRUSTED_ORIGINS: readonly string[] = [
   // HTTP localhost poses no CSRF risk (same machine only) and must work in
   // all environments including CI (NODE_ENV=test) so worktrees on any port pass.
@@ -29,6 +97,7 @@ export const TRUSTED_ORIGINS: readonly string[] = [
   ...DEV_HTTPS_ORIGINS,
   // start custom keeperhub code //
   "http://127.0.0.1:*", // CLI browser auth callback (dynamic port)
+  ...ADDITIONAL_TRUSTED_ORIGINS,
   // end keeperhub code //
   "https://*.keeperhub.com",
 ];

--- a/lib/turnkey/agentic-wallet.ts
+++ b/lib/turnkey/agentic-wallet.ts
@@ -17,16 +17,7 @@
  */
 import { Turnkey } from "@turnkey/sdk-server";
 import { provisionAgenticWallet } from "@/lib/agentic-wallet/provision";
-
-/**
- * Passkey Relying Party ID for agentic-wallet passkey enrollment.
- *
- * Apex domain (NOT the `app.` subdomain) so credentials registered via the
- * webapp can be used by future subdomains without re-enrollment (ONBOARD-05).
- *
- * This is the ONLY definition of the agentic-wallet RPID in the codebase.
- */
-export const AGENTIC_RPID = "keeperhub.com";
+import { TURNKEY_API_BASE_URL } from "./api-base-url";
 
 export type CreateAgenticWalletResult = {
   subOrgId: string;
@@ -59,7 +50,7 @@ function readTurnkeyEnv(): {
 export function getTurnkeyParentClient(): Turnkey {
   const { apiPublicKey, apiPrivateKey, organizationId } = readTurnkeyEnv();
   return new Turnkey({
-    apiBaseUrl: "https://api.turnkey.com",
+    apiBaseUrl: TURNKEY_API_BASE_URL,
     apiPublicKey,
     apiPrivateKey,
     defaultOrganizationId: organizationId,
@@ -77,7 +68,7 @@ export function getTurnkeyParentClient(): Turnkey {
 export function getTurnkeyClientForOrg(subOrgId: string): Turnkey {
   const { apiPublicKey, apiPrivateKey } = readTurnkeyEnv();
   return new Turnkey({
-    apiBaseUrl: "https://api.turnkey.com",
+    apiBaseUrl: TURNKEY_API_BASE_URL,
     apiPublicKey,
     apiPrivateKey,
     defaultOrganizationId: subOrgId,

--- a/lib/turnkey/api-base-url.ts
+++ b/lib/turnkey/api-base-url.ts
@@ -1,0 +1,14 @@
+/**
+ * The Turnkey API endpoint, shared by both custody models.
+ *
+ * This lives in its own module rather than in `turnkey-operations.ts` because
+ * `agentic-wallet.ts` must not import from that file - see the v1.8 custody
+ * boundary at the top of `agentic-wallet.ts`, enforced by
+ * `tests/unit/agentic-wallet-boundary.test.ts`. A base URL is not a custody
+ * primitive, so a third module both sides may read keeps the boundary intact.
+ *
+ * Overridable so a deployment can point at a Turnkey-compatible endpoint of its
+ * own. Unset yields the value all four call sites hardcoded before.
+ */
+export const TURNKEY_API_BASE_URL =
+  process.env.TURNKEY_API_BASE_URL || "https://api.turnkey.com";

--- a/lib/turnkey/turnkey-operations.ts
+++ b/lib/turnkey/turnkey-operations.ts
@@ -11,6 +11,7 @@ import { decryptExportBundle, generateP256KeyPair } from "@turnkey/crypto";
 import { Turnkey } from "@turnkey/sdk-server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { isSolanaWalletProvisioningEnabled } from "@/lib/turnkey/solana-provisioning-flag";
+import { TURNKEY_API_BASE_URL } from "./api-base-url";
 
 let turnkeyInstance: Turnkey | undefined;
 
@@ -30,7 +31,7 @@ function getTurnkeyClient(): Turnkey {
   }
 
   turnkeyInstance = new Turnkey({
-    apiBaseUrl: "https://api.turnkey.com",
+    apiBaseUrl: TURNKEY_API_BASE_URL,
     apiPublicKey,
     apiPrivateKey,
     defaultOrganizationId: organizationId,
@@ -428,7 +429,7 @@ export function getTurnkeySignerConfig(
   }
 
   const turnkey = new Turnkey({
-    apiBaseUrl: "https://api.turnkey.com",
+    apiBaseUrl: TURNKEY_API_BASE_URL,
     apiPublicKey,
     apiPrivateKey,
     defaultOrganizationId: subOrgId,

--- a/next.config.ts
+++ b/next.config.ts
@@ -303,10 +303,20 @@ const nextConfig = {
     ];
   },
   async redirects() {
+    // Points agent crawlers at the docs. DOCS_BASE_URL lets a deployment send
+    // them to its own docs, or drop the redirect entirely by setting the
+    // variable empty - otherwise every deployment permanently redirects its own
+    // /llms.txt to a host KeeperHub runs. Read at build time like the rest of
+    // this file, so it is set for the image build rather than at runtime.
+    const docsBaseUrl =
+      process.env.DOCS_BASE_URL ?? "https://docs.keeperhub.com";
+    if (!docsBaseUrl) {
+      return [];
+    }
     return [
       {
         source: "/llms.txt",
-        destination: "https://docs.keeperhub.com/llms.txt",
+        destination: `${docsBaseUrl}/llms.txt`,
         permanent: true,
       },
     ];

--- a/tests/unit/agent-identity.test.ts
+++ b/tests/unit/agent-identity.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("agent identity", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  async function loadWith(
+    overrides: Record<string, string | undefined>
+  ): Promise<typeof import("@/lib/agent-identity")> {
+    const {
+      AGENT_NAME: _n,
+      AGENT_DESCRIPTION: _d,
+      AGENT_ID: _i,
+      AGENT_REGISTRY_ADDRESS: _r,
+      AGENT_REGISTRY_CHAIN: _c,
+      AGENT_REGISTRY_CHAIN_ID: _ci,
+      ...rest
+    } = originalEnv;
+    const next: Record<string, string> = {
+      ...(rest as Record<string, string>),
+    };
+    for (const [key, value] of Object.entries(overrides)) {
+      if (value !== undefined) {
+        next[key] = value;
+      }
+    }
+    process.env = next as NodeJS.ProcessEnv;
+    return await import("@/lib/agent-identity");
+  }
+
+  // Production configures none of these, so the defaults are what it serves.
+  describe("unconfigured", () => {
+    it("keeps the KeeperHub name and registration", async () => {
+      const { agentName, onChainIdentity } = await loadWith({});
+      expect(agentName()).toBe("KeeperHub");
+      expect(onChainIdentity()).toEqual({
+        agentId: 31_875,
+        chain: "ethereum",
+        chainId: 1,
+        registry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+      });
+    });
+
+    it("falls back to the caller's description", async () => {
+      const { agentDescription } = await loadWith({});
+      expect(agentDescription("original text")).toBe("original text");
+    });
+  });
+
+  // The coherence guard. A renamed deployment publishing our agent id would be
+  // believed by a reputation reader, which is worse than publishing nothing.
+  describe("renamed without its own registration", () => {
+    it("withholds the on-chain identity", async () => {
+      const { agentName, onChainIdentity } = await loadWith({
+        AGENT_NAME: "Acme Automations",
+      });
+      expect(agentName()).toBe("Acme Automations");
+      expect(onChainIdentity()).toBeNull();
+    });
+
+    it("withholds it for a non-numeric or zero agent id too", async () => {
+      for (const bad of ["not-a-number", "0", "-1", "  "]) {
+        vi.resetModules();
+        const { onChainIdentity } = await loadWith({
+          AGENT_NAME: "Acme Automations",
+          AGENT_ID: bad,
+        });
+        expect(onChainIdentity()).toBeNull();
+      }
+    });
+  });
+
+  describe("renamed with its own registration", () => {
+    it("publishes the operator's identity, never ours", async () => {
+      const { onChainIdentity } = await loadWith({
+        AGENT_NAME: "Acme Automations",
+        AGENT_ID: "42",
+        AGENT_REGISTRY_ADDRESS: "0x00000000000000000000000000000000000000ff",
+        AGENT_REGISTRY_CHAIN: "base",
+        AGENT_REGISTRY_CHAIN_ID: "8453",
+      });
+      expect(onChainIdentity()).toEqual({
+        agentId: 42,
+        chain: "base",
+        chainId: 8453,
+        registry: "0x00000000000000000000000000000000000000ff",
+      });
+    });
+  });
+
+  describe("deriveBaseUrl", () => {
+    it("prefers the configured app URL and strips a trailing slash", async () => {
+      const { deriveBaseUrl } = await loadWith({
+        NEXT_PUBLIC_APP_URL: "https://kh.acme.example/",
+      });
+      expect(deriveBaseUrl(new Request("https://ignored.example/x"))).toBe(
+        "https://kh.acme.example"
+      );
+    });
+
+    it("falls back to the request host rather than a KeeperHub URL", async () => {
+      const { deriveBaseUrl } = await loadWith({
+        NEXT_PUBLIC_APP_URL: undefined,
+        BETTER_AUTH_URL: undefined,
+      });
+      expect(deriveBaseUrl(new Request("https://kh.acme.example/a/b"))).toBe(
+        "https://kh.acme.example"
+      );
+    });
+  });
+});

--- a/tests/unit/agent-registry-route.test.ts
+++ b/tests/unit/agent-registry-route.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const PROD_APP_URL = "https://app.keeperhub.com";
 
 const { mockDbSelect } = vi.hoisted(() => ({
   mockDbSelect: vi.fn(),
@@ -24,8 +26,19 @@ vi.mock("@/lib/logging", () => ({
 }));
 
 describe("GET /api/agent-registry", () => {
+  const originalEnv = process.env;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    // Endpoints are derived from the deployment's own URL rather than a
+    // hardcoded app.keeperhub.com, so the tests below pin that URL to the
+    // production value. That keeps them asserting exactly the payload
+    // production serves, while a deployment on another domain gets its own.
+    process.env = { ...originalEnv, NEXT_PUBLIC_APP_URL: PROD_APP_URL };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
   });
 
   function setupDbMock(rows: unknown[]) {
@@ -233,5 +246,34 @@ describe("GET /api/agent-registry", () => {
     const cacheControl = response.headers.get("Cache-Control");
     expect(cacheControl).toContain("max-age=300");
     expect(cacheControl).toContain("public");
+  });
+
+  // A deployment that renamed itself must not keep publishing KeeperHub's ENS
+  // name and agent wallet: a card carrying our wallet under someone else's name
+  // is worse than one without it, because a reader would act on it.
+  describe("when the deployment is not KeeperHub", () => {
+    it("uses its own name and withholds the KeeperHub-only services", async () => {
+      process.env = {
+        ...process.env,
+        AGENT_NAME: "Acme Automations",
+        NEXT_PUBLIC_APP_URL: "https://kh.acme.example",
+      };
+      vi.resetModules();
+      setupDbMock([]);
+      const { GET } = await import("@/app/api/agent-registry/route");
+      const response = await GET(
+        new Request("https://kh.acme.example/api/agent-registry")
+      );
+      const json = await response.json();
+
+      expect(json.name).toBe("Acme Automations");
+      const names = json.services.map((svc: { name: string }) => svc.name);
+      expect(names).not.toContain("ens");
+      expect(names).not.toContain("agentWallet");
+      for (const svc of json.services as { endpoint: string }[]) {
+        expect(svc.endpoint).not.toContain("keeperhub.com");
+      }
+      expect(json.image).not.toContain("keeperhub.com");
+    });
   });
 });

--- a/tests/unit/agentic-wallet-boundary.test.ts
+++ b/tests/unit/agentic-wallet-boundary.test.ts
@@ -65,10 +65,13 @@ describe("agentic-wallet.ts: file-specific invariants", () => {
     "utf8"
   );
 
-  it("defines AGENTIC_RPID exactly once as keeperhub.com", () => {
-    const matches = source.match(AGENTIC_RPID_DEFINITION);
-    expect(matches).toHaveLength(1);
-    expect(source).toContain('AGENTIC_RPID = "keeperhub.com"');
+  // The module defined an AGENTIC_RPID passkey relying-party id that nothing
+  // ever imported, and there is no WebAuthn code in the tree. It was removed
+  // rather than made configurable. This asserts it stays gone, so a future
+  // passkey feature has to choose its relying-party id deliberately instead of
+  // inheriting a hardcoded keeperhub.com from a constant nobody remembers.
+  it("defines no AGENTIC_RPID", () => {
+    expect(source.match(AGENTIC_RPID_DEFINITION)).toBeNull();
   });
 
   it("exports createAgenticWallet and getTurnkeyClientForOrg", () => {

--- a/tests/unit/foreign-origin.test.ts
+++ b/tests/unit/foreign-origin.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Acceptance test for running on a domain KeeperHub does not own.
+ *
+ * Before ADDITIONAL_TRUSTED_ORIGINS existed, a deployment on a client's own
+ * host loaded and signed in fine and then failed every write with 403 and
+ * `[csrf] blocked: untrusted origin`, because the trusted-origin list was fixed
+ * at build time. This drives the real proxy - the same gate that rejected those
+ * writes - with a foreign Origin header and asserts the mutating request now
+ * completes.
+ *
+ * Pairs with `tests/unit/trusted-origins.test.ts`, which covers the parser and
+ * the patterns it refuses. This one covers the request path end to end.
+ *
+ * The list is built once at module load, so each case sets the environment and
+ * then re-imports both the seam and the proxy.
+ */
+
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetSession,
+  mockGateCountry,
+  mockResolveDevice,
+  mockReadDeviceCookie,
+} = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockGateCountry: vi.fn(),
+  mockResolveDevice: vi.fn(),
+  mockReadDeviceCookie: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: { api: { getSession: mockGetSession } },
+}));
+vi.mock("@/lib/security/login-risk", () => ({
+  gateRequestCountry: mockGateCountry,
+}));
+vi.mock("@/lib/security/device-trust", () => ({
+  resolveSigninDevice: mockResolveDevice,
+}));
+vi.mock("@/lib/device-cookie", () => ({
+  readDeviceCookie: mockReadDeviceCookie,
+}));
+
+const CLIENT_HOST = "https://keeperhub.acme.example";
+const SESSION_COOKIE = "better-auth.session_token=abc";
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  vi.resetModules();
+  mockGetSession.mockReset();
+  mockGetSession.mockResolvedValue(null);
+  mockGateCountry.mockReset();
+  mockGateCountry.mockResolvedValue({ kind: "no_country" });
+  mockResolveDevice.mockReset();
+  mockResolveDevice.mockResolvedValue(null);
+  mockReadDeviceCookie.mockReset();
+  mockReadDeviceCookie.mockReturnValue(null);
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+/**
+ * Loads the proxy with ADDITIONAL_TRUSTED_ORIGINS set to `value`, or genuinely
+ * absent when undefined. The key is rebuilt out of the environment rather than
+ * assigned undefined, which would store the string "undefined" and be parsed as
+ * a configured value.
+ */
+async function proxyWith(
+  value: string | undefined
+): Promise<(typeof import("@/proxy"))["proxy"]> {
+  const { ADDITIONAL_TRUSTED_ORIGINS: _omitted, ...rest } = originalEnv;
+  process.env =
+    value === undefined
+      ? (rest as NodeJS.ProcessEnv)
+      : { ...rest, ADDITIONAL_TRUSTED_ORIGINS: value };
+  const mod = await import("@/proxy");
+  return mod.proxy;
+}
+
+function write(origin: string): NextRequest {
+  return new NextRequest(new URL("/api/workflows", "http://localhost:3000"), {
+    method: "POST",
+    headers: new Headers({ cookie: SESSION_COOKIE, origin }),
+  });
+}
+
+describe("a deployment served on a domain we do not own", () => {
+  // The acceptance criterion for KEEP-1110: sign in, then complete a mutating
+  // API call on an arbitrary domain.
+  it("completes a cookie-authenticated write from its own origin", async () => {
+    const proxy = await proxyWith(CLIENT_HOST);
+    const res = await proxy(write(CLIENT_HOST));
+    expect(res.status).toBe(200);
+  });
+
+  // The regression this guards. Without the seam the same request is refused,
+  // which is exactly what a client saw when saving a workflow.
+  it("is refused when the origin is not configured", async () => {
+    const proxy = await proxyWith(undefined);
+    const res = await proxy(write(CLIENT_HOST));
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid origin" });
+  });
+
+  // Widening the list for one host must not widen it for every host.
+  it("still refuses an origin nobody configured", async () => {
+    const proxy = await proxyWith(CLIENT_HOST);
+    const res = await proxy(write("https://evil.example.com"));
+    expect(res.status).toBe(403);
+  });
+
+  it("accepts a wildcard subdomain of the configured host", async () => {
+    const proxy = await proxyWith("https://*.acme.internal");
+    await expect(
+      proxy(write("https://keeperhub.acme.internal"))
+    ).resolves.toMatchObject({ status: 200 });
+    // The bare suffix is a different host and stays untrusted.
+    await expect(proxy(write("https://acme.internal"))).resolves.toMatchObject({
+      status: 403,
+    });
+  });
+
+  // An unsafe pattern is dropped by the parser rather than honoured, so a
+  // configuration mistake cannot silently trust the whole internet.
+  it("does not trust everything when given a bare wildcard", async () => {
+    const proxy = await proxyWith("https://*");
+    const res = await proxy(write("https://evil.example.com"));
+    expect(res.status).toBe(403);
+  });
+
+  // KeeperHub's own deployments must be unaffected by the seam existing.
+  it("keeps the built-in origins working when extra ones are configured", async () => {
+    const proxy = await proxyWith(CLIENT_HOST);
+    await expect(
+      proxy(write("https://app.keeperhub.com"))
+    ).resolves.toMatchObject({ status: 200 });
+  });
+});

--- a/tests/unit/geoip-resolver.test.ts
+++ b/tests/unit/geoip-resolver.test.ts
@@ -43,10 +43,12 @@ function uniqueIp(): string {
 beforeEach(() => {
   delete process.env.IPINFO_TOKEN;
   delete process.env.IPAPI_KEY;
+  delete process.env.GEOIP_ENABLED;
 });
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  delete process.env.GEOIP_ENABLED;
 });
 
 describe("parseLatLon", () => {
@@ -220,5 +222,54 @@ describe("resolveLocationFromIp provider chain", () => {
     });
     await resolveLocationFromIp(uniqueIp());
     expect(seen.some((u) => hostIs(u, "ipinfo.io"))).toBe(false);
+  });
+});
+
+describe("GEOIP_ENABLED", () => {
+  // The whole point of the switch. Every provider in the chain is keyless, so
+  // "configured nothing" is not the same as "sends nothing" without this.
+  it("makes no request at all when disabled", async () => {
+    process.env.GEOIP_ENABLED = "false";
+    const seen: string[] = [];
+    stubFetch((url) => {
+      seen.push(url);
+      return { ok: true, body: { country_code: "US" } };
+    });
+    const location = await resolveLocationFromIp(uniqueIp());
+    expect(seen).toEqual([]);
+    expect(location).toEqual({
+      country: null,
+      region: null,
+      city: null,
+      latitude: null,
+      longitude: null,
+    });
+  });
+
+  // Unset must reproduce today exactly, which is the production invariant for
+  // this whole branch.
+  it("resolves normally when unset", async () => {
+    stubFetch((url) =>
+      hostIs(url, "ipapi.co")
+        ? { ok: true, body: { country_code: "US", city: "Reno" } }
+        : { ok: false, body: {} }
+    );
+    const location = await resolveLocationFromIp(uniqueIp());
+    expect(location.country).toBe("US");
+    expect(location.city).toBe("Reno");
+  });
+
+  // A gate that switches off on any truthy value gets switched off by accident.
+  it("treats values other than the literal false as enabled", async () => {
+    process.env.GEOIP_ENABLED = "true";
+    stubFetch((url) =>
+      hostIs(url, "ipapi.co")
+        ? { ok: true, body: { country_code: "DE" } }
+        : { ok: false, body: {} }
+    );
+    expect((await resolveLocationFromIp(uniqueIp())).country).toBe("DE");
+
+    process.env.GEOIP_ENABLED = "0";
+    expect((await resolveLocationFromIp(uniqueIp())).country).toBe("DE");
   });
 });

--- a/tests/unit/rpc-config.test.ts
+++ b/tests/unit/rpc-config.test.ts
@@ -337,41 +337,43 @@ describe("RPC Config Resolution", () => {
       { json: "solana-devnet", public: PUBLIC_RPCS.SOLANA_DEVNET },
     ];
 
-    it.each(chainKeys)(
-      "should resolve $json from JSON config",
-      ({ json, public: publicDefault }) => {
-        const rpcConfig: RpcConfig = {
-          [json]: { primaryRpcUrl: `https://${json}.json.example.com` },
-        };
+    it.each(chainKeys)("should resolve $json from JSON config", ({
+      json,
+      public: publicDefault,
+    }) => {
+      const rpcConfig: RpcConfig = {
+        [json]: { primaryRpcUrl: `https://${json}.json.example.com` },
+      };
 
-        const result = getRpcUrl({
-          rpcConfig,
-          jsonKey: json,
-          envValue: undefined,
-          publicDefault,
-          type: "primary",
-        });
+      const result = getRpcUrl({
+        rpcConfig,
+        jsonKey: json,
+        envValue: undefined,
+        publicDefault,
+        type: "primary",
+      });
 
-        expect(result).toBe(`https://${json}.json.example.com`);
-      }
-    );
+      expect(result).toBe(`https://${json}.json.example.com`);
+    });
 
-    it.each(chainKeys)(
-      "should fall back to public default for $json when no config",
-      ({ json, public: publicDefault }) => {
-        const rpcConfig: RpcConfig = {};
+    it.each(
+      chainKeys
+    )("should fall back to public default for $json when no config", ({
+      json,
+      public: publicDefault,
+    }) => {
+      const rpcConfig: RpcConfig = {};
 
-        const result = getRpcUrl({
-          rpcConfig,
-          jsonKey: json,
-          envValue: undefined,
-          publicDefault,
-          type: "primary",
-        });
+      const result = getRpcUrl({
+        rpcConfig,
+        jsonKey: json,
+        envValue: undefined,
+        publicDefault,
+        type: "primary",
+      });
 
-        expect(result).toBe(publicDefault);
-      }
-    );
+      expect(result).toBe(publicDefault);
+    });
   });
 
   describe("edge cases", () => {
@@ -1098,5 +1100,43 @@ describe("RPC Config Resolution", () => {
         getConfigValue(rpcConfig, "tempo-mainnet", "isTestnet", true)
       ).toBe(false);
     });
+  });
+});
+
+/**
+ * A deployment that configures no RPCs falls through to PUBLIC_RPCS, and
+ * seed-chains.ts writes whatever it finds there into the chains table - on
+ * every deploy, so a hand-corrected row does not survive. An entry pointing at
+ * infrastructure KeeperHub operates would therefore route that deployment's
+ * chain traffic through us silently and durably.
+ *
+ * This asserts over the whole exported table rather than the one entry that was
+ * wrong, so an endpoint added later fails here rather than in someone's install.
+ */
+describe("PUBLIC_RPCS contains no KeeperHub-operated endpoint", () => {
+  const OPERATED_DOMAINS = ["techops.services", "keeperhub.com"];
+
+  function hostOf(url: string): string {
+    return new URL(url).hostname.toLowerCase();
+  }
+
+  it.each(
+    Object.entries(PUBLIC_RPCS)
+  )("%s is a third-party endpoint", (_name, url) => {
+    const host = hostOf(url);
+    for (const domain of OPERATED_DOMAINS) {
+      expect(
+        host === domain || host.endsWith(`.${domain}`),
+        `${url} is operated by KeeperHub; a deployment with no RPC config would route chain traffic through us`
+      ).toBe(false);
+    }
+  });
+
+  it("covers every entry, so the table cannot grow past the check", () => {
+    const entries = Object.entries(PUBLIC_RPCS);
+    expect(entries.length).toBeGreaterThan(0);
+    for (const [, url] of entries) {
+      expect(() => hostOf(url)).not.toThrow();
+    }
   });
 });

--- a/tests/unit/signup-defenses.test.ts
+++ b/tests/unit/signup-defenses.test.ts
@@ -27,6 +27,8 @@ function clearTurnstileEnv(): void {
   // biome-ignore lint/performance/noDelete: same
   delete process.env.TURNSTILE_ENFORCE;
   // biome-ignore lint/performance/noDelete: same
+  delete process.env.TURNSTILE_DISABLED;
+  // biome-ignore lint/performance/noDelete: same
   delete process.env.LOAD_TEST_BYPASS_TOKEN;
 }
 
@@ -144,6 +146,76 @@ describe("signup defenses: captcha plugin", () => {
     await expect(import("@/lib/auth")).rejects.toThrow(
       MISSING_CAPTCHA_SECRET_ERROR
     );
+  });
+
+  // A deployment that cannot use Cloudflare needs a way to boot that is not
+  // CI=true. These cases fix what that opt-out does and, more importantly, what
+  // it does not do when it is absent.
+  describe("TURNSTILE_DISABLED opt-out", () => {
+    it("boots in production without the secret", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("CI", "");
+      vi.stubEnv("TURNSTILE_DISABLED", "true");
+      const { auth } = await import("@/lib/auth");
+      expect(auth).toBeDefined();
+      const plugin = (auth.options.plugins ?? []).find(
+        (p) => (p as CaptchaPluginShape).id === "captcha"
+      );
+      expect(plugin).toBeUndefined();
+    });
+
+    // The point of the opt-out is no Cloudflare request. A leftover secret in
+    // the deployment's config must not quietly reinstate one.
+    it("loads no captcha plugin even when a secret is present", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("CI", "");
+      vi.stubEnv("TURNSTILE_DISABLED", "true");
+      process.env.TURNSTILE_SECRET_KEY = "test-secret";
+      const { auth } = await import("@/lib/auth");
+      const plugin = (auth.options.plugins ?? []).find(
+        (p) => (p as CaptchaPluginShape).id === "captcha"
+      );
+      expect(plugin).toBeUndefined();
+    });
+
+    // Fail safe. A deployment that asked for the captcha explicitly cannot lose
+    // it by also carrying this variable.
+    it("loses to TURNSTILE_ENFORCE", async () => {
+      vi.stubEnv("NODE_ENV", "development");
+      vi.stubEnv("CI", "");
+      vi.stubEnv("TURNSTILE_ENFORCE", "true");
+      vi.stubEnv("TURNSTILE_DISABLED", "true");
+      process.env.TURNSTILE_SECRET_KEY = "test-secret";
+      const { auth } = await import("@/lib/auth");
+      const plugin = (auth.options.plugins ?? []).find(
+        (p) => (p as CaptchaPluginShape).id === "captcha"
+      ) as CaptchaPluginShape | undefined;
+      expect(plugin).toBeDefined();
+      expect(plugin?.options.endpoints).toEqual(["/sign-up/email"]);
+    });
+
+    // And still throws when enforce is on and the secret is missing, so the
+    // opt-out cannot be used to dodge that assertion either.
+    it("does not suppress the missing-secret throw under TURNSTILE_ENFORCE", async () => {
+      vi.stubEnv("NODE_ENV", "development");
+      vi.stubEnv("CI", "");
+      vi.stubEnv("TURNSTILE_ENFORCE", "true");
+      vi.stubEnv("TURNSTILE_DISABLED", "true");
+      await expect(import("@/lib/auth")).rejects.toThrow(
+        MISSING_CAPTCHA_SECRET_ERROR
+      );
+    });
+
+    // Any value other than the exact string "true" is not an opt-out. Guards
+    // that accept truthiness get switched off by accident.
+    it("ignores values other than the literal true", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("CI", "");
+      vi.stubEnv("TURNSTILE_DISABLED", "1");
+      await expect(import("@/lib/auth")).rejects.toThrow(
+        MISSING_CAPTCHA_SECRET_ERROR
+      );
+    });
   });
 });
 

--- a/tests/unit/trusted-origins.test.ts
+++ b/tests/unit/trusted-origins.test.ts
@@ -1,5 +1,5 @@
 import { getCookies } from "better-auth/cookies";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   hasSessionCookie,
   isTrustedOrigin,
@@ -180,5 +180,106 @@ describe("better-auth cookie name pinning", () => {
     expect(SESSION_COOKIE_RE.test(`${cookies.sessionToken.name}=tok`)).toBe(
       true
     );
+  });
+});
+
+describe("ADDITIONAL_TRUSTED_ORIGINS", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    // The list is built once at module load, so the module has to be
+    // re-imported after the env changes rather than merely re-read.
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  async function loadWith(
+    value: string | undefined
+  ): Promise<typeof import("@/lib/trusted-origins")> {
+    // The env is rebuilt without the key rather than having it removed, so the
+    // unset case really is absent. Assigning undefined would not do: that
+    // stores the literal string "undefined", which the parser would then treat
+    // as a value and try to validate.
+    const { ADDITIONAL_TRUSTED_ORIGINS: _omitted, ...rest } = originalEnv;
+    process.env =
+      value === undefined
+        ? (rest as NodeJS.ProcessEnv)
+        : { ...rest, ADDITIONAL_TRUSTED_ORIGINS: value };
+    return await import("@/lib/trusted-origins");
+  }
+
+  // The whole backward-compatibility claim. Production sets nothing, so the
+  // list must be what it was before this variable existed.
+  it("unset reproduces the built-in list exactly", async () => {
+    const { TRUSTED_ORIGINS } = await loadWith(undefined);
+    expect([...TRUSTED_ORIGINS]).toEqual([
+      "http://localhost:*",
+      "http://127.0.0.1:*",
+      "https://*.keeperhub.com",
+    ]);
+  });
+
+  it("trusts an exact client origin", async () => {
+    const { isTrustedOrigin } = await loadWith(
+      "https://keeperhub.acme.example"
+    );
+    expect(isTrustedOrigin("https://keeperhub.acme.example")).toBe(true);
+    expect(isTrustedOrigin("https://evil.example.com")).toBe(false);
+  });
+
+  it("trusts a wildcard subdomain and still rejects the bare suffix", async () => {
+    const { isTrustedOrigin } = await loadWith("https://*.acme.internal");
+    expect(isTrustedOrigin("https://kh.acme.internal")).toBe(true);
+    expect(isTrustedOrigin("https://a.b.acme.internal")).toBe(true);
+    expect(isTrustedOrigin("https://acme.internal")).toBe(false);
+    expect(isTrustedOrigin("https://acme.internal.evil.com")).toBe(false);
+  });
+
+  it("accepts several entries and tolerates whitespace", async () => {
+    const { isTrustedOrigin } = await loadWith(
+      " https://one.example , https://two.example "
+    );
+    expect(isTrustedOrigin("https://one.example")).toBe(true);
+    expect(isTrustedOrigin("https://two.example")).toBe(true);
+  });
+
+  it("keeps the built-in entries when extra origins are added", async () => {
+    const { isTrustedOrigin } = await loadWith(
+      "https://keeperhub.acme.example"
+    );
+    expect(isTrustedOrigin("https://app.keeperhub.com")).toBe(true);
+    expect(isTrustedOrigin("http://localhost:3000")).toBe(true);
+  });
+
+  // A `*` compiles to [^/\\]*, which matches "." and ":" as well. Any of these
+  // would trust the whole internet while looking like configuration, so they
+  // are dropped rather than honoured.
+  it.each([
+    ["a bare wildcard", "*"],
+    ["a wildcard host", "https://*"],
+    ["a wildcard scheme", "*://acme.example"],
+    ["an empty host", "https://"],
+    ["a wildcard-only suffix", "https://*.*"],
+    ["a dangling wildcard label", "https://*."],
+    ["a scheme we do not serve", "ftp://acme.example"],
+    ["no scheme at all", "acme.example"],
+    ["an entry carrying a path", "https://acme.example/admin"],
+  ])("drops %s", async (_label, value) => {
+    const { TRUSTED_ORIGINS, isTrustedOrigin } = await loadWith(value);
+    expect([...TRUSTED_ORIGINS]).toEqual([
+      "http://localhost:*",
+      "http://127.0.0.1:*",
+      "https://*.keeperhub.com",
+    ]);
+    expect(isTrustedOrigin("https://evil.example.com")).toBe(false);
+  });
+
+  it("keeps the valid entries when one in the list is unsafe", async () => {
+    const { isTrustedOrigin } = await loadWith("https://*,https://ok.example");
+    expect(isTrustedOrigin("https://ok.example")).toBe(true);
+    expect(isTrustedOrigin("https://evil.example.com")).toBe(false);
   });
 });


### PR DESCRIPTION
Makes the application honest about what it talks to, so someone can install it on
their own cluster and know what leaves it.

The packaging half already landed. This is the part packaging cannot fix: the app
itself refused to boot without a Cloudflare account, sent every signing-in user's
IP to services nobody configured, and stamped our hostnames onto output produced
by deployments we do not run.

## The document is the point

`deploy/keeperhub-stack/self-hosted/DEPENDENCIES.md` lists every external host the
build, the install and the running product reach. Four sections, because the answer
differs by phase. Each entry names the variable that turns it off or points it
elsewhere; where none exists it says so rather than leaving the entry out.

It is written from reading the source, not from grepping for hostnames. The counts
in it come from reading the matches.

The result is better than expected. In the whole install path there is exactly one
host KeeperHub operates, the Helm chart repository, and two ways to avoid it. There
is no license server, no update check and no telemetry: no analytics SDK among the
project's 110 dependencies, and no analytics host in first-party source.

## Three services had no usable off switch

**Turnstile refused to boot.** `lib/auth.ts` throws at module load without
`TURNSTILE_SECRET_KEY`, and the only escape was `CI=true`, which also changes
unrelated behaviour. Cloudflare's always-pass test keys are worse than they look:
signup still calls Cloudflare twice and verifies nothing. `TURNSTILE_DISABLED=true`
is now a deliberate opt-out that warns at every boot, because it leaves
`/sign-up/email` open to automated requests. `TURNSTILE_ENFORCE` still wins over it.

Worth noting for its own sake: the self-hosted profile carried two contradictory
comments about whether `NODE_ENV` could avoid that guard. It cannot. Next.js
compiles the value in, and the compiled bundle drops the
`process.env.NODE_ENV === "production"` term from the condition entirely. The wrong
comment is corrected.

**Location lookup had no gate at all.** Three of the four providers report
themselves configured unconditionally, so a deployment that set no credentials still
sent every signing-in user's IP address to ipapi.co, then ipwho.is, then
freeipapi.com. `GEOIP_ENABLED=false` stops it and sessions simply show no location.

**Mail and wallet signing had hardcoded endpoints,** so an operator could not point
either at their own service. Both take a base URL now.

## Four hostnames removed from other people's output

The `/llms.txt` permanent redirect to our docs host, the `app.keeperhub.com`
watermark printed onto every generated social card, the `keeperhub.com` resource URL
signed into pay-as-you-go payment payloads, and the email logo fetched from our
public repository, which told GitHub whenever a recipient opened a message.

## Two seams written and then deliberately reverted

`SUPPORT_EMAIL` and `WALLET_EMAIL_DOMAIN` are both read by browser code. A
`NEXT_PUBLIC_` read there is compiled into the bundle, so the first would have looked
configurable without being so, and the second would have resolved differently on the
server and in the browser, making the two disagree about which accounts are wallet
accounts. Both are honest constants now, with the reason recorded in place and in
the document. A seam that cannot be used is worse than a constant.

## Production is unchanged, and that is checked rather than asserted

Every new read defaults to the value the code carried before it existed, with a unit
test for each. The one derived value, the social-card watermark, comes from
`NEXT_PUBLIC_APP_URL` - which is set in neither the prod nor the staging values, so
both fall back to the exact literal they printed before. The built
`routes-manifest.json` still contains the original redirect destination.

Each new guard was checked by breaking it and confirming the assertions fail, not
only by watching them pass.

## Also

Drops `AGENTIC_RPID`, a `keeperhub.com` passkey relying-party id with zero importers
and no WebAuthn code anywhere in the tree. The boundary test now asserts it stays
gone, so a future passkey feature has to choose one deliberately instead of
inheriting a constant nobody remembers.

Adds the acceptance test for running on a domain we do not own: a cookie-authenticated
write driven through the real proxy with a foreign `Origin`. The first two cases send
an identical request and differ only in whether the origin is configured, so a seam
that did nothing would fail the first rather than passing both.

## Checks run locally

`pnpm check` 0, `biome check` clean on every changed file, `pnpm type-check` 0,
`pnpm build` 0, 514 test files / 20748 tests, sandbox suite 39, shellcheck 0,
hadolint clean at error threshold, both docker-compose profiles valid, all eight
self-hosted mode combinations render, fork markers balanced tree-wide.

The rendered self-hosted manifest still contains zero ExternalSecret, zero
parameterStore and zero amazonaws.com references.

## Not in this change

An egress-denied CI job and a published allowlist were both considered and dropped:
what an installer permits on their own network is their decision, not ours.

The eight skill descriptions in `agent-card.json` still name KeeperHub commercial
rails, and no sandbox is deployed by the self-hosted profile so the Code step fails
there. Both are follow-ups; the second is recorded in the document as a limitation.
