### PR TITLE
docs(llms): describe what the OpenAPI spec actually covers

### DIFF
--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -29,7 +29,7 @@ The interactive product. Most routes require auth, but the surfaces below are ho
 - [Sign in](https://app.keeperhub.com): Entry point to the workflow builder, runs view, wallets, billing
 - [Hub](https://app.keeperhub.com/hub): Browseable catalog of supported protocols and plugins
 - [REST API](https://app.keeperhub.com/api): Base path for programmatic control (see [/api docs](https://docs.keeperhub.com/api))
-- [OpenAPI spec](https://app.keeperhub.com/api/openapi): Machine-readable schema for the published-workflow call endpoints (`POST /api/mcp/workflows/{slug}/call`) and their x402/SIWX payment schemes. The core REST API, including authentication and direct execution, is documented at [/api](https://docs.keeperhub.com/api)
+- [OpenAPI spec](https://app.keeperhub.com/api/openapi): Machine-readable schema for the listed-workflow call endpoints (`POST /api/mcp/workflows/{slug}/call`). Paid operations declare their price and accepted payment protocols (x402, and MPP over Tempo) in `x-payment-info` rather than in a per-operation `security` array. The core REST API, including authentication and direct execution, is documented at [/api](https://docs.keeperhub.com/api)
 - [MCP server](https://app.keeperhub.com/mcp): OAuth-authenticated Model Context Protocol endpoint for LLM clients
 
 ### docs.keeperhub.com — documentation

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -29,7 +29,7 @@ The interactive product. Most routes require auth, but the surfaces below are ho
 - [Sign in](https://app.keeperhub.com): Entry point to the workflow builder, runs view, wallets, billing
 - [Hub](https://app.keeperhub.com/hub): Browseable catalog of supported protocols and plugins
 - [REST API](https://app.keeperhub.com/api): Base path for programmatic control (see [/api docs](https://docs.keeperhub.com/api))
-- [OpenAPI spec](https://app.keeperhub.com/api/openapi): Machine-readable schema for the REST API
+- [OpenAPI spec](https://app.keeperhub.com/api/openapi): Machine-readable schema for the published-workflow call endpoints (`POST /api/mcp/workflows/{slug}/call`) and their x402/SIWX payment schemes. The core REST API, including authentication and direct execution, is documented at [/api](https://docs.keeperhub.com/api)
 - [MCP server](https://app.keeperhub.com/mcp): OAuth-authenticated Model Context Protocol endpoint for LLM clients
 
 ### docs.keeperhub.com — documentation


### PR DESCRIPTION
## Problem

`llms.txt` describes the OpenAPI document as the machine-readable schema for the REST API:

```
- [OpenAPI spec](https://app.keeperhub.com/api/openapi): Machine-readable schema for the REST API
```

It is not that. Reproduce:

```bash
curl -s https://app.keeperhub.com/api/openapi -o openapi.json
python3 -c "
import json; d=json.load(open('openapi.json')); p=list(d['paths'])
print('paths', len(p))
print('non-workflow paths', [x for x in p if not x.startswith('/api/mcp/workflows')])
print('paths containing execute', [x for x in p if 'execute' in x])
print('schemas', list(d.get('components',{}).get('schemas',{})))
print('securitySchemes', list(d.get('components',{}).get('securitySchemes',{})))"
```

Observed 2026-08-11:

```
paths 117
non-workflow paths []
paths containing execute []
schemas []
securitySchemes ['x402', 'siwx']
```

Every path is a published-workflow call endpoint. Not one core REST route appears: no
`/api/keys`, no `/api/user`, none of `/api/execute/*`. `components.schemas` is empty, and the
only declared security schemes are x402 and SIWX, so the `kh_` bearer scheme that every
documented REST call requires is not in the document at all.

## Why it matters here specifically

`llms.txt` is the file agents are pointed at, and this line is the one that tells an agent where
the machine-readable contract lives. An agent that follows it lands on a document that cannot
answer either of its first two questions: what endpoint executes a transaction, and how do I
authenticate. The prose docs at `/api` answer both, but the agent has been sent elsewhere.

## The change

One line. Describes what the document actually covers and points at `/api` for the core REST
surface.

Docs only, no behaviour change.

## The better fix, if you want it

Adding the core paths and a bearer security scheme to the generated spec would be strictly
better than correcting the description, and would make the original sentence true. I did not
attempt that, because I cannot see how the spec is generated and would be guessing at the
generator's constraints. Happy to close this in favour of that if it is already planned.

## Not included

I originally also had a change adding onboarding deep links to this file, on the basis that the
quickstart, headless onboarding and first-verified-transaction pages were unreachable from the
index. Re-checking today, the docs restructure has already addressed most of that: Getting
Started now has four entries, Wallet Management names Turnkey and sponsorship, and the Guides
line names the verified first transaction. So I dropped it. Only the OpenAPI description looked
still wrong on re-verification.

Found while building [keeperhub-flightcheck](https://github.com/winsznx/keeperhub-flightcheck)
for the Agents Onchain hackathon.
