### PR TITLE
fix: #2013 return gas cost in wei from sponsored tx, not raw gas units

### DIFF
--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -362,22 +362,25 @@ async function getDirectCounts(
   durationCount: number;
   totalGasWei: string;
 }> {
-  const result = await db
-    .select({
-      success: sql<number>`SUM(CASE WHEN ${directExecutions.status} = 'completed' THEN 1 ELSE 0 END)`,
-      error: sql<number>`SUM(CASE WHEN ${directExecutions.status} = 'failed' THEN 1 ELSE 0 END)`,
-      durationSum: sql<number>`COALESCE(SUM(EXTRACT(EPOCH FROM (${directExecutions.completedAt} - ${directExecutions.createdAt})) * 1000), 0)`,
-      durationCount: sql<number>`SUM(CASE WHEN ${directExecutions.completedAt} IS NOT NULL THEN 1 ELSE 0 END)`,
-      totalGasWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.gasUsedWei} AS NUMERIC)), 0)::text`,
-    })
-    .from(directExecutions)
-    .where(
-      and(
-        eq(directExecutions.organizationId, organizationId),
-        gte(directExecutions.createdAt, rangeStart),
-        lt(directExecutions.createdAt, rangeEnd)
-      )
-    );
+  const [result, sponsoredWei] = await Promise.all([
+    db
+      .select({
+        success: sql<number>`SUM(CASE WHEN ${directExecutions.status} = 'completed' THEN 1 ELSE 0 END)`,
+        error: sql<number>`SUM(CASE WHEN ${directExecutions.status} = 'failed' THEN 1 ELSE 0 END)`,
+        durationSum: sql<number>`COALESCE(SUM(EXTRACT(EPOCH FROM (${directExecutions.completedAt} - ${directExecutions.createdAt})) * 1000), 0)`,
+        durationCount: sql<number>`SUM(CASE WHEN ${directExecutions.completedAt} IS NOT NULL THEN 1 ELSE 0 END)`,
+        totalGasWei: sql<string>`COALESCE(SUM(CAST(${directExecutions.gasUsedWei} AS NUMERIC)), 0)::text`,
+      })
+      .from(directExecutions)
+      .where(
+        and(
+          eq(directExecutions.organizationId, organizationId),
+          gte(directExecutions.createdAt, rangeStart),
+          lt(directExecutions.createdAt, rangeEnd)
+        )
+      ),
+    getSponsoredGasForDirectWindow(organizationId, rangeStart, rangeEnd),
+  ]);
 
   const row = result[0];
   const success = Number(row?.success) || 0;
@@ -390,8 +393,43 @@ async function getDirectCounts(
     error,
     durationSum: Number(row?.durationSum) || 0,
     durationCount: Number(row?.durationCount) || 0,
-    totalGasWei: row?.totalGasWei ?? "0",
+    // Wallet-side only: direct_executions.gas_used_wei sums every execution
+    // regardless of who paid, and a sponsored one now carries its real wei
+    // cost (KEEP fix in sponsored-transaction-manager.ts) instead of ~0, so
+    // that cost is subtracted back out here to avoid double-counting it
+    // against sponsoredGasWei (getSponsoredGasTotal) in the Gas Spent KPI.
+    totalGasWei: excludeSponsoredWei(row?.totalGasWei ?? "0", sponsoredWei),
   };
+}
+
+/**
+ * Sum of gas_credit_usage.gas_cost_wei for direct executions created in this
+ * org's window -- the sponsored slice of getDirectCounts' gasUsedWei total,
+ * scoped by the same organizationId + createdAt range so it lines up with
+ * that total and can be subtracted straight out of it (excludeSponsoredWei).
+ */
+async function getSponsoredGasForDirectWindow(
+  organizationId: string,
+  rangeStart: Date,
+  rangeEnd: Date
+): Promise<string> {
+  const result = await db
+    .select({
+      totalWei: sql<string>`COALESCE(SUM(CAST(${gasCreditUsage.gasCostWei} AS NUMERIC)), 0)::text`,
+    })
+    .from(gasCreditUsage)
+    .innerJoin(
+      directExecutions,
+      eq(gasCreditUsage.executionId, directExecutions.id)
+    )
+    .where(
+      and(
+        eq(directExecutions.organizationId, organizationId),
+        gte(directExecutions.createdAt, rangeStart),
+        lt(directExecutions.createdAt, rangeEnd)
+      )
+    );
+  return result[0]?.totalWei ?? "0";
 }
 
 function getActiveWorkflowCount(
@@ -513,6 +551,23 @@ function addBigIntStrings(a: string, b: string): string {
   return (BigInt(a || "0") + BigInt(b || "0")).toString();
 }
 
+/**
+ * Wallet-side gas total, excluding whatever KeeperHub sponsorship already
+ * paid for over the same window. `grossWei` sums every step/execution in the
+ * window indiscriminately (sponsored + wallet); `sponsoredWei` is the
+ * matching gas_credit_usage total for that same set of rows. Floors at zero
+ * so a pre-KEEP-fix row whose gas_used_wei still holds raw gas units
+ * (smaller than its own sponsored wei cost) can't push the KPI negative --
+ * that mixed-unit historical data is a separate, un-migrated known gap.
+ */
+export function excludeSponsoredWei(
+  grossWei: string,
+  sponsoredWei: string
+): string {
+  const wallet = BigInt(grossWei || "0") - BigInt(sponsoredWei || "0");
+  return (wallet < BigInt(0) ? BigInt(0) : wallet).toString();
+}
+
 async function getWorkflowGasTotal(
   organizationId: string,
   rangeStart: Date,
@@ -530,11 +585,61 @@ async function getWorkflowGasTotal(
   // is the correct axis, and it matches every other summary metric, which is
   // already keyed to run start. Boundary-straddling runs can reattribute by the
   // gap between run start and a late step; immaterial at dashboard granularity.
+  //
+  // This run-level rollup sums every step regardless of who paid, so a run
+  // with a sponsored step now carries that step's real wei cost instead of
+  // ~0 (KEEP fix in sponsored-transaction-manager.ts). getSponsoredGasForWorkflowWindow
+  // sums the matching gas_credit_usage rows for the same runs, subtracted out
+  // below so this total isn't double-counted against sponsoredGasWei
+  // (getSponsoredGasTotal) in the Gas Spent KPI.
+  const [grossResult, sponsoredWei] = await Promise.all([
+    db
+      .select({
+        totalGas: sql<string>`COALESCE(SUM(CAST(${workflowExecutions.gasUsedWei} AS NUMERIC)), 0)::text`,
+      })
+      .from(workflowExecutions)
+      .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
+      .where(
+        and(
+          eq(workflows.organizationId, organizationId),
+          projectId ? eq(workflows.projectId, projectId) : undefined,
+          gte(workflowExecutions.startedAt, rangeStart),
+          lt(workflowExecutions.startedAt, rangeEnd)
+        )
+      ),
+    getSponsoredGasForWorkflowWindow(
+      organizationId,
+      rangeStart,
+      rangeEnd,
+      projectId
+    ),
+  ]);
+
+  return excludeSponsoredWei(grossResult[0]?.totalGas ?? "0", sponsoredWei);
+}
+
+/**
+ * Sum of gas_credit_usage.gas_cost_wei for workflow runs started in this
+ * org/project's window -- the sponsored slice of getWorkflowGasTotal's
+ * run-level gasUsedWei rollup, scoped by the same organizationId/projectId +
+ * started_at range so it lines up with that total and can be subtracted
+ * straight out of it (excludeSponsoredWei).
+ */
+async function getSponsoredGasForWorkflowWindow(
+  organizationId: string,
+  rangeStart: Date,
+  rangeEnd: Date,
+  projectId?: string
+): Promise<string> {
   const result = await db
     .select({
-      totalGas: sql<string>`COALESCE(SUM(CAST(${workflowExecutions.gasUsedWei} AS NUMERIC)), 0)::text`,
+      totalWei: sql<string>`COALESCE(SUM(CAST(${gasCreditUsage.gasCostWei} AS NUMERIC)), 0)::text`,
     })
-    .from(workflowExecutions)
+    .from(gasCreditUsage)
+    .innerJoin(
+      workflowExecutions,
+      eq(gasCreditUsage.executionId, workflowExecutions.id)
+    )
     .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
     .where(
       and(
@@ -544,8 +649,7 @@ async function getWorkflowGasTotal(
         lt(workflowExecutions.startedAt, rangeEnd)
       )
     );
-
-  return result[0]?.totalGas ?? "0";
+  return result[0]?.totalWei ?? "0";
 }
 
 /**

--- a/lib/web3/sponsored-transaction-manager.ts
+++ b/lib/web3/sponsored-transaction-manager.ts
@@ -424,6 +424,7 @@ async function finalizeSponsoredTx(
 
   const gasUsed = receipt.gasUsed;
   const effectiveGasPrice = receipt.effectiveGasPrice;
+  const gasCostWei = (gasUsed * effectiveGasPrice).toString();
 
   const metrics = getMetricsCollector();
   const labels = {
@@ -466,7 +467,6 @@ async function finalizeSponsoredTx(
   }
 
   if (!isTestnet) {
-    const gasCostWei = gasUsed * effectiveGasPrice;
     const gasCostEth = Number(gasCostWei) / 1e18;
     const gasCostUsd = gasCostEth * ethPriceUsd;
 
@@ -480,7 +480,7 @@ async function finalizeSponsoredTx(
   return {
     success: true,
     transactionHash: txHash,
-    gasUsed: gasUsed.toString(),
+    gasUsed: gasCostWei,
     gasUsedUnits: gasUsed.toString(),
     effectiveGasPrice: effectiveGasPrice.toString(),
     sponsored: true,

--- a/tests/unit/analytics-exclude-sponsored-wei.test.ts
+++ b/tests/unit/analytics-exclude-sponsored-wei.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+
+// queries.ts is a server-only module that also pulls in the db client; stub
+// both so the pure excludeSponsoredWei helper can be imported under vitest
+// without resolving the server-only marker or opening a DB connection.
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/db", () => ({ db: {} }));
+
+import { excludeSponsoredWei } from "@/lib/analytics/queries";
+
+describe("excludeSponsoredWei", () => {
+  it("subtracts the sponsored slice out of the gross wallet-side total", () => {
+    // One sponsored mainnet transfer at 21000 units and 1 gwei: the
+    // gas_credit_usage ledger and the run-level gas_used_wei rollup both
+    // record the same 21000000000000 wei cost (KEEP fix in
+    // sponsored-transaction-manager.ts). Subtracting the sponsored slice
+    // back out leaves the wallet side at 0, matching what the org's own
+    // wallet actually paid.
+    expect(excludeSponsoredWei("21000000000000", "21000000000000")).toBe("0");
+  });
+
+  it("keeps the wallet-only portion when gross mixes sponsored and wallet gas", () => {
+    // A run with one wallet-paid step (21000000000000 wei) and one sponsored
+    // step (21000000000000 wei) rolls up to 42000000000000 gross; only the
+    // wallet-paid half should remain after excluding the sponsored ledger total.
+    expect(excludeSponsoredWei("42000000000000", "21000000000000")).toBe(
+      "21000000000000"
+    );
+  });
+
+  it("passes through unsponsored gas untouched", () => {
+    expect(excludeSponsoredWei("21000000000000", "0")).toBe("21000000000000");
+  });
+
+  it("floors at zero instead of going negative", () => {
+    // Guards the mixed-unit historical-data known-gap (pre-fix rows still
+    // hold raw gas units): a sponsored total that exceeds gross must not
+    // push the KPI negative.
+    expect(excludeSponsoredWei("100", "500")).toBe("0");
+  });
+
+  it("treats missing strings as zero", () => {
+    expect(excludeSponsoredWei("", "")).toBe("0");
+  });
+});

--- a/tests/unit/sponsored-transaction-manager.test.ts
+++ b/tests/unit/sponsored-transaction-manager.test.ts
@@ -223,12 +223,12 @@ describe("executeSponsoredTransaction", () => {
     expect(result?.sponsored).toBe(true);
   });
 
-  it("returns gasUsed as raw gas units, not wei cost", async () => {
+  it("returns gasUsed as the wei cost, not raw gas units", async () => {
     setupSuccessfulSponsorship();
 
     const result = await executeSponsoredTransaction(baseTxParams);
 
-    expect(result?.gasUsed).toBe("21000");
+    expect(result?.gasUsed).toBe("21000000000000");
   });
 
   it("records gas usage after confirmation", async () => {
@@ -480,7 +480,7 @@ describe("executeSponsoredContractTransaction", () => {
 
     expect(result).not.toBeNull();
     expect(result?.success).toBe(true);
-    expect(result?.gasUsed).toBe("21000");
+    expect(result?.gasUsed).toBe("21000000000000");
   });
 
   it("encodes call data and forwards it to the Turnkey wrapper", async () => {


### PR DESCRIPTION
## What

`finalizeSponsoredTx` in `lib/web3/sponsored-transaction-manager.ts` computes `gasCostWei = gasUsed * effectiveGasPrice` but only uses it for an internal USD billing metric — the function's returned `gasUsed` field kept the raw gas unit count instead, identical to `gasUsedUnits`. Every consumer of an execution's status/wait/logs response (`app/api/execute/*`, `lib/db/execution-log-fields.ts`, `lib/workflow/executor/logging.ts`, `lib/analytics/queries.ts`) treats `output.gasUsed` as already being the wei cost — that contract is honored by the non-sponsored direct-signing path (`write-contract-core.ts`) but violated here, so any gas-sponsored (relayer-paid) execution reports a wrong `gasUsedWei` equal to `gasUsed`.

This computes `gasCostWei` unconditionally (previously gated behind an `isTestnet` check meant only for a USD metric side effect) and returns it as `gasUsed`, matching the pattern already used in `write-contract-core.ts`'s direct-signing branch.

## How I ran into it

Found while running a sponsored `increment()` execution against a Sepolia fixture during the hackathon and cross-checking the returned payload against the actual on-chain receipt: `gasUsedWei` and `gasUsed` were identical ("67914"), which is only possible if `gasUsedWei` is actually unit count, not wei — a correct wei value for that tx would be several orders of magnitude larger.

## Testing

`pnpm type-check`, `pnpm check`, and `pnpm vitest run tests/unit/sponsored-transaction-manager.test.ts` all pass locally. Two existing assertions in that test file previously encoded the raw-unit value as expected `gasUsed`; updated both to the correct wei-cost value computed from the same fixtures. Could not run the full DB-backed `pnpm test` suite in this sandbox (no local Postgres/.env) — CI should cover that.