### PR TITLE
fix: #2015 initialize execution progress on direct-dispatch paths

### DIFF
--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -232,6 +232,10 @@ async function startExecutionInBackground(
   // and in-process/SQS dispatch paths already do this before running).
   // Without it, total_steps stays NULL forever and the status endpoint's
   // progress.percentage is stuck at 0 even after a successful run.
+  // This sits between the committed payment (recordPayment, above) and
+  // start() below -- a display-only column must never be able to abort a
+  // paid dispatch, so a transient DB fault here is caught and logged
+  // rather than thrown, and execution proceeds to start() regardless.
   await db
     .update(workflowExecutions)
     .set({
@@ -246,7 +250,15 @@ async function startExecutionInBackground(
       lastSuccessfulNodeId: null,
       lastSuccessfulNodeName: null,
     })
-    .where(eq(workflowExecutions.id, executionId));
+    .where(eq(workflowExecutions.id, executionId))
+    .catch((err: unknown) => {
+      logSystemError(
+        ErrorCategory.WORKFLOW_ENGINE,
+        "[x402/call] Error initializing execution progress",
+        err,
+        { endpoint: "/api/mcp/workflows/[slug]/call", workflowId: workflow.id }
+      );
+    });
 
   start(executeWorkflow, [
     buildExecutorInput(workflow, {

--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -47,6 +47,8 @@ import { hashWorkflowDefinition } from "@/lib/workflow/content-hash";
 import { workflowReachableConditions } from "@/lib/workflow/executable";
 import { buildExecutorInput } from "@/lib/workflow/executor/build-executor-input";
 import { executeWorkflow } from "@/lib/workflow/executor/executor.workflow";
+import { calculateTotalSteps } from "@/lib/workflow/executor/progress";
+import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -225,6 +227,27 @@ async function startExecutionInBackground(
 ): Promise<void> {
   const { slug: organizationSlug, plan: organizationPlan } =
     await resolveExecutionOrgMetadata(workflow.organizationId);
+
+  // Mirrors keeperhub-executor's initializeExecutionProgress (the K8s Job
+  // and in-process/SQS dispatch paths already do this before running).
+  // Without it, total_steps stays NULL forever and the status endpoint's
+  // progress.percentage is stuck at 0 even after a successful run.
+  await db
+    .update(workflowExecutions)
+    .set({
+      totalSteps: calculateTotalSteps(
+        workflow.nodes as WorkflowNode[],
+        workflow.edges as WorkflowEdge[]
+      ).toString(),
+      completedSteps: "0",
+      executionTrace: [],
+      currentNodeId: null,
+      currentNodeName: null,
+      lastSuccessfulNodeId: null,
+      lastSuccessfulNodeName: null,
+    })
+    .where(eq(workflowExecutions.id, executionId));
+
   start(executeWorkflow, [
     buildExecutorInput(workflow, {
       triggerInput: body,

--- a/lib/workflow/execute-in-background.ts
+++ b/lib/workflow/execute-in-background.ts
@@ -16,6 +16,7 @@ import { recordExecutionErrorFinalized } from "@/lib/errors/finalize-error";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { signSqsMessageAttributes } from "@/lib/sqs-message-auth";
 import { executeWorkflow } from "@/lib/workflow/executor/executor.workflow";
+import { calculateTotalSteps } from "@/lib/workflow/executor/progress";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 
 let _sqsClient: SQSClient | null = null;
@@ -117,6 +118,23 @@ export async function executeWorkflowInBackground(
           eq(workflowExecutions.status, "pending")
         )
       );
+
+    // Mirrors keeperhub-executor's initializeExecutionProgress (the K8s Job
+    // and in-process/SQS dispatch paths already do this before running).
+    // Without it, total_steps stays NULL forever and the status endpoint's
+    // progress.percentage is stuck at 0 even after a successful run.
+    await db
+      .update(workflowExecutions)
+      .set({
+        totalSteps: calculateTotalSteps(nodes, edges).toString(),
+        completedSteps: "0",
+        executionTrace: [],
+        currentNodeId: null,
+        currentNodeName: null,
+        lastSuccessfulNodeId: null,
+        lastSuccessfulNodeName: null,
+      })
+      .where(eq(workflowExecutions.id, executionId));
 
     const run = await start(executeWorkflow, [
       {

--- a/lib/workflow/execute-in-background.ts
+++ b/lib/workflow/execute-in-background.ts
@@ -1,5 +1,5 @@
 import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
-import { and, eq, ne } from "drizzle-orm";
+import { and, eq, isNull, ne } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { start } from "workflow/api";
 import { db } from "@/lib/db";
@@ -123,6 +123,11 @@ export async function executeWorkflowInBackground(
     // and in-process/SQS dispatch paths already do this before running).
     // Without it, total_steps stays NULL forever and the status endpoint's
     // progress.percentage is stuck at 0 even after a successful run.
+    // Guarded on totalSteps being unset (like the status flip above is
+    // guarded on status) so a duplicate dispatch naming an already-running
+    // executionId can't reset its completedSteps/executionTrace/last-node
+    // fields back to zero mid-flight: this initializes once and is a no-op
+    // on every subsequent call for the same executionId.
     await db
       .update(workflowExecutions)
       .set({
@@ -134,7 +139,12 @@ export async function executeWorkflowInBackground(
         lastSuccessfulNodeId: null,
         lastSuccessfulNodeName: null,
       })
-      .where(eq(workflowExecutions.id, executionId));
+      .where(
+        and(
+          eq(workflowExecutions.id, executionId),
+          isNull(workflowExecutions.totalSteps)
+        )
+      );
 
     const run = await start(executeWorkflow, [
       {

--- a/tests/unit/execute-in-background-progress.test.ts
+++ b/tests/unit/execute-in-background-progress.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks -- must be defined before any vi.mock() calls
@@ -68,13 +68,17 @@ import { executeWorkflowInBackground } from "@/lib/workflow/execute-in-backgroun
 describe("executeWorkflowInBackground - progress initialization", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.WORKFLOW_DISPATCH_VIA_EXECUTOR = undefined;
+    vi.stubEnv("WORKFLOW_DISPATCH_VIA_EXECUTOR", "");
     mockDbUpdateSet.mockReturnValue({
       where: vi.fn().mockResolvedValue(undefined),
     });
     mockDbUpdate.mockReturnValue({ set: mockDbUpdateSet });
     mockStart.mockResolvedValue({ runId: "run-1" });
     mockSqsSend.mockResolvedValue({ MessageId: "msg-1" });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("initializes totalSteps from the workflow graph before start() is called (default/fallback dispatch path)", async () => {
@@ -128,9 +132,9 @@ describe("executeWorkflowInBackground - progress initialization", () => {
   });
 
   it("does not initialize progress on the SQS/executor dispatch branch (already handled by initializeExecutionProgress downstream)", async () => {
-    process.env.WORKFLOW_DISPATCH_VIA_EXECUTOR = "1";
-    process.env.SQS_QUEUE_URL = "http://sqs.local/queue";
-    process.env.INTERNAL_SERVICE_HMAC_SECRET = "test-secret";
+    vi.stubEnv("WORKFLOW_DISPATCH_VIA_EXECUTOR", "1");
+    vi.stubEnv("SQS_QUEUE_URL", "http://sqs.local/queue");
+    vi.stubEnv("INTERNAL_SERVICE_HMAC_SECRET", "test-secret");
 
     await executeWorkflowInBackground(
       "exec-2",

--- a/tests/unit/execute-in-background-progress.test.ts
+++ b/tests/unit/execute-in-background-progress.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks -- must be defined before any vi.mock() calls
+// ---------------------------------------------------------------------------
+
+const { mockDbUpdate, mockDbUpdateSet, mockStart, mockSqsSend } = vi.hoisted(
+  () => ({
+    mockDbUpdate: vi.fn(),
+    mockDbUpdateSet: vi.fn(),
+    mockStart: vi.fn(),
+    mockSqsSend: vi.fn(),
+  })
+);
+
+vi.mock("@/lib/db", () => ({
+  db: { update: mockDbUpdate },
+}));
+
+// Keeps the WORKFLOW_DISPATCH_VIA_EXECUTOR branch from making a real network
+// call; that branch is already covered end-to-end by keeperhub-executor's
+// own tests and is explicitly out of scope for this fix (it already
+// initializes progress correctly via initializeExecutionProgress).
+vi.mock("@aws-sdk/client-sqs", () => ({
+  SQSClient: class {
+    send = mockSqsSend;
+  },
+  SendMessageCommand: class {
+    constructor(input: unknown) {
+      Object.assign(this as object, input as object);
+    }
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: { id: "id", status: "status" },
+}));
+
+vi.mock("workflow/api", () => ({
+  start: mockStart,
+}));
+
+vi.mock("@/lib/workflow/executor/executor.workflow", () => ({
+  executeWorkflow: vi.fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { WORKFLOW_ENGINE: "workflow_engine" },
+  logSystemError: vi.fn(),
+}));
+
+// finalize-error.ts and its transitive deps are server-only; not exercised on
+// the happy path, mocked here purely so the module graph resolves.
+vi.mock("@/lib/errors/classify", () => ({
+  classifyExecutionError: vi.fn().mockReturnValue({
+    errorCategory: "workflow_engine",
+    errorType: "system",
+    code: "unknown",
+  }),
+  isDefaultClassification: vi.fn().mockReturnValue(true),
+}));
+vi.mock("@/lib/errors/finalize-error", () => ({
+  recordExecutionErrorFinalized: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { executeWorkflowInBackground } from "@/lib/workflow/execute-in-background";
+
+describe("executeWorkflowInBackground - progress initialization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.WORKFLOW_DISPATCH_VIA_EXECUTOR = undefined;
+    mockDbUpdateSet.mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    });
+    mockDbUpdate.mockReturnValue({ set: mockDbUpdateSet });
+    mockStart.mockResolvedValue({ runId: "run-1" });
+    mockSqsSend.mockResolvedValue({ MessageId: "msg-1" });
+  });
+
+  it("initializes totalSteps from the workflow graph before start() is called (default/fallback dispatch path)", async () => {
+    const callOrder: string[] = [];
+    mockDbUpdateSet.mockImplementation((values: Record<string, unknown>) => {
+      if ("totalSteps" in values) {
+        callOrder.push("initializeProgress");
+      }
+      return { where: vi.fn().mockResolvedValue(undefined) };
+    });
+    mockStart.mockImplementation(() => {
+      callOrder.push("start");
+      return Promise.resolve({ runId: "run-1" });
+    });
+
+    const nodes = [
+      {
+        id: "trigger-1",
+        type: "trigger",
+        position: { x: 0, y: 0 },
+        data: { type: "trigger", enabled: true },
+      },
+      {
+        id: "action-1",
+        type: "action",
+        position: { x: 0, y: 0 },
+        data: { type: "action", enabled: true },
+      },
+    ];
+    const edges = [{ id: "e1", source: "trigger-1", target: "action-1" }];
+
+    await executeWorkflowInBackground(
+      "exec-1",
+      "wf-1",
+      nodes as never,
+      edges as never,
+      {},
+      { logPrefix: "[Test]", endpoint: "/test" }
+    );
+
+    expect(mockDbUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ totalSteps: "2", completedSteps: "0" })
+    );
+    expect(mockStart).toHaveBeenCalled();
+
+    const progressIdx = callOrder.indexOf("initializeProgress");
+    const startIdx = callOrder.indexOf("start");
+    expect(progressIdx).toBeGreaterThanOrEqual(0);
+    expect(startIdx).toBeGreaterThanOrEqual(0);
+    expect(progressIdx).toBeLessThan(startIdx);
+  });
+
+  it("does not initialize progress on the SQS/executor dispatch branch (already handled by initializeExecutionProgress downstream)", async () => {
+    process.env.WORKFLOW_DISPATCH_VIA_EXECUTOR = "1";
+    process.env.SQS_QUEUE_URL = "http://sqs.local/queue";
+    process.env.INTERNAL_SERVICE_HMAC_SECRET = "test-secret";
+
+    await executeWorkflowInBackground(
+      "exec-2",
+      "wf-2",
+      [] as never,
+      [] as never,
+      {},
+      { logPrefix: "[Test]", endpoint: "/test" }
+    );
+
+    expect(mockSqsSend).toHaveBeenCalledTimes(1);
+    // The fallback branch's own progress-init query must not also run here.
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/mcp-call-route-progress.test.ts
+++ b/tests/unit/mcp-call-route-progress.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks -- must be defined before any vi.mock() calls
+// ---------------------------------------------------------------------------
+
+const {
+  mockDbSelect,
+  mockDbInsert,
+  mockDbUpdate,
+  mockDbUpdateSet,
+  mockResolveExecutionOrgMetadata,
+  mockStart,
+  mockEnforceExecutionLimit,
+  mockCheckConcurrencyLimit,
+  mockChargePaygIfBillable,
+  mockLogSystemError,
+  mockBuildCallCompletionResponse,
+  mockDetectProtocol,
+  mockGatePayment,
+} = vi.hoisted(() => ({
+  mockDbSelect: vi.fn(),
+  mockDbInsert: vi.fn(),
+  mockDbUpdate: vi.fn(),
+  mockDbUpdateSet: vi.fn(),
+  mockResolveExecutionOrgMetadata: vi.fn(),
+  mockStart: vi.fn(),
+  mockEnforceExecutionLimit: vi.fn(),
+  mockCheckConcurrencyLimit: vi.fn(),
+  mockChargePaygIfBillable: vi.fn(),
+  mockLogSystemError: vi.fn(),
+  mockBuildCallCompletionResponse: vi.fn(),
+  mockDetectProtocol: vi.fn(),
+  mockGatePayment: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Module mocks -- mirrors tests/unit/x402-call-route.test.ts, the existing
+// mock set for this route, trimmed to what the free/read happy path touches.
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: mockDbSelect,
+    insert: mockDbInsert,
+    update: mockDbUpdate,
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflows: {
+    id: "id",
+    listedSlug: "listed_slug",
+    isListed: "is_listed",
+    tagId: "tag_id",
+    enabled: "enabled",
+    deletedAt: "deleted_at",
+    deactivatedAt: "deactivated_at",
+    organizationId: "organization_id",
+    userId: "user_id",
+  },
+  workflowExecutions: { id: "id" },
+  tags: { id: "id", name: "name" },
+  organization: { id: "id", deactivatedAt: "deactivated_at" },
+}));
+
+vi.mock("@/lib/db/org-helpers", () => ({
+  resolveExecutionOrgMetadata: mockResolveExecutionOrgMetadata,
+}));
+
+vi.mock("workflow/api", () => ({
+  start: mockStart,
+}));
+
+vi.mock("@/lib/workflow/executor/executor.workflow", () => ({
+  executeWorkflow: vi.fn(),
+}));
+
+vi.mock("@/lib/billing/execution-guard", () => ({
+  enforceExecutionLimit: mockEnforceExecutionLimit,
+}));
+
+vi.mock("@/lib/billing/payg/charge", () => ({
+  chargePaygIfBillable: mockChargePaygIfBillable,
+}));
+
+vi.mock("@/lib/features/route-guard", () => ({
+  enforceWorkflowFeatures: vi.fn().mockResolvedValue({ blocked: false }),
+}));
+
+vi.mock("@/app/api/execute/_lib/concurrency-limit", () => ({
+  checkConcurrencyLimit: mockCheckConcurrencyLimit,
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { WORKFLOW_ENGINE: "workflow_engine" },
+  logSystemError: mockLogSystemError,
+}));
+
+vi.mock("@/lib/payments/x402/execution-wait", () => ({
+  buildCallCompletionResponse: mockBuildCallCompletionResponse,
+}));
+
+// Not exercised by the free-workflow happy path this file tests, but
+// @/lib/payments/router transitively resolves @x402/next -> next/server,
+// which fails to resolve outside a real Next.js build; mock it out like
+// tests/unit/x402-call-route.test.ts already does for this route.
+vi.mock("@/lib/payments/router", () => ({
+  gatePayment: mockGatePayment,
+  detectProtocol: mockDetectProtocol,
+}));
+
+vi.mock("@/lib/errors/classify", () => ({
+  classifyExecutionError: vi.fn().mockReturnValue({
+    errorCategory: "workflow_engine",
+    errorType: "system",
+  }),
+}));
+vi.mock("@/lib/errors/finalize-error", () => ({
+  recordExecutionErrorFinalized: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const FREE_WORKFLOW = {
+  id: "wf-1",
+  name: "Test Workflow",
+  description: "A test workflow",
+  organizationId: "org-1",
+  listedSlug: "test-workflow",
+  inputSchema: null,
+  outputMapping: null,
+  priceUsdcPerCall: "0",
+  isListed: true,
+  enabled: true,
+  nodes: [
+    {
+      id: "trigger-1",
+      type: "trigger",
+      position: { x: 0, y: 0 },
+      data: { type: "trigger", enabled: true },
+    },
+    {
+      id: "action-1",
+      type: "action",
+      position: { x: 0, y: 0 },
+      data: { type: "action", enabled: true },
+    },
+  ],
+  edges: [{ id: "e1", source: "trigger-1", target: "action-1" }],
+  userId: "user-1",
+};
+
+function setupDbSelectWorkflow(row: unknown) {
+  mockDbSelect.mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      leftJoin: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue(row ? [row] : []),
+          }),
+        }),
+      }),
+    }),
+  });
+}
+
+function setupDbInsertExecution(executionId: string) {
+  mockDbInsert.mockReturnValue({
+    values: vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: executionId }]),
+    }),
+  });
+}
+
+function makeRequest(slug: string): Request {
+  return new Request(`http://localhost/api/mcp/workflows/${slug}/call`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("startExecutionInBackground (MCP call route) - progress initialization", () => {
+  it("initializes totalSteps from the workflow graph before start() is called", async () => {
+    vi.clearAllMocks();
+    setupDbSelectWorkflow(FREE_WORKFLOW);
+    setupDbInsertExecution("exec-progress-1");
+    mockEnforceExecutionLimit.mockResolvedValue({ blocked: false });
+    mockCheckConcurrencyLimit.mockResolvedValue({ allowed: true });
+    mockChargePaygIfBillable.mockResolvedValue({ applicable: false });
+    mockResolveExecutionOrgMetadata.mockResolvedValue({
+      slug: "org-slug",
+      plan: "free",
+    });
+    mockBuildCallCompletionResponse.mockResolvedValue({
+      executionId: "exec-progress-1",
+      status: "running",
+    });
+
+    const callOrder: string[] = [];
+    mockDbUpdateSet.mockImplementation((values: Record<string, unknown>) => {
+      if (values && typeof values === "object" && "totalSteps" in values) {
+        callOrder.push("initializeProgress");
+      }
+      return { where: vi.fn().mockResolvedValue(undefined) };
+    });
+    mockDbUpdate.mockReturnValue({ set: mockDbUpdateSet });
+    mockStart.mockImplementation(() => {
+      callOrder.push("start");
+      return Promise.resolve({ runId: "run-1" });
+    });
+
+    const { POST } = await import("@/app/api/mcp/workflows/[slug]/call/route");
+    const response = await POST(makeRequest("test-workflow"), {
+      params: Promise.resolve({ slug: "test-workflow" }),
+    });
+
+    expect(response.status).toBe(200);
+    // Two nodes reachable from the trigger -> totalSteps === "2".
+    expect(mockDbUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ totalSteps: "2", completedSteps: "0" })
+    );
+    expect(mockStart).toHaveBeenCalled();
+
+    const progressIdx = callOrder.indexOf("initializeProgress");
+    const startIdx = callOrder.indexOf("start");
+    expect(progressIdx).toBeGreaterThanOrEqual(0);
+    expect(startIdx).toBeGreaterThanOrEqual(0);
+    expect(progressIdx).toBeLessThan(startIdx);
+  });
+});


### PR DESCRIPTION
## What

Of the four places that dispatch a workflow execution, two (`keeperhub-executor`'s K8s Job mode and in-process/SQS mode) correctly initialize progress before running, populating `workflow_executions.total_steps`. The other two -- `executeWorkflowInBackground`'s default/fallback branch in `lib/workflow/execute-in-background.ts` (used by the manual execute and webhook routes), and the MCP `call_workflow` route (`app/api/mcp/workflows/[slug]/call/route.ts`) -- call `start(executeWorkflow, ...)` directly and never initialize progress at all. `total_steps` stays `NULL`, and the execution status endpoint's `progress.percentage` is permanently stuck at `0` for any execution dispatched through either of these two paths, even after it finishes successfully.

This wires the same `calculateTotalSteps` + progress-reset write already used by the working paths (`keeperhub-executor`'s `initializeExecutionProgress` in `keeperhub-executor/lib/db-helpers.ts`) into both of these, right before their `start()` call.

Note on implementation: `lib/workflow/executor/logging.ts` also exports an `initializeProgress` helper with the same `{ totalSteps }` shape, but it (and everything it transitively imports -- metrics collectors, receipt verification, etc.) carries `import "server-only"`, which throws unconditionally outside a Next.js server/RSC context. Both of these call sites already sit inside heavily-mocked unit tests (`tests/unit/x402-call-route.test.ts`, `tests/integration/webhook-route.test.ts`) that don't mock that module, so wiring through it would break those tests. Instead this mirrors `initializeExecutionProgress`'s existing inline `db.update(workflowExecutions).set({ totalSteps, completedSteps: "0", ... })` pattern directly at both call sites -- same fields, same behavior, no new "server-only" dependency introduced into either file's test-time import graph.

## How I ran into it

Found while polling `GET .../status` on an execution I'd triggered manually during the hackathon: `execution.status` was already `"success"`, but `progress` still read `{ totalSteps: 0, completedSteps: 2, percentage: 0 }` -- the completed-step counter worked (it's incremented separately, per step), only the denominator was never set.

## Testing

`pnpm type-check`, `pnpm check` (biome, run directly to work around an unrelated ultracite CLI arg-quoting bug with `[slug]` bracket paths), and `pnpm vitest run` on the new test files pass locally. Also re-ran the full `tests/unit` suite (516 files / 20689 tests) plus the two existing tests that import these routes/functions unmocked (`tests/unit/x402-call-route.test.ts`, `tests/integration/webhook-route.test.ts`, `tests/unit/mcp-meta-tools.test.ts`) to confirm no regressions. Could not run the full DB-backed suite in this sandbox (no local Postgres/.env) -- CI should cover that.