### PR TITLE
fix: route an OAuth-only address out of the email signup dead end

### DIFF
--- a/app/api/auth/_lib/signup-conflict-rate-limit.ts
+++ b/app/api/auth/_lib/signup-conflict-rate-limit.ts
@@ -1,0 +1,84 @@
+/**
+ * Rate limiter for POST /api/auth/signup-conflict.
+ *
+ * Deliberately does NOT share buckets with credential-attempt-rate-limit.
+ * That limiter guards endpoints where a password must be supplied, so an
+ * attacker cannot spend a victim's budget without one. This endpoint needs
+ * only an email address, so sharing the per-email bucket would let anyone
+ * lock a known address out of sign-in for the whole window at zero cost.
+ *
+ * Two independent limiters, both consulted on every lookup:
+ *   - per-email: 5 lookups per 15 minutes per normalized email
+ *   - per-IP:    15 lookups per 15 minutes per client IP
+ *
+ * Same process-local Map storage and lazy reset as the sibling limiters. If
+ * the app grows multiple replicas, swap in a Redis-backed counter keyed the
+ * same way; the public API stays the same.
+ */
+
+const WINDOW_MS = 15 * 60 * 1000;
+const EMAIL_MAX = 5;
+const IP_MAX = 15;
+
+type Bucket = {
+  count: number;
+  resetAt: number;
+};
+
+const emailBuckets = new Map<string, Bucket>();
+const ipBuckets = new Map<string, Bucket>();
+
+export type SignupConflictRateLimitResult =
+  | { allowed: true }
+  | { allowed: false; retryAfterSeconds: number; scope: "email" | "ip" };
+
+function check(
+  store: Map<string, Bucket>,
+  key: string,
+  max: number,
+  now: number
+): { ok: boolean; retryAfter: number } {
+  const existing = store.get(key);
+  if (!existing || existing.resetAt <= now) {
+    store.set(key, { count: 1, resetAt: now + WINDOW_MS });
+    return { ok: true, retryAfter: 0 };
+  }
+  if (existing.count >= max) {
+    return {
+      ok: false,
+      retryAfter: Math.ceil((existing.resetAt - now) / 1000),
+    };
+  }
+  existing.count += 1;
+  return { ok: true, retryAfter: 0 };
+}
+
+export function checkSignupConflictRateLimit(
+  email: string,
+  ip: string
+): SignupConflictRateLimitResult {
+  const now = Date.now();
+  const emailResult = check(emailBuckets, email, EMAIL_MAX, now);
+  if (!emailResult.ok) {
+    return {
+      allowed: false,
+      retryAfterSeconds: emailResult.retryAfter,
+      scope: "email",
+    };
+  }
+  const ipResult = check(ipBuckets, ip, IP_MAX, now);
+  if (!ipResult.ok) {
+    return {
+      allowed: false,
+      retryAfterSeconds: ipResult.retryAfter,
+      scope: "ip",
+    };
+  }
+  return { allowed: true };
+}
+
+/** Test-only hook to reset all counters between unit tests. */
+export function __resetSignupConflictRateLimit(): void {
+  emailBuckets.clear();
+  ipBuckets.clear();
+}

--- a/app/api/auth/finish-credential-signup/route.ts
+++ b/app/api/auth/finish-credential-signup/route.ts
@@ -137,8 +137,16 @@ export async function POST(request: Request): Promise<NextResponse> {
     )
     .limit(1);
   if (!credentialAccount?.password) {
+    // No credential row means the address belongs to an OAuth-only account, so
+    // no password will ever satisfy this route. Say so instead of returning the
+    // generic invalid_state the caller can only retry into forever. The dialog
+    // routes around this before ever reaching here; this is the backstop for a
+    // direct caller, which discloses no more than /api/auth/signup-conflict.
     return NextResponse.json(
-      { error: "Invalid sign-up state", code: "invalid_state" },
+      {
+        error: "This email is registered with a social login. Sign in with it.",
+        code: "oauth_account",
+      },
       { status: 401 }
     );
   }

--- a/app/api/auth/signup-conflict/route.ts
+++ b/app/api/auth/signup-conflict/route.ts
@@ -1,0 +1,108 @@
+import { eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { OAUTH_PROVIDERS } from "@/lib/auth/account-kind";
+import { db } from "@/lib/db";
+import { accounts, users } from "@/lib/db/schema";
+import { ApiErrorCodes, apiError } from "@/lib/errors/api-envelope";
+import { HttpStatus } from "@/lib/http-status";
+import { resolveClientIpFromHeaders } from "@/lib/security/login-risk";
+import { checkSignupConflictRateLimit } from "../_lib/signup-conflict-rate-limit";
+
+/**
+ * Resolves how an already-registered address is supposed to sign in, so the
+ * signup dialog can route a duplicate-email failure somewhere recoverable.
+ *
+ * An OAuth-only account has no `credential` row in `accounts`, so the email
+ * verification flow the dialog used to start can never complete: the user
+ * verifies an OTP, then /api/auth/finish-credential-signup finds no credential
+ * password and rejects them. Proving control of the address cannot unblock
+ * them; only signing in with their original provider can.
+ *
+ * Disclosure posture. The response collapses "no account" and "has a credential
+ * account" into the same `oauthOnly: false` answer, so this endpoint never
+ * reveals that an ordinary email/password address is registered. It discloses
+ * exactly one thing: that a given address is an OAuth-only account, and which
+ * provider(s) it uses. That is the minimum needed to tell the user where to go,
+ * and it is a deliberate trade rather than an accident. Bounded by a dedicated
+ * per-email and per-IP limiter, kept separate from the credential-password
+ * limiter so a caller who supplies no password cannot spend a victim's
+ * sign-in budget.
+ */
+
+type Body = {
+  email?: string;
+};
+
+const SUPPORTED_OAUTH: ReadonlySet<string> = new Set(OAUTH_PROVIDERS);
+
+export async function POST(request: Request): Promise<NextResponse> {
+  let body: Body;
+  try {
+    body = (await request.json()) as Body;
+  } catch {
+    return apiError({
+      status: HttpStatus.BAD_REQUEST,
+      code: "bad_body",
+      detail: "Invalid JSON body",
+      requestHeaders: request.headers,
+    });
+  }
+
+  const email = body.email?.trim().toLowerCase() ?? "";
+  if (!email) {
+    return apiError({
+      status: HttpStatus.BAD_REQUEST,
+      code: ApiErrorCodes.INVALID_INPUT,
+      detail: "Email is required",
+      requestHeaders: request.headers,
+    });
+  }
+
+  const clientIp = resolveClientIpFromHeaders(request.headers) ?? "unknown";
+  const rateLimit = checkSignupConflictRateLimit(email, clientIp);
+  if (!rateLimit.allowed) {
+    return apiError({
+      status: HttpStatus.TOO_MANY_REQUESTS,
+      code: ApiErrorCodes.RATE_LIMITED,
+      detail: "Too many attempts. Wait and try again.",
+      requestHeaders: request.headers,
+      headers: { "Retry-After": String(rateLimit.retryAfterSeconds) },
+    });
+  }
+
+  const [user] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1);
+  if (!user) {
+    return NextResponse.json({ oauthOnly: false });
+  }
+
+  const rows = await db
+    .select({ providerId: accounts.providerId })
+    .from(accounts)
+    .where(eq(accounts.userId, user.id));
+
+  const hasCredential = rows.some((row) => row.providerId === "credential");
+  if (hasCredential) {
+    return NextResponse.json({ oauthOnly: false });
+  }
+
+  const providers = [
+    ...new Set(
+      rows
+        .map((row) => row.providerId)
+        .filter((providerId) => SUPPORTED_OAUTH.has(providerId))
+    ),
+  ];
+  // No credential row and no provider we can name: nothing actionable to send
+  // the user to, so answer as for any other address. Wallet (SIWE) accounts
+  // carry a synthetic @wallet.keeperhub.com address and cannot be reached by
+  // an email typed into the signup form, so this is effectively unreachable.
+  if (providers.length === 0) {
+    return NextResponse.json({ oauthOnly: false });
+  }
+
+  return NextResponse.json({ oauthOnly: true, providers });
+}

--- a/components/auth/connect-auth-panel.tsx
+++ b/components/auth/connect-auth-panel.tsx
@@ -32,7 +32,52 @@ type View =
 
 type Item = { key: string; node: React.ReactNode };
 
+type SocialProvider = "github" | "google";
+
 const EXISTING_ACCOUNT = /already|exists|duplicate/i;
+
+const PROVIDER_LABELS: Record<SocialProvider, string> = {
+  github: "GitHub",
+  google: "Google",
+};
+
+function isSocialProvider(value: string): value is SocialProvider {
+  return value === "github" || value === "google";
+}
+
+/**
+ * Asks the server whether a duplicate-email signup collided with an OAuth-only
+ * account. Those users have no credential password, so the email verification
+ * flow can never complete for them and they need their original provider
+ * instead. An empty list means "carry on as before": either the address has a
+ * credential account, or the lookup failed and the verification flow is still
+ * the better guess.
+ */
+async function resolveOauthOnlyProviders(
+  email: string
+): Promise<SocialProvider[]> {
+  try {
+    const response = await fetch("/api/auth/signup-conflict", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+    });
+    if (!response.ok) {
+      return [];
+    }
+    const body = (await response.json()) as {
+      oauthOnly?: boolean;
+      providers?: string[];
+    };
+    if (!body.oauthOnly) {
+      return [];
+    }
+    return (body.providers ?? []).filter(isSocialProvider);
+  } catch (err) {
+    console.error("[ConnectAuthPanel] signup conflict lookup failed:", err);
+    return [];
+  }
+}
 
 const GitHubIcon = (): React.ReactElement => (
   <svg
@@ -120,7 +165,10 @@ export function ConnectAuthPanel({
   const [confirmNewPassword, setConfirmNewPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const [social, setSocial] = useState<"github" | "google" | null>(null);
+  const [social, setSocial] = useState<SocialProvider | null>(null);
+  const [oauthOnlyProviders, setOauthOnlyProviders] = useState<
+    SocialProvider[]
+  >([]);
   const [captchaToken, setCaptchaToken] = useState("");
   const captchaRef = useRef<TurnstileInstance | null>(null);
 
@@ -145,7 +193,7 @@ export function ConnectAuthPanel({
     return () => observer.disconnect();
   }, []);
 
-  const handleSocial = async (provider: "github" | "google"): Promise<void> => {
+  const handleSocial = async (provider: SocialProvider): Promise<void> => {
     setSocial(provider);
     try {
       // Always land on "/" so the onboarding gate runs: social can be a new
@@ -194,6 +242,7 @@ export function ConnectAuthPanel({
   const handleSignUp = async (e: React.FormEvent): Promise<void> => {
     e.preventDefault();
     setError("");
+    setOauthOnlyProviders([]);
     setLoading(true);
     try {
       const result = await signUp.email({
@@ -209,18 +258,35 @@ export function ConnectAuthPanel({
         if (msg === DISPOSABLE_EMAIL_REJECTION_MESSAGE) {
           setError(DISPOSABLE_EMAIL_REJECTION_MESSAGE);
         } else if (EXISTING_ACCOUNT.test(msg)) {
-          await authClient.emailOtp.sendVerificationOtp({
-            email,
-            type: "email-verification",
-          });
-          setOtp("");
-          setView("verify");
-          toast.info("This email already exists. Verify it to continue.");
+          // An OAuth-only address cannot be unblocked by verifying email, so
+          // send it to its provider instead of into the verification flow.
+          const oauthProviders = await resolveOauthOnlyProviders(email);
+          if (oauthProviders.length > 0) {
+            setOauthOnlyProviders(oauthProviders);
+          } else {
+            await authClient.emailOtp.sendVerificationOtp({
+              email,
+              type: "email-verification",
+            });
+            setOtp("");
+            setView("verify");
+            toast.info("This email already exists. Verify it to continue.");
+          }
         } else {
           setError(msg);
         }
         captchaRef.current?.reset();
         setCaptchaToken("");
+        return;
+      }
+      // A duplicate address does not reach the error branch above: with
+      // requireEmailVerification set, Better Auth answers a signup for an
+      // existing email with a generic success against a synthetic user, so
+      // this is the only place a collision can be spotted before the user is
+      // sent off to type a code that cannot help them.
+      const oauthProviders = await resolveOauthOnlyProviders(email);
+      if (oauthProviders.length > 0) {
+        setOauthOnlyProviders(oauthProviders);
         return;
       }
       setOtp("");
@@ -254,9 +320,22 @@ export function ConnectAuthPanel({
       });
       const finishBody = (await finish.json().catch(() => ({}))) as {
         error?: string;
+        code?: string;
         redirect?: string;
       };
       if (!finish.ok) {
+        // Reached by anyone already part-way through the old loop: the address
+        // is OAuth-only, so hand them back to the signup view with their
+        // provider offered rather than leaving them on a dead-end error.
+        if (finishBody.code === "oauth_account") {
+          const oauthProviders = await resolveOauthOnlyProviders(email);
+          if (oauthProviders.length > 0) {
+            setOauthOnlyProviders(oauthProviders);
+            setOtp("");
+            setView("signup");
+            return;
+          }
+        }
         setError(finishBody.error ?? "Could not finish signup");
         return;
       }
@@ -499,7 +578,10 @@ export function ConnectAuthPanel({
       <Input
         autoComplete={autoComplete}
         id="auth-email"
-        onChange={(e) => setEmail(e.target.value)}
+        onChange={(e) => {
+          setEmail(e.target.value);
+          setOauthOnlyProviders([]);
+        }}
         placeholder="you@example.com"
         required
         type="email"
@@ -508,35 +590,30 @@ export function ConnectAuthPanel({
     </div>
   );
 
+  const socialButton = (provider: SocialProvider): React.ReactElement => {
+    const icon = provider === "github" ? <GitHubIcon /> : <GoogleIcon />;
+    return (
+      <Button
+        className="min-w-0 flex-1 justify-center"
+        disabled={social !== null}
+        key={provider}
+        onClick={() => handleSocial(provider)}
+        type="button"
+        variant="outline"
+      >
+        {social === provider ? <Spinner /> : icon}
+        {PROVIDER_LABELS[provider]}
+      </Button>
+    );
+  };
+
   if (view === "main") {
     items.push({
       key: "socials",
       node: (
         <div className="flex gap-2">
-          {providers.google ? (
-            <Button
-              className="min-w-0 flex-1 justify-center"
-              disabled={social !== null}
-              onClick={() => handleSocial("google")}
-              type="button"
-              variant="outline"
-            >
-              {social === "google" ? <Spinner /> : <GoogleIcon />}
-              Google
-            </Button>
-          ) : null}
-          {providers.github ? (
-            <Button
-              className="min-w-0 flex-1 justify-center"
-              disabled={social !== null}
-              onClick={() => handleSocial("github")}
-              type="button"
-              variant="outline"
-            >
-              {social === "github" ? <Spinner /> : <GitHubIcon />}
-              GitHub
-            </Button>
-          ) : null}
+          {providers.google ? socialButton("google") : null}
+          {providers.github ? socialButton("github") : null}
           {onWalletClick ? (
             <Button
               className="min-w-0 flex-1 justify-center"
@@ -622,6 +699,30 @@ export function ConnectAuthPanel({
 
   if (view === "signup") {
     items.push({ key: "email", node: emailField("email") });
+    if (oauthOnlyProviders.length > 0) {
+      // Name the provider even when it is disabled in this deployment, but only
+      // offer a button for one the user can actually complete.
+      const names = oauthOnlyProviders
+        .map((provider) => PROVIDER_LABELS[provider])
+        .join(" or ");
+      const usable = oauthOnlyProviders.filter(
+        (provider) => providers[provider]
+      );
+      items.push({
+        key: "oauth-conflict",
+        node: (
+          <div className="flex flex-col gap-2 rounded-md border border-border bg-muted p-3">
+            <p className="text-sm">
+              This email is already registered with {names}.
+              {usable.length > 0 ? " Sign in below to continue." : null}
+            </p>
+            {usable.length > 0 ? (
+              <div className="flex gap-2">{usable.map(socialButton)}</div>
+            ) : null}
+          </div>
+        ),
+      });
+    }
     items.push({
       key: "password",
       node: (

--- a/tests/integration/finish-credential-signup-oauth-account.test.ts
+++ b/tests/integration/finish-credential-signup-oauth-account.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Covers the OAuth-only backstop on POST /api/auth/finish-credential-signup.
+ *
+ * Run with: pnpm vitest tests/integration/finish-credential-signup-oauth-account.test.ts
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { queue, mockVerifyPassword } = vi.hoisted(() => ({
+  queue: [] as unknown[][],
+  mockVerifyPassword: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve(queue.shift() ?? []) }),
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  users: {
+    id: "id",
+    email: "email",
+    emailVerified: "emailVerified",
+    twoFactorEnabled: "twoFactorEnabled",
+  },
+  accounts: {
+    userId: "userId",
+    providerId: "providerId",
+    password: "password",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({ eq: () => ({}), and: () => ({}) }));
+
+vi.mock("@/lib/password", () => ({ verifyPassword: mockVerifyPassword }));
+
+vi.mock("@/lib/security/login-risk", () => ({
+  resolveClientIpFromHeaders: () => "127.0.0.1",
+}));
+
+vi.mock("@/app/api/auth/_lib/credential-attempt-rate-limit", () => ({
+  checkCredentialAttemptRateLimit: () => ({ allowed: true }),
+}));
+
+vi.mock("@/lib/pending-signup-cookie", () => ({
+  buildPendingSignupSetCookie: () => "pending=1",
+  encodePendingSignupCookie: () => "encoded",
+}));
+
+import { POST } from "@/app/api/auth/finish-credential-signup/route";
+
+type Body = { error?: string; code?: string; redirect?: string };
+
+function post(): Promise<Response> {
+  return POST(
+    new Request("http://localhost/api/auth/finish-credential-signup", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "oauth@example.com",
+        password: "SomePassword123!",
+      }),
+    })
+  );
+}
+
+const VERIFIED_USER = {
+  id: "user-1",
+  email: "oauth@example.com",
+  emailVerified: true,
+  twoFactorEnabled: false,
+};
+
+describe("POST /api/auth/finish-credential-signup", () => {
+  beforeEach(() => {
+    queue.length = 0;
+    vi.clearAllMocks();
+    process.env.BETTER_AUTH_SECRET = "test-secret-at-least-32-chars-long!!";
+  });
+
+  it("tells an OAuth-only caller to use their social login instead of failing generically", async () => {
+    queue.push([VERIFIED_USER], []);
+
+    const response = await post();
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as Body;
+    expect(body.code).toBe("oauth_account");
+    expect(body.error).toContain("social login");
+  });
+
+  it("still returns the generic invalid_state when the password is wrong", async () => {
+    queue.push([VERIFIED_USER], [{ password: "hashed" }]);
+    mockVerifyPassword.mockResolvedValueOnce(false);
+
+    const response = await post();
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as Body;
+    expect(body.code).toBe("invalid_state");
+  });
+
+  it("issues the pending-signup cookie when the credential password matches", async () => {
+    queue.push([VERIFIED_USER], [{ password: "hashed" }]);
+    mockVerifyPassword.mockResolvedValueOnce(true);
+
+    const response = await post();
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Body;
+    expect(body.redirect).toBe("/enroll-mfa");
+    expect(response.headers.get("Set-Cookie")).toContain("pending=1");
+  });
+});

--- a/tests/integration/signup-conflict-route.test.ts
+++ b/tests/integration/signup-conflict-route.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Integration tests for POST /api/auth/signup-conflict.
+ *
+ * Run with: pnpm vitest tests/integration/signup-conflict-route.test.ts
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { queue } = vi.hoisted(() => ({ queue: [] as unknown[][] }));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => {
+          const rows = queue.shift() ?? [];
+          return Object.assign(Promise.resolve(rows), {
+            limit: () => Promise.resolve(rows),
+          });
+        },
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  users: { id: "id", email: "email" },
+  accounts: { userId: "userId", providerId: "providerId" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: () => ({}),
+}));
+
+vi.mock("@/lib/security/login-risk", () => ({
+  resolveClientIpFromHeaders: () => "127.0.0.1",
+}));
+
+import { __resetSignupConflictRateLimit } from "@/app/api/auth/_lib/signup-conflict-rate-limit";
+import { POST } from "@/app/api/auth/signup-conflict/route";
+
+type ConflictBody = {
+  oauthOnly?: boolean;
+  providers?: string[];
+  error?: string;
+  detail?: string;
+};
+
+function post(email: unknown): Promise<Response> {
+  return POST(
+    new Request("http://localhost/api/auth/signup-conflict", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email }),
+    })
+  );
+}
+
+describe("POST /api/auth/signup-conflict", () => {
+  beforeEach(() => {
+    queue.length = 0;
+    __resetSignupConflictRateLimit();
+  });
+
+  it("reports the provider for an OAuth-only account", async () => {
+    queue.push([{ id: "user-1" }], [{ providerId: "github" }]);
+
+    const response = await post("oauth@example.com");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ConflictBody;
+    expect(body.oauthOnly).toBe(true);
+    expect(body.providers).toEqual(["github"]);
+  });
+
+  it("deduplicates and keeps every linked OAuth provider", async () => {
+    queue.push(
+      [{ id: "user-1" }],
+      [
+        { providerId: "github" },
+        { providerId: "google" },
+        { providerId: "github" },
+      ]
+    );
+
+    const response = await post("both@example.com");
+    const body = (await response.json()) as ConflictBody;
+    expect(body.oauthOnly).toBe(true);
+    expect(body.providers).toEqual(["github", "google"]);
+  });
+
+  it("does not flag an account that has a credential password", async () => {
+    queue.push(
+      [{ id: "user-1" }],
+      [{ providerId: "credential" }, { providerId: "github" }]
+    );
+
+    const response = await post("linked@example.com");
+    const body = (await response.json()) as ConflictBody;
+    expect(body.oauthOnly).toBe(false);
+    expect(body.providers).toBeUndefined();
+  });
+
+  it("names only providers a signup form can route to", async () => {
+    // Wallet (SIWE) accounts are MFA-exempt on a different axis and carry a
+    // synthetic address, so there is nothing to send the user to here.
+    queue.push([{ id: "user-1" }], [{ providerId: "siwe" }]);
+
+    const response = await post("wallet@example.com");
+    const body = (await response.json()) as ConflictBody;
+    expect(body.oauthOnly).toBe(false);
+  });
+
+  it("answers identically for an unregistered address, so it is not an existence oracle", async () => {
+    queue.push([]);
+    const unknown = (await (
+      await post("nobody@example.com")
+    ).json()) as ConflictBody;
+
+    queue.push([{ id: "user-1" }], [{ providerId: "credential" }]);
+    const credential = (await (
+      await post("known@example.com")
+    ).json()) as ConflictBody;
+
+    expect(unknown).toEqual(credential);
+  });
+
+  it("rejects a missing email", async () => {
+    const response = await post(undefined);
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as ConflictBody;
+    expect(body.error).toBe("invalid_input");
+  });
+
+  it("rate limits repeated lookups for the same address", async () => {
+    for (let i = 0; i < 5; i++) {
+      queue.push([]);
+      expect((await post("victim@example.com")).status).toBe(200);
+    }
+
+    const response = await post("victim@example.com");
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBeTruthy();
+    const body = (await response.json()) as ConflictBody;
+    expect(body.error).toBe("rate_limited");
+  });
+});

--- a/tests/unit/idempotency-409-route-body.test.ts
+++ b/tests/unit/idempotency-409-route-body.test.ts
@@ -182,57 +182,57 @@ beforeEach(() => {
   mockReadContractCore.mockResolvedValue({ success: true, result: "1" });
 });
 
-describe.each(ROUTES)("idempotency 409 bodies, as $name emits them", ({
-  post: handler,
-  request,
-}) => {
-  it("ships retryable true on an in-flight duplicate", async () => {
-    mockBeginIdempotentFromRequest.mockResolvedValue({ kind: "in_progress" });
+describe.each(ROUTES)(
+  "idempotency 409 bodies, as $name emits them",
+  ({ post: handler, request }) => {
+    it("ships retryable true on an in-flight duplicate", async () => {
+      mockBeginIdempotentFromRequest.mockResolvedValue({ kind: "in_progress" });
 
-    const res = await handler(request());
-    const body = (await res.json()) as { code?: string; retryable?: boolean };
+      const res = await handler(request());
+      const body = (await res.json()) as { code?: string; retryable?: boolean };
 
-    expect(res.status).toBe(409);
-    expect(body.code).toBe("idempotency_in_progress");
-    expect(body.retryable).toBe(true);
-  });
-
-  it("ships retryable false on a key reused with a different body", async () => {
-    mockBeginIdempotentFromRequest.mockResolvedValue({
-      kind: "conflict",
-      originalResourceId: "exec_1",
+      expect(res.status).toBe(409);
+      expect(body.code).toBe("idempotency_in_progress");
+      expect(body.retryable).toBe(true);
     });
 
-    const res = await handler(request());
-    const body = (await res.json()) as {
-      code?: string;
-      retryable?: boolean;
-      originalExecutionId?: string;
-    };
+    it("ships retryable false on a key reused with a different body", async () => {
+      mockBeginIdempotentFromRequest.mockResolvedValue({
+        kind: "conflict",
+        originalResourceId: "exec_1",
+      });
 
-    expect(res.status).toBe(409);
-    expect(body.code).toBe("idempotency_conflict");
-    expect(body.retryable).toBe(false);
-    expect(body.originalExecutionId).toBe("exec_1");
-  });
+      const res = await handler(request());
+      const body = (await res.json()) as {
+        code?: string;
+        retryable?: boolean;
+        originalExecutionId?: string;
+      };
 
-  // The status is identical on both, so a caller that reads only the status
-  // cannot tell an in-flight request from a spent key. This is the assertion
-  // the whole change exists for.
-  it("gives the two the same status and opposite dispositions", async () => {
-    mockBeginIdempotentFromRequest.mockResolvedValue({ kind: "in_progress" });
-    const inFlight = await handler(request());
-    const inFlightBody = (await inFlight.json()) as { retryable?: boolean };
-
-    mockBeginIdempotentFromRequest.mockResolvedValue({
-      kind: "conflict",
-      originalResourceId: null,
+      expect(res.status).toBe(409);
+      expect(body.code).toBe("idempotency_conflict");
+      expect(body.retryable).toBe(false);
+      expect(body.originalExecutionId).toBe("exec_1");
     });
-    const conflict = await handler(request());
-    const conflictBody = (await conflict.json()) as { retryable?: boolean };
 
-    expect(inFlight.status).toBe(conflict.status);
-    expect(inFlightBody.retryable).toBe(true);
-    expect(conflictBody.retryable).toBe(false);
-  });
-});
+    // The status is identical on both, so a caller that reads only the status
+    // cannot tell an in-flight request from a spent key. This is the assertion
+    // the whole change exists for.
+    it("gives the two the same status and opposite dispositions", async () => {
+      mockBeginIdempotentFromRequest.mockResolvedValue({ kind: "in_progress" });
+      const inFlight = await handler(request());
+      const inFlightBody = (await inFlight.json()) as { retryable?: boolean };
+
+      mockBeginIdempotentFromRequest.mockResolvedValue({
+        kind: "conflict",
+        originalResourceId: null,
+      });
+      const conflict = await handler(request());
+      const conflictBody = (await conflict.json()) as { retryable?: boolean };
+
+      expect(inFlight.status).toBe(conflict.status);
+      expect(inFlightBody.retryable).toBe(true);
+      expect(conflictBody.retryable).toBe(false);
+    });
+  }
+);

--- a/tests/unit/signup-conflict-rate-limit.test.ts
+++ b/tests/unit/signup-conflict-rate-limit.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { checkCredentialAttemptRateLimit } from "@/app/api/auth/_lib/credential-attempt-rate-limit";
+import {
+  __resetSignupConflictRateLimit,
+  checkSignupConflictRateLimit,
+} from "@/app/api/auth/_lib/signup-conflict-rate-limit";
+
+beforeEach(() => {
+  __resetSignupConflictRateLimit();
+});
+
+describe("checkSignupConflictRateLimit", () => {
+  it("allows the first 5 lookups per email then blocks", () => {
+    const email = "victim@example.com";
+    for (let i = 0; i < 5; i++) {
+      expect(checkSignupConflictRateLimit(email, `10.0.0.${i}`).allowed).toBe(
+        true
+      );
+    }
+    const blocked = checkSignupConflictRateLimit(email, "10.0.0.99");
+    expect(blocked.allowed).toBe(false);
+    if (!blocked.allowed) {
+      expect(blocked.scope).toBe("email");
+      expect(blocked.retryAfterSeconds).toBeGreaterThan(0);
+    }
+  });
+
+  it("blocks per-IP after 15 lookups across different emails", () => {
+    const ip = "203.0.113.5";
+    for (let i = 0; i < 15; i++) {
+      expect(
+        checkSignupConflictRateLimit(`user${i}@example.com`, ip).allowed
+      ).toBe(true);
+    }
+    const blocked = checkSignupConflictRateLimit("user99@example.com", ip);
+    expect(blocked.allowed).toBe(false);
+    if (!blocked.allowed) {
+      expect(blocked.scope).toBe("ip");
+    }
+  });
+
+  it("does not share buckets with the credential-password limiter", () => {
+    // This endpoint takes no password, so sharing would let anyone lock a known
+    // address out of sign-in for the window at zero cost.
+    const email = "target@example.com";
+    for (let i = 0; i < 5; i++) {
+      expect(
+        checkSignupConflictRateLimit(email, `198.51.100.${i}`).allowed
+      ).toBe(true);
+    }
+    expect(checkSignupConflictRateLimit(email, "198.51.100.200").allowed).toBe(
+      false
+    );
+    expect(
+      checkCredentialAttemptRateLimit(email, "198.51.100.200").allowed
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

A user with an OAuth-only account who later submits the email and password
signup form is sent into a verification flow that can never complete. They
verify an OTP, then `/api/auth/finish-credential-signup` looks for a
`credential` account row, finds none, and returns `Invalid sign-up state`.
The loop is repeatable indefinitely and no recovery path is offered.

Confirmed in production on an account that cycled through it six times over
roughly five hours without ever obtaining a session. An aggregate scan found
366 OAuth-only accounts with a post-creation write, 279 with zero session
rows. Sessions are deleted on sign-out and expiry, so that is an upper bound
rather than a precise count, but the pattern is not a one-off.

## The entry point is not where it looked

The report assumed the dialog reaches this via Better Auth returning "user
already exists", matched by the `EXISTING_ACCOUNT` regex. That branch is
dead on the current version. `emailAndPassword.requireEmailVerification` is
`true`, which makes Better Auth return a **generic success against a
synthetic user** for any address that already exists. Verified locally: the
signup POST answers 200 and the dialog walks straight into the verify view.

So the fix hooks the success path. The error branch stays wired up, since it
is still the behaviour on configurations without `requireEmailVerification`.

## Changes

- `POST /api/auth/signup-conflict` resolves how a registered address signs
  in. Returns `{oauthOnly: true, providers: [...]}` only for an account with
  no credential row.
- The signup dialog calls it after `signUp.email` and, on a collision, names
  the provider and renders its sign-in button instead of sending an OTP.
- `finish-credential-signup` answers `oauth_account` instead of the generic
  `invalid_state` when no credential row exists, so anyone already part-way
  through the old loop gets routed back to the provider.

## Disclosure posture

Called out because it is a deliberate trade, not an accident.

The endpoint collapses "no account" and "has a credential account" into the
same `oauthOnly: false` answer, so it never reveals that an ordinary email
and password address is registered. It discloses exactly one thing: that a
given address is OAuth-only, and which provider it uses. That is the minimum
needed to tell the user where to go.

It gets its own per-email (5) and per-IP (15) limiter rather than sharing
the credential-password buckets. Sharing would be actively worse than
separate: this endpoint needs no password, so a shared per-email bucket
would let anyone lock a known address out of sign-in for the whole 15 minute
window at zero cost. There is a test asserting the buckets stay separate.

It also removes an unauthenticated email-send primitive. The old branch sent
an OTP to any registered address on demand.

## MFA is unchanged

Sending the user back to their provider re-enters the same enrollment they
abandoned; it does not skip a factor.

- The OAuth callback branches on `twoFactorEnabled`. For `false` it destroys
  the session Better Auth minted, issues the signed `pending_signup_mfa`
  cookie and redirects to `/enroll-mfa`. The existing comment there already
  names this case: "existing OAuth user who never enrolled".
- The proxy independently hard-gates any non-wallet account with
  `twoFactorEnabled !== true` to `/enroll-mfa` on navigation, and 403s
  `mfa_enrollment_required` on API paths, so there is no route around it.
- `/api/user/totp/setup` upserts the secret on `user_id`, so an abandoned
  earlier attempt leaves nothing stale behind.
- `/api/user/totp/enroll` verifies the code, flips `two_factor_enabled`, and
  mints the account's first usable session in one transaction.

This also settles the secondary question raised on the ticket. Incomplete
enrollment is already resumable and the provider button is the resume
mechanism; it was simply never surfaced, which is what left people looping.
No change to the enrollment flow is needed.

## Verification

Reproduced against a local OAuth-only account seeded in Postgres, driving
the real dialog in Chromium:

| Case | Before | After |
|---|---|---|
| OAuth-only address | verify view, dead end | provider panel, no OTP sent |
| Existing credential account | verify view | verify view (unchanged) |
| Brand new address | verify view | verify view (unchanged) |

Type-check clean, `pnpm check` clean, token audit clean. 26 tests pass
across the new and adjacent auth suites: 7 covering the new route, 3
covering the `finish-credential-signup` backstop, 3 on the limiter.

## Unrelated commit included

`tests/unit/idempotency-409-route-body.test.ts` landed unformatted, and
`pnpm check` is a required check, so every branch cut from staging inherits
a red lint step. Fixed in its own commit, formatting only.

## Known gap

An account with no credential row and no nameable provider still falls back
to the OTP path and would still dead-end. Left deliberately: wallet accounts
carry a synthetic `@wallet.keeperhub.com` address and cannot be reached by
an email typed into the signup form, so the bucket only covers data
anomalies with zero account rows. There is a test pinning that a `siwe`-only
row is not flagged.
