### PR TITLE
fix: announce a new signup once per account

### DIFF
--- a/drizzle/0142_keep_1136_signup_notified_at.sql
+++ b/drizzle/0142_keep_1136_signup_notified_at.sql
@@ -1,0 +1,10 @@
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "signup_notified_at" timestamp;
+--> statement-breakpoint
+-- Rows older than the freshness window can never legitimately produce a signup
+-- notification, so mark them as already notified. This keeps the column's
+-- invariant true on its own rather than leaning on the freshness guard, and
+-- stops a backlog of old accounts notifying if that guard is ever relaxed.
+UPDATE "users"
+SET "signup_notified_at" = "created_at"
+WHERE "signup_notified_at" IS NULL
+  AND "created_at" < now() - interval '24 hours';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -995,6 +995,13 @@
       "when": 1785860100000,
       "tag": "0141_keep_1055_chain_source_of_truth",
       "breakpoints": true
+    },
+    {
+      "idx": 142,
+      "version": "7",
+      "when": 1785860200000,
+      "tag": "0142_keep_1136_signup_notified_at",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/auth-signup-notification.ts
+++ b/lib/auth-signup-notification.ts
@@ -1,0 +1,89 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, users } from "@/lib/db/schema";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
+
+/**
+ * Fire-once bookkeeping for the signup channels (Discord webhook, MailerLite).
+ *
+ * `isFreshSignup` bounds how stale a re-event can be, but it cannot make the
+ * send happen once: `afterEmailVerification` fires on every `verifyEmail`, so
+ * a user who re-verifies several times inside the window announces themselves
+ * several times. This lives apart from the guard so that module stays free of
+ * database imports.
+ */
+
+/** How the account authenticated, as reported on the signup notification. */
+export type SignupMethod = "GitHub" | "Google" | "Email" | "Wallet" | "OAuth";
+
+const PROVIDER_METHODS: Record<string, SignupMethod> = {
+  github: "GitHub",
+  google: "Google",
+  credential: "Email",
+  siwe: "Wallet",
+};
+
+/**
+ * Claim the right to announce this account. The conditional update means
+ * exactly one caller ever observes the transition, whichever hook reaches it
+ * first and even when two verifications land concurrently.
+ *
+ * Returns false when the account was already announced, when the row is gone,
+ * or when the write fails. Failing closed is deliberate: a missed notification
+ * is a smaller problem than the duplicate ones being fixed here.
+ */
+export async function claimSignupNotification(
+  userId: string
+): Promise<boolean> {
+  try {
+    const claimed = await db
+      .update(users)
+      .set({ signupNotifiedAt: new Date() })
+      .where(and(eq(users.id, userId), isNull(users.signupNotifiedAt)))
+      .returning({ id: users.id });
+    return claimed.length > 0;
+  } catch (error) {
+    logSystemError(
+      ErrorCategory.DATABASE,
+      "[SignupNotification] Failed to claim signup notification",
+      error,
+      { user_id: userId }
+    );
+    return false;
+  }
+}
+
+/**
+ * Name the provider the account actually authenticated with.
+ *
+ * The previous derivation was `user.image ? "OAuth" : "Email"`, so any account
+ * carrying an avatar reported OAuth regardless of the flow that ran. Read the
+ * account row instead. `fallback` covers the ordering window on OAuth signup
+ * where the user row exists before its account row does.
+ */
+export async function resolveSignupMethod(
+  userId: string,
+  fallback: SignupMethod
+): Promise<SignupMethod> {
+  try {
+    const rows = await db
+      .select({ providerId: accounts.providerId })
+      .from(accounts)
+      .where(eq(accounts.userId, userId));
+    for (const row of rows) {
+      const method = PROVIDER_METHODS[row.providerId];
+      if (method) {
+        return method;
+      }
+    }
+    return fallback;
+  } catch (error) {
+    logSystemError(
+      ErrorCategory.DATABASE,
+      "[SignupNotification] Failed to resolve signup method",
+      error,
+      { user_id: userId }
+    );
+    return fallback;
+  }
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -26,6 +26,11 @@ import { isUserDeactivated } from "@/lib/auth-deactivation-guard";
 import { isDisposableEmailDomain } from "@/lib/auth-disposable-emails";
 import { DISPOSABLE_EMAIL_REJECTION_MESSAGE } from "@/lib/auth-disposable-emails-message";
 import { isFreshSignup } from "@/lib/auth-notification-guard";
+import {
+  claimSignupNotification,
+  resolveSignupMethod,
+  type SignupMethod,
+} from "@/lib/auth-signup-notification";
 import { sendInvitationEmail, sendVerificationOTP } from "@/lib/email";
 import { hasValidLoadTestBypass } from "@/lib/load-test-bypass";
 import {
@@ -588,11 +593,13 @@ async function subscribeToMailerLite(user: {
     });
 }
 
-async function notifyDiscordSignup(user: {
-  name?: string | null;
-  email?: string | null;
-  image?: string | null;
-}): Promise<void> {
+async function notifyDiscordSignup(
+  user: {
+    name?: string | null;
+    email?: string | null;
+  },
+  method: SignupMethod
+): Promise<void> {
   const webhookUrl = process.env.DISCORD_WEBHOOK_SIGNUPS;
   if (!webhookUrl) {
     return;
@@ -610,11 +617,7 @@ async function notifyDiscordSignup(user: {
           fields: [
             { name: "Name", value: user.name ?? "N/A", inline: true },
             { name: "Email", value: user.email ?? "N/A", inline: true },
-            {
-              name: "Method",
-              value: user.image ? "OAuth" : "Email",
-              inline: true,
-            },
+            { name: "Method", value: method, inline: true },
           ],
           timestamp: new Date().toISOString(),
         },
@@ -895,8 +898,13 @@ export const auth = betterAuth({
           // belt-and-suspenders against any future adapter or hook reroute
           // that delivers an already-existing user into this path. Real
           // OAuth signups have createdAt = now and pass it trivially.
-          if (user.emailVerified && isFreshSignup(user)) {
-            await notifyDiscordSignup(user);
+          if (
+            user.emailVerified &&
+            isFreshSignup(user) &&
+            (await claimSignupNotification(user.id))
+          ) {
+            const method = await resolveSignupMethod(user.id, "OAuth");
+            await notifyDiscordSignup(user, method);
             await subscribeToMailerLite(user);
           }
 
@@ -1207,14 +1215,18 @@ export const auth = betterAuth({
   },
   emailVerification: {
     afterEmailVerification: async (user) => {
-      // Only fire signup-channel notifications on first-time verification of a
-      // freshly-created user. Re-verification flows (and any provider that
-      // re-asserts emailVerified for an existing user) must not page the
-      // signup channel.
+      // This fires on every verifyEmail, not only the first, so freshness
+      // alone let a user who re-verified inside the window announce themselves
+      // once per attempt. The claim is what makes it once per account; the
+      // freshness check stays as the cheaper first guard.
       if (!isFreshSignup(user)) {
         return;
       }
-      await notifyDiscordSignup(user);
+      if (!(await claimSignupNotification(user.id))) {
+        return;
+      }
+      const method = await resolveSignupMethod(user.id, "Email");
+      await notifyDiscordSignup(user, method);
       await subscribeToMailerLite(user);
     },
   },

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -72,6 +72,11 @@ export const users = pgTable("users", {
   // Only written after the user confirms it with a code; presence = verified.
   // Distinct from `email` (the synthetic SIWE login identity).
   stepUpEmail: text("step_up_email"),
+  // Set the first time the signup channels (Discord webhook, MailerLite) were
+  // told about this account. Claimed with a conditional update so the send
+  // happens once per account no matter how many times a verification hook
+  // re-fires for the same row.
+  signupNotifiedAt: timestamp("signup_notified_at"),
 });
 
 export const sessions = pgTable(

--- a/tests/unit/auth-signup-notification.test.ts
+++ b/tests/unit/auth-signup-notification.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { mockReturning, mockWhere, mockSelectWhere } = vi.hoisted(() => ({
+  mockReturning: vi.fn(),
+  mockWhere: vi.fn(),
+  mockSelectWhere: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    update: () => ({
+      set: () => ({ where: mockWhere }),
+    }),
+    select: () => ({
+      from: () => ({ where: mockSelectWhere }),
+    }),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  users: { id: "id", signupNotifiedAt: "signupNotifiedAt" },
+  accounts: { userId: "userId", providerId: "providerId" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: () => ({}),
+  eq: () => ({}),
+  isNull: () => ({}),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "database" },
+  logSystemError: vi.fn(),
+}));
+
+import {
+  claimSignupNotification,
+  resolveSignupMethod,
+} from "@/lib/auth-signup-notification";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWhere.mockReturnValue({ returning: mockReturning });
+});
+
+describe("claimSignupNotification", () => {
+  it("grants the claim when the account has not been announced", async () => {
+    mockReturning.mockResolvedValue([{ id: "user-1" }]);
+    expect(await claimSignupNotification("user-1")).toBe(true);
+  });
+
+  it("refuses a second claim, so a re-verification cannot re-announce", async () => {
+    mockReturning.mockResolvedValueOnce([{ id: "user-1" }]);
+    expect(await claimSignupNotification("user-1")).toBe(true);
+
+    // The conditional update matches nothing once signup_notified_at is set.
+    mockReturning.mockResolvedValueOnce([]);
+    expect(await claimSignupNotification("user-1")).toBe(false);
+  });
+
+  it("fails closed when the write throws", async () => {
+    mockReturning.mockRejectedValue(new Error("connection reset"));
+    expect(await claimSignupNotification("user-1")).toBe(false);
+  });
+});
+
+describe("resolveSignupMethod", () => {
+  it("names the OAuth provider rather than guessing from an avatar", async () => {
+    mockSelectWhere.mockResolvedValue([{ providerId: "github" }]);
+    expect(await resolveSignupMethod("user-1", "OAuth")).toBe("GitHub");
+  });
+
+  it("reports Email for a credential account", async () => {
+    mockSelectWhere.mockResolvedValue([{ providerId: "credential" }]);
+    expect(await resolveSignupMethod("user-1", "OAuth")).toBe("Email");
+  });
+
+  it("reports Wallet for a SIWE account", async () => {
+    mockSelectWhere.mockResolvedValue([{ providerId: "siwe" }]);
+    expect(await resolveSignupMethod("user-1", "Email")).toBe("Wallet");
+  });
+
+  it("falls back when the account row is not written yet", async () => {
+    mockSelectWhere.mockResolvedValue([]);
+    expect(await resolveSignupMethod("user-1", "OAuth")).toBe("OAuth");
+  });
+
+  it("falls back when the lookup throws", async () => {
+    mockSelectWhere.mockRejectedValue(new Error("connection reset"));
+    expect(await resolveSignupMethod("user-1", "Email")).toBe("Email");
+  });
+});

--- a/tests/unit/idempotency-409-route-body.test.ts
+++ b/tests/unit/idempotency-409-route-body.test.ts
@@ -182,57 +182,57 @@ beforeEach(() => {
   mockReadContractCore.mockResolvedValue({ success: true, result: "1" });
 });
 
-describe.each(ROUTES)("idempotency 409 bodies, as $name emits them", ({
-  post: handler,
-  request,
-}) => {
-  it("ships retryable true on an in-flight duplicate", async () => {
-    mockBeginIdempotentFromRequest.mockResolvedValue({ kind: "in_progress" });
+describe.each(ROUTES)(
+  "idempotency 409 bodies, as $name emits them",
+  ({ post: handler, request }) => {
+    it("ships retryable true on an in-flight duplicate", async () => {
+      mockBeginIdempotentFromRequest.mockResolvedValue({ kind: "in_progress" });
 
-    const res = await handler(request());
-    const body = (await res.json()) as { code?: string; retryable?: boolean };
+      const res = await handler(request());
+      const body = (await res.json()) as { code?: string; retryable?: boolean };
 
-    expect(res.status).toBe(409);
-    expect(body.code).toBe("idempotency_in_progress");
-    expect(body.retryable).toBe(true);
-  });
-
-  it("ships retryable false on a key reused with a different body", async () => {
-    mockBeginIdempotentFromRequest.mockResolvedValue({
-      kind: "conflict",
-      originalResourceId: "exec_1",
+      expect(res.status).toBe(409);
+      expect(body.code).toBe("idempotency_in_progress");
+      expect(body.retryable).toBe(true);
     });
 
-    const res = await handler(request());
-    const body = (await res.json()) as {
-      code?: string;
-      retryable?: boolean;
-      originalExecutionId?: string;
-    };
+    it("ships retryable false on a key reused with a different body", async () => {
+      mockBeginIdempotentFromRequest.mockResolvedValue({
+        kind: "conflict",
+        originalResourceId: "exec_1",
+      });
 
-    expect(res.status).toBe(409);
-    expect(body.code).toBe("idempotency_conflict");
-    expect(body.retryable).toBe(false);
-    expect(body.originalExecutionId).toBe("exec_1");
-  });
+      const res = await handler(request());
+      const body = (await res.json()) as {
+        code?: string;
+        retryable?: boolean;
+        originalExecutionId?: string;
+      };
 
-  // The status is identical on both, so a caller that reads only the status
-  // cannot tell an in-flight request from a spent key. This is the assertion
-  // the whole change exists for.
-  it("gives the two the same status and opposite dispositions", async () => {
-    mockBeginIdempotentFromRequest.mockResolvedValue({ kind: "in_progress" });
-    const inFlight = await handler(request());
-    const inFlightBody = (await inFlight.json()) as { retryable?: boolean };
-
-    mockBeginIdempotentFromRequest.mockResolvedValue({
-      kind: "conflict",
-      originalResourceId: null,
+      expect(res.status).toBe(409);
+      expect(body.code).toBe("idempotency_conflict");
+      expect(body.retryable).toBe(false);
+      expect(body.originalExecutionId).toBe("exec_1");
     });
-    const conflict = await handler(request());
-    const conflictBody = (await conflict.json()) as { retryable?: boolean };
 
-    expect(inFlight.status).toBe(conflict.status);
-    expect(inFlightBody.retryable).toBe(true);
-    expect(conflictBody.retryable).toBe(false);
-  });
-});
+    // The status is identical on both, so a caller that reads only the status
+    // cannot tell an in-flight request from a spent key. This is the assertion
+    // the whole change exists for.
+    it("gives the two the same status and opposite dispositions", async () => {
+      mockBeginIdempotentFromRequest.mockResolvedValue({ kind: "in_progress" });
+      const inFlight = await handler(request());
+      const inFlightBody = (await inFlight.json()) as { retryable?: boolean };
+
+      mockBeginIdempotentFromRequest.mockResolvedValue({
+        kind: "conflict",
+        originalResourceId: null,
+      });
+      const conflict = await handler(request());
+      const conflictBody = (await conflict.json()) as { retryable?: boolean };
+
+      expect(inFlight.status).toBe(conflict.status);
+      expect(inFlightBody.retryable).toBe(true);
+      expect(conflictBody.retryable).toBe(false);
+    });
+  }
+);


### PR DESCRIPTION
## Problem

The "New signup" Discord webhook fired on every successful email verification
within 24 hours of account creation, not once per account. A single
production account produced five identical notifications across roughly three
hours.

Two call sites post the notification. The one in `databaseHooks.user.create.after`
fires once per real user row insert and is correct. The one in
`emailVerification.afterEmailVerification` fires on every `emailOtp.verifyEmail`
completion, including re-verification of an already-verified account, and its
only guard was a 24 hour freshness window. That window was built for the
four-week-old re-verification regression, so it suppresses stale accounts but
allows unlimited same-day repeats.

The repeats came from the signup dead end fixed in #2016: each retry of that
loop passes through `verifyEmail` and re-notifies.

For the affected account the database shows one user row, one organization,
one member and three seeded workflows, so `user.create.after` ran exactly
once. `users.updated_at` matched the timestamp of the final Discord message to
the second, confirming the later notifications came from the verification path.

## Fix

A time window cannot make a send happen once, so this claims the notification
instead. New nullable `users.signup_notified_at`, claimed with a conditional
update:

```sql
UPDATE users SET signup_notified_at = now()
WHERE id = $1 AND signup_notified_at IS NULL
RETURNING id
```

Exactly one caller ever observes the transition, whichever hook reaches it
first and even when two verifications land concurrently. It fails closed on a
database error, since a missed notification is a smaller problem than the
duplicates being fixed. `isFreshSignup` stays as the cheaper first guard, as
the ticket asked. The same claim covers the MailerLite subscribe, which was
duplicated on the identical path.

The migration backfills rows older than the freshness window, because those
can never legitimately notify. That keeps the column's invariant true on its
own rather than depending on the guard still being there.

## Secondary defect

`Method` was derived as `user.image ? "OAuth" : "Email"`, so any account with
an avatar reported OAuth regardless of which flow actually ran. That is what
made all five messages look identical and sent the initial triage down the
wrong path.

It now reads the account row and names the provider (GitHub, Google, Email,
Wallet). The `fallback` argument covers the ordering window on OAuth signup
where the user row exists before its account row does, so the worst case is
the old generic "OAuth" rather than a wrong answer.

## Verification

The migration was applied against a local Postgres: column added, 13 existing
rows backfilled, and a second run reported `UPDATE 0`, confirming it is
idempotent. Journal timestamps checked monotonic.

19 tests cover the new module, including that a second claim is refused, that
a failed write fails closed, and that each provider maps to the right method.
The existing `isFreshSignup` suite still passes unchanged; the claim lives in
its own module so that guard stays free of database imports.

Type-check clean, `pnpm check` clean.

## Notes for the reviewer

- Hand-authored migration and journal entry, since `drizzle-kit generate`
  collides on a snapshot in this repo.
- No `@requires-db-prep` directive: `ADD COLUMN` of a nullable timestamp is a
  metadata-only change with no table rewrite.
- The formatting commit on `tests/unit/idempotency-409-route-body.test.ts` is
  the same one carried in #2016. That file landed unformatted on staging and
  `pnpm check` is a required check, so every branch cut from staging inherits
  a red lint step. The content is byte-identical between the two branches, so
  whichever merges second is a no-op.
