### PR TITLE
fix: scope the node history timeline in the query, not the page

### DIFF
--- a/app/api/workflows/[workflowId]/history/route.ts
+++ b/app/api/workflows/[workflowId]/history/route.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, inArray } from "drizzle-orm";
+import { and, count, desc, eq, inArray, type SQL, sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { users, workflowHistory, workflows } from "@/lib/db/schema";
@@ -15,6 +15,43 @@ import { getWorkflowAccess } from "@/lib/workflow/access";
  * snapshot is fetched on demand via GET /api/workflows/[id]?version=N.
  * `changedBy` is enriched with the actor's name/email so the UI can show "who".
  */
+/**
+ * Restrict the timeline to versions that touched one node.
+ *
+ * Mirrors `versionTouchesNode` in the History panel: a node matches by id on
+ * the three node buckets, and a connection matches by endpoint id, falling
+ * back to the endpoint label for diffs recorded before ids were stored.
+ * Keeping the predicate here rather than in the client is what makes the
+ * paging honest, since `total` has to count the same rows the page returns.
+ */
+function nodeScopeFilter(nodeId: string, nodeLabel: string | null): SQL {
+  const node = JSON.stringify([{ id: nodeId }]);
+  const from = JSON.stringify([{ fromId: nodeId }]);
+  const to = JSON.stringify([{ toId: nodeId }]);
+  const clauses = [
+    sql`${workflowHistory.change}->'nodesAdded' @> ${node}::jsonb`,
+    sql`${workflowHistory.change}->'nodesRemoved' @> ${node}::jsonb`,
+    sql`${workflowHistory.change}->'nodesChanged' @> ${node}::jsonb`,
+    sql`${workflowHistory.change}->'connectionsAdded' @> ${from}::jsonb`,
+    sql`${workflowHistory.change}->'connectionsAdded' @> ${to}::jsonb`,
+    sql`${workflowHistory.change}->'connectionsRemoved' @> ${from}::jsonb`,
+    sql`${workflowHistory.change}->'connectionsRemoved' @> ${to}::jsonb`,
+  ];
+  if (nodeLabel) {
+    // Legacy diffs carry endpoint labels only. Matching those by label is the
+    // reason a renamed node does not lose its older connection changes.
+    const labelFrom = JSON.stringify([{ from: nodeLabel }]);
+    const labelTo = JSON.stringify([{ to: nodeLabel }]);
+    clauses.push(
+      sql`${workflowHistory.change}->'connectionsAdded' @> ${labelFrom}::jsonb`,
+      sql`${workflowHistory.change}->'connectionsAdded' @> ${labelTo}::jsonb`,
+      sql`${workflowHistory.change}->'connectionsRemoved' @> ${labelFrom}::jsonb`,
+      sql`${workflowHistory.change}->'connectionsRemoved' @> ${labelTo}::jsonb`
+    );
+  }
+  return sql`(${sql.join(clauses, sql` OR `)})`;
+}
+
 export async function GET(
   request: Request,
   context: { params: Promise<{ workflowId: string }> }
@@ -51,7 +88,14 @@ export async function GET(
 
     const url = new URL(request.url);
     const req = parsePageRequest(url);
-    const where = eq(workflowHistory.workflowId, workflowId);
+    const nodeId = url.searchParams.get("nodeId");
+    const nodeLabel = url.searchParams.get("nodeLabel");
+    const where = nodeId
+      ? and(
+          eq(workflowHistory.workflowId, workflowId),
+          nodeScopeFilter(nodeId, nodeLabel)
+        )
+      : eq(workflowHistory.workflowId, workflowId);
 
     const [{ total }] = await db
       .select({ total: count() })
@@ -60,8 +104,10 @@ export async function GET(
 
     // Workflows created before versioning have no rows. Synthesize the current
     // state as version 1 so the timeline isn't empty -- the live workflow IS
-    // that version, so it reads as the current/initial entry.
-    if (total === 0) {
+    // that version, so it reads as the current/initial entry. Skipped when
+    // scoped to a node: an empty result there means the node has no recorded
+    // changes, and inventing an entry would misreport that.
+    if (total === 0 && !nodeId) {
       const [creator] = workflow.userId
         ? await db
             .select({ id: users.id, name: users.name, email: users.email })

--- a/components/workflow/version-history-content.tsx
+++ b/components/workflow/version-history-content.tsx
@@ -493,23 +493,6 @@ function filterDiffToNode(
   };
 }
 
-function versionTouchesNode(
-  change: unknown,
-  nodeId: string,
-  nodeLabel: string | null
-): boolean {
-  if (!isVersionDiff(change)) {
-    return false;
-  }
-  const scoped = filterDiffToNode(change, nodeId, nodeLabel);
-  return (
-    scoped.nodesAdded.length > 0 ||
-    scoped.nodesRemoved.length > 0 ||
-    scoped.nodesChanged.length > 0 ||
-    scoped.connectionsAdded.length > 0 ||
-    scoped.connectionsRemoved.length > 0
-  );
-}
 
 function VersionRow({
   version,
@@ -722,8 +705,10 @@ export function VersionHistoryContent({
       api.workflow.getHistory(workflowId ?? "", {
         page: p,
         limit: WORKFLOW_HISTORY_PAGE_SIZE,
+        nodeId,
+        nodeLabel,
       }),
-    `${workflowId}`,
+    `${workflowId}:${nodeId ?? ""}:${nodeLabel ?? ""}`,
     { enabled: active && !!workflowId, refetchIntervalMs: 30_000 }
   );
 
@@ -814,13 +799,10 @@ export function VersionHistoryContent({
       : Number.isNaN(parsedVersionParam)
         ? null
         : parsedVersionParam;
-  // Per-node scope: show only the versions that touched this node.
-  const shown = nodeId
-    ? versions.filter((v) =>
-        versionTouchesNode(v.change, nodeId, nodeLabel ?? null)
-      )
-    : versions;
-  const groups = groupByDate(shown, (v) => v.createdAt);
+  // Node scope is applied by the query, not here: filtering the fetched page
+  // dropped every version on it whenever the node's changes lived on another
+  // page, and left the pager counting versions it would not show.
+  const groups = groupByDate(versions, (v) => v.createdAt);
   const emptyMessage = nodeId
     ? "No changes recorded for this node yet."
     : "No versions recorded yet.";
@@ -841,7 +823,7 @@ export function VersionHistoryContent({
             ))}
           </div>
         )}
-        {!loading && shown.length === 0 && (
+        {!loading && versions.length === 0 && (
           <p className="p-2 text-muted-foreground text-sm">{emptyMessage}</p>
         )}
         {groups.map((group) => (

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -644,13 +644,29 @@ export const workflowApi = {
     ),
 
   // Version history timeline (admin/owner only).
-  getHistory: (id: string, options?: { page?: number; limit?: number }) => {
+  getHistory: (
+    id: string,
+    options?: {
+      page?: number;
+      limit?: number;
+      // Restrict the timeline to versions touching one node. Filtered on the
+      // server so paging counts only the matching versions.
+      nodeId?: string;
+      nodeLabel?: string | null;
+    }
+  ) => {
     const params = new URLSearchParams();
     if (options?.page !== undefined) {
       params.set("page", String(options.page));
     }
     if (options?.limit !== undefined) {
       params.set("limit", String(options.limit));
+    }
+    if (options?.nodeId) {
+      params.set("nodeId", options.nodeId);
+    }
+    if (options?.nodeLabel) {
+      params.set("nodeLabel", options.nodeLabel);
     }
     const qs = params.toString();
     return apiCall<Page<WorkflowVersionSummary>>(

--- a/tests/unit/idempotency-409-route-body.test.ts
+++ b/tests/unit/idempotency-409-route-body.test.ts
@@ -182,57 +182,57 @@ beforeEach(() => {
   mockReadContractCore.mockResolvedValue({ success: true, result: "1" });
 });
 
-describe.each(ROUTES)("idempotency 409 bodies, as $name emits them", ({
-  post: handler,
-  request,
-}) => {
-  it("ships retryable true on an in-flight duplicate", async () => {
-    mockBeginIdempotentFromRequest.mockResolvedValue({ kind: "in_progress" });
+describe.each(ROUTES)(
+  "idempotency 409 bodies, as $name emits them",
+  ({ post: handler, request }) => {
+    it("ships retryable true on an in-flight duplicate", async () => {
+      mockBeginIdempotentFromRequest.mockResolvedValue({ kind: "in_progress" });
 
-    const res = await handler(request());
-    const body = (await res.json()) as { code?: string; retryable?: boolean };
+      const res = await handler(request());
+      const body = (await res.json()) as { code?: string; retryable?: boolean };
 
-    expect(res.status).toBe(409);
-    expect(body.code).toBe("idempotency_in_progress");
-    expect(body.retryable).toBe(true);
-  });
-
-  it("ships retryable false on a key reused with a different body", async () => {
-    mockBeginIdempotentFromRequest.mockResolvedValue({
-      kind: "conflict",
-      originalResourceId: "exec_1",
+      expect(res.status).toBe(409);
+      expect(body.code).toBe("idempotency_in_progress");
+      expect(body.retryable).toBe(true);
     });
 
-    const res = await handler(request());
-    const body = (await res.json()) as {
-      code?: string;
-      retryable?: boolean;
-      originalExecutionId?: string;
-    };
+    it("ships retryable false on a key reused with a different body", async () => {
+      mockBeginIdempotentFromRequest.mockResolvedValue({
+        kind: "conflict",
+        originalResourceId: "exec_1",
+      });
 
-    expect(res.status).toBe(409);
-    expect(body.code).toBe("idempotency_conflict");
-    expect(body.retryable).toBe(false);
-    expect(body.originalExecutionId).toBe("exec_1");
-  });
+      const res = await handler(request());
+      const body = (await res.json()) as {
+        code?: string;
+        retryable?: boolean;
+        originalExecutionId?: string;
+      };
 
-  // The status is identical on both, so a caller that reads only the status
-  // cannot tell an in-flight request from a spent key. This is the assertion
-  // the whole change exists for.
-  it("gives the two the same status and opposite dispositions", async () => {
-    mockBeginIdempotentFromRequest.mockResolvedValue({ kind: "in_progress" });
-    const inFlight = await handler(request());
-    const inFlightBody = (await inFlight.json()) as { retryable?: boolean };
-
-    mockBeginIdempotentFromRequest.mockResolvedValue({
-      kind: "conflict",
-      originalResourceId: null,
+      expect(res.status).toBe(409);
+      expect(body.code).toBe("idempotency_conflict");
+      expect(body.retryable).toBe(false);
+      expect(body.originalExecutionId).toBe("exec_1");
     });
-    const conflict = await handler(request());
-    const conflictBody = (await conflict.json()) as { retryable?: boolean };
 
-    expect(inFlight.status).toBe(conflict.status);
-    expect(inFlightBody.retryable).toBe(true);
-    expect(conflictBody.retryable).toBe(false);
-  });
-});
+    // The status is identical on both, so a caller that reads only the status
+    // cannot tell an in-flight request from a spent key. This is the assertion
+    // the whole change exists for.
+    it("gives the two the same status and opposite dispositions", async () => {
+      mockBeginIdempotentFromRequest.mockResolvedValue({ kind: "in_progress" });
+      const inFlight = await handler(request());
+      const inFlightBody = (await inFlight.json()) as { retryable?: boolean };
+
+      mockBeginIdempotentFromRequest.mockResolvedValue({
+        kind: "conflict",
+        originalResourceId: null,
+      });
+      const conflict = await handler(request());
+      const conflictBody = (await conflict.json()) as { retryable?: boolean };
+
+      expect(inFlight.status).toBe(conflict.status);
+      expect(inFlightBody.retryable).toBe(true);
+      expect(conflictBody.retryable).toBe(false);
+    });
+  }
+);

--- a/tests/unit/workflow-history-node-scope.test.ts
+++ b/tests/unit/workflow-history-node-scope.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { api } from "@/lib/api-client";
+
+/**
+ * The node-scoped History tab depends on the scope reaching the server: the
+ * panel no longer filters the fetched page, so a dropped parameter would show
+ * the whole timeline instead of the node's.
+ */
+describe("api.workflow.getHistory node scope", () => {
+  let requestedUrl: string;
+
+  beforeEach(() => {
+    requestedUrl = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: string) => {
+        requestedUrl = String(input);
+        return Promise.resolve(
+          new Response(JSON.stringify({ items: [], meta: {} }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          })
+        );
+      })
+    );
+  });
+
+  it("forwards the node id and label", async () => {
+    await api.workflow.getHistory("wf-1", {
+      page: 3,
+      limit: 10,
+      nodeId: "node-a",
+      nodeLabel: "Send Webhook",
+    });
+
+    const params = new URL(requestedUrl, "http://localhost").searchParams;
+    expect(params.get("page")).toBe("3");
+    expect(params.get("limit")).toBe("10");
+    expect(params.get("nodeId")).toBe("node-a");
+    expect(params.get("nodeLabel")).toBe("Send Webhook");
+  });
+
+  it("omits the scope entirely for the unscoped timeline", async () => {
+    await api.workflow.getHistory("wf-1", { page: 1, limit: 10 });
+
+    const params = new URL(requestedUrl, "http://localhost").searchParams;
+    expect(params.has("nodeId")).toBe(false);
+    expect(params.has("nodeLabel")).toBe(false);
+  });
+
+  it("omits a null label so a node with no label still scopes by id", async () => {
+    await api.workflow.getHistory("wf-1", {
+      nodeId: "node-a",
+      nodeLabel: null,
+    });
+
+    const params = new URL(requestedUrl, "http://localhost").searchParams;
+    expect(params.get("nodeId")).toBe("node-a");
+    expect(params.has("nodeLabel")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

In the workflow editor's History tab, scoping the timeline to a selected node
rendered "No changes recorded for this node yet." even when the version
history API had returned versions whose `change.nodesChanged` included that
node.

The panel filtered `versions`, which holds only the current page of ten. Any
page whose ten versions did not happen to touch the selected node rendered the
empty state, regardless of what the rest of the history contained. Reproduced
on a workflow with 166 versions, so 17 pages, where the node's changes were
usually not on the page being displayed.

The pager was wrong for the same reason. `total` came from an unfiltered
count, so it advertised every version in the workflow while the list showed
only the subset of the current page that survived the filter.

## Fix

Move the scope into the query rather than applying it to an already-paginated
slice. The endpoint accepts `nodeId` and `nodeLabel` and filters with jsonb
containment across `nodesAdded`, `nodesRemoved`, `nodesChanged`,
`connectionsAdded` and `connectionsRemoved`. Because the same predicate feeds
the count, `total` now describes exactly the rows the page returns and paging
walks the filtered set.

The predicate mirrors the `versionTouchesNode` matcher it replaces, including
the fallback to endpoint labels for diffs recorded before connection ids were
stored. Dropping that fallback would make a node lose its older connection
changes as soon as it was renamed. `versionTouchesNode` is deleted, since the
query is now the only thing deciding membership. `filterDiffToNode` stays: it
still scopes the diff rendered for a version.

One behaviour change worth flagging: the synthesized version-1 entry is now
skipped when a node scope is present. That entry exists so a workflow created
before versioning shows something rather than an empty timeline, but under a
node scope an empty result is the correct answer and fabricating an entry
would misreport it.

## Verification

The containment predicate was checked against the local database using a node
id taken from real history rows. It returned 6 matching versions, identical to
the ground-truth count computed by expanding the jsonb arrays with
`jsonb_array_elements` and comparing ids element by element.

Containment was chosen over element expansion partly for this: `@>` yields
NULL for a missing or non-array key, so rows with a null `change`, or diffs
written before a bucket existed, drop out of the filter instead of raising.

Three tests cover the wiring the panel now depends on, since it no longer
filters client-side: both parameters forwarded, both omitted for the unscoped
timeline, and a null label still scoping by id.

Type-check clean, `pnpm check` clean, token audit unchanged.

## Note for the reviewer

The formatting commit on `tests/unit/idempotency-409-route-body.test.ts` is
the same one carried in #2016 and #2017. That file landed unformatted on
staging and `pnpm check` is a required check, so every branch cut from staging
inherits a red lint step. The content is byte-identical across the branches,
so whichever merges last is a no-op.
