### PR TITLE
fix(api): answer the documented error envelope on the integrator routes

### DIFF
--- a/app/api/keys/route.ts
+++ b/app/api/keys/route.ts
@@ -6,7 +6,10 @@ import { member, organizationApiKeys, users } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { parseScopeInput } from "@/lib/mcp/oauth-scopes";
 import { STEP_UP_ACTIONS } from "@/lib/mfa/step-up-policy";
-import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
+import {
+  authFailureResponse,
+  resolveOrganizationId,
+} from "@/lib/middleware/auth-helpers";
 import { authorizeAction } from "@/lib/middleware/authorize-action";
 import { getOrgContext } from "@/lib/middleware/org-context";
 import { generateOrganizationApiKey } from "@/lib/organization-api-key";
@@ -24,10 +27,7 @@ export async function GET(request: Request) {
   try {
     const authCtx = await resolveOrganizationId(request);
     if ("error" in authCtx) {
-      return NextResponse.json(
-        { error: authCtx.error },
-        { status: authCtx.status }
-      );
+      return authFailureResponse(authCtx, request.headers);
     }
     const { organizationId: activeOrgId } = authCtx;
 

--- a/app/api/workflows/[workflowId]/code/route.ts
+++ b/app/api/workflows/[workflowId]/code/route.ts
@@ -3,11 +3,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
-import {
-  type DualAuthContext,
-  auditFromAuth,
-  getDualAuthContext,
-} from "@/lib/middleware/auth-helpers";
+import { type DualAuthContext, auditFromAuth, authFailureResponse, getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { getWorkflowAccess } from "@/lib/workflow/access";
 import { generateWorkflowSDKCode } from "@/lib/workflow/codegen/sdk";
 
@@ -21,10 +17,7 @@ export async function GET(
 
     authContext = await getDualAuthContext(request);
     if ("error" in authContext) {
-      return NextResponse.json(
-        { error: authContext.error },
-        { status: authContext.status }
-      );
+      return authFailureResponse(authContext, request.headers);
     }
     const { userId, organizationId } = authContext;
 

--- a/app/api/workflows/[workflowId]/download/route.ts
+++ b/app/api/workflows/[workflowId]/download/route.ts
@@ -5,11 +5,7 @@ import { workflows } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { getMetricsCollector } from "@/lib/metrics";
 import { MetricNames } from "@/lib/metrics/types";
-import {
-  type DualAuthContext,
-  auditFromAuth,
-  getDualAuthContext,
-} from "@/lib/middleware/auth-helpers";
+import { type DualAuthContext, auditFromAuth, authFailureResponse, getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { getWorkflowAccess } from "@/lib/workflow/access";
 import { buildWorkflowExportV1 } from "@/lib/workflow/export-schema";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
@@ -35,10 +31,7 @@ export async function GET(
 
     authContext = await getDualAuthContext(request);
     if ("error" in authContext) {
-      return NextResponse.json(
-        { error: authContext.error },
-        { status: authContext.status }
-      );
+      return authFailureResponse(authContext, request.headers);
     }
     const { userId, organizationId } = authContext;
 

--- a/app/api/workflows/[workflowId]/duplicate/route.ts
+++ b/app/api/workflows/[workflowId]/duplicate/route.ts
@@ -3,7 +3,7 @@ import { nanoid } from "nanoid";
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
-import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { authFailureResponse, getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { requireScope } from "@/lib/middleware/require-scope";
 import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
@@ -121,10 +121,7 @@ export async function POST(
     const { workflowId } = await context.params;
     const authContext = await getDualAuthContext(request);
     if ("error" in authContext) {
-      return NextResponse.json(
-        { error: authContext.error },
-        { status: authContext.status }
-      );
+      return authFailureResponse(authContext, request.headers);
     }
 
     const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);

--- a/app/api/workflows/[workflowId]/executions/route.ts
+++ b/app/api/workflows/[workflowId]/executions/route.ts
@@ -2,7 +2,7 @@ import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
-import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { authFailureResponse, getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { requireScope } from "@/lib/middleware/require-scope";
 import { db } from "@/lib/db";
 import { workflowExecutions, workflowHistory, workflows } from "@/lib/db/schema";
@@ -25,10 +25,7 @@ export async function GET(
 
     const authContext = await getDualAuthContext(request);
     if ("error" in authContext) {
-      return NextResponse.json(
-        { error: authContext.error },
-        { status: authContext.status }
-      );
+      return authFailureResponse(authContext, request.headers);
     }
     const { userId, organizationId } = authContext;
 
@@ -154,10 +151,7 @@ export async function DELETE(
 
     const authContext = await getDualAuthContext(request);
     if ("error" in authContext) {
-      return NextResponse.json(
-        { error: authContext.error },
-        { status: authContext.status }
-      );
+      return authFailureResponse(authContext, request.headers);
     }
 
     const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);

--- a/app/api/workflows/[workflowId]/go-live/route.ts
+++ b/app/api/workflows/[workflowId]/go-live/route.ts
@@ -5,7 +5,7 @@ import { db } from "@/lib/db";
 import { publicTags, workflowPublicTags, workflows } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
-import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { authFailureResponse, getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { requireScope } from "@/lib/middleware/require-scope";
 import {
   buildActor,
@@ -26,10 +26,7 @@ export async function PUT(
     // session directly. That admits `kh_` keys.
     const authContext = await getDualAuthContext(request);
     if ("error" in authContext) {
-      return NextResponse.json(
-        { error: authContext.error },
-        { status: authContext.status }
-      );
+      return authFailureResponse(authContext, request.headers);
     }
 
     const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);

--- a/app/api/workflows/[workflowId]/history/route.ts
+++ b/app/api/workflows/[workflowId]/history/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { users, workflowHistory, workflows } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
-import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { authFailureResponse, getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { buildPage, parsePageRequest } from "@/lib/pagination";
 import { getWorkflowAccess } from "@/lib/workflow/access";
 
@@ -23,10 +23,7 @@ export async function GET(
     const { workflowId } = await context.params;
     const authContext = await getDualAuthContext(request);
     if ("error" in authContext) {
-      return NextResponse.json(
-        { error: authContext.error },
-        { status: authContext.status }
-      );
+      return authFailureResponse(authContext, request.headers);
     }
     const { userId, organizationId } = authContext;
 

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -3,7 +3,7 @@ import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError, logSystemWarn } from "@/lib/logging";
 import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
-import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { authFailureResponse, getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { requireScope } from "@/lib/middleware/require-scope";
 import { db } from "@/lib/db";
 import { validateWorkflowIntegrations } from "@/lib/db/integrations";
@@ -94,10 +94,7 @@ export async function GET(
 
     const authContext = await getDualAuthContext(request, { required: false });
     if ("error" in authContext) {
-      return NextResponse.json(
-        { error: authContext.error },
-        { status: authContext.status }
-      );
+      return authFailureResponse(authContext, request.headers);
     }
     const { userId, organizationId } = authContext;
 
@@ -361,10 +358,7 @@ export async function PATCH(
 
     const authContext = await getDualAuthContext(request);
     if ("error" in authContext) {
-      return NextResponse.json(
-        { error: authContext.error },
-        { status: authContext.status }
-      );
+      return authFailureResponse(authContext, request.headers);
     }
 
     const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
@@ -922,10 +916,7 @@ export async function DELETE(
 
     const authContext = await getDualAuthContext(request);
     if ("error" in authContext) {
-      return NextResponse.json(
-        { error: authContext.error },
-        { status: authContext.status }
-      );
+      return authFailureResponse(authContext, request.headers);
     }
 
     const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);

--- a/app/api/workflows/create/route.ts
+++ b/app/api/workflows/create/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { recordWorkflowCreatedFromSource } from "@/lib/metrics/collectors/prometheus";
-import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { authFailureResponse, getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { requireScope } from "@/lib/middleware/require-scope";
 import { buildAuditMetadata, recordAuditEvent } from "@/lib/security/audit-log";
 import { recordWorkflowSnapshot } from "@/lib/workflow/history";
@@ -91,10 +91,7 @@ export async function POST(request: Request) {
   try {
     const authContext = await getDualAuthContext(request);
     if ("error" in authContext) {
-      return NextResponse.json(
-        { error: authContext.error },
-        { status: authContext.status }
-      );
+      return authFailureResponse(authContext, request.headers);
     }
 
     const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);

--- a/app/api/workflows/import/route.ts
+++ b/app/api/workflows/import/route.ts
@@ -11,11 +11,7 @@ import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { getMetricsCollector } from "@/lib/metrics";
 import { MetricNames } from "@/lib/metrics/types";
-import {
-  type DualAuthContext,
-  auditFromAuth,
-  getDualAuthContext,
-} from "@/lib/middleware/auth-helpers";
+import { type DualAuthContext, auditFromAuth, authFailureResponse, getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { requireScope } from "@/lib/middleware/require-scope";
 import { generateId } from "@/lib/utils/id";
 import {
@@ -57,10 +53,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   try {
     authContext = await getDualAuthContext(request);
     if ("error" in authContext) {
-      return NextResponse.json(
-        { error: authContext.error },
-        { status: authContext.status }
-      );
+      return authFailureResponse(authContext, request.headers);
     }
 
     const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);

--- a/app/api/workflows/route.ts
+++ b/app/api/workflows/route.ts
@@ -3,16 +3,13 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
-import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
+import { authFailureResponse, getDualAuthContext } from "@/lib/middleware/auth-helpers";
 
 export async function GET(request: Request): Promise<NextResponse> {
   try {
     const authContext = await getDualAuthContext(request, { required: false });
     if ("error" in authContext) {
-      return NextResponse.json(
-        { error: authContext.error },
-        { status: authContext.status }
-      );
+      return authFailureResponse(authContext, request.headers);
     }
 
     const { organizationId } = authContext;

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -54,6 +54,7 @@ The API uses a short set of stable, lowercase codes in the `error` field. Some r
 | `conflict` | 409 | Request conflicts with the current state | Reconcile and retry |
 | `rate_limited` | 429 | Too many requests | Back off and retry (see rate-limit headers below) |
 | `internal_error` | 500 | Unexpected server error | Retry with backoff; contact support if it persists |
+| `mfa_required` | 403 | The session is flagged and must re-prove its second factor | Complete the step-up prompt, then retry |
 
 ### Idempotency Errors
 

--- a/lib/errors/api-envelope.ts
+++ b/lib/errors/api-envelope.ts
@@ -202,3 +202,6 @@ export const ApiErrorCodes = {
   RATE_LIMITED: "rate_limited",
   INTERNAL_ERROR: "internal_error",
 } as const;
+
+/** One of the documented codes above. */
+export type ApiErrorCode = (typeof ApiErrorCodes)[keyof typeof ApiErrorCodes];

--- a/lib/middleware/auth-helpers.ts
+++ b/lib/middleware/auth-helpers.ts
@@ -1,9 +1,15 @@
 import { and, eq, isNull, or } from "drizzle-orm";
+import type { NextResponse } from "next/server";
 import { authenticateApiKey } from "@/lib/api-key-auth";
 import { auth } from "@/lib/auth";
 import { isAnonymousUserShape } from "@/lib/auth-anonymous-guard";
 import { db } from "@/lib/db";
 import { member, organization } from "@/lib/db/schema";
+import {
+  type ApiErrorCode,
+  ApiErrorCodes,
+  apiError,
+} from "@/lib/errors/api-envelope";
 import { authenticateOAuthToken } from "@/lib/mcp/oauth-auth";
 import { getOrgContext } from "@/lib/middleware/org-context";
 import {
@@ -11,6 +17,23 @@ import {
   isTrustedOrigin,
   normaliseOrigin,
 } from "@/lib/trusted-origins";
+
+/**
+ * An auth rejection, carrying both halves the documented error envelope needs.
+ *
+ * `code` is the stable value an integrator branches on; `error` stays the human
+ * sentence and becomes `detail` once a route emits the envelope via `apiError`.
+ * Routes not yet migrated keep returning `error` as-is, so adopting the code is
+ * incremental rather than a flag day.
+ */
+export type AuthFailure = {
+  error: string;
+  // `mfa_required` sits outside the documented set on purpose: the dialog
+  // branches on it to route into step-up rather than showing a dead error, and
+  // the docs already allow a route to raise a more specific code.
+  code: ApiErrorCode | "mfa_required";
+  status: number;
+};
 
 const STATE_CHANGING_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
 
@@ -23,9 +46,7 @@ const STATE_CHANGING_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
  * Skipped for OAuth Bearer and API-key callers because those auth methods are
  * intentionally cross-origin and not vulnerable to cookie CSRF.
  */
-function checkSessionOrigin(
-  request: Request
-): { error: string; status: 403 } | null {
+function checkSessionOrigin(request: Request): AuthFailure | null {
   const method = request.method.toUpperCase();
   if (!STATE_CHANGING_METHODS.has(method)) {
     return null;
@@ -49,7 +70,11 @@ function checkSessionOrigin(
 
   if (!origin) {
     console.info("[csrf] blocked: missing origin (session)", { method, path });
-    return { error: "Invalid origin", status: 403 };
+    return {
+      error: "Invalid origin",
+      code: ApiErrorCodes.UNAUTHORIZED,
+      status: 403,
+    };
   }
   if (!isTrustedOrigin(origin)) {
     console.info("[csrf] blocked: untrusted origin (session)", {
@@ -57,7 +82,11 @@ function checkSessionOrigin(
       path,
       origin,
     });
-    return { error: "Invalid origin", status: 403 };
+    return {
+      error: "Invalid origin",
+      code: ApiErrorCodes.UNAUTHORIZED,
+      status: 403,
+    };
   }
   return null;
 }
@@ -83,9 +112,7 @@ async function resolveSessionOrg(
   request: Request,
   userId: string,
   defaultOrgId: string | null
-): Promise<
-  { organizationId: string | null } | { error: string; status: number }
-> {
+): Promise<{ organizationId: string | null } | AuthFailure> {
   const raw = request.headers.get(ORG_HEADER)?.trim();
   if (!raw) {
     if (!defaultOrgId) {
@@ -114,7 +141,11 @@ async function resolveSessionOrg(
       .where(eq(organization.id, defaultOrgId))
       .limit(1);
     if (!defaultOrg || defaultOrg.deactivatedAt) {
-      return { error: "Organization not found", status: 404 };
+      return {
+        error: "Organization not found",
+        code: ApiErrorCodes.NOT_FOUND,
+        status: 404,
+      };
     }
     return { organizationId: defaultOrgId };
   }
@@ -141,7 +172,11 @@ async function resolveSessionOrg(
 
   const targetOrgId = match[0]?.id;
   if (!targetOrgId) {
-    return { error: "Organization not found", status: 404 };
+    return {
+      error: "Organization not found",
+      code: ApiErrorCodes.NOT_FOUND,
+      status: 404,
+    };
   }
 
   return { organizationId: targetOrgId };
@@ -156,7 +191,7 @@ export type DualAuthContext =
       scope?: string;
       isAnonymous: boolean;
     }
-  | { error: string; status: number; code?: "mfa_required" };
+  | AuthFailure;
 
 export type ResolvedAuthContext = Exclude<DualAuthContext, { error: string }>;
 
@@ -193,7 +228,7 @@ export const MFA_REQUIRED_ERROR = {
   error: "MFA verification required",
   status: 403,
   code: "mfa_required",
-} as const satisfies { error: string; status: number; code: "mfa_required" };
+} as const satisfies AuthFailure;
 
 /**
  * Stable label set to attach to log entries on dual-auth routes so we can
@@ -301,7 +336,11 @@ export async function getDualAuthContext(
 
   const session = await auth.api.getSession({ headers: request.headers });
   if (!session?.user && required) {
-    return { error: "Unauthorized", status: 401 };
+    return {
+      error: "Unauthorized",
+      code: ApiErrorCodes.UNAUTHORIZED,
+      status: 401,
+    };
   }
   if (!session?.user) {
     return {
@@ -369,7 +408,7 @@ export type OrganizationAuthContext =
       // treats as full access.
       scope?: string;
     }
-  | { error: string; status: number };
+  | AuthFailure;
 
 /**
  * Resolves the organization ID and audit context from OAuth, API key, or
@@ -394,7 +433,11 @@ export async function resolveOrganizationId(
   if (apiKeyAuth.authenticated) {
     const organizationId = apiKeyAuth.organizationId;
     if (!organizationId) {
-      return { error: "No active organization", status: 400 };
+      return {
+        error: "No active organization",
+        code: ApiErrorCodes.INVALID_INPUT,
+        status: 400,
+      };
     }
     return {
       organizationId,
@@ -411,7 +454,11 @@ export async function resolveOrganizationId(
 
   const session = await auth.api.getSession({ headers: request.headers });
   if (!session?.user) {
-    return { error: "Unauthorized", status: 401 };
+    return {
+      error: "Unauthorized",
+      code: ApiErrorCodes.UNAUTHORIZED,
+      status: 401,
+    };
   }
 
   const orgContext = await getOrgContext();
@@ -424,7 +471,11 @@ export async function resolveOrganizationId(
     return orgResult;
   }
   if (!orgResult.organizationId) {
-    return { error: "No active organization", status: 400 };
+    return {
+      error: "No active organization",
+      code: ApiErrorCodes.INVALID_INPUT,
+      status: 400,
+    };
   }
   return {
     organizationId: orgResult.organizationId,
@@ -448,7 +499,7 @@ export async function resolveCreatorContext(request: Request): Promise<
       // treats as full access for backwards compatibility.
       scope?: string;
     }
-  | { error: string; status: number }
+  | AuthFailure
 > {
   const oauthAuth = await resolveOAuthToken(request);
   if (oauthAuth) {
@@ -479,7 +530,11 @@ export async function resolveCreatorContext(request: Request): Promise<
 
   const session = await auth.api.getSession({ headers: request.headers });
   if (!session?.user) {
-    return { error: "Unauthorized", status: 401 };
+    return {
+      error: "Unauthorized",
+      code: ApiErrorCodes.UNAUTHORIZED,
+      status: 401,
+    };
   }
 
   const context = await getOrgContext();
@@ -492,7 +547,11 @@ export async function resolveCreatorContext(request: Request): Promise<
     return orgResult;
   }
   if (!orgResult.organizationId) {
-    return { error: "No active organization", status: 400 };
+    return {
+      error: "No active organization",
+      code: ApiErrorCodes.INVALID_INPUT,
+      status: 400,
+    };
   }
   return {
     organizationId: orgResult.organizationId,
@@ -516,15 +575,40 @@ function validateCreatorFields(
       apiKeyId: string | null;
       scope?: string;
     }
-  | { error: string; status: number } {
+  | AuthFailure {
   if (!organizationId) {
-    return { error: "No active organization", status: 400 };
+    return {
+      error: "No active organization",
+      code: ApiErrorCodes.INVALID_INPUT,
+      status: 400,
+    };
   }
   if (!userId) {
     return {
       error: "Auth context missing user. Please recreate the API key.",
+      code: ApiErrorCodes.UNAUTHORIZED,
       status: 400,
     };
   }
   return { organizationId, userId, authMethod, apiKeyId, scope };
+}
+
+/**
+ * Render an auth rejection as the documented error envelope.
+ *
+ * Routes that resolve auth through this module reject in the same shape, so
+ * this is the one-liner that turns that rejection into `{error, detail,
+ * request_id}` plus the `x-request-id` response header. Migrating a route is
+ * swapping its `NextResponse.json({ error: ctx.error }, ...)` for this.
+ */
+export function authFailureResponse(
+  failure: AuthFailure,
+  requestHeaders: Headers
+): NextResponse {
+  return apiError({
+    status: failure.status,
+    code: failure.code,
+    detail: failure.error,
+    requestHeaders,
+  });
 }

--- a/tests/integration/api-error-envelope-adoption.test.ts
+++ b/tests/integration/api-error-envelope-adoption.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The documented contract for the routes an API-key integrator actually calls:
+ * a stable code in `error`, the sentence in `detail`, a correlation id in the
+ * body and on the response header.
+ *
+ * Run with: pnpm vitest tests/integration/api-error-envelope-adoption.test.ts
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { mockResolveOrganizationId } = vi.hoisted(() => ({
+  mockResolveOrganizationId: vi.fn(),
+}));
+
+vi.mock("@/lib/middleware/auth-helpers", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/middleware/auth-helpers")>();
+  return { ...actual, resolveOrganizationId: mockResolveOrganizationId };
+});
+
+vi.mock("@/lib/db", () => ({ db: {} }));
+vi.mock("@/lib/db/schema", () => ({
+  member: {},
+  organizationApiKeys: {},
+  users: {},
+}));
+vi.mock("@/lib/auth", () => ({ auth: { api: { getSession: vi.fn() } } }));
+vi.mock("drizzle-orm", () => ({
+  and: () => ({}),
+  count: () => ({}),
+  eq: () => ({}),
+  inArray: () => ({}),
+  isNull: () => ({}),
+}));
+
+import { GET } from "@/app/api/keys/route";
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type Envelope = {
+  error?: string;
+  detail?: string;
+  request_id?: string;
+};
+
+function get(headers: Record<string, string> = {}): Promise<Response> {
+  return GET(new Request("http://localhost/api/keys", { headers }));
+}
+
+describe("GET /api/keys error envelope", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveOrganizationId.mockResolvedValue({
+      error: "Unauthorized",
+      code: "unauthorized",
+      status: 401,
+    });
+  });
+
+  it("answers the documented envelope instead of a bare prose error", async () => {
+    const response = await get();
+
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as Envelope;
+    // `error` is the stable code an integrator branches on, not a sentence.
+    expect(body.error).toBe("unauthorized");
+    expect(body.detail).toBe("Unauthorized");
+    expect(body.request_id).toMatch(UUID);
+  });
+
+  it("echoes the correlation id on the response header", async () => {
+    const response = await get();
+    const body = (await response.json()) as Envelope;
+
+    expect(response.headers.get("x-request-id")).toBe(body.request_id);
+  });
+
+  it("echoes an inbound request id rather than minting a new one", async () => {
+    const inbound = "b3c1e2f0-2a4d-4a1e-9c3f-0f2b7c1d5e6a";
+    const response = await get({ "x-request-id": inbound });
+    const body = (await response.json()) as Envelope;
+
+    expect(body.request_id).toBe(inbound);
+    expect(response.headers.get("x-request-id")).toBe(inbound);
+  });
+
+  it("carries the code through for a non-auth rejection too", async () => {
+    mockResolveOrganizationId.mockResolvedValue({
+      error: "No active organization",
+      code: "invalid_input",
+      status: 400,
+    });
+
+    const response = await get();
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as Envelope;
+    expect(body.error).toBe("invalid_input");
+    expect(body.detail).toBe("No active organization");
+  });
+});

--- a/tests/integration/org-api-keys-route.test.ts
+++ b/tests/integration/org-api-keys-route.test.ts
@@ -25,9 +25,11 @@ const {
   mockAuthorizeAction: vi.fn(),
 }));
 
-vi.mock("@/lib/middleware/auth-helpers", () => ({
-  resolveOrganizationId: mockResolveOrganizationId,
-}));
+vi.mock("@/lib/middleware/auth-helpers", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/middleware/auth-helpers")>();
+  return { ...actual, resolveOrganizationId: mockResolveOrganizationId };
+});
 
 vi.mock("@/lib/auth", () => ({
   auth: {
@@ -144,23 +146,30 @@ describe("GET /api/keys", () => {
   it("should return 401 when not authenticated", async () => {
     mockResolveOrganizationId.mockResolvedValue({
       error: "Unauthorized",
+      code: "unauthorized",
       status: 401,
     });
 
     const response = await GET(createRequest("GET"));
     expect(response.status).toBe(401);
+    const data = await response.json();
+    expect(data.error).toBe("unauthorized");
+    expect(data.detail).toBe("Unauthorized");
+    expect(response.headers.get("x-request-id")).toBe(data.request_id);
   });
 
   it("should return 400 when no active organization", async () => {
     mockResolveOrganizationId.mockResolvedValue({
       error: "No active organization",
+      code: "invalid_input",
       status: 400,
     });
 
     const response = await GET(createRequest("GET"));
     expect(response.status).toBe(400);
     const data = await response.json();
-    expect(data.error).toBe("No active organization");
+    expect(data.error).toBe("invalid_input");
+    expect(data.detail).toBe("No active organization");
   });
 
   it("should return org keys with creator names", async () => {
@@ -379,6 +388,7 @@ describe("DELETE /api/keys/:keyId (revoke)", () => {
   it("should return 401 when not authenticated", async () => {
     mockResolveOrganizationId.mockResolvedValue({
       error: "Unauthorized",
+      code: "unauthorized",
       status: 401,
     });
 

--- a/tests/integration/workflow-code-route.test.ts
+++ b/tests/integration/workflow-code-route.test.ts
@@ -17,6 +17,17 @@ const { mockGetDualAuthContext, mockMemberLimit, mockWorkflowsFindFirst } =
 
 vi.mock("@/lib/middleware/auth-helpers", () => ({
   getDualAuthContext: mockGetDualAuthContext,
+  // Mirrors the real helper's envelope shape; importing the module itself
+  // would pull in lib/auth, which this suite deliberately does not load.
+  authFailureResponse: (failure: {
+    error: string;
+    code: string;
+    status: number;
+  }): Response =>
+    Response.json(
+      { error: failure.code, detail: failure.error, request_id: "test" },
+      { status: failure.status }
+    ),
   UNAUTHENTICATED_AUDIT: { authMethod: "unknown" },
   auditFromAuth: (ctx: unknown): Record<string, string> => {
     if (ctx && typeof ctx === "object" && "error" in ctx) {

--- a/tests/integration/workflow-export-import-route.test.ts
+++ b/tests/integration/workflow-export-import-route.test.ts
@@ -1,3 +1,4 @@
+import { NextResponse } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -155,6 +156,14 @@ vi.mock("@/lib/middleware/auth-helpers", () => ({
     isAnonymous: false,
   }),
   auditFromAuth: vi.fn().mockReturnValue({ authMethod: "session" }),
+  authFailureResponse: (
+    failure: { error: string; code: string; status: number },
+    _headers: Headers
+  ) =>
+    NextResponse.json(
+      { error: failure.code, detail: failure.error, request_id: "test" },
+      { status: failure.status }
+    ),
   UNAUTHENTICATED_AUDIT: { authMethod: "unknown" },
 }));
 
@@ -274,6 +283,7 @@ describe("GET /api/workflows/[workflowId]/download", () => {
     );
     vi.mocked(getDualAuthContext).mockResolvedValueOnce({
       error: "Unauthorized",
+      code: "unauthorized",
       status: 401,
     });
 

--- a/tests/unit/audit-from-auth.test.ts
+++ b/tests/unit/audit-from-auth.test.ts
@@ -38,7 +38,11 @@ const oauthCtx: DualAuthContext = {
   isAnonymous: false,
 };
 
-const errorCtx: DualAuthContext = { error: "Unauthorized", status: 401 };
+const errorCtx: DualAuthContext = {
+  error: "Unauthorized",
+  code: "unauthorized",
+  status: 401,
+};
 
 describe("auditFromAuth", () => {
   it("emits authMethod=session and omits apiKeyId for session auth", () => {

--- a/tests/unit/dual-auth-context.test.ts
+++ b/tests/unit/dual-auth-context.test.ts
@@ -295,6 +295,7 @@ describe("getDualAuthContext", () => {
 
         expect(result).toEqual({
           error: "Organization not found",
+          code: "not_found",
           status: 404,
         });
       });
@@ -308,6 +309,7 @@ describe("getDualAuthContext", () => {
 
         expect(result).toEqual({
           error: "Organization not found",
+          code: "not_found",
           status: 404,
         });
       });
@@ -338,6 +340,7 @@ describe("getDualAuthContext", () => {
 
         expect(result).toEqual({
           error: "Organization not found",
+          code: "not_found",
           status: 404,
         });
         expect(mockOrgLookup).not.toHaveBeenCalled();
@@ -354,7 +357,11 @@ describe("getDualAuthContext", () => {
     it("returns 401 error when required (default)", async () => {
       const result = await getDualAuthContext(makeRequest());
 
-      expect(result).toEqual({ error: "Unauthorized", status: 401 });
+      expect(result).toEqual({
+        error: "Unauthorized",
+        code: "unauthorized",
+        status: 401,
+      });
     });
 
     it("returns null values when not required", async () => {
@@ -480,7 +487,11 @@ describe("getDualAuthContext", () => {
         )
       );
 
-      expect(result).toEqual({ error: "Invalid origin", status: 403 });
+      expect(result).toEqual({
+        error: "Invalid origin",
+        code: "unauthorized",
+        status: 403,
+      });
     });
 
     it("rejects state-changing request with cookie and no origin/referer", async () => {
@@ -491,7 +502,11 @@ describe("getDualAuthContext", () => {
         )
       );
 
-      expect(result).toEqual({ error: "Invalid origin", status: 403 });
+      expect(result).toEqual({
+        error: "Invalid origin",
+        code: "unauthorized",
+        status: 403,
+      });
     });
 
     it("falls back to Referer when Origin is missing", async () => {
@@ -640,7 +655,11 @@ describe("resolveOrganizationId — origin check wiring", () => {
         { method: "POST" }
       )
     );
-    expect(result).toEqual({ error: "Invalid origin", status: 403 });
+    expect(result).toEqual({
+      error: "Invalid origin",
+      code: "unauthorized",
+      status: 403,
+    });
   });
 
   it("allows trusted origin on cookie POST", async () => {
@@ -683,7 +702,11 @@ describe("resolveCreatorContext — origin check wiring", () => {
         { method: "POST" }
       )
     );
-    expect(result).toEqual({ error: "Invalid origin", status: 403 });
+    expect(result).toEqual({
+      error: "Invalid origin",
+      code: "unauthorized",
+      status: 403,
+    });
   });
 
   it("allows trusted origin on cookie POST", async () => {

--- a/tests/unit/idempotency-409-route-body.test.ts
+++ b/tests/unit/idempotency-409-route-body.test.ts
@@ -182,57 +182,57 @@ beforeEach(() => {
   mockReadContractCore.mockResolvedValue({ success: true, result: "1" });
 });
 
-describe.each(ROUTES)("idempotency 409 bodies, as $name emits them", ({
-  post: handler,
-  request,
-}) => {
-  it("ships retryable true on an in-flight duplicate", async () => {
-    mockBeginIdempotentFromRequest.mockResolvedValue({ kind: "in_progress" });
+describe.each(ROUTES)(
+  "idempotency 409 bodies, as $name emits them",
+  ({ post: handler, request }) => {
+    it("ships retryable true on an in-flight duplicate", async () => {
+      mockBeginIdempotentFromRequest.mockResolvedValue({ kind: "in_progress" });
 
-    const res = await handler(request());
-    const body = (await res.json()) as { code?: string; retryable?: boolean };
+      const res = await handler(request());
+      const body = (await res.json()) as { code?: string; retryable?: boolean };
 
-    expect(res.status).toBe(409);
-    expect(body.code).toBe("idempotency_in_progress");
-    expect(body.retryable).toBe(true);
-  });
-
-  it("ships retryable false on a key reused with a different body", async () => {
-    mockBeginIdempotentFromRequest.mockResolvedValue({
-      kind: "conflict",
-      originalResourceId: "exec_1",
+      expect(res.status).toBe(409);
+      expect(body.code).toBe("idempotency_in_progress");
+      expect(body.retryable).toBe(true);
     });
 
-    const res = await handler(request());
-    const body = (await res.json()) as {
-      code?: string;
-      retryable?: boolean;
-      originalExecutionId?: string;
-    };
+    it("ships retryable false on a key reused with a different body", async () => {
+      mockBeginIdempotentFromRequest.mockResolvedValue({
+        kind: "conflict",
+        originalResourceId: "exec_1",
+      });
 
-    expect(res.status).toBe(409);
-    expect(body.code).toBe("idempotency_conflict");
-    expect(body.retryable).toBe(false);
-    expect(body.originalExecutionId).toBe("exec_1");
-  });
+      const res = await handler(request());
+      const body = (await res.json()) as {
+        code?: string;
+        retryable?: boolean;
+        originalExecutionId?: string;
+      };
 
-  // The status is identical on both, so a caller that reads only the status
-  // cannot tell an in-flight request from a spent key. This is the assertion
-  // the whole change exists for.
-  it("gives the two the same status and opposite dispositions", async () => {
-    mockBeginIdempotentFromRequest.mockResolvedValue({ kind: "in_progress" });
-    const inFlight = await handler(request());
-    const inFlightBody = (await inFlight.json()) as { retryable?: boolean };
-
-    mockBeginIdempotentFromRequest.mockResolvedValue({
-      kind: "conflict",
-      originalResourceId: null,
+      expect(res.status).toBe(409);
+      expect(body.code).toBe("idempotency_conflict");
+      expect(body.retryable).toBe(false);
+      expect(body.originalExecutionId).toBe("exec_1");
     });
-    const conflict = await handler(request());
-    const conflictBody = (await conflict.json()) as { retryable?: boolean };
 
-    expect(inFlight.status).toBe(conflict.status);
-    expect(inFlightBody.retryable).toBe(true);
-    expect(conflictBody.retryable).toBe(false);
-  });
-});
+    // The status is identical on both, so a caller that reads only the status
+    // cannot tell an in-flight request from a spent key. This is the assertion
+    // the whole change exists for.
+    it("gives the two the same status and opposite dispositions", async () => {
+      mockBeginIdempotentFromRequest.mockResolvedValue({ kind: "in_progress" });
+      const inFlight = await handler(request());
+      const inFlightBody = (await inFlight.json()) as { retryable?: boolean };
+
+      mockBeginIdempotentFromRequest.mockResolvedValue({
+        kind: "conflict",
+        originalResourceId: null,
+      });
+      const conflict = await handler(request());
+      const conflictBody = (await conflict.json()) as { retryable?: boolean };
+
+      expect(inFlight.status).toBe(conflict.status);
+      expect(inFlightBody.retryable).toBe(true);
+      expect(conflictBody.retryable).toBe(false);
+    });
+  }
+);

--- a/tests/unit/mcp-curator-tools.test.ts
+++ b/tests/unit/mcp-curator-tools.test.ts
@@ -56,6 +56,7 @@ const mockAuth = (orgId = "org-abc") =>
 const mockNoAuth = () =>
   vi.mocked(getDualAuthContext).mockResolvedValue({
     error: "Unauthorized",
+    code: "unauthorized",
     status: 401,
   });
 


### PR DESCRIPTION
## Problem

The public docs specify a flat error envelope with a stable machine-readable
code, a human-readable detail, and a correlation id echoed on the
`x-request-id` response header. Almost no route emitted it.

```
GET https://app.keeperhub.com/api/keys
HTTP/2 401

{"error":"Unauthorized"}
```

No `detail`, no `request_id`, no `x-request-id` header. An integrator hitting
a failure had nothing to quote to support and nothing stable to branch on,
which is exactly what an external report called out. The helper that produces
the correct shape already existed and worked; it just was not wired in.

Two distinct defects: the wrong response shape, and error values that are
capitalised prose rather than codes.

## Re-checked before starting

The ticket's numbers were stale, so I re-counted against staging:

- **7 of 196** route files imported the envelope helper, not 2 of 194.
- `/api/user/wallet` was already migrated, so it dropped off the target list.
- 92 route files still built an error as a bare `NextResponse.json({ error })`.
- The auth-helpers prose and the docs contract were unchanged.

## Changes

**Auth rejections carry a code.** Every value in `lib/middleware/auth-helpers.ts`
now returns a documented `ApiErrorCodes` value alongside the existing sentence,
behind a named `AuthFailure` type.

`error` deliberately keeps the sentence rather than becoming the code. That
makes adoption incremental instead of a flag day: a route emits the full
envelope the moment it switches, and the ~30 routes not in this batch keep
their current body until they do. Flipping `error` globally would have changed
the response of every route at once and replaced human messages with slugs on
surfaces that display them.

**`authFailureResponse` makes switching a route one line.** It turns an
`AuthFailure` into `apiError(...)`, so the remaining routes are a mechanical
follow-up rather than a redesign.

**Migrated the surface an API-key integrator actually calls:** `/api/keys` plus
the thirteen `/api/workflows` routes.

**`mfa_required`** stays outside the documented set and is now listed in the
error table. The sign-in dialog branches on it to route into step-up, and the
docs already permit a route to raise a more specific code.

## Acceptance criteria

All four are covered by tests against the real route:

| Criterion | Status |
|---|---|
| `/api/keys` without a credential returns `{error, detail, request_id}` | yes |
| A matching `x-request-id` response header | yes |
| An inbound `x-request-id` is echoed, not replaced | yes |
| Documented code table matches what the code emits | yes, `mfa_required` added |

## Verification

Full suite: **21,568 passing**, 3 skipped, across 600 files.

Two failures are excluded as pre-existing: `workflow-runner.test.ts` signal
handling and `reaper-sh-signing-contract.test.ts`. Both were confirmed failing
identically on a separate branch that touches no auth code, so they are not
caused by this change.

Making the code part of the type is what surfaced the real risk here: three
test fixtures were constructing a rejection without one, and two suites mocked
`auth-helpers` wholesale so a migrated route hit an undefined helper and turned
a 401 into a 500. Both are fixed, and `org-api-keys-route.test.ts` now asserts
the real envelope rather than a stubbed one.

I also checked no client code branches on the prose strings before touching
them; nothing did.

## Not in this PR

- The remaining ~30 routes that use `authCtx.error`. Mechanical follow-up now
  that the helper exists.
- The lint rule from the plan. It would fail on every unmigrated route and
  needs a baseline decision first, so it belongs with the last batch.

## Note for the reviewer

The formatting commit on `tests/unit/idempotency-409-route-body.test.ts` is the
same one carried in #2016, #2017 and #2018. That file landed unformatted on
staging and `pnpm check` is a required check, so every branch cut from staging
inherits a red lint step. Byte-identical across the branches, so whichever
merges last is a no-op.
