### PR TITLE
feat: KEEP-1087 add Robinhood Chain (4663) and testnet (46630) as supported chains

### DIFF
--- a/lib/rpc/rpc-config.ts
+++ b/lib/rpc/rpc-config.ts
@@ -71,6 +71,21 @@ export const PUBLIC_RPCS = {
   ZERO_G_MAINNET_FALLBACK: "https://0g.drpc.org",
   ZERO_G_GALILEO: "https://evmrpc-testnet.0g.ai",
   ZERO_G_GALILEO_FALLBACK: "https://16602.rpc.thirdweb.com",
+  // Robinhood Chain. Both of these rate-limit by returning empty result sets
+  // rather than erroring, so under load an eth_getLogs reads as "no activity"
+  // instead of as a failure. That is survivable for a last-resort default and
+  // not for real traffic: every deployed environment gets a keyed endpoint
+  // through CHAIN_RPC_CONFIG, which takes priority over everything here.
+  ROBINHOOD_MAINNET: "https://rpc.mainnet.chain.robinhood.com",
+  ROBINHOOD_MAINNET_FALLBACK: "https://robinhood.drpc.org",
+  ROBINHOOD_TESTNET: "https://rpc.testnet.chain.robinhood.com",
+  ROBINHOOD_TESTNET_FALLBACK: "https://robinhood-testnet.drpc.org",
+  // No publicWssDefault for either chain, deliberately. Robinhood publishes
+  // wss://feed.mainnet.chain.robinhood.com, but it is not a JSON-RPC socket --
+  // it streams raw Arbitrum sequencer-feed messages and cannot serve
+  // eth_subscribe -- and dRPC's free tier rejects eth_subscribe outright. There
+  // is no public WSS endpoint for this chain to fall back to, so event and
+  // block triggers depend on the WSS URLs in CHAIN_RPC_CONFIG.
   SOLANA_MAINNET: "https://api.mainnet-beta.solana.com",
   SOLANA_DEVNET: "https://api.devnet.solana.com",
 } as const;
@@ -248,6 +263,22 @@ export const CHAIN_CONFIG: Record<number, ChainConfigEntry> = {
     fallbackEnvKey: "CHAIN_ZERO_G_GALILEO_FALLBACK_RPC",
     publicDefault: PUBLIC_RPCS.ZERO_G_GALILEO,
     publicFallback: PUBLIC_RPCS.ZERO_G_GALILEO_FALLBACK,
+  },
+  // Robinhood Chain Mainnet (Arbitrum Orbit L2)
+  4663: {
+    jsonKey: "robinhood-mainnet",
+    envKey: "CHAIN_ROBINHOOD_MAINNET_PRIMARY_RPC",
+    fallbackEnvKey: "CHAIN_ROBINHOOD_MAINNET_FALLBACK_RPC",
+    publicDefault: PUBLIC_RPCS.ROBINHOOD_MAINNET,
+    publicFallback: PUBLIC_RPCS.ROBINHOOD_MAINNET_FALLBACK,
+  },
+  // Robinhood Chain Testnet
+  46630: {
+    jsonKey: "robinhood-testnet",
+    envKey: "CHAIN_ROBINHOOD_TESTNET_PRIMARY_RPC",
+    fallbackEnvKey: "CHAIN_ROBINHOOD_TESTNET_FALLBACK_RPC",
+    publicDefault: PUBLIC_RPCS.ROBINHOOD_TESTNET,
+    publicFallback: PUBLIC_RPCS.ROBINHOOD_TESTNET_FALLBACK,
   },
   // Solana Mainnet
   101: {

--- a/lib/web3/gas-strategy.ts
+++ b/lib/web3/gas-strategy.ts
@@ -566,6 +566,25 @@ export class AdaptiveGasStrategy {
         minPriorityFeeGwei: 30,
         maxPriorityFeeGwei: 1000,
       },
+      // Robinhood Chain (Arbitrum Orbit L2) and its testnet. Priority fees are
+      // inert here: the sequencer orders first-come-first-served, so a tip buys
+      // no inclusion advantage. Measured on 4663 (2026-08-12): eth_feeHistory
+      // returned 0 reward at the 25th, 50th, 75th and 99th percentiles across
+      // 10 consecutive blocks, eth_maxPriorityFeePerGas returned 0, and
+      // eth_gasPrice (0.0423 gwei) matched the base fee (0.0428 gwei).
+      // The 0.1 gwei default floor would therefore add roughly 2.3x the base
+      // fee as a tip nothing consumes, so the floor is dropped to 0. The cap
+      // stays low to bound a bad percentile read rather than to price anything.
+      4663: {
+        gasLimitMultiplier: 1.5, // Orbit L2, same estimate accuracy as Arbitrum
+        minPriorityFeeGwei: 0,
+        maxPriorityFeeGwei: 1,
+      },
+      46630: {
+        gasLimitMultiplier: 1.5,
+        minPriorityFeeGwei: 0,
+        maxPriorityFeeGwei: 1,
+      },
       // 0G Galileo testnet. The mempool admits tips at 2 gwei (matching the
       // node's "needed 2 gwei" floor) but validators only include txs paying
       // >= ~4 gwei. Validated 2026-05-01: sampled 10k recent blocks (400 txs);

--- a/plugins/blockscout/chains.ts
+++ b/plugins/blockscout/chains.ts
@@ -20,6 +20,7 @@ export const BLOCKSCOUT_INSTANCES: Record<number, string> = {
   42_161: "https://arbitrum.blockscout.com",
   100: "https://gnosis.blockscout.com",
   137: "https://polygon.blockscout.com",
+  4663: "https://robinhoodchain.blockscout.com",
 };
 
 // Chain IDs (as strings) with a hosted instance, for chain-select allowlists.

--- a/scripts/seed/seed-chains.ts
+++ b/scripts/seed/seed-chains.ts
@@ -532,6 +532,59 @@ const DEFAULT_CHAINS: NewChain[] = [
     usePrivateMempoolRpc: getUsePrivateMempoolRpc({ rpcConfig, jsonKey: "0g-galileo" }),
     defaultPrivateRpcUrl: getPrivateRpcUrl({ rpcConfig, jsonKey: "0g-galileo" }),
   },
+  {
+    chainId: getChainConfigValue("robinhood-mainnet", "chainId", 4663),
+    name: "Robinhood Chain",
+    symbol: getChainConfigValue("robinhood-mainnet", "symbol", "ETH"),
+    chainType: "evm",
+    defaultPrimaryRpc: getRpcUrlByChainId(4663, "primary"),
+    defaultFallbackRpc: getRpcUrlByChainId(4663, "fallback"),
+    defaultPrimaryWss: getWssUrl({
+      rpcConfig,
+      jsonKey: CHAIN_CONFIG[4663].jsonKey,
+      type: "primary",
+    }),
+    defaultFallbackWss: getWssUrl({
+      rpcConfig,
+      jsonKey: CHAIN_CONFIG[4663].jsonKey,
+      type: "fallback",
+    }),
+    isTestnet: getChainConfigValue("robinhood-mainnet", "isTestnet", false),
+    // Unlike every other chain here, the hardcoded default is false rather than
+    // true. production.json disables this chain explicitly, so the default is
+    // only reached where CHAIN_RPC_CONFIG is absent or fails to parse -- and on
+    // a parse failure the seed falls back to hardcoded defaults throughout,
+    // which with a `true` default would silently enable mainnet in production.
+    // Flip this to true alongside the production.json entry, not before.
+    isEnabled: getChainConfigValue("robinhood-mainnet", "isEnabled", false),
+    status: "experimental",
+    usePrivateMempoolRpc: getUsePrivateMempoolRpc({ rpcConfig, jsonKey: "robinhood-mainnet" }),
+    defaultPrivateRpcUrl: getPrivateRpcUrl({ rpcConfig, jsonKey: "robinhood-mainnet" }),
+    aliases: ["robinhood"],
+  },
+  {
+    chainId: getChainConfigValue("robinhood-testnet", "chainId", 46_630),
+    name: "Robinhood Chain Testnet",
+    symbol: getChainConfigValue("robinhood-testnet", "symbol", "ETH"),
+    chainType: "evm",
+    defaultPrimaryRpc: getRpcUrlByChainId(46_630, "primary"),
+    defaultFallbackRpc: getRpcUrlByChainId(46_630, "fallback"),
+    defaultPrimaryWss: getWssUrl({
+      rpcConfig,
+      jsonKey: CHAIN_CONFIG[46_630].jsonKey,
+      type: "primary",
+    }),
+    defaultFallbackWss: getWssUrl({
+      rpcConfig,
+      jsonKey: CHAIN_CONFIG[46_630].jsonKey,
+      type: "fallback",
+    }),
+    isTestnet: getChainConfigValue("robinhood-testnet", "isTestnet", true),
+    isEnabled: getChainConfigValue("robinhood-testnet", "isEnabled", true),
+    status: "experimental",
+    usePrivateMempoolRpc: getUsePrivateMempoolRpc({ rpcConfig, jsonKey: "robinhood-testnet" }),
+    defaultPrivateRpcUrl: getPrivateRpcUrl({ rpcConfig, jsonKey: "robinhood-testnet" }),
+  },
   // Solana chains (non-EVM - uses SolanaProviderManager)
   {
     chainId: getChainConfigValue("solana-mainnet", "chainId", 101),
@@ -787,6 +840,26 @@ const EXPLORER_CONFIG_TEMPLATES: Record<
     explorerAddressPath: "/address/{address}",
     explorerContractPath: "/address/{address}?tab=contract-viewer",
   },
+  // Robinhood Chain Mainnet - hosted Blockscout
+  4663: {
+    chainType: "evm",
+    explorerUrl: "https://robinhoodchain.blockscout.com",
+    explorerApiType: "blockscout",
+    explorerApiUrl: "https://robinhoodchain.blockscout.com/api",
+    explorerTxPath: "/tx/{hash}",
+    explorerAddressPath: "/address/{address}",
+    explorerContractPath: "/address/{address}?tab=contract",
+  },
+  // Robinhood Chain Testnet - Blockscout
+  46630: {
+    chainType: "evm",
+    explorerUrl: "https://explorer.testnet.chain.robinhood.com",
+    explorerApiType: "blockscout",
+    explorerApiUrl: "https://explorer.testnet.chain.robinhood.com/api",
+    explorerTxPath: "/tx/{hash}",
+    explorerAddressPath: "/address/{address}",
+    explorerContractPath: "/address/{address}?tab=contract",
+  },
   // Solana Mainnet - Solscan
   101: {
     chainType: "solana",
@@ -922,6 +995,8 @@ async function seedChains() {
     "Plasma Testnet": 9746,
     "0G": 16_661,
     "0G Galileo": 16_602,
+    "Robinhood Chain": 4663,
+    "Robinhood Chain Testnet": 46_630,
     Solana: 101,
     "Solana Devnet": 103,
   };


### PR DESCRIPTION
Declares Robinhood Chain (4663) and Robinhood Chain Testnet (46630) so the seed
can write them. Pairs with KeeperHub/chain-config#38, already merged, which
supplies the per-environment RPC overrides.

Chain enablement only. The plugin, x402 rail, event-tracker batching and gas
feed are tracked separately (KEEP-1096, KEEP-1089, KEEP-1088, KEEP-1091).

## Why CHAIN_CONFIG is the load-bearing edit

`seed-chains.ts` indexes `CHAIN_CONFIG[chainId].jsonKey` directly, so a chain
missing from that map throws at seed time rather than being skipped. The
`jsonKey` values match the chain-config keys exactly, which is what makes the
SSM overrides resolve.

Two wiring details that fail quietly if missed, both covered here:

- `chainToDefaultIdMap` is keyed by the chain's display **name**, not its id. A
  name that does not match drops the explorer config with only a
  `console.warn`. Verified statically: all 24 chain names resolve to an
  explorer template, no orphans.
- `EXPLORER_CONFIG_TEMPLATES` is keyed by id, so both keys have to agree.

## Endpoint choices

Public RPC defaults are the chain's own public endpoints, with dRPC's free
public endpoints as fallback - genuinely public, no key, in keeping with the
rest of `PUBLIC_RPCS`. Both rate-limit by returning empty result sets rather
than erroring, so under load an `eth_getLogs` reads as "no activity" instead of
as a failure. That is survivable for a last-resort default and not for real
traffic: every deployed environment gets a keyed endpoint through
`CHAIN_RPC_CONFIG`, which takes priority over everything in this file.

Neither chain gets a `publicWssDefault`, deliberately. Robinhood publishes
`wss://feed.mainnet.chain.robinhood.com`, but it streams raw Arbitrum
sequencer-feed messages rather than JSON-RPC and cannot serve `eth_subscribe`,
and dRPC's free tier rejects `eth_subscribe` outright. There is no public WSS
endpoint for this chain, so event and block triggers depend on the WSS URLs in
`CHAIN_RPC_CONFIG`.

## Mainnet defaults to disabled

`isEnabled` for 4663 hardcodes `false`, unlike every other chain here, which
hardcodes `true`. `production.json` disables the chain explicitly, so this
default is only reached where `CHAIN_RPC_CONFIG` is absent or fails to parse -
and on a parse failure the seed falls back to hardcoded defaults throughout.
With a `true` default that failure mode silently enables mainnet in production.

Staging enables both chains. Flip this constant at the same time as the
production.json entry, not before.

## Gas configuration

The priority-fee floor drops to 0 for both chains. Measured on 4663:
`eth_feeHistory` returned 0 reward at the 25th, 50th, 75th and 99th percentiles
across 10 consecutive blocks, `eth_maxPriorityFeePerGas` returned 0, and
`eth_gasPrice` (0.0423 gwei) matched the base fee (0.0428 gwei) - the sequencer
orders first-come-first-served, so a tip buys no inclusion advantage. The 0.1
gwei default floor would add roughly 2.3x the base fee as a tip nothing
consumes. `gasLimitMultiplier` is 1.5, matching Arbitrum, since this is an
Arbitrum Orbit L2.

## Deliberately not changed

`lib/rpc/types.ts` (`SUPPORTED_CHAIN_IDS`), `lib/rpc/network-utils.ts` and
`lib/chain-utils.ts` appear in the ticket's touch list but are not gates, and
no recently added chain touched them. Measured against the 22 chains currently
seeded, `SUPPORTED_CHAIN_IDS` is missing 14 of them, `EXPLORER_URLS` 17, and
`CHAIN_NAMES` 11 - Plasma, 0G, BNB, Polygon, Arbitrum, Avalanche and Optimism
are all live and absent. `getChainIdFromNetwork` parses numeric strings before
consulting its map, so `"4663"` already resolves.

Adding one chain to those maps would imply the edits are required while fixing
nothing systematically. The consolidation is filed separately as its own piece
of work; these maps want to become views over the `chains` table, following the
pattern KEEP-1055 established in `lib/agentic-wallet/workflow-binding.ts`.

The Safe chain prefix is also omitted. `api.safe.global/tx-service/robinhood`
resolves, so the slug is almost certainly right, but that map drives
`app.safe.global` deep links and I could not confirm their UI supports 4663.
Unmapped chains currently hide the link, which fails safe; a wrong prefix would
turn a hidden link into a broken one.

## Verification

Endpoints and explorers were probed live rather than taken from the ticket:

| Check | Result |
| -- | -- |
| chain-config CI, HTTPS | 84/84 URLs returned the configured chainId |
| chain-config CI, WSS | 80/80 URLs accepted `eth_subscribe newHeads` |
| `robinhoodchain.blockscout.com` | 200 on `/api/v2/stats` and the Etherscan-compat `/api` |
| `explorer.testnet.chain.robinhood.com` | 200 on both |
| Explorer wiring | 24/24 chain names resolve to a template, no orphans |

Type-check and the seed were not run locally against this branch - CI is the
gate for both.
