### PR TITLE
chore: make migrate-check actually run its migration checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -35,9 +35,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          CHANGED=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files \
-            --paginate --per-page 100 -q '.[].filename' | grep -E '^(drizzle/|lib/db/schema)' || true | head -1)
-          if [ -n "$CHANGED" ]; then
+          # set -e matters here: this step decides whether every migration check
+          # below runs at all, so a failure to list the PR's files must fail the
+          # job rather than silently resolve to "no migrations changed".
+          set -euo pipefail
+          # per_page is a query parameter, not a gh flag. `gh api --per-page`
+          # exits with "unknown flag", which the old `|| true` swallowed into
+          # relevant=false -- skipping the fresh-database migration and the
+          # drift check while still reporting success.
+          FILES=$(gh api \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files?per_page=100" \
+            --paginate -q '.[].filename')
+          # grep -q inside `if` does not trip set -e when it finds no match.
+          if printf '%s\n' "$FILES" | grep -qE '^(drizzle/|lib/db/schema)'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
           else
             echo "relevant=false" >> "$GITHUB_OUTPUT"

--- a/docs/agent/agentic-wallet.md
+++ b/docs/agent/agentic-wallet.md
@@ -176,7 +176,7 @@ Nothing stops you installing multiple wallets side by side; they do not conflict
 Whichever wallet you install, the agent calls KeeperHub through two meta-tools (described in its OpenAPI at `/openapi.json`):
 
 - `search_workflows` — find workflows by category, tag, or free text. Returns slug, description, inputSchema, and price for each match.
-- `call_workflow` — execute a listed workflow by slug. For read workflows the call executes and returns the result; for write workflows it returns unsigned calldata `{to, data, value}` for the caller to submit. A priced write listing returns a 402 payment challenge first, exactly like a priced read listing; the price buys the calldata, and on-chain gas is separate. A priced write listing returns a 402 payment challenge first, exactly like a priced read listing; the price buys the calldata, and on-chain gas is separate.
+- `call_workflow` — execute a listed workflow by slug. For read workflows the call executes and returns the result; for write workflows it returns unsigned calldata `{to, data, value}` for the caller to submit. A priced write listing returns a 402 payment challenge first, exactly like a priced read listing; the price buys the calldata, and on-chain gas is separate.
 
 The meta-tool pattern keeps the agent's tool list small regardless of how many workflows are listed: the agent discovers available workflows at runtime instead of registering one tool per workflow.
 


### PR DESCRIPTION
## The bug

`migrate-check` is a **required status check** that has been failing open since `01e0c59c3` (13 April 2026).

`.github/workflows/pr-checks.yml` detected migration-relevant changes with:

```bash
CHANGED=$(gh api repos/.../pulls/N/files \
  --paginate --per-page 100 -q '.[].filename' | grep -E '^(drizzle/|lib/db/schema)' || true | head -1)
```

`--per-page` is not a `gh api` flag — `per_page` is a query parameter. The command exits with `unknown flag: --per-page`, the trailing `|| true` swallows it, `relevant` resolves to `false`, and **every subsequent step is skipped while the job reports success**.

From #2022's own job log (93992494411): `unknown flag: --per-page`, steps 5-10 skipped, conclusion `success`. That PR changed **4** migration-relevant files.

## What has not been running

For four months, on every PR touching `drizzle/` or `lib/db/schema`:

- the fresh-database migration run (`pnpm db:setup-workflow` + `pnpm db:migrate`)
- the drizzle drift check

This is the direct cause of the 0138-0142 snapshot drift going unnoticed: those migrations merged without a fresh-DB validation, so a later `drizzle-kit generate` diffed against a stale baseline and swept four already-applied columns into a new migration.

## The fix

- `per_page` moves into the URL, where `gh` expects it
- `set -euo pipefail`, so a failure to list the PR's files **fails the job loudly** rather than silently disabling the checks it guards
- the `|| true | head -1` precedence bug goes with it — `grep -q` inside the `if` handles no-match without tripping `set -e`

## Verification

Run against real PRs before committing:

| Case | Expected | Result |
|---|---|---|
| #2022 — 4 migration files | `relevant=true` | pass |
| #2023 — lockfile only | `relevant=false` | pass |
| API failure (bad PR number) | non-zero exit | **exits 1** (was 0) |

That last row is the actual defect: the step used to succeed when it could not do its job.

## Also included

Removes a sentence duplicated verbatim in `docs/agent/agentic-wallet.md`, introduced by #2022. `docs/` is symlinked as `docs-site/content` and publishes to docs.keeperhub.com, so it is worth not shipping.

## Note for reviewers

This PR is the second CI gate found reporting success while checking nothing — #2027 armed the lint gate, which had been swallowing Biome's exit code. Worth a look at whether other `|| true` guards in CI hide the same class of failure.

A follow-up worth filing separately: assert in this same job that every added `drizzle/*.sql` ships its matching `drizzle/meta/NNNN_snapshot.json`. The snapshot chain has now drifted twice (repaired in `0d20ab66a` in July, and again here).