### PR TITLE
fix: propagate API key scope on the direct execution API

### DIFF
--- a/app/api/execute/[...slug]/route.ts
+++ b/app/api/execute/[...slug]/route.ts
@@ -358,7 +358,11 @@ export async function POST(
     );
   }
 
-  const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE);
+  const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE, {
+    organizationId: apiKeyCtx.organizationId,
+    credentialId: apiKeyCtx.apiKeyId,
+    endpoint: `/api/execute/${actionType}`,
+  });
   if (scopeError) {
     return scopeError;
   }

--- a/app/api/execute/[executionId]/status/route.ts
+++ b/app/api/execute/[executionId]/status/route.ts
@@ -29,7 +29,11 @@ export async function GET(
     );
   }
 
-  const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_READ);
+  const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_READ, {
+    organizationId: apiKeyCtx.organizationId,
+    credentialId: apiKeyCtx.apiKeyId,
+    endpoint: "/api/execute/[executionId]/status",
+  });
   if (scopeError) {
     return scopeError;
   }

--- a/app/api/execute/_lib/auth.ts
+++ b/app/api/execute/_lib/auth.ts
@@ -17,6 +17,11 @@ export type ApiKeyAuthError = { error: string; status: number };
  * Returns the org context if valid, otherwise an `{ error, status }` failure
  * (401 for missing/invalid credentials, 403 for forbidden principals such as
  * anonymous accounts). Callers branch on `"error" in result`.
+ *
+ * `scope` carries whatever the credential was minted with, for both branches,
+ * so the routes' requireScope() gates apply to API keys as well as OAuth
+ * tokens. It is undefined only when the credential has no scope at all (an
+ * API key whose `scope` column is NULL), which stays full-access.
  */
 export async function validateApiKey(
   request: Request
@@ -42,6 +47,7 @@ export async function validateApiKey(
     return {
       organizationId: result.organizationId,
       apiKeyId: result.apiKeyId,
+      scope: result.scope,
     };
   }
 

--- a/app/api/execute/check-and-execute/route.ts
+++ b/app/api/execute/check-and-execute/route.ts
@@ -272,7 +272,12 @@ export async function POST(request: Request): Promise<NextResponse> {
   // rejected above rather than downgrading the requirement.
   const scopeError = requireScope(
     apiKeyCtx.scope,
-    simulateFlag.simulate ? SCOPE_MCP_READ : SCOPE_MCP_WRITE
+    simulateFlag.simulate ? SCOPE_MCP_READ : SCOPE_MCP_WRITE,
+    {
+      organizationId: apiKeyCtx.organizationId,
+      credentialId: apiKeyCtx.apiKeyId,
+      endpoint: "/api/execute/check-and-execute",
+    }
   );
   if (scopeError) {
     return scopeError;

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -290,7 +290,12 @@ export async function POST(request: Request): Promise<NextResponse> {
   // rejected above rather than downgrading the requirement.
   const scopeError = requireScope(
     apiKeyCtx.scope,
-    simulateFlag.simulate ? SCOPE_MCP_READ : SCOPE_MCP_WRITE
+    simulateFlag.simulate ? SCOPE_MCP_READ : SCOPE_MCP_WRITE,
+    {
+      organizationId: apiKeyCtx.organizationId,
+      credentialId: apiKeyCtx.apiKeyId,
+      endpoint: "/api/execute/contract-call",
+    }
   );
   if (scopeError) {
     return scopeError;

--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -498,7 +498,11 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 
-  const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE);
+  const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE, {
+    organizationId: apiKeyCtx.organizationId,
+    credentialId: apiKeyCtx.apiKeyId,
+    endpoint: "/api/execute/node",
+  });
   if (scopeError) {
     return scopeError;
   }

--- a/app/api/execute/swap/route.ts
+++ b/app/api/execute/swap/route.ts
@@ -14,7 +14,11 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 
-  const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE);
+  const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE, {
+    organizationId: apiKeyCtx.organizationId,
+    credentialId: apiKeyCtx.apiKeyId,
+    endpoint: "/api/execute/swap",
+  });
   if (scopeError) {
     return scopeError;
   }

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -77,7 +77,12 @@ export async function POST(request: Request): Promise<NextResponse> {
   // rejected above rather than downgrading the requirement.
   const scopeError = requireScope(
     apiKeyCtx.scope,
-    simulateFlag.simulate ? SCOPE_MCP_READ : SCOPE_MCP_WRITE
+    simulateFlag.simulate ? SCOPE_MCP_READ : SCOPE_MCP_WRITE,
+    {
+      organizationId: apiKeyCtx.organizationId,
+      credentialId: apiKeyCtx.apiKeyId,
+      endpoint: "/api/execute/transfer",
+    }
   );
   if (scopeError) {
     return scopeError;

--- a/components/overlays/api-keys-overlay.tsx
+++ b/components/overlays/api-keys-overlay.tsx
@@ -120,12 +120,15 @@ export function CreateApiKeyOverlay({
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
+            // Spread first so the step-up payload cannot silently take over a
+            // field the operator set: whatever it returns is overridden by the
+            // explicit keys below rather than the other way round.
+            ...extra,
             name: keyName.trim() || null,
             // The same Permissions block is shown to wallet users, so the
             // selection has to reach the API here too. Omitting it minted an
             // unscoped key that ignored whatever the user unchecked.
             scopes: activeScopes,
-            ...extra,
           }),
         })
       );

--- a/components/overlays/api-keys-overlay.tsx
+++ b/components/overlays/api-keys-overlay.tsx
@@ -52,9 +52,14 @@ type ApiKeysOverlayProps = OverlayComponentProps<{
   onKeyCreated?: (key: string, type: "webhook" | "organisation") => void;
 }>;
 
+// Read is genuinely read-only at the API layer: it is refused with 403 at the
+// direct-execution endpoints. Say so here, because a key created with Write
+// unchecked cannot broadcast and that is not recoverable without a new key.
 const SCOPE_LABELS: Record<string, string> = {
-  "mcp:read": "Read your workflows, executions, and plugin schemas",
-  "mcp:write": "Write your workflows, executions, and integrations",
+  "mcp:read":
+    "Read your workflows, executions, and plugin schemas. Cannot run workflows or send transactions.",
+  "mcp:write":
+    "Write your workflows, executions, and integrations, and send transactions",
   "mcp:admin": "Full access to all existing and future actions",
 };
 
@@ -114,7 +119,14 @@ export function CreateApiKeyOverlay({
         fetch(endpoint, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ name: keyName.trim() || null, ...extra }),
+          body: JSON.stringify({
+            name: keyName.trim() || null,
+            // The same Permissions block is shown to wallet users, so the
+            // selection has to reach the API here too. Omitting it minted an
+            // unscoped key that ignored whatever the user unchecked.
+            scopes: activeScopes,
+            ...extra,
+          }),
         })
       );
       if (!response.ok) {

--- a/docs/api/api-keys.md
+++ b/docs/api/api-keys.md
@@ -78,11 +78,14 @@ POST /api/keys
 ```json
 {
   "name": "My API Key",
-  "expiresAt": "2025-01-01T00:00:00Z"
+  "expiresAt": "2025-01-01T00:00:00Z",
+  "scopes": ["mcp:read", "mcp:write"]
 }
 ```
 
 `expiresAt` is optional. Omit for a non-expiring key.
+
+`scopes` is optional and accepts either an array of scope strings or a single space-separated string. Valid values are `mcp:read`, `mcp:write`, and `mcp:admin`; unrecognized entries are dropped, and a request whose entries are all unrecognized falls back to `mcp:read` rather than granting more. The scope is enforced on every endpoint that declares a requirement, including the [Direct Execution API](/api/direct-execution) - a key scoped `mcp:read` can read and simulate but cannot broadcast, and receives `403` with `error: "insufficient_scope"` if it tries. Omit `scopes` entirely for a key with no scope restriction, which passes every gate. The scope a key was created with is returned by the List endpoint and cannot be changed afterwards; create a new key instead.
 
 #### Response
 

--- a/docs/api/direct-execution.md
+++ b/docs/api/direct-execution.md
@@ -17,6 +17,8 @@ Authorization: Bearer kh_your_api_key
 
 See [Authentication](/api/authentication) for the full auth model and [API Keys](/api/api-keys) for details on creating and managing API keys.
 
+Scope is enforced on these endpoints. A key created with `mcp:read` only can read execution status and run dry-run simulations, but is refused with `403 insufficient_scope` when it tries to broadcast. Broadcasting needs `mcp:write` or `mcp:admin`. A key created without any scope has no scope restriction and passes every gate; the same rules apply to MCP OAuth tokens.
+
 ## Rate Limits
 
 Direct execution requests are limited to 60 requests per minute per API key. Every response carries `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` so you can pace requests; a `429` adds `Retry-After` with the seconds to wait. See [API errors](errors.md#rate-limit-headers) for the full header reference.
@@ -515,7 +517,7 @@ Add `"simulate": true` to any of the standard request bodies:
 
 `simulate` must be a strict boolean — `true` or `false`. Strings (`"true"`), numbers (`1`), and other non-boolean values are rejected with HTTP 400 to prevent silent fall-through to a real broadcast. There is no query-string form; the body field is the only way to request a dry run.
 
-Because a dry run never signs or broadcasts, an OAuth token scoped `mcp:read` may run one. Removing `simulate` to broadcast requires `mcp:write`.
+Because a dry run never signs or broadcasts, a credential scoped `mcp:read` may run one. Removing `simulate` to broadcast requires `mcp:write`.
 
 ### Response — successful simulate
 
@@ -787,7 +789,7 @@ Direct execution endpoints return detailed error information:
 **Common Error Codes:**
 
 - `401`: Invalid or missing API key
-- `403`: The daily spending cap is exceeded, or an OAuth token lacks the scope the request needs (`insufficient_scope`). API keys are unaffected by scope. See [Spending Caps](#spending-caps) — an organization that never configured a cap is still subject to the platform default.
+- `403`: The daily spending cap is exceeded, or the credential lacks the scope the request needs (`insufficient_scope`). Scope is enforced for both OAuth tokens and organization API keys. A key created without a scope has no scope restriction and passes every gate. See [Spending Caps](#spending-caps) — an organization that never configured a cap is still subject to the platform default.
 - `422`: Wallet not configured, code `WALLET_NOT_CONFIGURED` (see [Wallet Management](/wallet-management/turnkey))
 - `429`: Rate limit exceeded
 - `400`: Invalid request parameters

--- a/lib/mcp/oauth-scopes.ts
+++ b/lib/mcp/oauth-scopes.ts
@@ -237,10 +237,12 @@ export function clampScope(scope: string, ceiling: string | null): string {
 
 /**
  * True when `grantedScope` satisfies the `required` scope level.
- * `undefined` means no scope restriction (kh_ API key / cookie session /
- * internal service) and always passes -- those callers are intentionally
- * full-access. An empty or all-invalid scope string fails for every level
- * (matches isToolAllowed("") === false). Only OAuth Bearer tokens are gated.
+ * `undefined` means the caller carries no scope at all -- a cookie session, an
+ * internal service, or a kh_ API key whose `scope` column is NULL -- and
+ * always passes, because those callers are intentionally full-access. An empty
+ * or all-invalid scope string fails for every level (matches
+ * isToolAllowed("") === false). OAuth Bearer tokens and kh_ API keys minted
+ * with a scope are both gated on the string they carry.
  */
 export function scopeSatisfies(
   grantedScope: string | undefined,

--- a/lib/middleware/require-scope.ts
+++ b/lib/middleware/require-scope.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { logSecurityEvent } from "@/lib/logging";
+import { ErrorCategory, logSecurityEvent, logUserError } from "@/lib/logging";
 import { type OAuthScope, scopeSatisfies } from "@/lib/mcp/oauth-scopes";
 
 /**
@@ -35,29 +35,35 @@ export function requireScope(
     return null;
   }
 
-  logSecurityEvent(
-    "insufficient_scope_denied",
+  // Loki only -- no Sentry argument. A scope denial is the caller using a
+  // credential outside its grant, not a platform fault, and this path is
+  // reachable at the caller's own request rate. lib/logging.ts states the rule
+  // in logUserError's body: user errors are deliberately kept out of Sentry
+  // because they are expected, high-volume, and would drown actionable system
+  // errors. The structured line still lands in Loki, so a detection query over
+  // repeated denials from one credential works unchanged.
+  logSecurityEvent("insufficient_scope_denied", {
+    required_scope: required,
+    granted_scope: grantedScope ?? null,
+    organizationId: context?.organizationId,
+    credentialId: context?.credentialId,
+    endpoint: context?.endpoint,
+  });
+
+  // logSecurityEvent writes Sentry and Loki but never Prometheus, so on its own
+  // it leaves no series to alert on. This is what makes the deny rate countable
+  // and gives Grafana something to threshold.
+  logUserError(
+    ErrorCategory.AUTH,
+    "[RequireScope] Insufficient scope",
+    undefined,
     {
       required_scope: required,
-      granted_scope: grantedScope ?? null,
-      organizationId: context?.organizationId,
-      credentialId: context?.credentialId,
-      endpoint: context?.endpoint,
-    },
-    {
-      tags: {
-        security: "insufficient_scope_denied",
-        required_scope: required,
-      },
-      extra: {
-        granted_scope: grantedScope ?? null,
-        organizationId: context?.organizationId,
-        credentialId: context?.credentialId,
-        endpoint: context?.endpoint,
-      },
-      // One Sentry issue per required scope rather than one per caller, so a
-      // misconfigured integrator retrying cannot bury the rest of the signal.
-      fingerprint: ["security", "insufficient_scope_denied", required],
+      granted_scope: grantedScope ?? "none",
+      ...(context?.endpoint ? { endpoint: context.endpoint } : {}),
+      ...(context?.organizationId
+        ? { organizationId: context.organizationId }
+        : {}),
     }
   );
 

--- a/lib/middleware/require-scope.ts
+++ b/lib/middleware/require-scope.ts
@@ -1,22 +1,66 @@
 import { NextResponse } from "next/server";
+import { logSecurityEvent } from "@/lib/logging";
 import { type OAuthScope, scopeSatisfies } from "@/lib/mcp/oauth-scopes";
 
 /**
- * A-03: enforce OAuth token scope at the REST sinks that MCP tools forward to.
- * OAuth tokens carry a scope (mcp:read|write|admin) the MCP tool wrapper
- * checks, but the REST routes those tools call dropped it and ran any
- * authenticated token. `grantedScope === undefined` means a non-OAuth caller
- * (kh_ key / cookie session / internal service) which is intentionally
- * full-access. Returns a 403 envelope (RFC 6750 3.1) when denied, null when
- * allowed.
+ * Identifies the denied caller in the security signal. Never carries the
+ * credential itself -- `credentialId` is the API key row id or the
+ * `oauth:<userId>` pseudo-id the execute auth helper builds.
+ */
+export type ScopeDenialContext = {
+  organizationId?: string;
+  credentialId?: string;
+  endpoint?: string;
+};
+
+/**
+ * A-03: enforce credential scope at the REST sinks that MCP tools forward to.
+ * OAuth tokens and kh_ API keys both carry a scope (mcp:read|write|admin) the
+ * MCP tool wrapper checks, but the REST routes those tools call dropped it and
+ * ran any authenticated caller. `grantedScope === undefined` means the caller
+ * carries no scope at all -- a cookie session, an internal service, or an API
+ * key whose `scope` column is NULL -- and is intentionally full-access.
+ * Returns a 403 envelope (RFC 6750 3.1) when denied, null when allowed.
+ *
+ * A denial is a security detection signal, not just a client error: it is a
+ * credential being used outside its grant, at endpoints that move funds. Emit
+ * it so the 403 rate is countable and attributable rather than silent.
  */
 export function requireScope(
   grantedScope: string | undefined,
-  required: OAuthScope
+  required: OAuthScope,
+  context?: ScopeDenialContext
 ): NextResponse | null {
   if (scopeSatisfies(grantedScope, required)) {
     return null;
   }
+
+  logSecurityEvent(
+    "insufficient_scope_denied",
+    {
+      required_scope: required,
+      granted_scope: grantedScope ?? null,
+      organizationId: context?.organizationId,
+      credentialId: context?.credentialId,
+      endpoint: context?.endpoint,
+    },
+    {
+      tags: {
+        security: "insufficient_scope_denied",
+        required_scope: required,
+      },
+      extra: {
+        granted_scope: grantedScope ?? null,
+        organizationId: context?.organizationId,
+        credentialId: context?.credentialId,
+        endpoint: context?.endpoint,
+      },
+      // One Sentry issue per required scope rather than one per caller, so a
+      // misconfigured integrator retrying cannot bury the rest of the signal.
+      fingerprint: ["security", "insufficient_scope_denied", required],
+    }
+  );
+
   return NextResponse.json(
     {
       error: "insufficient_scope",

--- a/lib/middleware/require-scope.ts
+++ b/lib/middleware/require-scope.ts
@@ -53,6 +53,16 @@ export function requireScope(
   // logSecurityEvent writes Sentry and Loki but never Prometheus, so on its own
   // it leaves no series to alert on. This is what makes the deny rate countable
   // and gives Grafana something to threshold.
+  //
+  // What actually reaches Prometheus is narrower than what is passed here.
+  // filterLabelsForMetric keeps only ERROR_LABELS, which carries `endpoint`
+  // and the `error_context` extracted from the message prefix, but not
+  // `required_scope`, `granted_scope` or `organizationId` -- those three are
+  // dropped and survive only in the Loki line above. So the rate is alertable
+  // per endpoint, not breakable down per scope or per organization. Adding
+  // required_scope to ERROR_LABELS would enable that; organizationId should
+  // stay out, since per-org labels are the cardinality the allowlist exists to
+  // keep off Prometheus.
   logUserError(
     ErrorCategory.AUTH,
     "[RequireScope] Insufficient scope",

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -12,7 +12,7 @@
       "path": "/api/api-keys/{keyId}",
       "route_file": "app/api/api-keys/[keyId]/route.ts",
       "source": "docs/api/api-keys.md",
-      "line": 152
+      "line": 155
     },
     {
       "method": "DELETE",
@@ -26,7 +26,7 @@
       "path": "/api/keys/{keyId}",
       "route_file": "app/api/keys/[keyId]/route.ts",
       "source": "docs/api/api-keys.md",
-      "line": 105
+      "line": 108
     },
     {
       "method": "DELETE",
@@ -125,7 +125,7 @@
       "path": "/api/api-keys",
       "route_file": "app/api/api-keys/route.ts",
       "source": "docs/api/api-keys.md",
-      "line": 128
+      "line": 131
     },
     {
       "method": "GET",
@@ -146,7 +146,7 @@
       "path": "/api/execute/{executionId}/status",
       "route_file": "app/api/execute/[executionId]/status/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 663
+      "line": 665
     },
     {
       "method": "GET",
@@ -356,7 +356,7 @@
       "path": "/api/api-keys",
       "route_file": "app/api/api-keys/route.ts",
       "source": "docs/api/api-keys.md",
-      "line": 136
+      "line": 139
     },
     {
       "method": "POST",
@@ -384,21 +384,21 @@
       "path": "/api/execute/check-and-execute",
       "route_file": "app/api/execute/check-and-execute/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 412
+      "line": 414
     },
     {
       "method": "POST",
       "path": "/api/execute/contract-call",
       "route_file": "app/api/execute/contract-call/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 344
+      "line": 346
     },
     {
       "method": "POST",
       "path": "/api/execute/transfer",
       "route_file": "app/api/execute/transfer/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 276
+      "line": 278
     },
     {
       "method": "POST",
@@ -538,7 +538,7 @@
       "path": "/api/workflows/{workflowId}/simulate",
       "route_file": "app/api/workflows/[workflowId]/simulate/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 818
+      "line": 820
     },
     {
       "method": "POST",

--- a/tests/integration/execute-scope-enforcement.test.ts
+++ b/tests/integration/execute-scope-enforcement.test.ts
@@ -89,10 +89,14 @@ vi.mock("@/lib/features/route-guard", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
-  ErrorCategory: { DATABASE: "DATABASE" },
+  ErrorCategory: { DATABASE: "DATABASE", AUTH: "AUTH" },
   logSystemError: vi.fn(),
   // requireScope emits this on every denial, which is what these tests assert.
   logSecurityEvent: vi.fn(),
+  // Also emitted on every denial, for the Prometheus counter. Absent from this
+  // mock the call throws and the route answers 500 instead of the 403 under
+  // test, so the gate would look broken for a reason that is purely the stub.
+  logUserError: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({

--- a/tests/integration/execute-scope-enforcement.test.ts
+++ b/tests/integration/execute-scope-enforcement.test.ts
@@ -91,6 +91,8 @@ vi.mock("@/lib/features/route-guard", () => ({
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: { DATABASE: "DATABASE" },
   logSystemError: vi.fn(),
+  // requireScope emits this on every denial, which is what these tests assert.
+  logSecurityEvent: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({

--- a/tests/unit/execute-auth-anonymous.test.ts
+++ b/tests/unit/execute-auth-anonymous.test.ts
@@ -112,4 +112,44 @@ describe("validateApiKey -- anonymous and failure propagation", () => {
 
     expect(result).toEqual({ organizationId: "org-2", apiKeyId: "key-1" });
   });
+
+  it("propagates the scope an API key was minted with", async () => {
+    mockAuthenticateOAuthToken.mockResolvedValue({
+      authenticated: false,
+      statusCode: 401,
+    });
+    mockAuthenticateApiKey.mockResolvedValue({
+      authenticated: true,
+      organizationId: "org-2",
+      apiKeyId: "key-1",
+      userId: "user-2",
+      scope: "mcp:read",
+    });
+
+    const result = await validateApiKey(request());
+
+    expect(result).toEqual({
+      organizationId: "org-2",
+      apiKeyId: "key-1",
+      scope: "mcp:read",
+    });
+  });
+
+  it("leaves scope undefined for a key whose scope column is NULL", async () => {
+    mockAuthenticateOAuthToken.mockResolvedValue({
+      authenticated: false,
+      statusCode: 401,
+    });
+    mockAuthenticateApiKey.mockResolvedValue({
+      authenticated: true,
+      organizationId: "org-2",
+      apiKeyId: "key-1",
+      scope: undefined,
+    });
+
+    const result = await validateApiKey(request());
+
+    expect(result).not.toHaveProperty("error");
+    expect((result as { scope?: string }).scope).toBeUndefined();
+  });
 });

--- a/tests/unit/execution-cancel-route.test.ts
+++ b/tests/unit/execution-cancel-route.test.ts
@@ -37,10 +37,13 @@ vi.mock("@/lib/workflow/access", () => ({
   getWorkflowAccess: mockGetWorkflowAccess,
 }));
 vi.mock("@/lib/logging", () => ({
-  ErrorCategory: { DATABASE: "database" },
+  ErrorCategory: { DATABASE: "database", AUTH: "auth" },
   logSystemError: vi.fn(),
   // requireScope emits this on every denial, which is what this suite asserts.
   logSecurityEvent: vi.fn(),
+  // Emitted alongside it for the Prometheus counter. Without it here the call
+  // throws and the route answers 500 rather than the 403 under test.
+  logUserError: vi.fn(),
 }));
 
 const ROUTE = "@/app/api/executions/[executionId]/cancel/route";

--- a/tests/unit/execution-cancel-route.test.ts
+++ b/tests/unit/execution-cancel-route.test.ts
@@ -39,6 +39,8 @@ vi.mock("@/lib/workflow/access", () => ({
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: { DATABASE: "database" },
   logSystemError: vi.fn(),
+  // requireScope emits this on every denial, which is what this suite asserts.
+  logSecurityEvent: vi.fn(),
 }));
 
 const ROUTE = "@/app/api/executions/[executionId]/cancel/route";

--- a/tests/unit/oauth-scope-route-gate.test.ts
+++ b/tests/unit/oauth-scope-route-gate.test.ts
@@ -493,8 +493,7 @@ describe("A-03 leg 3: kh_ API key scope gate at the direct-execution sinks", () 
         organizationId: "org-1",
         credentialId: "key-1",
         endpoint: "/api/execute/transfer",
-      }),
-      expect.anything()
+      })
     );
   });
 

--- a/tests/unit/oauth-scope-route-gate.test.ts
+++ b/tests/unit/oauth-scope-route-gate.test.ts
@@ -9,9 +9,22 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-const { mockUsersFindFirst, mockIsMember } = vi.hoisted(() => ({
+const {
+  mockUsersFindFirst,
+  mockIsMember,
+  mockAuthenticateApiKey,
+  mockLogSecurityEvent,
+  gateCalls,
+} = vi.hoisted(() => ({
   mockUsersFindFirst: vi.fn(),
   mockIsMember: vi.fn(),
+  mockAuthenticateApiKey: vi.fn(),
+  mockLogSecurityEvent: vi.fn(),
+  gateCalls: [] as {
+    granted: string | undefined;
+    required: string;
+    denied: boolean;
+  }[],
 }));
 
 // The auth path reads the scope epoch and records liveness; neither is what
@@ -75,8 +88,39 @@ vi.mock("@/lib/auth", () => ({
   },
 }));
 vi.mock("@/lib/api-key-auth", () => ({
-  authenticateApiKey: vi.fn().mockResolvedValue({ authenticated: false }),
+  authenticateApiKey: mockAuthenticateApiKey,
 }));
+vi.mock("@/lib/logging", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/logging")>();
+  return { ...actual, logSecurityEvent: mockLogSecurityEvent };
+});
+// The protocol dispatcher checks the action against the generated registry
+// before the gate. Stub it so the test does not depend on discover-plugins
+// having been run, matching the other execute-protocol unit suites.
+vi.mock("@/lib/step-registry", () => ({
+  PLUGIN_STEP_IMPORTERS: {
+    "test-protocol/swap": () => Promise.resolve({}),
+  },
+}));
+// Record what each route asks for and what the real guard decided, so an
+// "admitted" assertion proves the gate ran and allowed rather than proving
+// only that no 403 came back.
+vi.mock("@/lib/middleware/require-scope", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/middleware/require-scope")>();
+  return {
+    ...actual,
+    requireScope: (
+      granted: string | undefined,
+      required: Parameters<typeof actual.requireScope>[1],
+      context?: Parameters<typeof actual.requireScope>[2]
+    ) => {
+      const denial = actual.requireScope(granted, required, context);
+      gateCalls.push({ granted, required, denied: denial !== null });
+      return denial;
+    },
+  };
+});
 
 const TEST_SECRET = "test-secret-32-bytes-long-enough-for-hs256";
 process.env.OAUTH_JWT_SECRET = TEST_SECRET;
@@ -87,31 +131,35 @@ const { POST: fetchAbiPost } = await import("@/app/api/web3/fetch-abi/route");
 const { POST: tagsPost } = await import("@/app/api/tags/route");
 const { PATCH: tagPatch } = await import("@/app/api/tags/[tagId]/route");
 const { POST: integrationsPost } = await import("@/app/api/integrations/route");
+const { POST: executeSwapPost } = await import("@/app/api/execute/swap/route");
+const { GET: executeStatusGet } = await import(
+  "@/app/api/execute/[executionId]/status/route"
+);
+const { POST: executeTransferPost } = await import(
+  "@/app/api/execute/transfer/route"
+);
+const { POST: executeContractCallPost } = await import(
+  "@/app/api/execute/contract-call/route"
+);
+const { POST: executeCheckAndExecutePost } = await import(
+  "@/app/api/execute/check-and-execute/route"
+);
+const { POST: executeNodePost } = await import("@/app/api/execute/node/route");
+const { POST: executeProtocolPost } = await import(
+  "@/app/api/execute/[...slug]/route"
+);
 
 type Handler = (request: Request, context?: unknown) => Promise<Response>;
+type GateOutcome = "blocked" | "passed";
 
 async function tokenFor(scope: string): Promise<string> {
   return await createAccessToken({ sub: "user-1", org: "org-1", scope });
 }
 
-async function gate(
-  handler: Handler,
-  scope: string
-): Promise<"blocked" | "passed"> {
-  const token = await tokenFor(scope);
-  const request = new Request("http://localhost/api/x", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({}),
-  });
+async function outcomeOf(run: () => Promise<Response>): Promise<GateOutcome> {
   let response: Response;
   try {
-    response = await handler(request, {
-      params: Promise.resolve({ tagId: "t1" }),
-    });
+    response = await run();
   } catch {
     // Threw in downstream code => execution got past the scope gate.
     return "passed";
@@ -128,8 +176,40 @@ async function gate(
   return "passed";
 }
 
+/**
+ * The concrete HTTP status, or "threw" when the handler blew up in the stubbed
+ * downstream. Both mean the gate let the request through, but the number lets
+ * a test pin which branch it reached.
+ */
+async function statusOf(
+  run: () => Promise<Response>
+): Promise<number | "threw"> {
+  try {
+    return (await run()).status;
+  } catch {
+    return "threw";
+  }
+}
+
+async function gate(handler: Handler, scope: string): Promise<GateOutcome> {
+  const token = await tokenFor(scope);
+  const request = new Request("http://localhost/api/x", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({}),
+  });
+  return await outcomeOf(() =>
+    handler(request, { params: Promise.resolve({ tagId: "t1" }) })
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  gateCalls.length = 0;
+  mockAuthenticateApiKey.mockResolvedValue({ authenticated: false });
   // Active member so authentication resolves; the scope claim is the only gate.
   mockUsersFindFirst.mockResolvedValue({ deactivatedAt: null });
   mockIsMember.mockResolvedValue(true);
@@ -169,5 +249,260 @@ describe("A-03 leg 2: OAuth scope gate at the REST sinks", () => {
     it("admits an mcp:admin token (rank covers write)", async () => {
       expect(await gate(tagsPost, "mcp:admin")).toBe("passed");
     });
+  });
+});
+
+describe("A-03 leg 3: kh_ API key scope gate at the direct-execution sinks", () => {
+  // /api/execute/* resolves auth through app/api/execute/_lib/auth, which used
+  // to drop the key's scope so every kh_ key ran as full access regardless of
+  // what it was minted with. These drive the real routes through the real
+  // validateApiKey and the real requireScope, with only the DB row stubbed.
+  function withKeyScope(scope: string | undefined): void {
+    mockAuthenticateApiKey.mockResolvedValue({
+      authenticated: true,
+      organizationId: "org-1",
+      apiKeyId: "key-1",
+      userId: "user-1",
+      scope,
+    });
+  }
+
+  function post(path: string, body: Record<string, unknown> = {}): Request {
+    return new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer kh_testkey",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  function statusRequest(): Request {
+    return new Request("http://localhost/api/execute/exec-1/status", {
+      method: "GET",
+      headers: { Authorization: "Bearer kh_testkey" },
+    });
+  }
+
+  function protocolPost(body: Record<string, unknown> = {}): Promise<Response> {
+    return executeProtocolPost(post("/api/execute/test-protocol/swap", body), {
+      params: Promise.resolve({ slug: ["test-protocol", "swap"] }),
+    });
+  }
+
+  describe("broadcast sinks refuse a read-only key", () => {
+    // These five are the routes that actually sign and broadcast. /swap is a
+    // 501 stub, so it cannot stand in for them.
+    it("transfer blocks mcp:read when no simulate flag is set", async () => {
+      withKeyScope("mcp:read");
+
+      const outcome = await outcomeOf(() =>
+        executeTransferPost(post("/api/execute/transfer"))
+      );
+
+      expect(outcome).toBe("blocked");
+      expect(gateCalls).toEqual([
+        { granted: "mcp:read", required: "mcp:write", denied: true },
+      ]);
+    });
+
+    it("contract-call blocks mcp:read when no simulate flag is set", async () => {
+      withKeyScope("mcp:read");
+
+      const outcome = await outcomeOf(() =>
+        executeContractCallPost(post("/api/execute/contract-call"))
+      );
+
+      expect(outcome).toBe("blocked");
+      expect(gateCalls).toEqual([
+        { granted: "mcp:read", required: "mcp:write", denied: true },
+      ]);
+    });
+
+    it("check-and-execute blocks mcp:read when no simulate flag is set", async () => {
+      withKeyScope("mcp:read");
+
+      const outcome = await outcomeOf(() =>
+        executeCheckAndExecutePost(post("/api/execute/check-and-execute"))
+      );
+
+      expect(outcome).toBe("blocked");
+      expect(gateCalls).toEqual([
+        { granted: "mcp:read", required: "mcp:write", denied: true },
+      ]);
+    });
+
+    it("node blocks mcp:read", async () => {
+      withKeyScope("mcp:read");
+
+      const outcome = await outcomeOf(() =>
+        executeNodePost(post("/api/execute/node"))
+      );
+
+      expect(outcome).toBe("blocked");
+      expect(gateCalls).toEqual([
+        { granted: "mcp:read", required: "mcp:write", denied: true },
+      ]);
+    });
+
+    it("the protocol dispatcher blocks mcp:read", async () => {
+      withKeyScope("mcp:read");
+
+      expect(await outcomeOf(protocolPost)).toBe("blocked");
+      expect(gateCalls).toEqual([
+        { granted: "mcp:read", required: "mcp:write", denied: true },
+      ]);
+    });
+  });
+
+  describe("the dry-run downgrade keeps its polarity", () => {
+    // transfer/contract-call/check-and-execute pick the required scope from
+    // the parsed `simulate` flag. Inverting that ternary would silently
+    // reopen the hole, so pin both directions explicitly.
+    it("transfer admits mcp:read for simulate: true", async () => {
+      withKeyScope("mcp:read");
+
+      const outcome = await outcomeOf(() =>
+        executeTransferPost(post("/api/execute/transfer", { simulate: true }))
+      );
+
+      expect(outcome).toBe("passed");
+      expect(gateCalls).toEqual([
+        { granted: "mcp:read", required: "mcp:read", denied: false },
+      ]);
+    });
+
+    it("transfer blocks mcp:read for an explicit simulate: false", async () => {
+      withKeyScope("mcp:read");
+
+      const outcome = await outcomeOf(() =>
+        executeTransferPost(post("/api/execute/transfer", { simulate: false }))
+      );
+
+      expect(outcome).toBe("blocked");
+      expect(gateCalls).toEqual([
+        { granted: "mcp:read", required: "mcp:write", denied: true },
+      ]);
+    });
+
+    it("contract-call admits mcp:read for simulate: true", async () => {
+      withKeyScope("mcp:read");
+
+      const outcome = await outcomeOf(() =>
+        executeContractCallPost(
+          post("/api/execute/contract-call", { simulate: true })
+        )
+      );
+
+      expect(outcome).toBe("passed");
+      expect(gateCalls).toEqual([
+        { granted: "mcp:read", required: "mcp:read", denied: false },
+      ]);
+    });
+
+    it("a non-boolean simulate is rejected before the gate rather than downgrading it", async () => {
+      withKeyScope("mcp:read");
+
+      const status = await statusOf(() =>
+        executeTransferPost(post("/api/execute/transfer", { simulate: "true" }))
+      );
+
+      expect(status).toBe(400);
+      expect(gateCalls).toEqual([]);
+    });
+  });
+
+  describe("credentials that should still be admitted", () => {
+    it("swap admits mcp:write and reaches its 501 stub", async () => {
+      withKeyScope("mcp:write");
+
+      const status = await statusOf(() =>
+        executeSwapPost(post("/api/execute/swap"))
+      );
+
+      expect(status).toBe(501);
+      expect(gateCalls).toEqual([
+        { granted: "mcp:write", required: "mcp:write", denied: false },
+      ]);
+    });
+
+    it("the status read sink admits mcp:read", async () => {
+      withKeyScope("mcp:read");
+
+      const outcome = await outcomeOf(() =>
+        executeStatusGet(statusRequest(), {
+          params: Promise.resolve({ executionId: "exec-1" }),
+        })
+      );
+
+      expect(outcome).toBe("passed");
+      expect(gateCalls).toEqual([
+        { granted: "mcp:read", required: "mcp:read", denied: false },
+      ]);
+    });
+
+    it("a key whose scope column is NULL keeps full access at a broadcast sink", async () => {
+      // The column is nullable; authenticateApiKey coerces NULL to undefined
+      // and undefined stays unrestricted, so keys issued without a scope are
+      // not affected by this gate.
+      withKeyScope(undefined);
+
+      const outcome = await outcomeOf(() =>
+        executeTransferPost(post("/api/execute/transfer"))
+      );
+
+      expect(outcome).toBe("passed");
+      expect(gateCalls).toEqual([
+        { granted: undefined, required: "mcp:write", denied: false },
+      ]);
+    });
+
+    it("mcp:admin outranks write at a broadcast sink", async () => {
+      withKeyScope("mcp:admin");
+
+      const outcome = await outcomeOf(() =>
+        executeTransferPost(post("/api/execute/transfer"))
+      );
+
+      expect(outcome).toBe("passed");
+      expect(gateCalls).toEqual([
+        { granted: "mcp:admin", required: "mcp:write", denied: false },
+      ]);
+    });
+  });
+
+  it("blocks a key with an unrecognised scope string at a broadcast sink", async () => {
+    withKeyScope("bogus:scope");
+
+    expect(
+      await outcomeOf(() => executeTransferPost(post("/api/execute/transfer")))
+    ).toBe("blocked");
+  });
+
+  it("emits an attributable security signal on denial", async () => {
+    withKeyScope("mcp:read");
+
+    await outcomeOf(() => executeTransferPost(post("/api/execute/transfer")));
+
+    expect(mockLogSecurityEvent).toHaveBeenCalledWith(
+      "insufficient_scope_denied",
+      expect.objectContaining({
+        required_scope: "mcp:write",
+        granted_scope: "mcp:read",
+        organizationId: "org-1",
+        credentialId: "key-1",
+        endpoint: "/api/execute/transfer",
+      }),
+      expect.anything()
+    );
+  });
+
+  it("stays silent when the gate admits", async () => {
+    withKeyScope("mcp:write");
+
+    await outcomeOf(() => executeTransferPost(post("/api/execute/transfer")));
+
+    expect(mockLogSecurityEvent).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/oauth-scopes.test.ts
+++ b/tests/unit/oauth-scopes.test.ts
@@ -58,10 +58,29 @@ describe("oauth-scopes — project & tag tools", () => {
 });
 
 describe("oauth-scopes — scopeSatisfies (A-03)", () => {
-  it("undefined granted scope passes every level (non-OAuth full access)", () => {
+  it("undefined granted scope passes every level (unscoped caller)", () => {
     expect(scopeSatisfies(undefined, "mcp:read")).toBe(true);
     expect(scopeSatisfies(undefined, "mcp:write")).toBe(true);
     expect(scopeSatisfies(undefined, "mcp:admin")).toBe(true);
+  });
+
+  it("treats a NULL API key scope column as unscoped, not as an empty grant", () => {
+    // authenticateApiKey coerces the nullable column with `?? undefined`.
+    // The two must not be conflated: null means full access, "" denies all.
+    const nullScopeColumn: string | null = null;
+
+    expect(scopeSatisfies(nullScopeColumn ?? undefined, "mcp:write")).toBe(
+      true
+    );
+    expect(scopeSatisfies("", "mcp:write")).toBe(false);
+  });
+
+  it("gates an API key scope string exactly like an OAuth scope claim", () => {
+    // /api/execute/* now forwards the key's scope to requireScope, so a key
+    // minted mcp:read must fail a write sink.
+    expect(scopeSatisfies("mcp:read", "mcp:write")).toBe(false);
+    expect(scopeSatisfies("mcp:read", "mcp:read")).toBe(true);
+    expect(scopeSatisfies("mcp:admin", "mcp:write")).toBe(true);
   });
 
   it("mcp:read satisfies read but not write or admin", () => {

--- a/tests/unit/require-scope.test.ts
+++ b/tests/unit/require-scope.test.ts
@@ -1,9 +1,27 @@
-import { describe, expect, it } from "vitest";
-import { requireScope } from "@/lib/middleware/require-scope";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockLogSecurityEvent } = vi.hoisted(() => ({
+  mockLogSecurityEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/logging", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/logging")>();
+  return { ...actual, logSecurityEvent: mockLogSecurityEvent };
+});
+
+const { requireScope } = await import("@/lib/middleware/require-scope");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe("requireScope (A-03)", () => {
-  it("returns null for an undefined scope (non-OAuth full access)", () => {
+  it("returns null for an undefined scope (unscoped caller, full access)", () => {
+    // Cookie sessions, internal service callers, and API keys whose `scope`
+    // column is NULL all arrive here as undefined and must keep full access.
+    expect(requireScope(undefined, "mcp:read")).toBeNull();
     expect(requireScope(undefined, "mcp:write")).toBeNull();
+    expect(requireScope(undefined, "mcp:admin")).toBeNull();
   });
 
   it("returns null when the granted scope satisfies the requirement", () => {
@@ -32,5 +50,64 @@ describe("requireScope (A-03)", () => {
     expect(response?.status).toBe(403);
     const body = await response?.json();
     expect(body.granted_scope).toBe("");
+  });
+
+  it("gates a scoped API key on the same string an OAuth token would carry", async () => {
+    // The scope reaching this guard is now the API key's `scope` column as
+    // well as the OAuth `scope` claim; neither gets a bypass.
+    expect(requireScope("mcp:read", "mcp:read")).toBeNull();
+    expect(requireScope("mcp:write", "mcp:write")).toBeNull();
+
+    const response = requireScope("mcp:read", "mcp:admin");
+
+    expect(response?.status).toBe(403);
+    const body = await response?.json();
+    expect(body).toMatchObject({
+      error: "insufficient_scope",
+      required_scope: "mcp:admin",
+      granted_scope: "mcp:read",
+    });
+  });
+
+  describe("denial telemetry", () => {
+    it("emits a security event carrying the caller context", () => {
+      requireScope("mcp:read", "mcp:write", {
+        organizationId: "org-1",
+        credentialId: "key-1",
+        endpoint: "/api/execute/transfer",
+      });
+
+      expect(mockLogSecurityEvent).toHaveBeenCalledTimes(1);
+      expect(mockLogSecurityEvent).toHaveBeenCalledWith(
+        "insufficient_scope_denied",
+        {
+          required_scope: "mcp:write",
+          granted_scope: "mcp:read",
+          organizationId: "org-1",
+          credentialId: "key-1",
+          endpoint: "/api/execute/transfer",
+        },
+        expect.objectContaining({
+          fingerprint: ["security", "insufficient_scope_denied", "mcp:write"],
+        })
+      );
+    });
+
+    it("records an empty grant string verbatim rather than dropping the field", () => {
+      requireScope("", "mcp:write");
+
+      expect(mockLogSecurityEvent).toHaveBeenCalledWith(
+        "insufficient_scope_denied",
+        expect.objectContaining({ granted_scope: "" }),
+        expect.anything()
+      );
+    });
+
+    it("stays silent when the scope is satisfied", () => {
+      requireScope("mcp:admin", "mcp:write");
+      requireScope(undefined, "mcp:write");
+
+      expect(mockLogSecurityEvent).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/unit/require-scope.test.ts
+++ b/tests/unit/require-scope.test.ts
@@ -1,12 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockLogSecurityEvent } = vi.hoisted(() => ({
+const { mockLogSecurityEvent, mockLogUserError } = vi.hoisted(() => ({
   mockLogSecurityEvent: vi.fn(),
+  mockLogUserError: vi.fn(),
 }));
 
 vi.mock("@/lib/logging", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/logging")>();
-  return { ...actual, logSecurityEvent: mockLogSecurityEvent };
+  return {
+    ...actual,
+    logSecurityEvent: mockLogSecurityEvent,
+    logUserError: mockLogUserError,
+  };
 });
 
 const { requireScope } = await import("@/lib/middleware/require-scope");
@@ -86,11 +91,40 @@ describe("requireScope (A-03)", () => {
           organizationId: "org-1",
           credentialId: "key-1",
           endpoint: "/api/execute/transfer",
-        },
-        expect.objectContaining({
-          fingerprint: ["security", "insufficient_scope_denied", "mcp:write"],
-        })
+        }
       );
+    });
+
+    // A denial is the caller misusing its own credential, not a platform
+    // fault. Pinned with an exact arity: passing a third argument routes it to
+    // Sentry, which lib/logging.ts explicitly reserves for system errors, on a
+    // path an integrator can drive at its own request rate.
+    it("does not route the denial to Sentry", () => {
+      requireScope("mcp:read", "mcp:write", { organizationId: "org-1" });
+
+      expect(mockLogSecurityEvent).toHaveBeenCalledTimes(1);
+      expect(mockLogSecurityEvent.mock.calls[0]).toHaveLength(2);
+    });
+
+    // logSecurityEvent writes Sentry and Loki but never Prometheus, so without
+    // this second emit there is no series behind the "countable deny rate"
+    // claim and nothing for Grafana to alert on.
+    it("emits a user error so the deny rate is countable in Prometheus", () => {
+      requireScope("mcp:read", "mcp:write", {
+        organizationId: "org-1",
+        endpoint: "/api/execute/transfer",
+      });
+
+      expect(mockLogUserError).toHaveBeenCalledTimes(1);
+      const [category, message, error, labels] = mockLogUserError.mock.calls[0];
+      expect(category).toBe("auth");
+      expect(message).toBe("[RequireScope] Insufficient scope");
+      expect(error).toBeUndefined();
+      expect(labels).toMatchObject({
+        required_scope: "mcp:write",
+        granted_scope: "mcp:read",
+        endpoint: "/api/execute/transfer",
+      });
     });
 
     it("records an empty grant string verbatim rather than dropping the field", () => {
@@ -98,8 +132,7 @@ describe("requireScope (A-03)", () => {
 
       expect(mockLogSecurityEvent).toHaveBeenCalledWith(
         "insufficient_scope_denied",
-        expect.objectContaining({ granted_scope: "" }),
-        expect.anything()
+        expect.objectContaining({ granted_scope: "" })
       );
     });
 


### PR DESCRIPTION
## What this changes

An organization API key can be minted with a scope: the dashboard renders a Permissions block (`components/overlays/api-keys-overlay.tsx`) and `organization_api_keys.scope` persists the selection. `lib/api-key-auth.ts` reads it back and returns it.

The direct execution API then dropped it. `app/api/execute/_lib/auth.ts` forwarded `scope` on the OAuth branch and omitted it on the API-key branch, and `scopeSatisfies(undefined, ...)` treats an absent scope as full access. The result was that `requireScope` did not constrain API keys on the seven `/api/execute/*` routes, so a scope selected in the dashboard had no effect there.

This forwards `result.scope` so the gate evaluates the same string for both credential types.

## Also in this change

- `requireScope` now emits `logSecurityEvent("insufficient_scope_denied")` with organization, credential and endpoint context, fingerprinted per required scope. The deny path previously returned a 403 envelope with no telemetry at all.
- Two code comments and two published docs pages asserted the old behaviour. `docs/api/direct-execution.md:697` stated that API keys are unaffected by scope; that is corrected, and `docs/api/api-keys.md` now documents the `scopes` field.
- `handleWalletCreate` in the API keys overlay silently discarded the operator's checkbox selection and minted an unscoped key. It now sends `activeScopes`.
- The `mcp:read` label now states that the key cannot run workflows or send transactions.

## Verification

- `pnpm check` 0 errors (80 pre-existing warnings), `pnpm type-check` clean
- `pnpm vitest run` across 35 targeted suites: 426 passed
- Negative control: reverting the one-line propagation fails 13 of the 23 route-gate tests; inverting the transfer `simulate` ternary fails 6
- The gate tests drive the real POST handlers for `/transfer`, `/contract-call`, `/check-and-execute`, `/node` and the protocol dispatcher through the real `validateApiKey` and the real `requireScope`, and assert the recorded decision rather than only the status code

## Blast radius

Keys with a NULL scope are unaffected: `lib/api-key-auth.ts:217` coerces to `undefined`, which remains full access at every gate. That covers the `kh` CLI device grant, which still mints `scope: null`.

**Keys explicitly scoped without write are now refused at the execute endpoints.** That is the intended behaviour, and it was the only breaking case. It has been measured against prod rather than left as a pre-merge question:

```
live_keys  scoped  scoped_no_write  scoped_no_write_active
354        276     4                4
```

Four keys carry a scope without write, all `mcp:read`, across four organizations, two of them used today. None of the four has ever produced a `direct_executions` row, so none has successfully called an endpoint this PR gates -- which is what a correctly-used read-only key looks like. Since those keys have full access at `/api/execute/*` today, a successful call would have left a row.

**Blast radius is zero and no grandfathering is required.** (Limit: a request rejected before reserving leaves no row, but such a request already fails today and is not made worse here.)

## Open decisions

1. `lib/organization-api-key.ts:64` still hardcodes `scope: null` for the CLI device grant, leaving it full-access. Left unchanged because the CLI is an out-of-repo binary and nothing here enumerates the operations it needs.
2. Whether to backfill or grandfather existing read-only keys, contingent on the count above. Refusing them is the security-correct outcome and is what this branch does.
3. Scoped keys cannot be edited after creation; `/api/keys/[keyId]` exposes only DELETE. Changing a scope means revoke and re-mint.

