### PR TITLE
fix(mcp): correct destructive annotations on value-moving tools

### DIFF
--- a/lib/mcp/action-type.ts
+++ b/lib/mcp/action-type.ts
@@ -34,15 +34,36 @@ const NON_CALLDATA_MUTATING_ACTION_TYPES = new Set([
   "web3/approve-token",
   "web3/transfer-funds",
   "web3/transfer-token",
+  // Tempo is a stablecoin chain with no native gas token, so none of its
+  // writes carry native value and the daily value cap never sees them. Every
+  // one broadcasts a signed TIP-20 transaction from the org wallet, and none
+  // matches write-contract/protocol-write, so without these entries a
+  // Tempo-only workflow reads as non-mutating.
+  "tempo/transfer-with-memo",
+  "tempo/batch-payout",
+  "tempo/dex-swap",
+  "tempo/hold-payment",
+]);
+
+// Actions with no on-chain effect that are still not read-only: each one
+// leaves a message a caller cannot recall. lib/mcp/tools.ts already applies
+// exactly this rule to test_notification, annotating it destructive because it
+// "sends to a caller-named target and cannot recall the message"; a listing
+// whose nodes do the same send has to be treated the same way or the two
+// surfaces disagree about identical behaviour.
+const OUTBOUND_MESSAGE_ACTION_TYPES = new Set([
+  "discord/send-message",
+  "slack/send-message",
+  "telegram/send-message",
+  "sendgrid/send-email",
+  "resend/send-email",
 ]);
 
 /**
  * Broader than isWriteActionType: true for any action type that mutates
  * chain state, whether or not it can be served by the calldata-handoff
- * route. Use this for signals that describe real-world effect (e.g. an MCP
- * tool's readOnlyHint annotation), never for anything that gates the
- * calldata-generation/workflowType="write" path, which must stay scoped to
- * isWriteActionType.
+ * route. Never use this to gate the calldata-generation/workflowType="write"
+ * path, which must stay scoped to isWriteActionType.
  */
 export function isMutatingActionType(actionType: unknown): boolean {
   if (typeof actionType !== "string") {
@@ -51,5 +72,32 @@ export function isMutatingActionType(actionType: unknown): boolean {
   return (
     NON_CALLDATA_MUTATING_ACTION_TYPES.has(actionType) ||
     isWriteActionType(actionType)
+  );
+}
+
+/**
+ * True for any action type with an effect the caller cannot take back: a
+ * broadcast transaction or an outbound message.
+ *
+ * This is the predicate for MCP annotations, not isMutatingActionType. Under
+ * the MCP spec readOnlyHint means the tool does not modify its environment,
+ * which is wider than "does not modify chain state" -- sending an email
+ * modifies the world just as permanently as a transfer does, and an agent
+ * auto-approving one on a read-only hint is the same failure.
+ *
+ * Both sets are allowlists of known effects, so an action type absent from
+ * them still reads as side-effect-free. Deriving this from a declared
+ * side-effect field on PluginAction would close that gap for good; until then
+ * a new broadcasting plugin has to be added here, and the test suite pins the
+ * current membership so the omission surfaces as a failing case rather than a
+ * silent auto-approval.
+ */
+export function hasIrreversibleEffect(actionType: unknown): boolean {
+  if (typeof actionType !== "string") {
+    return false;
+  }
+  return (
+    isMutatingActionType(actionType) ||
+    OUTBOUND_MESSAGE_ACTION_TYPES.has(actionType)
   );
 }

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -1355,12 +1355,16 @@ export function registerTools(
         .optional()
         .describe("Additional context or constraints for the AI generator"),
     },
-    // Persists nothing, but /api/ai/generate hard-requires mcp:write and
-    // spends a rate-limited external model call, so claiming read-only would
-    // contradict the scope model in oauth-scopes.ts.
+    // Persists nothing and changes no state, so it stays read-only. The hint
+    // describes effect, not grant: withScopeCheck enforces mcp:write on this
+    // tool regardless of any annotation, so flipping readOnlyHint would buy no
+    // enforcement and cost an accurate signal -- clients that allowlist
+    // read-only tools would start prompting for a call that mutates nothing.
+    // The rate-limited model spend is a cost concern the annotation vocabulary
+    // has no way to express.
     {
       title: "AI Generate Workflow",
-      readOnlyHint: false,
+      readOnlyHint: true,
       destructiveHint: false,
     },
     withScopeCheck("ai_generate_workflow", scope, async (args) =>

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -810,6 +810,33 @@ const GET_EXECUTION_SCHEMA = {
     ),
 };
 
+/**
+ * Tool annotation policy.
+ *
+ * Clients use these hints to decide what to auto-approve, so an inaccurate
+ * hint is a security control failure, not a cosmetic one. The MCP spec
+ * defaults are readOnlyHint=false, destructiveHint=true, idempotentHint=false
+ * and openWorldHint=true, and destructiveHint/idempotentHint are only
+ * meaningful when readOnlyHint is false. Writing `destructiveHint: false` is
+ * therefore an explicit downgrade away from the safe default and must be
+ * justified per tool.
+ *
+ * Rules applied here:
+ *  - readOnlyHint: true only when the tool reads and computes and changes no
+ *    state anywhere, including in other orgs and on chain. It must never
+ *    contradict the read/write split in oauth-scopes.ts.
+ *  - destructiveHint: false only for writes that are purely additive -- they
+ *    create a new record that starts inert, overwrite and destroy nothing,
+ *    and emit nothing outside the platform.
+ *  - destructiveHint: true for anything that overwrites existing state, moves
+ *    value, broadcasts a transaction, changes public exposure, sends an
+ *    unrecallable outbound message, or dispatches or arms an execution whose
+ *    effects we cannot bound from the arguments alone.
+ *  - idempotentHint and openWorldHint are left at their spec defaults: every
+ *    write here is unsafe to blind-retry (several take an explicit
+ *    idempotency_key for exactly that reason) and every tool can reach an
+ *    external system, so the defaults are already the conservative values.
+ */
 export function registerTools(
   server: McpServer,
   internalApiBaseUrl: string,
@@ -906,7 +933,11 @@ export function registerTools(
         .describe("Optional tag ID to label the workflow"),
       idempotency_key: IDEMPOTENCY_KEY_ARG,
     },
-    { title: "Create Workflow", readOnlyHint: false, destructiveHint: false },
+    // nodes is an unconstrained record array, so it accepts write-contract
+    // and transfer actions, and enabled=true arms a schedule/event/block/
+    // webhook trigger on the same call. One call therefore starts a
+    // recurring unattended run of arbitrary node content.
+    { title: "Create Workflow", readOnlyHint: false, destructiveHint: true },
     withScopeCheck("create_workflow", scope, async (args) =>
       withToolLogging("create_workflow", undefined, async () => {
         const data = await callApi(
@@ -965,7 +996,9 @@ export function registerTools(
         .optional()
         .describe("Tag ID to assign (null to unassign)"),
     },
-    { title: "Update Workflow", readOnlyHint: false, destructiveHint: false },
+    // nodes/edges are a full replace, and enabled toggles live triggers, so
+    // this overwrites state a caller may not be able to reconstruct.
+    { title: "Update Workflow", readOnlyHint: false, destructiveHint: true },
     withScopeCheck("update_workflow", scope, async (args) =>
       withToolLogging("update_workflow", undefined, async () => {
         const { workflowId, ...body } = args;
@@ -1133,7 +1166,9 @@ export function registerTools(
         .describe("Optional input data to pass to the workflow trigger"),
       idempotency_key: IDEMPOTENCY_KEY_ARG,
     },
-    { title: "Execute Workflow", readOnlyHint: false, destructiveHint: false },
+    // The workflow body is arbitrary: a run can transfer funds or call any
+    // contract. Nothing in the arguments bounds that, so assume the worst.
+    { title: "Execute Workflow", readOnlyHint: false, destructiveHint: true },
     withScopeCheck("execute_workflow", scope, async (args) =>
       withToolLogging("execute_workflow", undefined, async () => {
         const data = await callApi(
@@ -1320,9 +1355,12 @@ export function registerTools(
         .optional()
         .describe("Additional context or constraints for the AI generator"),
     },
+    // Persists nothing, but /api/ai/generate hard-requires mcp:write and
+    // spends a rate-limited external model call, so claiming read-only would
+    // contradict the scope model in oauth-scopes.ts.
     {
       title: "AI Generate Workflow",
-      readOnlyHint: true,
+      readOnlyHint: false,
       destructiveHint: false,
     },
     withScopeCheck("ai_generate_workflow", scope, async (args) =>
@@ -1564,6 +1602,9 @@ export function registerTools(
         .optional()
         .describe("Optional name for the cloned workflow"),
     },
+    // Unlike create_workflow this takes no `enabled` argument, and the
+    // duplicate route inserts without one so the row falls to the schema
+    // default of disabled. The clone is inert until a separate call arms it.
     { title: "Deploy Template", readOnlyHint: false, destructiveHint: false },
     withScopeCheck("deploy_template", scope, async (args) =>
       withToolLogging("deploy_template", undefined, async () => {
@@ -2045,7 +2086,11 @@ export function registerTools(
           "Credential fields to test (same shape as integration config)"
         ),
     },
-    { title: "Test Notification", readOnlyHint: false, destructiveHint: false },
+    // type and config are caller-supplied and reach the plugin unfiltered,
+    // so this sends a real message to an address the caller chooses, or
+    // opens a database connection to a host it names. The send cannot be
+    // recalled; persisting nothing does not make it additive.
+    { title: "Test Notification", readOnlyHint: false, destructiveHint: true },
     withScopeCheck("test_notification", scope, async (args) =>
       withToolLogging("test_notification", undefined, async () => {
         const data = await callApi(
@@ -2087,10 +2132,12 @@ export function registerTools(
         .describe("Optional on-chain expiry override"),
       idempotency_key: IDEMPOTENCY_KEY_ARG,
     },
+    // Produces a signed transfer authorization against org funds, and
+    // broadcastMode "schedule" sends it without a further call.
     {
       title: "Tempo Sign and Hold",
       readOnlyHint: false,
-      destructiveHint: false,
+      destructiveHint: true,
     },
     withScopeCheck("tempo_sign_and_hold", scope, async (args) =>
       withToolLogging("tempo_sign_and_hold", undefined, async () => {
@@ -2138,10 +2185,11 @@ export function registerTools(
         .string()
         .describe("Held payment ID from tempo_sign_and_hold"),
     },
+    // Permanently voids a pending payment; the signature cannot be revived.
     {
       title: "Tempo Cancel Hold",
       readOnlyHint: false,
-      destructiveHint: false,
+      destructiveHint: true,
     },
     withScopeCheck("tempo_cancel_hold", scope, async (args) =>
       withToolLogging("tempo_cancel_hold", undefined, async () => {
@@ -2168,10 +2216,11 @@ export function registerTools(
         .describe("Held payment ID from tempo_sign_and_hold"),
       idempotency_key: IDEMPOTENCY_KEY_ARG,
     },
+    // Broadcasts the held transfer. Irreversible movement of real funds.
     {
       title: "Tempo Release Hold",
       readOnlyHint: false,
-      destructiveHint: false,
+      destructiveHint: true,
     },
     withScopeCheck("tempo_release_hold", scope, async (args) =>
       withToolLogging("tempo_release_hold", undefined, async () => {
@@ -2341,10 +2390,13 @@ export function registerMetaTools(
           "Action parameters as key-value pairs (e.g., {network: '1', address: '0x...'}). Use search_protocol_actions to discover required params."
         ),
     },
+    // actionType selects both reads (chronicle/eth-usd-read) and writes
+    // (aave-v3/supply) through one entry point, and a static annotation
+    // cannot vary by argument, so it takes the worst case of the two.
     {
       title: "Execute Protocol Action",
       readOnlyHint: false,
-      destructiveHint: false,
+      destructiveHint: true,
     },
     withScopeCheck("execute_protocol_action", scope, async (args) =>
       withToolLogging("execute_protocol_action", undefined, async () => {
@@ -2455,7 +2507,9 @@ export function registerMetaTools(
         .record(z.string(), z.unknown())
         .describe("Input fields as declared in the workflow's inputSchema"),
     },
-    { title: "Call Workflow", readOnlyHint: false, destructiveHint: false },
+    // Invokes a third-party listing whose body we do not control, and a paid
+    // listing charges USDC on retry after the 402 is settled.
+    { title: "Call Workflow", readOnlyHint: false, destructiveHint: true },
     withScopeCheck("call_workflow", scope, async (args) =>
       withToolLogging("call_workflow", undefined, async () => {
         try {
@@ -2523,7 +2577,10 @@ export function registerMetaTools(
           "Workflow type: 'read' for read-only, 'write' for state-changing"
         ),
     },
-    { title: "List Workflow", readOnlyHint: false, destructiveHint: false },
+    // Makes a private workflow publicly callable and full-replaces the
+    // listing's inputSchema/outputMapping, matching unlist_workflow, its
+    // inverse.
+    { title: "List Workflow", readOnlyHint: false, destructiveHint: true },
     withScopeCheck("list_workflow", scope, async (args) =>
       withToolLogging("list_workflow", undefined, async () => {
         const { workflowId, ...metadata } = args;
@@ -2599,10 +2656,12 @@ export function registerMetaTools(
         .optional()
         .describe("Updated price in USDC (only allowed while unlisted)"),
     },
+    // inputSchema, outputMapping and price are full replaces on a listing
+    // other agents are already calling.
     {
       title: "Update Workflow Listing",
       readOnlyHint: false,
-      destructiveHint: false,
+      destructiveHint: true,
     },
     withScopeCheck("update_workflow_listing", scope, async (args) =>
       withToolLogging("update_workflow_listing", undefined, async () => {

--- a/lib/mcp/workflow-server.ts
+++ b/lib/mcp/workflow-server.ts
@@ -162,6 +162,8 @@ export function createWorkflowMcpServer(
   const toolDescription = buildToolDescription(listing);
   const triggerKind = detectListingTriggerType(listing.nodes);
   const inputSchema = buildTriggerInputSchema(triggerKind);
+  const isReadOnlyListing =
+    listing.workflowType === "read" && !hasMutatingNode(listing.nodes);
 
   server.registerTool(
     slug,
@@ -169,10 +171,23 @@ export function createWorkflowMcpServer(
       title: listing.name,
       description: toolDescription,
       inputSchema,
+      // listing.workflowType alone does not describe side effects: the call
+      // route runs a "read" listing server-side with the owner's wallet and
+      // credentials (handleReadWorkflow -> startExecutionInBackground) while
+      // a "write" listing only returns unsigned calldata for the caller to
+      // sign, so "read" is the branch that actually executes. hasMutatingNode
+      // is the wider check that catches the mutating nodes deriveWorkflowType
+      // leaves typed "read".
+      //
+      // destructiveHint tracks readOnlyHint rather than being pinned false.
+      // Under the MCP spec destructiveHint defaults to true and is only
+      // meaningful when readOnlyHint is false, so an explicit false on a
+      // non-read listing is a positive assertion that a call is safe to run
+      // unattended -- which nothing here establishes. A listing that is not
+      // provably read-only is therefore advertised as destructive.
       annotations: {
-        readOnlyHint:
-          listing.workflowType === "read" && !hasMutatingNode(listing.nodes),
-        destructiveHint: false,
+        readOnlyHint: isReadOnlyListing,
+        destructiveHint: !isReadOnlyListing,
       },
     },
     async (args: unknown) => {

--- a/lib/mcp/workflow-server.ts
+++ b/lib/mcp/workflow-server.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { isMutatingActionType } from "@/lib/mcp/action-type";
+import { hasIrreversibleEffect } from "@/lib/mcp/action-type";
 import {
   buildTriggerInputSchema,
   detectListingTriggerType,
@@ -28,16 +28,15 @@ function getNodeActionType(node: unknown): unknown {
   return configActionType ?? legacyActionType;
 }
 
-// Broader than workflowType === "write": also catches genuinely-mutating
-// actions (batch-write-contract, approve-token, transfer-funds,
-// transfer-token) that deriveWorkflowType deliberately never promotes to
-// "write" because they cannot be served by the calldata-handoff MCP route.
-// Those workflows correctly stay workflowType="read" for routing purposes,
-// but they still broadcast a real transaction, so the readOnlyHint
-// annotation needs this separate, wider check rather than reusing
-// workflowType.
+// Broader than workflowType === "write": also catches actions that
+// deriveWorkflowType never promotes to "write" because they cannot be served
+// by the calldata-handoff MCP route, plus the outbound-message actions that
+// have no chain effect at all. Those workflows correctly stay
+// workflowType="read" for routing purposes, but they still broadcast a
+// transaction or send a message the caller cannot recall, so the annotations
+// need this separate, wider check rather than reusing workflowType.
 function hasMutatingNode(nodes: unknown[]): boolean {
-  return nodes.some((node) => isMutatingActionType(getNodeActionType(node)));
+  return nodes.some((node) => hasIrreversibleEffect(getNodeActionType(node)));
 }
 
 type ApiResponse = Record<string, unknown>;

--- a/tests/integration/workflow-duplicate.test.ts
+++ b/tests/integration/workflow-duplicate.test.ts
@@ -189,6 +189,34 @@ describe("Workflow duplicate API", () => {
     expect(nodeIds).toContain(body.edges[0].target);
   });
 
+  // Pins the invariant the MCP deploy_template annotation rests on. That tool
+  // is annotated destructiveHint: false on the grounds that a cloned workflow
+  // is inert until a separate call arms it, which is true only because this
+  // insert omits `enabled` and the column defaults false in lib/db/schema.ts.
+  // Nothing else couples the two: if this route ever starts arming the clone,
+  // the annotation silently becomes a promise that a deploy_template call is
+  // safe to auto-approve when it can immediately start executing. Breaking
+  // here is the loud version of that.
+  it("creates the clone disabled so deploy_template stays non-destructive", async () => {
+    const { POST } = await import(
+      "@/app/api/workflows/[workflowId]/duplicate/route"
+    );
+    const request = new Request(
+      "http://localhost/api/workflows/source-wf-1/duplicate",
+      { method: "POST" }
+    );
+    const response = await POST(request, {
+      params: Promise.resolve({ workflowId: "source-wf-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    // The db mock echoes the inserted values straight back, so an absent key
+    // here means the route never set it and the schema default (false) stands.
+    expect(body.enabled).toBeUndefined();
+  });
+
   it("remaps template references inside arrays in config", async () => {
     mockDbQuery.workflows.findFirst.mockResolvedValue(workflowWithArrayConfig);
 

--- a/tests/unit/mcp-tool-annotations.test.ts
+++ b/tests/unit/mcp-tool-annotations.test.ts
@@ -62,11 +62,23 @@ function collectAnnotations(): Map<string, ToolAnnotations> {
  * rather than silently reaching clients as auto-approvable.
  */
 const ADDITIVE_WRITE_TOOLS = [
-  "ai_generate_workflow",
   "create_project",
   "create_tag",
   "deploy_template",
 ];
+
+/**
+ * Tools that are genuinely read-only in effect but still require a write
+ * grant. readOnlyHint describes whether the tool modifies its environment;
+ * the scope describes who may call it. They are separate axes and this is
+ * where they legitimately diverge, so the check below allows exactly these
+ * rather than assuming a read-only tool implies a read scope.
+ *
+ * ai_generate_workflow persists nothing and changes no state, but
+ * /api/ai/generate requires mcp:write because it spends a rate-limited model
+ * call. withScopeCheck enforces that regardless of any annotation.
+ */
+const READ_ONLY_TOOLS_REQUIRING_WRITE = ["ai_generate_workflow"];
 
 /**
  * Tools that move value, broadcast a transaction, or dispatch an execution
@@ -143,9 +155,22 @@ describe("MCP tool annotations", () => {
 
   it("never claims a write tool is read-only", () => {
     for (const [name, annotation] of annotations) {
-      if (annotation.readOnlyHint === true) {
+      if (
+        annotation.readOnlyHint === true &&
+        !READ_ONLY_TOOLS_REQUIRING_WRITE.includes(name)
+      ) {
         expect(getRequiredScopeForTool(name), name).toBe(SCOPE_MCP_READ);
       }
+    }
+  });
+
+  // Guards the exception list itself: an entry that stops needing a write
+  // grant should leave the list rather than sit there masking a real
+  // read-only tool that was mis-scoped.
+  it("keeps the read-only-but-write-scoped list minimal", () => {
+    for (const name of READ_ONLY_TOOLS_REQUIRING_WRITE) {
+      expect(annotations.get(name)?.readOnlyHint, name).toBe(true);
+      expect(getRequiredScopeForTool(name), name).not.toBe(SCOPE_MCP_READ);
     }
   });
 });
@@ -250,19 +275,51 @@ describe("per-listing workflow MCP server annotations", () => {
     expect(annotation.destructiveHint).toBe(false);
   });
 
-  // Guard on the residual gap rather than leaving it silent. isMutatingActionType
-  // is a denylist: it matches write-contract/protocol-write plus three named
-  // web3 transfer/approve types, so a mutating action outside that set is not
-  // detected and the listing is still advertised read-only. tempo/transfer-with-memo
-  // moves real TIP-20 stablecoin value and is the concrete instance. Closing this
-  // needs a side-effect declaration on PluginAction so the classification is an
-  // allowlist derived from the registry; until then this test documents the
-  // exposure and will fail the moment the denylist is widened, prompting the
-  // expectation below to be flipped.
-  it("does not yet detect mutating actions outside the web3 denylist", () => {
+  // Tempo carries no native gas token, so none of its writes register on the
+  // daily native value cap and this annotation is the only thing standing
+  // between an MCP client and an auto-approved stablecoin transfer.
+  it.each([
+    "tempo/transfer-with-memo",
+    "tempo/batch-payout",
+    "tempo/dex-swap",
+    "tempo/hold-payment",
+  ])("treats a read-typed listing containing %s as destructive", (actionType) => {
     const annotation = listingAnnotations({
       workflowType: "read" as const,
-      nodes: [actionNode("n1", "tempo/transfer-with-memo")],
+      nodes: [actionNode("n1", actionType)],
+    });
+    expect(annotation.readOnlyHint).toBe(false);
+    expect(annotation.destructiveHint).toBe(true);
+  });
+
+  // tools.ts annotates test_notification destructive because it "sends to a
+  // caller-named target and cannot recall the message". A listing whose nodes
+  // do the same send has to land the same way, or the two MCP surfaces
+  // disagree about identical behaviour.
+  it.each([
+    "discord/send-message",
+    "slack/send-message",
+    "telegram/send-message",
+    "sendgrid/send-email",
+    "resend/send-email",
+  ])("treats a read-typed listing containing %s as destructive", (actionType) => {
+    const annotation = listingAnnotations({
+      workflowType: "read" as const,
+      nodes: [actionNode("n1", actionType)],
+    });
+    expect(annotation.readOnlyHint).toBe(false);
+    expect(annotation.destructiveHint).toBe(true);
+  });
+
+  // The predicate is an allowlist of known effects, so an unrecognised action
+  // type still reads as side-effect-free. Stated as a test so the residual is
+  // visible rather than assumed away: a new broadcasting plugin must be added
+  // to lib/mcp/action-type.ts, and deriving the classification from a declared
+  // field on PluginAction is what would close it for good.
+  it("still reads an unknown action type as side-effect-free", () => {
+    const annotation = listingAnnotations({
+      workflowType: "read" as const,
+      nodes: [actionNode("n1", "somefutureplugin/send-value")],
     });
     expect(annotation.readOnlyHint).toBe(true);
     expect(annotation.destructiveHint).toBe(false);

--- a/tests/unit/mcp-tool-annotations.test.ts
+++ b/tests/unit/mcp-tool-annotations.test.ts
@@ -1,0 +1,270 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mockRegisterTool = vi.fn();
+
+vi.mock("@modelcontextprotocol/sdk/server/mcp.js", () => {
+  const MockMcpServer = vi.fn(function (this: {
+    registerTool: typeof mockRegisterTool;
+  }) {
+    this.registerTool = mockRegisterTool;
+  });
+  return { McpServer: MockMcpServer };
+});
+
+import {
+  getRequiredScopeForTool,
+  SCOPE_MCP_ADMIN,
+  SCOPE_MCP_READ,
+} from "@/lib/mcp/oauth-scopes";
+import { registerMetaTools, registerTools } from "@/lib/mcp/tools";
+import {
+  createWorkflowMcpServer,
+  type WorkflowListing,
+} from "@/lib/mcp/workflow-server";
+
+type ToolAnnotations = {
+  title?: string;
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+};
+
+/**
+ * Every tool registered on the authenticated /mcp surface, keyed by name.
+ * Both registrars are invoked because they share the same surface and a
+ * caller cannot tell which function declared a given tool.
+ */
+function collectAnnotations(): Map<string, ToolAnnotations> {
+  const collected = new Map<string, ToolAnnotations>();
+  const server = {
+    tool: (
+      toolName: string,
+      _description: string,
+      _schema: Record<string, unknown>,
+      annotations: ToolAnnotations
+    ): void => {
+      collected.set(toolName, annotations);
+    },
+  } as unknown as McpServer;
+
+  registerTools(server, "http://internal", "Bearer test", SCOPE_MCP_ADMIN);
+  registerMetaTools(server, "http://internal", "Bearer test", SCOPE_MCP_ADMIN);
+  return collected;
+}
+
+/**
+ * Writes whose new record starts inert and which overwrite, delete, publish,
+ * broadcast or emit nothing. This is the complete allowlist: any other
+ * non-read tool must keep the MCP default of destructiveHint true, so adding
+ * a tool with destructiveHint false fails the exhaustiveness assertion below
+ * rather than silently reaching clients as auto-approvable.
+ */
+const ADDITIVE_WRITE_TOOLS = [
+  "ai_generate_workflow",
+  "create_project",
+  "create_tag",
+  "deploy_template",
+];
+
+/**
+ * Tools that move value, broadcast a transaction, or dispatch an execution
+ * whose effects cannot be bounded from the arguments. Listed explicitly
+ * rather than derived so a future edit flipping one back to non-destructive
+ * has to delete a named case.
+ */
+const VALUE_MOVING_TOOLS = [
+  "call_workflow",
+  "execute_check_and_execute",
+  "execute_contract_call",
+  "execute_protocol_action",
+  "execute_transfer",
+  "execute_workflow",
+  "tempo_cancel_hold",
+  "tempo_release_hold",
+  "tempo_sign_and_hold",
+];
+
+describe("MCP tool annotations", () => {
+  const annotations = collectAnnotations();
+
+  it("annotates every registered tool", () => {
+    expect(annotations.size).toBeGreaterThan(0);
+    for (const [name, annotation] of annotations) {
+      expect(annotation.readOnlyHint, name).toBeTypeOf("boolean");
+    }
+  });
+
+  it.each(VALUE_MOVING_TOOLS)("marks %s as destructive", (name) => {
+    const annotation = annotations.get(name);
+    expect(annotation, name).toBeDefined();
+    expect(annotation?.readOnlyHint).toBe(false);
+    expect(annotation?.destructiveHint).toBe(true);
+  });
+
+  it.each([
+    "update_workflow",
+    "delete_workflow",
+    "list_workflow",
+    "unlist_workflow",
+    "update_workflow_listing",
+  ])("marks %s as destructive because it overwrites state", (name) => {
+    expect(annotations.get(name)?.destructiveHint).toBe(true);
+  });
+
+  // create_workflow takes `enabled` alongside an unconstrained `nodes` array,
+  // so one call can arm a scheduled run of a transfer action. test_notification
+  // sends to a caller-named target and cannot recall the message. Neither
+  // persists over existing state, so they would read as additive without an
+  // explicit case.
+  it.each([
+    "create_workflow",
+    "test_notification",
+  ])("marks %s as destructive because it arms or emits an unbounded effect", (name) => {
+    const annotation = annotations.get(name);
+    expect(annotation, name).toBeDefined();
+    expect(annotation?.readOnlyHint).toBe(false);
+    expect(annotation?.destructiveHint).toBe(true);
+  });
+
+  it("downgrades destructiveHint only for the additive write allowlist", () => {
+    const downgraded = [...annotations.entries()]
+      .filter(
+        ([, annotation]) =>
+          annotation.readOnlyHint === false &&
+          annotation.destructiveHint === false
+      )
+      .map(([name]) => name)
+      .sort();
+
+    expect(downgraded).toEqual([...ADDITIVE_WRITE_TOOLS].sort());
+  });
+
+  it("never claims a write tool is read-only", () => {
+    for (const [name, annotation] of annotations) {
+      if (annotation.readOnlyHint === true) {
+        expect(getRequiredScopeForTool(name), name).toBe(SCOPE_MCP_READ);
+      }
+    }
+  });
+});
+
+const baseListing: WorkflowListing = {
+  id: "wf-001",
+  name: "Aave Position Monitor",
+  description: "Monitors Aave positions.",
+  listedSlug: "aave-position-monitor",
+  inputSchema: null,
+  outputMapping: null,
+  priceUsdcPerCall: null,
+  workflowType: "read",
+  listingVersion: 1,
+  nodes: [],
+};
+
+/** Node shape per lib/mcp/calldata.ts findFirstWriteActionNode. */
+function actionNode(id: string, actionType: string): unknown {
+  return {
+    id,
+    type: "action",
+    data: { type: "action", config: { actionType } },
+  };
+}
+
+function listingAnnotations(
+  overrides: Partial<WorkflowListing>
+): ToolAnnotations {
+  createWorkflowMcpServer({
+    slug: "aave-position-monitor",
+    listing: { ...baseListing, ...overrides },
+    internalApiBaseUrl: "http://localhost:3000",
+    authHeader: "Bearer kh_test",
+  });
+  const config = mockRegisterTool.mock.calls[0][1] as {
+    annotations: ToolAnnotations;
+  };
+  return config.annotations;
+}
+
+describe("per-listing workflow MCP server annotations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The call route sends workflowType "read" to handleReadWorkflow, which runs
+  // the whole body server-side on the owner's wallet, while "write" only
+  // returns unsigned calldata. deriveWorkflowType additionally types a
+  // transfer-only workflow as "read", so hasMutatingNode is what actually
+  // separates the two here.
+  it.each([
+    {
+      label: "a read listing whose nodes transfer funds",
+      overrides: {
+        workflowType: "read" as const,
+        nodes: [actionNode("n1", "web3/transfer-funds")],
+      },
+    },
+    {
+      label: "a read listing whose nodes approve a token",
+      overrides: {
+        workflowType: "read" as const,
+        nodes: [actionNode("n1", "web3/approve-token")],
+      },
+    },
+    {
+      label: "a read listing carrying a batch write",
+      overrides: {
+        workflowType: "read" as const,
+        nodes: [actionNode("n1", "web3/batch-write-contract")],
+      },
+    },
+    {
+      label: "a write listing",
+      overrides: { workflowType: "write" as const, nodes: [] },
+    },
+  ])("advertises $label as destructive", ({ overrides }) => {
+    const annotation = listingAnnotations(overrides);
+    expect(annotation.readOnlyHint).toBe(false);
+    expect(annotation.destructiveHint).toBe(true);
+  });
+
+  // The inverse: destructiveHint must track readOnlyHint rather than sitting
+  // pinned at false. These are the cases hasMutatingNode clears, and they are
+  // the only ones allowed to advertise a non-destructive call.
+  it.each([
+    {
+      label: "a read listing whose only node reads",
+      overrides: {
+        workflowType: "read" as const,
+        nodes: [actionNode("n1", "web3/read-contract")],
+      },
+    },
+    {
+      label: "a read listing with no nodes at all",
+      overrides: { workflowType: "read" as const, nodes: [] },
+    },
+  ])("advertises $label as read-only and non-destructive", ({ overrides }) => {
+    const annotation = listingAnnotations(overrides);
+    expect(annotation.readOnlyHint).toBe(true);
+    expect(annotation.destructiveHint).toBe(false);
+  });
+
+  // Guard on the residual gap rather than leaving it silent. isMutatingActionType
+  // is a denylist: it matches write-contract/protocol-write plus three named
+  // web3 transfer/approve types, so a mutating action outside that set is not
+  // detected and the listing is still advertised read-only. tempo/transfer-with-memo
+  // moves real TIP-20 stablecoin value and is the concrete instance. Closing this
+  // needs a side-effect declaration on PluginAction so the classification is an
+  // allowlist derived from the registry; until then this test documents the
+  // exposure and will fail the moment the denylist is widened, prompting the
+  // expectation below to be flipped.
+  it("does not yet detect mutating actions outside the web3 denylist", () => {
+    const annotation = listingAnnotations({
+      workflowType: "read" as const,
+      nodes: [actionNode("n1", "tempo/transfer-with-memo")],
+    });
+    expect(annotation.readOnlyHint).toBe(true);
+    expect(annotation.destructiveHint).toBe(false);
+  });
+});


### PR DESCRIPTION
## What this changes

MCP clients decide what to auto-approve from the `readOnlyHint` and `destructiveHint` tool annotations. Under the MCP spec `destructiveHint` defaults to **true**, so an explicit `false` is a deliberate assertion that the tool is safe to run unattended.

Twelve tools asserted that incorrectly, including every value-moving one. `execute_workflow`, `call_workflow`, `execute_protocol_action` and the three Tempo hold tools all advertised `destructiveHint: false`, so an agent workspace could execute them without surfacing anything to a human.

## Annotation changes

| Tool | Before | After |
|---|---|---|
| `execute_workflow` | ro:false, destr:false | destr:**true** |
| `call_workflow` | ro:false, destr:false | destr:**true** |
| `execute_protocol_action` | ro:false, destr:false | destr:**true** |
| `tempo_sign_and_hold` | ro:false, destr:false | destr:**true** |
| `tempo_release_hold` | ro:false, destr:false | destr:**true** |
| `tempo_cancel_hold` | ro:false, destr:false | destr:**true** |
| `create_workflow` | ro:false, destr:false | destr:**true** |
| `update_workflow` | ro:false, destr:false | destr:**true** |
| `update_workflow_listing` | ro:false, destr:false | destr:**true** |
| `list_workflow` | ro:false, destr:false | destr:**true** |
| `test_notification` | ro:false, destr:false | destr:**true** |
| `ai_generate_workflow` | ro:**true**, destr:false | ro:**false** |

`lib/mcp/workflow-server.ts` carried a second copy of the per-listing annotations; it is updated too.

## Verification

- `pnpm check` exit 0, `pnpm type-check` exit 0
- 3 suites / 39 tests pass, including a new `tests/unit/mcp-tool-annotations.test.ts`
- Negative control: with `tools.ts` and `workflow-server.ts` reverted, the new suite fails 17 of 23

## Blast radius

No API or schema break. Behavioural change for MCP clients only: eleven authenticated tools that previously advertised non-destructive now advertise destructive, so workspaces that auto-approved them will prompt.

The widest item is **`create_workflow`**, the primary authoring tool. Any agent loop that builds workflows unattended will now prompt on every create. `ai_generate_workflow` flipping to `readOnlyHint: false` means clients that allowlist read-only tools stop auto-running it; it already required `mcp:write`, so no caller loses access, only auto-approval.

## Deliberately not done

`execute_protocol_action` routes both `chronicle/eth-usd-read` and `aave-v3/supply` through one `actionType` argument, so no single static annotation is correct. It is annotated conservatively as destructive here. Splitting it into read and write tools is a breaking change to a public MCP surface and belongs in its own PR with a deprecation path.

## Open decisions

1. Add a side-effect declaration to `PluginAction` in `plugins/registry.ts` and derive both the per-listing annotations and `deriveWorkflowType` from it. This is the real fix for the marketplace surface, and the reason every listing is currently annotated destructive.
2. Whether `create_workflow` should split on the `enabled` argument. A create with `enabled=false` is genuinely inert; a static annotation cannot vary on an argument.
3. Whether `list_workflow` (publishing a private workflow publicly) deserves its own approval class. "Makes org data publicly callable" is a different risk category from "overwrites a row", and the MCP annotation vocabulary cannot express it.
4. Whether `call_workflow`'s paid-listing path needs a spend-approval surface beyond `destructiveHint`, since a retry after settling the 402 charges USDC.
