### PR TITLE
fix: make the MCP per-org rate limit fleet-wide via Redis

### DIFF
--- a/app/mcp/route.ts
+++ b/app/mcp/route.ts
@@ -430,7 +430,7 @@ export async function POST(request: Request): Promise<Response> {
 
   const organizationId = auth.organizationId ?? "";
 
-  const rateLimit = checkMcpRateLimit(organizationId);
+  const rateLimit = await checkMcpRateLimit(organizationId);
   if (!rateLimit.allowed) {
     logMcpEvent("mcp.rate.limited", { orgId: organizationId });
     return rateLimitResponse(rateLimit);

--- a/app/mcp/w/[slug]/route.ts
+++ b/app/mcp/w/[slug]/route.ts
@@ -376,7 +376,7 @@ export async function POST(
 
   const organizationId = auth.organizationId ?? "";
 
-  const rateLimit = checkMcpRateLimit(organizationId);
+  const rateLimit = await checkMcpRateLimit(organizationId);
   if (!rateLimit.allowed) {
     logMcpEvent("mcp.rate.limited", { orgId: organizationId });
     return rateLimitResponse(rateLimit);

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -99,10 +99,17 @@ export async function register() {
     // maps. Inline cleanup on the request path can't reach keys that never
     // come back, so without this the maps grow unbounded with one-shot
     // organisations or IPs. See KEEP-419.
-    const { startRateLimitCleanupInterval } = await import(
+    const { startRateLimitCleanupInterval, warmRateLimitRedis } = await import(
       "@/lib/mcp/rate-limit"
     );
     startRateLimitCleanupInterval();
+
+    // The shared Redis client connects lazily with its offline queue disabled,
+    // so the first command on a cold client is rejected while the socket is
+    // still opening. Open it here so the first MCP request reaches the
+    // fleet-wide window instead of the per-pod fallback, and so a cold start
+    // is never reported as an outage. Never rejects; bounded by connectTimeout.
+    await warmRateLimitRedis();
 
     // Initialize Workflow Postgres World (pg-boss queue polling)
     if (process.env.WORKFLOW_TARGET_WORLD === "@workflow/world-postgres") {

--- a/lib/mcp/rate-limit.ts
+++ b/lib/mcp/rate-limit.ts
@@ -3,7 +3,11 @@
 // The per-organization limiter is Redis-backed so the ceiling is fleet-wide.
 // It previously lived in a module-level Map, which made the real ceiling
 // LIMIT * num_replicas: an agent spraying requests across pods got a multiple
-// of the intended budget.
+// of the intended budget. Prod runs replicaCount 4
+// (deploy/keeperhub-stack/prod/values.yaml), so the advertised 120/min was
+// really 480/min and this change cuts the effective ceiling by three quarters.
+// Staging runs 1 replica, so the limit there is already 120/min and the change
+// is a no-op: staging cannot surface the impact before prod does.
 //
 // The per-IP limiter below is still in-memory per pod, and is not built on
 // lib/rate-limit/sliding-window.ts: the stale-entry sweep below iterates this

--- a/lib/mcp/rate-limit.ts
+++ b/lib/mcp/rate-limit.ts
@@ -1,11 +1,19 @@
-// In-memory per pod. In a multi-replica deployment, each pod tracks its own window.
-// Effective limit is LIMIT * num_replicas. Replace with Redis-backed solution
-// when replica count grows.
+// Rate limits for the MCP surface.
 //
-// Not built on lib/rate-limit/sliding-window.ts: the stale-entry sweep below
-// iterates this module's maps directly, and checkIpRateLimit takes a per-call
-// limit/window (feeding the tracked maxWindowMs), neither of which fits the
-// shared fixed-config factory.
+// The per-organization limiter is Redis-backed so the ceiling is fleet-wide.
+// It previously lived in a module-level Map, which made the real ceiling
+// LIMIT * num_replicas: an agent spraying requests across pods got a multiple
+// of the intended budget.
+//
+// The per-IP limiter below is still in-memory per pod, and is not built on
+// lib/rate-limit/sliding-window.ts: the stale-entry sweep below iterates this
+// module's maps directly, and checkIpRateLimit takes a per-call limit/window
+// (feeding the tracked maxWindowMs), neither of which fits the shared
+// fixed-config factory.
+
+import { ErrorCategory, logSystemWarn } from "@/lib/logging";
+import { getRedis } from "@/lib/redis";
+import { mcpRateLimitKey } from "@/lib/redis-keys";
 
 export const WINDOW_MS = 60_000; // 1 minute
 export const LIMIT = 120; // requests per window (higher than execute endpoint; MCP sessions are chatty)
@@ -18,11 +26,25 @@ export const LIMIT = 120; // requests per window (higher than execute endpoint; 
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
 const STALE_THRESHOLD_MULTIPLIER = 5;
 
+// Hard cap on organizations tracked by the in-memory fallback. The fallback
+// only fills while Redis is down, and an outage must not let a flood of
+// distinct organization ids grow the map without bound.
+const MAX_FALLBACK_ORGANIZATIONS = 10_000;
+
+const DEGRADED_LOG_INTERVAL_MS = 60_000;
+
 const requestLog = new Map<string, number[]>();
 const ipRequestLog = new Map<string, number[]>();
 
 let maxWindowMs = WINDOW_MS;
 let cleanupTimer: ReturnType<typeof setInterval> | null = null;
+let lastDegradedLogAt = 0;
+let memberSequence = 0;
+
+// Unique per process so two pods adding a member in the same millisecond
+// cannot collide on the same sorted-set entry and silently merge two
+// requests into one.
+const PROCESS_TOKEN = globalThis.crypto.randomUUID();
 
 export type RateLimitResult =
   | { allowed: true; limit: number; remaining: number; reset: number }
@@ -34,36 +56,215 @@ export type RateLimitResult =
       reset: number;
     };
 
-export function checkMcpRateLimit(organizationId: string): RateLimitResult {
-  const now = Date.now();
-  const windowStart = now - WINDOW_MS;
+// Sliding window over a sorted set, scored by request timestamp. Trim, count
+// and add have to happen in one server-side step: split across round trips,
+// two concurrent requests both read a count below the limit and both get
+// admitted, which is a bypass of exactly the size of the concurrency.
+//
+// Sliding rather than fixed window because a fixed window admits 2 * LIMIT
+// across a boundary, and because it preserves the reset/retryAfter semantics
+// the existing callers and headers already expose.
+//
+// Returns { allowed, count-in-window, oldest-score-ms }.
+const SLIDING_WINDOW_SCRIPT = `
+local key = KEYS[1]
+local now = tonumber(ARGV[1])
+local windowMs = tonumber(ARGV[2])
+local limit = tonumber(ARGV[3])
+local member = ARGV[4]
 
-  const timestamps = requestLog.get(organizationId);
-  const recent = timestamps ? timestamps.filter((t) => t > windowStart) : [];
+redis.call('ZREMRANGEBYSCORE', key, '-inf', now - windowMs)
+local count = redis.call('ZCARD', key)
 
-  if (recent.length >= LIMIT) {
-    // Oldest timestamp in window determines when the first slot opens
-    const oldestInWindow = recent[0];
-    const retryAfter = Math.ceil((oldestInWindow + WINDOW_MS - now) / 1000);
+if count >= limit then
+  local head = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+  local oldest = now
+  if head[2] then oldest = tonumber(head[2]) end
+  return {0, count, oldest}
+end
+
+redis.call('ZADD', key, now, member)
+redis.call('PEXPIRE', key, windowMs)
+
+local head = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+local oldest = now
+if head[2] then oldest = tonumber(head[2]) end
+return {1, count + 1, oldest}
+`;
+
+function nextMember(now: number): string {
+  memberSequence += 1;
+  return `${now}-${PROCESS_TOKEN}-${memberSequence}`;
+}
+
+function buildResult(input: {
+  allowed: boolean;
+  count: number;
+  oldestMs: number;
+  now: number;
+  limit: number;
+  windowMs: number;
+}): RateLimitResult {
+  const { allowed, count, oldestMs, now, limit, windowMs } = input;
+  // The oldest request in the window is what frees the next slot.
+  const resetMs = oldestMs + windowMs;
+  const reset = Math.ceil(resetMs / 1000);
+
+  if (allowed) {
     return {
-      allowed: false,
-      retryAfter: Math.max(retryAfter, 1),
-      limit: LIMIT,
-      remaining: 0,
-      reset: Math.ceil((oldestInWindow + WINDOW_MS) / 1000),
+      allowed: true,
+      limit,
+      remaining: Math.max(limit - count, 0),
+      reset,
     };
   }
 
-  recent.push(now);
-  requestLog.set(organizationId, recent);
-
-  const reset = Math.ceil((recent[0] + WINDOW_MS) / 1000);
   return {
-    allowed: true,
-    limit: LIMIT,
-    remaining: LIMIT - recent.length,
+    allowed: false,
+    retryAfter: Math.max(Math.ceil((resetMs - now) / 1000), 1),
+    limit,
+    remaining: 0,
     reset,
   };
+}
+
+function parseWindowReply(
+  reply: unknown
+): { allowed: boolean; count: number; oldestMs: number } | null {
+  if (!Array.isArray(reply) || reply.length < 3) {
+    return null;
+  }
+  const [allowed, count, oldestMs] = reply.map(Number);
+  if (
+    !(
+      Number.isFinite(allowed) &&
+      Number.isFinite(count) &&
+      Number.isFinite(oldestMs)
+    )
+  ) {
+    return null;
+  }
+  return { allowed: allowed === 1, count, oldestMs };
+}
+
+// Losing Redis means losing the shared counter, not the limit. The fallback
+// below keeps enforcing LIMIT per replica, so an outage degrades the ceiling
+// to what it was before this module was Redis-backed rather than removing it:
+// failing open would hand an attacker an unmetered MCP endpoint at precisely
+// the moment the platform is least healthy. Throttled because this sits on
+// the request hot path and logSystemWarn reaches Sentry.
+function warnDegraded(reason: string, error: unknown): void {
+  const now = Date.now();
+  if (now - lastDegradedLogAt < DEGRADED_LOG_INTERVAL_MS) {
+    return;
+  }
+  lastDegradedLogAt = now;
+  logSystemWarn(
+    ErrorCategory.INFRASTRUCTURE,
+    `[MCP Rate Limit] Redis unavailable (${reason}), falling back to per-pod limiting`,
+    error,
+    { operation: "mcp_rate_limit" }
+  );
+}
+
+// Called only when the fallback is at its cap and needs room for a new
+// organization. Sweeping stale entries usually frees space; if every tracked
+// organization is still active, drop the least recently active one so memory
+// stays bounded.
+function evictForNewFallbackEntry(): void {
+  cleanupExpiredRateLimitEntries();
+  if (requestLog.size < MAX_FALLBACK_ORGANIZATIONS) {
+    return;
+  }
+
+  let stalestKey: string | null = null;
+  let stalestSeen = Number.POSITIVE_INFINITY;
+  for (const [key, timestamps] of requestLog) {
+    const newest = timestamps.at(-1) ?? 0;
+    if (newest < stalestSeen) {
+      stalestSeen = newest;
+      stalestKey = key;
+    }
+  }
+  if (stalestKey !== null) {
+    requestLog.delete(stalestKey);
+  }
+}
+
+function checkInMemoryWindow(
+  log: Map<string, number[]>,
+  key: string,
+  limit: number,
+  windowMs: number,
+  now: number
+): RateLimitResult {
+  const windowStart = now - windowMs;
+  const timestamps = log.get(key);
+  const recent = timestamps ? timestamps.filter((t) => t > windowStart) : [];
+
+  if (recent.length >= limit) {
+    return buildResult({
+      allowed: false,
+      count: recent.length,
+      oldestMs: recent[0],
+      now,
+      limit,
+      windowMs,
+    });
+  }
+
+  recent.push(now);
+  log.set(key, recent);
+
+  return buildResult({
+    allowed: true,
+    count: recent.length,
+    oldestMs: recent[0],
+    now,
+    limit,
+    windowMs,
+  });
+}
+
+export async function checkMcpRateLimit(
+  organizationId: string
+): Promise<RateLimitResult> {
+  const now = Date.now();
+  const redis = getRedis();
+
+  if (redis) {
+    try {
+      const reply = await redis.eval(
+        SLIDING_WINDOW_SCRIPT,
+        1,
+        mcpRateLimitKey(organizationId),
+        now,
+        WINDOW_MS,
+        LIMIT,
+        nextMember(now)
+      );
+      const parsed = parseWindowReply(reply);
+      if (parsed) {
+        return buildResult({
+          ...parsed,
+          now,
+          limit: LIMIT,
+          windowMs: WINDOW_MS,
+        });
+      }
+      warnDegraded("unexpected reply", undefined);
+    } catch (error) {
+      warnDegraded("command failed", error);
+    }
+  }
+
+  if (
+    !requestLog.has(organizationId) &&
+    requestLog.size >= MAX_FALLBACK_ORGANIZATIONS
+  ) {
+    evictForNewFallbackEntry();
+  }
+  return checkInMemoryWindow(requestLog, organizationId, LIMIT, WINDOW_MS, now);
 }
 
 export function checkIpRateLimit(
@@ -74,29 +275,7 @@ export function checkIpRateLimit(
   if (windowMs > maxWindowMs) {
     maxWindowMs = windowMs;
   }
-  const now = Date.now();
-  const windowStart = now - windowMs;
-
-  const timestamps = ipRequestLog.get(ip);
-  const recent = timestamps ? timestamps.filter((t) => t > windowStart) : [];
-
-  if (recent.length >= limit) {
-    const oldestInWindow = recent[0];
-    const retryAfter = Math.ceil((oldestInWindow + windowMs - now) / 1000);
-    return {
-      allowed: false,
-      retryAfter: Math.max(retryAfter, 1),
-      limit,
-      remaining: 0,
-      reset: Math.ceil((oldestInWindow + windowMs) / 1000),
-    };
-  }
-
-  recent.push(now);
-  ipRequestLog.set(ip, recent);
-
-  const reset = Math.ceil((recent[0] + windowMs) / 1000);
-  return { allowed: true, limit, remaining: limit - recent.length, reset };
+  return checkInMemoryWindow(ipRequestLog, ip, limit, windowMs, Date.now());
 }
 
 export function getClientIp(request: Request): string {
@@ -160,7 +339,8 @@ export function stopRateLimitCleanupInterval(): void {
   }
 }
 
-// Tracked-entry counts. Useful for /healthz or memory observability.
+// Tracked-entry counts. Useful for /healthz or memory observability. The
+// organization count only moves while the Redis-backed limiter is degraded.
 export function getRateLimitStats(): {
   organizationCount: number;
   ipCount: number;
@@ -178,4 +358,5 @@ export function resetRateLimitState(): void {
   requestLog.clear();
   ipRequestLog.clear();
   maxWindowMs = WINDOW_MS;
+  lastDegradedLogAt = 0;
 }

--- a/lib/mcp/rate-limit.ts
+++ b/lib/mcp/rate-limit.ts
@@ -11,7 +11,10 @@
 // (feeding the tracked maxWindowMs), neither of which fits the shared
 // fixed-config factory.
 
+import type { Redis } from "ioredis";
 import { ErrorCategory, logSystemWarn } from "@/lib/logging";
+import { getMetricsCollector } from "@/lib/metrics";
+import { MetricNames } from "@/lib/metrics/types";
 import { getRedis } from "@/lib/redis";
 import { mcpRateLimitKey } from "@/lib/redis-keys";
 
@@ -26,10 +29,12 @@ export const LIMIT = 120; // requests per window (higher than execute endpoint; 
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
 const STALE_THRESHOLD_MULTIPLIER = 5;
 
-// Hard cap on organizations tracked by the in-memory fallback. The fallback
-// only fills while Redis is down, and an outage must not let a flood of
-// distinct organization ids grow the map without bound.
-const MAX_FALLBACK_ORGANIZATIONS = 10_000;
+// Hard cap on keys tracked by each in-memory map. The organization map only
+// fills while Redis is down, but the IP map is reachable by unauthenticated
+// callers who can rotate source addresses freely between sweeps, so both are
+// bounded: an evicted key gets a fresh window, which is strictly better than
+// the pod running out of memory.
+const MAX_TRACKED_KEYS = 10_000;
 
 const DEGRADED_LOG_INTERVAL_MS = 60_000;
 
@@ -40,6 +45,7 @@ let maxWindowMs = WINDOW_MS;
 let cleanupTimer: ReturnType<typeof setInterval> | null = null;
 let lastDegradedLogAt = 0;
 let memberSequence = 0;
+let connectAttempt: Promise<void> | null = null;
 
 // Unique per process so two pods adding a member in the same millisecond
 // cannot collide on the same sorted-set entry and silently merge two
@@ -65,13 +71,21 @@ export type RateLimitResult =
 // across a boundary, and because it preserves the reset/retryAfter semantics
 // the existing callers and headers already expose.
 //
-// Returns { allowed, count-in-window, oldest-score-ms }.
-const SLIDING_WINDOW_SCRIPT = `
+// The window is scored by Redis's own clock, not the calling pod's: replicas
+// only share a window if they agree on what time it is, and a pod whose clock
+// drifts past the window length would write entries every other replica
+// immediately trims, quietly buying itself a private budget. TIME is safe
+// inside a script under effect replication (Redis 5+).
+//
+// Returns { allowed, count-in-window, oldest-score-ms, server-now-ms }.
+export const MCP_SLIDING_WINDOW_SCRIPT = `
 local key = KEYS[1]
-local now = tonumber(ARGV[1])
-local windowMs = tonumber(ARGV[2])
-local limit = tonumber(ARGV[3])
-local member = ARGV[4]
+local windowMs = tonumber(ARGV[1])
+local limit = tonumber(ARGV[2])
+local member = ARGV[3]
+
+local clock = redis.call('TIME')
+local now = tonumber(clock[1]) * 1000 + math.floor(tonumber(clock[2]) / 1000)
 
 redis.call('ZREMRANGEBYSCORE', key, '-inf', now - windowMs)
 local count = redis.call('ZCARD', key)
@@ -80,7 +94,7 @@ if count >= limit then
   local head = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
   local oldest = now
   if head[2] then oldest = tonumber(head[2]) end
-  return {0, count, oldest}
+  return {0, count, oldest, now}
 end
 
 redis.call('ZADD', key, now, member)
@@ -89,12 +103,12 @@ redis.call('PEXPIRE', key, windowMs)
 local head = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
 local oldest = now
 if head[2] then oldest = tonumber(head[2]) end
-return {1, count + 1, oldest}
+return {1, count + 1, oldest, now}
 `;
 
-function nextMember(now: number): string {
+function nextMember(): string {
   memberSequence += 1;
-  return `${now}-${PROCESS_TOKEN}-${memberSequence}`;
+  return `${PROCESS_TOKEN}-${memberSequence}`;
 }
 
 function buildResult(input: {
@@ -130,30 +144,48 @@ function buildResult(input: {
 
 function parseWindowReply(
   reply: unknown
-): { allowed: boolean; count: number; oldestMs: number } | null {
-  if (!Array.isArray(reply) || reply.length < 3) {
+): { allowed: boolean; count: number; oldestMs: number; now: number } | null {
+  if (!Array.isArray(reply) || reply.length < 4) {
     return null;
   }
-  const [allowed, count, oldestMs] = reply.map(Number);
+  const [allowed, count, oldestMs, now] = reply.map(Number);
   if (
     !(
       Number.isFinite(allowed) &&
       Number.isFinite(count) &&
-      Number.isFinite(oldestMs)
+      Number.isFinite(oldestMs) &&
+      Number.isFinite(now)
     )
   ) {
     return null;
   }
-  return { allowed: allowed === 1, count, oldestMs };
+  return { allowed: allowed === 1, count, oldestMs, now };
+}
+
+function describeReply(reply: unknown): string {
+  if (Array.isArray(reply)) {
+    return `array(length=${reply.length})`;
+  }
+  if (typeof reply === "string") {
+    return `string("${reply.slice(0, 64)}")`;
+  }
+  return reply === null ? "null" : typeof reply;
 }
 
 // Losing Redis means losing the shared counter, not the limit. The fallback
 // below keeps enforcing LIMIT per replica, so an outage degrades the ceiling
 // to what it was before this module was Redis-backed rather than removing it:
 // failing open would hand an attacker an unmetered MCP endpoint at precisely
-// the moment the platform is least healthy. Throttled because this sits on
-// the request hot path and logSystemWarn reaches Sentry.
-function warnDegraded(reason: string, error: unknown): void {
+// the moment the platform is least healthy.
+//
+// The counter carries every degraded decision so a dashboard can answer
+// whether the shared ceiling is actually being enforced. The Sentry warning is
+// throttled instead, because it sits on the request hot path.
+function recordDegraded(reason: string, error: unknown): void {
+  getMetricsCollector().incrementCounter(MetricNames.MCP_RATE_LIMIT_DEGRADED, {
+    reason,
+  });
+
   const now = Date.now();
   if (now - lastDegradedLogAt < DEGRADED_LOG_INTERVAL_MS) {
     return;
@@ -163,32 +195,60 @@ function warnDegraded(reason: string, error: unknown): void {
     ErrorCategory.INFRASTRUCTURE,
     `[MCP Rate Limit] Redis unavailable (${reason}), falling back to per-pod limiting`,
     error,
-    { operation: "mcp_rate_limit" }
+    { operation: "mcp_rate_limit", reason }
   );
 }
 
-// Called only when the fallback is at its cap and needs room for a new
-// organization. Sweeping stale entries usually frees space; if every tracked
-// organization is still active, drop the least recently active one so memory
-// stays bounded.
-function evictForNewFallbackEntry(): void {
-  cleanupExpiredRateLimitEntries();
-  if (requestLog.size < MAX_FALLBACK_ORGANIZATIONS) {
-    return;
+// The shared client is created with lazyConnect and enableOfflineQueue=false,
+// so the very first command on a cold client is rejected outright while the
+// socket is still opening. Left alone that turns every process start into a
+// bogus "Redis unavailable" report, and the throttled warning would then hide
+// a genuine outage for the rest of the minute. Open the connection explicitly
+// and wait for it instead of firing a command into a socket that cannot yet
+// carry it.
+function ensureConnected(redis: Redis): Promise<void> {
+  if (typeof redis.connect !== "function") {
+    return Promise.resolve();
   }
+  if (redis.status === "wait") {
+    // Rejections here are not swallowed silently: the command that follows
+    // fails too and is reported as a degradation with its own error.
+    connectAttempt ??= redis.connect().then(
+      () => undefined,
+      () => undefined
+    );
+  }
+  return connectAttempt ?? Promise.resolve();
+}
 
-  let stalestKey: string | null = null;
-  let stalestSeen = Number.POSITIVE_INFINITY;
-  for (const [key, timestamps] of requestLog) {
-    const newest = timestamps.at(-1) ?? 0;
-    if (newest < stalestSeen) {
-      stalestSeen = newest;
-      stalestKey = key;
+/**
+ * Opens the shared Redis connection ahead of the first request. Idempotent,
+ * never rejects. Called at boot from instrumentation so no request pays the
+ * connection setup or is mistaken for an outage.
+ */
+export function warmRateLimitRedis(): Promise<void> {
+  const redis = getRedis();
+  return redis ? ensureConnected(redis) : Promise.resolve();
+}
+
+// Map iteration follows insertion order, so re-inserting a key on every touch
+// makes the first key the least recently used one and eviction O(1). Scanning
+// for the stalest entry instead would run over the whole map on every request
+// from an untracked key once it is full -- extra CPU exactly when the platform
+// is already degraded.
+function touchTrackedKey(
+  log: Map<string, number[]>,
+  key: string,
+  timestamps: number[]
+): void {
+  log.delete(key);
+  if (log.size >= MAX_TRACKED_KEYS) {
+    const leastRecent = log.keys().next().value;
+    if (leastRecent !== undefined) {
+      log.delete(leastRecent);
     }
   }
-  if (stalestKey !== null) {
-    requestLog.delete(stalestKey);
-  }
+  log.set(key, timestamps);
 }
 
 function checkInMemoryWindow(
@@ -201,23 +261,17 @@ function checkInMemoryWindow(
   const windowStart = now - windowMs;
   const timestamps = log.get(key);
   const recent = timestamps ? timestamps.filter((t) => t > windowStart) : [];
+  const denied = recent.length >= limit;
 
-  if (recent.length >= limit) {
-    return buildResult({
-      allowed: false,
-      count: recent.length,
-      oldestMs: recent[0],
-      now,
-      limit,
-      windowMs,
-    });
+  if (!denied) {
+    recent.push(now);
   }
-
-  recent.push(now);
-  log.set(key, recent);
+  // Denied callers are written back too: a key being actively refused is the
+  // last one that should be evicted, since eviction hands it a fresh window.
+  touchTrackedKey(log, key, recent);
 
   return buildResult({
-    allowed: true,
+    allowed: !denied,
     count: recent.length,
     oldestMs: recent[0],
     now,
@@ -229,42 +283,45 @@ function checkInMemoryWindow(
 export async function checkMcpRateLimit(
   organizationId: string
 ): Promise<RateLimitResult> {
-  const now = Date.now();
   const redis = getRedis();
 
   if (redis) {
+    if (redis.status !== "ready") {
+      await ensureConnected(redis);
+    }
     try {
       const reply = await redis.eval(
-        SLIDING_WINDOW_SCRIPT,
+        MCP_SLIDING_WINDOW_SCRIPT,
         1,
         mcpRateLimitKey(organizationId),
-        now,
         WINDOW_MS,
         LIMIT,
-        nextMember(now)
+        nextMember()
       );
       const parsed = parseWindowReply(reply);
       if (parsed) {
         return buildResult({
           ...parsed,
-          now,
           limit: LIMIT,
           windowMs: WINDOW_MS,
         });
       }
-      warnDegraded("unexpected reply", undefined);
+      recordDegraded(
+        "unexpected_reply",
+        new Error(`unexpected reply: ${describeReply(reply)}`)
+      );
     } catch (error) {
-      warnDegraded("command failed", error);
+      recordDegraded("command_failed", error);
     }
   }
 
-  if (
-    !requestLog.has(organizationId) &&
-    requestLog.size >= MAX_FALLBACK_ORGANIZATIONS
-  ) {
-    evictForNewFallbackEntry();
-  }
-  return checkInMemoryWindow(requestLog, organizationId, LIMIT, WINDOW_MS, now);
+  return checkInMemoryWindow(
+    requestLog,
+    organizationId,
+    LIMIT,
+    WINDOW_MS,
+    Date.now()
+  );
 }
 
 export function checkIpRateLimit(
@@ -359,4 +416,5 @@ export function resetRateLimitState(): void {
   ipRequestLog.clear();
   maxWindowMs = WINDOW_MS;
   lastDegradedLogAt = 0;
+  connectAttempt = null;
 }

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -871,6 +871,18 @@ const safeFetchBlocks = getOrCreateCounter(
   ["reason", "plugin_name", "shadow"]
 );
 
+// Degradation signal for the per-organization MCP rate limit. Every increment
+// is a decision served by the per-pod fallback instead of the shared Redis
+// window, i.e. a decision taken against a ceiling of LIMIT * num_replicas
+// rather than LIMIT. A non-zero rate here means the fleet-wide limit is not
+// being enforced.
+const mcpRateLimitDegraded = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_mcp_rate_limit_degraded_total",
+  "MCP rate-limit decisions served from the per-pod fallback because the shared Redis window was unavailable, labelled by reason",
+  ["reason"]
+);
+
 // Error counters
 const pluginErrors = getOrCreateCounter(
   apiRegistry,
@@ -1412,6 +1424,7 @@ const counterMap: Record<string, Counter> = {
   "billing.overage.charged": billingOverageCharged,
   // KEEP-612: see safeFetchBlocks definition above for rationale.
   "safe_fetch.blocks.total": safeFetchBlocks,
+  "ratelimit.mcp.degraded.total": mcpRateLimitDegraded,
 };
 
 const errorCounterMap: Record<string, Counter> = {

--- a/lib/metrics/types.ts
+++ b/lib/metrics/types.ts
@@ -138,6 +138,12 @@ export const MetricNames = {
   // A dropped security audit row is itself security-relevant: make silent loss
   // observable so the best-effort path can be alerted on.
   SECURITY_AUDIT_WRITE_FAILED: "errors.system.security_audit_write.total",
+  // The per-organization MCP limiter serves a decision from its per-pod
+  // fallback whenever the shared Redis window is unreachable, which silently
+  // multiplies the fleet-wide ceiling by the replica count. A throttled log
+  // line cannot answer "is the shared limiter enforcing right now"; this
+  // counter can.
+  MCP_RATE_LIMIT_DEGRADED: "ratelimit.mcp.degraded.total",
 
   // Sponsorship metrics
   SPONSORSHIP_TRANSACTIONS_TOTAL: "sponsorship.transactions.total",

--- a/lib/redis-keys.ts
+++ b/lib/redis-keys.ts
@@ -49,6 +49,14 @@ export function trustedCountryKey(userId: string, country: string): string {
   return deploymentKey("trust-country", userId, country);
 }
 
+/**
+ * Sliding-window counter for the per-organization MCP rate limit. Shared
+ * across replicas so the limit is a fleet-wide ceiling, not a per-pod one.
+ */
+export function mcpRateLimitKey(organizationId: string): string {
+  return deploymentKey("ratelimit", "mcp", organizationId);
+}
+
 /** Short-lived cache of a holder's native balance in wei, for the gas preflight. */
 export function nativeBalanceKey(chainId: number, address: string): string {
   return deploymentKey("gas-balance", String(chainId), address.toLowerCase());

--- a/tests/integration/mcp-rate-limit-lua-script.test.ts
+++ b/tests/integration/mcp-rate-limit-lua-script.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Runs the MCP rate limiter's Lua script against a real Redis.
+ *
+ * The unit suite drives a JS stand-in for the sorted-set semantics, which
+ * pins the wrapper's contract but cannot tell whether the script itself
+ * compiles or does what the wrapper assumes. A script that silently fails to
+ * EVAL in production would not fail any unit test: the limiter would fall
+ * back to its per-pod window forever and the fleet-wide ceiling this control
+ * exists to enforce would quietly revert to LIMIT * num_replicas.
+ *
+ * Gated on a reachable Redis so local runs and CI without one are unaffected:
+ *
+ *   docker run --rm -p 63790:6379 redis:7-alpine
+ *   TEST_REDIS_URL=redis://127.0.0.1:63790 pnpm vitest run \
+ *     tests/integration/mcp-rate-limit-lua-script.test.ts
+ */
+
+import { Redis } from "ioredis";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { MCP_SLIDING_WINDOW_SCRIPT } from "@/lib/mcp/rate-limit";
+
+const TEST_REDIS_URL = process.env.TEST_REDIS_URL ?? "redis://127.0.0.1:6379";
+const PROBE_TIMEOUT_MS = 750;
+
+async function connectIfReachable(): Promise<Redis | null> {
+  const client = new Redis(TEST_REDIS_URL, {
+    lazyConnect: true,
+    connectTimeout: PROBE_TIMEOUT_MS,
+    commandTimeout: PROBE_TIMEOUT_MS,
+    maxRetriesPerRequest: 0,
+    retryStrategy: () => null,
+  });
+  // A failed probe must not surface as an unhandled 'error' event.
+  client.on("error", () => undefined);
+  try {
+    await client.connect();
+    await client.ping();
+    return client;
+  } catch {
+    client.disconnect();
+    return null;
+  }
+}
+
+const redis = await connectIfReachable();
+const KEY = "test:mcp-rate-limit-lua";
+
+type ScriptReply = [number, number, number, number];
+
+function evalScript(
+  client: Redis,
+  key: string,
+  windowMs: number,
+  limit: number,
+  member: string
+): Promise<ScriptReply> {
+  return client.eval(
+    MCP_SLIDING_WINDOW_SCRIPT,
+    1,
+    key,
+    windowMs,
+    limit,
+    member
+  ) as Promise<ScriptReply>;
+}
+
+afterAll(async () => {
+  if (redis) {
+    await redis.del(KEY);
+    await redis.quit();
+  }
+});
+
+describe.skipIf(redis === null)("MCP sliding-window Lua script", () => {
+  beforeEach(async () => {
+    await redis?.del(KEY);
+  });
+
+  it("admits exactly the limit and then refuses", async () => {
+    if (!redis) {
+      return;
+    }
+    const limit = 5;
+    const replies: ScriptReply[] = [];
+    for (let i = 0; i < limit + 2; i++) {
+      replies.push(await evalScript(redis, KEY, 60_000, limit, `m-${i}`));
+    }
+
+    expect(replies.slice(0, limit).map((r) => r[0])).toEqual(
+      Array.from({ length: limit }, () => 1)
+    );
+    expect(replies.slice(limit).map((r) => r[0])).toEqual([0, 0]);
+    expect(replies.at(-1)?.[1]).toBe(limit);
+    expect(await redis.zcard(KEY)).toBe(limit);
+  });
+
+  it("returns integer count, oldest score and server clock without precision loss", async () => {
+    if (!redis) {
+      return;
+    }
+    const [allowed, count, oldest, now] = await evalScript(
+      redis,
+      KEY,
+      60_000,
+      3,
+      "m-precision"
+    );
+
+    expect(allowed).toBe(1);
+    expect(count).toBe(1);
+    expect(Number.isInteger(oldest)).toBe(true);
+    expect(Number.isInteger(now)).toBe(true);
+    expect(oldest).toBe(now);
+    // Scored by Redis's clock, not the caller's: the two only have to agree
+    // to within normal NTP drift.
+    expect(Math.abs(Date.now() - now)).toBeLessThan(5000);
+  });
+
+  it("does not collide members written in the same millisecond", async () => {
+    if (!redis) {
+      return;
+    }
+    const replies = await Promise.all(
+      Array.from({ length: 4 }, (_, i) =>
+        evalScript(redis, KEY, 60_000, 10, `same-ms-${i}`)
+      )
+    );
+
+    expect(replies.map((r) => r[0])).toEqual([1, 1, 1, 1]);
+    expect(await redis.zcard(KEY)).toBe(4);
+  });
+
+  it("sets the key TTL on admit and does not extend it on refusal", async () => {
+    if (!redis) {
+      return;
+    }
+    await evalScript(redis, KEY, 60_000, 1, "ttl-a");
+    const afterAdmit = await redis.pttl(KEY);
+    expect(afterAdmit).toBeGreaterThan(0);
+    expect(afterAdmit).toBeLessThanOrEqual(60_000);
+
+    const denied = await evalScript(redis, KEY, 60_000, 1, "ttl-b");
+    expect(denied[0]).toBe(0);
+    // A refused caller must not be able to hold its own window open.
+    expect(await redis.pttl(KEY)).toBeLessThanOrEqual(afterAdmit);
+  });
+
+  it("trims entries that fall out of the window", async () => {
+    if (!redis) {
+      return;
+    }
+    const windowMs = 50;
+    expect((await evalScript(redis, KEY, windowMs, 1, "old"))[0]).toBe(1);
+    expect((await evalScript(redis, KEY, windowMs, 1, "blocked"))[0]).toBe(0);
+
+    await new Promise((resolve) => setTimeout(resolve, windowMs + 30));
+
+    const afterWindow = await evalScript(redis, KEY, windowMs, 1, "fresh");
+    expect(afterWindow[0]).toBe(1);
+    expect(afterWindow[1]).toBe(1);
+  });
+});

--- a/tests/unit/mcp-rate-limit-redis.test.ts
+++ b/tests/unit/mcp-rate-limit-redis.test.ts
@@ -1,23 +1,47 @@
+import { createHash } from "node:crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockGetRedis, mockLogSystemWarn } = vi.hoisted(() => ({
-  mockGetRedis: vi.fn(),
-  mockLogSystemWarn: vi.fn(),
-}));
+const { mockGetRedis, mockLogSystemWarn, mockIncrementCounter } = vi.hoisted(
+  () => ({
+    mockGetRedis: vi.fn(),
+    mockLogSystemWarn: vi.fn(),
+    mockIncrementCounter: vi.fn(),
+  })
+);
 
 vi.mock("@/lib/redis", () => ({ getRedis: mockGetRedis }));
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: { INFRASTRUCTURE: "infrastructure" },
   logSystemWarn: mockLogSystemWarn,
 }));
+vi.mock("@/lib/metrics", () => ({
+  getMetricsCollector: () => ({ incrementCounter: mockIncrementCounter }),
+}));
+
+import { MCP_SLIDING_WINDOW_SCRIPT } from "@/lib/mcp/rate-limit";
+
+/**
+ * SHA-1 of the Lua the limiter ships, transcribed here rather than derived
+ * from the module: everything else in this file drives a JS stand-in for the
+ * sorted-set semantics, so nothing here can tell whether the script itself
+ * still compiles or still does what the wrapper assumes. Comparing the module
+ * constant to itself would prove nothing.
+ *
+ * If this fails, the Lua changed. Re-verify it against a real Redis with
+ * tests/integration/mcp-rate-limit-lua-script.test.ts (its header has the
+ * one-line docker command), then update this hash.
+ */
+const SHIPPED_SCRIPT_SHA1 = "c60d3e1d217beecb927c72a7cd7b3943f270f47a";
 
 type RateLimitModule = typeof import("@/lib/mcp/rate-limit");
 
 type SortedSetEntry = { score: number; member: string };
 
 type FakeRedis = {
+  status: string;
   eval: (...args: unknown[]) => Promise<unknown>;
   evalCalls: () => number;
+  lastArgs: () => unknown[];
 };
 
 /**
@@ -26,32 +50,50 @@ type FakeRedis = {
  * dispatch models the network hop, so concurrent callers genuinely overlap
  * around it -- a limiter that split the check and the increment across two
  * round trips would over-admit against this fake.
+ *
+ * A real server rejects a missing script and a wrong key count, so this does
+ * too. It cannot check what the Lua does -- the golden hash above and the
+ * integration suite cover that. The window is scored by this fake's own clock
+ * because the real script reads Redis's TIME rather than trusting the caller.
  */
 function createFakeRedis(): FakeRedis {
   const store = new Map<string, SortedSetEntry[]>();
   let calls = 0;
+  let seen: unknown[] = [];
 
   const evalScript = async (...args: unknown[]): Promise<unknown> => {
     calls += 1;
-    const [, , key, now, windowMs, limit, member] = args;
+    seen = args;
+    const [script, numKeys, key, windowMs, limit, member] = args;
+    if (script !== MCP_SLIDING_WINDOW_SCRIPT) {
+      throw new Error("ERR Error compiling script (new function): unknown");
+    }
+    if (numKeys !== 1) {
+      throw new Error("ERR Number of keys can't be negative");
+    }
     await Promise.resolve();
 
-    const nowMs = Number(now);
+    const nowMs = Date.now();
     const kept = (store.get(String(key)) ?? []).filter(
       (entry) => entry.score > nowMs - Number(windowMs)
     );
     store.set(String(key), kept);
 
     if (kept.length >= Number(limit)) {
-      return [0, kept.length, kept[0].score];
+      return [0, kept.length, kept[0].score, nowMs];
     }
 
     kept.push({ score: nowMs, member: String(member) });
     kept.sort((a, b) => a.score - b.score);
-    return [1, kept.length, kept[0].score];
+    return [1, kept.length, kept[0].score, nowMs];
   };
 
-  return { eval: evalScript, evalCalls: (): number => calls };
+  return {
+    status: "ready",
+    eval: evalScript,
+    evalCalls: (): number => calls,
+    lastArgs: (): unknown[] => seen,
+  };
 }
 
 // A fresh module instance stands in for another pod: its own in-memory maps,
@@ -141,8 +183,94 @@ describe("checkMcpRateLimit (Redis-backed)", () => {
     }
   });
 
+  it("pins the shipped Lua so any change has to be re-verified against a real Redis", () => {
+    const digest = createHash("sha1")
+      .update(MCP_SLIDING_WINDOW_SCRIPT)
+      .digest("hex");
+    expect(digest).toBe(SHIPPED_SCRIPT_SHA1);
+  });
+
+  it("evaluates the shipped script over exactly one key", async () => {
+    const redis = createFakeRedis();
+    mockGetRedis.mockReturnValue(redis);
+    const pod = await loadReplica();
+
+    await pod.checkMcpRateLimit("org-script");
+
+    const [script, numKeys, key, windowMs, limit] = redis.lastArgs();
+    expect(script).toBe(pod.MCP_SLIDING_WINDOW_SCRIPT);
+    expect(numKeys).toBe(1);
+    expect(key).toBe("local:ratelimit:mcp:org-script");
+    expect(windowMs).toBe(pod.WINDOW_MS);
+    expect(limit).toBe(pod.LIMIT);
+    // The window is scored by Redis's clock, so no caller timestamp is sent.
+    expect(pod.MCP_SLIDING_WINDOW_SCRIPT).toContain("redis.call('TIME')");
+  });
+
+  it("connects before the first command instead of reporting a cold start as an outage", async () => {
+    const backing = createFakeRedis();
+    let status = "wait";
+    const connect = vi.fn(() => {
+      status = "ready";
+      return Promise.resolve();
+    });
+    const client = {
+      get status(): string {
+        return status;
+      },
+      connect,
+      // ioredis is built with enableOfflineQueue=false, so a command issued
+      // before the socket is up is rejected rather than queued.
+      eval: (...args: unknown[]): Promise<unknown> =>
+        status === "ready"
+          ? backing.eval(...args)
+          : Promise.reject(
+              new Error(
+                "Stream isn't writeable and enableOfflineQueue options is false"
+              )
+            ),
+    };
+    mockGetRedis.mockReturnValue(client);
+
+    const pod = await loadReplica();
+    const first = await pod.checkMcpRateLimit("org-cold-start");
+
+    expect(first.allowed).toBe(true);
+    expect(client.connect).toHaveBeenCalledTimes(1);
+    // The decision came from the shared store, and a boot is not an outage.
+    expect(pod.getRateLimitStats().organizationCount).toBe(0);
+    expect(mockLogSystemWarn).not.toHaveBeenCalled();
+    expect(mockIncrementCounter).not.toHaveBeenCalled();
+
+    // The connection is opened once, not once per request.
+    await pod.checkMcpRateLimit("org-cold-start");
+    expect(client.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("warms the connection at boot without waiting for a request", async () => {
+    let status = "wait";
+    const connect = vi.fn(() => {
+      status = "ready";
+      return Promise.resolve();
+    });
+    mockGetRedis.mockReturnValue({
+      get status(): string {
+        return status;
+      },
+      connect,
+      eval: (): Promise<unknown> => Promise.resolve([1, 1, Date.now(), 0]),
+    });
+
+    const pod = await loadReplica();
+    await pod.warmRateLimitRedis();
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(status).toBe("ready");
+  });
+
   it("falls back to per-pod limiting rather than open when Redis is unreachable", async () => {
     mockGetRedis.mockReturnValue({
+      status: "ready",
       eval: (): Promise<unknown> => Promise.reject(new Error("ECONNREFUSED")),
     });
 
@@ -160,8 +288,29 @@ describe("checkMcpRateLimit (Redis-backed)", () => {
     expect(mockLogSystemWarn).toHaveBeenCalled();
   });
 
+  it("counts every degraded decision even though the warning is throttled", async () => {
+    mockGetRedis.mockReturnValue({
+      status: "ready",
+      eval: (): Promise<unknown> => Promise.reject(new Error("ECONNREFUSED")),
+    });
+
+    const pod = await loadReplica();
+    await pod.checkMcpRateLimit("org-counted");
+    await pod.checkMcpRateLimit("org-counted");
+    await pod.checkMcpRateLimit("org-counted");
+
+    // A throttled log line is not a rate; the counter is what a dashboard can
+    // alert on to see the fleet-wide ceiling has reverted to per-pod.
+    expect(mockIncrementCounter).toHaveBeenCalledTimes(3);
+    expect(mockIncrementCounter).toHaveBeenCalledWith(
+      "ratelimit.mcp.degraded.total",
+      { reason: "command_failed" }
+    );
+  });
+
   it("logs the degradation once per interval instead of per request", async () => {
     mockGetRedis.mockReturnValue({
+      status: "ready",
       eval: (): Promise<unknown> => Promise.reject(new Error("ECONNREFUSED")),
     });
 
@@ -177,7 +326,7 @@ describe("checkMcpRateLimit (Redis-backed)", () => {
     mockGetRedis.mockReturnValue(null);
     const pod = await loadReplica();
 
-    // MAX_FALLBACK_ORGANIZATIONS is 10_000; push past it with distinct ids.
+    // MAX_TRACKED_KEYS is 10_000; push past it with distinct ids.
     const flood = 10_050;
     for (let i = 0; i < flood; i++) {
       await pod.checkMcpRateLimit(`org-flood-${i}`);
@@ -188,8 +337,39 @@ describe("checkMcpRateLimit (Redis-backed)", () => {
     );
   });
 
+  it("bounds the IP map the same way, since anonymous callers can rotate keys", async () => {
+    mockGetRedis.mockReturnValue(null);
+    const pod = await loadReplica();
+
+    for (let i = 0; i < 10_050; i++) {
+      pod.checkIpRateLimit(`10.0.${Math.floor(i / 256)}.${i % 256}`, 5, 60_000);
+    }
+
+    expect(pod.getRateLimitStats().ipCount).toBeLessThanOrEqual(10_000);
+  });
+
+  it("keeps refusing a key that is at its limit rather than evicting it", async () => {
+    mockGetRedis.mockReturnValue(null);
+    const pod = await loadReplica();
+
+    const victim = "1.2.3.4";
+    for (let i = 0; i < 5; i++) {
+      pod.checkIpRateLimit(victim, 5, 60_000);
+    }
+    expect(pod.checkIpRateLimit(victim, 5, 60_000).allowed).toBe(false);
+
+    // Flood past the cap; the key still being refused is the most recently
+    // used one, so LRU eviction must not hand it a fresh window.
+    for (let i = 0; i < 10_050; i++) {
+      pod.checkIpRateLimit(`10.1.${Math.floor(i / 256)}.${i % 256}`, 5, 60_000);
+      pod.checkIpRateLimit(victim, 5, 60_000);
+    }
+    expect(pod.checkIpRateLimit(victim, 5, 60_000).allowed).toBe(false);
+  });
+
   it("treats an unrecognised reply as a failure and falls back", async () => {
     mockGetRedis.mockReturnValue({
+      status: "ready",
       eval: (): Promise<unknown> => Promise.resolve("MOVED 1234"),
     });
 
@@ -198,7 +378,14 @@ describe("checkMcpRateLimit (Redis-backed)", () => {
 
     expect(result.allowed).toBe(true);
     expect(pod.getRateLimitStats().organizationCount).toBe(1);
-    expect(mockLogSystemWarn).toHaveBeenCalled();
+    expect(mockIncrementCounter).toHaveBeenCalledWith(
+      "ratelimit.mcp.degraded.total",
+      { reason: "unexpected_reply" }
+    );
+    // The reply shape is the only diagnostic this branch has; it must reach
+    // the error rather than arriving as an Error titled "undefined".
+    const reported = mockLogSystemWarn.mock.calls[0][2] as Error;
+    expect(reported.message).toContain("MOVED 1234");
   });
 
   it("uses the in-memory window silently when no Redis is configured", async () => {
@@ -212,12 +399,13 @@ describe("checkMcpRateLimit (Redis-backed)", () => {
     // Self-hosted and local runs have no Redis by design; that is not a
     // degradation worth paging on.
     expect(mockLogSystemWarn).not.toHaveBeenCalled();
+    expect(mockIncrementCounter).not.toHaveBeenCalled();
   });
 
   it("namespaces the counter key per deployment and organization", async () => {
     const redis = createFakeRedis();
     const evalSpy = vi.fn(redis.eval);
-    mockGetRedis.mockReturnValue({ eval: evalSpy });
+    mockGetRedis.mockReturnValue({ status: "ready", eval: evalSpy });
 
     const pod = await loadReplica();
     await pod.checkMcpRateLimit("org-keyed");

--- a/tests/unit/mcp-rate-limit-redis.test.ts
+++ b/tests/unit/mcp-rate-limit-redis.test.ts
@@ -1,0 +1,227 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetRedis, mockLogSystemWarn } = vi.hoisted(() => ({
+  mockGetRedis: vi.fn(),
+  mockLogSystemWarn: vi.fn(),
+}));
+
+vi.mock("@/lib/redis", () => ({ getRedis: mockGetRedis }));
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { INFRASTRUCTURE: "infrastructure" },
+  logSystemWarn: mockLogSystemWarn,
+}));
+
+type RateLimitModule = typeof import("@/lib/mcp/rate-limit");
+
+type SortedSetEntry = { score: number; member: string };
+
+type FakeRedis = {
+  eval: (...args: unknown[]) => Promise<unknown>;
+  evalCalls: () => number;
+};
+
+/**
+ * Stands in for one Redis server: a single store every replica talks to, and
+ * a script that runs start to finish without interleaving. The awaited
+ * dispatch models the network hop, so concurrent callers genuinely overlap
+ * around it -- a limiter that split the check and the increment across two
+ * round trips would over-admit against this fake.
+ */
+function createFakeRedis(): FakeRedis {
+  const store = new Map<string, SortedSetEntry[]>();
+  let calls = 0;
+
+  const evalScript = async (...args: unknown[]): Promise<unknown> => {
+    calls += 1;
+    const [, , key, now, windowMs, limit, member] = args;
+    await Promise.resolve();
+
+    const nowMs = Number(now);
+    const kept = (store.get(String(key)) ?? []).filter(
+      (entry) => entry.score > nowMs - Number(windowMs)
+    );
+    store.set(String(key), kept);
+
+    if (kept.length >= Number(limit)) {
+      return [0, kept.length, kept[0].score];
+    }
+
+    kept.push({ score: nowMs, member: String(member) });
+    kept.sort((a, b) => a.score - b.score);
+    return [1, kept.length, kept[0].score];
+  };
+
+  return { eval: evalScript, evalCalls: (): number => calls };
+}
+
+// A fresh module instance stands in for another pod: its own in-memory maps,
+// the same shared Redis behind them.
+async function loadReplica(): Promise<RateLimitModule> {
+  vi.resetModules();
+  return await import("@/lib/mcp/rate-limit");
+}
+
+describe("checkMcpRateLimit (Redis-backed)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("enforces one fleet-wide ceiling across replicas sharing a store", async () => {
+    mockGetRedis.mockReturnValue(createFakeRedis());
+
+    const podA = await loadReplica();
+    const podB = await loadReplica();
+
+    const spread = Array.from({ length: podA.LIMIT }, (_, index) =>
+      index % 2 === 0 ? podA : podB
+    );
+    let allowed = 0;
+    for (const pod of spread) {
+      const result = await pod.checkMcpRateLimit("org-shared");
+      if (result.allowed) {
+        allowed += 1;
+      }
+    }
+    expect(allowed).toBe(podA.LIMIT);
+
+    // Each pod served only half the budget; both must still deny, which is
+    // the whole point -- per-pod maps gave every replica its own LIMIT.
+    const deniedOnB = await podB.checkMcpRateLimit("org-shared");
+    const deniedOnA = await podA.checkMcpRateLimit("org-shared");
+    expect(deniedOnB.allowed).toBe(false);
+    expect(deniedOnA.allowed).toBe(false);
+
+    // Nothing was tracked locally: the decisions came from the shared store.
+    expect(podA.getRateLimitStats().organizationCount).toBe(0);
+    expect(podB.getRateLimitStats().organizationCount).toBe(0);
+  });
+
+  it("admits at most the limit when requests arrive concurrently", async () => {
+    const redis = createFakeRedis();
+    mockGetRedis.mockReturnValue(redis);
+
+    const pod = await loadReplica();
+    const overshoot = 25;
+    const attempts = pod.LIMIT + overshoot;
+
+    const results = await Promise.all(
+      Array.from({ length: attempts }, () =>
+        pod.checkMcpRateLimit("org-concurrent")
+      )
+    );
+
+    expect(results.filter((r) => r.allowed)).toHaveLength(pod.LIMIT);
+    expect(results.filter((r) => !r.allowed)).toHaveLength(overshoot);
+    // One round trip per decision: there is no window between the count and
+    // the increment for a concurrent request to slip through.
+    expect(redis.evalCalls()).toBe(attempts);
+  });
+
+  it("reports the standard metadata on both allowed and denied decisions", async () => {
+    mockGetRedis.mockReturnValue(createFakeRedis());
+    const pod = await loadReplica();
+
+    const first = await pod.checkMcpRateLimit("org-metadata");
+    expect(first.allowed).toBe(true);
+    expect(first.limit).toBe(pod.LIMIT);
+    expect(first.remaining).toBe(pod.LIMIT - 1);
+    expect(first.reset).toBeGreaterThan(0);
+
+    for (let i = 1; i < pod.LIMIT; i++) {
+      await pod.checkMcpRateLimit("org-metadata");
+    }
+
+    const denied = await pod.checkMcpRateLimit("org-metadata");
+    expect(denied.allowed).toBe(false);
+    if (!denied.allowed) {
+      expect(denied.limit).toBe(pod.LIMIT);
+      expect(denied.remaining).toBe(0);
+      expect(denied.retryAfter).toBeGreaterThanOrEqual(1);
+      expect(denied.reset).toBeGreaterThan(0);
+    }
+  });
+
+  it("falls back to per-pod limiting rather than open when Redis is unreachable", async () => {
+    mockGetRedis.mockReturnValue({
+      eval: (): Promise<unknown> => Promise.reject(new Error("ECONNREFUSED")),
+    });
+
+    const pod = await loadReplica();
+    const results: Awaited<ReturnType<RateLimitModule["checkMcpRateLimit"]>>[] =
+      [];
+    for (let i = 0; i < pod.LIMIT + 5; i++) {
+      results.push(await pod.checkMcpRateLimit("org-outage"));
+    }
+
+    // Degraded, not disabled: the pod-local window still caps the org.
+    expect(results.filter((r) => r.allowed)).toHaveLength(pod.LIMIT);
+    expect(results.at(-1)?.allowed).toBe(false);
+    expect(pod.getRateLimitStats().organizationCount).toBe(1);
+    expect(mockLogSystemWarn).toHaveBeenCalled();
+  });
+
+  it("logs the degradation once per interval instead of per request", async () => {
+    mockGetRedis.mockReturnValue({
+      eval: (): Promise<unknown> => Promise.reject(new Error("ECONNREFUSED")),
+    });
+
+    const pod = await loadReplica();
+    await pod.checkMcpRateLimit("org-noisy");
+    await pod.checkMcpRateLimit("org-noisy");
+    await pod.checkMcpRateLimit("org-noisy");
+
+    expect(mockLogSystemWarn).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds the fallback map so an outage is not a memory-growth vector", async () => {
+    mockGetRedis.mockReturnValue(null);
+    const pod = await loadReplica();
+
+    // MAX_FALLBACK_ORGANIZATIONS is 10_000; push past it with distinct ids.
+    const flood = 10_050;
+    for (let i = 0; i < flood; i++) {
+      await pod.checkMcpRateLimit(`org-flood-${i}`);
+    }
+
+    expect(pod.getRateLimitStats().organizationCount).toBeLessThanOrEqual(
+      10_000
+    );
+  });
+
+  it("treats an unrecognised reply as a failure and falls back", async () => {
+    mockGetRedis.mockReturnValue({
+      eval: (): Promise<unknown> => Promise.resolve("MOVED 1234"),
+    });
+
+    const pod = await loadReplica();
+    const result = await pod.checkMcpRateLimit("org-garbled");
+
+    expect(result.allowed).toBe(true);
+    expect(pod.getRateLimitStats().organizationCount).toBe(1);
+    expect(mockLogSystemWarn).toHaveBeenCalled();
+  });
+
+  it("uses the in-memory window silently when no Redis is configured", async () => {
+    mockGetRedis.mockReturnValue(null);
+
+    const pod = await loadReplica();
+    const result = await pod.checkMcpRateLimit("org-unconfigured");
+
+    expect(result.allowed).toBe(true);
+    expect(pod.getRateLimitStats().organizationCount).toBe(1);
+    // Self-hosted and local runs have no Redis by design; that is not a
+    // degradation worth paging on.
+    expect(mockLogSystemWarn).not.toHaveBeenCalled();
+  });
+
+  it("namespaces the counter key per deployment and organization", async () => {
+    const redis = createFakeRedis();
+    const evalSpy = vi.fn(redis.eval);
+    mockGetRedis.mockReturnValue({ eval: evalSpy });
+
+    const pod = await loadReplica();
+    await pod.checkMcpRateLimit("org-keyed");
+
+    expect(evalSpy.mock.calls[0][2]).toBe("local:ratelimit:mcp:org-keyed");
+  });
+});

--- a/tests/unit/mcp-rate-limit.test.ts
+++ b/tests/unit/mcp-rate-limit.test.ts
@@ -1,4 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// These cases cover the in-memory bookkeeping (sweep, stats). Pinning Redis to
+// absent keeps them on the fallback path regardless of the ambient env.
+vi.mock("@/lib/redis", () => ({ getRedis: () => null }));
+
 import {
   checkIpRateLimit,
   checkMcpRateLimit,
@@ -26,8 +31,8 @@ describe("mcp/rate-limit", () => {
   });
 
   describe("cleanupExpiredRateLimitEntries", () => {
-    it("removes organisation entries whose newest timestamp is past the stale threshold", () => {
-      checkMcpRateLimit("org-a");
+    it("removes organisation entries whose newest timestamp is past the stale threshold", async () => {
+      await checkMcpRateLimit("org-a");
       expect(getRateLimitStats().organizationCount).toBe(1);
 
       vi.setSystemTime(Date.now() + STALE_AFTER_MS + 1);
@@ -46,8 +51,8 @@ describe("mcp/rate-limit", () => {
       expect(getRateLimitStats().ipCount).toBe(0);
     });
 
-    it("preserves entries with activity inside the stale threshold", () => {
-      checkMcpRateLimit("org-active");
+    it("preserves entries with activity inside the stale threshold", async () => {
+      await checkMcpRateLimit("org-active");
       checkIpRateLimit("9.9.9.9", 10, WINDOW_MS);
 
       // Half-way through the stale window
@@ -59,13 +64,13 @@ describe("mcp/rate-limit", () => {
       expect(stats.ipCount).toBe(1);
     });
 
-    it("does not break rate-limit decisions when called against an at-limit entry", () => {
-      const allowed = Array.from({ length: LIMIT }, () =>
-        checkMcpRateLimit("org-busy")
+    it("does not break rate-limit decisions when called against an at-limit entry", async () => {
+      const allowed = await Promise.all(
+        Array.from({ length: LIMIT }, () => checkMcpRateLimit("org-busy"))
       );
       expect(allowed.every((r) => r.allowed)).toBe(true);
 
-      const blocked = checkMcpRateLimit("org-busy");
+      const blocked = await checkMcpRateLimit("org-busy");
       expect(blocked.allowed).toBe(false);
 
       // Cleanup must NOT drop an entry whose newest timestamp is `now`.
@@ -73,7 +78,7 @@ describe("mcp/rate-limit", () => {
       expect(getRateLimitStats().organizationCount).toBe(1);
 
       // And the block must persist.
-      const stillBlocked = checkMcpRateLimit("org-busy");
+      const stillBlocked = await checkMcpRateLimit("org-busy");
       expect(stillBlocked.allowed).toBe(false);
     });
 
@@ -96,12 +101,12 @@ describe("mcp/rate-limit", () => {
       expect(getRateLimitStats().ipCount).toBe(0);
     });
 
-    it("reproduces the leak case: idle keys accumulate without cleanup, are released after cleanup", () => {
-      checkMcpRateLimit("org-a");
+    it("reproduces the leak case: idle keys accumulate without cleanup, are released after cleanup", async () => {
+      await checkMcpRateLimit("org-a");
       vi.setSystemTime(Date.now() + STALE_AFTER_MS + 1);
 
       // Without cleanup: a brand-new key is added and the stale one stays.
-      checkMcpRateLimit("org-b");
+      await checkMcpRateLimit("org-b");
       expect(getRateLimitStats().organizationCount).toBe(2);
 
       // With cleanup: only the recently-active key remains.

--- a/tests/unit/mcp-route-anon.test.ts
+++ b/tests/unit/mcp-route-anon.test.ts
@@ -29,8 +29,17 @@ vi.mock("@/lib/mcp/logging", () => ({
   logMcpEvent: vi.fn(),
 }));
 
+// Resolves rather than returns: the limiter is async, and a plain object
+// would read the same whether or not the route awaited it. With a Promise, a
+// missing await leaves `allowed` undefined and every request 429s, so the
+// happy-path assertions below fail loudly instead of silently passing.
 vi.mock("@/lib/mcp/rate-limit", () => ({
-  checkMcpRateLimit: vi.fn().mockReturnValue({ allowed: true }),
+  checkMcpRateLimit: vi.fn().mockResolvedValue({
+    allowed: true,
+    limit: 120,
+    remaining: 119,
+    reset: 0,
+  }),
   startCleanupInterval: vi.fn(),
 }));
 

--- a/tests/unit/mcp-workflow-route.test.ts
+++ b/tests/unit/mcp-workflow-route.test.ts
@@ -14,8 +14,17 @@ vi.mock("@/lib/mcp/oauth-auth", () => ({
   authenticateOAuthToken: vi.fn(),
 }));
 
+// Resolves rather than returns: the limiter is async, and a plain object
+// would read the same whether or not the route awaited it. With a Promise, a
+// missing await leaves `allowed` undefined and every request 429s, so the
+// happy-path assertions below fail loudly instead of silently passing.
 vi.mock("@/lib/mcp/rate-limit", () => ({
-  checkMcpRateLimit: vi.fn(() => ({ allowed: true, retryAfter: 0 })),
+  checkMcpRateLimit: vi.fn().mockResolvedValue({
+    allowed: true,
+    limit: 120,
+    remaining: 119,
+    reset: 0,
+  }),
 }));
 
 vi.mock("@/lib/mcp/session-token", () => ({

--- a/tests/unit/rate-limit-metadata.test.ts
+++ b/tests/unit/rate-limit-metadata.test.ts
@@ -73,18 +73,27 @@ describe("checkMcpRateLimit", () => {
   });
 });
 
+// checkIpRateLimit shares its window bookkeeping with the MCP limiter and
+// backs seven other routes (OAuth token/register, the public MCP surface, the
+// marketplace workflow routes, execution-status polling). These pin the full
+// result shape on both branches so the shared helper cannot drift underneath
+// callers this file does not exercise.
 describe("checkIpRateLimit", () => {
   it("honours the caller-supplied limit in the metadata", () => {
+    const before = Math.floor(Date.now() / 1000);
     const allowed = checkIpRateLimit("ip-meta-1", 3, 60_000);
     expect(allowed.allowed).toBe(true);
     if (allowed.allowed) {
       expect(allowed.limit).toBe(3);
       expect(allowed.remaining).toBe(2);
+      expect(allowed.reset).toBeGreaterThanOrEqual(before + 60);
+      expect(allowed.reset).toBeLessThanOrEqual(before + 61);
     }
   });
 
   it("denies once the limit is reached with remaining 0 and a Retry-After", () => {
     const key = "ip-meta-2";
+    const before = Math.floor(Date.now() / 1000);
     checkIpRateLimit(key, 2, 60_000);
     checkIpRateLimit(key, 2, 60_000);
     const denied = checkIpRateLimit(key, 2, 60_000);
@@ -93,7 +102,19 @@ describe("checkIpRateLimit", () => {
       expect(denied.limit).toBe(2);
       expect(denied.remaining).toBe(0);
       expect(denied.retryAfter).toBeGreaterThanOrEqual(1);
+      expect(denied.retryAfter).toBeLessThanOrEqual(60);
+      // The oldest request in the window is what frees the next slot, so the
+      // denial points at that entry's expiry, not at a fresh window.
+      expect(denied.reset).toBeGreaterThanOrEqual(before + 60);
+      expect(denied.reset).toBeLessThanOrEqual(before + 61);
     }
+  });
+
+  it("keeps counting a key across denials instead of forgetting it", () => {
+    const key = "ip-meta-3";
+    checkIpRateLimit(key, 1, 60_000);
+    expect(checkIpRateLimit(key, 1, 60_000).allowed).toBe(false);
+    expect(checkIpRateLimit(key, 1, 60_000).allowed).toBe(false);
   });
 });
 

--- a/tests/unit/rate-limit-metadata.test.ts
+++ b/tests/unit/rate-limit-metadata.test.ts
@@ -1,4 +1,9 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The MCP limiter prefers Redis; pin it to absent so this file asserts the
+// shared result metadata rather than the store behind it.
+vi.mock("@/lib/redis", () => ({ getRedis: () => null }));
+
 import {
   __resetAiGenerateRateLimitForTests,
   checkAiGenerateRateLimit,
@@ -58,8 +63,8 @@ describe("checkRateLimit (execute)", () => {
 });
 
 describe("checkMcpRateLimit", () => {
-  it("reports the MCP limit and remaining on an allowed request", () => {
-    const result = checkMcpRateLimit("org-meta-1");
+  it("reports the MCP limit and remaining on an allowed request", async () => {
+    const result = await checkMcpRateLimit("org-meta-1");
     expect(result.allowed).toBe(true);
     if (result.allowed) {
       expect(result.limit).toBe(MCP_LIMIT);


### PR DESCRIPTION
## What this changes

`lib/mcp/rate-limit.ts` held its window in a module-level `Map`, so the limit applied per pod rather than per fleet. The file's own comment said so: "Effective limit is LIMIT * num_replicas. Replace with Redis-backed solution." Production runs `replicaCount: 4` (`deploy/keeperhub-stack/prod/values.yaml`), so the advertised 120/min ceiling was really 480/min. Staging runs 1 replica, so its limit is already 120/min and this change is a no-op there.

This moves the per-organization window into Redis, shared across replicas. `ioredis` was already a dependency, so nothing new is added to the tree.

## How

- Sliding window over a sorted set, evaluated in a **Lua script** so the check and the increment are atomic. A non-atomic check-then-increment is itself a bypass under concurrency.
- The script reads Redis `TIME` rather than trusting the caller's clock, so a skewed pod cannot widen its own window.
- `checkMcpRateLimit` becomes async. Both in-repo call sites (`app/mcp/route.ts`, `app/mcp/w/[slug]/route.ts`) await it, and both route suites mock with `mockResolvedValue` so a dropped await fails the tests.
- `RateLimitResult` and the rate-limit headers are unchanged, so callers and `rate-limit-headers.test.ts` do not churn.

## Redis outage behaviour

Degrades to the previous per-pod window rather than to unlimited. An outage weakens the ceiling from 120/min fleet-wide to 120/min per replica, which is exactly what shipped before this branch, instead of failing open. The degradation is logged and counted.

## Verification

- `pnpm check` exit 0, `pnpm type-check` exit 0
- 21 suites / 152 tests pass, with Redis supplied by a throwaway `redis:7-alpine` on port 63790. Without it the same run passes with the 5 Lua integration cases skipped.

## Blast radius

- **The effective ceiling drops by three quarters in production, 480/min to 120/min**, because 120 now means what it says. Legitimate high-volume agent traffic that fitted under the old de-facto ceiling will start seeing 429s. Staging is unaffected (1 replica), so it cannot surface the impact ahead of prod.
- New Prometheus counter `keeperhub_mcp_rate_limit_degraded_total` (label: `reason`). Scrape config needs nothing, but a Grafana alert on a non-zero rate is the point of adding it.
- `instrumentation.ts` awaits `warmRateLimitRedis()` during `register()`. Boot is delayed by the Redis connect, bounded by the 1000ms `connectTimeout`, and is a no-op where `REDIS_HOST` is unset. A broken Redis adds up to a second to pod startup.
- Mid-rollout both script versions run against the same sorted set. Scores are milliseconds-since-epoch in both, so entries interoperate.

## Open decisions

1. **Is 120/min still right now that it is actually 120?** The real ceiling drops to a quarter of today's on merge, from 480/min to 120/min. This is the main thing to decide, and the 4x figure is the one to decide against.
2. **Confirm fail-closed-ish is the intended posture** on a Redis outage.
3. **Two per-pod IP limiters are left alone** and still carry the replica multiplier: `app/api/mcp/workflows/[slug]/call/route.ts` and `app/mcp/public/route.ts`. Both are anonymous surfaces where the shared store has different tradeoffs. Deliberately out of scope; worth its own PR.
4. `MAX_TRACKED_KEYS` is 10,000 and now applies to the IP map too. Under a flood the least recently used key is evicted, handing that key a fresh window.
5. The Lua relies on effect replication permitting `TIME` inside a script. Verified against `redis:7-alpine`, which is what `deploy/pr-environment/redis.template.yaml` ships. A managed Redis with different semantics would need re-checking.

