### PR TITLE
fix: default mainnet Solana event ingestion to the filtered source

### DIFF
--- a/.github/workflows/pr-checks-events.yml
+++ b/.github/workflows/pr-checks-events.yml
@@ -44,7 +44,10 @@ jobs:
       - uses: ./.github/actions/setup-events-deps
       - name: Run unit tests
         working-directory: keeperhub-events
-        run: pnpm --filter @techops/events-tracker test:unit
+        # -r, not a single --filter: the workspace holds event-tracker AND
+        # solana-tracker, and filtering to the former left every solana-tracker
+        # unit test unenforced.
+        run: pnpm -r test:unit
 
   test-integration:
     runs-on: ubuntu-latest

--- a/keeperhub-events/solana-tracker/lib/config/environment.ts
+++ b/keeperhub-events/solana-tracker/lib/config/environment.ts
@@ -7,6 +7,15 @@ export const JWT_TOKEN_PASSWORD: string = process.env.JWT_TOKEN_PASSWORD || "";
 export const ETHERSCAN_API_KEY: string = process.env.ETHERSCAN_API_KEY || "";
 export const NODE_ENV: string = process.env.NODE_ENV || "development";
 
+/**
+ * Floor on how often the signatures source queries each watched program. The
+ * slot tick alone would drive it as fast as RPC latency allows (~2.5 slots/s on
+ * Solana mainnet, one query per program per poll), which is a large sustained
+ * RPC bill for no latency gain that matters downstream of SQS.
+ */
+export const SOLANA_SIGNATURES_POLL_INTERVAL_MS: number =
+  Number(process.env.SOLANA_SIGNATURES_POLL_INTERVAL_MS) || 2000;
+
 export const SQS_QUEUE_URL: string = process.env.SQS_QUEUE_URL || "";
 export const AWS_REGION: string = process.env.AWS_REGION || "us-east-1";
 export const AWS_ENDPOINT_URL: string | undefined =

--- a/keeperhub-events/solana-tracker/src/ingest/composite-source.ts
+++ b/keeperhub-events/solana-tracker/src/ingest/composite-source.ts
@@ -1,0 +1,69 @@
+import { logger } from "../../lib/utils/logger";
+import { formatError } from "../format-error";
+import {
+  type BlockSource,
+  type ConnectionHealth,
+  type Endpoint,
+  disconnectedHealth,
+} from "./block-source";
+
+/**
+ * Runs several BlockSources for one chain behind the single BlockSource
+ * contract. Used when one chain needs two ingestion strategies at once: the
+ * filtered `signatures` source for event triggers plus a header-only `getBlock`
+ * for block triggers, because no single source serves both without pulling
+ * whole blocks.
+ *
+ * Members produce blocks independently and each calls `onBlock` itself. They
+ * serve disjoint trigger sets (signatures emits one-tx blocks with a null
+ * blockHeight, so block matching is a no-op on them; the header-only getBlock
+ * carries no transactions, so event matching is a no-op on it), which is what
+ * keeps a workflow from firing twice for the same on-chain activity.
+ */
+export class CompositeSource implements BlockSource {
+  constructor(
+    private readonly chainId: number,
+    private readonly endpoints: Endpoint[],
+    readonly sources: BlockSource[],
+  ) {}
+
+  async start(): Promise<void> {
+    const started: BlockSource[] = [];
+    try {
+      for (const source of this.sources) {
+        await source.start();
+        started.push(source);
+      }
+    } catch (err) {
+      // A half-started composite would serve one trigger type and silently drop
+      // the other. Unwind what did start so the reconciler sees a clean failure
+      // and retries the whole chain.
+      for (const source of started) {
+        await source.stop().catch(() => {
+          // best-effort unwind; the start error is the one worth propagating
+        });
+      }
+      throw err;
+    }
+  }
+
+  async stop(): Promise<void> {
+    for (const source of this.sources) {
+      await source.stop().catch((err) => {
+        logger.warn(
+          `[composite] chain ${this.chainId} member stop failed: ${formatError(err)}`,
+        );
+      });
+    }
+  }
+
+  getHealth(): ConnectionHealth {
+    const healths = this.sources.map((source) => source.getHealth());
+    if (healths.length === 0) {
+      return disconnectedHealth(this.chainId, this.endpoints, "no sources");
+    }
+    // Healthy only when every member is: one disconnected member means a whole
+    // trigger type has stopped being served, which the chain's health must show.
+    return healths.find((health) => !health.connected) ?? healths[0];
+  }
+}

--- a/keeperhub-events/solana-tracker/src/ingest/signatures-source.ts
+++ b/keeperhub-events/solana-tracker/src/ingest/signatures-source.ts
@@ -1,3 +1,4 @@
+import { SOLANA_SIGNATURES_POLL_INTERVAL_MS } from "../../lib/config/environment";
 import { logger } from "../../lib/utils/logger";
 import { formatError } from "../format-error";
 import type { NormalizedBlock } from "../match/types";
@@ -18,6 +19,11 @@ import { type ConnectionHealth, SolanaConnection } from "./solana-connection";
  * counts. EVENT triggers only: it produces one-transaction "blocks" (blockHeight
  * null) so the same matcher/enqueue path runs unchanged; block-height triggers
  * are served by the getBlock or Geyser sources.
+ *
+ * Polling is floored at `pollIntervalMs`: the slot tick is only a wake-up, and
+ * honouring every one would issue a query per program about as fast as RPC
+ * latency allows. Ticks arriving inside the interval coalesce into a single
+ * deferred poll, so a wake-up is delayed to the interval boundary, never lost.
  */
 const MAX_SIGNATURES_PER_TICK = 1_000;
 
@@ -26,8 +32,13 @@ export class SignaturesSource implements BlockSource {
   private readonly cursors = new Map<string, string>();
   private isProcessing = false;
   private pendingTick = false;
+  private lastPollAt = 0;
+  private pollTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor(private readonly opts: BlockSourceOptions) {}
+  constructor(
+    private readonly opts: BlockSourceOptions,
+    private readonly pollIntervalMs: number = SOLANA_SIGNATURES_POLL_INTERVAL_MS,
+  ) {}
 
   async start(): Promise<void> {
     this.connection = new SolanaConnection({
@@ -59,6 +70,11 @@ export class SignaturesSource implements BlockSource {
   }
 
   async stop(): Promise<void> {
+    if (this.pollTimer !== null) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.pendingTick = false;
     if (this.connection) {
       await this.connection.stop();
       this.connection = null;
@@ -77,7 +93,24 @@ export class SignaturesSource implements BlockSource {
       this.pendingTick = true;
       return;
     }
+    const sinceLastPoll = Date.now() - this.lastPollAt;
+    if (sinceLastPoll < this.pollIntervalMs) {
+      // Too soon. Defer to the interval boundary, coalescing every tick that
+      // arrives before then into this one timer.
+      if (this.pollTimer === null) {
+        this.pollTimer = setTimeout(() => {
+          this.pollTimer = null;
+          this.onTick();
+        }, this.pollIntervalMs - sinceLastPoll);
+      }
+      return;
+    }
+    this.runPoll();
+  }
+
+  private runPoll(): void {
     this.isProcessing = true;
+    this.lastPollAt = Date.now();
     void this.poll()
       .catch((err) => {
         logger.warn(

--- a/keeperhub-events/solana-tracker/src/ingest/source-factory.ts
+++ b/keeperhub-events/solana-tracker/src/ingest/source-factory.ts
@@ -1,5 +1,5 @@
-import { logger } from "../../lib/utils/logger";
 import type { BlockSource, BlockSourceOptions } from "./block-source";
+import { CompositeSource } from "./composite-source";
 import { GetBlockSource } from "./getblock-source";
 import { GeyserSource } from "./geyser-source";
 import { SignaturesSource } from "./signatures-source";
@@ -7,7 +7,7 @@ import { SignaturesSource } from "./signatures-source";
 /**
  * Ingestion strategy per chain, all satisfying the same BlockSource contract:
  *   - "getblock"    : whole-block pull, batched but unfiltered. Serves BOTH event
- *                     and block triggers. Default; cheap on low-volume chains.
+ *                     and block triggers. Cheap on low-volume chains only.
  *   - "signatures"  : getSignaturesForAddress per program - server-side filtered
  *                     (the EVM eth_getLogs analog), event triggers only.
  *   - Geyser        : filtered + batched + pushed gRPC stream (mainnet scale).
@@ -38,10 +38,15 @@ export function createBlockSource(
   }
   if (selection.sourceMode === "signatures") {
     if (selection.hasBlockTriggers) {
-      logger.warn(
-        `[source-factory] chain ${opts.chainId}: signatures mode cannot serve block triggers; falling back to getBlock`,
-      );
-      return new GetBlockSource(opts);
+      // The signatures source emits one-tx blocks with no header, so it cannot
+      // serve block triggers. Pair it with a header-only getBlock (no watched
+      // programs -> transactionDetails "none") rather than reverting the whole
+      // chain to getBlock: that revert would put event matching back on the
+      // full-block firehose, which is unaffordable at mainnet throughput.
+      return new CompositeSource(opts.chainId, opts.endpoints, [
+        new SignaturesSource(opts),
+        new GetBlockSource({ ...opts, watchedProgramIds: [] }),
+      ]);
     }
     return new SignaturesSource(opts);
   }

--- a/keeperhub-events/solana-tracker/src/mapper.ts
+++ b/keeperhub-events/solana-tracker/src/mapper.ts
@@ -76,6 +76,41 @@ function toBlockTrigger(
   };
 }
 
+type SourceMode = "getblock" | "signatures";
+
+/**
+ * Explicit operator override applied to every chain, for incident response and
+ * for chains whose shape the default below gets wrong (e.g. a mainnet chain
+ * watching so many programs that per-program signature queries cost more than
+ * one whole-block pull). Any other value leaves selection to the default.
+ */
+function sourceModeOverride(): SourceMode | undefined {
+  const raw = process.env.SOLANA_SOURCE_MODE;
+  return raw === "signatures" || raw === "getblock" ? raw : undefined;
+}
+
+/**
+ * Default ingestion strategy for a chain, from the chain's own shape.
+ *
+ * Mainnet event ingestion defaults to the server-side filtered `signatures`
+ * source: `getBlock` pulls every produced block with full transaction detail,
+ * which on mainnet is a firehose (see specs/solana-event-ingestion.md) that no
+ * CPU request can absorb, and which silently skips slots - and so misses
+ * triggers - once it falls behind. Testnets keep `getBlock`, where whole-block
+ * pulls are cheap and one source serves event and block triggers together.
+ *
+ * `undefined` means the `getblock` default, matching the factory.
+ */
+function defaultSourceMode(
+  network: NetworkConfig,
+  hasEventTriggers: boolean,
+): SourceMode | undefined {
+  if (!hasEventTriggers || network.isTestnet) {
+    return undefined;
+  }
+  return "signatures";
+}
+
 interface ChainEndpoints {
   rpcUrl: string;
   fallbackRpcUrl?: string;
@@ -156,18 +191,13 @@ export function buildRegistrations(data: DiscoveryData): ChainRegistration[] {
     ...eventsByChain.keys(),
     ...blocksByChain.keys(),
   ]);
-  // Ingestion strategy lever. Global env override for now; a future per-chain
-  // chains-config field replaces this. "signatures" runs the eth_getLogs-style
-  // filtered-query source for event triggers.
-  const sourceMode =
-    process.env.SOLANA_SOURCE_MODE === "signatures"
-      ? ("signatures" as const)
-      : undefined;
+  const override = sourceModeOverride();
   const registrations: ChainRegistration[] = [];
 
   for (const chainId of chainIds) {
-    const endpoints = resolveEndpoints(data.networks[chainId], chainId);
-    if (!endpoints) {
+    const network = data.networks[chainId];
+    const endpoints = resolveEndpoints(network, chainId);
+    if (!endpoints || !network) {
       continue;
     }
     const eventTriggers: SolanaEventTrigger[] = (
@@ -176,6 +206,8 @@ export function buildRegistrations(data: DiscoveryData): ChainRegistration[] {
     const blockTriggers: SolanaBlockTrigger[] = (
       blocksByChain.get(chainId) ?? []
     ).map((t) => ({ ...t, configHash: sha256(t) }));
+    const sourceMode =
+      override ?? defaultSourceMode(network, eventTriggers.length > 0);
 
     const configHash = sha256({
       endpoints,

--- a/keeperhub-events/solana-tracker/tests/unit/composite-source.test.ts
+++ b/keeperhub-events/solana-tracker/tests/unit/composite-source.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  BlockSource,
+  ConnectionHealth,
+  Endpoint,
+} from "../../src/ingest/block-source";
+import { CompositeSource } from "../../src/ingest/composite-source";
+
+const ENDPOINTS: Endpoint[] = [{ rpcUrl: "https://rpc", wssUrl: "wss://ws" }];
+
+function health(connected: boolean, endpoint = "wss://ws"): ConnectionHealth {
+  return {
+    chainId: 101,
+    connected,
+    reconnecting: false,
+    lastSlotAt: null,
+    activeEndpoint: endpoint,
+    lastError: connected ? null : "down",
+  };
+}
+
+function member(overrides: Partial<BlockSource> = {}): BlockSource {
+  return {
+    start: vi.fn(() => Promise.resolve()),
+    stop: vi.fn(() => Promise.resolve()),
+    getHealth: () => health(true),
+    ...overrides,
+  };
+}
+
+describe("CompositeSource", () => {
+  it("starts and stops every member", async () => {
+    const a = member();
+    const b = member();
+    const composite = new CompositeSource(101, ENDPOINTS, [a, b]);
+
+    await composite.start();
+    expect(a.start).toHaveBeenCalledTimes(1);
+    expect(b.start).toHaveBeenCalledTimes(1);
+
+    await composite.stop();
+    expect(a.stop).toHaveBeenCalledTimes(1);
+    expect(b.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("unwinds already-started members when a later member fails to start", async () => {
+    // A half-started composite would serve one trigger type and silently drop
+    // the other, which is the failure mode this guards.
+    const started = member();
+    const failing = member({
+      start: vi.fn(() => Promise.reject(new Error("geyser down"))),
+    });
+    const composite = new CompositeSource(101, ENDPOINTS, [started, failing]);
+
+    await expect(composite.start()).rejects.toThrow("geyser down");
+    expect(started.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps stopping the remaining members when one stop throws", async () => {
+    const throwing = member({
+      stop: vi.fn(() => Promise.reject(new Error("stop boom"))),
+    });
+    const other = member();
+    const composite = new CompositeSource(101, ENDPOINTS, [throwing, other]);
+
+    await expect(composite.stop()).resolves.toBeUndefined();
+    expect(other.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports unhealthy when any member is disconnected", async () => {
+    const composite = new CompositeSource(101, ENDPOINTS, [
+      member(),
+      member({ getHealth: () => health(false) }),
+    ]);
+
+    expect(composite.getHealth().connected).toBe(false);
+    await composite.stop();
+  });
+
+  it("reports the first member's health when every member is connected", () => {
+    const composite = new CompositeSource(101, ENDPOINTS, [
+      member({ getHealth: () => health(true, "wss://primary") }),
+      member({ getHealth: () => health(true, "wss://secondary") }),
+    ]);
+
+    const result = composite.getHealth();
+    expect(result.connected).toBe(true);
+    expect(result.activeEndpoint).toBe("wss://primary");
+  });
+
+  it("reports disconnected when it has no members", () => {
+    const composite = new CompositeSource(101, ENDPOINTS, []);
+    expect(composite.getHealth().connected).toBe(false);
+  });
+});

--- a/keeperhub-events/solana-tracker/tests/unit/mapper.test.ts
+++ b/keeperhub-events/solana-tracker/tests/unit/mapper.test.ts
@@ -147,18 +147,79 @@ describe("buildRegistrations", () => {
     expect(regs).toEqual([]);
   });
 
-  it("changes the config hash and sourceMode when SOLANA_SOURCE_MODE=signatures", () => {
+  it("defaults mainnet event ingestion to the filtered signatures source", () => {
+    // getBlock pulls every produced block in full; on mainnet that is a
+    // firehose no CPU request absorbs, and it skips slots (missing triggers)
+    // once it falls behind.
+    const regs = buildRegistrations(
+      data({
+        eventWorkflows: [eventWorkflow("wf-1", "101", VALID_PROGRAM)],
+        networks: { 101: solanaNetwork(101) },
+      }),
+    );
+    expect(regs[0].sourceMode).toBe("signatures");
+  });
+
+  it("leaves testnet chains on getBlock, where whole-block pulls are cheap", () => {
+    const regs = buildRegistrations(
+      data({
+        eventWorkflows: [eventWorkflow("wf-1", "103", VALID_PROGRAM)],
+        networks: { 103: solanaNetwork(103, { isTestnet: true }) },
+      }),
+    );
+    expect(regs[0].sourceMode).toBeUndefined();
+  });
+
+  it("leaves a mainnet chain with only block triggers on getBlock", () => {
+    // No event triggers means no full-detail pull: getBlock runs header-only
+    // and is the only source that serves block triggers.
+    const regs = buildRegistrations(
+      data({
+        blockWorkflows: [blockWorkflow("wf-b", "101", "1")],
+        networks: { 101: solanaNetwork(101) },
+      }),
+    );
+    expect(regs[0].sourceMode).toBeUndefined();
+  });
+
+  it("lets SOLANA_SOURCE_MODE override the per-chain default in both directions", () => {
+    const mainnet = data({
+      eventWorkflows: [eventWorkflow("wf-1", "101", VALID_PROGRAM)],
+      networks: { 101: solanaNetwork(101) },
+    });
+    const testnet = data({
+      eventWorkflows: [eventWorkflow("wf-1", "103", VALID_PROGRAM)],
+      networks: { 103: solanaNetwork(103, { isTestnet: true }) },
+    });
+
+    process.env.SOLANA_SOURCE_MODE = "getblock";
+    expect(buildRegistrations(mainnet)[0].sourceMode).toBe("getblock");
+
+    process.env.SOLANA_SOURCE_MODE = "signatures";
+    expect(buildRegistrations(testnet)[0].sourceMode).toBe("signatures");
+  });
+
+  it("ignores an unrecognised SOLANA_SOURCE_MODE and keeps the default", () => {
+    process.env.SOLANA_SOURCE_MODE = "geyser";
+    const regs = buildRegistrations(
+      data({
+        eventWorkflows: [eventWorkflow("wf-1", "101", VALID_PROGRAM)],
+        networks: { 101: solanaNetwork(101) },
+      }),
+    );
+    expect(regs[0].sourceMode).toBe("signatures");
+  });
+
+  it("changes the config hash when the source mode changes, so the ingestor restarts", () => {
     const input = data({
       eventWorkflows: [eventWorkflow("wf-1", "101", VALID_PROGRAM)],
       networks: { 101: solanaNetwork(101) },
     });
 
     const defaultReg = buildRegistrations(input)[0];
-    expect(defaultReg.sourceMode).toBeUndefined();
+    process.env.SOLANA_SOURCE_MODE = "getblock";
+    const overriddenReg = buildRegistrations(input)[0];
 
-    process.env.SOLANA_SOURCE_MODE = "signatures";
-    const signaturesReg = buildRegistrations(input)[0];
-    expect(signaturesReg.sourceMode).toBe("signatures");
-    expect(signaturesReg.configHash).not.toBe(defaultReg.configHash);
+    expect(overriddenReg.configHash).not.toBe(defaultReg.configHash);
   });
 });

--- a/keeperhub-events/solana-tracker/tests/unit/signatures-source.test.ts
+++ b/keeperhub-events/solana-tracker/tests/unit/signatures-source.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Controllable stand-in for the per-chain Solana connection so the source's
+// poll cadence can be driven deterministically without any network.
+const hooks = vi.hoisted(() => ({
+  onSlot: null as null | ((slot: number) => void),
+  signatureCalls: [] as { address: string; until?: string }[],
+  signatures: (_address: string): { signature: string; slot: number }[] => [],
+}));
+
+vi.mock("@/src/ingest/solana-connection", () => ({
+  SolanaConnection: class {
+    constructor(opts: { onSlot: (slot: number) => void }) {
+      hooks.onSlot = opts.onSlot;
+    }
+    start(): void {
+      /* no-op mock */
+    }
+    stop(): Promise<void> {
+      return Promise.resolve();
+    }
+    getSignaturesForAddress(
+      address: string,
+      options: { until?: string },
+    ): Promise<unknown[]> {
+      hooks.signatureCalls.push({ address, until: options.until });
+      return Promise.resolve(hooks.signatures(address));
+    }
+    getTransaction(): Promise<unknown> {
+      return Promise.resolve({ meta: { logMessages: [] }, blockTime: 0 });
+    }
+    getHealth(): unknown {
+      return {};
+    }
+  },
+}));
+
+const { SignaturesSource } = await import("@/src/ingest/signatures-source");
+
+const PROGRAM = "So11111111111111111111111111111111111111112";
+const POLL_INTERVAL_MS = 1000;
+
+function source(): InstanceType<typeof SignaturesSource> {
+  return new SignaturesSource(
+    {
+      chainId: 101,
+      endpoints: [{ rpcUrl: "r", wssUrl: "w" }],
+      commitment: "confirmed",
+      watchedProgramIds: [PROGRAM],
+      onBlock: () => Promise.resolve(),
+    },
+    POLL_INTERVAL_MS,
+  );
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  hooks.signatureCalls = [];
+  hooks.signatures = () => [];
+});
+
+describe("SignaturesSource poll throttle", () => {
+  it("coalesces a burst of slot ticks into one deferred poll", async () => {
+    vi.useFakeTimers();
+    hooks.signatures = () => [{ signature: "seed-sig", slot: 1 }];
+
+    const src = source();
+    await src.start();
+    // start() seeds one cursor per watched program.
+    expect(hooks.signatureCalls).toHaveLength(1);
+
+    hooks.signatures = () => [];
+
+    // Solana mainnet delivers ~2.5 slot ticks/s. Honouring each one would issue
+    // a query per program per tick; they must collapse to one poll instead.
+    for (let slot = 1; slot <= 5; slot++) {
+      hooks.onSlot?.(slot);
+    }
+    await vi.advanceTimersByTimeAsync(0);
+    expect(hooks.signatureCalls).toHaveLength(2);
+
+    // The ticks that arrived inside the interval are not dropped - they fire as
+    // a single poll once the interval elapses.
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    expect(hooks.signatureCalls).toHaveLength(3);
+
+    // With no further ticks the source goes quiet rather than free-running.
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 5);
+    expect(hooks.signatureCalls).toHaveLength(3);
+
+    await src.stop();
+  });
+
+  it("polls immediately when a tick arrives after the interval has elapsed", async () => {
+    vi.useFakeTimers();
+    hooks.signatures = () => [{ signature: "seed-sig", slot: 1 }];
+
+    const src = source();
+    await src.start();
+    hooks.signatures = () => [];
+
+    hooks.onSlot?.(1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(hooks.signatureCalls).toHaveLength(2);
+
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 2);
+    hooks.onSlot?.(2);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(hooks.signatureCalls).toHaveLength(3);
+
+    await src.stop();
+  });
+
+  it("cancels a deferred poll on stop", async () => {
+    vi.useFakeTimers();
+    hooks.signatures = () => [{ signature: "seed-sig", slot: 1 }];
+
+    const src = source();
+    await src.start();
+    hooks.signatures = () => [];
+
+    hooks.onSlot?.(1);
+    await vi.advanceTimersByTimeAsync(0);
+    hooks.onSlot?.(2); // deferred to the interval boundary
+    const callsBeforeStop = hooks.signatureCalls.length;
+
+    await src.stop();
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 3);
+
+    expect(hooks.signatureCalls).toHaveLength(callsBeforeStop);
+
+    await src.stop();
+  });
+});

--- a/keeperhub-events/solana-tracker/tests/unit/source-factory.test.ts
+++ b/keeperhub-events/solana-tracker/tests/unit/source-factory.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { BlockSourceOptions } from "../../src/ingest/block-source";
+import { CompositeSource } from "../../src/ingest/composite-source";
 import { GetBlockSource } from "../../src/ingest/getblock-source";
 import { GeyserSource } from "../../src/ingest/geyser-source";
 import { SignaturesSource } from "../../src/ingest/signatures-source";
@@ -26,13 +27,31 @@ describe("createBlockSource selection", () => {
     ).toBeInstanceOf(SignaturesSource);
   });
 
-  it("falls back to getBlock when signatures mode meets block triggers", () => {
-    expect(
-      createBlockSource(opts(), {
-        sourceMode: "signatures",
-        hasBlockTriggers: true,
-      }),
-    ).toBeInstanceOf(GetBlockSource);
+  it("pairs signatures with a header-only getBlock when block triggers are present", () => {
+    const source = createBlockSource(opts(), {
+      sourceMode: "signatures",
+      hasBlockTriggers: true,
+    });
+
+    expect(source).toBeInstanceOf(CompositeSource);
+    const members = (source as CompositeSource).sources;
+    expect(members[0]).toBeInstanceOf(SignaturesSource);
+    expect(members[1]).toBeInstanceOf(GetBlockSource);
+  });
+
+  it("gives the composite's getBlock member no watched programs, so it stays header-only", () => {
+    // watchedProgramIds drives GetBlockSource's detail level. Leaving them set
+    // would make the block-trigger member pull full blocks - the firehose this
+    // pairing exists to avoid.
+    const source = createBlockSource(opts(), {
+      sourceMode: "signatures",
+      hasBlockTriggers: true,
+    }) as CompositeSource;
+
+    const getBlockMember = source.sources[1] as unknown as {
+      opts: BlockSourceOptions;
+    };
+    expect(getBlockMember.opts.watchedProgramIds).toEqual([]);
   });
 
   it("uses Geyser whenever an endpoint is configured, overriding sourceMode", () => {

--- a/specs/solana-event-ingestion.md
+++ b/specs/solana-event-ingestion.md
@@ -171,13 +171,29 @@ Rather than commit to one method, `solana-tracker` puts ingestion behind a `Bloc
 block metadata + `NormalizedTx[]`, where `programIds` come from the `Program <id> invoke` log lines), so the
 **matcher → Anchor decode → dedup → phantom → SQS** pipeline is entirely source-agnostic.
 
-- `GetBlockSource` — Option 1 (default; events + blocks). **Live-verified.**
+- `GetBlockSource` — Option 1 (events + blocks; testnet default). **Live-verified.**
 - `SignaturesSource` — Option 2 (filtered; events only, emits one-tx blocks). **Live-verified.**
+- `CompositeSource` — runs two of the above for one chain (see below).
 - `GeyserSource` — Option 4 (seam in place; provider-gated follow-up).
 
-Selection is per chain (a `chains`-config `sourceMode` + optional `geyserEndpoint`; currently a
-`SOLANA_SOURCE_MODE` env lever). The factory falls back to `getBlock` if `signatures` is chosen but the chain has
-block triggers.
+Selection is per chain, derived from the chain's own shape: a **mainnet** chain with event triggers defaults to
+`signatures`, everything else to `getBlock`. `SOLANA_SOURCE_MODE` (`signatures` | `getblock`) overrides the
+default on every chain, for incident response and for chains the default gets wrong (e.g. so many watched
+programs that per-program queries cost more than one whole-block pull).
+
+The default is mainnet-aware because `getBlock` on mainnet is not merely expensive, it is lossy: the source caps
+catch-up at `MAX_BACKFILL_SLOTS` and skips the remainder, so a source that cannot keep up silently stops firing
+triggers. Enabling the first mainnet event trigger on the previously idle prod pod (2026-08-11) drove exactly
+this, alerting on >2x CPU request.
+
+Because `signatures` cannot serve block triggers, a chain needing both runs a `CompositeSource`: the signatures
+source for event triggers plus a header-only `getBlock` (`transactionDetails: "none"`) for block triggers. The
+members serve disjoint trigger sets, so no workflow double-fires. Reverting the whole chain to `getBlock`
+instead — the earlier behaviour — would put event matching back on the full-block firehose.
+
+`SignaturesSource` polling is floored by `SOLANA_SIGNATURES_POLL_INTERVAL_MS` (default 2000). The slot tick is
+only a wake-up; honouring every tick issues one query per program roughly as fast as RPC latency allows, which
+at the metering below is a large sustained bill for latency that SQS and the executor dwarf anyway.
 
 ## Recommendation matrix
 


### PR DESCRIPTION
## Problem

`getBlock` pulls every produced block with full transaction detail. At mainnet throughput that is a firehose, and it is lossy as well as expensive: catch-up is capped at `MAX_BACKFILL_SLOTS` and the remainder is skipped, so a source that cannot keep up silently stops firing triggers.

Nothing selected a cheaper source in production. The `SOLANA_SOURCE_MODE` env lever was unset in the deploy values, and `geyserEndpoint` is never populated by the mapper (`GeyserSource` is an unimplemented seam that rejects on start), so `createBlockSource` fell through to `GetBlockSource` on mainnet. Enabling the first mainnet event trigger took the previously idle pod past twice its CPU request.

Sizing is not the fix here: the filtered path the spec already recommends for this case was simply never reachable in production.

## Changes

- **Chain-aware source default** (`src/mapper.ts`). A mainnet chain with event triggers defaults to the server-side filtered `signatures` source; testnets and block-only chains stay on `getBlock`, where whole-block pulls are cheap and one source serves both trigger types. `SOLANA_SOURCE_MODE` (`signatures` | `getblock`) still overrides on every chain, for incident response and for chains the default gets wrong.
- **Composite source** (`src/ingest/composite-source.ts`, `source-factory.ts`). A chain with both trigger types now runs `signatures` for events alongside a header-only `getBlock` (`transactionDetails: "none"`) for blocks. Previously that combination reverted the whole chain to full-block pulls, putting event matching back on the firehose. The members serve disjoint trigger sets, so no workflow double-fires; a partial start unwinds rather than leaving one trigger type silently unserved.
- **Poll floor** (`src/ingest/signatures-source.ts`). New `SOLANA_SIGNATURES_POLL_INTERVAL_MS`, default 2000. The slot tick is only a wake-up, and the previous code re-entered as soon as the in-flight poll resolved, issuing one query per watched program about as fast as RPC latency allowed. Ticks arriving inside the interval now coalesce into a single deferred poll rather than being dropped.
- **CI coverage** (`.github/workflows/pr-checks-events.yml`). The unit-test job filtered `@techops/events-tracker`, so every `solana-tracker` unit test - the pre-existing ones included - has been unenforced. Now runs `pnpm -r test:unit` across the workspace.
- Spec updated with the defaults, the composite rationale, and the incident.

## Verification

Run from `keeperhub-events`, matching the workflow:

- `pnpm -r test:unit` - 68 passing across 12 files. New coverage for composite start/stop fan-out, partial-start unwind, health aggregation, poll coalescing and timer cancellation, and per-chain default resolution.
- `pnpm typecheck` - clean, both packages.
- `pnpm lint` - clean, 105 files.

## Deliberately not included

- No deploy values or resource changes. `150m`/`256Mi` was sized for the idle case, but source selection is the defect; re-baseline once there is a steady-state figure. Worth a separate look: the deployment sets a memory limit and no CPU limit, which is why the container could run well past its request rather than being throttled.
- `solana-tracker`'s integration suite is still not wired into `test-integration`. That job provisions anvil/localstack/redis for the EVM tracker and this suite's requirements are unverified, so enabling it blind risks unrelated CI failures.
- A log-based alert on the `behind by N slots` warning. Skipped slots mean missed triggers, and that currently surfaces only in logs. There is no metrics exporter in this workspace, so a Loki alert rule is the cheap path.

## Follow-up

Whether triggers silently missed firings during the incident window is still unconfirmed and should be checked in Loki against the `[getblock] chain 101 behind by` pattern. If present, the user-visible impact is missed executions, not just a CPU alert.
