### PR TITLE
ci: run pr-issue-link gate only for outside contributors

### DIFF
--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -5,6 +5,10 @@ name: PR Issue Link
 # maintainer approval, which would leave the gate silent exactly where it is
 # needed.
 #
+# The gate applies to outside contributors only: the job skips when the PR
+# author is an OWNER, MEMBER, or COLLABORATOR (team PRs are tracked in Linear,
+# not GitHub issues). A skipped job still satisfies branch protection.
+#
 # SAFETY: pull_request_target runs with the base repository's token. This job
 # therefore never checks out, builds, or executes pull request code. It reads
 # the title, the labels, and the referenced issue through the API and nothing
@@ -24,6 +28,9 @@ permissions:
 
 jobs:
   check-issue-link:
+    if: >-
+      !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+      github.event.pull_request.author_association)
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The PR Issue Link gate currently runs for every pull request into staging and prod, so it also fails internal team PRs, whose titles carry Linear ticket codes rather than GitHub issue references (e.g. the run on fix/KEEP-1161-solana-tracker-mainnet-cpu).

The gate exists for fork PRs from outside contributors, as its own header comment states. This adds a job-level condition that skips the job when the PR author's association is OWNER, MEMBER, or COLLABORATOR; all other associations (CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, NONE, MANNEQUIN) remain gated. A skipped job still satisfies branch protection where the check is required.

Because pull_request_target runs the workflow definition from the base branch, merging this immediately applies the skip to all open member PRs on their next trigger (title edit, label change, or manual re-run).

Note: this PR carries the no-issue-required label because the run on this PR itself uses the current staging version of the gate, and ci is not among its exempt types.

Validated with actionlint.