### PR TITLE
fix: make an unpriced billable chain a compile error and report every gas-price fallback

### DIFF
--- a/lib/billing/gas-credits.ts
+++ b/lib/billing/gas-credits.ts
@@ -6,6 +6,7 @@ import {
   gasCreditAllocations,
   gasCreditUsage,
 } from "@/lib/db/schema-extensions";
+import { ErrorCategory, logSystemError, logSystemWarn } from "@/lib/logging";
 import {
   AGGREGATOR_V3_ABI,
   getGasTokenUsdFeedAddress,
@@ -288,10 +289,37 @@ export async function getGasTokenPriceUsd(
 
     ethPriceCache.set(chainId, { usd: price, fetchedAt: now });
     return price;
-  } catch {
+  } catch (error) {
+    // Both branches below were previously a bare `catch {}`, which made a feed
+    // that has been dead for a week indistinguishable from a single failed RPC
+    // call. The fallback is only defensible while it is transient, and nothing
+    // here was checking or reporting whether it was.
     if (cached !== undefined) {
+      // Still a real observed price, just past its TTL. Recoverable, so warn.
+      logSystemWarn(
+        ErrorCategory.BILLING,
+        "[GasCredits] Gas-token price feed unavailable, billing on cached price",
+        error,
+        {
+          chain_id: String(chainId),
+          cached_usd: String(cached.usd),
+          cached_age_ms: String(now - cached.fetchedAt),
+        }
+      );
       return cached.usd;
     }
+    // No observed price at all: every sponsored transaction on this chain is
+    // now billed against a hardcoded constant that tracks nothing. That is a
+    // revenue-affecting condition, not a blip, so it is an error.
+    logSystemError(
+      ErrorCategory.BILLING,
+      "[GasCredits] Gas-token price feed unavailable and no cached price, billing on the hardcoded fallback",
+      error,
+      {
+        chain_id: String(chainId),
+        fallback_usd: String(FALLBACK_ETH_PRICE_USD),
+      }
+    );
     return FALLBACK_ETH_PRICE_USD;
   }
 }

--- a/lib/billing/gas-credits.ts
+++ b/lib/billing/gas-credits.ts
@@ -241,6 +241,57 @@ const ETH_PRICE_CACHE_TTL_MS = 60_000;
 const STALE_PRICE_THRESHOLD_MS = 3_600_000; // 1 hour
 const FALLBACK_ETH_PRICE_USD = 3000;
 
+// Minimum gap between two reports of the same condition on the same chain.
+// getGasTokenPriceUsd runs once per sponsored transaction, so an unthrottled
+// report turns a single provider outage into one Sentry event and one metric
+// increment per transaction for its whole duration. Keyed by severity as well
+// as chain so an escalation from warn to error is reported immediately rather
+// than swallowed by a window opened by the warning.
+const FALLBACK_REPORT_INTERVAL_MS = 300_000; // 5 minutes
+const fallbackReportedAt = new Map<string, number>();
+
+/**
+ * Report that a sponsored transaction is about to be billed against something
+ * other than a fresh oracle read.
+ *
+ * `error` means the billed number is a hardcoded constant that tracks nothing,
+ * or a cached price older than the same staleness threshold an oracle answer
+ * itself is held to. `warn` means a real observed price that is merely past
+ * its 60-second TTL.
+ *
+ * Never throws. The caller runs after the sponsored transaction is already
+ * on-chain, where anything escaping is converted into SponsoredTxPendingError
+ * and the org is never billed at all.
+ */
+function reportPriceFallback(args: {
+  severity: "warn" | "error";
+  chainId: number;
+  now: number;
+  message: string;
+  error: unknown;
+  labels: Record<string, string>;
+}): void {
+  const throttleKey = `${args.chainId}:${args.severity}`;
+  const reportedAt = fallbackReportedAt.get(throttleKey);
+  if (
+    reportedAt !== undefined &&
+    args.now - reportedAt < FALLBACK_REPORT_INTERVAL_MS
+  ) {
+    return;
+  }
+  fallbackReportedAt.set(throttleKey, args.now);
+
+  try {
+    const log = args.severity === "error" ? logSystemError : logSystemWarn;
+    log(ErrorCategory.BILLING, args.message, args.error, {
+      chain_id: String(args.chainId),
+      ...args.labels,
+    });
+  } catch {
+    // Reporting is best-effort; settling a confirmed transaction is not.
+  }
+}
+
 /**
  * Fetch the current USD price of a chain's native gas token (ETH on the L1 and
  * ETH L2s, POL on Polygon) from the Chainlink oracle on that chain. Results are
@@ -260,7 +311,16 @@ export async function getGasTokenPriceUsd(
 
   const feedAddress = getGasTokenUsdFeedAddress(chainId);
   if (feedAddress === undefined) {
-    return cached?.usd ?? FALLBACK_ETH_PRICE_USD;
+    reportPriceFallback({
+      severity: "error",
+      chainId,
+      now,
+      message:
+        "[GasCredits] No gas-token USD price feed configured for chain, billing on the hardcoded fallback",
+      error: new Error(`No gas-token USD price feed for chain ${chainId}`),
+      labels: { fallback_usd: String(FALLBACK_ETH_PRICE_USD) },
+    });
+    return FALLBACK_ETH_PRICE_USD;
   }
 
   try {
@@ -290,36 +350,35 @@ export async function getGasTokenPriceUsd(
     ethPriceCache.set(chainId, { usd: price, fetchedAt: now });
     return price;
   } catch (error) {
-    // Both branches below were previously a bare `catch {}`, which made a feed
-    // that has been dead for a week indistinguishable from a single failed RPC
-    // call. The fallback is only defensible while it is transient, and nothing
-    // here was checking or reporting whether it was.
     if (cached !== undefined) {
-      // Still a real observed price, just past its TTL. Recoverable, so warn.
-      logSystemWarn(
-        ErrorCategory.BILLING,
-        "[GasCredits] Gas-token price feed unavailable, billing on cached price",
+      const cachedAgeMs = now - cached.fetchedAt;
+      reportPriceFallback({
+        // A cached price still beats the hardcoded constant, so it is what
+        // gets billed either way. But once it is older than the threshold an
+        // oracle answer itself is rejected at, it has stopped being a recent
+        // observation, and the feed has been failing for at least that long.
+        severity: cachedAgeMs > STALE_PRICE_THRESHOLD_MS ? "error" : "warn",
+        chainId,
+        now,
+        message:
+          "[GasCredits] Gas-token price feed unavailable, billing on cached price",
         error,
-        {
-          chain_id: String(chainId),
+        labels: {
           cached_usd: String(cached.usd),
-          cached_age_ms: String(now - cached.fetchedAt),
-        }
-      );
+          cached_age_ms: String(cachedAgeMs),
+        },
+      });
       return cached.usd;
     }
-    // No observed price at all: every sponsored transaction on this chain is
-    // now billed against a hardcoded constant that tracks nothing. That is a
-    // revenue-affecting condition, not a blip, so it is an error.
-    logSystemError(
-      ErrorCategory.BILLING,
-      "[GasCredits] Gas-token price feed unavailable and no cached price, billing on the hardcoded fallback",
+    reportPriceFallback({
+      severity: "error",
+      chainId,
+      now,
+      message:
+        "[GasCredits] Gas-token price feed unavailable and no cached price, billing on the hardcoded fallback",
       error,
-      {
-        chain_id: String(chainId),
-        fallback_usd: String(FALLBACK_ETH_PRICE_USD),
-      }
-    );
+      labels: { fallback_usd: String(FALLBACK_ETH_PRICE_USD) },
+    });
     return FALLBACK_ETH_PRICE_USD;
   }
 }

--- a/lib/billing/gas-sponsorship-history.ts
+++ b/lib/billing/gas-sponsorship-history.ts
@@ -7,7 +7,10 @@ import {
   gasSponsorshipMonthly,
   type NewGasSponsorshipMonthly,
 } from "@/lib/db/schema-extensions";
-import { SPONSORSHIP_CHAINS } from "@/lib/web3/sponsorship-chains-meta";
+import {
+  SPONSORSHIP_CHAINS,
+  type SponsorshipChain,
+} from "@/lib/web3/sponsorship-chains-meta";
 
 export type ChainSponsorship = {
   chainId: number;
@@ -26,7 +29,11 @@ export type MonthlySponsorship = {
   byChain: ChainSponsorship[];
 };
 
-const CHAIN_META = new Map(SPONSORSHIP_CHAINS.map((c) => [c.chainId, c]));
+// Keyed as `number`, not the literal chain ids: lookups come from DB rows,
+// which can name a chain no longer on the sponsorship list.
+const CHAIN_META: ReadonlyMap<number, SponsorshipChain> = new Map(
+  SPONSORSHIP_CHAINS.map((c) => [c.chainId, c])
+);
 
 function chainName(chainId: number): string {
   return CHAIN_META.get(chainId)?.name ?? `Chain ${chainId}`;

--- a/lib/rpc/scrub-rpc-urls.ts
+++ b/lib/rpc/scrub-rpc-urls.ts
@@ -16,10 +16,13 @@
  * Failure mode: if a vendor inlines its key in a shape none of these
  * patterns match (e.g. an opaque 8-char host prefix, or a custom header
  * echoed into a multi-line error body), this helper passes the string
- * through unchanged. The mitigation for that residual risk is a Sentry
- * `beforeSend` hook (tracked as a follow-up) plus the higher-level
- * guidance to log `code` + `shortMessage` instead of full messages
- * (ethers v6 today does not inline `requestUrl` into `shortMessage`).
+ * through unchanged. The remaining mitigation is the higher-level guidance
+ * to log `code` + `shortMessage` instead of full messages (ethers v6 today
+ * does not inline `requestUrl` into `shortMessage`).
+ *
+ * `scrubSentryEvent` below applies this to outbound Sentry events, which is
+ * the only path that carries a raw provider error without going through
+ * `buildErrPayload` first.
  */
 
 const URL_RE = /\bhttps?:\/\/[^\s)'"<>]+|wss?:\/\/[^\s)'"<>]+/gi;
@@ -68,6 +71,47 @@ export function scrubRpcUrls(text: string): string {
     return text;
   }
   return text.replace(URL_RE, maskUrl);
+}
+
+/**
+ * The parts of a Sentry event that carry free text an SDK error can have
+ * inlined a provider URL into. Structural rather than imported from
+ * `@sentry/*` so this module stays dependency-free; the real `ErrorEvent` is
+ * assignable to it at the `beforeSend` call site.
+ */
+type ScrubbableSentryEvent = {
+  message?: string;
+  logentry?: { message?: string };
+  exception?: { values?: { value?: string }[] };
+  breadcrumbs?: { message?: string }[];
+};
+
+/**
+ * Scrub provider secrets out of an outbound Sentry event, in place.
+ *
+ * `logSystemError`/`logSystemWarn` scrub the Loki payload via `buildErrPayload`
+ * but hand `captureException` the original Error, so a viem/ethers error whose
+ * message inlines a keyed RPC URL reaches Sentry verbatim. The `exception`
+ * sweep covers the `cause` chain too: the LinkedErrors integration flattens it
+ * into additional `exception.values` entries, each of which is scrubbed here.
+ */
+export function scrubSentryEvent(event: ScrubbableSentryEvent): void {
+  if (event.message !== undefined) {
+    event.message = scrubRpcUrls(event.message);
+  }
+  if (event.logentry?.message !== undefined) {
+    event.logentry.message = scrubRpcUrls(event.logentry.message);
+  }
+  for (const value of event.exception?.values ?? []) {
+    if (value.value !== undefined) {
+      value.value = scrubRpcUrls(value.value);
+    }
+  }
+  for (const breadcrumb of event.breadcrumbs ?? []) {
+    if (breadcrumb.message !== undefined) {
+      breadcrumb.message = scrubRpcUrls(breadcrumb.message);
+    }
+  }
 }
 
 const URL_PLACEHOLDER = "[REDACTED-URL]";

--- a/lib/web3/chainlink-feeds.ts
+++ b/lib/web3/chainlink-feeds.ts
@@ -3,12 +3,30 @@ import type { Address } from "viem";
 import { SPONSORSHIP_CHAINS } from "@/lib/web3/sponsorship-chains-meta";
 
 /**
+ * The chains that can actually be billed for sponsorship, as a literal union
+ * derived from the shared sponsorship surface. Testnets are excluded because
+ * they are never charged.
+ */
+type BillableChainId = Extract<
+  (typeof SPONSORSHIP_CHAINS)[number],
+  { isTestnet: false }
+>["chainId"];
+
+/**
  * Chainlink native-gas-token/USD price feed addresses per chain. Gas is paid in
  * each chain's native token, so the feed must match that token: ETH on the L1
  * and the ETH L2s, POL on Polygon. Pricing Polygon gas with an ETH feed
  * overstates its USD cost by orders of magnitude. All feeds report 8 decimals.
+ *
+ * The `Record<BillableChainId, Address>` half of the annotation is what makes
+ * adding a mainnet to SPONSORSHIP_CHAINS without a feed a compile error rather
+ * than a runtime surprise: an unmapped chain is billed at
+ * `FALLBACK_ETH_PRICE_USD`, which tracks nothing. Extra entries for chains
+ * outside the sponsorship surface stay legal via the `Record<number, Address>`
+ * half.
  */
-const GAS_TOKEN_USD_FEEDS: Record<number, Address> = {
+const GAS_TOKEN_USD_FEEDS: Record<number, Address> &
+  Record<BillableChainId, Address> = {
   1: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419", // Ethereum ETH/USD
   10: "0x13e3Ee699D1909E989722E753853AE30b17e08c5", // Optimism ETH/USD
   137: "0xAB594600376Ec9fD91F8e885dADF0CE036862dE0", // Polygon POL/USD

--- a/lib/web3/sponsorship-chains-meta.ts
+++ b/lib/web3/sponsorship-chains-meta.ts
@@ -11,7 +11,11 @@ export type SponsorshipChain = {
 // runtime sponsorship preflight and the billing UI, so the two cannot drift.
 // Turnkey supports four mainnets and their canonical testnets; Optimism and
 // BNB are intentionally absent because the Gas Station does not cover them.
-export const SPONSORSHIP_CHAINS: readonly SponsorshipChain[] = [
+// `as const satisfies` rather than a `readonly SponsorshipChain[]` annotation:
+// the literal chainId/isTestnet types survive, which lets chainlink-feeds.ts
+// derive the set of billable chain ids as a type and require a price feed for
+// each one at compile time.
+export const SPONSORSHIP_CHAINS = [
   { chainId: 1, name: "Ethereum", isTestnet: false, symbol: "ETH" },
   { chainId: 137, name: "Polygon", isTestnet: false, symbol: "POL" },
   { chainId: 8453, name: "Base", isTestnet: false, symbol: "ETH" },
@@ -30,7 +34,7 @@ export const SPONSORSHIP_CHAINS: readonly SponsorshipChain[] = [
     isTestnet: true,
     symbol: "ETH",
   },
-];
+] as const satisfies readonly SponsorshipChain[];
 
 export const SPONSORSHIP_CHAIN_IDS: ReadonlySet<number> = new Set(
   SPONSORSHIP_CHAINS.map((c) => c.chainId)

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -2,6 +2,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import { init } from "@sentry/nextjs";
+import { scrubSentryEvent } from "@/lib/rpc/scrub-rpc-urls";
 
 const { SENTRY_DSN, SENTRY_ENVIRONMENT } = process.env;
 
@@ -24,5 +25,12 @@ if (SENTRY_DSN) {
     // Enable sending user PII (Personally Identifiable Information)
     // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
     sendDefaultPii: true,
+
+    // Same reasoning as sentry.server.config.ts: strip provider keys that an
+    // SDK error inlined into its message before the event leaves the process.
+    beforeSend(event) {
+      scrubSentryEvent(event);
+      return event;
+    },
   });
 }

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -3,6 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import { init } from "@sentry/nextjs";
+import { scrubSentryEvent } from "@/lib/rpc/scrub-rpc-urls";
 
 const { SENTRY_DSN, SENTRY_ENVIRONMENT } = process.env;
 
@@ -27,5 +28,14 @@ if (SENTRY_DSN) {
     // Enable sending user PII (Personally Identifiable Information)
     // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
     sendDefaultPii: true,
+
+    // captureException receives the raw SDK error, so a provider URL inlined
+    // into its message (viem's HttpRequestError does this) would otherwise
+    // reach Sentry with the API key intact. The Loki path already scrubs via
+    // buildErrPayload; this is the equivalent for the Sentry path.
+    beforeSend(event) {
+      scrubSentryEvent(event);
+      return event;
+    },
   });
 }

--- a/tests/unit/chainlink-feeds.test.ts
+++ b/tests/unit/chainlink-feeds.test.ts
@@ -48,22 +48,11 @@ describe("isTestnetChain", () => {
 });
 
 describe("every billable sponsorship chain has a price feed", () => {
-  // GAS_TOKEN_USD_FEEDS and SPONSORSHIP_CHAINS are two hand-maintained lists
-  // that have to agree, and nothing at runtime notices when they do not.
-  // getGasTokenPriceUsd returns a hardcoded $3000 for an unmapped chain, so a
-  // mainnet added to SPONSORSHIP_CHAINS without a feed here would bill every
-  // sponsored transaction against a constant, silently and indefinitely.
-  //
-  // This is currently unreachable - the four sponsorship mainnets are all
-  // mapped, and testnets never reach the price lookup because
-  // sponsored-transaction-manager short-circuits them to $0. This test exists
-  // so that stays true: it fails when the chain is added, in CI, rather than
-  // after it ships.
+  // A mainnet on the sponsorship surface with no feed is billed at the
+  // hardcoded fallback price. The primary guard is the type annotation on
+  // GAS_TOKEN_USD_FEEDS, which makes that a compile error; this is the
+  // runtime backstop for anyone who widens the annotation.
   const billable = SPONSORSHIP_CHAINS.filter((chain) => !chain.isTestnet);
-
-  it("covers at least one chain, so the filter cannot silently pass empty", () => {
-    expect(billable.length).toBeGreaterThan(0);
-  });
 
   it.each(billable)("$name ($chainId) resolves a gas-token USD feed", ({
     chainId,

--- a/tests/unit/chainlink-feeds.test.ts
+++ b/tests/unit/chainlink-feeds.test.ts
@@ -6,6 +6,7 @@ import {
   getGasTokenUsdFeedAddress,
   isTestnetChain,
 } from "@/lib/web3/chainlink-feeds";
+import { SPONSORSHIP_CHAINS } from "@/lib/web3/sponsorship-chains-meta";
 
 describe("getGasTokenUsdFeedAddress", () => {
   it("prices Polygon gas with the POL feed, not an ETH feed", () => {
@@ -43,5 +44,30 @@ describe("isTestnetChain", () => {
     for (const chainId of [1, 137, 8453, 42_161]) {
       expect(isTestnetChain(chainId)).toBe(false);
     }
+  });
+});
+
+describe("every billable sponsorship chain has a price feed", () => {
+  // GAS_TOKEN_USD_FEEDS and SPONSORSHIP_CHAINS are two hand-maintained lists
+  // that have to agree, and nothing at runtime notices when they do not.
+  // getGasTokenPriceUsd returns a hardcoded $3000 for an unmapped chain, so a
+  // mainnet added to SPONSORSHIP_CHAINS without a feed here would bill every
+  // sponsored transaction against a constant, silently and indefinitely.
+  //
+  // This is currently unreachable - the four sponsorship mainnets are all
+  // mapped, and testnets never reach the price lookup because
+  // sponsored-transaction-manager short-circuits them to $0. This test exists
+  // so that stays true: it fails when the chain is added, in CI, rather than
+  // after it ships.
+  const billable = SPONSORSHIP_CHAINS.filter((chain) => !chain.isTestnet);
+
+  it("covers at least one chain, so the filter cannot silently pass empty", () => {
+    expect(billable.length).toBeGreaterThan(0);
+  });
+
+  it.each(billable)("$name ($chainId) resolves a gas-token USD feed", ({
+    chainId,
+  }) => {
+    expect(getGasTokenUsdFeedAddress(chainId)).toBeDefined();
   });
 });

--- a/tests/unit/gas-credits.test.ts
+++ b/tests/unit/gas-credits.test.ts
@@ -9,12 +9,25 @@ vi.mock("viem", () => ({
   http: () => ({}),
 }));
 
+const mockLogSystemWarn = vi.fn();
+const mockLogSystemError = vi.fn();
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { BILLING: "billing" },
+  logSystemWarn: (...args: unknown[]) => mockLogSystemWarn(...args),
+  logSystemError: (...args: unknown[]) => mockLogSystemError(...args),
+}));
+
 vi.mock("@/lib/web3/chainlink-feeds", () => ({
   AGGREGATOR_V3_ABI: [],
   getGasTokenUsdFeedAddress: (chainId: number) => {
     const feeds: Record<number, string> = {
       1: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
       8453: "0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70",
+      // Used only by the fallback-logging tests below, which cache a price and
+      // then fail the feed. Kept off 1 and 8453 so that cache write cannot
+      // leak into the tests above, which depend on those chains being uncached.
+      137: "0xAB594600376Ec9fD91F8e885dADF0CE036862dE0",
     };
     return feeds[chainId];
   },
@@ -217,6 +230,54 @@ describe("getGasTokenPriceUsd", () => {
     const price = await getGasTokenPriceUsd("https://rpc.example.com", 8453);
 
     expect(price).toBe(3000);
+  });
+
+  // The fallback is only defensible while it is transient. These two assert the
+  // condition is reported, so a feed that has been dead for a week is
+  // distinguishable from one failed RPC call - previously both were a bare
+  // `catch {}` and every sponsored transaction billed at $3000 in silence.
+  it("logs an error when it bills on the hardcoded fallback", async () => {
+    mockReadContract.mockRejectedValue(new Error("RPC timeout"));
+
+    const price = await getGasTokenPriceUsd("https://rpc.example.com", 137);
+
+    expect(price).toBe(3000);
+    expect(mockLogSystemError).toHaveBeenCalledOnce();
+    const [category, message, , labels] = mockLogSystemError.mock.calls[0];
+    expect(category).toBe("billing");
+    expect(message).toContain("hardcoded fallback");
+    expect(labels).toMatchObject({ chain_id: "137", fallback_usd: "3000" });
+    expect(mockLogSystemWarn).not.toHaveBeenCalled();
+  });
+
+  it("warns rather than errors when a cached price covers the failure", async () => {
+    vi.useFakeTimers();
+    try {
+      const seconds = BigInt(Math.floor(Date.now() / 1000));
+      mockReadContract.mockResolvedValue([
+        BigInt(1),
+        BigInt(250_000_000_000),
+        seconds,
+        seconds,
+        BigInt(1),
+      ]);
+      expect(await getGasTokenPriceUsd("https://rpc.example.com", 137)).toBe(
+        2500
+      );
+
+      // Past the 60s cache TTL, so the next call re-reads the feed and fails.
+      vi.advanceTimersByTime(61_000);
+      mockReadContract.mockRejectedValue(new Error("RPC timeout"));
+
+      const price = await getGasTokenPriceUsd("https://rpc.example.com", 137);
+
+      expect(price).toBe(2500);
+      expect(mockLogSystemWarn).toHaveBeenCalledOnce();
+      expect(mockLogSystemWarn.mock.calls[0][0]).toBe("billing");
+      expect(mockLogSystemError).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/tests/unit/gas-credits.test.ts
+++ b/tests/unit/gas-credits.test.ts
@@ -12,22 +12,33 @@ vi.mock("viem", () => ({
 const mockLogSystemWarn = vi.fn();
 const mockLogSystemError = vi.fn();
 
-vi.mock("@/lib/logging", () => ({
-  ErrorCategory: { BILLING: "billing" },
-  logSystemWarn: (...args: unknown[]) => mockLogSystemWarn(...args),
-  logSystemError: (...args: unknown[]) => mockLogSystemError(...args),
-}));
+// Only the two emitters are faked. ErrorCategory is passed through from the
+// real module so the category assertions below fail if the constant is
+// renamed or its value changes - a hardcoded copy here would only ever
+// validate the mock against itself, while the error_category label every Loki
+// query and Prometheus alert is built on changed underneath them.
+vi.mock("@/lib/logging", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/logging")>();
+  return {
+    ...actual,
+    logSystemWarn: (...args: unknown[]) => mockLogSystemWarn(...args),
+    logSystemError: (...args: unknown[]) => mockLogSystemError(...args),
+  };
+});
 
+// getGasTokenPriceUsd keeps a module-level price cache and report-throttle
+// keyed by chainId, and no beforeEach can reset them. Every test that asserts
+// on caching or reporting therefore owns a distinct chain id.
 vi.mock("@/lib/web3/chainlink-feeds", () => ({
   AGGREGATOR_V3_ABI: [],
   getGasTokenUsdFeedAddress: (chainId: number) => {
     const feeds: Record<number, string> = {
       1: "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
-      8453: "0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70",
-      // Used only by the fallback-logging tests below, which cache a price and
-      // then fail the feed. Kept off 1 and 8453 so that cache write cannot
-      // leak into the tests above, which depend on those chains being uncached.
+      10: "0x13e3Ee699D1909E989722E753853AE30b17e08c5",
       137: "0xAB594600376Ec9fD91F8e885dADF0CE036862dE0",
+      5000: "0x0000000000000000000000000000000000005000",
+      8453: "0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70",
+      42161: "0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612",
     };
     return feeds[chainId];
   },
@@ -111,6 +122,7 @@ import {
 } from "@/lib/billing/gas-credits";
 import type { PlanLimits } from "@/lib/billing/plans";
 import { getOrgSubscription } from "@/lib/billing/plans-server";
+import { ErrorCategory } from "@/lib/logging";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -232,25 +244,46 @@ describe("getGasTokenPriceUsd", () => {
     expect(price).toBe(3000);
   });
 
-  // The fallback is only defensible while it is transient. These two assert the
-  // condition is reported, so a feed that has been dead for a week is
-  // distinguishable from one failed RPC call - previously both were a bare
-  // `catch {}` and every sponsored transaction billed at $3000 in silence.
-  it("logs an error when it bills on the hardcoded fallback", async () => {
-    mockReadContract.mockRejectedValue(new Error("RPC timeout"));
-
-    const price = await getGasTokenPriceUsd("https://rpc.example.com", 137);
+  // Billing on anything other than a fresh oracle read has to be reported,
+  // and how loudly depends on how far the billed number has drifted from an
+  // observed price. The four tests below pin one branch each.
+  it("logs an error when the chain has no configured feed", async () => {
+    const price = await getGasTokenPriceUsd("https://rpc.example.com", 31_337);
 
     expect(price).toBe(3000);
+    expect(mockReadContract).not.toHaveBeenCalled();
     expect(mockLogSystemError).toHaveBeenCalledOnce();
-    const [category, message, , labels] = mockLogSystemError.mock.calls[0];
-    expect(category).toBe("billing");
-    expect(message).toContain("hardcoded fallback");
-    expect(labels).toMatchObject({ chain_id: "137", fallback_usd: "3000" });
+    const [category, message, error, labels] = mockLogSystemError.mock.calls[0];
+    expect(category).toBe(ErrorCategory.BILLING);
+    expect(message).toContain("No gas-token USD price feed configured");
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("31337");
+    expect(labels).toMatchObject({
+      chain_id: "31337",
+      fallback_usd: "3000",
+    });
     expect(mockLogSystemWarn).not.toHaveBeenCalled();
   });
 
-  it("warns rather than errors when a cached price covers the failure", async () => {
+  it("logs an error when it bills on the hardcoded fallback", async () => {
+    mockReadContract.mockRejectedValue(new Error("RPC timeout"));
+
+    const price = await getGasTokenPriceUsd("https://rpc.example.com", 42_161);
+
+    expect(price).toBe(3000);
+    expect(mockLogSystemError).toHaveBeenCalledOnce();
+    const [category, message, error, labels] = mockLogSystemError.mock.calls[0];
+    expect(category).toBe(ErrorCategory.BILLING);
+    expect(message).toContain("hardcoded fallback");
+    // The caught error is forwarded, not dropped: without it every Sentry
+    // event for a feed outage is an untyped `Error: undefined` with no stack.
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe("RPC timeout");
+    expect(labels).toMatchObject({ chain_id: "42161", fallback_usd: "3000" });
+    expect(mockLogSystemWarn).not.toHaveBeenCalled();
+  });
+
+  it("warns rather than errors when a recent cached price covers the failure", async () => {
     vi.useFakeTimers();
     try {
       const seconds = BigInt(Math.floor(Date.now() / 1000));
@@ -272,9 +305,84 @@ describe("getGasTokenPriceUsd", () => {
       const price = await getGasTokenPriceUsd("https://rpc.example.com", 137);
 
       expect(price).toBe(2500);
-      expect(mockLogSystemWarn).toHaveBeenCalledOnce();
-      expect(mockLogSystemWarn.mock.calls[0][0]).toBe("billing");
       expect(mockLogSystemError).not.toHaveBeenCalled();
+      expect(mockLogSystemWarn).toHaveBeenCalledOnce();
+      const [category, message, error, labels] =
+        mockLogSystemWarn.mock.calls[0];
+      expect(category).toBe(ErrorCategory.BILLING);
+      expect(message).toContain("billing on cached price");
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("RPC timeout");
+      // The observed price and its age are the whole point of this branch:
+      // without them the warning does not say what is being billed.
+      expect(labels).toMatchObject({
+        chain_id: "137",
+        cached_usd: "2500",
+        cached_age_ms: "61000",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("escalates to an error once the cached price passes the staleness threshold", async () => {
+    vi.useFakeTimers();
+    try {
+      const seconds = BigInt(Math.floor(Date.now() / 1000));
+      mockReadContract.mockResolvedValue([
+        BigInt(1),
+        BigInt(250_000_000_000),
+        seconds,
+        seconds,
+        BigInt(1),
+      ]);
+      expect(await getGasTokenPriceUsd("https://rpc.example.com", 10)).toBe(
+        2500
+      );
+
+      // Past the 1h threshold an oracle answer itself is rejected at, so the
+      // feed has been failing for at least that long.
+      vi.advanceTimersByTime(3_600_001);
+      mockReadContract.mockRejectedValue(new Error("RPC timeout"));
+
+      const price = await getGasTokenPriceUsd("https://rpc.example.com", 10);
+
+      // Still billed on the cached price - it beats the hardcoded constant.
+      // Only the severity changes.
+      expect(price).toBe(2500);
+      expect(mockLogSystemWarn).not.toHaveBeenCalled();
+      expect(mockLogSystemError).toHaveBeenCalledOnce();
+      const [, message, , labels] = mockLogSystemError.mock.calls[0];
+      expect(message).toContain("billing on cached price");
+      expect(labels).toMatchObject({
+        chain_id: "10",
+        cached_usd: "2500",
+        cached_age_ms: "3600001",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reports a sustained outage once per interval, not once per transaction", async () => {
+    vi.useFakeTimers();
+    try {
+      mockReadContract.mockRejectedValue(new Error("RPC timeout"));
+
+      for (let i = 0; i < 5; i++) {
+        expect(await getGasTokenPriceUsd("https://rpc.example.com", 5000)).toBe(
+          3000
+        );
+      }
+      expect(mockLogSystemError).toHaveBeenCalledOnce();
+
+      // Throttled, not one-shot: the condition is reported again once the
+      // window closes, so a still-broken feed does not go quiet.
+      vi.advanceTimersByTime(300_001);
+      expect(await getGasTokenPriceUsd("https://rpc.example.com", 5000)).toBe(
+        3000
+      );
+      expect(mockLogSystemError).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }

--- a/tests/unit/scrub-rpc-urls.test.ts
+++ b/tests/unit/scrub-rpc-urls.test.ts
@@ -3,6 +3,7 @@ import {
   redactAllUrls,
   redactSecretUrls,
   scrubRpcUrls,
+  scrubSentryEvent,
 } from "@/lib/rpc/scrub-rpc-urls";
 
 // Fake key markers. Long enough to trip the generic 32+ char path mask;
@@ -295,5 +296,55 @@ describe("scrubRpcUrls - CHAIN_RPC_CONFIG provider coverage", () => {
         expect(out).not.toContain(c.fakeKey);
       }
     }
+  });
+});
+
+describe("scrubSentryEvent", () => {
+  it("scrubs the exception chain, so a linked cause cannot leak a key", () => {
+    // LinkedErrors flattens `cause` into extra exception.values entries, which
+    // is how a viem HttpRequestError wrapping a keyed RPC URL reaches Sentry
+    // even when the top-level error message is clean.
+    const event = {
+      exception: {
+        values: [
+          { value: "HTTP request failed" },
+          {
+            value: `URL: https://eth-mainnet.g.alchemy.com/v2/${FAKE_ALCHEMY_KEY}`,
+          },
+        ],
+      },
+    };
+
+    scrubSentryEvent(event);
+
+    expect(event.exception.values[1].value).not.toContain(FAKE_ALCHEMY_KEY);
+    expect(event.exception.values[1].value).toContain(
+      "eth-mainnet.g.alchemy.com"
+    );
+    expect(event.exception.values[0].value).toBe("HTTP request failed");
+  });
+
+  it("scrubs message, logentry and breadcrumbs", () => {
+    const event = {
+      message: `boom https://mainnet.infura.io/v3/${FAKE_INFURA_KEY}`,
+      logentry: {
+        message: `entry https://mainnet.infura.io/v3/${FAKE_INFURA_KEY}`,
+      },
+      breadcrumbs: [
+        { message: `crumb https://mainnet.infura.io/v3/${FAKE_INFURA_KEY}` },
+      ],
+    };
+
+    scrubSentryEvent(event);
+
+    expect(event.message).not.toContain(FAKE_INFURA_KEY);
+    expect(event.logentry.message).not.toContain(FAKE_INFURA_KEY);
+    expect(event.breadcrumbs[0].message).not.toContain(FAKE_INFURA_KEY);
+  });
+
+  it("leaves an event with no free-text fields alone", () => {
+    const event: Record<string, unknown> = {};
+    expect(() => scrubSentryEvent(event)).not.toThrow();
+    expect(event).toEqual({});
   });
 });


### PR DESCRIPTION
`getGasTokenPriceUsd` billed every sponsored transaction at a hardcoded `$3000`
whenever it could not read a fresh price, and said nothing. An unmapped chain, a
feed dead for a week, and one failed RPC call were the same event: a bare
`catch {}` and a constant that tracks nothing.

## An unpriced billable chain is now a compile error

`GAS_TOKEN_USD_FEEDS` and the sponsorship surface were two hand-maintained lists
that had to agree, with nothing noticing when they did not. Adding a mainnet to
one without the other is what bills it against a constant, indefinitely.

`SPONSORSHIP_CHAINS` becomes `as const satisfies readonly SponsorshipChain[]`, so
the literal `chainId`/`isTestnet` types survive. `chainlink-feeds.ts` derives the
billable ids from it and annotates the feed map
`Record<number, Address> & Record<BillableChainId, Address>`. A mainnet with no
feed fails `tsc` at the point of addition rather than in production:

```
lib/web3/chainlink-feeds.ts(28,7): error TS2322: Type '{ 1: ...; 137: ...; 8453: ...; 42161: ... }'
  is not assignable to type 'Record<number, `0x${string}`> & Record<1 | 4217 | 137 | 8453 | 42161, `0x${string}`>'.
```

Extra entries for chains outside the sponsorship surface stay legal, so the
existing Optimism feed is unaffected.

The runtime branch reports as well. Today `isSponsorshipSupported()` gates the
only caller, so the branch is unreachable - but that is a property of one call
site, not of the function, and a second caller would silently reintroduce the
original bug.

## Severity tracks price drift, not cache warmth

The obvious split - warn if a cached price covers the failure, error if not -
keys the distinction on whether the in-memory cache happens to be warm. That
gets it wrong in both directions: a pod restart makes one transient timeout look
like a revenue incident, and a feed dead for a week on a long-lived pod stays a
warning forever while serving a week-old price.

Severity is now keyed on the cached price's age against `STALE_PRICE_THRESHOLD_MS`,
the same bound an oracle answer itself is rejected at. Past it, the feed has been
failing for at least an hour and the report escalates to error.

**The billed number does not change.** A two-hour-old real price still beats the
hardcoded constant, so it is what gets billed either way; only the severity
moves. Refusing to bill on a stale price is a pricing decision, not a bug fix.

## Reporting is throttled, and cannot break billing

`getGasTokenPriceUsd` runs once per sponsored transaction. Unthrottled, a
thirty-minute provider incident is one Sentry event and one metric increment per
transaction for one condition. Reports are now capped at one per chain per
severity per five minutes - keyed by severity so an escalation from warn to
error is not swallowed by a window the warning opened.

The call site runs *after* the transaction is on-chain, where anything that
escapes is converted into `SponsoredTxPendingError` and the org is never billed
at all. Adding logging to the catch block put the metrics collector, the ALS
context lookup and `captureException` on that path, so the report is wrapped: a
failure to report can no longer convert a settled transaction into an unbilled
one.

## Sentry events are scrubbed

`logSystemError` scrubs the Loki payload through `buildErrPayload`, then hands
`captureException` the original `Error`. A viem `HttpRequestError` inlines
`URL: https://<host>/v2/<KEY>` into its message, and the server config defines no
`beforeSend`, so this change opened a path from billing code to Sentry carrying a
provider key.

`scrubSentryEvent` is added beside `scrubRpcUrls` and wired as `beforeSend` on
the server and edge configs. It sweeps `exception.values[]` - where the
LinkedErrors integration flattens the `cause` chain - plus `message`, `logentry`
and breadcrumbs. `scrub-rpc-urls.ts` documented this hook as the mitigation for
its own residual risk; that comment is updated to describe what exists.

## Verification

Run in a `node:22` container before pushing:

| Check | Result |
| -- | -- |
| `vitest` on the three touched test files | 84 passed |
| `vitest --sequence.shuffle`, three runs | 84 passed each time |
| `tsc --noEmit` (whole project) | clean |
| `biome check` on all ten changed files | clean |

The shuffle runs are the point of the test changes, not a formality. The
previous assertions were order-coupled through the module-level price cache,
which `vi.clearAllMocks()` cannot reset; every test that asserts on caching or
reporting now owns a distinct chain id. The logging mock also spreads
`importOriginal` rather than hardcoding `ErrorCategory`, so a rename of the
constant fails the test instead of silently changing the `error_category` label
every Loki query and Prometheus alert is built on.

Nine mutations were checked rather than assumed. Each was caught by exactly the
intended test:

| Mutation | Caught by |
| -- | -- |
| Drop the caught error on the no-cache branch | `logs an error when it bills on the hardcoded fallback` |
| Drop the caught error on the cached branch | `warns rather than errors when a recent cached price covers the failure` |
| Delete the `cached_age_ms` label | both cached-branch tests |
| Freeze severity at `warn` | `escalates to an error once the cached price passes the staleness threshold` |
| Silence the unmapped-chain branch | `logs an error when the chain has no configured feed` |
| Remove the throttle | `reports a sustained outage once per interval, not once per transaction` |
| Make the throttle one-shot | same |
| Remove a feed from the map | `tsc` |
| Add a mainnet with no feed | `tsc` |

## Tradeoffs and what is not changed

- **Throttling the report also throttles the Prometheus counter.** It now counts
  reported conditions, not mispriced transactions, so outage volume is no longer
  readable from the metric. Loki still has the per-condition line with
  `cached_age_ms`.
- **`ErrorCategory.BILLING` has no case in `getMetricName`**, so this error lands
  on the generic `api_errors_total` counter. That is pre-existing and shared with
  thirteen other billing call sites; adding the case would move all of them and
  break anything built on them, so it is left for a separate change.
- **`10: Optimism` in the feed map is unused.** Optimism is deliberately absent
  from the sponsorship surface and `getGasTokenUsdFeedAddress` has no other
  caller. Not removed here.
- **`gas-sponsorship-history.ts` is touched** only because `as const` narrowed a
  derived `Map`'s key type to the literal chain ids. Its lookups come from DB
  rows that can name a delisted chain, so the map is annotated
  `ReadonlyMap<number, SponsorshipChain>`.
