### PR TITLE
fix: rebuild the Solana source when its trigger inputs change

### DIFF
--- a/keeperhub-events/solana-tracker/lib/config/environment.ts
+++ b/keeperhub-events/solana-tracker/lib/config/environment.ts
@@ -1,3 +1,5 @@
+import { logger } from "../utils/logger";
+
 export const KEEPERHUB_API_URL: string = process.env.KEEPERHUB_API_URL || "";
 export const REDIS_HOST: string = process.env.REDIS_HOST || "localhost";
 export const REDIS_PORT: number = Number(process.env.REDIS_PORT) || 6379;
@@ -13,8 +15,29 @@ export const NODE_ENV: string = process.env.NODE_ENV || "development";
  * Solana mainnet, one query per program per poll), which is a large sustained
  * RPC bill for no latency gain that matters downstream of SQS.
  */
-export const SOLANA_SIGNATURES_POLL_INTERVAL_MS: number =
-  Number(process.env.SOLANA_SIGNATURES_POLL_INTERVAL_MS) || 2000;
+export const SOLANA_SIGNATURES_POLL_INTERVAL_MS: number = parsePollIntervalMs(
+  process.env.SOLANA_SIGNATURES_POLL_INTERVAL_MS,
+);
+
+/**
+ * `Number(x) || fallback` would swallow an explicit `0` - the value an operator
+ * uses to disable the floor - and would silently accept a typo as the default.
+ * Honour any finite non-negative number, and say so when a value is rejected.
+ */
+function parsePollIntervalMs(raw: string | undefined): number {
+  const fallback = 2000;
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    logger.warn(
+      `[env] SOLANA_SIGNATURES_POLL_INTERVAL_MS="${raw}" is not a non-negative number; using ${fallback}`,
+    );
+    return fallback;
+  }
+  return parsed;
+}
 
 export const SQS_QUEUE_URL: string = process.env.SQS_QUEUE_URL || "";
 export const AWS_REGION: string = process.env.AWS_REGION || "us-east-1";

--- a/keeperhub-events/solana-tracker/src/ingest/block-ingestor.ts
+++ b/keeperhub-events/solana-tracker/src/ingest/block-ingestor.ts
@@ -22,8 +22,8 @@ import type { BlockSource, ConnectionHealth, Endpoint } from "./block-source";
 import { createBlockSource } from "./source-factory";
 
 /**
- * Per-chain ingestor. Owns a BlockSource (getBlock polling by default, Geyser
- * when configured) and, for every block it produces, runs both matchers and
+ * Per-chain ingestor. Owns a BlockSource (selected per chain by the mapper -
+ * see `defaultSourceMode`) and, for every block it produces, runs both matchers and
  * fans out to phantom + SQS. The source-vs-match split keeps ingestion swappable
  * without touching matching/decode/enqueue.
  */
@@ -32,6 +32,25 @@ export interface BlockIngestorDeps {
   sqs: SQSClient;
   sqsQueueUrl: string;
   dedup: DedupStore;
+}
+
+/**
+ * The distinct programs a chain watches, as a stable key. Distinct, because the
+ * signatures source issues one RPC round trip per entry: two workflows on the
+ * same program are one program to watch, not two.
+ */
+function watchedProgramIds(registration: ChainRegistration): string[] {
+  return [
+    ...new Set(registration.eventTriggers.map((t) => t.programId)),
+  ].sort();
+}
+
+function watchedProgramKey(registration: ChainRegistration): string {
+  return watchedProgramIds(registration).join(",");
+}
+
+function hasBlockTriggers(registration: ChainRegistration): boolean {
+  return registration.blockTriggers.length > 0;
 }
 
 export class BlockIngestor {
@@ -56,9 +75,7 @@ export class BlockIngestor {
         chainId: this.registration.chainId,
         endpoints: this.endpoints(),
         commitment: this.registration.commitment,
-        watchedProgramIds: this.registration.eventTriggers.map(
-          (t) => t.programId,
-        ),
+        watchedProgramIds: watchedProgramIds(this.registration),
         onBlock: (block) => this.processBlock(block),
       },
       {
@@ -69,7 +86,7 @@ export class BlockIngestor {
             }
           : undefined,
         sourceMode: this.registration.sourceMode,
-        hasBlockTriggers: this.registration.blockTriggers.length > 0,
+        hasBlockTriggers: hasBlockTriggers(this.registration),
       },
     );
     await this.source.start();
@@ -88,7 +105,11 @@ export class BlockIngestor {
     logger.log(`[ingestor] chain ${this.registration.chainId} stopped`);
   }
 
-  /** In-place refresh when only the trigger set changed (endpoints unchanged). */
+  /**
+   * Refreshes what the matchers read per block. Only valid when
+   * `canUpdateInPlace` holds - it cannot reach inputs the running source
+   * captured at construction.
+   */
   updateRegistration(registration: ChainRegistration): void {
     this.registration = registration;
     this.rebuildDecoders();
@@ -98,7 +119,28 @@ export class BlockIngestor {
     return registration.configHash !== this.registration.configHash;
   }
 
-  sameEndpoints(registration: ChainRegistration): boolean {
+  /**
+   * Whether a changed registration can be absorbed by `updateRegistration`
+   * instead of a source restart.
+   *
+   * `updateRegistration` can only refresh what the matchers read on every block.
+   * Anything baked into the BlockSource at construction - the endpoints, the
+   * watched program set, and whether block triggers exist - is unreachable once
+   * the source is running, so a change there needs a new source. Absorbing it in
+   * place instead leaves the source serving the previous trigger set with no
+   * error: a program added to a `signatures` chain is never queried, and a block
+   * trigger added to one is never served at all.
+   */
+  canUpdateInPlace(registration: ChainRegistration): boolean {
+    return (
+      this.sameEndpoints(registration) &&
+      watchedProgramKey(registration) ===
+        watchedProgramKey(this.registration) &&
+      hasBlockTriggers(registration) === hasBlockTriggers(this.registration)
+    );
+  }
+
+  private sameEndpoints(registration: ChainRegistration): boolean {
     return (
       registration.rpcUrl === this.registration.rpcUrl &&
       registration.fallbackRpcUrl === this.registration.fallbackRpcUrl &&

--- a/keeperhub-events/solana-tracker/src/ingest/signatures-source.ts
+++ b/keeperhub-events/solana-tracker/src/ingest/signatures-source.ts
@@ -1,3 +1,4 @@
+import type { ConfirmedSignatureInfo } from "@solana/web3.js";
 import { SOLANA_SIGNATURES_POLL_INTERVAL_MS } from "../../lib/config/environment";
 import { logger } from "../../lib/utils/logger";
 import { formatError } from "../format-error";
@@ -26,6 +27,8 @@ import { type ConnectionHealth, SolanaConnection } from "./solana-connection";
  * deferred poll, so a wake-up is delayed to the interval boundary, never lost.
  */
 const MAX_SIGNATURES_PER_TICK = 1_000;
+/** Bounds one poll's paging at 10k signatures per program. */
+const MAX_SIGNATURE_PAGES = 10;
 
 export class SignaturesSource implements BlockSource {
   private connection: SolanaConnection | null = null;
@@ -110,7 +113,6 @@ export class SignaturesSource implements BlockSource {
 
   private runPoll(): void {
     this.isProcessing = true;
-    this.lastPollAt = Date.now();
     void this.poll()
       .catch((err) => {
         logger.warn(
@@ -118,6 +120,11 @@ export class SignaturesSource implements BlockSource {
         );
       })
       .finally(() => {
+        // Stamped on completion, not on entry. Measuring from entry means any
+        // poll slower than the interval leaves the guard already satisfied when
+        // it finishes, so the source runs back-to-back on exactly the busy
+        // chains the floor exists to protect.
+        this.lastPollAt = Date.now();
         this.isProcessing = false;
         if (this.pendingTick) {
           this.pendingTick = false;
@@ -142,17 +149,9 @@ export class SignaturesSource implements BlockSource {
         }
         continue;
       }
-      const sigs = await this.connection.getSignaturesForAddress(programId, {
-        until,
-        limit: MAX_SIGNATURES_PER_TICK,
-      });
+      const sigs = await this.collectSignaturesSince(programId, until);
       if (sigs.length === 0) {
         continue;
-      }
-      if (sigs.length === MAX_SIGNATURES_PER_TICK) {
-        logger.warn(
-          `[signatures] chain ${this.opts.chainId} program ${programId} hit the ${MAX_SIGNATURES_PER_TICK} cap; older signatures in this window may be skipped`,
-        );
       }
       // Newest-first from the RPC; advance the cursor to the newest, process
       // oldest-first so downstream ordering matches on-chain ordering.
@@ -162,10 +161,55 @@ export class SignaturesSource implements BlockSource {
         if (info.err) {
           continue; // failed tx emits no meaningful events
         }
+        if (!this.connection) {
+          // stop() ran mid-window; drop the rest rather than dispatching for a
+          // chain the reconciler has already torn down.
+          return;
+        }
         await this.processSignature(info.signature, info.slot);
       }
       this.cursors.set(programId, newest);
     }
+  }
+
+  /**
+   * Every signature for `programId` newer than `until`, newest-first.
+   *
+   * One request returns at most `MAX_SIGNATURES_PER_TICK`, so a busy window
+   * needs paging: without it the caller would advance its cursor to the newest
+   * signature while never seeing anything older than the page boundary, dropping
+   * those events permanently and silently. Paging walks backwards with `before`
+   * until the window is exhausted. `MAX_SIGNATURE_PAGES` bounds the work a
+   * single poll can do; hitting it is loud, because past that point events are
+   * being dropped for real.
+   */
+  private async collectSignaturesSince(
+    programId: string,
+    until: string,
+  ): Promise<ConfirmedSignatureInfo[]> {
+    const collected: ConfirmedSignatureInfo[] = [];
+    let before: string | undefined;
+
+    for (let page = 0; page < MAX_SIGNATURE_PAGES; page++) {
+      if (!this.connection) {
+        break;
+      }
+      const batch = await this.connection.getSignaturesForAddress(programId, {
+        until,
+        before,
+        limit: MAX_SIGNATURES_PER_TICK,
+      });
+      collected.push(...batch);
+      if (batch.length < MAX_SIGNATURES_PER_TICK) {
+        return collected;
+      }
+      before = batch[batch.length - 1].signature;
+    }
+
+    logger.error(
+      `[signatures] chain ${this.opts.chainId} program ${programId} exceeded ${MAX_SIGNATURE_PAGES} pages (${collected.length} signatures) in one window; older signatures are being dropped - raise SOLANA_SIGNATURES_POLL_INTERVAL_MS pressure or move this chain to Geyser`,
+    );
+    return collected;
   }
 
   private async processSignature(

--- a/keeperhub-events/solana-tracker/src/ingest/source-factory.ts
+++ b/keeperhub-events/solana-tracker/src/ingest/source-factory.ts
@@ -25,6 +25,25 @@ export interface SourceSelection {
   hasBlockTriggers?: boolean;
 }
 
+/**
+ * Chains calls so each block is fully processed before the next begins,
+ * regardless of which source produced it.
+ *
+ * The rejection still reaches the caller - `GetBlockSource` relies on a thrown
+ * `onBlock` to hold its cursor at the failed slot - while the internal chain
+ * absorbs it, so one failed block does not stall every block queued behind it.
+ */
+function serializeBlocks(
+  onBlock: BlockSourceOptions["onBlock"],
+): BlockSourceOptions["onBlock"] {
+  let tail: Promise<unknown> = Promise.resolve();
+  return (block) => {
+    const processed = tail.then(() => onBlock(block));
+    tail = processed.catch(() => undefined);
+    return processed;
+  };
+}
+
 export function createBlockSource(
   opts: BlockSourceOptions,
   selection: SourceSelection = {},
@@ -43,9 +62,16 @@ export function createBlockSource(
       // programs -> transactionDetails "none") rather than reverting the whole
       // chain to getBlock: that revert would put event matching back on the
       // full-block firehose, which is unaffordable at mainnet throughput.
+      // Both members feed the same onBlock, and BlockSourceOptions specifies
+      // that blocks are delivered serially - the ingestor's dedup is a
+      // check-then-set spanning two awaits, so concurrent delivery could let one
+      // signature past the check twice. Independent sources cannot honour that
+      // between themselves, so serialize here rather than relying on the
+      // members never producing the same transaction.
+      const onBlock = serializeBlocks(opts.onBlock);
       return new CompositeSource(opts.chainId, opts.endpoints, [
-        new SignaturesSource(opts),
-        new GetBlockSource({ ...opts, watchedProgramIds: [] }),
+        new SignaturesSource({ ...opts, onBlock }),
+        new GetBlockSource({ ...opts, watchedProgramIds: [], onBlock }),
       ]);
     }
     return new SignaturesSource(opts);

--- a/keeperhub-events/solana-tracker/src/main.ts
+++ b/keeperhub-events/solana-tracker/src/main.ts
@@ -12,8 +12,9 @@ import type { ChainRegistration } from "./registrations";
 /**
  * Reconciler: one BlockIngestor per Solana chain, keyed by chainId. Mirrors the
  * block-dispatcher's converge loop - remove stale chains, add new ones, and on
- * a config change either refresh the trigger set in place (endpoints unchanged)
- * or restart the ingestor (endpoints changed).
+ * a config change either refresh the trigger set in place or restart the
+ * ingestor, depending on whether the change reaches inputs the running
+ * BlockSource baked in at construction (see `canUpdateInPlace`).
  */
 
 const registry = new Map<number, BlockIngestor>();
@@ -56,11 +57,11 @@ async function reconcile(registrations: ChainRegistration[]): Promise<void> {
       if (!existing) {
         await startIngestor(registration);
       } else if (existing.hasConfigChanged(registration)) {
-        if (existing.sameEndpoints(registration)) {
+        if (existing.canUpdateInPlace(registration)) {
           existing.updateRegistration(registration);
         } else {
           logger.log(
-            `[Reconciler] chain ${registration.chainId} endpoints changed; restarting`,
+            `[Reconciler] chain ${registration.chainId} source inputs changed; restarting`,
           );
           await existing.stop();
           registry.delete(registration.chainId);

--- a/keeperhub-events/solana-tracker/src/mapper.ts
+++ b/keeperhub-events/solana-tracker/src/mapper.ts
@@ -85,8 +85,21 @@ type SourceMode = "getblock" | "signatures";
  * one whole-block pull). Any other value leaves selection to the default.
  */
 function sourceModeOverride(): SourceMode | undefined {
-  const raw = process.env.SOLANA_SOURCE_MODE;
-  return raw === "signatures" || raw === "getblock" ? raw : undefined;
+  const raw = process.env.SOLANA_SOURCE_MODE?.trim().toLowerCase();
+  if (!raw) {
+    return undefined;
+  }
+  if (raw === "signatures" || raw === "getblock") {
+    return raw;
+  }
+  // Unrecognised values fall through to the per-chain default, which is
+  // `signatures` on mainnet - the opposite of what an operator typing
+  // "getBlock" during an incident intends. Say so rather than silently
+  // running the mode they were trying to leave.
+  logger.warn(
+    `[mapper] SOLANA_SOURCE_MODE="${process.env.SOLANA_SOURCE_MODE}" is not "signatures" or "getblock"; ignoring it and using the per-chain default`,
+  );
+  return undefined;
 }
 
 /**
@@ -105,7 +118,11 @@ function defaultSourceMode(
   network: NetworkConfig,
   hasEventTriggers: boolean,
 ): SourceMode | undefined {
-  if (!hasEventTriggers || network.isTestnet) {
+  // Explicit `!== false` rather than a truthiness test: discovery payloads are
+  // not runtime-validated and `chains.is_testnet` is nullable, so a null would
+  // otherwise read as mainnet and pull a testnet onto the mainnet path.
+  const isMainnet = network.isTestnet === false;
+  if (!hasEventTriggers || !isMainnet) {
     return undefined;
   }
   return "signatures";

--- a/keeperhub-events/solana-tracker/tests/unit/block-ingestor-reconcile.test.ts
+++ b/keeperhub-events/solana-tracker/tests/unit/block-ingestor-reconcile.test.ts
@@ -1,0 +1,156 @@
+import type { SQSClient } from "@aws-sdk/client-sqs";
+import { describe, expect, it } from "vitest";
+import type { DedupStore } from "../../src/dedup";
+import { BlockIngestor } from "../../src/ingest/block-ingestor";
+import type {
+  ChainRegistration,
+  SolanaBlockTrigger,
+  SolanaEventTrigger,
+} from "../../src/registrations";
+
+const PROGRAM_A = "So11111111111111111111111111111111111111112";
+const PROGRAM_B = "Vote111111111111111111111111111111111111111";
+
+function eventTrigger(
+  workflowId: string,
+  programId: string,
+  overrides: Partial<SolanaEventTrigger> = {},
+): SolanaEventTrigger {
+  return {
+    workflowId,
+    userId: "user-1",
+    workflowName: workflowId,
+    programId,
+    configHash: `${workflowId}-${programId}`,
+    ...overrides,
+  };
+}
+
+function blockTrigger(workflowId: string): SolanaBlockTrigger {
+  return {
+    workflowId,
+    userId: "user-1",
+    workflowName: workflowId,
+    blockInterval: 1,
+    configHash: workflowId,
+  };
+}
+
+function registration(
+  overrides: Partial<ChainRegistration> = {},
+): ChainRegistration {
+  return {
+    chainId: 101,
+    rpcUrl: "https://rpc.example",
+    wssUrl: "wss://ws.example",
+    commitment: "confirmed",
+    sourceMode: "signatures",
+    eventTriggers: [eventTrigger("wf-1", PROGRAM_A)],
+    blockTriggers: [],
+    configHash: "base",
+    ...overrides,
+  };
+}
+
+function ingestorFor(reg: ChainRegistration): BlockIngestor {
+  // Constructing does not open connections; start() is never called here.
+  return new BlockIngestor({
+    registration: reg,
+    sqs: {} as SQSClient,
+    sqsQueueUrl: "",
+    dedup: {} as DedupStore,
+  });
+}
+
+describe("BlockIngestor.canUpdateInPlace", () => {
+  it("allows an in-place update when only trigger metadata changed", () => {
+    const ingestor = ingestorFor(registration());
+    const next = registration({
+      eventTriggers: [
+        eventTrigger("wf-1", PROGRAM_A, {
+          eventName: "OFTSent",
+          configHash: "changed",
+        }),
+      ],
+      configHash: "next",
+    });
+
+    expect(ingestor.canUpdateInPlace(next)).toBe(true);
+  });
+
+  it("requires a restart when a new watched program appears", () => {
+    // The running signatures source queries a program list frozen at start, so
+    // absorbing this in place would leave the new program's workflow dead.
+    const ingestor = ingestorFor(registration());
+    const next = registration({
+      eventTriggers: [
+        eventTrigger("wf-1", PROGRAM_A),
+        eventTrigger("wf-2", PROGRAM_B),
+      ],
+      configHash: "next",
+    });
+
+    expect(ingestor.canUpdateInPlace(next)).toBe(false);
+  });
+
+  it("requires a restart when a watched program disappears", () => {
+    const ingestor = ingestorFor(
+      registration({
+        eventTriggers: [
+          eventTrigger("wf-1", PROGRAM_A),
+          eventTrigger("wf-2", PROGRAM_B),
+        ],
+      }),
+    );
+
+    expect(ingestor.canUpdateInPlace(registration())).toBe(false);
+  });
+
+  it("requires a restart when block triggers appear, so the composite is built", () => {
+    const ingestor = ingestorFor(registration());
+    const next = registration({
+      blockTriggers: [blockTrigger("wf-block")],
+      configHash: "next",
+    });
+
+    expect(ingestor.canUpdateInPlace(next)).toBe(false);
+  });
+
+  it("requires a restart when block triggers disappear", () => {
+    const ingestor = ingestorFor(
+      registration({ blockTriggers: [blockTrigger("wf-block")] }),
+    );
+
+    expect(ingestor.canUpdateInPlace(registration())).toBe(false);
+  });
+
+  it("still allows an in-place update when a second workflow watches a program already watched", () => {
+    // Two triggers on one program are one program to watch, so the source's
+    // inputs are unchanged and a restart would be pure downtime.
+    const ingestor = ingestorFor(registration());
+    const next = registration({
+      eventTriggers: [
+        eventTrigger("wf-1", PROGRAM_A),
+        eventTrigger("wf-2", PROGRAM_A),
+      ],
+      configHash: "next",
+    });
+
+    expect(ingestor.canUpdateInPlace(next)).toBe(true);
+  });
+
+  it("requires a restart when endpoints or source mode change", () => {
+    const ingestor = ingestorFor(registration());
+
+    expect(
+      ingestor.canUpdateInPlace(
+        registration({ wssUrl: "wss://other.example", configHash: "next" }),
+      ),
+    ).toBe(false);
+    expect(
+      ingestor.canUpdateInPlace(
+        registration({ sourceMode: "getblock", configHash: "next" }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/keeperhub-events/solana-tracker/tests/unit/mapper.test.ts
+++ b/keeperhub-events/solana-tracker/tests/unit/mapper.test.ts
@@ -199,6 +199,35 @@ describe("buildRegistrations", () => {
     expect(buildRegistrations(testnet)[0].sourceMode).toBe("signatures");
   });
 
+  it("accepts SOLANA_SOURCE_MODE regardless of case or surrounding space", () => {
+    // "getBlock" is the spelling used by the class name, the code comments and
+    // the spec, so it is what an operator reaches for under pressure.
+    process.env.SOLANA_SOURCE_MODE = " getBlock ";
+    const regs = buildRegistrations(
+      data({
+        eventWorkflows: [eventWorkflow("wf-1", "101", VALID_PROGRAM)],
+        networks: { 101: solanaNetwork(101) },
+      }),
+    );
+    expect(regs[0].sourceMode).toBe("getblock");
+  });
+
+  it("treats a chain with an unknown isTestnet as a testnet, not mainnet", () => {
+    // chains.is_testnet is nullable and discovery payloads are not validated;
+    // a null must not read as mainnet and pull a testnet onto the mainnet path.
+    const regs = buildRegistrations(
+      data({
+        eventWorkflows: [eventWorkflow("wf-1", "103", VALID_PROGRAM)],
+        networks: {
+          103: solanaNetwork(103, {
+            isTestnet: undefined as unknown as boolean,
+          }),
+        },
+      }),
+    );
+    expect(regs[0].sourceMode).toBeUndefined();
+  });
+
   it("ignores an unrecognised SOLANA_SOURCE_MODE and keeps the default", () => {
     process.env.SOLANA_SOURCE_MODE = "geyser";
     const regs = buildRegistrations(

--- a/keeperhub-events/solana-tracker/tests/unit/signatures-source.test.ts
+++ b/keeperhub-events/solana-tracker/tests/unit/signatures-source.test.ts
@@ -1,11 +1,19 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+type SignatureInfo = { signature: string; slot: number };
+type SignatureQuery = { until?: string; before?: string; limit?: number };
+
 // Controllable stand-in for the per-chain Solana connection so the source's
-// poll cadence can be driven deterministically without any network.
+// poll cadence and paging can be driven deterministically without any network.
 const hooks = vi.hoisted(() => ({
   onSlot: null as null | ((slot: number) => void),
-  signatureCalls: [] as { address: string; until?: string }[],
-  signatures: (_address: string): { signature: string; slot: number }[] => [],
+  signatureCalls: [] as { address: string; until?: string; before?: string }[],
+  signatures: (
+    _address: string,
+    _options: { until?: string; before?: string; limit?: number },
+  ): { signature: string; slot: number }[] => [],
+  // Simulates a poll slower than the interval. Resolved by fake timers.
+  delayMs: 0,
 }));
 
 vi.mock("@/src/ingest/solana-connection", () => ({
@@ -21,10 +29,20 @@ vi.mock("@/src/ingest/solana-connection", () => ({
     }
     getSignaturesForAddress(
       address: string,
-      options: { until?: string },
+      options: SignatureQuery,
     ): Promise<unknown[]> {
-      hooks.signatureCalls.push({ address, until: options.until });
-      return Promise.resolve(hooks.signatures(address));
+      hooks.signatureCalls.push({
+        address,
+        until: options.until,
+        before: options.before,
+      });
+      const result = hooks.signatures(address, options);
+      if (hooks.delayMs === 0) {
+        return Promise.resolve(result);
+      }
+      return new Promise((resolve) => {
+        setTimeout(() => resolve(result), hooks.delayMs);
+      });
     }
     getTransaction(): Promise<unknown> {
       return Promise.resolve({ meta: { logMessages: [] }, blockTime: 0 });
@@ -39,24 +57,35 @@ const { SignaturesSource } = await import("@/src/ingest/signatures-source");
 
 const PROGRAM = "So11111111111111111111111111111111111111112";
 const POLL_INTERVAL_MS = 1000;
+const PAGE_SIZE = 1000;
 
-function source(): InstanceType<typeof SignaturesSource> {
+function source(
+  onBlock: () => Promise<void> = () => Promise.resolve(),
+): InstanceType<typeof SignaturesSource> {
   return new SignaturesSource(
     {
       chainId: 101,
       endpoints: [{ rpcUrl: "r", wssUrl: "w" }],
       commitment: "confirmed",
       watchedProgramIds: [PROGRAM],
-      onBlock: () => Promise.resolve(),
+      onBlock,
     },
     POLL_INTERVAL_MS,
   );
+}
+
+function page(prefix: string, count: number): SignatureInfo[] {
+  return Array.from({ length: count }, (_, i) => ({
+    signature: `${prefix}-${i}`,
+    slot: i,
+  }));
 }
 
 afterEach(() => {
   vi.useRealTimers();
   hooks.signatureCalls = [];
   hooks.signatures = () => [];
+  hooks.delayMs = 0;
 });
 
 describe("SignaturesSource poll throttle", () => {
@@ -86,6 +115,32 @@ describe("SignaturesSource poll throttle", () => {
 
     // With no further ticks the source goes quiet rather than free-running.
     await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 5);
+    expect(hooks.signatureCalls).toHaveLength(3);
+
+    await src.stop();
+  });
+
+  it("still waits a full interval after a poll that outlasts the interval", async () => {
+    // Regression guard: measuring the interval from poll start leaves the guard
+    // already satisfied when a slow poll returns, so the source free-runs on
+    // exactly the busy chains the floor protects.
+    vi.useFakeTimers();
+    hooks.signatures = () => [{ signature: "seed-sig", slot: 1 }];
+
+    const src = source();
+    await src.start();
+    hooks.signatures = () => [];
+    hooks.delayMs = POLL_INTERVAL_MS * 3;
+
+    hooks.onSlot?.(1);
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 3);
+    expect(hooks.signatureCalls).toHaveLength(2);
+
+    hooks.onSlot?.(2);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(hooks.signatureCalls).toHaveLength(2);
+
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
     expect(hooks.signatureCalls).toHaveLength(3);
 
     await src.stop();
@@ -128,6 +183,55 @@ describe("SignaturesSource poll throttle", () => {
     await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 3);
 
     expect(hooks.signatureCalls).toHaveLength(callsBeforeStop);
+
+    await src.stop();
+  });
+});
+
+describe("SignaturesSource windowing", () => {
+  it("pages backwards instead of skipping past a full response", async () => {
+    // A full page means the window is not exhausted. Advancing the cursor to
+    // the newest signature at that point drops everything older, permanently.
+    hooks.signatures = () => [{ signature: "seed-sig", slot: 1 }];
+    let processed = 0;
+    const src = source(() => {
+      processed++;
+      return Promise.resolve();
+    });
+    await src.start();
+
+    const first = page("new", PAGE_SIZE);
+    const second = page("old", 3);
+    hooks.signatures = (_address, options) =>
+      options.before === undefined ? first : second;
+
+    hooks.onSlot?.(1);
+    await vi.waitFor(() => expect(processed).toBe(PAGE_SIZE + second.length));
+
+    const pollCalls = hooks.signatureCalls.slice(1);
+    expect(pollCalls).toHaveLength(2);
+    expect(pollCalls[0].before).toBeUndefined();
+    // Second page continues from the oldest signature of the first.
+    expect(pollCalls[1].before).toBe(`new-${PAGE_SIZE - 1}`);
+    expect(pollCalls[1].until).toBe("seed-sig");
+
+    await src.stop();
+  });
+
+  it("stops paging once a short page shows the window is exhausted", async () => {
+    hooks.signatures = () => [{ signature: "seed-sig", slot: 1 }];
+    let processed = 0;
+    const src = source(() => {
+      processed++;
+      return Promise.resolve();
+    });
+    await src.start();
+
+    hooks.signatures = () => page("new", 2);
+
+    hooks.onSlot?.(1);
+    await vi.waitFor(() => expect(processed).toBe(2));
+    expect(hooks.signatureCalls.slice(1)).toHaveLength(1);
 
     await src.stop();
   });

--- a/keeperhub-events/solana-tracker/tests/unit/source-factory.test.ts
+++ b/keeperhub-events/solana-tracker/tests/unit/source-factory.test.ts
@@ -54,6 +54,47 @@ describe("createBlockSource selection", () => {
     expect(getBlockMember.opts.watchedProgramIds).toEqual([]);
   });
 
+  it("serializes onBlock across composite members", async () => {
+    // The ingestor's dedup is a check-then-set spanning two awaits, so the two
+    // members must not deliver blocks concurrently.
+    const order: string[] = [];
+    let resolveFirst: (() => void) | undefined;
+    const base = opts();
+    const source = createBlockSource(
+      {
+        ...base,
+        onBlock: (block) => {
+          order.push(`start:${block.slot}`);
+          if (block.slot === 1) {
+            return new Promise<void>((resolve) => {
+              resolveFirst = () => {
+                order.push("end:1");
+                resolve();
+              };
+            });
+          }
+          order.push(`end:${block.slot}`);
+          return Promise.resolve();
+        },
+      },
+      { sourceMode: "signatures", hasBlockTriggers: true },
+    ) as CompositeSource;
+
+    const members = source.sources as unknown as {
+      opts: BlockSourceOptions;
+    }[];
+    const first = members[0].opts.onBlock({ slot: 1 } as never);
+    const second = members[1].opts.onBlock({ slot: 2 } as never);
+
+    // The second member's block must not begin while the first is in flight.
+    await Promise.resolve();
+    expect(order).toEqual(["start:1"]);
+
+    resolveFirst?.();
+    await Promise.all([first, second]);
+    expect(order).toEqual(["start:1", "end:1", "start:2", "end:2"]);
+  });
+
   it("uses Geyser whenever an endpoint is configured, overriding sourceMode", () => {
     expect(
       createBlockSource(opts(), {


### PR DESCRIPTION
Follow-up to #2034, which made the filtered `signatures` source the mainnet default for Solana event ingestion. A review of that change surfaced defects it introduced or promoted; this fixes them. The behaviour below is live on `staging` now.

## The regression that matters most

`reconcile` absorbed any config change with unchanged endpoints via `updateRegistration`, which only refreshes what the matchers read per block. The watched program set and whether block triggers exist are captured by the `BlockSource` at construction and unreachable afterwards. So on a chain running `signatures`:

- adding an event workflow for a new program left that program unqueried, and
- adding a block-interval workflow left it unserved entirely, since the signatures source emits `blockHeight: null` and `matchBlocks` returns nothing for it.

Both silent, both until the pod restarted. This worked before #2034 because a whole-block `getBlock` pull is program-agnostic and serves both trigger types.

`canUpdateInPlace` now also compares the distinct watched programs and block-trigger presence; anything else restarts the source.

## Data loss in the newly default path

`getSignaturesForAddress` returns at most 1000 entries. On a full response the window is not exhausted, but the cursor still advanced to the newest signature - so everything older than the page boundary was dropped permanently, with only a warn line. The 2000 ms poll floor widened the window that triggers it.

`collectSignaturesSince` now pages backwards with `before` until the window is exhausted. Paging is bounded per program per poll; exceeding the bound logs at error level. That ceiling is a real limit of this approach on very hot programs and is the argument for Geyser there, but it is now loud rather than silent.

## The poll floor did not engage where it was needed

`lastPollAt` was stamped on entry, so any poll slower than the interval left the guard already satisfied when it returned and the source ran back-to-back - on exactly the busy chains the floor was added to protect. It is now stamped on completion.

## Smaller fixes

- Watched program IDs are deduped, so ten workflows on one program cost one RPC round trip per poll rather than ten. The source's own cost model is per program; the implementation was per trigger.
- `onBlock` is serialized across composite members. `BlockSourceOptions` specifies serial delivery and the ingestor's dedup is a check-then-set spanning two awaits; independent sources cannot honour that between themselves. Rejections still propagate, so `GetBlockSource`'s resume-at-failed-slot behaviour is preserved.
- An in-flight poll whose connection was torn down mid-window now stops instead of dereferencing null and dispatching one more trigger for a removed chain.
- `isTestnet` is checked with `=== false`. The column is nullable and discovery payloads are not runtime-validated, so a null read as mainnet.
- `SOLANA_SOURCE_MODE` is matched case- and space-insensitively, and an unrecognised value warns. `getBlock` is the spelling used by the class name, the comments and the spec, and an unrecognised value now falls through to a mainnet default of `signatures` - the opposite of what an operator typing it during an incident intends.
- An explicit poll interval of `0` is honoured instead of being coerced back to the default by `Number(x) || 2000`; a malformed value warns.

## Verification

From `keeperhub-events`, matching the workflow:

- `pnpm -r test:unit` - 81 passing across 13 files, up from 68 across 12. New coverage for in-place-versus-restart resolution, backward paging and its exhaustion case, the slow-poll regression guard, onBlock serialization ordering, case-insensitive override, and null `isTestnet`.
- `pnpm typecheck` - clean, both packages.
- `pnpm lint` - clean, 106 files.

## Deliberately not included

- **Sharing one `SolanaConnection` across composite members.** `/healthz` already returns 503 when any chain is disconnected, so the composite does not create that blast radius - it doubles the odds per chain. Removing the doubling means multi-listener slot subscriptions, which is a refactor rather than a patch, and the composite is not reachable in production today (it needs a chain with both trigger types).
- **`SOLANA_SOURCE_MODE` and `SOLANA_SIGNATURES_POLL_INTERVAL_MS` in the Helm env block.** Both are documented as operator levers but neither is settable without a chart change. Small separate PR.
- **Type-checking the test files.** `tsconfig.json` includes only `src` and `lib`, so tsc never sees `tests/**` and vitest erases types via esbuild - the new suites run but are not type-gated.
- **The integration job's `--filter`**, which still skips solana-tracker, and the composite's per-slot header fetches for block triggers.
