### PR TITLE
docs(wallet): make funding guidance sponsorship-aware

### DIFF
--- a/docs/guides/first-verified-transaction.md
+++ b/docs/guides/first-verified-transaction.md
@@ -62,7 +62,7 @@ to read. Four roles are easy to conflate, and they are frequently different addr
 
 | Role | What it does |
 | --- | --- |
-| Turnkey EOA | signs and broadcasts the outer transaction, and pays gas |
+| Turnkey EOA | signs the transaction. On an unsponsored route it also broadcasts the outer transaction and pays the gas. On a [sponsored](/wallet-management/gas) route a relayer submits and pays instead, so `receipt.from` is not your wallet |
 | Safe | `msg.sender` at the target contract, when signer routing is on |
 | Zodiac Roles modifier | validates the call against an allowlist and per-token allowances, when enabled |
 | Token holder | the account whose balance actually decreases |

--- a/docs/wallet-management/turnkey.md
+++ b/docs/wallet-management/turnkey.md
@@ -27,13 +27,24 @@ before concluding a run did not work.
 
 ## Wallet Funding
 
-Topping up your Turnkey EOA with native gas tokens (ETH on Ethereum, ETH on Base, MATIC on Polygon, SOL on Solana, etc.) is required for any workflow that broadcasts a transaction.
+Whether your Turnkey EOA needs native gas tokens (ETH on Ethereum, ETH on Base, MATIC on
+Polygon, SOL on Solana, etc.) depends on the route the write takes.
+
+- **On a sponsored route**, the transaction is submitted on your wallet's behalf and the gas is
+  paid for you, so the EOA can hold zero native balance. Eligibility is per organization and is
+  metered against your gas credits, so it is a condition rather than a guarantee. See
+  [Gas Management](/wallet-management/gas) for what sponsorship covers and when it applies.
+- **On an unsponsored route**, the wallet that signs and broadcasts pays the fee, so it needs
+  native gas.
+
+Value is a separate question from gas. Any transaction that moves ETH or tokens needs the sending
+account to hold that asset, whether or not the gas is sponsored.
 
 **When funding is needed**:
 
-- Write function calls (require gas fees)
-- Token or ETH transfer operations
-- Any workflow steps that execute blockchain transactions
+- Write function calls on an unsponsored route (the signer pays the gas fee)
+- Token or ETH transfer operations (the sender must hold the asset being moved)
+- Any workflow step that both executes onchain and is not covered by sponsorship
 
 **When funding is not needed**:
 

--- a/docs/wallet-management/turnkey.md
+++ b/docs/wallet-management/turnkey.md
@@ -27,15 +27,19 @@ before concluding a run did not work.
 
 ## Wallet Funding
 
-Whether your Turnkey EOA needs native gas tokens (ETH on Ethereum, ETH on Base, MATIC on
-Polygon, SOL on Solana, etc.) depends on the route the write takes.
+Whether your Turnkey EOA needs native gas tokens depends on the route the write takes. This
+route condition applies to EVM chains (ETH on Ethereum, ETH on Base, MATIC on Polygon, etc.)
+only -- there is no sponsored route on Solana, so a Solana account always pays its own
+transaction fee from its SOL balance.
 
-- **On a sponsored route**, the transaction is submitted on your wallet's behalf and the gas is
-  paid for you, so the EOA can hold zero native balance. Eligibility is per organization and is
-  metered against your gas credits, so it is a condition rather than a guarantee. See
+- **On a sponsored EVM route**, the transaction is submitted on your wallet's behalf and the gas
+  is paid for you, so the EOA can hold zero native balance. Eligibility is per organization and
+  is metered against your gas credits, so it is a condition rather than a guarantee. See
   [Gas Management](/wallet-management/gas) for what sponsorship covers and when it applies.
-- **On an unsponsored route**, the wallet that signs and broadcasts pays the fee, so it needs
-  native gas.
+- **On an unsponsored EVM route**, the wallet that signs and broadcasts pays the fee, so it
+  needs native gas.
+- **On Solana**, fund the account with SOL to cover the transaction fee; sponsorship does not
+  apply.
 
 Value is a separate question from gas. Any transaction that moves ETH or tokens needs the sending
 account to hold that asset, whether or not the gas is sponsored.
@@ -56,7 +60,7 @@ account to hold that asset, whether or not the gas is sponsored.
 
 The EOA plays two distinct roles in a workflow write. Keep them separate when topping up.
 
-1. **Gas (depends on the route).** The EOA always signs. On an unsponsored route it also broadcasts and pays the fee from its own native balance. On a sponsored route the transaction is submitted on the wallet's behalf and the gas is paid for it, so the EOA's native balance is untouched. See [Wallet Funding](#wallet-funding) above and [Gas Management](/wallet-management/gas). Either way, this is independent of whether you have a Safe configured as the Sender.
+1. **Gas (depends on the route).** The EOA always signs. On an unsponsored route it also broadcasts and pays the fee from its own native balance. On a sponsored route the transaction is submitted on the wallet's behalf and the gas is paid for it, so the EOA's native balance is untouched. See [Wallet Funding](#wallet-funding) above and [Gas Management](/wallet-management/gas). A Safe configured as the Sender forces the unsponsored route, so the EOA needs native gas whenever a Safe is the Sender -- see [Safe wallets](/wallet-management/gas#safe-wallets).
 
 2. **Transactable balance (the active Sender).** If you have a [Safe](/wallet-management/safe) deployed and marked as the Sender on a chain, the Safe's balance is what gets debited when the workflow transfers a native token, approves or transfers an ERC20, swaps, or deposits into a protocol. If no Safe is the Sender, the EOA's own token balance is used instead.
 

--- a/docs/wallet-management/turnkey.md
+++ b/docs/wallet-management/turnkey.md
@@ -56,7 +56,7 @@ account to hold that asset, whether or not the gas is sponsored.
 
 The EOA plays two distinct roles in a workflow write. Keep them separate when topping up.
 
-1. **Gas (always the EOA).** Every workflow transaction is signed and broadcast by the EOA, and the gas fee is paid from the EOA's native balance. This is true whether or not you have a Safe configured as the Sender.
+1. **Gas (depends on the route).** The EOA always signs. On an unsponsored route it also broadcasts and pays the fee from its own native balance. On a sponsored route the transaction is submitted on the wallet's behalf and the gas is paid for it, so the EOA's native balance is untouched. See [Wallet Funding](#wallet-funding) above and [Gas Management](/wallet-management/gas). Either way, this is independent of whether you have a Safe configured as the Sender.
 
 2. **Transactable balance (the active Sender).** If you have a [Safe](/wallet-management/safe) deployed and marked as the Sender on a chain, the Safe's balance is what gets debited when the workflow transfers a native token, approves or transfers an ERC20, swaps, or deposits into a protocol. If no Safe is the Sender, the EOA's own token balance is used instead.
 


### PR DESCRIPTION
## The contradiction

`docs/wallet-management/turnkey.md` contradicts itself within one page. Line 22:

> On networks where gas is sponsored, a workflow write is submitted on your wallet's behalf rather than directly by it

Line 30, under **Wallet Funding**:

> Topping up your Turnkey EOA with native gas tokens ... **is required for any workflow that broadcasts a transaction.**

`docs/wallet-management/gas.md` documents the opposite for eligible routes:

> ...through Turnkey's Gas Station, so a workflow can run even when the sending wallet holds no native gas token. Sponsorship is enabled per organization and metered against a monthly gas [credit]

`docs/api/headless-onboarding.md` is already correct and even carries a measured Base example, so the drift is not everywhere.

The second one is `docs/guides/first-verified-transaction.md`, in the role table a reader uses to interpret a receipt:

> | Turnkey EOA | signs and broadcasts the outer transaction, and pays gas |

Stated unconditionally. Under a sponsored route the EOA does neither.

## Why it matters for a first run

These are the two pages someone reads before their first write, and both failure modes cost real time.

A builder reads "required for any workflow that broadcasts" and goes hunting for testnet gas they do not need. Then they run the transaction, open their organisation wallet on a block explorer expecting to see it because the role table told them that wallet broadcasts and pays, find an empty transaction list, and conclude the run failed.

## The change

Separates the two questions a first-run builder actually has, which the current text conflates:

- does this **route** need gas (sponsored or not)
- does this **transaction** move value (ETH or tokens)

Gas Management stays the single source of truth for eligibility, so the rules are cross-linked rather than duplicated into pages where they can drift. Sponsorship is described as a metered, per-organization condition rather than a guarantee.

Two files, 16 added lines. I deliberately left the conservative "fund your wallet first" advice in `FAQ.md` and `platform-reference.md` alone: it is cautious rather than wrong, and changing it is a separate judgement call I would rather you make. Happy to include it if you want.

## Supporting evidence

External measured behaviour, offered as reproduction rather than as a source of platform policy. Your own docs remain the authority on what sponsorship covers.

Two independent KeeperHub organisations, each executing a zero-value contract call on Base Sepolia from an organisation wallet holding **zero** native balance:

| | canonical | clean-room |
|---|---|---|
| transaction | [`0xb4098917…d452dc`](https://sepolia.basescan.org/tx/0xb4098917d12030a249e9376217d765b715362c744dd23e9b03e0213253d452dc) | [`0x642002f7…aff852`](https://sepolia.basescan.org/tx/0x642002f79b9a6ae4570c84f6b8d3c0a12a9f001304a7921e48f5eb7149aff852) |
| execution | `exnn6k0y1ojnnvb8sa1fu` | `j6cjarjfr3obh6syblyjd` |
| org wallet balance | 0 before and after | 0 before and after |
| status `sponsored` | true | true |
| `receipt.from` | a relayer, not the org wallet | same relayer |

The second organisation was created that morning specifically to check this without inheriting any state from the first: its wallet was balance 0, nonce 0, no code, never used.

**This shows sponsorship occurred for two organisations. It does not prove it applies to all of them**, which is exactly why the patch describes eligibility as a condition and links to Gas Management rather than promising anything.

Found while building [keeperhub-flightcheck](https://github.com/winsznx/keeperhub-flightcheck) for the Agents Onchain hackathon.
