### PR TITLE
fix: #2108 default tools/call arguments to {} — only null hits the opaque -32603, omitted already fails cleanly

### DIFF
--- a/app/mcp/public/route.ts
+++ b/app/mcp/public/route.ts
@@ -5,6 +5,7 @@ import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { McpEventStore } from "@/lib/mcp/event-store";
 import { getInternalApiBaseUrl } from "@/lib/mcp/internal-url";
 import { logMcpEvent } from "@/lib/mcp/logging";
+import { normalizeToolCallArguments } from "@/lib/mcp/normalize-tool-call-arguments";
 import { SCOPE_MCP_PUBLIC } from "@/lib/mcp/oauth-scopes";
 import { checkIpRateLimit, getClientIp } from "@/lib/mcp/rate-limit";
 import { createMcpServer } from "@/lib/mcp/server";
@@ -182,7 +183,7 @@ export async function POST(request: Request): Promise<Response> {
   let body: unknown;
   let bodyParsed = false;
   try {
-    body = await request.json();
+    body = normalizeToolCallArguments(await request.json());
     bodyParsed = true;
   } catch {
     // handled below

--- a/app/mcp/route.ts
+++ b/app/mcp/route.ts
@@ -6,6 +6,7 @@ import { type ApiKeyAuthResult, authenticateApiKey } from "@/lib/api-key-auth";
 import { McpEventStore } from "@/lib/mcp/event-store";
 import { getInternalApiBaseUrl } from "@/lib/mcp/internal-url";
 import { logMcpEvent } from "@/lib/mcp/logging";
+import { normalizeToolCallArguments } from "@/lib/mcp/normalize-tool-call-arguments";
 import { authenticateOAuthToken } from "@/lib/mcp/oauth-auth";
 import { checkMcpRateLimit, type RateLimitResult } from "@/lib/mcp/rate-limit";
 import { createMcpServer } from "@/lib/mcp/server";
@@ -369,7 +370,7 @@ export async function POST(request: Request): Promise<Response> {
   let body: unknown;
   let bodyParsed = false;
   try {
-    body = await request.json();
+    body = normalizeToolCallArguments(await request.json());
     bodyParsed = true;
   } catch {
     // Leave bodyParsed = false; handled below after auth check.

--- a/app/mcp/w/[slug]/route.ts
+++ b/app/mcp/w/[slug]/route.ts
@@ -7,6 +7,7 @@ import { McpEventStore } from "@/lib/mcp/event-store";
 import { getInternalApiBaseUrl } from "@/lib/mcp/internal-url";
 import { getWorkflowListing } from "@/lib/mcp/listing";
 import { logMcpEvent } from "@/lib/mcp/logging";
+import { normalizeToolCallArguments } from "@/lib/mcp/normalize-tool-call-arguments";
 import { authenticateOAuthToken } from "@/lib/mcp/oauth-auth";
 import { checkMcpRateLimit, type RateLimitResult } from "@/lib/mcp/rate-limit";
 import { buildSessionErrorResponse } from "@/lib/mcp/session-error";
@@ -62,12 +63,13 @@ function ensureMcpAcceptHeader(request: Request): Request {
 
   const headers = new Headers(request.headers);
   headers.set("accept", parts.join(", "));
+  // Rebuild from url+method with NO body: POST parses the body up front and
+  // hands the transport the parsed value via parsedBody, and GET carries no
+  // body at all. Constructing `new Request(request, ...)` from a used Request
+  // would throw.
   return new Request(request.url, {
     method: request.method,
     headers,
-    body: request.body,
-    // @ts-expect-error -- duplex is required for streaming bodies in Node
-    duplex: "half",
   });
 }
 
@@ -382,6 +384,21 @@ export async function POST(
     return rateLimitResponse(rateLimit);
   }
 
+  // Parsed here rather than in the initialize branch below so the session
+  // path gets it too: that is where every tools/call on this route lands, and
+  // an `arguments: null` handed straight to the SDK surfaces as an opaque
+  // -32603. Consuming request.body means every transport call from here on
+  // must pass parsedBody.
+  let body: unknown;
+  try {
+    body = normalizeToolCallArguments(await request.json());
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
+      status: HttpStatus.BAD_REQUEST,
+      headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+    });
+  }
+
   const sessionId = request.headers.get("mcp-session-id");
 
   if (sessionId) {
@@ -398,22 +415,13 @@ export async function POST(
       });
     }
     const response = await resolved.transport.handleRequest(
-      ensureMcpAcceptHeader(request)
+      ensureMcpAcceptHeader(request),
+      { parsedBody: body }
     );
     return applyRateLimitHeaders(
       withRenewedSessionHeader(response, resolved.renewedSessionId),
       rateLimit
     );
-  }
-
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
-      status: HttpStatus.BAD_REQUEST,
-      headers: { "Content-Type": "application/json", ...CORS_HEADERS },
-    });
   }
 
   if (!isInitializeRequestBody(body)) {

--- a/lib/mcp/normalize-tool-call-arguments.ts
+++ b/lib/mcp/normalize-tool-call-arguments.ts
@@ -1,0 +1,43 @@
+type JsonRpcMessage = Record<string, unknown>;
+
+function normalizeMessage(message: unknown): unknown {
+  if (
+    !message ||
+    typeof message !== "object" ||
+    (message as JsonRpcMessage).method !== "tools/call"
+  ) {
+    return message;
+  }
+
+  const params = (message as JsonRpcMessage).params;
+  if (!params || typeof params !== "object") {
+    return message;
+  }
+
+  const args = (params as JsonRpcMessage).arguments;
+  if (args !== null && args !== undefined) {
+    return message;
+  }
+
+  return {
+    ...(message as JsonRpcMessage),
+    params: { ...(params as JsonRpcMessage), arguments: {} },
+  };
+}
+
+/**
+ * A `tools/call` sent with `arguments` omitted or explicitly `null` fails the
+ * SDK's `z.record().optional()` params schema with a raw Zod error, which the
+ * transport surfaces as -32603 (Internal error) rather than a validation
+ * error. That reads as "the server is down" on exactly the call an agent is
+ * most likely to make first: a tool with no required parameters, invoked
+ * with no arguments object at all. Defaulting to `{}` here, before the
+ * request reaches the SDK, keeps every per-tool schema (e.g.
+ * get_wallet_integration's required `integrationId`) enforced downstream
+ * unchanged.
+ */
+export function normalizeToolCallArguments(body: unknown): unknown {
+  return Array.isArray(body)
+    ? body.map(normalizeMessage)
+    : normalizeMessage(body);
+}

--- a/lib/mcp/normalize-tool-call-arguments.ts
+++ b/lib/mcp/normalize-tool-call-arguments.ts
@@ -9,8 +9,11 @@ function normalizeMessage(message: unknown): unknown {
     return message;
   }
 
+  // By-position `params` (a JSON-RPC 2.0 array) is not a shape MCP uses, and
+  // spreading one would silently rewrite it into an object. Leave it alone and
+  // let the SDK reject it on its own terms.
   const params = (message as JsonRpcMessage).params;
-  if (!params || typeof params !== "object") {
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
     return message;
   }
 

--- a/lib/mcp/normalize-tool-call-arguments.ts
+++ b/lib/mcp/normalize-tool-call-arguments.ts
@@ -26,15 +26,17 @@ function normalizeMessage(message: unknown): unknown {
 }
 
 /**
- * A `tools/call` sent with `arguments` omitted or explicitly `null` fails the
- * SDK's `z.record().optional()` params schema with a raw Zod error, which the
+ * A `tools/call` with `arguments` explicitly `null` fails the SDK's
+ * `z.record().optional()` params schema with a raw Zod error, which the
  * transport surfaces as -32603 (Internal error) rather than a validation
- * error. That reads as "the server is down" on exactly the call an agent is
- * most likely to make first: a tool with no required parameters, invoked
- * with no arguments object at all. Defaulting to `{}` here, before the
- * request reaches the SDK, keeps every per-tool schema (e.g.
- * get_wallet_integration's required `integrationId`) enforced downstream
- * unchanged.
+ * error - indistinguishable from the server being down. Omitting the key
+ * entirely already parses fine at this schema and fails one layer in with a
+ * proper tool-scoped error instead, so it isn't broken the same way - but on
+ * a tool with no required parameters it should just run. Defaulting both
+ * shapes to `{}` here, before the request reaches the SDK, fixes the null
+ * case's opaque error and lets an all-optional tool run without an
+ * arguments key, while every per-tool schema (e.g. get_wallet_integration's
+ * required `integrationId`) is still enforced downstream unchanged.
  */
 export function normalizeToolCallArguments(body: unknown): unknown {
   return Array.isArray(body)

--- a/tests/unit/mcp-normalize-tool-call-arguments.test.ts
+++ b/tests/unit/mcp-normalize-tool-call-arguments.test.ts
@@ -1,0 +1,64 @@
+/**
+ * KH-1: a `tools/call` with `arguments` omitted or explicitly `null` fails
+ * the SDK's params schema with a raw Zod error, surfaced as -32603 (Internal
+ * error) rather than a validation error - indistinguishable from the server
+ * being down, on exactly the call an agent tries first. This pins the
+ * dispatch-layer default that keeps that from reaching the SDK at all.
+ */
+import { describe, expect, it } from "vitest";
+import { normalizeToolCallArguments } from "@/lib/mcp/normalize-tool-call-arguments";
+
+function toolCall(params: Record<string, unknown>) {
+  return {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params,
+  };
+}
+
+describe("normalizeToolCallArguments", () => {
+  it("defaults arguments to {} when the key is omitted entirely", () => {
+    const body = toolCall({ name: "get_wallet_integration" });
+    const result = normalizeToolCallArguments(body) as typeof body;
+    expect(result.params.arguments).toEqual({});
+  });
+
+  it("defaults arguments to {} when it is explicitly null", () => {
+    const body = toolCall({ name: "get_wallet_integration", arguments: null });
+    const result = normalizeToolCallArguments(body) as typeof body;
+    expect(result.params.arguments).toEqual({});
+  });
+
+  it("leaves a populated arguments object untouched", () => {
+    const body = toolCall({
+      name: "get_wallet_integration",
+      arguments: { integrationId: "abc" },
+    });
+    const result = normalizeToolCallArguments(body) as typeof body;
+    expect(result.params.arguments).toEqual({ integrationId: "abc" });
+  });
+
+  it("leaves non-tools/call messages untouched", () => {
+    const body = { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} };
+    expect(normalizeToolCallArguments(body)).toEqual(body);
+  });
+
+  it("normalizes each message in a JSON-RPC batch", () => {
+    const body = [
+      toolCall({ name: "list_integrations" }),
+      toolCall({ name: "get_wallet_integration", arguments: null }),
+    ];
+    const result = normalizeToolCallArguments(body) as Array<{
+      params: { arguments: unknown };
+    }>;
+    expect(result[0].params.arguments).toEqual({});
+    expect(result[1].params.arguments).toEqual({});
+  });
+
+  it("passes through malformed bodies without throwing", () => {
+    expect(normalizeToolCallArguments(null)).toBeNull();
+    expect(normalizeToolCallArguments(undefined)).toBeUndefined();
+    expect(normalizeToolCallArguments("not json-rpc")).toBe("not json-rpc");
+  });
+});

--- a/tests/unit/mcp-normalize-tool-call-arguments.test.ts
+++ b/tests/unit/mcp-normalize-tool-call-arguments.test.ts
@@ -59,6 +59,13 @@ describe("normalizeToolCallArguments", () => {
     expect(result[1].params.arguments).toEqual({});
   });
 
+  it("leaves by-position array params untouched", () => {
+    const body = { jsonrpc: "2.0", id: 1, method: "tools/call", params: [] };
+    const result = normalizeToolCallArguments(body) as typeof body;
+    expect(Array.isArray(result.params)).toBe(true);
+    expect(result).toEqual(body);
+  });
+
   it("passes through malformed bodies without throwing", () => {
     expect(normalizeToolCallArguments(null)).toBeNull();
     expect(normalizeToolCallArguments(undefined)).toBeUndefined();

--- a/tests/unit/mcp-normalize-tool-call-arguments.test.ts
+++ b/tests/unit/mcp-normalize-tool-call-arguments.test.ts
@@ -1,9 +1,12 @@
 /**
- * KH-1: a `tools/call` with `arguments` omitted or explicitly `null` fails
- * the SDK's params schema with a raw Zod error, surfaced as -32603 (Internal
- * error) rather than a validation error - indistinguishable from the server
- * being down, on exactly the call an agent tries first. This pins the
- * dispatch-layer default that keeps that from reaching the SDK at all.
+ * KH-1: a `tools/call` with `arguments` explicitly `null` fails the SDK's
+ * params schema with a raw Zod error, surfaced as -32603 (Internal error)
+ * rather than a validation error - indistinguishable from the server being
+ * down. Omitting `arguments` entirely doesn't hit that path - it fails one
+ * layer in with a proper tool-scoped error instead - but on a tool with no
+ * required parameters it should just run. This pins the dispatch-layer
+ * default that fixes the null case and lets an all-optional tool run
+ * without an arguments key.
  */
 import { describe, expect, it } from "vitest";
 import { normalizeToolCallArguments } from "@/lib/mcp/normalize-tool-call-arguments";

--- a/tests/unit/mcp-public-route.test.ts
+++ b/tests/unit/mcp-public-route.test.ts
@@ -230,3 +230,36 @@ describe("/mcp/public — per-IP rate limiting (c)", () => {
     expect(response.headers.get("X-RateLimit-Limit")).toBe("60");
   });
 });
+
+describe("/mcp/public — tools/call argument normalization", () => {
+  // Same reasoning as the /mcp route test: the helper is only a fix if the
+  // route still routes the body through it on the way to the transport.
+  it.each([
+    ["explicitly null", true],
+    ["omitted entirely", false],
+  ])("defaults tools/call arguments to {} when %s, before the transport sees it", async (_label, includeNullArguments) => {
+    mockGetSession.mockReturnValue({
+      organizationId: "__anon_public__",
+      scope: "mcp:public",
+      transport: { handleRequest: mockHandleRequest },
+    });
+
+    const params: Record<string, unknown> = { name: "search_workflows" };
+    if (includeNullArguments) {
+      params.arguments = null;
+    }
+    await POST(
+      makeRequest(
+        { "mcp-session-id": "anon-session" },
+        JSON.stringify({ jsonrpc: "2.0", id: 4, method: "tools/call", params })
+      )
+    );
+
+    expect(mockHandleRequest).toHaveBeenCalledTimes(1);
+    const [, options] = mockHandleRequest.mock.calls[0] as [
+      Request,
+      { parsedBody: { params: { arguments: unknown } } },
+    ];
+    expect(options.parsedBody.params.arguments).toEqual({});
+  });
+});

--- a/tests/unit/mcp-route-anon.test.ts
+++ b/tests/unit/mcp-route-anon.test.ts
@@ -334,6 +334,42 @@ describe("POST /mcp — authed session-resume forwards parsedBody", () => {
     expect(options).toEqual({ parsedBody: parsed });
   });
 
+  // The -32603 fix lives at the dispatch layer, not in the SDK. Asserting it
+  // on the helper alone would stay green if the route went back to handing
+  // `await request.json()` straight to the transport, so pin it here: what
+  // the transport receives is what actually decides the wire response.
+  it.each([
+    ["explicitly null", null],
+    ["omitted entirely", undefined],
+  ])("defaults tools/call arguments to {} when %s, before the transport sees it", async (_label, argumentsValue) => {
+    const handleRequest = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    mockGetSession.mockReturnValue({
+      organizationId: "org-1",
+      apiKeyId: "key-1",
+      transport: { handleRequest },
+    });
+
+    const params: Record<string, unknown> = { name: "get_wallet_integration" };
+    if (argumentsValue === null) {
+      params.arguments = null;
+    }
+    const request = makeRequest(
+      "POST",
+      { "mcp-session-id": "session-abc" },
+      JSON.stringify({ jsonrpc: "2.0", id: 12, method: "tools/call", params })
+    );
+    await POST(request);
+
+    expect(handleRequest).toHaveBeenCalledTimes(1);
+    const [, options] = handleRequest.mock.calls[0] as [
+      Request,
+      { parsedBody: { params: { arguments: unknown } } },
+    ];
+    expect(options.parsedBody.params.arguments).toEqual({});
+  });
+
   it("rejects a cached session whose apiKeyId differs from the caller (cross-principal binding)", async () => {
     const handleRequest = vi.fn();
     mockGetSession.mockReturnValue({

--- a/tests/unit/mcp-workflow-route.test.ts
+++ b/tests/unit/mcp-workflow-route.test.ts
@@ -82,6 +82,7 @@ vi.mock("@modelcontextprotocol/sdk/types.js", () => ({
 import { authenticateApiKey } from "@/lib/api-key-auth";
 import { getWorkflowListing } from "@/lib/mcp/listing";
 import { authenticateOAuthToken } from "@/lib/mcp/oauth-auth";
+import { getSession } from "@/lib/mcp/sessions";
 import type { WorkflowListing } from "@/lib/mcp/workflow-server";
 
 const { POST, GET, DELETE, OPTIONS } = await import("@/app/mcp/w/[slug]/route");
@@ -112,8 +113,8 @@ function makeInitializeRequest(authHeader = "Bearer kh_test"): Request {
     headers: {
       "Content-Type": "application/json",
       Authorization: authHeader,
-      // Include both accept types so ensureMcpAcceptHeader short-circuits
-      // and does not attempt to clone the already-consumed body stream.
+      // Both accept types, so ensureMcpAcceptHeader short-circuits and the
+      // request reaches the transport unmodified.
       Accept: "application/json, text/event-stream",
     },
     body: JSON.stringify({ method: "initialize", id: 1, jsonrpc: "2.0" }),
@@ -370,5 +371,61 @@ describe("DELETE /mcp/w/[slug]", () => {
     });
     const res = await DELETE(req, makeParams());
     expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /mcp/w/[slug] — tools/call argument normalization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTransportHandleRequest.mockResolvedValue(
+      new Response("{}", { status: 200 })
+    );
+  });
+
+  // Every tools/call on this route arrives with a session header, so the
+  // session branch is the only path that matters here - and it used to hand
+  // the live Request to the SDK, where `arguments: null` became an opaque
+  // -32603.
+  it.each([
+    ["explicitly null", true],
+    ["omitted entirely", false],
+  ])("defaults tools/call arguments to {} when %s, before the transport sees it", async (_label, includeNullArguments) => {
+    vi.mocked(getWorkflowListing).mockResolvedValue({
+      ok: true,
+      listing: { ...makeListing(), isListed: true } as never,
+    });
+    mockAuthSuccess();
+    vi.mocked(getSession).mockReturnValue({
+      organizationId: "org-x",
+      transport: { handleRequest: mockTransportHandleRequest },
+    } as never);
+
+    const params: Record<string, unknown> = { name: "call_workflow" };
+    if (includeNullArguments) {
+      params.arguments = null;
+    }
+    const req = new Request("http://localhost/mcp/w/my-workflow", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer kh_test",
+        Accept: "application/json, text/event-stream",
+        "Mcp-Session-Id": "session-abc",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 5,
+        method: "tools/call",
+        params,
+      }),
+    });
+    await POST(req, makeParams());
+
+    expect(mockTransportHandleRequest).toHaveBeenCalledTimes(1);
+    const [, options] = mockTransportHandleRequest.mock.calls[0] as unknown as [
+      Request,
+      { parsedBody: { params: { arguments: unknown } } },
+    ];
+    expect(options.parsedBody.params.arguments).toEqual({});
   });
 });


### PR DESCRIPTION
KH-1 from the teardown referenced in #1949: `get_wallet_integration` (and any tool with no required parameters) returns JSON-RPC `-32603` (Internal error) when called with `arguments` explicitly `null`, instead of a normal validation error.

```
mcp rpc -32603: [
  {
    "expected": "record",
    "code": "invalid_type",
    "path": ["params", "arguments"],
    "message": "Invalid input: expected record, received null"
  }
]
```

**Why it matters, and a correction from review.** `-32603` is the code a client uses to decide "the server is broken, stop." That's what `arguments: null` produces: it fails the SDK's `z.record(...).optional()` params schema with a raw Zod error the transport doesn't wrap as `-32602`.

Omitting `arguments` entirely is a different failure, and the original title/description here conflated the two. It passes that same outer schema fine (`.optional()` accepts `undefined`) and fails one layer in, at `validateToolInput`, with an already-correct, tool-scoped error — not `-32603`. So an omitted-arguments call on a tool with no required parameters doesn't look broken, it's just unnecessarily rejected when it could simply run.

Verified against the pinned SDK/zod versions with raw JSON-RPC (bypassing the SDK's own client, which never sends `null` or omits the key), for a tool with no required parameters:

| `params.arguments` | result |
|---|---|
| omitted | HTTP 200, `isError:true`, tool-scoped validation message |
| `null` | JSON-RPC `error.code = -32603` |
| `{}` | success, tool runs |

**Fix.** Normalize `params.arguments` to `{}` for any `tools/call` message where it's `null` or absent, at the dispatch layer in `app/mcp/route.ts`, `app/mcp/public/route.ts` and `app/mcp/w/[slug]/route.ts`, before the request reaches the SDK transport. One fix closes both cases: it removes the opaque `-32603` on `null`, and it lets an all-optional tool (`tools_documentation`'s empty `{}` schema, `search_workflows`'s all-optional fields) run without an `arguments` key instead of failing validation for no reason. `get_wallet_integration` is *not* in `PUBLIC_TOOLS` — excluded by name in `lib/mcp/oauth-scopes.ts` — so the public-route edit isn't for it; `tools_documentation` and `search_workflows` are the tools actually reachable on `/mcp/public` that this applies to there.

**Scope.** All three MCP POST handlers are covered. `app/mcp/w/[slug]/route.ts` was initially left out because its session path hands the live `Request` straight to the SDK with no `parsedBody` we control — but that is the only path a `tools/call` takes on that route, so deferring it left the per-workflow marketplace surface entirely unfixed. It now parses the body up front and passes `parsedBody`, the same pattern `app/mcp/route.ts` already uses; `ensureMcpAcceptHeader` there no longer forwards the (now consumed) body stream, which also drops its `duplex` `ts-expect-error`. One visible consequence: malformed JSON on a session POST returns that route's own 400 instead of reaching the transport, matching `/mcp`.

This closes the two shapes above, not the broader complaint that any malformed `arguments` (`"abc"`, `[]`, a missing `params`) still returns a raw `-32603`, because `Protocol`'s rejection handler falls back to `InternalError` for anything without a numeric `.code`. That's a larger change against the SDK boundary; happy to file it separately if useful.

Every per-tool schema is enforced exactly as before, just downstream of a request that now actually reaches it — `get_wallet_integration` without a real `integrationId` still fails. Note the wire shape it fails with: `validateToolInput` throws `McpError(InvalidParams)`, and the SDK's `tools/call` handler catches that and returns it as `createToolError(...)`, so the caller sees HTTP 200 with `isError: true` and a tool-scoped message, not a JSON-RPC `-32602`. Only `UrlElicitationRequired` is rethrown as a wire-level error. The table above already shows this for the omitted case; the point of the fix is that a client can now tell a rejected call from a broken server, not that the rejection becomes a different error code.

Tests: `tests/unit/mcp-normalize-tool-call-arguments.test.ts` (7 cases covering omitted/null/populated `arguments`, by-position array `params`, non-`tools/call` passthrough, and JSON-RPC batches), plus route-level cases in `mcp-route-anon.test.ts`, `mcp-public-route.test.ts` and `mcp-workflow-route.test.ts` asserting that what reaches `transport.handleRequest` has `parsedBody.params.arguments === {}` for both the null and omitted shapes. The helper test alone stayed green when either route was reverted to handing `await request.json()` straight to the transport, so the route-level cases are the ones that pin the actual fix; each was verified red against the unwired route. `tsc --noEmit` and `biome check` clean on the touched files.

Full writeup: https://github.com/harshkas4na/chaos-keeper/blob/main/docs/teardown.md#kh-1

