### PR TITLE
docs: clarify transactionHashes entries are receipt objects, not hash strings

### DIFF
--- a/docs/agent/mcp-server.md
+++ b/docs/agent/mcp-server.md
@@ -169,7 +169,7 @@ mid-flight.
 | Tool | Description |
 |------|-------------|
 | `execute_workflow` | Trigger a manual execution. Returns an execution ID for status polling. |
-| `get_execution` | Get combined status and step-by-step logs for an execution in one response. Replaces the earlier `get_execution_status` + `get_execution_logs` pair. |
+| `get_execution` | Get combined status and step-by-step logs for an execution in one response. Replaces the earlier `get_execution_status` + `get_execution_logs` pair. Its `transactionHashes` entries are receipt objects, not plain hash strings -- see [Transaction Hashes](/api/executions#transaction-hashes) for the field shape. |
 | `get_execution_status` | **Deprecated (v1.13)** — status only. Use `get_execution`. |
 | `get_execution_logs` | **Deprecated (v1.13)** — logs only. Use `get_execution`. |
 | `list_executions` | List workflow and direct executions with cursor pagination. |

--- a/docs/workflows/schema-reference.md
+++ b/docs/workflows/schema-reference.md
@@ -139,7 +139,9 @@ GET /api/workflows/executions/{executionId}/status
 
 Returns a `transactionHashes` array in the success payload —
 you can read tx hashes directly from the status response
-without fetching logs separately.
+without fetching logs separately. Each entry is a receipt object
+(`hash`, `nodeId`, `verified`, ...), not a bare hash string — see
+[Transaction Hashes](/api/executions#transaction-hashes).
 
 ### Get execution logs
 ```
@@ -213,11 +215,13 @@ const walletId = res.data[0].id; // bare array, no wrapper
 
 The workflow execution status endpoint returns `transactionHashes`
 directly in the success payload. You can read tx hashes from
-the status response without fetching logs:
+the status response without fetching logs. Each entry is a receipt
+object, so pull `.hash` out of it rather than using the entry itself
+as the hash:
 
 ```typescript
 const status = await getExecutionStatus(executionId);
-const txHashes = status.transactionHashes;
+const txHashes = status.transactionHashes.map((entry) => entry.hash);
 ```
 
 ---


### PR DESCRIPTION
KH-6 from the teardown referenced in #1949 and #2040.

`transactionHashes` reads as a list of hash strings from its name. The REST API docs (`docs/api/executions.md`) already document the real shape correctly — an array of receipt objects with `hash`, `nodeId`, `verified`, `receiptStatus`, etc. — but two other doc surfaces either didn't mention the shape at all or showed it being used in a way that only works if you already know better:

- `docs/agent/mcp-server.md` — the `get_execution` row in the MCP tools table said nothing about `transactionHashes`' shape.
- `docs/workflows/schema-reference.md` — the "Transaction hash location" section's own code sample assigned the raw entries straight to a variable named `txHashes`, with no `.hash` access.

Both now link to the field table already in `docs/api/executions.md#transaction-hashes` rather than duplicating it, and the code sample now does `.map((entry) => entry.hash)`.

**Why it matters.** A client that decodes this field as `string[]` — the natural read of the name, and what an empty array during a `running` execution suggests — gets a decode error or silently drops every hash. That's what happened building an MCP client for the Agents Onchain Hackathon: a decoder that expected strings dropped every hash and produced a false "escaped" verdict in a chaos test, when the transfers had in fact landed with distinct hashes. Caught by inspecting the raw payload; full writeup: https://github.com/harshkas4na/chaos-keeper/blob/main/docs/teardown.md#kh-6

Docs only, no behavior change.