### PR TITLE
docs: make first-write onboarding safer and more consistent

### DIFF
--- a/docs/getting-started/api.md
+++ b/docs/getting-started/api.md
@@ -44,8 +44,8 @@ from wallet sign-in instead. See [Headless Onboarding](/api/headless-onboarding)
 
 ## 2. Fund the wallet, if the workflow spends
 
-Your organization's Turnkey wallet is provisioned on signup and gets a monthly allowance of
-sponsored gas on mainnet.
+Your organization's Turnkey wallet is provisioned on signup. Eligible transactions on supported
+EVM mainnets and testnets may use the organization's monthly sponsored-gas allowance.
 
 Sponsorship pays the **network fee**, not the value moved. A workflow that sends 0.1 ETH still
 needs 0.1 ETH in the wallet, and an ERC-20 transfer still needs the token balance. Sponsorship

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -80,14 +80,15 @@ kh run logs <run-id>
 
 ## 4. Call a contract directly
 
-For a one-off call with no workflow around it:
+For a one-off call with no workflow around it, start on a testnet. The examples below use Ethereum
+Sepolia (`11155111`); use `kh chain list` to choose another enabled testnet if needed.
 
 ```bash
 # Read a value
-kh execute contract-call --chain 1 --contract 0x... --method balanceOf --args '["0x..."]'
+kh execute contract-call --chain 11155111 --contract 0x... --method balanceOf --args '["0x..."]'
 
 # Write, and wait for the transaction
-kh execute contract-call --chain 1 --contract 0x... --method transfer \
+kh execute contract-call --chain 11155111 --contract 0x... --method transfer \
   --args '["0x...","1000"]' --wait
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,8 +98,10 @@ Pick the path that matches how you work:
 | Calling from a backend service | [API](/getting-started/api) |
 | Working from a terminal | [CLI](/getting-started/cli) |
 
-All four provision a Turnkey wallet automatically on signup and include a monthly allowance of
-sponsored gas, so a first run does not require funding anything. See
+All four provision a Turnkey wallet automatically on signup. Eligible EVM transactions may use
+KeeperHub's monthly gas sponsorship, but sponsorship covers network fees only and depends on the
+network, sender routing, mempool path, and available credits. Any native value or tokens being
+transferred must still be funded. See [Gas Management](/wallet-management/gas) and
 [Getting Started](/getting-started).
 
 ## Coming from Another Platform?


### PR DESCRIPTION
## Summary

Tightens three small onboarding inconsistencies that can affect a new builder's first onchain write:

- clarifies that gas sponsorship is conditional and covers network fees, not transferred value/assets
- aligns the API getting-started page with the documented sponsorship support on eligible EVM mainnets and testnets
- changes the beginner CLI direct-write example from Ethereum mainnet (`1`) to Ethereum Sepolia (`11155111`) and explicitly recommends starting on a testnet

## Why

The existing docs already have strong execution and verification references, including the verified-transaction guide. These changes keep the entry-point pages consistent with those deeper references and reduce the chance that a first-time builder:

- assumes no funding is ever required
- misses eligible testnet gas sponsorship
- copies a first-write example that targets mainnet

## Scope

Docs only. No API or runtime behavior changes.

The wording is intentionally minimal and points back to the existing Gas Management and chain-discovery guidance rather than introducing another parallel onboarding flow.

Related builder-side onboarding audit and safe first-write starter:
https://github.com/mystiquemide/keeperhub-zero-to-first-tx