### PR TITLE
fix: #2109 expose force on delete_workflow, stop telling MCP callers to do an impossible step

### DIFF
--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -911,6 +911,9 @@ export async function DELETE(
   request: Request,
   context: { params: Promise<{ workflowId: string }> }
 ) {
+  const { searchParams } = new URL(request.url);
+  const force = searchParams.get("force") === "true";
+
   try {
     const { workflowId } = await context.params;
 
@@ -941,9 +944,6 @@ export async function DELETE(
     }
 
     // Check for existing executions before deleting
-    const { searchParams } = new URL(request.url);
-    const force = searchParams.get("force") === "true";
-
     const hasExecutions = await db.query.workflowExecutions.findFirst({
       where: eq(workflowExecutions.workflowId, workflowId),
       columns: { id: true },

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -953,7 +953,7 @@ export async function DELETE(
       return NextResponse.json(
         {
           error:
-            "Workflow has execution history. Delete executions first before deleting the workflow.",
+            "Workflow has execution history. Pass force=true to also delete its execution history in the same call.",
           hasExecutions: true,
         },
         { status: 409 }
@@ -1036,7 +1036,7 @@ export async function DELETE(
       return NextResponse.json(
         {
           error:
-            "Workflow has execution history. Delete executions first before deleting the workflow.",
+            "Workflow has execution history. Pass force=true to also delete its execution history in the same call.",
         },
         { status: 409 }
       );

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -1035,8 +1035,9 @@ export async function DELETE(
     if (cause && typeof cause === "object" && "code" in cause && cause.code === "23503") {
       return NextResponse.json(
         {
-          error:
-            "Workflow has execution history. Pass force=true to also delete its execution history in the same call.",
+          error: force
+            ? "Workflow has execution history that was inserted concurrently with this delete. Retry the request."
+            : "Workflow has execution history. Pass force=true to also delete its execution history in the same call.",
         },
         { status: 409 }
       );

--- a/docs/agent/mcp-server.md
+++ b/docs/agent/mcp-server.md
@@ -145,7 +145,7 @@ The server registers more than 30 tools. Call `tools_documentation` (or `list_ac
 | `get_workflow` | Get a single workflow by ID, including nodes, edges, and configuration. |
 | `create_workflow` | Create a workflow with nodes and edges. Created disabled by default; pass `enabled=true` to make schedule, event, block, or webhook triggers fire immediately. Pass `idempotency_key` so cold-start retries are safe. |
 | `update_workflow` | Update a workflow's name, description, nodes, edges, project/tag assignment, or enabled state. Set `enabled=false` to stop triggers without deleting the workflow. |
-| `delete_workflow` | Permanently delete a workflow. This action is irreversible. |
+| `delete_workflow` | Permanently delete a workflow. This action is irreversible. A workflow with execution history rejects a plain delete with 409 -- pass `force: true` to also delete its executions in the same call. |
 | `validate_workflow` | Check a workflow's structural and Web3-specific correctness before creating or executing it. |
 | `prepare_test_pin_data` | Return the JSON Schema each node expects as pin data, so an agent can construct valid test inputs. |
 | `validate_cron` | Validate a cron expression or interval schedule before wiring a schedule trigger. |

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -804,17 +804,26 @@ export function registerTools(
 
   server.tool(
     "delete_workflow",
-    "Delete a workflow by ID. This action is irreversible.",
+    "Delete a workflow by ID. This action is irreversible. A workflow that has ever executed rejects a plain delete with 409 -- pass force=true to also delete its execution history in the same call.",
     {
       workflowId: z.string().describe("The workflow ID to delete"),
+      force: z
+        .boolean()
+        .optional()
+        .describe(
+          "Required to delete a workflow that has execution history. Also soft-deletes its executions and hard-deletes their step logs. Ignored (and unnecessary) for a workflow with no executions."
+        ),
     },
     { title: "Delete Workflow", readOnlyHint: false, destructiveHint: true },
     withScopeCheck("delete_workflow", scope, async (args) =>
       withToolLogging("delete_workflow", undefined, async () => {
+        const path = args.force
+          ? `/api/workflows/${args.workflowId}?force=true`
+          : `/api/workflows/${args.workflowId}`;
         const data = await callApi(
           internalApiBaseUrl,
           authHeader,
-          `/api/workflows/${args.workflowId}`,
+          path,
           "DELETE"
         );
         return {

--- a/tests/unit/mcp-delete-workflow-force.test.ts
+++ b/tests/unit/mcp-delete-workflow-force.test.ts
@@ -1,0 +1,94 @@
+/**
+ * KH-3: `delete_workflow` on a workflow with execution history returns a 409
+ * that says "delete executions first" - but no tool exists to do that, and
+ * the underlying route already supports a `?force=true` cascade the MCP tool
+ * never forwarded. This pins the MCP-layer argument through to the query
+ * string the route actually reads.
+ */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import { registerTools } from "@/lib/mcp/tools";
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+let fetchMock: FetchMock;
+
+function jsonOkResponse(body: Record<string, unknown>): unknown {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: { get: () => "application/json" },
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(""),
+  };
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn(() => Promise.resolve(jsonOkResponse({ success: true })));
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+async function callDeleteWorkflow(
+  args: Record<string, unknown>
+): Promise<void> {
+  const server = new McpServer({
+    name: "delete-workflow-test",
+    version: "0.0.0",
+  });
+  registerTools(server, "http://internal", "Bearer test", SCOPE_MCP_WRITE);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client({
+    name: "delete-workflow-test-client",
+    version: "0.0.0",
+  });
+
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+
+  try {
+    await client.callTool({ name: "delete_workflow", arguments: args });
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+function requestedUrl(): string {
+  const call = fetchMock.mock.calls.at(-1);
+  if (!call) {
+    throw new Error("fetch was not called");
+  }
+  return call[0] as string;
+}
+
+describe("delete_workflow force parameter", () => {
+  it("omits force from the query string when not passed", async () => {
+    await callDeleteWorkflow({ workflowId: "wf_1" });
+    expect(requestedUrl()).toBe("http://internal/api/workflows/wf_1");
+  });
+
+  it("omits force from the query string when explicitly false", async () => {
+    await callDeleteWorkflow({ workflowId: "wf_1", force: false });
+    expect(requestedUrl()).toBe("http://internal/api/workflows/wf_1");
+  });
+
+  it("appends ?force=true when force is true", async () => {
+    await callDeleteWorkflow({ workflowId: "wf_1", force: true });
+    expect(requestedUrl()).toBe(
+      "http://internal/api/workflows/wf_1?force=true"
+    );
+  });
+});


### PR DESCRIPTION
KH-3 from the teardown referenced in #1949, #2040, #2041, #2042.

Deleting a workflow that has ever executed returns a 409:

```json
{
  "error": "Workflow has execution history. Delete executions first before deleting the workflow.",
  "hasExecutions": true
}
```

There is no `delete_execution` tool or endpoint, so that instruction can't actually be followed — the 35-tool MCP surface has nothing that deletes an execution.

**What's actually there.** `DELETE /api/workflows/{workflowId}` already supports a `?force=true` cascade (soft-deletes the workflow's executions, hard-deletes their step logs, then soft-deletes the workflow) — it just wasn't reachable from the MCP `delete_workflow` tool, which always called the endpoint with no query string regardless of what the caller passed. So an MCP agent hitting the 409 had no way to satisfy it either, which is exactly the finding: the REST API grew the fix, the MCP tool schema never picked it up.

**Fix:**
- `delete_workflow` gains an optional `force: boolean` argument, forwarded as `?force=true` when set.
- The 409 message, on both places it's emitted (the pre-check and the FK-violation race-condition catch), now names the actual fix instead of an unsupported action.
- `docs/agent/mcp-server.md`'s `delete_workflow` row documents `force`.

Deliberately not touching the "no `delete_execution` tool" gap itself (the teardown's proposed fix #1) — this closes it via the cascade that's already implemented and tested at the REST layer, which is a much smaller surface than a new standalone delete-execution endpoint would be.

Tests: `tests/unit/mcp-delete-workflow-force.test.ts` (new, 3 cases — no `force`, `force: false`, `force: true` — pins the exact query string sent to the route). All 311 existing `tests/unit/mcp-*` tests still pass; `tsc --noEmit` and `biome check` clean on the touched files.

Full writeup: https://github.com/harshkas4na/chaos-keeper/blob/main/docs/teardown.md#kh-3