### PR TITLE
docs: show how to land a first transaction without funding a wallet

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -29,8 +29,25 @@ that sends 0.1 ETH still needs 0.1 ETH in the wallet. See
 
 Read-only workflows, including most monitoring, never need a funded wallet at all.
 
+### Your first transaction, without funding anything
+
+Sponsored gas covers the network fee, and a write that moves no tokens needs nothing else. So you
+can land a real mainnet transaction before you fund anything at all: call `approve(spender, 0)` on
+any ERC-20 contract.
+
+It changes state, it produces a transaction hash you can open on a block explorer, and it transfers
+nothing, so it succeeds on an empty wallet. USDC on Base is
+`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`, and any address will do as the spender.
+
+Worth knowing because most templates read data and send alerts. Those are useful, but they produce
+no transaction, so they cannot give you the moment where you see your own hash confirm on mainnet.
+A zero-value write is the shortest path to that.
+
 ## If you are new to the model
 
 A workflow is a **trigger** plus a sequence of **actions**, with **conditions** to branch between
 them. [Core Concepts](/concepts) covers the vocabulary; you do not need it to finish any of the
 four paths above.
+
+
+


### PR DESCRIPTION
I went from zero to a working agent on KeeperHub this week and kept notes on
where I lost time. The biggest single delay was right at the start, and this page
is one sentence away from preventing it.

"What you get on signup" currently says two true things:

- sponsored gas covers the network fee, but a workflow that sends 0.1 ETH still
  needs 0.1 ETH in the wallet
- read-only workflows never need a funded wallet at all

Reading those together, I concluded I needed to fund a wallet before I could see
a transaction, because reads don't produce one. So I stopped and went to buy
crypto, and lost most of a day to exchanges and bridging before I got back to
building.

I didn't need to. A write that moves no tokens costs nothing but the sponsored
gas. `approve(spender, 0)` on any ERC-20 changes state, produces a real hash on a
block explorer, and succeeds on a completely empty wallet.

That single fact is the difference between "I'll come back to this once I've
funded something" and "I have a mainnet transaction, this thing works". It felt
worth three paragraphs on the page where people decide whether to continue.

I noticed getting-started was consolidated into four interface paths two days
ago, so I've kept this additive and worked inside the new structure rather than
reorganising anything.