### PR TITLE
fix: skip Solana write nodes silently in workflow run preflight

### DIFF
--- a/lib/workflow/run-simulation.ts
+++ b/lib/workflow/run-simulation.ts
@@ -568,17 +568,9 @@ async function simulateNode(
   }
 
   if (isSolanaChain(chainId)) {
-    return {
-      status: "skipped",
-      warning: makeIssue(context, {
-        code: "SIMULATION_UNSUPPORTED_CHAIN",
-        fieldKey: "network",
-        message: `${nodeLabel(
-          context.node,
-          context.actionType
-        )} uses Solana. Workflow Run preflight currently supports EVM writes only.`,
-      }),
-    };
+    // Preflight is EVM-only by design; Solana writes are skipped without a
+    // warning so valid Solana workflows do not surface issues in the editor.
+    return { status: "skipped" };
   }
 
   const signerEligibility = await withSimulationDeadline(

--- a/tests/unit/workflow-run-simulation.test.ts
+++ b/tests/unit/workflow-run-simulation.test.ts
@@ -318,7 +318,7 @@ describe("runWorkflowSimulation", () => {
     expect(spies.simulateNativeTransfer).not.toHaveBeenCalled();
   });
 
-  it("does not simulate an EVM-only preflight on Solana", async () => {
+  it("skips Solana writes silently without a warning", async () => {
     spies.getChainIdFromNetwork.mockReturnValueOnce(101);
     spies.isSolanaChain.mockReturnValueOnce(true);
 
@@ -333,7 +333,11 @@ describe("runWorkflowSimulation", () => {
       ],
     });
 
-    expect(result.warnings[0]?.code).toBe("SIMULATION_UNSUPPORTED_CHAIN");
+    expect(result).toEqual({
+      warnings: [],
+      simulatedNodeCount: 0,
+      skippedNodeCount: 1,
+    });
     expect(spies.simulateNativeTransfer).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Problem

The workflow editor's Run preflight surfaces a warning for Solana write nodes:

> Transfer Native Token uses Solana. Workflow Run preflight currently supports EVM writes only.

Preflight simulation is EVM-only by design, so Solana write nodes are skipped - but the skip attached a `SIMULATION_UNSUPPORTED_CHAIN` warning that renders in the Workflow Issues panel ("This workflow has issues that may cause it to fail"), flagging valid Solana workflows as broken even though running them works fine.

## Fix

`simulateNode` in `lib/workflow/run-simulation.ts` now skips Solana-network write nodes silently: no warning is attached, and the node still counts toward `skippedNodeCount` so the simulate response stays truthful. The unit test that asserted the warning now asserts a clean silent skip.

## Verification

- `tests/unit/workflow-run-simulation.test.ts`: 22/22 pass
- Biome clean on both changed files
- Full `tsc --noEmit`: exit 0
