### PR TITLE
fix: record sponsored gas as a fee in wei, not a gas unit count

### DIFF
--- a/components/analytics/kpi-cards.tsx
+++ b/components/analytics/kpi-cards.tsx
@@ -18,7 +18,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { formatGasSplit } from "@/lib/analytics/format-gas";
+import { formatGasSplit, walletShareWei } from "@/lib/analytics/format-gas";
 import type { TimeRange } from "@/lib/analytics/types";
 import {
   analyticsLoadingAtom,
@@ -40,17 +40,6 @@ function formatDuration(ms: number | null): string {
   const minutes = Math.floor(ms / 60_000);
   const seconds = Math.round((ms % 60_000) / 1000);
   return `${minutes}m ${seconds}s`;
-}
-
-// Wallet-paid and sponsored gas are tracked in separate ledgers, so the headline
-// figure is their sum. BigInt keeps the addition exact before the lossy
-// Number() conversion that the delta needs.
-function addWeiStrings(a: string, b: string): string {
-  try {
-    return (BigInt(a) + BigInt(b)).toString();
-  } catch {
-    return a;
-  }
 }
 
 function computeDelta(current: number, previous: number): number | null {
@@ -278,15 +267,12 @@ export function KpiCards(): ReactNode {
         ? computeDelta(summary.avgDurationMs, prev.avgDurationMs)
         : null;
 
-    const walletGasWei = summary.totalGasWei;
+    const totalGasWei = summary.totalGasWei;
     const sponsoredGasWei = summary.sponsoredGasWei;
-    const totalGasWei = addWeiStrings(walletGasWei, sponsoredGasWei);
+    const walletGasWei = walletShareWei(totalGasWei, sponsoredGasWei);
 
     const gasDelta = prev
-      ? computeDelta(
-          Number(totalGasWei),
-          Number(addWeiStrings(prev.totalGasWei, prev.sponsoredGasWei))
-        )
+      ? computeDelta(Number(totalGasWei), Number(prev.totalGasWei))
       : null;
 
     const hasSponsoredGas = sponsoredGasWei !== "0" && sponsoredGasWei !== "";

--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -129,13 +129,19 @@ function formatGasAsEth(weiString: string | null): string {
 
 // Run-level gas: multi-network runs can't sum into one token, so they render
 // as "Composed" (per-network amounts live in the expanded steps). A single
-// network shows its real sponsored total in that network's token.
+// network shows its total in that network's token.
+//
+// The step rollup wins over the sponsorship ledger because it covers every
+// transaction the run made. A run that starts sponsored and falls back to
+// direct signing has only its sponsored leg in the ledger, so preferring the
+// ledger would drop the rest.
 function runGasDisplay(run: UnifiedRun): ReactNode {
   if (run.networks.length > 1) {
     return "Composed";
   }
-  if (run.gasCostWei) {
-    return formatGasNative(run.gasCostWei, run.networks[0] ?? run.network);
+  const wei = run.gasUsedWei ?? run.gasCostWei;
+  if (wei) {
+    return formatGasNative(wei, run.networks[0] ?? run.network);
   }
   return formatGasAsEth(run.gasUsedWei);
 }

--- a/lib/analytics/format-gas.ts
+++ b/lib/analytics/format-gas.ts
@@ -72,6 +72,24 @@ export function formatGasAsEth(
   return renderUnits(toDisplayUnits(wei, decimals), decimals);
 }
 
+/**
+ * The wallet-paid share of a period's gas.
+ *
+ * `totalWei` is every wei the runs burned, sponsored included, so the wallet
+ * share is what is left after removing the sponsorship ledger. Clamped at zero:
+ * the two figures sit on different time axes (run start vs ledger insert), so a
+ * window edge can put a sponsored transaction in one and not the other.
+ */
+export function walletShareWei(totalWei: string, sponsoredWei: string): string {
+  const total = parseWei(totalWei);
+  const sponsored = parseWei(sponsoredWei);
+  if (total === null || sponsored === null) {
+    return totalWei;
+  }
+  const wallet = total - sponsored;
+  return wallet > ZERO ? wallet.toString() : "0";
+}
+
 export type GasSplit = {
   total: string;
   wallet: string;

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -1019,8 +1019,9 @@ async function fetchWorkflowRuns(
     .as("log_summary");
 
   // Total native gas cost sponsored per execution, from the sponsorship ledger.
-  // Used to show a single-network run's real total (the wallet-side gas above is
-  // ~0 for sponsored runs); multi-network runs render as "Composed" instead.
+  // Preferred for a single-network run because it carries the chain, so the
+  // amount renders in that chain's own token; multi-network runs render as
+  // "Composed" instead.
   const gasCostSummary = db
     .select({
       executionId: gasCreditUsage.executionId,

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -467,10 +467,17 @@ async function getPreviousPeriodSummary(
 }
 
 /**
- * Sum of gas paid by KeeperHub sponsorship over the window (in wei), read
- * straight from the gas_credit_usage ledger. Org-level only: sponsorship is not
- * project-attributable, so a project-scoped view returns "0" rather than
- * leaking org-wide totals under a project filter.
+ * Sum of gas paid by KeeperHub sponsorship over the window (in wei), read from
+ * the gas_credit_usage ledger but scoped to the same runs `getWorkflowGasTotal`
+ * counts: joined through the execution, windowed on `started_at`, and limited
+ * to runs that have already written their `gas_used_wei` rollup.
+ *
+ * The scoping is what lets the KPI derive the wallet share by subtraction. The
+ * ledger inserts per confirmed transaction while the rollup is only written at
+ * finalize, so summing the ledger on its own axis would subtract gas from runs
+ * that have not landed in the total yet - on a 1h range that is the normal
+ * case, not an edge, and it would drive the wallet figure to zero. The join
+ * also makes the figure project-attributable, where the raw ledger is not.
  *
  * Caveat: this sums native gas across chains and the Gas Spent KPI renders it
  * as ETH, so a non-ETH chain's gas (e.g. Polygon's POL) is counted as ETH. It
@@ -484,19 +491,24 @@ async function getSponsoredGasTotal(
   rangeEnd: Date,
   projectId?: string
 ): Promise<string> {
-  if (projectId) {
-    return "0";
-  }
   const result = await db
     .select({
       totalWei: sql<string>`COALESCE(SUM(CAST(${gasCreditUsage.gasCostWei} AS NUMERIC)), 0)::text`,
     })
     .from(gasCreditUsage)
+    .innerJoin(
+      workflowExecutions,
+      eq(workflowExecutions.id, gasCreditUsage.executionId)
+    )
+    .innerJoin(workflows, eq(workflows.id, workflowExecutions.workflowId))
     .where(
       and(
         eq(gasCreditUsage.organizationId, organizationId),
-        gte(gasCreditUsage.createdAt, rangeStart),
-        lt(gasCreditUsage.createdAt, rangeEnd)
+        eq(workflows.organizationId, organizationId),
+        projectId ? eq(workflows.projectId, projectId) : undefined,
+        isNotNull(workflowExecutions.gasUsedWei),
+        gte(workflowExecutions.startedAt, rangeStart),
+        lt(workflowExecutions.startedAt, rangeEnd)
       )
     );
   return result[0]?.totalWei ?? "0";

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -75,12 +75,13 @@ export type AnalyticsSummary = {
   cancelledCount: number;
   successRate: number;
   avgDurationMs: number | null;
-  /** Gas paid by the org's own wallet over the range, in wei. */
+  /** Every wei the runs burned over the range, sponsored gas included. */
   totalGasWei: string;
   /**
-   * Gas paid by KeeperHub sponsorship over the range, in wei, read from the
-   * gas-credit ledger. Disjoint from `totalGasWei`, so the headline figure the
-   * Gas Spent KPI renders is the two added together.
+   * The sponsored portion of `totalGasWei`, in wei, read from the gas-credit
+   * ledger and scoped to the same runs. A subset, NOT a disjoint figure: the
+   * Gas Spent KPI renders `totalGasWei` as the headline and derives the
+   * wallet-paid share by subtracting this. Adding the two double counts.
    */
   sponsoredGasWei: string;
   activeRuns: number;

--- a/lib/web3/sponsored-transaction-manager.ts
+++ b/lib/web3/sponsored-transaction-manager.ts
@@ -29,7 +29,9 @@ import { isSponsorshipSupported } from "@/lib/web3/turnkey-sponsorship-config";
 type SponsoredTransactionResult = {
   success: true;
   transactionHash: string;
+  /** Fee in wei (units * effectiveGasPrice), matching the direct-signing path. */
   gasUsed: string;
+  /** Raw gas unit count from the receipt. */
   gasUsedUnits: string;
   effectiveGasPrice: string;
   sponsored: true;
@@ -424,6 +426,11 @@ async function finalizeSponsoredTx(
 
   const gasUsed = receipt.gasUsed;
   const effectiveGasPrice = receipt.effectiveGasPrice;
+  // `gasUsed` on the receipt is a unit count; the fee is units * price. Callers
+  // put this in `output.gasUsed`, which finalize sums into
+  // `workflow_executions.gas_used_wei`, so it has to be the fee like the
+  // direct-signing path returns.
+  const gasCostWei = gasUsed * effectiveGasPrice;
 
   const metrics = getMetricsCollector();
   const labels = {
@@ -466,7 +473,6 @@ async function finalizeSponsoredTx(
   }
 
   if (!isTestnet) {
-    const gasCostWei = gasUsed * effectiveGasPrice;
     const gasCostEth = Number(gasCostWei) / 1e18;
     const gasCostUsd = gasCostEth * ethPriceUsd;
 
@@ -480,7 +486,7 @@ async function finalizeSponsoredTx(
   return {
     success: true,
     transactionHash: txHash,
-    gasUsed: gasUsed.toString(),
+    gasUsed: gasCostWei.toString(),
     gasUsedUnits: gasUsed.toString(),
     effectiveGasPrice: effectiveGasPrice.toString(),
     sponsored: true,

--- a/tests/e2e/playwright/analytics-gas.test.ts
+++ b/tests/e2e/playwright/analytics-gas.test.ts
@@ -30,7 +30,7 @@ test.describe("Analytics Gas Tracking", () => {
       { timeout: 15_000 }
     );
 
-    // Headline value is wallet-paid plus sponsored gas for the range
+    // Headline value is every wei the runs burned, sponsored included
     const gasCard = page.locator('[data-kpi="gas-spent"]');
     await expect(gasCard).toBeVisible({ timeout: 10_000 });
 

--- a/tests/unit/analytics-format-gas.test.ts
+++ b/tests/unit/analytics-format-gas.test.ts
@@ -3,6 +3,7 @@ import {
   formatGasAsEth,
   formatGasSplit,
   gasDecimals,
+  walletShareWei,
 } from "@/lib/analytics/format-gas";
 
 const ETH_AMOUNT_RE = /^([\d.]+) ETH$/;
@@ -99,5 +100,53 @@ describe("formatGasAsEth", () => {
   it("returns -- for missing input and 0 ETH for zero", () => {
     expect(formatGasAsEth(null)).toBe("--");
     expect(formatGasAsEth("0")).toBe("0 ETH");
+  });
+});
+
+describe("walletShareWei", () => {
+  it("subtracts the sponsorship ledger from the run total", () => {
+    expect(walletShareWei("13698054300000000", "11323838600000000")).toBe(
+      "2374215700000000"
+    );
+  });
+
+  it("returns the whole total when nothing was sponsored", () => {
+    expect(walletShareWei("2374215600000000", "0")).toBe("2374215600000000");
+  });
+
+  it("returns 0 when every wei was sponsored", () => {
+    expect(walletShareWei("11323838600000000", "11323838600000000")).toBe("0");
+  });
+
+  // Run start and ledger insert are different time axes, so a window edge can
+  // hold a sponsored tx in one and not the other.
+  it("clamps to 0 when the ledger exceeds the run total", () => {
+    expect(walletShareWei("1000", "5000")).toBe("0");
+  });
+
+  it("stays exact beyond float53", () => {
+    expect(walletShareWei("9007199254740993000", "1")).toBe(
+      "9007199254740992999"
+    );
+  });
+
+  it("falls back to the total when either figure is unparseable", () => {
+    expect(walletShareWei("2374215600000000", "not-a-number")).toBe(
+      "2374215600000000"
+    );
+  });
+});
+
+// The two sub-lines must add back to the headline, which is what broke when
+// the wallet figure was the run total and sponsored was added on top of it.
+describe("gas split against a real sponsored period", () => {
+  it("renders wallet plus sponsored as the total", () => {
+    const total = "13698054300000000";
+    const sponsored = "11323838600000000";
+    const split = formatGasSplit(walletShareWei(total, sponsored), sponsored);
+
+    expect(split.wallet).toBe("0.0024 ETH");
+    expect(split.sponsored).toBe("0.0113 ETH");
+    expect(split.total).toBe("0.0137 ETH");
   });
 });

--- a/tests/unit/sponsored-transaction-manager.test.ts
+++ b/tests/unit/sponsored-transaction-manager.test.ts
@@ -223,12 +223,16 @@ describe("executeSponsoredTransaction", () => {
     expect(result?.sponsored).toBe(true);
   });
 
-  it("returns gasUsed as raw gas units, not wei cost", async () => {
+  // gasUsed feeds output.gasUsed, which finalize sums into
+  // workflow_executions.gas_used_wei. It must be the fee, like the direct path.
+  it("returns gasUsed as the wei fee and gasUsedUnits as the unit count", async () => {
     setupSuccessfulSponsorship();
 
     const result = await executeSponsoredTransaction(baseTxParams);
 
-    expect(result?.gasUsed).toBe("21000");
+    expect(result?.gasUsed).toBe("21000000000000");
+    expect(result?.gasUsedUnits).toBe("21000");
+    expect(result?.effectiveGasPrice).toBe("1000000000");
   });
 
   it("records gas usage after confirmation", async () => {
@@ -479,7 +483,8 @@ describe("executeSponsoredContractTransaction", () => {
 
     expect(result).not.toBeNull();
     expect(result?.success).toBe(true);
-    expect(result?.gasUsed).toBe("21000");
+    expect(result?.gasUsed).toBe("21000000000000");
+    expect(result?.gasUsedUnits).toBe("21000");
   });
 
   it("encodes call data and forwards it to the Turnkey wrapper", async () => {


### PR DESCRIPTION
## Problem

The Turnkey Gas Station path returned `receipt.gasUsed`, a gas unit count, as its `gasUsed` field. Steps write that into `output.gasUsed`, which finalize sums into `workflow_executions.gas_used_wei`. The direct-signing path multiplies by `effectiveGasPrice` first and was correct, so the same column held two different quantities depending on which path ran.

Same workflow, same column, hours apart on prod:

```
path       units_from_receipt   stored_in_gas_used_wei   ledger_fee_wei
direct                347078          244920726760244
sponsored             372157                   372157   105155190686901
```

Sponsored rows store the unit count verbatim. The fee is elsewhere, in `gas_credit_usage`.

Effect: 9,157 execution rows across 77 organizations under-report gas by roughly nine orders of magnitude. For one organization, 21 of the last 32 days show 0.00000000 ETH despite 25 to 37 transactions a day. Surfaces affected are the Gas Spent KPI, the Networks tab, and execution digest emails.

## Fix

Multiply by `effectiveGasPrice` before returning, and keep the raw count in `gasUsedUnits`. `gasCostWei` is hoisted out of the testnet branch so the metric and the return value share one computation.

The Gas Spent card compounded this: it labelled the whole run total as "from wallet" and added the sponsorship ledger on top. That only survived because the sponsored contribution was dust; fixing the units alone would have made the headline double count. The wallet share is now derived by subtracting the ledger from the total, clamped at zero because the two figures sit on different time axes (run start vs ledger insert).

`walletShareWei` lives next to `formatGasSplit` so it is unit testable without React.

## Follow-up

Existing rows still hold unit counts. A backfill from `gas_credit_usage` is needed after this deploys, and the order matters: between deploy and backfill the wallet line reads low, whereas backfilling first would make the old code double count.

Billing is unaffected. `recordGasUsage` still receives the unit count and gas price, so `gas_cost_wei` and `gas_cost_micro_usd` are unchanged and the gas-credit guardrail behaves exactly as before.

Two tests asserted the old shape and are updated, one of them named "returns gasUsed as raw gas units, not wei cost".