### PR TITLE
fix: give keeperhub-common memory headroom and in-process memory metrics

### DIFF
--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -58,11 +58,53 @@ app:
       type: kv
       value: "http://keeperhub-sandbox-common.keeperhub.svc.cluster.local:8787"
 
-  replicaCount: 2
+  # Four replicas, not two. Work arrives in bursts that allocate roughly 1GB of
+  # off-heap RSS on the pod that receives them. With two replicas a pair of
+  # concurrent bursts stacks on one pod and crosses the memory limit, and the
+  # kernel OOM-kills it. More standing replicas spread the bursts immediately.
+  # An HPA cannot help here: the burst completes in about 90 seconds, which is
+  # shorter than the detect-schedule-boot cycle.
+  replicaCount: 4
 
   podDisruptionBudget:
     enabled: true
-    minAvailable: 1
+    # 3 of 4, so a Karpenter consolidation or a node roll can take one pod at a
+    # time. minAvailable 1 would let a drain remove three pods at once and
+    # concentrate every burst on the survivor.
+    minAvailable: 3
+
+  # Spread the replicas over distinct nodes, and keep them on nodes large enough
+  # to honour the memory limit below.
+  #
+  # The node affinity is required because the scheduler places pods by REQUEST,
+  # not by limit. The Karpenter default-private NodePool admits every instance
+  # size above `medium`, so a 4Gi request alone still fits on an 8GB node that
+  # can never deliver the 6Gi limit. Gating on instance-memory keeps these pods
+  # on nodes with real headroom.
+  #
+  # The pod anti-affinity is preferred, not required, so a replica still
+  # schedules when the node count is temporarily low. It selects on
+  # app.kubernetes.io/serviceName, which is the only selector label that is
+  # unique per component - every component in this umbrella release shares
+  # name=common and instance=keeperhub, so selecting on those would push these
+  # pods away from the executor and dispatcher pods as well.
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: karpenter.k8s.aws/instance-memory
+                operator: Gt
+                values:
+                  - "12000"
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/serviceName: keeperhub-common
 
   service:
     enabled: true
@@ -173,13 +215,24 @@ app:
 
   resources:
     limits:
-      # Must exceed NODE_OPTIONS --max-old-space-size by ~1 GiB to leave headroom
-      # for off-heap RSS (Buffers, source maps, native addons, worker threads).
-      # Setting these equal causes the kernel OOM-killer to fire before V8 GCs.
-      memory: 4Gi
+      # 6Gi against a 3072MB V8 ceiling, so the off-heap side gets 3GiB rather
+      # than the 1GiB the earlier 4Gi limit left it. The kills that drove this
+      # are off-heap: no container logged a V8 "heap out of memory" or FATAL
+      # line, so V8 never reached its ceiling and RSS crossed the cgroup limit
+      # on its own. Raising --max-old-space-size would take headroom away from
+      # the side that actually overflows, so leave it at 3072.
+      memory: 6Gi
     requests:
-      cpu: 100m
-      memory: 2Gi
+      # Requests, not limits, decide where a pod lands and how large a node
+      # Karpenter provisions for it. A 2Gi request let a replica schedule onto
+      # a node that could never supply the limit above. Keep this in step with
+      # the nodeAffinity gate on instance-memory.
+      #
+      # cpu 250m reflects measured use: p95 sits near 0.12 cores and the daily
+      # max near 0.22, so the previous 100m understated the pod on every node
+      # it ran on.
+      cpu: 250m
+      memory: 4Gi
 
   env:
     <<: *shared_env

--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -73,8 +73,8 @@ app:
     # concentrate every burst on the survivor.
     minAvailable: 3
 
-  # Spread the replicas over distinct nodes, and keep them on nodes large enough
-  # to honour the memory limit below.
+  # One replica per node, on nodes large enough to honour the memory limit
+  # below. Both rules are required, and that is deliberate.
   #
   # The node affinity is required because the scheduler places pods by REQUEST,
   # not by limit. The Karpenter default-private NodePool admits every instance
@@ -82,9 +82,20 @@ app:
   # can never deliver the 6Gi limit. Gating on instance-memory keeps these pods
   # on nodes with real headroom.
   #
-  # The pod anti-affinity is preferred, not required, so a replica still
-  # schedules when the node count is temporarily low. It selects on
-  # app.kubernetes.io/serviceName, which is the only selector label that is
+  # The pod anti-affinity is required rather than preferred because a preferred
+  # rule buys nothing here. Four pods at a 4Gi request fit on the two nodes
+  # that satisfy the gate today, so Karpenter would never add a node and the
+  # best available spread would be two per node. Two co-located pods can each
+  # reach 6Gi, and the nodes peak near 10GiB of 15.25GiB already, so that turns
+  # a single cgroup kill into node memory pressure - which is worse, because
+  # the kubelet then evicts neighbouring pods too. Concurrent bursts across
+  # replicas are observed, not hypothetical.
+  #
+  # If Karpenter cannot provision a qualifying node, the extra replicas stay
+  # Pending. That is the intended failure mode: Pending is visible and leaves
+  # the surviving replicas alone, while silent co-location is neither.
+  #
+  # Both selectors use app.kubernetes.io/serviceName, the only selector label
   # unique per component - every component in this umbrella release shares
   # name=common and instance=keeperhub, so selecting on those would push these
   # pods away from the executor and dispatcher pods as well.
@@ -98,13 +109,11 @@ app:
                 values:
                   - "12000"
     podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            topologyKey: kubernetes.io/hostname
-            labelSelector:
-              matchLabels:
-                app.kubernetes.io/serviceName: keeperhub-common
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/serviceName: keeperhub-common
 
   service:
     enabled: true

--- a/lib/metrics/METRICS_REFERENCE.md
+++ b/lib/metrics/METRICS_REFERENCE.md
@@ -112,6 +112,22 @@ Gauge metrics tracking resource usage and capacity.
 | `workflow.queue.depth` | Pending workflow jobs | - | < 50 | DB |
 | `workflow.concurrent.count` | Concurrent workflow executions | - | gauge | DB |
 
+### Process Memory
+
+Per-pod Node.js memory, emitted from `lib/metrics/instrumentation/process-memory.ts`. These are registered directly on the API-process registry rather than through `setGauge()`, so they appear on `/api/metrics/api` only and have no console-collector equivalent. Prometheus names are listed in full because these gauges are not routed through `MetricNames`.
+
+| Metric Name | Description | Labels | Source |
+|-------------|-------------|--------|--------|
+| `keeperhub_process_memory_rss_bytes` | Resident set size of the process | - | API |
+| `keeperhub_process_memory_heap_used_bytes` | V8 heap in use | - | API |
+| `keeperhub_process_memory_external_bytes` | Memory held by C++ objects bound to JavaScript | - | API |
+| `keeperhub_process_memory_array_buffers_bytes` | Memory held by ArrayBuffers and Buffers, a subset of `external` | - | API |
+| `keeperhub_process_memory_*_peak_bytes` | High-water mark of the matching bucket since the previous scrape | - | API |
+
+Read the `_peak_` variants, not the instantaneous ones, when investigating an OOM kill. A container can cross its memory limit and die entirely between two scrapes: cadvisor samples once per 60s and the app ServiceMonitor scrapes every 30s, so an allocation that starts and ends inside one interval leaves no trace in either. The sampler behind the peak gauges runs every second and reports the highest value it saw, so a spike of a few seconds still reaches the scrape that follows it. Each export opens a new window, which means `delta()` and `rate()` are meaningless on these; graph them with `max_over_time()`.
+
+`prom-client`'s default Node.js metrics are registered on the same registry, so `nodejs_gc_duration_seconds`, the per-space `nodejs_heap_space_size_*_bytes` breakdown, and `nodejs_eventloop_lag_seconds` are available alongside them. The heap-space breakdown plus `external` and `array_buffers` are what separate a burst that returns its memory from growth that does not.
+
 ---
 
 ## Safe Wallet Metrics

--- a/lib/metrics/METRICS_REFERENCE.md
+++ b/lib/metrics/METRICS_REFERENCE.md
@@ -124,9 +124,28 @@ Per-pod Node.js memory, emitted from `lib/metrics/instrumentation/process-memory
 | `keeperhub_process_memory_array_buffers_bytes` | Memory held by ArrayBuffers and Buffers, a subset of `external` | - | API |
 | `keeperhub_process_memory_*_peak_bytes` | High-water mark of the matching bucket since the previous scrape | - | API |
 
-Read the `_peak_` variants, not the instantaneous ones, when investigating an OOM kill. A container can cross its memory limit and die entirely between two scrapes: cadvisor samples once per 60s and the app ServiceMonitor scrapes every 30s, so an allocation that starts and ends inside one interval leaves no trace in either. The sampler behind the peak gauges runs every second and reports the highest value it saw, so a spike of a few seconds still reaches the scrape that follows it. Each export opens a new window, which means `delta()` and `rate()` are meaningless on these; graph them with `max_over_time()`.
+Alongside these, the cgroup v2 accounting for the container itself, read from `lib/metrics/cgroup-memory.ts`. These are absent off-cluster, where the files do not exist.
 
-`prom-client`'s default Node.js metrics are registered on the same registry, so `nodejs_gc_duration_seconds`, the per-space `nodejs_heap_space_size_*_bytes` breakdown, and `nodejs_eventloop_lag_seconds` are available alongside them. The heap-space breakdown plus `external` and `array_buffers` are what separate a burst that returns its memory from growth that does not.
+| Metric Name | Description | Labels | Source |
+|-------------|-------------|--------|--------|
+| `keeperhub_container_memory_current_bytes` | Current cgroup charge for the container | - | API |
+| `keeperhub_container_memory_peak_bytes` | Kernel high-water mark since the container started | - | API |
+| `keeperhub_container_memory_limit_bytes` | The cgroup limit, from `memory.max` | - | API |
+| `keeperhub_container_memory_oom_kills` | OOM kills the kernel performed in this cgroup | - | API |
+
+### Which one to read
+
+**`keeperhub_container_memory_peak_bytes` answers "how close did this container get to being killed".** The kernel maintains that high-water mark continuously, so unlike everything else here it cannot miss a spike that opens and closes between two reads. `container_memory_working_set_bytes` from cadvisor can and does: it samples once per 60s, `container_memory_max_usage_bytes` is not shipped to our Mimir tenant, and prod containers have crossed the limit and died inside a single sample gap leaving nothing behind. Prefer the cgroup number over cadvisor and over `rss` - the cgroup charge is what the OOM killer compares, and it counts page cache that RSS does not.
+
+**The `_peak_bytes` process buckets answer "which part of the process grew".** The cgroup cannot say, and that is the question when deciding whether a change is a heap problem or an off-heap one. These are sampled every second, so a spike shorter than that interval can still slip past them.
+
+Each export of the process buckets opens a new window, so `delta()` and `rate()` are meaningless on them; graph with `max_over_time()`. The cgroup peak is monotonic for the life of the container instead, and resets on restart.
+
+### The gap none of these close
+
+A container killed mid-burst never reaches the scrape that would have carried its window, so **no gauge here can describe the burst that actually kills a pod** - only near misses. For that case the sampler writes a log line when the cgroup charge crosses 75% of the limit, carrying the bucket split, and re-arms once it falls below 65%. That line ships as it is written and outlives the kill. Search Loki for `[ProcessMemory]`.
+
+`prom-client`'s default Node.js metrics are registered on the same registry, so `nodejs_gc_duration_seconds`, the per-space `nodejs_heap_space_size_*_bytes` breakdown, and `nodejs_eventloop_lag_seconds` are available alongside them.
 
 ---
 

--- a/lib/metrics/cgroup-memory.ts
+++ b/lib/metrics/cgroup-memory.ts
@@ -1,0 +1,85 @@
+/**
+ * cgroup v2 Memory Readings
+ *
+ * Reads the kernel's own memory accounting for this container. This is the
+ * number the OOM killer compares against the limit, so it is what decides
+ * whether the process lives, and it is strictly more authoritative than
+ * process.memoryUsage().rss - RSS excludes page cache that still counts toward
+ * the cgroup.
+ *
+ * memory.peak is the important one. It is a high-water mark maintained by the
+ * kernel continuously, so unlike any sampled value it cannot miss a spike that
+ * opens and closes between two reads. cadvisor samples once per 60s and
+ * container_memory_max_usage_bytes is not shipped to our Mimir tenant, which is
+ * why a container has crossed its limit and died leaving nothing behind.
+ *
+ * Everything here degrades to null rather than throwing. The files are absent
+ * on macOS, on cgroup v1 hosts, and in most local dev setups, and none of that
+ * is worth an error.
+ */
+
+import "server-only";
+
+import { readFileSync } from "node:fs";
+
+const CGROUP_ROOT = "/sys/fs/cgroup";
+
+// Anchored to the line start so it cannot match oom_group_kill, which sits on
+// its own line in memory.events and carries a different meaning.
+const OOM_KILL_REGEX = /^oom_kill (\d+)$/m;
+
+export type CgroupMemory = {
+  /** Current charge against the cgroup, in bytes. */
+  current: number;
+  /** Kernel high-water mark since the container started, in bytes. */
+  peak: number | null;
+  /** The limit, in bytes. null when the cgroup is unlimited ("max"). */
+  limit: number | null;
+};
+
+function readBytes(file: string): number | null {
+  try {
+    const raw = readFileSync(`${CGROUP_ROOT}/${file}`, "utf8").trim();
+    // memory.max reads the literal string "max" when no limit is set.
+    if (raw === "max" || raw === "") {
+      return null;
+    }
+    const value = Number(raw);
+    return Number.isFinite(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the cgroup memory triple. Returns null when this process is not in a
+ * readable cgroup v2, which is the normal case off-cluster.
+ */
+export function readCgroupMemory(): CgroupMemory | null {
+  const current = readBytes("memory.current");
+  if (current === null) {
+    return null;
+  }
+  return {
+    current,
+    peak: readBytes("memory.peak"),
+    limit: readBytes("memory.max"),
+  };
+}
+
+/**
+ * Count of OOM kills the kernel has performed in this cgroup.
+ *
+ * Resets with the cgroup, so it counts kills of the *current* container rather
+ * than restarts of the pod. A non-zero value means this container survived a
+ * kill of one of its child processes.
+ */
+export function readCgroupOomKills(): number | null {
+  try {
+    const raw = readFileSync(`${CGROUP_ROOT}/memory.events`, "utf8");
+    const match = raw.match(OOM_KILL_REGEX);
+    return match ? Number(match[1]) : null;
+  } catch {
+    return null;
+  }
+}

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -7,7 +7,13 @@
 
 import "server-only";
 
-import { Counter, Gauge, Histogram, Registry } from "prom-client";
+import {
+  Counter,
+  collectDefaultMetrics,
+  Gauge,
+  Histogram,
+  Registry,
+} from "prom-client";
 import type { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 import type { ErrorStatus } from "@/lib/errors/execution-status";
 import { ErrorCategory, logSystemWarn, logWarn } from "@/lib/logging";
@@ -1150,6 +1156,88 @@ const dbPoolUtilization = getOrCreateGauge(
   POOL_LABELS
 );
 
+// Process memory gauges (API-process, per-pod). No labels: each value belongs
+// to one process, and the pod identity arrives with the scrape.
+//
+// The _peak_ variants carry the high-water mark of the window between scrapes,
+// sampled every second by lib/metrics/instrumentation/process-memory.ts. They
+// exist because the container-level metrics cannot resolve the spike that
+// causes an OOM kill: cadvisor samples once per 60s, and a 30s scrape of an
+// instantaneous gauge has the same blind spot.
+const processMemoryRss = getOrCreateGauge(
+  apiRegistry,
+  "keeperhub_process_memory_rss_bytes",
+  "Resident set size of the Node.js process in bytes",
+  []
+);
+
+const processMemoryHeapUsed = getOrCreateGauge(
+  apiRegistry,
+  "keeperhub_process_memory_heap_used_bytes",
+  "V8 heap in use by the Node.js process in bytes",
+  []
+);
+
+const processMemoryExternal = getOrCreateGauge(
+  apiRegistry,
+  "keeperhub_process_memory_external_bytes",
+  "Memory held by C++ objects bound to JavaScript, in bytes",
+  []
+);
+
+const processMemoryArrayBuffers = getOrCreateGauge(
+  apiRegistry,
+  "keeperhub_process_memory_array_buffers_bytes",
+  "Memory held by ArrayBuffers and Buffers, in bytes (a subset of external)",
+  []
+);
+
+const processMemoryRssPeak = getOrCreateGauge(
+  apiRegistry,
+  "keeperhub_process_memory_rss_peak_bytes",
+  "Highest resident set size seen since the previous scrape, in bytes",
+  []
+);
+
+const processMemoryHeapUsedPeak = getOrCreateGauge(
+  apiRegistry,
+  "keeperhub_process_memory_heap_used_peak_bytes",
+  "Highest V8 heap in use seen since the previous scrape, in bytes",
+  []
+);
+
+const processMemoryExternalPeak = getOrCreateGauge(
+  apiRegistry,
+  "keeperhub_process_memory_external_peak_bytes",
+  "Highest external memory seen since the previous scrape, in bytes",
+  []
+);
+
+const processMemoryArrayBuffersPeak = getOrCreateGauge(
+  apiRegistry,
+  "keeperhub_process_memory_array_buffers_peak_bytes",
+  "Highest ArrayBuffer memory seen since the previous scrape, in bytes",
+  []
+);
+
+// prom-client's default Node.js metrics, on apiRegistry for the same reason the
+// gauges above are: only /api/metrics/api is scraped from the app pods, and
+// these values are per-pod. They add the per-V8-space heap breakdown, GC pause
+// counts and durations, and event-loop lag, which is what separates a burst
+// that returns its memory from growth that does not.
+//
+// The flag lives on globalThis for the same reason the registries do: a dev
+// hot reload re-evaluates this module, and a second collectDefaultMetrics call
+// against the retained registry throws on the duplicate names.
+const globalForRuntimeMetrics = globalThis as unknown as {
+  nodeRuntimeMetricsRegistered: boolean | undefined;
+};
+
+if (!globalForRuntimeMetrics.nodeRuntimeMetricsRegistered) {
+  globalForRuntimeMetrics.nodeRuntimeMetricsRegistered = true;
+  collectDefaultMetrics({ register: apiRegistry });
+}
+
 // TODO(HARDEN-03 / v1.13): register keeperhub_scan_address_duration_ms
 // (histogram, label: status), keeperhub_scan_cache_hit_total,
 // keeperhub_scan_cache_miss_total, and keeperhub_scan_zerion_calls_total
@@ -1947,6 +2035,13 @@ export async function getApiProcessMetrics(): Promise<string> {
   await initRpcMetricsForAllChains();
   const { startRpcHealthProbe } = await import("../rpc-health-probe");
   startRpcHealthProbe();
+
+  const { startProcessMemorySampler, updateProcessMemoryGauges } = await import(
+    "../instrumentation/process-memory"
+  );
+  startProcessMemorySampler();
+  updateProcessMemoryGauges();
+
   return await apiRegistry.metrics();
 }
 
@@ -1979,6 +2074,25 @@ export const rpcProbeMetrics = {
   latency: rpcProbeLatency,
   errorsTotal: rpcProbeErrorsTotal,
   lastSuccess: rpcProbeLastSuccess,
+};
+
+/**
+ * Process memory gauge accessors for the process-memory sampler.
+ *
+ * These stay out of gaugeMap on purpose. gaugeMap serves the
+ * setGauge(name, value) collector interface, which routes through the console
+ * collector as well; these gauges are written directly by the sampler and have
+ * no console-mode equivalent.
+ */
+export const processMemoryMetrics = {
+  rss: processMemoryRss,
+  heapUsed: processMemoryHeapUsed,
+  external: processMemoryExternal,
+  arrayBuffers: processMemoryArrayBuffers,
+  rssPeak: processMemoryRssPeak,
+  heapUsedPeak: processMemoryHeapUsedPeak,
+  externalPeak: processMemoryExternalPeak,
+  arrayBuffersPeak: processMemoryArrayBuffersPeak,
 };
 
 /**

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -1220,6 +1220,41 @@ const processMemoryArrayBuffersPeak = getOrCreateGauge(
   []
 );
 
+// cgroup v2 accounting for this container. This is the number the OOM killer
+// compares against the limit, so it decides whether the process lives, and it
+// counts page cache that RSS does not.
+//
+// The peak matters most. The kernel maintains it continuously, so it cannot
+// miss a spike that opens and closes between two reads - unlike every gauge
+// above it, and unlike cadvisor, which samples once per 60s.
+const containerMemoryCurrent = getOrCreateGauge(
+  apiRegistry,
+  "keeperhub_container_memory_current_bytes",
+  "Current cgroup v2 memory charge for this container, in bytes",
+  []
+);
+
+const containerMemoryPeak = getOrCreateGauge(
+  apiRegistry,
+  "keeperhub_container_memory_peak_bytes",
+  "Kernel high-water mark of cgroup memory since this container started, in bytes",
+  []
+);
+
+const containerMemoryLimit = getOrCreateGauge(
+  apiRegistry,
+  "keeperhub_container_memory_limit_bytes",
+  "cgroup v2 memory limit for this container, in bytes",
+  []
+);
+
+const containerMemoryOomKills = getOrCreateGauge(
+  apiRegistry,
+  "keeperhub_container_memory_oom_kills",
+  "OOM kills the kernel performed in this cgroup since the container started",
+  []
+);
+
 // prom-client's default Node.js metrics, on apiRegistry for the same reason the
 // gauges above are: only /api/metrics/api is scraped from the app pods, and
 // these values are per-pod. They add the per-V8-space heap breakdown, GC pause
@@ -2093,6 +2128,10 @@ export const processMemoryMetrics = {
   heapUsedPeak: processMemoryHeapUsedPeak,
   externalPeak: processMemoryExternalPeak,
   arrayBuffersPeak: processMemoryArrayBuffersPeak,
+  cgroupCurrent: containerMemoryCurrent,
+  cgroupPeak: containerMemoryPeak,
+  cgroupLimit: containerMemoryLimit,
+  cgroupOomKills: containerMemoryOomKills,
 };
 
 /**

--- a/lib/metrics/instrumentation/process-memory.ts
+++ b/lib/metrics/instrumentation/process-memory.ts
@@ -1,0 +1,124 @@
+/**
+ * Process Memory Instrumentation
+ *
+ * Tracks Node.js process memory and exposes it as per-pod gauges.
+ *
+ * Why a sampler rather than a plain read at scrape time: prod containers have
+ * been OOM-killed between two consecutive cadvisor samples, which are 60s
+ * apart. A gauge read only when Prometheus scrapes has the same blind spot at
+ * its own 30s interval - the allocation that crosses the limit starts and ends
+ * inside one gap, so nothing records it. This module samples every second and
+ * keeps a high-water mark, so a spike that lasts a few seconds still reaches
+ * the scrape that follows it.
+ *
+ * Started lazily on the first /api/metrics/api scrape, the same way
+ * startRpcHealthProbe() is.
+ */
+
+import "server-only";
+
+import { processMemoryMetrics } from "../collectors/prometheus";
+
+const SAMPLE_INTERVAL_MS = 1000;
+
+type MemoryPeak = {
+  rss: number;
+  heapUsed: number;
+  external: number;
+  arrayBuffers: number;
+};
+
+// Hot-reload safe: keep the timer and the running peak on globalThis so a dev
+// restart does not spawn a second sampler or lose the window.
+const globalForMemory = globalThis as unknown as {
+  processMemoryTimer: ReturnType<typeof setInterval> | undefined;
+  processMemoryPeak: MemoryPeak | undefined;
+};
+
+function readUsage(): MemoryPeak {
+  const usage = process.memoryUsage();
+  return {
+    rss: usage.rss,
+    heapUsed: usage.heapUsed,
+    external: usage.external,
+    arrayBuffers: usage.arrayBuffers,
+  };
+}
+
+function mergePeak(
+  peak: MemoryPeak | undefined,
+  sample: MemoryPeak
+): MemoryPeak {
+  if (!peak) {
+    return sample;
+  }
+  return {
+    rss: Math.max(peak.rss, sample.rss),
+    heapUsed: Math.max(peak.heapUsed, sample.heapUsed),
+    external: Math.max(peak.external, sample.external),
+    arrayBuffers: Math.max(peak.arrayBuffers, sample.arrayBuffers),
+  };
+}
+
+/**
+ * Take one sample and fold it into the running peak.
+ */
+export function sampleProcessMemory(): void {
+  globalForMemory.processMemoryPeak = mergePeak(
+    globalForMemory.processMemoryPeak,
+    readUsage()
+  );
+}
+
+/**
+ * Start the 1s sampler. Idempotent, so repeated scrapes do not stack timers.
+ * The timer is unref'd, so it never keeps the process alive on its own.
+ */
+export function startProcessMemorySampler(): void {
+  if (globalForMemory.processMemoryTimer !== undefined) {
+    return;
+  }
+
+  sampleProcessMemory();
+  globalForMemory.processMemoryTimer = setInterval(
+    sampleProcessMemory,
+    SAMPLE_INTERVAL_MS
+  );
+  globalForMemory.processMemoryTimer.unref();
+}
+
+/**
+ * Stop the sampler and drop the running peak. Used by tests.
+ */
+export function stopProcessMemorySampler(): void {
+  if (globalForMemory.processMemoryTimer !== undefined) {
+    clearInterval(globalForMemory.processMemoryTimer);
+    globalForMemory.processMemoryTimer = undefined;
+  }
+  globalForMemory.processMemoryPeak = undefined;
+}
+
+/**
+ * Publish the current reading and the peak of the window that just ended, then
+ * open a new window.
+ *
+ * The new window is seeded with the reading taken here rather than with zero,
+ * so the peak gauges never report below the instantaneous ones when a scrape
+ * lands before the first tick of the next window.
+ */
+export function updateProcessMemoryGauges(): void {
+  const current = readUsage();
+  const peak = mergePeak(globalForMemory.processMemoryPeak, current);
+
+  processMemoryMetrics.rss.set(current.rss);
+  processMemoryMetrics.heapUsed.set(current.heapUsed);
+  processMemoryMetrics.external.set(current.external);
+  processMemoryMetrics.arrayBuffers.set(current.arrayBuffers);
+
+  processMemoryMetrics.rssPeak.set(peak.rss);
+  processMemoryMetrics.heapUsedPeak.set(peak.heapUsed);
+  processMemoryMetrics.externalPeak.set(peak.external);
+  processMemoryMetrics.arrayBuffersPeak.set(peak.arrayBuffers);
+
+  globalForMemory.processMemoryPeak = current;
+}

--- a/lib/metrics/instrumentation/process-memory.ts
+++ b/lib/metrics/instrumentation/process-memory.ts
@@ -1,7 +1,8 @@
 /**
  * Process Memory Instrumentation
  *
- * Tracks Node.js process memory and exposes it as per-pod gauges.
+ * Tracks Node.js process memory and the container's cgroup accounting, and
+ * exposes both as per-pod gauges.
  *
  * Why a sampler rather than a plain read at scrape time: prod containers have
  * been OOM-killed between two consecutive cadvisor samples, which are 60s
@@ -11,15 +12,36 @@
  * keeps a high-water mark, so a spike that lasts a few seconds still reaches
  * the scrape that follows it.
  *
+ * The per-bucket peaks are still sampled and can still miss a spike shorter
+ * than the interval. The cgroup peak cannot: the kernel maintains it
+ * continuously. Read the cgroup peak for "how close did this container get to
+ * its limit" and the buckets for "which part of the process grew".
+ *
+ * Neither survives the process. A container killed mid-burst never reaches the
+ * scrape that would have carried its window, so a threshold crossing also
+ * writes one log line. That line is shipped as it is written and outlives the
+ * kill, which is the only signal available for a burst that turns out to be
+ * fatal.
+ *
  * Started lazily on the first /api/metrics/api scrape, the same way
  * startRpcHealthProbe() is.
  */
 
 import "server-only";
 
+import { logWarn } from "@/lib/logging";
+import { readCgroupMemory, readCgroupOomKills } from "../cgroup-memory";
 import { processMemoryMetrics } from "../collectors/prometheus";
 
 const SAMPLE_INTERVAL_MS = 1000;
+
+// Fraction of the cgroup limit that arms a log line, and the lower fraction
+// that re-arms it. The gap is what stops a container sitting just above the
+// line from logging every second. 0.75 sits above every non-fatal excursion
+// observed so far (the worst reached about 0.78 of the old 4Gi limit, which is
+// 0.52 of the new one), so a crossing means a genuinely unusual burst.
+const LOG_THRESHOLD_FRACTION = 0.75;
+const LOG_REARM_FRACTION = 0.65;
 
 type MemoryPeak = {
   rss: number;
@@ -28,11 +50,13 @@ type MemoryPeak = {
   arrayBuffers: number;
 };
 
-// Hot-reload safe: keep the timer and the running peak on globalThis so a dev
-// restart does not spawn a second sampler or lose the window.
+// Hot-reload safe: keep the timer, the running peak and the latch on
+// globalThis so a dev restart does not spawn a second sampler, lose the
+// window, or re-fire a log line that already went out.
 const globalForMemory = globalThis as unknown as {
   processMemoryTimer: ReturnType<typeof setInterval> | undefined;
   processMemoryPeak: MemoryPeak | undefined;
+  processMemoryLogArmed: boolean | undefined;
 };
 
 function readUsage(): MemoryPeak {
@@ -60,14 +84,61 @@ function mergePeak(
   };
 }
 
+function mib(bytes: number): string {
+  return String(Math.round(bytes / 1024 / 1024));
+}
+
 /**
- * Take one sample and fold it into the running peak.
+ * Write one line when the container crosses the threshold, and stay quiet
+ * until it has dropped back below the re-arm level.
+ *
+ * The line carries the bucket split, because the bucket that grew is the whole
+ * question and the cgroup number alone cannot answer it. Anything read here is
+ * already in hand, so the line costs one formatted string.
+ */
+function checkLogThreshold(usage: MemoryPeak, current: number, limit: number) {
+  const armed = globalForMemory.processMemoryLogArmed ?? true;
+  const fraction = current / limit;
+
+  if (armed && fraction >= LOG_THRESHOLD_FRACTION) {
+    globalForMemory.processMemoryLogArmed = false;
+    logWarn("[ProcessMemory] Container memory crossed the alert threshold", {
+      container_current_mib: mib(current),
+      container_limit_mib: mib(limit),
+      container_used_percent: (fraction * 100).toFixed(1),
+      rss_mib: mib(usage.rss),
+      heap_used_mib: mib(usage.heapUsed),
+      external_mib: mib(usage.external),
+      array_buffers_mib: mib(usage.arrayBuffers),
+    });
+    return;
+  }
+
+  if (!armed && fraction < LOG_REARM_FRACTION) {
+    globalForMemory.processMemoryLogArmed = true;
+    logWarn("[ProcessMemory] Container memory returned below the threshold", {
+      container_current_mib: mib(current),
+      container_limit_mib: mib(limit),
+      container_used_percent: (fraction * 100).toFixed(1),
+    });
+  }
+}
+
+/**
+ * Take one sample, fold it into the running peak, and log a threshold
+ * crossing. Never throws: a failure here would take down the scrape path.
  */
 export function sampleProcessMemory(): void {
+  const usage = readUsage();
   globalForMemory.processMemoryPeak = mergePeak(
     globalForMemory.processMemoryPeak,
-    readUsage()
+    usage
   );
+
+  const cgroup = readCgroupMemory();
+  if (cgroup?.limit) {
+    checkLogThreshold(usage, cgroup.current, cgroup.limit);
+  }
 }
 
 /**
@@ -88,7 +159,7 @@ export function startProcessMemorySampler(): void {
 }
 
 /**
- * Stop the sampler and drop the running peak. Used by tests.
+ * Stop the sampler and drop the running peak and the latch. Used by tests.
  */
 export function stopProcessMemorySampler(): void {
   if (globalForMemory.processMemoryTimer !== undefined) {
@@ -96,6 +167,7 @@ export function stopProcessMemorySampler(): void {
     globalForMemory.processMemoryTimer = undefined;
   }
   globalForMemory.processMemoryPeak = undefined;
+  globalForMemory.processMemoryLogArmed = undefined;
 }
 
 /**
@@ -121,4 +193,20 @@ export function updateProcessMemoryGauges(): void {
   processMemoryMetrics.arrayBuffersPeak.set(peak.arrayBuffers);
 
   globalForMemory.processMemoryPeak = current;
+
+  const cgroup = readCgroupMemory();
+  if (cgroup) {
+    processMemoryMetrics.cgroupCurrent.set(cgroup.current);
+    if (cgroup.peak !== null) {
+      processMemoryMetrics.cgroupPeak.set(cgroup.peak);
+    }
+    if (cgroup.limit !== null) {
+      processMemoryMetrics.cgroupLimit.set(cgroup.limit);
+    }
+  }
+
+  const oomKills = readCgroupOomKills();
+  if (oomKills !== null) {
+    processMemoryMetrics.cgroupOomKills.set(oomKills);
+  }
 }

--- a/tests/unit/cgroup-memory.test.ts
+++ b/tests/unit/cgroup-memory.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { readFileSync } = vi.hoisted(() => ({ readFileSync: vi.fn() }));
+vi.mock("node:fs", () => ({ readFileSync }));
+
+import {
+  readCgroupMemory,
+  readCgroupOomKills,
+} from "@/lib/metrics/cgroup-memory";
+
+/**
+ * Values copied from a live prod pod on 2026-08-12, so the parser is exercised
+ * against the exact bytes the kernel writes rather than an invented shape.
+ */
+const PROD = {
+  "memory.current": "980123648\n",
+  "memory.peak": "3347591168\n",
+  "memory.max": "4294967296\n",
+  "memory.events":
+    "low 0\nhigh 0\nmax 0\noom 0\noom_kill 0\noom_group_kill 0\n",
+};
+
+function serve(files: Record<string, string | Error>): void {
+  readFileSync.mockImplementation((path: string) => {
+    const key = path.replace("/sys/fs/cgroup/", "");
+    const value = files[key];
+    if (value === undefined) {
+      throw new Error(`ENOENT: ${path}`);
+    }
+    if (value instanceof Error) {
+      throw value;
+    }
+    return value;
+  });
+}
+
+describe("cgroup v2 memory reader", () => {
+  beforeEach(() => {
+    readFileSync.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parses the values a live prod container reports", () => {
+    serve(PROD);
+
+    expect(readCgroupMemory()).toEqual({
+      current: 980_123_648,
+      peak: 3_347_591_168,
+      limit: 4_294_967_296,
+    });
+  });
+
+  it("reads the oom_kill counter out of memory.events", () => {
+    serve({ ...PROD, "memory.events": "low 0\nmax 3\noom 2\noom_kill 1\n" });
+
+    expect(readCgroupOomKills()).toBe(1);
+  });
+
+  it("does not confuse oom_group_kill for oom_kill", () => {
+    serve({
+      ...PROD,
+      "memory.events": "oom 5\noom_kill 2\noom_group_kill 9\n",
+    });
+
+    expect(readCgroupOomKills()).toBe(2);
+  });
+
+  it("treats an unlimited cgroup as no limit rather than a number", () => {
+    serve({ ...PROD, "memory.max": "max\n" });
+
+    expect(readCgroupMemory()?.limit).toBeNull();
+  });
+
+  it("returns null off-cluster, where the files do not exist", () => {
+    serve({});
+
+    expect(readCgroupMemory()).toBeNull();
+    expect(readCgroupOomKills()).toBeNull();
+  });
+
+  it("survives a cgroup v1 host, which has no memory.current", () => {
+    serve({ "memory.limit_in_bytes": "4294967296\n" });
+
+    expect(readCgroupMemory()).toBeNull();
+  });
+
+  it("degrades to null on an unreadable or garbage file rather than throwing", () => {
+    serve({ "memory.current": "not-a-number\n" });
+    expect(readCgroupMemory()).toBeNull();
+
+    serve({ "memory.current": new Error("EACCES") });
+    expect(() => readCgroupMemory()).not.toThrow();
+    expect(readCgroupMemory()).toBeNull();
+  });
+
+  it("reports a present peak of zero rather than dropping it", () => {
+    serve({ ...PROD, "memory.current": "0\n", "memory.peak": "0\n" });
+
+    expect(readCgroupMemory()).toEqual({
+      current: 0,
+      peak: 0,
+      limit: 4_294_967_296,
+    });
+  });
+});

--- a/tests/unit/process-memory-metrics.test.ts
+++ b/tests/unit/process-memory-metrics.test.ts
@@ -4,9 +4,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // whole point of the marker. Stub it so the guard stays in the source.
 vi.mock("server-only", () => ({}));
 
-// vi.mock is hoisted above the imports, so the gauge stubs have to be hoisted
-// with it rather than declared as ordinary top-level consts.
-const { processMemoryMetrics } = vi.hoisted(() => {
+// vi.mock is hoisted above the imports, so the stubs have to be hoisted with
+// it rather than declared as ordinary top-level consts.
+const { processMemoryMetrics, cgroup, logWarn } = vi.hoisted(() => {
   const gauge = () => ({ set: vi.fn() });
   return {
     processMemoryMetrics: {
@@ -18,7 +18,16 @@ const { processMemoryMetrics } = vi.hoisted(() => {
       heapUsedPeak: gauge(),
       externalPeak: gauge(),
       arrayBuffersPeak: gauge(),
+      cgroupCurrent: gauge(),
+      cgroupPeak: gauge(),
+      cgroupLimit: gauge(),
+      cgroupOomKills: gauge(),
     },
+    cgroup: {
+      readCgroupMemory: vi.fn(),
+      readCgroupOomKills: vi.fn(),
+    },
+    logWarn: vi.fn(),
   };
 });
 
@@ -27,6 +36,22 @@ const { processMemoryMetrics } = vi.hoisted(() => {
 vi.mock("@/lib/metrics/collectors/prometheus", () => ({
   processMemoryMetrics,
 }));
+
+// The cgroup files exist only inside a container, so the reader is stubbed and
+// its own behaviour is covered separately.
+vi.mock("@/lib/metrics/cgroup-memory", () => cgroup);
+
+vi.mock("@/lib/logging", () => ({ logWarn }));
+
+const LIMIT = 6 * 1024 * 1024 * 1024;
+
+function cgroupAt(fraction: number): void {
+  cgroup.readCgroupMemory.mockReturnValue({
+    current: Math.round(LIMIT * fraction),
+    peak: Math.round(LIMIT * fraction),
+    limit: LIMIT,
+  });
+}
 
 import {
   sampleProcessMemory,
@@ -77,6 +102,10 @@ describe("Process Memory Instrumentation", () => {
     for (const g of Object.values(processMemoryMetrics)) {
       g.set.mockClear();
     }
+    logWarn.mockClear();
+    // Default: no cgroup, which is the off-cluster case.
+    cgroup.readCgroupMemory.mockReturnValue(null);
+    cgroup.readCgroupOomKills.mockReturnValue(null);
   });
 
   afterEach(() => {
@@ -164,6 +193,142 @@ describe("Process Memory Instrumentation", () => {
 
       expect(processMemoryMetrics.rss.set).toHaveBeenCalledWith(BASE.rss);
       expect(processMemoryMetrics.rssPeak.set).toHaveBeenCalledWith(BASE.rss);
+    });
+  });
+
+  describe("threshold logging", () => {
+    it("writes one line when the container crosses the threshold", () => {
+      mockUsage(SPIKE);
+      cgroupAt(0.8);
+
+      sampleProcessMemory();
+
+      expect(logWarn).toHaveBeenCalledTimes(1);
+      const [message, labels] = logWarn.mock.calls[0];
+      expect(message).toContain("crossed the alert threshold");
+      expect(labels.container_used_percent).toBe("80.0");
+      // The bucket split is the point: the cgroup number alone cannot say
+      // which part of the process grew.
+      expect(labels.array_buffers_mib).toBe(
+        String(Math.round(2400 / 1_048_576))
+      );
+      expect(labels.rss_mib).toBeDefined();
+      expect(labels.heap_used_mib).toBeDefined();
+      expect(labels.external_mib).toBeDefined();
+    });
+
+    it("does not repeat while the container stays above the threshold", () => {
+      mockUsage(SPIKE);
+      cgroupAt(0.8);
+      startProcessMemorySampler();
+
+      vi.advanceTimersByTime(10_000);
+
+      expect(logWarn).toHaveBeenCalledTimes(1);
+    });
+
+    it("stays latched in the hysteresis band", () => {
+      mockUsage(SPIKE);
+      cgroupAt(0.8);
+      sampleProcessMemory();
+      logWarn.mockClear();
+
+      // Below the threshold but above the re-arm level.
+      cgroupAt(0.7);
+      sampleProcessMemory();
+
+      expect(logWarn).not.toHaveBeenCalled();
+    });
+
+    it("re-arms after dropping below the re-arm level, and can fire again", () => {
+      mockUsage(SPIKE);
+      cgroupAt(0.8);
+      sampleProcessMemory();
+      expect(logWarn).toHaveBeenCalledTimes(1);
+
+      cgroupAt(0.5);
+      sampleProcessMemory();
+      expect(logWarn).toHaveBeenCalledTimes(2);
+      expect(logWarn.mock.calls[1][0]).toContain(
+        "returned below the threshold"
+      );
+
+      cgroupAt(0.9);
+      sampleProcessMemory();
+      expect(logWarn).toHaveBeenCalledTimes(3);
+      expect(logWarn.mock.calls[2][0]).toContain("crossed the alert threshold");
+    });
+
+    it("stays silent below the threshold", () => {
+      mockUsage(BASE);
+      cgroupAt(0.3);
+      startProcessMemorySampler();
+
+      vi.advanceTimersByTime(10_000);
+
+      expect(logWarn).not.toHaveBeenCalled();
+    });
+
+    it("stays silent when there is no cgroup limit to compare against", () => {
+      mockUsage(SPIKE);
+      cgroup.readCgroupMemory.mockReturnValue({
+        current: 5_000_000_000,
+        peak: 5_000_000_000,
+        limit: null,
+      });
+
+      sampleProcessMemory();
+
+      expect(logWarn).not.toHaveBeenCalled();
+    });
+
+    it("samples normally when the cgroup is unreadable", () => {
+      mockUsage(BASE);
+      cgroup.readCgroupMemory.mockReturnValue(null);
+      startProcessMemorySampler();
+
+      mockUsage(SPIKE);
+      vi.advanceTimersByTime(1000);
+      mockUsage(BASE);
+      updateProcessMemoryGauges();
+
+      expect(logWarn).not.toHaveBeenCalled();
+      expect(processMemoryMetrics.rssPeak.set).toHaveBeenCalledWith(SPIKE.rss);
+      expect(processMemoryMetrics.cgroupCurrent.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("cgroup gauges", () => {
+    it("publishes current, peak, limit and oom kills", () => {
+      mockUsage(BASE);
+      cgroup.readCgroupMemory.mockReturnValue({
+        current: 1000,
+        peak: 3500,
+        limit: LIMIT,
+      });
+      cgroup.readCgroupOomKills.mockReturnValue(2);
+
+      updateProcessMemoryGauges();
+
+      expect(processMemoryMetrics.cgroupCurrent.set).toHaveBeenCalledWith(1000);
+      expect(processMemoryMetrics.cgroupPeak.set).toHaveBeenCalledWith(3500);
+      expect(processMemoryMetrics.cgroupLimit.set).toHaveBeenCalledWith(LIMIT);
+      expect(processMemoryMetrics.cgroupOomKills.set).toHaveBeenCalledWith(2);
+    });
+
+    it("skips the peak and limit gauges when the kernel does not expose them", () => {
+      mockUsage(BASE);
+      cgroup.readCgroupMemory.mockReturnValue({
+        current: 1000,
+        peak: null,
+        limit: null,
+      });
+
+      updateProcessMemoryGauges();
+
+      expect(processMemoryMetrics.cgroupCurrent.set).toHaveBeenCalledWith(1000);
+      expect(processMemoryMetrics.cgroupPeak.set).not.toHaveBeenCalled();
+      expect(processMemoryMetrics.cgroupLimit.set).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/process-memory-metrics.test.ts
+++ b/tests/unit/process-memory-metrics.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// `server-only` throws on import outside a React Server Component, which is the
+// whole point of the marker. Stub it so the guard stays in the source.
+vi.mock("server-only", () => ({}));
+
+// vi.mock is hoisted above the imports, so the gauge stubs have to be hoisted
+// with it rather than declared as ordinary top-level consts.
+const { processMemoryMetrics } = vi.hoisted(() => {
+  const gauge = () => ({ set: vi.fn() });
+  return {
+    processMemoryMetrics: {
+      rss: gauge(),
+      heapUsed: gauge(),
+      external: gauge(),
+      arrayBuffers: gauge(),
+      rssPeak: gauge(),
+      heapUsedPeak: gauge(),
+      externalPeak: gauge(),
+      arrayBuffersPeak: gauge(),
+    },
+  };
+});
+
+// The real module pulls in prom-client and `server-only`. The sampler logic is
+// what this suite covers, so the gauges are stubbed out entirely.
+vi.mock("@/lib/metrics/collectors/prometheus", () => ({
+  processMemoryMetrics,
+}));
+
+import {
+  sampleProcessMemory,
+  startProcessMemorySampler,
+  stopProcessMemorySampler,
+  updateProcessMemoryGauges,
+} from "@/lib/metrics/instrumentation/process-memory";
+
+type Usage = {
+  rss: number;
+  heapUsed: number;
+  external: number;
+  arrayBuffers: number;
+};
+
+function usage(u: Usage): NodeJS.MemoryUsage {
+  return {
+    rss: u.rss,
+    heapTotal: u.heapUsed * 2,
+    heapUsed: u.heapUsed,
+    external: u.external,
+    arrayBuffers: u.arrayBuffers,
+  };
+}
+
+function mockUsage(u: Usage): void {
+  vi.spyOn(process, "memoryUsage").mockReturnValue(usage(u));
+}
+
+const BASE: Usage = {
+  rss: 700,
+  heapUsed: 300,
+  external: 80,
+  arrayBuffers: 40,
+};
+
+const SPIKE: Usage = {
+  rss: 4000,
+  heapUsed: 900,
+  external: 2600,
+  arrayBuffers: 2400,
+};
+
+describe("Process Memory Instrumentation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    stopProcessMemorySampler();
+    for (const g of Object.values(processMemoryMetrics)) {
+      g.set.mockClear();
+    }
+  });
+
+  afterEach(() => {
+    stopProcessMemorySampler();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  describe("peak tracking", () => {
+    it("reports a spike that has already passed by the time of the scrape", () => {
+      mockUsage(BASE);
+      startProcessMemorySampler();
+
+      // The spike opens and closes entirely between two scrapes.
+      mockUsage(SPIKE);
+      vi.advanceTimersByTime(2000);
+      mockUsage(BASE);
+      vi.advanceTimersByTime(2000);
+
+      updateProcessMemoryGauges();
+
+      expect(processMemoryMetrics.rss.set).toHaveBeenCalledWith(BASE.rss);
+      expect(processMemoryMetrics.rssPeak.set).toHaveBeenCalledWith(SPIKE.rss);
+      expect(processMemoryMetrics.arrayBuffersPeak.set).toHaveBeenCalledWith(
+        SPIKE.arrayBuffers
+      );
+    });
+
+    it("tracks each bucket independently", () => {
+      mockUsage(BASE);
+      startProcessMemorySampler();
+
+      mockUsage({ ...BASE, external: 5000 });
+      vi.advanceTimersByTime(1000);
+      mockUsage({ ...BASE, heapUsed: 2500 });
+      vi.advanceTimersByTime(1000);
+
+      updateProcessMemoryGauges();
+
+      expect(processMemoryMetrics.externalPeak.set).toHaveBeenCalledWith(5000);
+      expect(processMemoryMetrics.heapUsedPeak.set).toHaveBeenCalledWith(2500);
+      expect(processMemoryMetrics.rssPeak.set).toHaveBeenCalledWith(BASE.rss);
+    });
+
+    it("opens a new window on each export so an old spike does not persist", () => {
+      mockUsage(BASE);
+      startProcessMemorySampler();
+
+      mockUsage(SPIKE);
+      vi.advanceTimersByTime(1000);
+      mockUsage(BASE);
+      updateProcessMemoryGauges();
+
+      expect(processMemoryMetrics.rssPeak.set).toHaveBeenLastCalledWith(
+        SPIKE.rss
+      );
+
+      vi.advanceTimersByTime(2000);
+      updateProcessMemoryGauges();
+
+      expect(processMemoryMetrics.rssPeak.set).toHaveBeenLastCalledWith(
+        BASE.rss
+      );
+    });
+
+    it("never reports a peak below the instantaneous reading", () => {
+      mockUsage(BASE);
+      startProcessMemorySampler();
+      updateProcessMemoryGauges();
+
+      // No tick has run in the new window yet.
+      mockUsage(SPIKE);
+      updateProcessMemoryGauges();
+
+      expect(processMemoryMetrics.rss.set).toHaveBeenLastCalledWith(SPIKE.rss);
+      expect(processMemoryMetrics.rssPeak.set).toHaveBeenLastCalledWith(
+        SPIKE.rss
+      );
+    });
+
+    it("exports without a running sampler", () => {
+      mockUsage(BASE);
+
+      updateProcessMemoryGauges();
+
+      expect(processMemoryMetrics.rss.set).toHaveBeenCalledWith(BASE.rss);
+      expect(processMemoryMetrics.rssPeak.set).toHaveBeenCalledWith(BASE.rss);
+    });
+  });
+
+  describe("sampler lifecycle", () => {
+    it("starts one timer no matter how many scrapes call it", () => {
+      mockUsage(BASE);
+      const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+      startProcessMemorySampler();
+      startProcessMemorySampler();
+      startProcessMemorySampler();
+
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("unrefs the timer so it cannot hold the process open", () => {
+      mockUsage(BASE);
+      startProcessMemorySampler();
+      const unref = vi.fn();
+      const setIntervalSpy = vi
+        .spyOn(globalThis, "setInterval")
+        .mockReturnValue({ unref } as unknown as NodeJS.Timeout);
+
+      stopProcessMemorySampler();
+      startProcessMemorySampler();
+
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+      expect(unref).toHaveBeenCalledTimes(1);
+    });
+
+    it("drops the running peak when stopped", () => {
+      mockUsage(BASE);
+      startProcessMemorySampler();
+      mockUsage(SPIKE);
+      sampleProcessMemory();
+
+      stopProcessMemorySampler();
+
+      mockUsage(BASE);
+      updateProcessMemoryGauges();
+
+      expect(processMemoryMetrics.rssPeak.set).toHaveBeenCalledWith(BASE.rss);
+    });
+
+    it("stops sampling after stopProcessMemorySampler", () => {
+      mockUsage(BASE);
+      startProcessMemorySampler();
+      stopProcessMemorySampler();
+
+      mockUsage(SPIKE);
+      vi.advanceTimersByTime(5000);
+      mockUsage(BASE);
+      updateProcessMemoryGauges();
+
+      expect(processMemoryMetrics.rssPeak.set).toHaveBeenCalledWith(BASE.rss);
+    });
+  });
+});

--- a/tests/unit/process-memory-registration.test.ts
+++ b/tests/unit/process-memory-registration.test.ts
@@ -1,0 +1,86 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+// `server-only` throws on import outside a React Server Component. Stub it so
+// the guard stays in the source while the real collector loads here.
+vi.mock("server-only", () => ({}));
+
+/**
+ * Registration test against the real prom-client registry.
+ *
+ * The sampler suite stubs the gauges out; this one covers the other half - that
+ * the gauges exist under the expected names and reach the scrape output. A
+ * gauge registered on dbRegistry instead of apiRegistry would never be scraped
+ * from the app pods, because only /api/metrics/api is wired to a ServiceMonitor.
+ */
+const GAUGE_NAMES = [
+  "keeperhub_process_memory_rss_bytes",
+  "keeperhub_process_memory_heap_used_bytes",
+  "keeperhub_process_memory_external_bytes",
+  "keeperhub_process_memory_array_buffers_bytes",
+  "keeperhub_process_memory_rss_peak_bytes",
+  "keeperhub_process_memory_heap_used_peak_bytes",
+  "keeperhub_process_memory_external_peak_bytes",
+  "keeperhub_process_memory_array_buffers_peak_bytes",
+];
+
+const RUNTIME_NAMES = [
+  "nodejs_heap_space_size_used_bytes",
+  "nodejs_eventloop_lag_seconds",
+  "nodejs_gc_duration_seconds",
+  "process_resident_memory_bytes",
+];
+
+describe("Process memory gauge registration", () => {
+  let merged: string;
+  let dbOnly: string;
+
+  beforeAll(async () => {
+    const { getDbMetrics, getPrometheusMetrics } = await import(
+      "@/lib/metrics/collectors/prometheus"
+    );
+    const { updateProcessMemoryGauges } = await import(
+      "@/lib/metrics/instrumentation/process-memory"
+    );
+
+    updateProcessMemoryGauges();
+    merged = await getPrometheusMetrics();
+    dbOnly = await getDbMetrics();
+  });
+
+  it("exposes every bucket and its peak under the keeperhub_ prefix", () => {
+    for (const name of GAUGE_NAMES) {
+      expect(merged).toContain(`# TYPE ${name} gauge`);
+    }
+  });
+
+  it("reports a real, non-zero resident set size", () => {
+    const match = merged.match(/^keeperhub_process_memory_rss_bytes (\d+)$/m);
+
+    expect(match).not.toBeNull();
+    expect(Number(match?.[1])).toBeGreaterThan(0);
+  });
+
+  it("registers the Node runtime metrics too", () => {
+    for (const name of RUNTIME_NAMES) {
+      expect(merged).toContain(name);
+    }
+  });
+
+  // The scrape split is the load-bearing part: only /api/metrics/api is wired
+  // to a ServiceMonitor on the app pods, and that route serves apiRegistry
+  // alone. Anything registered on dbRegistry by mistake would render here (the
+  // merged view) and still never be scraped in prod.
+  it("keeps the per-pod metrics off the DB registry", () => {
+    for (const name of [...GAUGE_NAMES, ...RUNTIME_NAMES]) {
+      expect(dbOnly).not.toContain(name);
+    }
+  });
+
+  it("survives a second import without a duplicate registration", async () => {
+    vi.resetModules();
+
+    await expect(
+      import("@/lib/metrics/collectors/prometheus")
+    ).resolves.toBeDefined();
+  });
+});

--- a/tests/unit/process-memory-registration.test.ts
+++ b/tests/unit/process-memory-registration.test.ts
@@ -21,6 +21,10 @@ const GAUGE_NAMES = [
   "keeperhub_process_memory_heap_used_peak_bytes",
   "keeperhub_process_memory_external_peak_bytes",
   "keeperhub_process_memory_array_buffers_peak_bytes",
+  "keeperhub_container_memory_current_bytes",
+  "keeperhub_container_memory_peak_bytes",
+  "keeperhub_container_memory_limit_bytes",
+  "keeperhub_container_memory_oom_kills",
 ];
 
 const RUNTIME_NAMES = [


### PR DESCRIPTION
## Why

The prod `keeperhub-common` pods cross their 4Gi memory limit and the kernel kills them. This is chronic, not a pair of events: `kube_pod_container_status_last_terminated_reason` reports `OOMKilled` on 11 distinct pods across 7 separate days in the last 14 (07-30, 08-02 x2, 08-04, 08-06 x2, 08-08 x2, 08-09, 08-12 x2).

The kill is off-heap. Loki returns 0 lines matching `heap out of memory`, `FATAL ERROR`, `Allocation failed` or `Reached heap limit` over 14 days, so V8 never reached its 3072MB ceiling and RSS crossed the cgroup limit on its own. `NODE_OPTIONS` is therefore unchanged - a larger V8 heap would take headroom away from the side that actually overflows.

Nothing in the current telemetry can show the spike that does the killing. cadvisor samples once per 60s (measured: 10 samples per 10 minutes) and Mimir does not carry `container_memory_max_usage_bytes`. One container's last sample before its kill read 1290Mi working set, so it went from 1.3Gi to past 4Gi inside a single scrape gap.

## Capacity, prod values only

| Setting | Was | Now |
| --- | --- | --- |
| `replicaCount` | 2 | 4 |
| `podDisruptionBudget.minAvailable` | 1 | 3 |
| `resources.limits.memory` | 4Gi | 6Gi |
| `resources.requests.memory` | 2Gi | 4Gi |
| `resources.requests.cpu` | 100m | 250m |
| `affinity` | absent | required node affinity + required pod anti-affinity |

Four replicas rather than an HPA: the burst completes in about 90 seconds, which is shorter than the time an autoscaler needs to detect it, schedule a pod and boot Next.js.

`requests.memory` moves with the limit because requests, not limits, decide placement and the node size Karpenter provisions. The `default-private` NodePool excludes only the `small` and `medium` instance sizes, so a 2Gi request left a replica free to land on a `c6a.large` or `c6a.xlarge` node that could never supply 6Gi. The required node affinity on `karpenter.k8s.aws/instance-memory` closes the rest of that gap.

The pod anti-affinity is **required**, one replica per node. A preferred rule would buy nothing: four pods at a 4Gi request fit on the two qualifying nodes, so Karpenter would never add a node and the best spread would be two per node. Those nodes already peak near 10 GiB of 15.25 GiB with a single app pod on them, so two co-located pods each able to reach 6Gi trades one cgroup kill for node memory pressure, which also evicts neighbours. If Karpenter cannot provision, the extra replicas stay Pending - visible, and it leaves the survivors alone.

`requests.cpu` was simply wrong. Measured p95 is 0.116 to 0.125 cores with a 24h max of 0.22, against a 100m request.

The anti-affinity selects on `app.kubernetes.io/serviceName`. Every component in this umbrella release shares `name=common` and `instance=keeperhub`, so selecting on those would also push these pods away from the executor and dispatcher pods.

## Metrics

The container's cgroup v2 accounting: `keeperhub_container_memory_{current,peak,limit,oom_kills}`. **`memory.peak` is a high-water mark the kernel maintains continuously, so it cannot miss a spike between two reads** - unlike every sampled value, and unlike cadvisor at 60s. `memory.current` is the charge the OOM killer compares, and it counts page cache RSS excludes.

Per-pod `rss`, `heapUsed`, `external` and `arrayBuffers` gauges, each with a `_peak_bytes` variant, held by a 1s sampler. The cgroup cannot say *which* part of the process grew, which is the question when separating a heap problem from an off-heap one.

No gauge can describe the burst that actually kills a pod, because the process never reaches the scrape that would carry its window. A crossing of 75% of the limit therefore also writes one `[ProcessMemory]` log line carrying the bucket split, re-arming below 65%. That line ships as it is written and outlives the kill. The threshold derives from `memory.max`, so it cannot drift from a copy in the values file.

`prom-client`'s default Node.js metrics register on the same registry, adding `nodejs_gc_duration_seconds`, the per-space `nodejs_heap_space_size_*_bytes` breakdown and `nodejs_eventloop_lag_seconds`.

All of it lands on `apiRegistry`, because only `/api/metrics/api` is scraped from the app pods. A test asserts none of it leaks onto the DB registry, since a gauge misfiled there would render in the merged view and still never be scraped in prod.

The matching dashboard row is in techops-services/infrastructure#329.

## Verification

- `pnpm check`, `pnpm type-check`, `pnpm build` all exit 0.
- `pnpm test:unit __tests__ keeperhub-metrics-collector`: 527 files, 20853 tests, all pass. 14 of those are new.
- `helm template` against the edited values renders `keeperhub-common` with 4 replicas, `limits.memory 6Gi`, `requests.memory 4Gi`, `requests.cpu 250m`, both affinity rules and `minAvailable 3`. The other four components and every cronjob render unchanged.
- The three new dashboard queries execute against prod Prometheus. The two referencing the new gauges return 0 series today, which is expected until this deploys.

Post-merge this is on staging only. Prod needs the `staging` -> `prod` promotion, and the acceptance criterion is 0 new `OOMKilled` pods over a 7-day soak after that.



