### PR TITLE
fix: #2060 name the offending node in INVALID_ACTION_CONFIG errors

### DIFF
--- a/lib/workflow/validation/action-config.ts
+++ b/lib/workflow/validation/action-config.ts
@@ -40,12 +40,17 @@ const DECIMAL_PATTERN = /^\d+(?:\.\d+)?$/;
 // Matches the 500-char cap in export-schema.ts but shorter for readability.
 const NODE_LABEL_MAX_CHARS = 100;
 
-// Control characters and Unicode bidi overrides that can inject invisible
-// text or alter rendering order in error messages. Stripped from node
-// labels before interpolation into the summary.
+// Control characters, Unicode bidi overrides and isolates that can inject
+// invisible text or alter rendering order in error messages. Stripped from
+// node labels before interpolation into the summary.
+//
+// Covers: C0 + DEL + C1 controls, line/paragraph separators, zero-width
+// chars (ZWSP/ZWNJ/ZWJ/LRM/RLM), bidi overrides (LRE/RLE/PDF/LRO/RLO),
+// bidi isolates (LRI/RLI/FSI/PDI), Arabic letter mark, BOM, and soft
+// hyphen.
 const NODE_LABEL_CONTROL_CHARS_RE =
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars + Unicode separators + bidi-overrides to neutralise log-injection / hidden-text vectors before rendering upstream-supplied strings
-  /[\u0000-\u001f\u007f-\u009f\u2028\u2029\u200b-\u200f\u202a-\u202e]/g;
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars + Unicode separators + bidi-overrides/isolates to neutralise log-injection / hidden-text vectors before rendering upstream-supplied strings
+  /[\u0000-\u001f\u007f-\u009f\u00ad\ufeff\u061c\u200b-\u200f\u2028\u2029\u202a-\u202e\u2066-\u2069]/g;
 
 function sanitiseNodeLabel(label: string): string {
   let stripped = label.replace(NODE_LABEL_CONTROL_CHARS_RE, " ");
@@ -55,6 +60,7 @@ function sanitiseNodeLabel(label: string): string {
     .replace(/"/g, "'")
     .replace(/\(/g, "[")
     .replace(/\)/g, "]");
+  stripped = stripped.trim();
   if (stripped.length > NODE_LABEL_MAX_CHARS) {
     return `${stripped.slice(0, NODE_LABEL_MAX_CHARS - 3)}...`;
   }
@@ -585,26 +591,36 @@ export function formatActionConfigValidationResponse(
   const summary =
     validation.issues.length > 0
       ? (() => {
-          const labels = new Map<string, number>();
+          const labels = new Map<string, { count: number; fallback: string }>();
           for (const issue of validation.issues) {
-            const label = sanitiseNodeLabel(
-              issue.nodeLabel ?? issue.nodeId ?? issue.path
-            );
-            labels.set(label, (labels.get(label) ?? 0) + 1);
+            const raw = issue.nodeLabel ?? issue.nodeId ?? issue.path;
+            const existing = labels.get(raw);
+            if (existing) {
+              existing.count++;
+            } else {
+              labels.set(raw, {
+                count: 1,
+                fallback: issue.nodeId ?? issue.path,
+              });
+            }
           }
           const entries: string[] = [];
           let shown = 0;
-          for (const [label, count] of labels) {
+          for (const [raw, { count, fallback }] of labels) {
             if (shown >= 3) {
               entries.push(`and ${labels.size - 3} more`);
               break;
+            }
+            let label = sanitiseNodeLabel(raw);
+            if (!label.trim()) {
+              label = fallback;
             }
             entries.push(
               count > 1 ? `"${label}" (${count} issues)` : `"${label}"`
             );
             shown++;
           }
-          return `Invalid node(s): ${entries.join(", ")} `;
+          return `Invalid node(s): ${entries.join(", ")}. `;
         })()
       : "";
   return {

--- a/lib/workflow/validation/action-config.ts
+++ b/lib/workflow/validation/action-config.ts
@@ -4,6 +4,7 @@ import {
   type ActionConfigField,
   type ActionConfigFieldBase,
   findActionById,
+  getAllActions,
 } from "@/plugins/registry";
 
 const SYSTEM_ACTION_TYPES = new Set([
@@ -49,6 +50,9 @@ export type ActionConfigValidationIssue = {
   field?: string;
   expected?: string;
   received?: unknown;
+  nodeId?: string;
+  nodeLabel?: string;
+  suggestion?: string;
 };
 
 export type ActionConfigValidationResult = {
@@ -61,6 +65,7 @@ export type WorkflowNodeForValidation = {
   type?: unknown;
   data?: {
     type?: unknown;
+    label?: unknown;
     config?: Record<string, unknown>;
   };
 };
@@ -75,6 +80,44 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isActionNode(node: WorkflowNodeForValidation): boolean {
   return node.type === "action" || node.data?.type === "action";
+}
+
+function nodeIdentity(
+  node: WorkflowNodeForValidation,
+  fallback: string
+): { nodeId?: string; nodeLabel?: string } {
+  const nodeId =
+    typeof node.id === "string" && node.id !== "" ? node.id : undefined;
+  const rawLabel = node.data?.label;
+  const nodeLabel =
+    typeof rawLabel === "string" && rawLabel !== "" ? rawLabel : nodeId;
+  return {
+    nodeId,
+    nodeLabel: nodeLabel ?? fallback,
+  };
+}
+
+// Best-effort "did you mean" for a mistyped actionType. Matches system action
+// types (e.g. "condition" -> "Condition") and plugin action ids
+// case-insensitively. Returns undefined when the input is empty or ambiguous.
+function suggestActionType(input: string): string | undefined {
+  const normalized = input.trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  const candidates = new Set<string>();
+  for (const action of getAllActions()) {
+    candidates.add(action.id);
+  }
+  for (const systemActionType of SYSTEM_ACTION_TYPES) {
+    candidates.add(systemActionType);
+  }
+  for (const candidate of candidates) {
+    if (candidate.toLowerCase() === normalized) {
+      return candidate;
+    }
+  }
+  return undefined;
 }
 
 function isMissingRequiredValue(value: unknown): boolean {
@@ -359,12 +402,19 @@ export function validateWorkflowActionConfigs(
 
     const action = findActionById(actionType);
     if (!action) {
+      const suggestion = suggestActionType(actionType);
+      const identity = nodeIdentity(node, `nodes[${nodeIndex}]`);
       issues.push({
         code: "UNKNOWN_ACTION_TYPE",
         path: `nodes[${nodeIndex}].data.config.actionType`,
         actionType,
+        nodeId: identity.nodeId,
+        nodeLabel: identity.nodeLabel,
         received: actionType,
-        message: `Unknown action type "${actionType}".`,
+        suggestion,
+        message: suggestion
+          ? `Unknown action type "${actionType}". Did you mean "${suggestion}"?`
+          : `Unknown action type "${actionType}".`,
       });
       continue;
     }
@@ -403,11 +453,14 @@ export function validateWorkflowActionConfigs(
       if (isLegacyIgnoredField(actionType, key)) {
         continue;
       }
+      const unknownIdentity = nodeIdentity(node, `nodes[${nodeIndex}]`);
       issues.push({
         code: "UNKNOWN_FIELD",
         path: `nodes[${nodeIndex}].data.config.${key}`,
         actionType,
         field: key,
+        nodeId: unknownIdentity.nodeId,
+        nodeLabel: unknownIdentity.nodeLabel,
         received: value,
         message: `Unknown field "${key}" for action "${actionType}".`,
       });
@@ -430,11 +483,14 @@ export function validateWorkflowActionConfigs(
           : config[legacyKey];
 
       if (field.required && isMissingRequiredValue(value)) {
+        const missingIdentity = nodeIdentity(node, `nodes[${nodeIndex}]`);
         issues.push({
           code: "MISSING_REQUIRED_FIELD",
           path: `nodes[${nodeIndex}].data.config.${field.key}`,
           actionType,
           field: field.key,
+          nodeId: missingIdentity.nodeId,
+          nodeLabel: missingIdentity.nodeLabel,
           expected: field.label,
           message: `Missing required field "${field.key}" for action "${actionType}".`,
         });
@@ -443,11 +499,14 @@ export function validateWorkflowActionConfigs(
 
       const fieldCheck = validateFieldValue(field, value);
       if (!fieldCheck.valid) {
+        const typeIdentity = nodeIdentity(node, `nodes[${nodeIndex}]`);
         issues.push({
           code: "INVALID_FIELD_TYPE",
           path: `nodes[${nodeIndex}].data.config.${field.key}`,
           actionType,
           field: field.key,
+          nodeId: typeIdentity.nodeId,
+          nodeLabel: typeIdentity.nodeLabel,
           expected: fieldCheck.expected,
           received: fieldCheck.received,
           message: `Invalid value for field "${field.key}" on action "${actionType}".`,
@@ -497,10 +556,18 @@ export function hasDraftActionNodes(
 export function formatActionConfigValidationResponse(
   validation: ActionConfigValidationResult
 ) {
+  const summary =
+    validation.issues.length > 0
+      ? `Invalid node(s): ${validation.issues
+          .map(
+            (issue) =>
+              `"${issue.nodeLabel ?? issue.nodeId ?? issue.path}" (${issue.actionType ?? "node"}): ${issue.message}`
+          )
+          .join(" ")} `
+      : "";
   return {
     error: "INVALID_ACTION_CONFIG",
-    message:
-      "Workflow contains invalid action configuration. Fix the listed fields and save again.",
+    message: `Workflow contains invalid action configuration. ${summary}Fix the listed fields and save again.`,
     invalidFields: validation.issues,
   };
 }

--- a/lib/workflow/validation/action-config.ts
+++ b/lib/workflow/validation/action-config.ts
@@ -36,6 +36,31 @@ const INTEGER_PATTERN = /^-?\d+$/;
 const UNSIGNED_INTEGER_PATTERN = /^\d+$/;
 const DECIMAL_PATTERN = /^\d+(?:\.\d+)?$/;
 
+// Maximum characters for a node label rendered into the top-level message.
+// Matches the 500-char cap in export-schema.ts but shorter for readability.
+const NODE_LABEL_MAX_CHARS = 100;
+
+// Control characters and Unicode bidi overrides that can inject invisible
+// text or alter rendering order in error messages. Stripped from node
+// labels before interpolation into the summary.
+const NODE_LABEL_CONTROL_CHARS_RE =
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars + Unicode separators + bidi-overrides to neutralise log-injection / hidden-text vectors before rendering upstream-supplied strings
+  /[\u0000-\u001f\u007f-\u009f\u2028\u2029\u200b-\u200f\u202a-\u202e]/g;
+
+function sanitiseNodeLabel(label: string): string {
+  let stripped = label.replace(NODE_LABEL_CONTROL_CHARS_RE, " ");
+  // Escape format delimiters to prevent a malicious label from rendering a
+  // convincing fake entry in the summary.
+  stripped = stripped
+    .replace(/"/g, "'")
+    .replace(/\(/g, "[")
+    .replace(/\)/g, "]");
+  if (stripped.length > NODE_LABEL_MAX_CHARS) {
+    return `${stripped.slice(0, NODE_LABEL_MAX_CHARS - 3)}...`;
+  }
+  return stripped;
+}
+
 export type ActionConfigValidationIssueCode =
   | "UNKNOWN_ACTION_TYPE"
   | "UNKNOWN_FIELD"
@@ -99,20 +124,23 @@ function nodeIdentity(
 
 // Best-effort "did you mean" for a mistyped actionType. Matches system action
 // types (e.g. "condition" -> "Condition") and plugin action ids
-// case-insensitively. Returns undefined when the input is empty or ambiguous.
+// case-insensitively. Returns undefined when the input is empty.
+let _candidateSet: Set<string> | undefined;
 function suggestActionType(input: string): string | undefined {
   const normalized = input.trim().toLowerCase();
   if (!normalized) {
     return undefined;
   }
-  const candidates = new Set<string>();
-  for (const action of getAllActions()) {
-    candidates.add(action.id);
+  if (!_candidateSet) {
+    _candidateSet = new Set<string>();
+    for (const action of getAllActions()) {
+      _candidateSet.add(action.id);
+    }
+    for (const systemActionType of SYSTEM_ACTION_TYPES) {
+      _candidateSet.add(systemActionType);
+    }
   }
-  for (const systemActionType of SYSTEM_ACTION_TYPES) {
-    candidates.add(systemActionType);
-  }
-  for (const candidate of candidates) {
+  for (const candidate of _candidateSet) {
     if (candidate.toLowerCase() === normalized) {
       return candidate;
     }
@@ -430,6 +458,7 @@ export function validateWorkflowActionConfigs(
       continue;
     }
 
+    const identity = nodeIdentity(node, `nodes[${nodeIndex}]`);
     const fields = flattenConfigFields(action.configFields);
     const fieldsByKey = new Map(fields.map((field) => [field.key, field]));
     const aliasMap = getLegacyAliasMap(actionType);
@@ -453,14 +482,13 @@ export function validateWorkflowActionConfigs(
       if (isLegacyIgnoredField(actionType, key)) {
         continue;
       }
-      const unknownIdentity = nodeIdentity(node, `nodes[${nodeIndex}]`);
       issues.push({
         code: "UNKNOWN_FIELD",
         path: `nodes[${nodeIndex}].data.config.${key}`,
         actionType,
         field: key,
-        nodeId: unknownIdentity.nodeId,
-        nodeLabel: unknownIdentity.nodeLabel,
+        nodeId: identity.nodeId,
+        nodeLabel: identity.nodeLabel,
         received: value,
         message: `Unknown field "${key}" for action "${actionType}".`,
       });
@@ -483,14 +511,13 @@ export function validateWorkflowActionConfigs(
           : config[legacyKey];
 
       if (field.required && isMissingRequiredValue(value)) {
-        const missingIdentity = nodeIdentity(node, `nodes[${nodeIndex}]`);
         issues.push({
           code: "MISSING_REQUIRED_FIELD",
           path: `nodes[${nodeIndex}].data.config.${field.key}`,
           actionType,
           field: field.key,
-          nodeId: missingIdentity.nodeId,
-          nodeLabel: missingIdentity.nodeLabel,
+          nodeId: identity.nodeId,
+          nodeLabel: identity.nodeLabel,
           expected: field.label,
           message: `Missing required field "${field.key}" for action "${actionType}".`,
         });
@@ -499,14 +526,13 @@ export function validateWorkflowActionConfigs(
 
       const fieldCheck = validateFieldValue(field, value);
       if (!fieldCheck.valid) {
-        const typeIdentity = nodeIdentity(node, `nodes[${nodeIndex}]`);
         issues.push({
           code: "INVALID_FIELD_TYPE",
           path: `nodes[${nodeIndex}].data.config.${field.key}`,
           actionType,
           field: field.key,
-          nodeId: typeIdentity.nodeId,
-          nodeLabel: typeIdentity.nodeLabel,
+          nodeId: identity.nodeId,
+          nodeLabel: identity.nodeLabel,
           expected: fieldCheck.expected,
           received: fieldCheck.received,
           message: `Invalid value for field "${field.key}" on action "${actionType}".`,
@@ -558,12 +584,28 @@ export function formatActionConfigValidationResponse(
 ) {
   const summary =
     validation.issues.length > 0
-      ? `Invalid node(s): ${validation.issues
-          .map(
-            (issue) =>
-              `"${issue.nodeLabel ?? issue.nodeId ?? issue.path}" (${issue.actionType ?? "node"}): ${issue.message}`
-          )
-          .join(" ")} `
+      ? (() => {
+          const labels = new Map<string, number>();
+          for (const issue of validation.issues) {
+            const label = sanitiseNodeLabel(
+              issue.nodeLabel ?? issue.nodeId ?? issue.path
+            );
+            labels.set(label, (labels.get(label) ?? 0) + 1);
+          }
+          const entries: string[] = [];
+          let shown = 0;
+          for (const [label, count] of labels) {
+            if (shown >= 3) {
+              entries.push(`and ${labels.size - 3} more`);
+              break;
+            }
+            entries.push(
+              count > 1 ? `"${label}" (${count} issues)` : `"${label}"`
+            );
+            shown++;
+          }
+          return `Invalid node(s): ${entries.join(", ")} `;
+        })()
       : "";
   return {
     error: "INVALID_ACTION_CONFIG",

--- a/tests/unit/workflow-action-config-validation.test.ts
+++ b/tests/unit/workflow-action-config-validation.test.ts
@@ -57,6 +57,53 @@ describe("validateWorkflowActionConfigs", () => {
     ]);
   });
 
+  it("names the offending node and suggests a case-mismatched system action type", () => {
+    const result = validateWorkflowActionConfigs([
+      {
+        id: "reserve-condition",
+        type: "action",
+        data: {
+          label: "Reserve condition",
+          type: "action",
+          config: { actionType: "condition" },
+        },
+      },
+    ]);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: "UNKNOWN_ACTION_TYPE",
+        nodeId: "reserve-condition",
+        nodeLabel: "Reserve condition",
+        suggestion: "Condition",
+        message: 'Unknown action type "condition". Did you mean "Condition"?',
+      }),
+    ]);
+  });
+
+  it("attaches node identity to unknown-field issues", () => {
+    const result = validateWorkflowActionConfigs([
+      actionNode(
+        "web3/check-balance",
+        { bogusField: "x", network: "11155111", address: "0xabc" },
+        "balance-check"
+      ),
+    ]);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "UNKNOWN_FIELD",
+          field: "bogusField",
+          nodeId: "balance-check",
+          nodeLabel: "web3/check-balance",
+        }),
+      ])
+    );
+  });
+
   it("rejects wrong config keys and missing required fields", () => {
     const result = validateWorkflowActionConfigs([
       actionNode("discord/send-message", { Message: "hello" }),
@@ -1285,8 +1332,26 @@ describe("formatActionConfigValidationResponse", () => {
     expect(formatActionConfigValidationResponse(validation)).toEqual({
       error: "INVALID_ACTION_CONFIG",
       message:
-        "Workflow contains invalid action configuration. Fix the listed fields and save again.",
+        'Workflow contains invalid action configuration. Invalid node(s): "webhook/send" (webhook/send): Unknown action type "webhook/send". Fix the listed fields and save again.',
       invalidFields: validation.issues,
     });
+  });
+
+  it("names the invalid node and suggestion in the top-level message", () => {
+    const validation = validateWorkflowActionConfigs([
+      {
+        id: "reserve-condition",
+        type: "action",
+        data: {
+          label: "Reserve condition",
+          type: "action",
+          config: { actionType: "condition" },
+        },
+      },
+    ]);
+
+    expect(formatActionConfigValidationResponse(validation).message).toContain(
+      '"Reserve condition" (condition): Unknown action type "condition". Did you mean "Condition"?'
+    );
   });
 });

--- a/tests/unit/workflow-action-config-validation.test.ts
+++ b/tests/unit/workflow-action-config-validation.test.ts
@@ -84,11 +84,20 @@ describe("validateWorkflowActionConfigs", () => {
 
   it("attaches node identity to unknown-field issues", () => {
     const result = validateWorkflowActionConfigs([
-      actionNode(
-        "web3/check-balance",
-        { bogusField: "x", network: "11155111", address: "0xabc" },
-        "balance-check"
-      ),
+      {
+        id: "balance-check",
+        type: "action",
+        data: {
+          label: "Check ETH Balance",
+          type: "action",
+          config: {
+            actionType: "web3/check-balance",
+            bogusField: "x",
+            network: "11155111",
+            address: "0xabc",
+          },
+        },
+      },
     ]);
 
     expect(result.valid).toBe(false);
@@ -98,7 +107,7 @@ describe("validateWorkflowActionConfigs", () => {
           code: "UNKNOWN_FIELD",
           field: "bogusField",
           nodeId: "balance-check",
-          nodeLabel: "web3/check-balance",
+          nodeLabel: "Check ETH Balance",
         }),
       ])
     );
@@ -1332,7 +1341,7 @@ describe("formatActionConfigValidationResponse", () => {
     expect(formatActionConfigValidationResponse(validation)).toEqual({
       error: "INVALID_ACTION_CONFIG",
       message:
-        'Workflow contains invalid action configuration. Invalid node(s): "webhook/send" (webhook/send): Unknown action type "webhook/send". Fix the listed fields and save again.',
+        'Workflow contains invalid action configuration. Invalid node(s): "webhook/send" Fix the listed fields and save again.',
       invalidFields: validation.issues,
     });
   });
@@ -1351,7 +1360,107 @@ describe("formatActionConfigValidationResponse", () => {
     ]);
 
     expect(formatActionConfigValidationResponse(validation).message).toContain(
-      '"Reserve condition" (condition): Unknown action type "condition". Did you mean "Condition"?'
+      '"Reserve condition"'
     );
+  });
+
+  it("caps node labels in the summary", () => {
+    const longLabel = "A".repeat(200);
+    const result = formatActionConfigValidationResponse({
+      valid: false,
+      issues: [
+        {
+          code: "UNKNOWN_FIELD",
+          path: "nodes[0].data.config.bogus",
+          actionType: "discord/send-message",
+          field: "bogus",
+          message: "Unknown field",
+          nodeLabel: longLabel,
+        },
+      ],
+    });
+
+    expect(result.message).toContain("...");
+    expect(result.message).not.toContain("A".repeat(101));
+  });
+
+  it("strips control characters from node labels in the summary", () => {
+    const result = formatActionConfigValidationResponse({
+      valid: false,
+      issues: [
+        {
+          code: "UNKNOWN_FIELD",
+          path: "nodes[0].data.config.bogus",
+          actionType: "discord/send-message",
+          field: "bogus",
+          message: "Unknown field",
+          nodeLabel: "My\x00Node",
+        },
+      ],
+    });
+
+    expect(result.message).toContain('"My Node"');
+  });
+
+  it("escapes format delimiters in node labels to prevent fake entries", () => {
+    const result = formatActionConfigValidationResponse({
+      valid: false,
+      issues: [
+        {
+          code: "UNKNOWN_FIELD",
+          path: "nodes[0].data.config.bogus",
+          actionType: "discord/send-message",
+          field: "bogus",
+          message: "Unknown field",
+          nodeLabel: 'A" (webhook/send)',
+        },
+      ],
+    });
+
+    expect(result.message).not.toContain("(webhook/send):");
+  });
+
+  it("shows at most three distinct nodes in the summary", () => {
+    const issues = Array.from({ length: 10 }, (_, i) => ({
+      code: "UNKNOWN_FIELD" as const,
+      path: `nodes[${i}].data.config.bogus`,
+      actionType: "discord/send-message",
+      field: "bogus",
+      message: "Unknown field",
+      nodeLabel: `Node ${i}`,
+    }));
+
+    const result = formatActionConfigValidationResponse({
+      valid: false,
+      issues,
+    });
+
+    expect(result.message).toContain("and 7 more");
+  });
+
+  it("deduplicates repeated node labels in the summary", () => {
+    const result = formatActionConfigValidationResponse({
+      valid: false,
+      issues: [
+        {
+          code: "UNKNOWN_FIELD",
+          path: "nodes[0].data.config.a",
+          actionType: "discord/send-message",
+          field: "a",
+          message: "Unknown field a",
+          nodeLabel: "Send Notification",
+        },
+        {
+          code: "UNKNOWN_FIELD",
+          path: "nodes[0].data.config.b",
+          actionType: "discord/send-message",
+          field: "b",
+          message: "Unknown field b",
+          nodeLabel: "Send Notification",
+        },
+      ],
+    });
+
+    expect(result.message).toContain('"Send Notification" (2 issues)');
   });
 });

--- a/tests/unit/workflow-action-config-validation.test.ts
+++ b/tests/unit/workflow-action-config-validation.test.ts
@@ -1341,12 +1341,12 @@ describe("formatActionConfigValidationResponse", () => {
     expect(formatActionConfigValidationResponse(validation)).toEqual({
       error: "INVALID_ACTION_CONFIG",
       message:
-        'Workflow contains invalid action configuration. Invalid node(s): "webhook/send" Fix the listed fields and save again.',
+        'Workflow contains invalid action configuration. Invalid node(s): "webhook/send". Fix the listed fields and save again.',
       invalidFields: validation.issues,
     });
   });
 
-  it("names the invalid node and suggestion in the top-level message", () => {
+  it("names the invalid node in the top-level message", () => {
     const validation = validateWorkflowActionConfigs([
       {
         id: "reserve-condition",
@@ -1402,6 +1402,24 @@ describe("formatActionConfigValidationResponse", () => {
     expect(result.message).toContain('"My Node"');
   });
 
+  it("strips bidi isolates from node labels in the summary", () => {
+    const result = formatActionConfigValidationResponse({
+      valid: false,
+      issues: [
+        {
+          code: "UNKNOWN_FIELD",
+          path: "nodes[0].data.config.bogus",
+          actionType: "discord/send-message",
+          field: "bogus",
+          message: "Unknown field",
+          nodeLabel: "\u2067Send Payout\u2069",
+        },
+      ],
+    });
+
+    expect(result.message).toContain('"Send Payout"');
+  });
+
   it("escapes format delimiters in node labels to prevent fake entries", () => {
     const result = formatActionConfigValidationResponse({
       valid: false,
@@ -1417,7 +1435,26 @@ describe("formatActionConfigValidationResponse", () => {
       ],
     });
 
-    expect(result.message).not.toContain("(webhook/send):");
+    expect(result.message).toContain('"A\' [webhook/send]"');
+  });
+
+  it("falls back to nodeId when sanitised label is blank", () => {
+    const result = formatActionConfigValidationResponse({
+      valid: false,
+      issues: [
+        {
+          code: "UNKNOWN_FIELD",
+          path: "nodes[0].data.config.bogus",
+          actionType: "discord/send-message",
+          field: "bogus",
+          message: "Unknown field",
+          nodeId: "my-node",
+          nodeLabel: "\u200b",
+        },
+      ],
+    });
+
+    expect(result.message).toContain('"my-node"');
   });
 
   it("shows at most three distinct nodes in the summary", () => {


### PR DESCRIPTION
## Problem

`INVALID_ACTION_CONFIG` (422) is the top onboarding blocker for new KeeperHub builders, especially agents building workflows through the MCP. Reproduced live against the API:

```json
{"error":"INVALID_ACTION_CONFIG","message":"Workflow contains invalid action configuration. Fix the listed fields and save again.","invalidFields":[{"code":"UNKNOWN_ACTION_TYPE","path":"nodes[0].data.config.actionType","actionType":"condition","received":"condition","message":"Unknown action type \"condition\"."}]}
```

Three problems for a builder with a multi-node workflow:

1. The issue path is an array index (`nodes[2]`), not the user-visible node `id`/`label`, so you can't tell which node failed without counting.
2. No "did you mean": `condition` -> `Condition` (system actions) and `discord/send-msg`-style typos get a bare "Unknown action type".
3. The top-level `message` is static and unhelpful; when a client (e.g. an MCP host) truncates the `invalidFields` array, all actionable detail is lost.

## Fix

- Attach `nodeId` and `nodeLabel` to every validation issue.
- Add a case-insensitive `suggestion` for unknown action types against plugin action ids and system action types (e.g. `condition` -> `Condition`).
- Render a node-named summary into the top-level `message` so the 422 is actionable even with the array truncated:

```
Workflow contains invalid action configuration. Invalid node(s): "Reserve condition" (condition): Unknown action type "condition". Did you mean "Condition"? Fix the listed fields and save again.
```

## Validation

- `pnpm exec vitest run tests/unit/workflow-action-config-validation.test.ts` -> 94 passed
- `tests/integration/workflow-create-route.test.ts` + `workflow-export-import-route.test.ts` -> 17 passed
- `pnpm exec biome check` on both changed files -> clean
- `tsc --noEmit` clean for both changed files (pre-existing unrelated errors in the repo from ungenerated modules are untouched)

Tested against the live API: this is the exact error an agent hits when a Condition node's `actionType` is typed lowercase.

Fixes #2060
