### PR TITLE
feat(self-hosted): require a SendGrid account for transactional mail

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,6 +109,21 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=
 
+# Transactional mail (SendGrid)
+# Required for any deployment a person signs up on. SendGrid is the only
+# supported sender: lib/email.ts posts to its HTTP API, so there is no SMTP
+# setting. Verification codes, invitations, password resets and MFA step-up
+# codes all go through it.
+# Without a key the app still generates and stores those codes but delivers
+# none of them, so signup dead-ends at the six-digit code prompt. sendEmail
+# returns false and logs it; it does not throw.
+# FROM_ADDRESS must be a sender identity verified in the SAME SendGrid account
+# that issued the key, or SendGrid rejects every send with 403. It defaults to
+# noreply@keeperhub.com, which is verified in KeeperHub's account and in nobody
+# else's.
+SENDGRID_API_KEY=
+FROM_ADDRESS=
+
 # Cloudflare Turnstile (signup captcha)
 # Required in production - lib/auth.ts throws at module load if the secret
 # key is missing under NODE_ENV=production. Only gates /sign-up/email; OAuth

--- a/deploy/keeperhub-stack/self-hosted/DEPENDENCIES.md
+++ b/deploy/keeperhub-stack/self-hosted/DEPENDENCIES.md
@@ -86,7 +86,7 @@ install either. It does not use External Secrets, and needs no AWS credentials.
 | Blockchain RPC | ~17 public endpoints, e.g. `ethereum-rpc.publicnode.com`, `mainnet.base.org`, `api.mainnet-beta.solana.com` | wallet and contract addresses, calldata, signed transactions | `CHAIN_RPC_CONFIG`, or per-chain `CHAIN_<NAME>_PRIMARY_RPC`. None of the defaults is a host KeeperHub operates, and a test enforces that |
 | Queue | `sqs.<region>.amazonaws.com` | workflow and execution ids, trigger payloads | Set `AWS_ENDPOINT_URL` to use the bundled in-cluster queue instead, which is what the bundled mode does |
 | Cloudflare Turnstile | `challenges.cloudflare.com` | a captcha token and the client IP, on signup | See below |
-| Email delivery | `api.sendgrid.com` | recipient address, signup codes, invite links | `SENDGRID_API_URL` points at any relay accepting SendGrid's v3 `mail/send` shape |
+| Email delivery | `api.sendgrid.com` | recipient address, signup codes, invite links | Required. Supply `SENDGRID_API_KEY` from your own SendGrid account and `FROM_ADDRESS` as a sender verified in it. The installer refuses without both. `SENDGRID_API_URL` points at any relay accepting SendGrid's v3 `mail/send` shape |
 | Wallet signing | `api.turnkey.com` | wallet addresses and the payloads to be signed | `TURNKEY_API_BASE_URL`. Only used when wallets are configured |
 
 **About Turnstile.** The server refuses to start without `TURNSTILE_SECRET_KEY`. That check runs
@@ -144,8 +144,17 @@ discover them.
 
 - **No sandbox is deployed.** The Code step needs one and fails with a connection error without
   it. Everything else works.
-- **Signup needs working email.** Verification codes, invitations, password resets and MFA
-  step-up all go through the mail path, so an install with no mail relay cannot complete a signup.
+- **Signup needs working email, so SendGrid is required.** Verification codes, invitations,
+  password resets and MFA step-up all go through the mail path, so an install with no working mail
+  cannot complete a signup. `install.sh` therefore refuses to install without `SENDGRID_API_KEY`
+  and `FROM_ADDRESS`. SendGrid is the only supported sender and there is no SMTP option.
+- **A failed invitation send is invisible to the sender.** `sendInvitationEmail` returns false on
+  failure rather than throwing, and the caller ignores that return value, so the only trace is a
+  log line at warning level. The invitation row is written either way, so the inviter sees a sent
+  invitation that nobody received. A revoked or wrong key looks the same as a working one on that
+  path. Signup and MFA step-up do surface the failure, and the forgot-password route ignores it on
+  purpose so it cannot be used to enumerate accounts. This is application behaviour and this
+  profile does not change it.
 
 ## About this document
 

--- a/deploy/keeperhub-stack/self-hosted/README.md
+++ b/deploy/keeperhub-stack/self-hosted/README.md
@@ -261,13 +261,16 @@ What the wrapper adds over plain helm:
   missing operator is a message rather than a rolled-back release
 - it checks the bring-your-own database Secret exists, for the same reason
 - it refuses half an AWS key pair
+- it refuses to install without a SendGrid key and a sender address, because an
+  install without mail cannot complete a signup
 - it puts real AWS credentials in a Secret rather than a values file
 - it reports which optional runner credentials are absent, which nothing else does
 
 Every setting lives in `config.sh` and can be overridden in the environment:
 `NAMESPACE`, `APP_HOST`, `INGRESS_CLASS`, `TLS_ISSUER`, `IMAGE_REPO`,
-`FROM_ADDRESS`, `TURNSTILE_SECRET_KEY`, the `DB_MODE`/`QUEUE_MODE` settings
-above, and the `PG_*` and `SQS_*` values behind them.
+`SENDGRID_API_KEY`, `FROM_ADDRESS`, `TURNSTILE_SECRET_KEY`, the
+`DB_MODE`/`QUEUE_MODE` settings above, and the `PG_*` and `SQS_*` values behind
+them.
 
 `--dry-run` renders the chart without touching the cluster. `PROFILE=minikube`
 merges the test-harness overlay. `CHART_DIR` points the install at a working-tree
@@ -288,7 +291,9 @@ a key.
 
 `SENDGRID_API_KEY` and the three `TURNKEY_` keys are never generated. They are
 rendered empty, because an invented API key replaces a clean unconfigured state
-with 401s. Supply them under `secrets.values` when you have them.
+with 401s. They come from `secrets.values`, and `install.sh` passes
+`SENDGRID_API_KEY` there for you. Supply the `TURNKEY_` keys yourself when you
+have them.
 
 Two things to know before relying on this:
 
@@ -349,11 +354,28 @@ domain is trusted without further configuration. Set it yourself only if the app
 is reached on more origins than that one - a vanity domain, or a separate
 hostname for an internal network.
 
-**There is no email.** `lib/email.ts` posts to SendGrid's HTTP API, so there is
-no SMTP setting and no local mail-catcher option. Without `SENDGRID_API_KEY`,
-verification codes, invitations and password resets are generated and stored but
-never delivered, and signup dead-ends at "enter the 6-digit code". Configurable
-SMTP is KEEP-1119.
+**Email needs a SendGrid account of your own.** `lib/email.ts` posts to
+SendGrid's HTTP API, so there is no SMTP setting and no local mail-catcher
+option. SendGrid is the only supported sender, and it is a required dependency
+rather than an optional one: verification codes, invitations, password resets
+and MFA step-up codes all go through it.
+
+Set `SENDGRID_API_KEY` to a key from your own account, and `FROM_ADDRESS` to a
+sender identity verified in that same account. `install.sh` refuses to install
+without both, because the failure mode otherwise is quiet - everything is
+generated and stored, nothing is delivered, and signup dead-ends at "enter the
+6-digit code".
+
+If your egress policy forbids a direct call to SendGrid, set `SENDGRID_API_URL`
+to a relay of yours that accepts SendGrid's v3 `mail/send` request shape. That
+changes where the request goes, not what speaks it.
+
+One thing the product does not tell you: a failed send on the invitation path is
+invisible to the person who sent the invitation. `sendInvitationEmail` returns
+false rather than throwing, the caller ignores the return value, and the log line
+is a warning that does not page. The invitation row is still written, so a
+revoked or wrong key looks exactly like a working one there. Test a real
+invitation after you change the key.
 
 **Code action nodes fail.** No sandbox is deployed, so `SANDBOX_URL` points at
 nothing. Everything else runs.
@@ -383,7 +405,7 @@ kubectl -n keeperhub create secret generic keeperhub-executor-openai-api-key \
 | `etherscan-api-key` | contract ABI auto-fetch fails, so web3 steps needing an ABI fail |
 | `metrics-ingest-token` | runner metrics are not shipped, so executions are invisible |
 | `openai-api-key` | AI steps and AI workflow generation fail |
-| `sendgrid-api-key` | email steps send nothing |
+| `sendgrid-api-key` | email steps send nothing. This is the workflow plugin's key, not the one transactional mail uses. The two are separate settings and may hold different keys |
 | `simple-account-7702-address` | EIP-7702 smart-account steps fail |
 | `turnkey-api-private-key` | managed wallet signing fails |
 | `turnkey-api-public-key` | managed wallet signing fails |

--- a/deploy/keeperhub-stack/self-hosted/config.sh
+++ b/deploy/keeperhub-stack/self-hosted/config.sh
@@ -70,6 +70,27 @@ IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-}"
 APP_HOST="${APP_HOST:-}"
 INGRESS_CLASS="${INGRESS_CLASS:-}"
 TLS_ISSUER="${TLS_ISSUER:-}"
+
+# Transactional mail. Both are required, and the preflight refuses to install
+# without them.
+#
+# SendGrid is the only supported sender, so bring your own account. The app
+# posts to SendGrid's HTTP API and reads the key at runtime, which means no mail
+# server is involved and there is no SMTP setting to look for.
+#
+# The failure mode without a key is quiet rather than loud: the app still
+# generates verification codes, invitations and password resets and still stores
+# them, but delivers none of them. Signup then stops at the six-digit code
+# prompt with no way to obtain a code, which reads as a broken app rather than
+# an unconfigured one. That is why this is a preflight failure.
+#
+# FROM_ADDRESS must be a sender identity verified in the SAME SendGrid account
+# that issued the key. SendGrid rejects every send from an unverified sender.
+#
+# A separate variable, SENDGRID_API_URL, overrides where the send is posted.
+# Leave it alone unless your egress policy forbids a direct call, in which case
+# point it at a relay of yours that accepts SendGrid's request shape.
+SENDGRID_API_KEY="${SENDGRID_API_KEY:-}"
 FROM_ADDRESS="${FROM_ADDRESS:-}"
 
 # Cloudflare Turnstile.

--- a/deploy/keeperhub-stack/self-hosted/install.sh
+++ b/deploy/keeperhub-stack/self-hosted/install.sh
@@ -59,11 +59,20 @@ preflight() {
     # profile overlay is merged, because the overlay supplies these itself and
     # the chart's own `required` is then the accurate check - this one would only
     # report values that are about to be set.
+    #
+    # The two mail settings are the exception: no chart `required` backs them,
+    # so this is the only check. That is deliberate. A profile overlay builds a
+    # throwaway cluster that nobody signs up on, and demanding a real SendGrid
+    # account to bring one up would be a tax with nothing behind it. Every other
+    # install needs mail to complete a signup, so the check is not optional
+    # there.
     if [ -z "$PROFILE" ]; then
         local missing=()
         [ -n "$IMAGE_REPO" ] || missing+=("IMAGE_REPO")
         [ -n "$IMAGE_TAG" ] || missing+=("IMAGE_TAG")
         [ -n "$APP_HOST" ] || missing+=("APP_HOST")
+        [ -n "$SENDGRID_API_KEY" ] || missing+=("SENDGRID_API_KEY")
+        [ -n "$FROM_ADDRESS" ] || missing+=("FROM_ADDRESS")
         if [ "${#missing[@]}" -gt 0 ]; then
             echo "Required settings are not set: ${missing[*]}" >&2
             echo "See config.sh for what each one is." >&2
@@ -232,6 +241,12 @@ compose_set() {
         "global.tlsIssuer=$TLS_ISSUER"
         "global.awsRegion=$AWS_REGION"
         "global.fromAddress=$FROM_ADDRESS"
+        # The mail key is a Secret value rather than a global, so it goes
+        # through secrets.values, which the chart reads before it reads the
+        # cluster and before it generates anything. The chart never generates
+        # this one: an invented API key would replace a clean unconfigured state
+        # with 401s.
+        "secrets.values.SENDGRID_API_KEY=$SENDGRID_API_KEY"
         "global.turnstileSecretKey=$TURNSTILE_SECRET_KEY"
         "global.db.secretName=$DB_SECRET_NAME"
         "global.db.secretKey=$DB_SECRET_KEY"

--- a/deploy/keeperhub-stack/self-hosted/values.yaml
+++ b/deploy/keeperhub-stack/self-hosted/values.yaml
@@ -377,11 +377,21 @@ app:
     METRICS_COLLECTOR:
       type: kv
       value: "prometheus"
-    # Outbound email. Without this the app still generates verification codes,
-    # invitations and password resets, but sendEmail returns false and nothing is
-    # delivered, so signup dead-ends at "enter the 6-digit code" with no way to
-    # obtain one. lib/email.ts hardcodes SendGrid's HTTP API, so there is no
-    # local mail-catcher option today - see KEEP-1119 for configurable SMTP.
+    # Outbound email, and a required setting. SendGrid is the only supported
+    # sender, so supply a key from your own account. lib/email.ts posts to
+    # SendGrid's HTTP API, which means there is no SMTP setting and no local
+    # mail-catcher option.
+    #
+    # Without a key the app still generates verification codes, invitations and
+    # password resets, but sendEmail returns false and nothing is delivered, so
+    # signup dead-ends at "enter the 6-digit code" with no way to obtain one.
+    # install.sh refuses to install rather than let you find that out later. A
+    # plain `helm install` has no such check, so supply the key under
+    # secrets.values yourself when you install this file directly.
+    #
+    # SENDGRID_API_URL overrides where the send is posted. Set it only when your
+    # egress policy forbids a direct call to SendGrid, and point it at a relay
+    # that accepts SendGrid's v3 mail/send request shape.
     #
     # The chart always creates this Secret, with an empty value when no key is
     # given, and the app treats an empty key as "no email configured" and returns


### PR DESCRIPTION
## What

An install could succeed with no mail configured, and the first person to try signing up found out.
The app generates the verification code, stores it, and delivers nothing, so signup stops at "enter
the 6-digit code" with no way to obtain one.

The installer had no way to fix that. `config.sh` had no `SENDGRID_API_KEY` input, and `install.sh`
set nothing under `secrets.values`, so the only way to supply a key was to hand edit a values file
the profile never mentions.

SendGrid is now a required dependency rather than an optional one:

- the preflight refuses to install without `SENDGRID_API_KEY` and `FROM_ADDRESS`, listed beside
  `IMAGE_REPO` and `APP_HOST`
- `compose_set` passes the key through `secrets.values.SENDGRID_API_KEY`, so supplying it is one
  environment variable

This replaces the earlier plan to add a configurable SMTP transport. A second transport means a mail
library, a second code path in `lib/email.ts` and a second thing to support, and it gives nothing
that a SendGrid account does not already give. The reversal is recorded as a numbered decision on
the concept ticket.

## Scope

No application code. Four executable lines in total:

```
config.sh    SENDGRID_API_KEY="${SENDGRID_API_KEY:-}"
install.sh   [ -n "$SENDGRID_API_KEY" ] || missing+=("SENDGRID_API_KEY")
install.sh   [ -n "$FROM_ADDRESS" ] || missing+=("FROM_ADDRESS")
install.sh   "secrets.values.SENDGRID_API_KEY=$SENDGRID_API_KEY"
```

`values.yaml` is comment only, zero functional lines. `.env.example` adds two empty variable names.
The remaining 40 lines are documentation.

A profile overlay stays exempt, deliberately. `PROFILE=minikube` builds a throwaway cluster that
nobody signs up on, so demanding a real SendGrid account to bring one up would be a tax with nothing
behind it. The four other required settings are exempt there for the same reason.

Staging and production values are untouched. They supply the key through External Secrets and never
reach the chart secret generator, so our own environments are unchanged.

The `SENDGRID_API_URL` seam is untouched, so an operator whose egress policy forbids a direct call
can still point the send at a relay of their own.

## Documentation corrected

The documentation claimed the opposite of all this. The README said there is no email,
`DEPENDENCIES.md` listed mail as configurable rather than required, and `values.yaml` pointed the
reader at a ticket for configurable SMTP that is not coming. `.env.example` documented neither
`SENDGRID_API_KEY` nor `FROM_ADDRESS` although the code reads both, which the env-sync check
reports.

## Verified

- all eight database, queue and overlay combinations render, and `SENDGRID_API_KEY` reads back out
  of the rendered `keeperhub-email` Secret in every one
- with no key supplied the Secret renders empty, which is the clean unconfigured state the chart
  README describes
- preflight against a throwaway minikube cluster, four cases: neither setting refuses and names
  both; the key alone missing refuses and names only it; `PROFILE=minikube` with neither still
  installs; both supplied renders with the key and sender in place
- `shellcheck --severity=warning` clean on both scripts, which is the severity CI uses
- `pnpm type-check` exits 0

## Not verified

A real message delivered through a real SendGrid account. That needs a key and a verified sender I
do not have. This change proves the key is required and that it reaches the Secret. It does not
prove delivery.

## Reported, not fixed

A failed send on the invitation path is invisible to the sender. `sendInvitationEmail` returns false
rather than throwing, and the caller ignores the return value, so the only trace is a log line at
warning level. The invitation row is written either way, so a revoked or wrong key looks the same as
a working one there. This is recorded in `DEPENDENCIES.md`. It is application behaviour, it affects
the SaaS too, and it belongs in its own change rather than in this one.

## Pre-existing, unrelated to this change

`pnpm check` reports three formatter errors, in `tests/unit/foreign-origin.test.ts`,
`tests/unit/rpc-config.test.ts` and `tests/unit/idempotency-409-route-body.test.ts`. None of the
three is touched here. CI does not catch them because Ultracite fails to parse Biome's output and
the command still exits 0.
