### PR TITLE
feat: show the exact gas figure on hover

### DIFF
--- a/components/analytics/kpi-cards.tsx
+++ b/components/analytics/kpi-cards.tsx
@@ -18,7 +18,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { formatGasSplit, walletShareWei } from "@/lib/analytics/format-gas";
+import {
+  formatGasExactEth,
+  formatGasSplit,
+  walletShareWei,
+} from "@/lib/analytics/format-gas";
 import type { TimeRange } from "@/lib/analytics/types";
 import {
   analyticsLoadingAtom,
@@ -136,7 +140,42 @@ type KpiBreakdownLine = {
   key: string;
   text: string;
   highlighted?: boolean;
+  /** Shown on hover, for figures the headline rounds. */
+  exact?: string;
 };
+
+function BreakdownLine({ line }: { line: KpiBreakdownLine }): ReactNode {
+  const className = cn(
+    "text-xs font-medium",
+    line.highlighted ? "text-green-600 dark:text-green-400" : "text-foreground"
+  );
+  if (!line.exact) {
+    return (
+      <p className={className} data-kpi-line={line.key}>
+        {line.text}
+      </p>
+    );
+  }
+  // A button, not a <p> with tabIndex: Radix needs a focusable trigger, so the
+  // exact figure has to be reachable by keyboard and not only by hover.
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          className={cn(className, "block cursor-help text-left")}
+          data-exact={line.exact}
+          data-kpi-line={line.key}
+          type="button"
+        >
+          {line.text}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs font-mono text-xs">
+        {line.exact}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
 
 type KpiCardProps = {
   cardKey: string;
@@ -149,6 +188,8 @@ type KpiCardProps = {
   iconClassName?: string;
   breakdown?: readonly KpiBreakdownLine[];
   tooltip?: string;
+  /** Shown on hover over the headline, for values the display rounds. */
+  exactValue?: string;
 };
 
 function KpiCard({
@@ -162,6 +203,7 @@ function KpiCard({
   iconClassName,
   breakdown,
   tooltip,
+  exactValue,
 }: KpiCardProps): ReactNode {
   return (
     <Card data-kpi={cardKey} data-testid="kpi-card">
@@ -188,12 +230,30 @@ function KpiCard({
               ) : null}
             </div>
             <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
-              <p
-                className="whitespace-nowrap font-bold text-2xl tracking-tight xl:text-xl"
-                data-testid="kpi-value"
-              >
-                {value}
-              </p>
+              {exactValue ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      className="cursor-help whitespace-nowrap text-left font-bold text-2xl tracking-tight xl:text-xl"
+                      data-exact={exactValue}
+                      data-testid="kpi-value"
+                      type="button"
+                    >
+                      {value}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs font-mono text-xs">
+                    {exactValue}
+                  </TooltipContent>
+                </Tooltip>
+              ) : (
+                <p
+                  className="whitespace-nowrap font-bold text-2xl tracking-tight xl:text-xl"
+                  data-testid="kpi-value"
+                >
+                  {value}
+                </p>
+              )}
               <DeltaDisplay
                 delta={delta}
                 invertColor={invertDeltaColor}
@@ -203,18 +263,7 @@ function KpiCard({
             {breakdown && breakdown.length > 0 ? (
               <div className="space-y-0.5">
                 {breakdown.map((line) => (
-                  <p
-                    className={cn(
-                      "text-xs font-medium",
-                      line.highlighted
-                        ? "text-green-600 dark:text-green-400"
-                        : "text-foreground"
-                    )}
-                    data-kpi-line={line.key}
-                    key={line.key}
-                  >
-                    {line.text}
-                  </p>
+                  <BreakdownLine key={line.key} line={line} />
                 ))}
               </div>
             ) : null}
@@ -318,16 +367,19 @@ export function KpiCards(): ReactNode {
         deltaTooltip: deltaTooltip("total gas spent"),
         invertDeltaColor: true,
         iconClassName: "bg-purple-500/10 text-purple-600 dark:text-purple-400",
+        exactValue: formatGasExactEth(totalGasWei),
         breakdown: hasSponsoredGas
           ? ([
               {
                 key: "wallet",
                 text: `${gas.wallet} from wallet`,
+                exact: formatGasExactEth(walletGasWei),
               },
               {
                 key: "sponsored",
                 text: `${gas.sponsored} sponsored`,
                 highlighted: true,
+                exact: formatGasExactEth(sponsoredGasWei),
               },
             ] as const)
           : undefined,
@@ -371,6 +423,7 @@ export function KpiCards(): ReactNode {
           cardKey={card.key}
           delta={card.delta}
           deltaTooltip={card.deltaTooltip}
+          exactValue={"exactValue" in card ? card.exactValue : undefined}
           icon={card.icon}
           iconClassName={card.iconClassName}
           invertDeltaColor={card.invertDeltaColor}

--- a/lib/analytics/format-gas.ts
+++ b/lib/analytics/format-gas.ts
@@ -72,6 +72,33 @@ export function formatGasAsEth(
   return renderUnits(toDisplayUnits(wei, decimals), decimals);
 }
 
+const WEI_DECIMALS = 18;
+const TRAILING_ZEROS = /0+$/;
+
+/**
+ * Every wei the value holds, rendered as ETH with nothing rounded away.
+ *
+ * The headline figures round to 4 significant places, which is unreadable to
+ * compare against a block explorer. This is the number to show on hover so the
+ * two can be reconciled digit for digit. Trailing zeros are trimmed because
+ * they carry no information.
+ */
+export function formatGasExactEth(
+  weiString: string | null | undefined
+): string {
+  const wei = parseWei(weiString);
+  if (wei === null) {
+    return "--";
+  }
+  if (wei === ZERO) {
+    return "0 ETH";
+  }
+  const digits = wei.toString().padStart(WEI_DECIMALS + 1, "0");
+  const whole = digits.slice(0, -WEI_DECIMALS);
+  const fraction = digits.slice(-WEI_DECIMALS).replace(TRAILING_ZEROS, "");
+  return fraction ? `${whole}.${fraction} ETH` : `${whole} ETH`;
+}
+
 /**
  * The wallet-paid share of a period's gas.
  *

--- a/tests/unit/analytics-format-gas.test.ts
+++ b/tests/unit/analytics-format-gas.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   formatGasAsEth,
+  formatGasExactEth,
   formatGasSplit,
   gasDecimals,
   walletShareWei,
@@ -100,6 +101,41 @@ describe("formatGasAsEth", () => {
   it("returns -- for missing input and 0 ETH for zero", () => {
     expect(formatGasAsEth(null)).toBe("--");
     expect(formatGasAsEth("0")).toBe("0 ETH");
+  });
+});
+
+describe("formatGasExactEth", () => {
+  // The value the headline renders as "0.0002 ETH", taken off a real receipt.
+  it("keeps every wei the headline rounds away", () => {
+    expect(formatGasExactEth("244920726760244")).toBe(
+      "0.000244920726760244 ETH"
+    );
+    expect(formatGasAsEth("244920726760244", 4)).toBe("0.0002 ETH");
+  });
+
+  it("trims trailing zeros but keeps interior ones", () => {
+    expect(formatGasExactEth("2374215600000000")).toBe("0.0023742156 ETH");
+    expect(formatGasExactEth("1000000000000000000")).toBe("1 ETH");
+    expect(formatGasExactEth("1000000000000000001")).toBe(
+      "1.000000000000000001 ETH"
+    );
+  });
+
+  it("renders a single wei rather than collapsing it to zero", () => {
+    expect(formatGasExactEth("1")).toBe("0.000000000000000001 ETH");
+  });
+
+  it("stays exact past float53", () => {
+    expect(formatGasExactEth("9007199254740993123456789")).toBe(
+      "9007199.254740993123456789 ETH"
+    );
+  });
+
+  it("returns -- for missing input and 0 ETH for zero", () => {
+    expect(formatGasExactEth(null)).toBe("--");
+    expect(formatGasExactEth("")).toBe("--");
+    expect(formatGasExactEth("nonsense")).toBe("--");
+    expect(formatGasExactEth("0")).toBe("0 ETH");
   });
 });
 


### PR DESCRIPTION
## Problem

The Gas Spent card rounds to four decimals. That is right for a dashboard and useless for reconciliation: verifying a keeper wallet against a block explorer meant comparing `0.0024` against `0.00237415` and guessing whether the gap was rounding or a real defect.

It was rounding. All 90 transactions in the explorer export match our stored values one for one, and the stored values are the more precise of the two because the explorer's CSV truncates at 8 decimals. But nothing on the page let you see that.

## Change

`formatGasExactEth` renders every wei with nothing rounded and trailing zeros trimmed. The Gas Spent card exposes it on hover, on the headline and on both breakdown lines:

```
headline      0.0137 ETH   ->  0.01287351 ETH
from wallet   0.0024 ETH   ->  0.0023742156 ETH
sponsored     0.0113 ETH   ->  0.0104992944 ETH
```

Monospace in the tooltip so digits line up against an explorer. The same string is also set as `data-exact`, so end-to-end tests can assert full precision without driving a hover.

Only the Gas Spent card passes `exactValue` and `exact`, so every other KPI renders exactly as before.

## Note on the trigger element

The triggers are `<button>`, not `<p>` with `tabIndex`. A paragraph is not focusable, so Radix would have made the exact figure mouse-only, and Biome flags the tabIndex workaround for the same reason.