### PR TITLE
test: assert that a refused credential is refused

### DIFF
--- a/tests/e2e/vitest/api-key-auth.test.ts
+++ b/tests/e2e/vitest/api-key-auth.test.ts
@@ -246,10 +246,9 @@ describe.skipIf(shouldSkip)("API Key Authentication", () => {
       const response = await fetch(`${baseUrl}/api/workflows`, {
         headers: { Authorization: "Bearer kh_invalid_key" },
       });
-      expect(response.status).toBe(200);
-      const workflows = await response.json();
-      expect(Array.isArray(workflows)).toBe(true);
-      expect(workflows.length).toBe(0);
+      expect(response.status).toBe(401);
+      const body = await response.json();
+      expect(body.error).toBeTruthy();
     });
 
     it("should reject malformed API key", async ({ skip }) => {
@@ -259,9 +258,9 @@ describe.skipIf(shouldSkip)("API Key Authentication", () => {
       const response = await fetch(`${baseUrl}/api/workflows`, {
         headers: { Authorization: "Bearer invalid_prefix_key" },
       });
-      expect(response.status).toBe(200);
-      const workflows = await response.json();
-      expect(Array.isArray(workflows)).toBe(true);
+      expect(response.status).toBe(401);
+      const body = await response.json();
+      expect(body.error).toBeTruthy();
     });
   });
 
@@ -524,9 +523,9 @@ describe.skipIf(shouldSkip)("API Key Authentication", () => {
       const response = await fetch(`${baseUrl}/api/workflows`, {
         headers: { Authorization: `Bearer ${expiredKey}` },
       });
-      expect(response.status).toBe(200);
-      const workflows = await response.json();
-      expect(workflows.length).toBe(0);
+      expect(response.status).toBe(401);
+      const body = await response.json();
+      expect(body.error).toBeTruthy();
     });
   });
 
@@ -557,9 +556,9 @@ describe.skipIf(shouldSkip)("API Key Authentication", () => {
       const response = await fetch(`${baseUrl}/api/workflows`, {
         headers: { Authorization: `Bearer ${revokedKey}` },
       });
-      expect(response.status).toBe(200);
-      const workflows = await response.json();
-      expect(workflows.length).toBe(0);
+      expect(response.status).toBe(401);
+      const body = await response.json();
+      expect(body.error).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
Four cases in `api-key-auth.test.ts` are failing on `staging`:

```
GET /api/workflows > should reject invalid API key     expected 401 to be 200
GET /api/workflows > should reject malformed API key   expected 401 to be 200
Expired API Keys    > should reject expired API key    expected 401 to be 200
Revoked API Keys    > should reject revoked API key    expected 401 to be 200
```

Each presents a bad bearer credential to `GET /api/workflows` and asserts `200` with an empty list. That was the route behaviour until the settings hub merged: a caller whose credential resolved to no principal was answered as though the workspace were empty.

That is wrong for the callers who hit it. An MCP client whose connection was revoked or narrowed reads `200 []` as "nothing here" rather than "reauthenticate", so it never refreshes and goes quiet. The route now answers `401` when a credential was presented and refused. Anonymous callers, who send no credential, still get the empty list.

The tests encoded the old behaviour while their names said the opposite. The assertions now follow the names.

## Why this reached staging

The e2e vitest job did not run on the PR that changed the route, only on the push to `staging` afterwards. Worth deciding separately whether that job should gate PRs touching `app/api/**`.

## Verification

Full file run locally against a dev server and a seeded database:

```
Tests  12 passed | 2 skipped (14)
```

The two skips are the `POST /api/ai/generate` pair, which skip by design without a provider key.