### PR TITLE
fix(metrics): keep trialing subscriptions out of the MRR total

### DIFF
--- a/lib/metrics/METRICS_REFERENCE.md
+++ b/lib/metrics/METRICS_REFERENCE.md
@@ -206,8 +206,8 @@ Billing-aware observability layered onto the org model. Plan distribution, per-o
 | `org.executions.30d` | Workflow executions per org in the last 30 days | `org_slug`, `plan` | DB |
 | `org.executions.month` | Workflow executions per org since start of current calendar month | `org_slug`, `plan` | DB |
 | `org.plan_usage_ratio` | Current-month executions / monthly plan limit (0 when unlimited) | `org_slug`, `plan` | DB |
-| `mrr.usd_cents` | Approximate MRR in USD cents per plan (PLANS table * current tier) | `plan` | DB |
-| `mrr.usd_cents.total` | Approximate total MRR across all plans | - | DB |
+| `mrr.usd_cents` | Approximate MRR in USD cents per plan (PLANS table * current tier) | `plan`, `tier`, `billing_status` | DB |
+| `mrr.usd_cents.total` | Approximate committed MRR across all plans (excludes trials) | - | DB |
 | `billing.subscription.created` | Subscriptions created (paid plan attached after checkout) | `plan`, `tier` | API |
 | `billing.subscription.updated` | Subscription update events from the billing provider | `plan` | API |
 | `billing.subscription.canceled` | Subscriptions canceled (provider-side or downgraded to free) | `plan`, `tier` | API |
@@ -218,7 +218,19 @@ Billing-aware observability layered onto the org model. Plan distribution, per-o
 
 **Billing status values** (`billing_status` label): `active`, `trialing`, `past_due`, `canceled`, `unpaid`, `paused`, `none` (orgs without a subscription row).
 
-**MRR caveat:** `mrr.usd_cents` is computed from `lib/billing/plans.ts` × the org's current `(plan, tier)` tuple, summed across subscriptions in `active`, `trialing`, or `past_due` status. Stripe Dashboard remains the source of truth for accounting; this gauge exists for trend visibility only.
+**MRR caveat:** `mrr.usd_cents` is computed from `lib/billing/plans.ts` × the org's current `(plan, tier)` tuple, for every subscription in `active`, `trialing`, or `past_due` status. Stripe Dashboard remains the source of truth for accounting; this gauge exists for trend visibility only.
+
+**Committed vs trial MRR:** `mrr.usd_cents.total` sums `active` and `past_due` subscriptions only. A trialing org has not been charged, so it must not appear in a revenue figure. Its list price still ships on `mrr.usd_cents` under `billing_status="trialing"`, so trial pipeline revenue stays visible:
+
+```promql
+# committed revenue in USD
+max(keeperhub_mrr_usd_cents_total{cluster=~"$cluster", namespace="keeperhub"}) / 100
+
+# trial pipeline revenue in USD, not yet earned
+sum(max by (plan, tier, billing_status) (keeperhub_mrr_usd_cents{cluster=~"$cluster", namespace="keeperhub", billing_status="trialing"})) / 100
+```
+
+`past_due` counts as committed because the subscription is still on the plan and the invoice is being retried.
 
 ### Workflow Definition Metrics
 

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -424,21 +424,28 @@ const orgPlanUsageRatio = getOrCreateGauge(
   ["org_slug"]
 );
 
-// Directional MRR per (plan, tier) in USD cents. Computed from
-// PLANS[plan].tiers[tier].monthlyPrice for every active/trialing/past_due
+// Directional MRR per (plan, tier, billing_status) in USD cents. Computed
+// from PLANS[plan].tiers[tier].monthlyPrice for every active/trialing/past_due
 // subscription. Stripe Dashboard remains the source of truth for actual
 // revenue accounting; this gauge is for trend/observability only.
+//
+// The billing_status label separates committed revenue from trial pipeline
+// revenue. A trialing org carries its full tier price here but pays nothing
+// yet, so query billing_status="trialing" to see the pipeline on its own.
 const mrrUsdCents = getOrCreateGauge(
   dbRegistry,
   "keeperhub_mrr_usd_cents",
-  "Approximate MRR in USD cents per (plan, tier)",
-  ["plan", "tier"]
+  "Approximate MRR in USD cents per (plan, tier, billing_status)",
+  ["plan", "tier", "billing_status"]
 );
 
+// Committed MRR only: active and past_due subscriptions. Trialing orgs are
+// excluded because they have not been charged. Their revenue stays visible
+// through keeperhub_mrr_usd_cents{billing_status="trialing"}.
 const mrrUsdCentsTotal = getOrCreateGauge(
   dbRegistry,
   "keeperhub_mrr_usd_cents_total",
-  "Approximate total MRR in USD cents across all plans",
+  "Approximate committed MRR in USD cents across all plans (excludes trials)",
   []
 );
 
@@ -1963,7 +1970,11 @@ async function refreshDbMetricsNow(): Promise<void> {
     mrrUsdCents.reset();
     for (const entry of billingStats.mrrCentsByPlan) {
       mrrUsdCents.set(
-        { plan: entry.plan, tier: entry.tier ?? "" },
+        {
+          plan: entry.plan,
+          tier: entry.tier ?? "",
+          billing_status: entry.billingStatus,
+        },
         entry.cents
       );
     }

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -1204,9 +1204,13 @@ export async function getEnabledChainNamesFromDb(): Promise<string[]> {
   }
 }
 
-// Subscription statuses that count toward MRR — kept inline in the SQL
+// Subscription statuses that carry a priced tier. Kept inline in the SQL
 // query (active / trialing / past_due). Canceled / unpaid / paused
 // subscriptions do not contribute.
+//
+// Not every priced status is committed revenue. A trialing org pays nothing
+// yet, so it is reported as its own labelled series and left out of the
+// total. See MRR_COMMITTED_STATUSES below.
 
 export type BillingStats = {
   // Org count per (plan, tier, billing_status). One entry per unique
@@ -1229,16 +1233,20 @@ export type BillingStats = {
     monthlyLimit: number;
   }>;
 
-  // Approximate MRR in USD cents per (plan, tier), computed from
-  // PLANS[plan].tiers[tier].monthlyPrice. Stripe remains the source of
-  // truth for accounting.
+  // Approximate MRR in USD cents per (plan, tier, billing_status), computed
+  // from PLANS[plan].tiers[tier].monthlyPrice. Stripe remains the source of
+  // truth for accounting. The billingStatus split lets a consumer separate
+  // committed revenue from trial pipeline revenue.
   mrrCentsByPlan: Array<{
     plan: PlanName;
     tier: TierKey | null;
+    billingStatus: BillingStatus;
     cents: number;
   }>;
 
-  // Total MRR in USD cents across all plans and tiers.
+  // Committed MRR in USD cents across all plans and tiers. Counts the
+  // statuses in MRR_COMMITTED_STATUSES only, so a trialing org contributes
+  // nothing until it converts. Read mrrCentsByPlan for the trial pipeline.
   mrrCentsTotal: number;
 
   // Trial funnel snapshot: orgs that have ever started a trial, by current
@@ -1257,6 +1265,15 @@ const VALID_TRIAL_OUTCOMES: ReadonlySet<string> = new Set<TrialOutcome>([
   "converted",
   "churned",
 ]);
+
+// Billing statuses that count as committed revenue in mrrCentsTotal. A
+// past_due org stays on the plan and is still billed, so it counts. A
+// trialing org pays nothing yet, so it does not.
+//
+// Tested against the parsed status rather than a "not trialing" check, so
+// the total stays correct if the SQL query widens its status filter.
+const MRR_COMMITTED_STATUSES: ReadonlySet<BillingStatus> =
+  new Set<BillingStatus>(["active", "past_due"]);
 
 function emptyBillingStats(): BillingStats {
   return {
@@ -1342,13 +1359,15 @@ export async function getBillingStatsFromDb(): Promise<BillingStats> {
         organizationSubscriptions.tier
       );
 
-    // Active-subscription tier list for MRR computation. We include past_due
+    // Priced-subscription tier list for MRR computation. We include past_due
     // because those orgs are still on the plan; only canceled/unpaid/paused
-    // are excluded.
+    // are excluded. We also include trialing, but the status comes back with
+    // the row so the tally can keep trial revenue out of the total.
     const mrrSubsResult = await db
       .select({
         plan: organizationSubscriptions.plan,
         tier: organizationSubscriptions.tier,
+        status: organizationSubscriptions.status,
       })
       .from(organizationSubscriptions)
       .where(
@@ -1416,20 +1435,27 @@ export async function getBillingStatsFromDb(): Promise<BillingStats> {
       });
     }
 
-    // Compute MRR per (plan, tier) from active subscriptions × tier price
+    // Compute MRR per (plan, tier, billing_status) from priced subscriptions
+    // × tier price. Only committed statuses reach the total.
     for (const row of mrrSubsResult) {
       const plan = parsePlanName(row.plan, "free");
       const tier = parseTierKey(row.tier);
+      const billingStatus = parseBillingStatus(row.status);
       const cents = tierMonthlyPriceCents(plan, tier);
       const existing = stats.mrrCentsByPlan.find(
-        (e) => e.plan === plan && e.tier === tier
+        (e) =>
+          e.plan === plan &&
+          e.tier === tier &&
+          e.billingStatus === billingStatus
       );
       if (existing) {
         existing.cents += cents;
       } else {
-        stats.mrrCentsByPlan.push({ plan, tier, cents });
+        stats.mrrCentsByPlan.push({ plan, tier, billingStatus, cents });
       }
-      stats.mrrCentsTotal += cents;
+      if (MRR_COMMITTED_STATUSES.has(billingStatus)) {
+        stats.mrrCentsTotal += cents;
+      }
     }
 
     // Tally trial outcomes (active / converted / churned)

--- a/tests/unit/db-metrics-billing-mrr.test.ts
+++ b/tests/unit/db-metrics-billing-mrr.test.ts
@@ -1,0 +1,152 @@
+/**
+ * getBillingStatsFromDb() must not price a trialing org into MRR.
+ *
+ * A trialing org carries a real (plan, tier) tuple, so the old tally added its
+ * full list price to mrrCentsTotal while the customer paid nothing. On prod
+ * that overstated MRR by 57% (8 trialing of 14 priced pro/25k subscriptions).
+ *
+ * The fix keeps trialing rows in mrrCentsByPlan, now labelled with
+ * billingStatus, and counts only MRR_COMMITTED_STATUSES into the total.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// getBillingStatsFromDb issues four queries, always in this order:
+//   1. orgs by (plan, tier, status)   2. executions per org
+//   3. priced subscriptions for MRR   4. trial outcomes
+// The stub below ignores every chain method and resolves to the next queued
+// row set, so each test only has to describe the rows it cares about.
+const queuedRows: unknown[][] = [];
+
+function queueRows(...rowSets: unknown[][]): void {
+  queuedRows.length = 0;
+  queuedRows.push(...rowSets);
+}
+
+type QueryChain = Promise<unknown[]> & Record<string, () => QueryChain>;
+
+function makeChain(): QueryChain {
+  // A real Promise, so `await db.select()...` resolves natively. The builder
+  // methods hang off it and return the same object, so any chain shape works.
+  const chain = Promise.resolve(queuedRows.shift() ?? []) as QueryChain;
+  for (const method of [
+    "select",
+    "from",
+    "leftJoin",
+    "innerJoin",
+    "where",
+    "groupBy",
+    "orderBy",
+    "limit",
+  ]) {
+    chain[method] = () => chain;
+  }
+  return chain;
+}
+
+// db-metrics.ts reads the dedicated metrics pool, not the app pool:
+// `import { metricsDb as db } from "@/lib/db"`. Mocking `db` alone leaves
+// metricsDb undefined, and getBillingStatsFromDb swallows the resulting
+// error and returns empty stats, so every assertion would read 0.
+vi.mock("@/lib/db", () => ({
+  db: { select: () => makeChain() },
+  metricsDb: { select: () => makeChain() },
+}));
+
+import { getBillingStatsFromDb } from "@/lib/metrics/db-metrics";
+
+// Pro 25k lists at $49/mo (lib/billing/plans.ts), so 4900 cents per seat.
+const PRO_25K_CENTS = 4900;
+
+function proSub(status: string) {
+  return { plan: "pro", tier: "25k", status };
+}
+
+/** Queue only the MRR query (3rd); the other three return no rows. */
+function queueMrrRows(rows: unknown[]): void {
+  queueRows([], [], rows, []);
+}
+
+describe("getBillingStatsFromDb MRR split", () => {
+  beforeEach(() => {
+    queuedRows.length = 0;
+  });
+
+  it("keeps trialing revenue out of the committed total", async () => {
+    // The prod mix on 2026-08-13: 5 active, 8 trialing, 1 past_due.
+    queueMrrRows([
+      ...Array.from({ length: 5 }, () => proSub("active")),
+      ...Array.from({ length: 8 }, () => proSub("trialing")),
+      proSub("past_due"),
+    ]);
+
+    const stats = await getBillingStatsFromDb();
+
+    // Committed = active (5) + past_due (1) = 6 x 4900 = 29400.
+    expect(stats.mrrCentsTotal).toBe(6 * PRO_25K_CENTS);
+    // Not the pre-fix figure of 14 x 4900 = 68600.
+    expect(stats.mrrCentsTotal).not.toBe(14 * PRO_25K_CENTS);
+  });
+
+  it("still reports trial pipeline revenue as its own labelled series", async () => {
+    queueMrrRows([
+      ...Array.from({ length: 5 }, () => proSub("active")),
+      ...Array.from({ length: 8 }, () => proSub("trialing")),
+      proSub("past_due"),
+    ]);
+
+    const stats = await getBillingStatsFromDb();
+    const find = (billingStatus: string) =>
+      stats.mrrCentsByPlan.find(
+        (e) =>
+          e.plan === "pro" &&
+          e.tier === "25k" &&
+          e.billingStatus === billingStatus
+      );
+
+    expect(find("active")?.cents).toBe(5 * PRO_25K_CENTS);
+    expect(find("trialing")?.cents).toBe(8 * PRO_25K_CENTS);
+    expect(find("past_due")?.cents).toBe(1 * PRO_25K_CENTS);
+    // One entry per status, not one merged (plan, tier) bucket.
+    expect(stats.mrrCentsByPlan).toHaveLength(3);
+  });
+
+  it("counts past_due as committed, because the org stays on the plan", async () => {
+    queueMrrRows([proSub("past_due")]);
+
+    const stats = await getBillingStatsFromDb();
+
+    expect(stats.mrrCentsTotal).toBe(PRO_25K_CENTS);
+  });
+
+  it("reports zero committed revenue when every subscription is trialing", async () => {
+    queueMrrRows([proSub("trialing"), proSub("trialing")]);
+
+    const stats = await getBillingStatsFromDb();
+
+    expect(stats.mrrCentsTotal).toBe(0);
+    expect(stats.mrrCentsByPlan).toEqual([
+      {
+        plan: "pro",
+        tier: "25k",
+        billingStatus: "trialing",
+        cents: 2 * PRO_25K_CENTS,
+      },
+    ]);
+  });
+
+  it("prices an untiered enterprise subscription at zero without dropping the row", async () => {
+    queueMrrRows([{ plan: "enterprise", tier: null, status: "active" }]);
+
+    const stats = await getBillingStatsFromDb();
+
+    // Prod carries 4 active enterprise orgs that contribute no MRR, because
+    // they have no priced tier. The series must still exist so the zero is
+    // visible rather than missing.
+    expect(stats.mrrCentsTotal).toBe(0);
+    expect(stats.mrrCentsByPlan).toEqual([
+      { plan: "enterprise", tier: null, billingStatus: "active", cents: 0 },
+    ]);
+  });
+});

--- a/tests/unit/db-metrics-cache.test.ts
+++ b/tests/unit/db-metrics-cache.test.ts
@@ -158,6 +158,20 @@ const FINISHED_AGE_17_RE =
 const FINISHED_AGE_ZERO_RE =
   /keeperhub_workflow_executions_finished_age_seconds\s+0(\s|$)/m;
 
+// MRR series. Label order follows the object passed to .set()
+// (plan, tier, billing_status), but stay tolerant of extra labels.
+const MRR_ACTIVE_RE =
+  /keeperhub_mrr_usd_cents\{[^}]*plan="pro"[^}]*tier="25k"[^}]*billing_status="active"[^}]*\}\s+24500/;
+const MRR_TRIALING_RE =
+  /keeperhub_mrr_usd_cents\{[^}]*plan="pro"[^}]*tier="25k"[^}]*billing_status="trialing"[^}]*\}\s+39200/;
+const MRR_PAST_DUE_RE =
+  /keeperhub_mrr_usd_cents\{[^}]*plan="pro"[^}]*tier="25k"[^}]*billing_status="past_due"[^}]*\}\s+4900/;
+const MRR_ENTERPRISE_NO_TIER_RE =
+  /keeperhub_mrr_usd_cents\{[^}]*plan="enterprise"[^}]*tier=""[^}]*billing_status="active"[^}]*\}\s+0/;
+// Unlabeled gauge: name followed by the value, no `{...}` block.
+const MRR_TOTAL_COMMITTED_RE = /keeperhub_mrr_usd_cents_total\s+29400(\s|$)/m;
+const MRR_TOTAL_WITH_TRIALS_RE = /keeperhub_mrr_usd_cents_total\s+68600(\s|$)/m;
+
 describe("updateDbMetrics TTL cache", () => {
   const originalTtl = process.env.DB_METRICS_CACHE_TTL_MS;
 
@@ -547,5 +561,99 @@ describe("keeperhub_workflow_executions_finished_age_seconds gauge", () => {
     const out = await getDbMetrics();
     expect(out).toMatch(FINISHED_AGE_17_RE);
     expect(out).not.toMatch(FINISHED_AGE_ZERO_RE);
+  });
+});
+
+// The MRR gauge must carry billing_status so a dashboard can tell
+// committed revenue from trial pipeline revenue, and the total must exclude
+// trials. On prod the old total read $686 while only $294 was committed.
+describe("keeperhub_mrr_usd_cents gauge", () => {
+  const originalTtl = process.env.DB_METRICS_CACHE_TTL_MS;
+
+  beforeEach(() => {
+    __resetDbMetricsCacheForTest();
+    for (const fn of Object.values(dbMocks)) {
+      fn.mockReset();
+    }
+    rebindDefaultDbMockImplementations();
+    process.env.DB_METRICS_CACHE_TTL_MS = "0";
+  });
+
+  afterEach(() => {
+    if (originalTtl === undefined) {
+      delete process.env.DB_METRICS_CACHE_TTL_MS;
+    } else {
+      process.env.DB_METRICS_CACHE_TTL_MS = originalTtl;
+    }
+  });
+
+  it("labels each series with billing_status and keeps trials out of the total", async () => {
+    dbMocks.getBillingStatsFromDb.mockResolvedValue({
+      orgsByPlan: [],
+      orgsExecutions: [],
+      mrrCentsByPlan: [
+        { plan: "pro", tier: "25k", billingStatus: "active", cents: 24_500 },
+        { plan: "pro", tier: "25k", billingStatus: "trialing", cents: 39_200 },
+        { plan: "pro", tier: "25k", billingStatus: "past_due", cents: 4900 },
+      ],
+      mrrCentsTotal: 29_400,
+      trialsByOutcome: [],
+    });
+
+    await updateDbMetrics();
+    const out = await getDbMetrics();
+
+    expect(out).toMatch(MRR_ACTIVE_RE);
+    expect(out).toMatch(MRR_TRIALING_RE);
+    expect(out).toMatch(MRR_PAST_DUE_RE);
+    // Committed only. 68600 was the pre-fix figure that counted trials.
+    expect(out).toMatch(MRR_TOTAL_COMMITTED_RE);
+    expect(out).not.toMatch(MRR_TOTAL_WITH_TRIALS_RE);
+  });
+
+  it("emits an empty tier label for a plan with no tier", async () => {
+    dbMocks.getBillingStatsFromDb.mockResolvedValue({
+      orgsByPlan: [],
+      orgsExecutions: [],
+      mrrCentsByPlan: [
+        { plan: "enterprise", tier: null, billingStatus: "active", cents: 0 },
+      ],
+      mrrCentsTotal: 0,
+      trialsByOutcome: [],
+    });
+
+    await updateDbMetrics();
+
+    expect(await getDbMetrics()).toMatch(MRR_ENTERPRISE_NO_TIER_RE);
+  });
+
+  it("clears the trialing series once the org converts to active", async () => {
+    dbMocks.getBillingStatsFromDb.mockResolvedValueOnce({
+      orgsByPlan: [],
+      orgsExecutions: [],
+      mrrCentsByPlan: [
+        { plan: "pro", tier: "25k", billingStatus: "trialing", cents: 4900 },
+      ],
+      mrrCentsTotal: 0,
+      trialsByOutcome: [],
+    });
+    await updateDbMetrics();
+    expect(await getDbMetrics()).toContain('billing_status="trialing"');
+
+    // The trial converted, so the next scrape reports it as active. reset()
+    // must drop the trialing series rather than strand it at its old value.
+    dbMocks.getBillingStatsFromDb.mockResolvedValue({
+      orgsByPlan: [],
+      orgsExecutions: [],
+      mrrCentsByPlan: [
+        { plan: "pro", tier: "25k", billingStatus: "active", cents: 4900 },
+      ],
+      mrrCentsTotal: 4900,
+      trialsByOutcome: [],
+    });
+    await updateDbMetrics();
+    const out = await getDbMetrics();
+    expect(out).not.toContain('billing_status="trialing"');
+    expect(out).toContain('billing_status="active"');
   });
 });


### PR DESCRIPTION
## Problem

`keeperhub_mrr_usd_cents_total` prices every trialing subscription at its full tier rate. A trialing org has not been charged, so the gauge reports revenue that does not exist.

Read from prod on 2026-08-13:

| Metric | Value |
| --- | --- |
| `keeperhub_mrr_usd_cents_total` | 68600 cents ($686.00) |
| Priced pro/25k subscriptions | 5 active + 8 trialing + 1 past_due = 14 |
| Committed revenue | 6 x $49 = $294 |

Trials are 57% of the reported number. Trials have run in prod since 2026-07-14, so this is live today, not a future risk.

## Change

`getBillingStatsFromDb()` now selects `status` alongside `plan` and `tier`. Each `mrrCentsByPlan` entry is keyed on `(plan, tier, billingStatus)`, and a row reaches `mrrCentsTotal` only when its status is committed.

`MRR_COMMITTED_STATUSES` holds `active` and `past_due`. A past_due subscription still counts, because the org stays on the plan while the invoice is retried. The check reads the parsed status rather than testing "not trialing", so the total stays correct if the SQL status filter ever widens.

`keeperhub_mrr_usd_cents` gains a `billing_status` label. Trial pipeline revenue stays visible rather than disappearing along with the total correction:

```promql
# committed revenue in USD
max(keeperhub_mrr_usd_cents_total{cluster=~"$cluster", namespace="keeperhub"}) / 100

# trial pipeline revenue in USD, not yet earned
sum(max by (plan, tier, billing_status) (keeperhub_mrr_usd_cents{cluster=~"$cluster", namespace="keeperhub", billing_status="trialing"})) / 100
```

The gauge keeps its existing framing: Stripe stays the source of truth for revenue accounting, and this metric serves trend observation only.

## Compatibility

Nothing read the per-plan gauge before this change, so the new label breaks no query. I checked every dashboard in the Grafana org and all 91 provisioned alert rules.

Two panels read `keeperhub_mrr_usd_cents_total` and both will step down about $392 on deploy, with no customer lost:

- `KeeperHub Growth + Revenue`, panel "MRR (USD)" and panel "MRR change vs 30d ago"
- `KeeperHub`, "Billing & Plans" row, panel "Approx MRR"

Those descriptions are corrected in a follow-up PR to `techops-services/infrastructure`. The panel change cannot ride ahead of this one, because the `billing_status` label does not exist until this deploys.

## Tests

`tests/unit/db-metrics-billing-mrr.test.ts` is new and covers the tally itself: the committed total, the trialing series, past_due counted as committed, an all-trials org set, and an untiered enterprise row. I confirmed these have teeth by removing the committed-status guard, which fails 2 of them.

`tests/unit/db-metrics-cache.test.ts` gains gauge exposition tests: the `billing_status` label reaches the scrape output, an empty tier renders as `tier=""`, and the trialing series clears when the org converts.

## Local checks

Every job the PR pipeline runs:

- `pnpm check` clean
- `pnpm discover-plugins && pnpm type-check` clean
- `pnpm test:unit __tests__ keeperhub-metrics-collector`: 536 files, 20948 tests passed
- `pnpm build` passed against a local Postgres with migrations applied
- `collector-build-check`: built the `metrics-collector` Docker stage and ran `import-check.ts`, which returned `IMPORTS_OK prometheus-api=6 db-metrics=20`

`metrics-db-review-gate` fires because this touches `lib/metrics/**`. It needs the `metrics-db-reviewed` label. The attestation holds: this adds one already-projected column to an existing `SELECT` on `organization_subscriptions`. No new query, no new join, no new scan, and the row count is bounded by the paying-customer count.