### PR TITLE
fix(billing): refuse over-quota dispatches before they reach the queue

### DIFF
--- a/app/api/analytics/runs/route.ts
+++ b/app/api/analytics/runs/route.ts
@@ -15,6 +15,7 @@ const VALID_STATUSES = new Set<NormalizedStatus>([
   "error",
   "system_error",
   "external_error",
+  "skipped",
   "cancelled",
 ]);
 

--- a/app/api/internal/execution-digest/route.ts
+++ b/app/api/internal/execution-digest/route.ts
@@ -103,7 +103,10 @@ async function processOrg(
       since,
       until
     );
-    if (digest.total === 0) {
+    // Skipped runs are excluded from `total`, but an org whose triggers were
+    // all refused is exactly the one that needs the email, so they still count
+    // as activity here.
+    if (digest.total === 0 && digest.skipped === 0) {
       // No activity this window; send nothing and leave this cadence's last-sent
       // so the next run re-evaluates once there is something to report.
       continue;
@@ -122,6 +125,7 @@ async function processOrg(
           total: digest.total,
           success: digest.success,
           error: digest.error,
+          skipped: digest.skipped,
           distinctWorkflows: digest.distinctWorkflows,
           transactionCount: digest.transactionCount,
           gasUsedWei: digest.gasUsedWei,
@@ -129,6 +133,7 @@ async function processOrg(
         },
         topFailing: digest.topFailing,
         mostExecuted: digest.mostExecuted,
+        topSkipped: digest.topSkipped,
       });
     }
 

--- a/app/api/internal/executions/[executionId]/route.ts
+++ b/app/api/internal/executions/[executionId]/route.ts
@@ -1,4 +1,4 @@
-import { and, eq, ne } from "drizzle-orm";
+import { and, eq, notInArray } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
@@ -133,7 +133,7 @@ export async function PATCH(
       and(
         eq(workflowExecutions.id, executionId),
         eq(prevExecution.id, workflowExecutions.id),
-        ne(workflowExecutions.status, "cancelled")
+        notInArray(workflowExecutions.status, ["cancelled", "skipped"])
       )
     )
     .returning({

--- a/app/api/internal/executions/route.ts
+++ b/app/api/internal/executions/route.ts
@@ -1,12 +1,19 @@
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
+import {
+  checkDispatchAdmission,
+  type DispatchRefusal,
+} from "@/lib/billing/dispatch-admission";
 import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { db } from "@/lib/db";
 import { workflowExecutions, workflows } from "@/lib/db/schema";
 import { extractActionTypeNodes } from "@/lib/features";
 import { enforceWorkflowFeatures } from "@/lib/features/route-guard";
 import { authenticateInternalService } from "@/lib/internal-service-auth";
+import { logWarn } from "@/lib/logging";
+import { recordWorkflowExecutionSkipped } from "@/lib/metrics/collectors/prometheus";
+import { resolveOrgSlugForCounter } from "@/lib/metrics/org-slug.server";
 import { withBackstopCapture } from "@/lib/security/backstop-capture";
 import {
   buildAttribution,
@@ -39,6 +46,64 @@ function resolveTriggerSource(value: unknown): TriggerSource {
     }
   }
   return "internal";
+}
+
+/**
+ * Record a refused dispatch so its author still sees why the trigger stopped
+ * firing, without writing one row per occurrence. The synthetic dispatch key
+ * buckets by hour, so the unique index collapses every further refusal of the
+ * same workflow for the same reason within that hour into a no-op insert. A
+ * block trigger on a fast chain would otherwise write a row per block.
+ *
+ * Best-effort: the refusal itself is already decided, so a failed insert must
+ * not turn into a failed response, which the dispatcher would read as a
+ * transport error and fall through to the id-less enqueue.
+ */
+async function recordRefusedDispatch(params: {
+  request: Request;
+  workflowId: string;
+  userId: string;
+  source: TriggerSource;
+  refusal: DispatchRefusal;
+}): Promise<void> {
+  const now = new Date();
+  const hourBucket = now.toISOString().slice(0, 13);
+  const dispatchKey = `refused:${params.workflowId}:${params.refusal.reason}:${hourBucket}`;
+
+  try {
+    await db
+      .insert(workflowExecutions)
+      .values({
+        workflowId: params.workflowId,
+        userId: params.userId,
+        // Refused before it started, so it is neither a failure nor billable.
+        // Matches what the executor writes when it refuses the same run.
+        status: "skipped",
+        billable: false,
+        input: {},
+        dispatchKey,
+        error: params.refusal.message,
+        errorCategory: "billing",
+        errorType: "user",
+        startedAt: now,
+        completedAt: now,
+        ...buildAttribution({ request: params.request, source: params.source }),
+      })
+      .onConflictDoNothing({ target: workflowExecutions.dispatchKey });
+
+    // Counted per refusal, not per row, so the hour bucketing above does not
+    // hide the real volume from the metric.
+    recordWorkflowExecutionSkipped({
+      orgSlug: await resolveOrgSlugForCounter(params.workflowId),
+      reason: params.refusal.reason,
+    });
+  } catch (error) {
+    logWarn("[Admission] Failed to record refused dispatch", {
+      workflowId: params.workflowId,
+      reason: params.refusal.reason,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 export async function POST(request: Request): Promise<NextResponse> {
@@ -98,25 +163,47 @@ export async function POST(request: Request): Promise<NextResponse> {
   // workflow's userId FK is non-null, so ownerId is always resolved here.
   const ownerId: string = userId ?? workflow.userId;
 
-  const featureGuard = await enforceWorkflowFeatures(
-    extractActionTypeNodes(workflow.nodes as unknown[]),
-    workflow.organizationId
-  );
-  if (featureGuard.blocked) {
-    return featureGuard.response;
-  }
+  const source = resolveTriggerSource(triggerSource);
 
-  // Phantom rows do not consume execution quota at creation time -- the limit
-  // is enforced when the executor upgrades the row to running. A real (running)
-  // row enforces it up front as before.
-  if (!isPhantom) {
+  // A phantom is created by a dispatcher on every occurrence of its trigger, so
+  // admission runs here rather than one hop later on the executor: a refused
+  // occurrence then costs an hour-bucketed row at most, instead of a row plus an
+  // SQS message plus an executor round-trip every time. The refusal is reported
+  // as a 200 so it can never be read as a transport failure, which the
+  // dispatchers deliberately fall through to the id-less enqueue.
+  if (isPhantom) {
+    const refusal = await checkDispatchAdmission({
+      organizationId: workflow.organizationId,
+      nodes: workflow.nodes as unknown[],
+    });
+    if (refusal) {
+      await recordRefusedDispatch({
+        request,
+        workflowId,
+        userId: ownerId,
+        source,
+        refusal,
+      });
+      return NextResponse.json(
+        { refused: true, reason: refusal.reason, error: refusal.message },
+        { status: 200 }
+      );
+    }
+  } else {
+    const featureGuard = await enforceWorkflowFeatures(
+      extractActionTypeNodes(workflow.nodes as unknown[]),
+      workflow.organizationId
+    );
+    if (featureGuard.blocked) {
+      return featureGuard.response;
+    }
+
     const executionGuard = await enforceExecutionLimit(workflow.organizationId);
     if (executionGuard.blocked) {
       return executionGuard.response;
     }
   }
 
-  const source = resolveTriggerSource(triggerSource);
   const attribution = buildAttribution({ request, source });
 
   const inserted = await withBackstopCapture(

--- a/app/api/workflows/executions/[executionId]/status/route.ts
+++ b/app/api/workflows/executions/[executionId]/status/route.ts
@@ -28,6 +28,7 @@ const TERMINAL_STATUSES = new Set([
   "success",
   "error",
   "system_error",
+  "skipped",
   "cancelled",
 ]);
 const POLL_INTERVAL_HINT_SECONDS = 2;

--- a/app/api/workflows/executions/[executionId]/status/route.ts
+++ b/app/api/workflows/executions/[executionId]/status/route.ts
@@ -2,7 +2,10 @@ import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs } from "@/lib/db/schema";
-import { isErrorStatus } from "@/lib/errors/execution-status";
+import {
+  isErrorStatus,
+  type NodeExecutionStatus,
+} from "@/lib/errors/execution-status";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { createTimer } from "@/lib/metrics";
 import { recordStatusPollMetrics } from "@/lib/metrics/instrumentation/api";
@@ -19,7 +22,7 @@ import { checkExecutionStatusRateLimit } from "@/lib/workflow/execution-status-r
 
 type NodeStatus = {
   nodeId: string;
-  status: "pending" | "running" | "success" | "error" | "cancelled";
+  status: NodeExecutionStatus;
 };
 
 // Statuses after which there is nothing left to poll for. Mirrors the set the

--- a/components/analytics/kpi-cards.tsx
+++ b/components/analytics/kpi-cards.tsx
@@ -112,6 +112,12 @@ function DeltaDisplay({
   );
 }
 
+// Shown on Total Runs, which is where a user notices runs are missing: the
+// trigger fired but the platform refused the run before it started, so it is
+// neither a success nor a failure and belongs in no rate.
+const SKIPPED_TOOLTIP =
+  "Runs that finished, successfully or not, over this period. Runs still in flight, runs you cancelled, and skipped runs are excluded. A run is skipped when the trigger fired but the run was refused before it started, because the plan's monthly execution limit was reached, the workflow uses an action your plan does not include, or a pay-as-you-go charge could not be collected. Nothing ran, so skipped runs do not count towards your success rate or your usage.";
+
 const COMPARISON_LABELS: Record<TimeRange, string> = {
   "1h": "the previous hour",
   "24h": "the previous 24 hours",
@@ -297,6 +303,7 @@ export function KpiCards(): ReactNode {
       `Change in ${metric} compared with ${versus}.`;
 
     const prev = summary.previousPeriod;
+    const skippedCount = summary.skippedCount;
 
     const totalRunsDelta = prev
       ? computeDelta(summary.totalRuns, prev.totalRuns)
@@ -337,6 +344,16 @@ export function KpiCards(): ReactNode {
         deltaTooltip: deltaTooltip("total runs"),
         invertDeltaColor: false,
         iconClassName: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+        breakdown:
+          skippedCount > 0
+            ? ([
+                {
+                  key: "skipped",
+                  text: `${skippedCount.toLocaleString()} skipped`,
+                },
+              ] as const)
+            : undefined,
+        tooltip: SKIPPED_TOOLTIP,
       },
       {
         key: "success-rate",

--- a/components/analytics/runs-filters.tsx
+++ b/components/analytics/runs-filters.tsx
@@ -24,6 +24,7 @@ const STATUS_OPTIONS: Array<{
   { value: "external_error", label: "External" },
   { value: "system_error", label: "System Error" },
   { value: "cancelled", label: "Cancelled" },
+  { value: "skipped", label: "Skipped" },
   { value: "running", label: "Running" },
   { value: "pending", label: "Pending" },
 ];

--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -197,14 +197,41 @@ const STATUS_LABELS: Partial<Record<NormalizedStatus, string>> = {
   skipped: "Skipped",
 };
 
+// The four outcome badges a user cannot tell apart from the label alone. Each
+// one answers "whose fault is it and what do I do about it".
+const STATUS_TOOLTIPS: Partial<Record<NormalizedStatus, string>> = {
+  skipped:
+    "The trigger fired but the run was refused before it started. Either the monthly execution limit was reached, or the workflow uses an action your plan does not include, or a pay-as-you-go charge could not be collected. Nothing ran, so a skipped run is not a failure and does not count towards your success rate or your usage.",
+  error:
+    "The run started and failed on something in the workflow itself: bad input, a missing or invalid credential, or a 4xx from an endpoint you configured. Fix the workflow and run it again.",
+  external_error:
+    "The run failed on a third party it called, not on the workflow and not on KeeperHub. Typical causes are an API or endpoint that timed out, a webhook host that was down, or a provider that returned a 5xx. Retrying usually works once the provider recovers.",
+  system_error:
+    "The run failed inside KeeperHub: dispatch, the queue, or a run that was reaped after it timed out. There is nothing to fix in your workflow.",
+};
+
 function StatusBadge({ status }: { status: NormalizedStatus }): ReactNode {
-  return (
+  const badge = (
     <Badge
       className={cn("capitalize", STATUS_STYLES[status])}
       variant="outline"
     >
       {STATUS_LABELS[status] ?? status}
     </Badge>
+  );
+
+  const tooltip = STATUS_TOOLTIPS[status];
+  if (!tooltip) {
+    return badge;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex cursor-help">{badge}</span>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs">{tooltip}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -178,6 +178,8 @@ const STATUS_STYLES: Record<NormalizedStatus, string> = {
     "bg-purple-500/10 text-purple-700 dark:text-purple-400 border-purple-500/20",
   cancelled:
     "bg-orange-500/10 text-orange-700 dark:text-orange-400 border-orange-500/20",
+  // Refused before it started: neutral, not a failure colour.
+  skipped: "bg-muted text-muted-foreground border-border",
   running: "bg-blue-500/10 text-blue-700 dark:text-blue-400 border-blue-500/20",
   pending: "bg-gray-500/10 text-gray-700 dark:text-gray-400 border-gray-500/20",
 } as const;
@@ -185,6 +187,7 @@ const STATUS_STYLES: Record<NormalizedStatus, string> = {
 const STATUS_LABELS: Partial<Record<NormalizedStatus, string>> = {
   system_error: "System Error",
   external_error: "External",
+  skipped: "Skipped",
 };
 
 function StatusBadge({ status }: { status: NormalizedStatus }): ReactNode {

--- a/components/analytics/time-series-chart.tsx
+++ b/components/analytics/time-series-chart.tsx
@@ -24,6 +24,8 @@ const CHART_COLORS = {
   success: "var(--color-keeperhub-green)",
   error: "var(--color-orange-500, #f97316)",
   cancelled: "var(--chart-1)",
+  // Refused before it started: muted, so it never reads as a failure band.
+  skipped: "var(--color-muted-foreground)",
   running: "var(--chart-2)",
   pending: "var(--chart-4)",
 } as const;
@@ -119,6 +121,7 @@ function TimeSeriesContent({
     success: number;
     error: number;
     cancelled: number;
+    skipped: number;
     pending: number;
     running: number;
   }[];
@@ -132,6 +135,7 @@ function TimeSeriesContent({
       "success",
       "error",
       "cancelled",
+      "skipped",
       "running",
       "pending",
     ] as const;

--- a/components/executions/execution-share-view.tsx
+++ b/components/executions/execution-share-view.tsx
@@ -13,6 +13,7 @@ const TERMINAL_STATUSES = new Set([
   "success",
   "error",
   "system_error",
+  "skipped",
   "cancelled",
 ]);
 

--- a/components/executions/execution-share-view.tsx
+++ b/components/executions/execution-share-view.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { Check, Clock, ExternalLink, Loader2, X } from "lucide-react";
+import {
+  Check,
+  Clock,
+  ExternalLink,
+  Loader2,
+  SkipForward,
+  X,
+} from "lucide-react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -57,6 +64,8 @@ function getStatusLabel(status: string): string {
       return "Running";
     case "cancelled":
       return "Cancelled";
+    case "skipped":
+      return "Skipped";
     default:
       return status;
   }
@@ -71,6 +80,9 @@ function StatusIcon({ status }: { status: string }): React.ReactElement {
       return <X aria-hidden="true" className="h-4 w-4" />;
     case "running":
       return <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />;
+    // Terminal, so it must not fall through to the pending clock.
+    case "skipped":
+      return <SkipForward aria-hidden="true" className="h-4 w-4" />;
     default:
       return <Clock aria-hidden="true" className="h-4 w-4" />;
   }
@@ -227,7 +239,10 @@ export function ExecutionShareView({
                   "bg-destructive/15 text-destructive",
                 statusData.status === "running" && "bg-primary/15 text-primary",
                 statusData.status === "cancelled" &&
-                  "bg-orange-500/15 text-orange-600 dark:text-orange-400"
+                  "bg-orange-500/15 text-orange-600 dark:text-orange-400",
+                // Refused before it started: neutral, not a failure colour.
+                statusData.status === "skipped" &&
+                  "bg-muted text-muted-foreground"
               )}
             >
               <StatusIcon status={statusData.status} />

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -12,6 +12,7 @@ import {
   GitBranch,
   Loader2,
   Play,
+  SkipForward,
   TriangleAlert,
   X,
 } from "lucide-react";
@@ -66,7 +67,14 @@ type ExecutionLog = {
 type WorkflowExecution = {
   id: string;
   workflowId: string;
-  status: "pending" | "running" | "success" | "error" | "cancelled" | "phantom";
+  status:
+    | "pending"
+    | "running"
+    | "success"
+    | "error"
+    | "skipped"
+    | "cancelled"
+    | "phantom";
   startedAt: Date;
   completedAt: Date | null;
   duration: string | null;
@@ -799,6 +807,8 @@ function getStatusLabel(status: string): string {
       return "Running";
     case "cancelled":
       return "Cancelled before it finished";
+    case "skipped":
+      return "Skipped - expand for why it did not run";
     default:
       return "Pending - has not run yet";
   }
@@ -1226,6 +1236,8 @@ export function WorkflowRuns({
         return <Loader2 className="h-3 w-3 animate-spin text-white" />;
       case "cancelled":
         return <Ban className="h-3 w-3 text-white" />;
+      case "skipped":
+        return <SkipForward className="h-3 w-3 text-white" />;
       default:
         return <Clock className="h-3 w-3 text-white" />;
     }
@@ -1243,6 +1255,9 @@ export function WorkflowRuns({
         return "bg-blue-600";
       case "cancelled":
         return "bg-orange-500";
+      // Neutral: refused before it started, not a failure.
+      case "skipped":
+        return "bg-muted-foreground";
       default:
         return "bg-muted-foreground";
     }

--- a/components/workflow/workflow-runs.tsx
+++ b/components/workflow/workflow-runs.tsx
@@ -23,6 +23,10 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { toChecksumAddress } from "@/lib/address-utils";
 import { getCustomerRunErrorMessage } from "@/lib/errors/customer-message";
 import type { ExecutionErrorType } from "@/lib/errors/execution-error-type";
+import type {
+  NodeExecutionStatus,
+  WorkflowExecutionStatus,
+} from "@/lib/errors/execution-status";
 import {
   FOR_EACH_GROUP_TYPE,
   buildChildLogsLookup,
@@ -53,7 +57,7 @@ type ExecutionLog = {
   nodeId: string;
   nodeName: string;
   nodeType: string;
-  status: "pending" | "running" | "success" | "error" | "cancelled";
+  status: NodeExecutionStatus;
   startedAt: Date;
   completedAt: Date | null;
   duration: string | null;
@@ -67,14 +71,7 @@ type ExecutionLog = {
 type WorkflowExecution = {
   id: string;
   workflowId: string;
-  status:
-    | "pending"
-    | "running"
-    | "success"
-    | "error"
-    | "skipped"
-    | "cancelled"
-    | "phantom";
+  status: WorkflowExecutionStatus;
   startedAt: Date;
   completedAt: Date | null;
   duration: string | null;
@@ -153,7 +150,7 @@ function createExecutionLogsMap(logs: ExecutionLog[]): Record<
     nodeId: string;
     nodeName: string;
     nodeType: string;
-    status: "pending" | "running" | "success" | "error" | "cancelled";
+    status: NodeExecutionStatus;
     output?: unknown;
   }
 > {
@@ -163,7 +160,7 @@ function createExecutionLogsMap(logs: ExecutionLog[]): Record<
       nodeId: string;
       nodeName: string;
       nodeType: string;
-      status: "pending" | "running" | "success" | "error" | "cancelled";
+      status: NodeExecutionStatus;
       output?: unknown;
     }
   > = {};
@@ -1027,7 +1024,7 @@ export function WorkflowRuns({
         nodeId: string;
         nodeName: string;
         nodeType: string;
-        status: "pending" | "running" | "success" | "error" | "cancelled";
+        status: NodeExecutionStatus;
         input: unknown;
         output: unknown;
         error: string | null;
@@ -1159,6 +1156,7 @@ export function WorkflowRuns({
           "success",
           "error",
           "system_error",
+          "skipped",
         ]);
         const executionMap = new Map(data.map((e) => [e.id, e]));
         for (const executionId of expandedRuns) {

--- a/keeperhub-events/event-tracker/lib/phantom.ts
+++ b/keeperhub-events/event-tracker/lib/phantom.ts
@@ -22,19 +22,36 @@ import { logger } from "./utils/logger";
 /** Failure codes the event tracker assigns when an enqueue fails. */
 export type EventErrorCode = "ES-0001" | "N-0002";
 
+/** Why the platform refused to create the phantom. */
+export type PhantomRefusalReason = "plan_feature" | "execution_limit";
+
+/** Result of a phantom pre-create attempt. */
+export type PhantomCreateResult = {
+  /** Id of the phantom row, or undefined when the call failed. */
+  executionId?: string;
+  /**
+   * Set when the platform refused this dispatch on plan grounds. The caller
+   * must skip its enqueue: the executor would refuse the same run. Distinct
+   * from an undefined `executionId` with no refusal, which is a transport
+   * failure and still falls back to the id-less enqueue.
+   */
+  refused?: PhantomRefusalReason;
+};
+
 function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
 /**
- * Pre-create a phantom execution row. Returns its id, or undefined when the
- * call fails (the caller then enqueues without an id and the executor inserts
- * its own row).
+ * Pre-create a phantom execution row. Returns its id, a refusal when the
+ * platform declined the dispatch on plan grounds, or neither when the call
+ * fails (the caller then enqueues without an id and the executor inserts its
+ * own row).
  */
 export async function createPhantomExecution(
   workflowId: string,
   userId: string,
-): Promise<string | undefined> {
+): Promise<PhantomCreateResult> {
   const url = `${KEEPERHUB_API_URL}/api/internal/executions`;
   const body = JSON.stringify({
     workflowId,
@@ -54,13 +71,25 @@ export async function createPhantomExecution(
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`);
     }
-    const data = (await response.json()) as { executionId: string };
-    return data.executionId;
+    const data = (await response.json()) as {
+      executionId?: string;
+      refused?: boolean;
+      reason?: PhantomRefusalReason;
+      error?: string;
+    };
+    if (data.refused) {
+      const reason: PhantomRefusalReason = data.reason ?? "execution_limit";
+      logger.log(
+        `[Phantom] Dispatch refused for ${workflowId} (${reason}): ${data.error ?? ""}`,
+      );
+      return { refused: reason };
+    }
+    return { executionId: data.executionId };
   } catch (error) {
     logger.warn(
       `[Phantom] Failed to pre-create execution for ${workflowId}: ${formatError(error)}`,
     );
-    return undefined;
+    return {};
   }
 }
 

--- a/keeperhub-events/event-tracker/src/listener/event-listener.ts
+++ b/keeperhub-events/event-tracker/src/listener/event-listener.ts
@@ -226,17 +226,14 @@ export class EventListener {
 
       const args = extractEventArgs(parsed, this.opts.rawEventsAbi);
       const payload = buildEventPayload(log, parsed, args);
-      const sent = await this.sendToSqs(payload);
+      await this.sendToSqs(payload);
 
-      // Nothing was sent because the dispatch was refused: leave the event
-      // unmarked rather than spending a dedup write on it.
-      if (!sent) {
-        return;
-      }
-
-      // Mark after the send. A crash between send and mark would re-fire
-      // the event on the next reconnect (documented best-effort trade).
-      // A mark failure here does not un-send SQS - fine, dedup is best-effort.
+      // Mark after the send, and after a refusal too: a refused event is
+      // settled, and leaving it unmarked only buys another admission
+      // round-trip the next time a reconnect replays the log.
+      // A crash between send and mark would re-fire the event on the next
+      // reconnect (documented best-effort trade). A mark failure here does not
+      // un-send SQS - fine, dedup is best-effort.
       try {
         await this.opts.dedup.markProcessed(this.opts.workflowId, txHash);
       } catch (err) {
@@ -251,8 +248,7 @@ export class EventListener {
     }
   }
 
-  /** Returns false when the dispatch was refused and nothing was enqueued. */
-  private async sendToSqs(payload: unknown): Promise<boolean> {
+  private async sendToSqs(payload: unknown): Promise<void> {
     // KEEP-693: pre-create a phantom row (best-effort) so the run is visible
     // even if it never reaches the executor, and carry its id so the executor
     // upgrades that row instead of inserting.
@@ -267,7 +263,7 @@ export class EventListener {
       logger.log(
         `[EventListener:${this.opts.workflowId}] skipping refused dispatch (${refused})`,
       );
-      return false;
+      return;
     }
 
     try {
@@ -289,6 +285,5 @@ export class EventListener {
     }
 
     logger.log(`[EventListener:${this.opts.workflowId}] enqueued to SQS`);
-    return true;
   }
 }

--- a/keeperhub-events/event-tracker/src/listener/event-listener.ts
+++ b/keeperhub-events/event-tracker/src/listener/event-listener.ts
@@ -226,7 +226,13 @@ export class EventListener {
 
       const args = extractEventArgs(parsed, this.opts.rawEventsAbi);
       const payload = buildEventPayload(log, parsed, args);
-      await this.sendToSqs(payload);
+      const sent = await this.sendToSqs(payload);
+
+      // Nothing was sent because the dispatch was refused: leave the event
+      // unmarked rather than spending a dedup write on it.
+      if (!sent) {
+        return;
+      }
 
       // Mark after the send. A crash between send and mark would re-fire
       // the event on the next reconnect (documented best-effort trade).
@@ -245,14 +251,24 @@ export class EventListener {
     }
   }
 
-  private async sendToSqs(payload: unknown): Promise<void> {
+  /** Returns false when the dispatch was refused and nothing was enqueued. */
+  private async sendToSqs(payload: unknown): Promise<boolean> {
     // KEEP-693: pre-create a phantom row (best-effort) so the run is visible
     // even if it never reaches the executor, and carry its id so the executor
     // upgrades that row instead of inserting.
-    const executionId = await createPhantomExecution(
+    const { executionId, refused } = await createPhantomExecution(
       this.opts.workflowId,
       this.opts.userId,
     );
+
+    // Refused on plan grounds: the executor would refuse the same run, and a
+    // busy contract would otherwise pay for that round-trip on every match.
+    if (refused) {
+      logger.log(
+        `[EventListener:${this.opts.workflowId}] skipping refused dispatch (${refused})`,
+      );
+      return false;
+    }
 
     try {
       await enqueueWorkflowEventTrigger(this.opts.sqs, this.opts.sqsQueueUrl, {
@@ -273,5 +289,6 @@ export class EventListener {
     }
 
     logger.log(`[EventListener:${this.opts.workflowId}] enqueued to SQS`);
+    return true;
   }
 }

--- a/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
@@ -156,6 +156,7 @@ describe("EventListener", () => {
   beforeEach(() => {
     clearInterfaceCache();
     createPhantomExecution.mockReset();
+    createPhantomExecution.mockResolvedValue({});
     failPhantomExecution.mockReset();
   });
 
@@ -252,7 +253,7 @@ describe("EventListener", () => {
 
     // KEEP-693: phantom pre-creation wiring.
     it("pre-creates a phantom and carries its id on the event message", async () => {
-      createPhantomExecution.mockResolvedValue("exec_ph");
+      createPhantomExecution.mockResolvedValue({ executionId: "exec_ph" });
       const providerMock = makeProviderManagerMock();
       const sqs = makeSqsMock();
       const listener = new EventListener(
@@ -279,8 +280,33 @@ describe("EventListener", () => {
       expect(JSON.parse(command.input.MessageBody).executionId).toBe("exec_ph");
     });
 
+    it("skips the enqueue entirely when the dispatch is refused", async () => {
+      createPhantomExecution.mockResolvedValue({ refused: "execution_limit" });
+      const providerMock = makeProviderManagerMock();
+      const sqs = makeSqsMock();
+      const listener = new EventListener(
+        buildOptions({
+          providerManager: providerMock.manager,
+          dedup: makeDedupMock(),
+          sqs,
+        }),
+      );
+      await listener.start();
+
+      await providerMock.capturedHandler!(
+        makeLog({
+          txHash: `0x${"c".repeat(64)}`,
+          sender: SENDER,
+          value: 7n,
+        }),
+      );
+
+      expect(sqs.send).not.toHaveBeenCalled();
+      expect(failPhantomExecution).not.toHaveBeenCalled();
+    });
+
     it("marks the phantom failed with ES-0001 when the enqueue fails", async () => {
-      createPhantomExecution.mockResolvedValue("exec_ph");
+      createPhantomExecution.mockResolvedValue({ executionId: "exec_ph" });
       const providerMock = makeProviderManagerMock();
       const sqs = makeSqsMock();
       sqs.send.mockRejectedValueOnce(new Error("SQS down"));

--- a/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
@@ -284,10 +284,11 @@ describe("EventListener", () => {
       createPhantomExecution.mockResolvedValue({ refused: "execution_limit" });
       const providerMock = makeProviderManagerMock();
       const sqs = makeSqsMock();
+      const dedup = makeDedupMock();
       const listener = new EventListener(
         buildOptions({
           providerManager: providerMock.manager,
-          dedup: makeDedupMock(),
+          dedup,
           sqs,
         }),
       );
@@ -303,6 +304,9 @@ describe("EventListener", () => {
 
       expect(sqs.send).not.toHaveBeenCalled();
       expect(failPhantomExecution).not.toHaveBeenCalled();
+      // A refusal is settled, so the event is marked: leaving it unmarked
+      // only buys another admission round-trip on the next reconnect.
+      expect(dedup.markProcessed).toHaveBeenCalledTimes(1);
     });
 
     it("marks the phantom failed with ES-0001 when the enqueue fails", async () => {

--- a/keeperhub-events/event-tracker/tests/unit/phantom.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/phantom.test.ts
@@ -36,9 +36,9 @@ describe("createPhantomExecution (event-tracker)", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const id = await createPhantomExecution("wf_1", "owner_1");
+    const result = await createPhantomExecution("wf_1", "owner_1");
 
-    expect(id).toBe("exec_evt");
+    expect(result).toEqual({ executionId: "exec_evt" });
     const [url, init] = fetchMock.mock.calls[0];
     expect(String(url)).toMatch(/\/api\/internal\/executions$/);
     expect(init.method).toBe("POST");
@@ -51,23 +51,43 @@ describe("createPhantomExecution (event-tracker)", () => {
     });
   });
 
-  it("returns undefined on a non-2xx response (best-effort)", async () => {
+  it("returns no id and no refusal on a non-2xx response (best-effort)", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({ ok: false, status: 500 }),
     );
 
-    await expect(
-      createPhantomExecution("wf_1", "owner_1"),
-    ).resolves.toBeUndefined();
+    await expect(createPhantomExecution("wf_1", "owner_1")).resolves.toEqual(
+      {},
+    );
   });
 
-  it("returns undefined when fetch rejects", async () => {
+  it("returns no id and no refusal when fetch rejects", async () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network")));
 
-    await expect(
-      createPhantomExecution("wf_1", "owner_1"),
-    ).resolves.toBeUndefined();
+    await expect(createPhantomExecution("wf_1", "owner_1")).resolves.toEqual(
+      {},
+    );
+  });
+
+  // A transport failure and a refusal must stay distinguishable: the first
+  // still falls back to the id-less enqueue, the second must not enqueue.
+  it("reports a refusal instead of an id when the platform declines", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          refused: true,
+          reason: "execution_limit",
+          error: "limit reached",
+        }),
+      }),
+    );
+
+    await expect(createPhantomExecution("wf_1", "owner_1")).resolves.toEqual({
+      refused: "execution_limit",
+    });
   });
 });
 

--- a/keeperhub-events/solana-tracker/lib/phantom.ts
+++ b/keeperhub-events/solana-tracker/lib/phantom.ts
@@ -17,6 +17,22 @@ export type PhantomTriggerSource = "event" | "block";
 /** ES-* = event enqueue failure, BS-* = block enqueue failure, N-* = generic. */
 export type PhantomErrorCode = "ES-0001" | "BS-0001" | "N-0002";
 
+/** Why the platform refused to create the phantom. */
+export type PhantomRefusalReason = "plan_feature" | "execution_limit";
+
+/** Result of a phantom pre-create attempt. */
+export type PhantomCreateResult = {
+  /** Id of the phantom row, or undefined when the call failed. */
+  executionId?: string;
+  /**
+   * Set when the platform refused this dispatch on plan grounds. The caller
+   * must skip its enqueue: the executor would refuse the same run. Distinct
+   * from an undefined `executionId` with no refusal, which is a transport
+   * failure and still falls back to the id-less enqueue.
+   */
+  refused?: PhantomRefusalReason;
+};
+
 function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -26,7 +42,7 @@ export async function createPhantomExecution(
   userId: string,
   source: PhantomTriggerSource,
   caller: HmacCaller,
-): Promise<string | undefined> {
+): Promise<PhantomCreateResult> {
   const url = `${KEEPERHUB_API_URL}/api/internal/executions`;
   const body = JSON.stringify({
     workflowId,
@@ -46,13 +62,25 @@ export async function createPhantomExecution(
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`);
     }
-    const data = (await response.json()) as { executionId: string };
-    return data.executionId;
+    const data = (await response.json()) as {
+      executionId?: string;
+      refused?: boolean;
+      reason?: PhantomRefusalReason;
+      error?: string;
+    };
+    if (data.refused) {
+      const reason: PhantomRefusalReason = data.reason ?? "execution_limit";
+      logger.log(
+        `[Phantom] Dispatch refused for ${workflowId} (${reason}): ${data.error ?? ""}`,
+      );
+      return { refused: reason };
+    }
+    return { executionId: data.executionId };
   } catch (error) {
     logger.warn(
       `[Phantom] Failed to pre-create execution for ${workflowId}: ${formatError(error)}`,
     );
-    return undefined;
+    return {};
   }
 }
 

--- a/keeperhub-events/solana-tracker/src/ingest/block-ingestor.ts
+++ b/keeperhub-events/solana-tracker/src/ingest/block-ingestor.ts
@@ -210,12 +210,20 @@ export class BlockIngestor {
     if (alreadyProcessed) {
       return;
     }
-    const executionId = await createPhantomExecution(
+    const { executionId, refused } = await createPhantomExecution(
       fire.workflowId,
       fire.userId,
       "event",
       "events",
     );
+    // Refused on plan grounds: the executor would refuse the same run, so skip
+    // the enqueue instead of paying for the round-trip on every match.
+    if (refused) {
+      logger.log(
+        `[ingestor] skipping refused event dispatch for ${fire.workflowId} (${refused})`,
+      );
+      return;
+    }
     try {
       await enqueueWorkflowEventTrigger(this.deps.sqs, this.deps.sqsQueueUrl, {
         executionId,
@@ -266,12 +274,18 @@ export class BlockIngestor {
     if (alreadyProcessed) {
       return;
     }
-    const executionId = await createPhantomExecution(
+    const { executionId, refused } = await createPhantomExecution(
       fire.workflowId,
       fire.userId,
       "block",
       "scheduler",
     );
+    if (refused) {
+      logger.log(
+        `[ingestor] skipping refused block dispatch for ${fire.workflowId} (${refused})`,
+      );
+      return;
+    }
     try {
       await enqueueWorkflowBlockTrigger(this.deps.sqs, this.deps.sqsQueueUrl, {
         executionId,

--- a/keeperhub-events/solana-tracker/src/ingest/block-ingestor.ts
+++ b/keeperhub-events/solana-tracker/src/ingest/block-ingestor.ts
@@ -217,11 +217,14 @@ export class BlockIngestor {
       "events",
     );
     // Refused on plan grounds: the executor would refuse the same run, so skip
-    // the enqueue instead of paying for the round-trip on every match.
+    // the enqueue instead of paying for the round-trip on every match. The
+    // event is still marked: it is settled, and leaving it unmarked only buys
+    // another admission round-trip when the block is re-processed.
     if (refused) {
       logger.log(
         `[ingestor] skipping refused event dispatch for ${fire.workflowId} (${refused})`,
       );
+      await this.markProcessed(fire.workflowId, fire.signature);
       return;
     }
     try {
@@ -245,13 +248,7 @@ export class BlockIngestor {
     logger.log(
       `[ingestor] chain ${this.registration.chainId} enqueued event ${fire.workflowId}/${fire.signature.slice(0, 12)} (slot ${fire.payload.slot})`,
     );
-    try {
-      await this.deps.dedup.markProcessed(fire.workflowId, fire.signature);
-    } catch (err) {
-      logger.warn(
-        `[ingestor] dedup mark failed for ${fire.workflowId}/${fire.signature}: ${formatError(err)}`,
-      );
-    }
+    await this.markProcessed(fire.workflowId, fire.signature);
   }
 
   private async enqueueBlock(fire: BlockFire): Promise<void> {
@@ -284,6 +281,7 @@ export class BlockIngestor {
       logger.log(
         `[ingestor] skipping refused block dispatch for ${fire.workflowId} (${refused})`,
       );
+      await this.markProcessed(fire.workflowId, dedupKey);
       return;
     }
     try {
@@ -307,11 +305,16 @@ export class BlockIngestor {
     logger.log(
       `[ingestor] chain ${this.registration.chainId} enqueued block ${fire.workflowId} (height ${fire.payload.blockHeight})`,
     );
+    await this.markProcessed(fire.workflowId, dedupKey);
+  }
+
+  /** Best-effort dedup mark: a failure is logged and never blocks the caller. */
+  private async markProcessed(workflowId: string, key: string): Promise<void> {
     try {
-      await this.deps.dedup.markProcessed(fire.workflowId, dedupKey);
+      await this.deps.dedup.markProcessed(workflowId, key);
     } catch (err) {
       logger.warn(
-        `[ingestor] dedup mark failed for ${fire.workflowId}/${dedupKey}: ${formatError(err)}`,
+        `[ingestor] dedup mark failed for ${workflowId}/${key}: ${formatError(err)}`,
       );
     }
   }

--- a/keeperhub-events/solana-tracker/tests/e2e/injected-block.ts
+++ b/keeperhub-events/solana-tracker/tests/e2e/injected-block.ts
@@ -56,7 +56,7 @@ async function main(): Promise<void> {
     throw new Error("matcher produced no fire for the injected block");
   }
 
-  const executionId = await createPhantomExecution(
+  const { executionId } = await createPhantomExecution(
     fire.workflowId,
     fire.userId,
     "block",

--- a/keeperhub-events/solana-tracker/tests/e2e/injected.ts
+++ b/keeperhub-events/solana-tracker/tests/e2e/injected.ts
@@ -65,7 +65,7 @@ async function main(): Promise<void> {
   }
 
   const fire = fires[0];
-  const executionId = await createPhantomExecution(
+  const { executionId } = await createPhantomExecution(
     fire.workflowId,
     fire.userId,
     "event",

--- a/keeperhub-events/solana-tracker/tests/integration/block-ingestor.test.ts
+++ b/keeperhub-events/solana-tracker/tests/integration/block-ingestor.test.ts
@@ -13,7 +13,7 @@ const mocks = vi.hoisted(() => ({
   onBlock: null as ((block: unknown) => Promise<void>) | null,
   enqueueEvent: vi.fn(() => Promise.resolve()),
   enqueueBlock: vi.fn(() => Promise.resolve()),
-  createPhantom: vi.fn(() => Promise.resolve("exec-1")),
+  createPhantom: vi.fn(() => Promise.resolve({ executionId: "exec-1" })),
   failPhantom: vi.fn(() => Promise.resolve()),
 }));
 
@@ -125,6 +125,9 @@ async function startIngestor(dedup: DedupStore): Promise<void> {
 beforeEach(() => {
   mocks.onBlock = null;
   vi.clearAllMocks();
+  // clearAllMocks keeps implementations, so restore the admitted default for
+  // every test that does not override it.
+  mocks.createPhantom.mockResolvedValue({ executionId: "exec-1" });
 });
 
 describe("BlockIngestor end-to-end fan-out", () => {
@@ -146,6 +149,17 @@ describe("BlockIngestor end-to-end fan-out", () => {
     expect(eventArg.workflowId).toBe("wf-event");
     expect(eventArg.triggerData.chainType).toBe("solana");
     expect(eventArg.triggerData.programId).toBe(PROGRAM);
+  });
+
+  it("skips both enqueues when the dispatch is refused on plan grounds", async () => {
+    mocks.createPhantom.mockResolvedValue({ refused: "execution_limit" });
+    const dedup = fakeDedup(false);
+    await startIngestor(dedup);
+
+    await mocks.onBlock?.(block());
+
+    expect(mocks.enqueueEvent).not.toHaveBeenCalled();
+    expect(mocks.enqueueBlock).not.toHaveBeenCalled();
   });
 
   it("skips the event enqueue when its signature is already processed", async () => {

--- a/keeperhub-events/solana-tracker/tests/integration/block-ingestor.test.ts
+++ b/keeperhub-events/solana-tracker/tests/integration/block-ingestor.test.ts
@@ -160,6 +160,11 @@ describe("BlockIngestor end-to-end fan-out", () => {
 
     expect(mocks.enqueueEvent).not.toHaveBeenCalled();
     expect(mocks.enqueueBlock).not.toHaveBeenCalled();
+    // A refusal is settled, so it is marked: re-processing the block would
+    // otherwise pay for the admission round-trip again and reach the same
+    // answer.
+    expect(dedup.markProcessed).toHaveBeenCalledWith("wf-event", "sig-1");
+    expect(dedup.markProcessed).toHaveBeenCalledWith("wf-block", "block:10");
   });
 
   it("skips the event enqueue when its signature is already processed", async () => {

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -68,6 +68,7 @@ import {
   resolveToSkipped,
 } from "./lib/db-helpers";
 import { applyCounterDeltas, isIngestPayload } from "./lib/metrics-shipping";
+import { recordSkippedSample } from "./lib/terminal-counters";
 import { toJsonSafe } from "./lib/serialize";
 import { executorMessageSchema } from "./message-schema";
 import {
@@ -140,7 +141,7 @@ async function settlePaygOverflow(params: {
     `[Executor] PAYG charge blocked ${params.triggerType} trigger for workflow ${params.workflowId}: org=${params.organizationId} reason=${charge.reason}`
   );
   if (params.claimedStatus === "running") {
-    await db
+    const resolved = await db
       .update(workflowExecutions)
       .set({
         // Refused before it started: 'skipped', not 'error'. Same reasoning as
@@ -158,7 +159,17 @@ async function settlePaygOverflow(params: {
           eq(workflowExecutions.id, params.executionId),
           eq(workflowExecutions.status, "running")
         )
-      );
+      )
+      .returning({ id: workflowExecutions.id });
+
+    // The row no longer carries an error status, so nothing else counts it.
+    // Gated on the CAS matching so a re-delivery cannot double-count.
+    if (resolved.length > 0) {
+      await recordSkippedSample(db, {
+        workflowId: params.workflowId,
+        reason: "payg_unpaid",
+      });
+    }
   } else {
     await resolveToSkipped(db, params.executionId, {
       error: charge.message,
@@ -483,6 +494,10 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
           })
       );
     }
+
+    // Exactly one row was written above, by whichever branch ran, and it is no
+    // longer an error row, so this is the only thing that counts the refusal.
+    await recordSkippedSample(db, { workflowId, reason: "plan_feature" });
     return;
   }
 

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -65,7 +65,7 @@ import {
   claimPhantomForExecution,
   discardPhantomRow,
   failExecutionAsSystemError,
-  resolvePhantomToError,
+  resolveToSkipped,
 } from "./lib/db-helpers";
 import { applyCounterDeltas, isIngestPayload } from "./lib/metrics-shipping";
 import { toJsonSafe } from "./lib/serialize";
@@ -143,7 +143,9 @@ async function settlePaygOverflow(params: {
     await db
       .update(workflowExecutions)
       .set({
-        status: "error",
+        // Refused before it started: 'skipped', not 'error'. Same reasoning as
+        // resolveToSkipped - an unpaid charge is not a failed run.
+        status: "skipped",
         error: charge.message,
         errorCategory: "billing",
         errorType: "user",
@@ -158,10 +160,11 @@ async function settlePaygOverflow(params: {
         )
       );
   } else {
-    await resolvePhantomToError(db, params.executionId, {
+    await resolveToSkipped(db, params.executionId, {
       error: charge.message,
       errorCategory: "billing",
       errorType: "user",
+      reason: "payg_unpaid",
     });
   }
   return false;
@@ -389,14 +392,15 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
     console.warn(
       `[Executor] Billing guard blocked ${triggerType} trigger for workflow ${workflowId}: org=${workflow.organizationId} plan=${billingResult.plan} used=${billingResult.used} limit=${billingResult.limit} effectiveLimit=${billingResult.effectiveLimit} debt=${billingResult.debtExecutions} reason=${billingResult.reason}`
     );
-    // KEEP-693: resolve a pre-created phantom to a user-actionable billing
-    // error so it surfaces correctly instead of being aged to a system P-code.
+    // KEEP-693: resolve a pre-created phantom to a user-actionable refusal so
+    // it surfaces correctly instead of being aged to a system P-code.
     // No phantom -> keep the prior silent-skip behaviour.
-    await resolvePhantomToError(db, message.executionId, {
+    await resolveToSkipped(db, message.executionId, {
       error:
         "Execution skipped: your plan's monthly execution limit has been reached.",
       errorCategory: "billing",
       errorType: "user",
+      reason: "execution_limit",
     });
     return;
   }
@@ -425,7 +429,7 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
       "userId" in message ? message.userId : workflow.userId;
 
     // KEEP-693: if a pre-created row exists for this trigger, resolve it in
-    // place to the blocked (billing/user) state rather than inserting a second
+    // place to the refused (billing/user) state rather than inserting a second
     // row -- and so the reaper does not later age the orphan to a system P-code.
     // Matches both 'phantom' (scheduler/event-tracker pre-created) and 'pending'
     // (API pre-created for manual triggers). Falls through to an insert when
@@ -435,10 +439,12 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
       const resolved = await db
         .update(workflowExecutions)
         .set({
-          status: "error",
+          // A gated action means the run was refused, not that it failed.
+          status: "skipped",
           error: errorMessage,
           errorCategory: "billing",
           errorType: "user",
+          billable: false,
           input: toJsonSafe(blockedInput) as Record<string, unknown>,
           completedAt: new Date(),
         })
@@ -465,7 +471,8 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
             id: blockedExecutionId,
             workflowId,
             userId: blockedUserId,
-            status: "error",
+            status: "skipped",
+            billable: false,
             input: toJsonSafe(blockedInput) as Record<string, unknown>,
             error: errorMessage,
             errorCategory: "billing",

--- a/keeperhub-executor/lib/db-helpers.ts
+++ b/keeperhub-executor/lib/db-helpers.ts
@@ -19,7 +19,10 @@ import { calculateTotalSteps } from "../../lib/workflow/executor/progress";
 import type { WorkflowEdge, WorkflowNode } from "../../lib/workflow/store";
 import type { executeWorkflow } from "../../lib/workflow/executor/executor.workflow";
 import { toJsonSafe } from "./serialize";
-import { recordTerminalSample } from "./terminal-counters";
+import {
+  recordSkippedSample,
+  recordTerminalSample,
+} from "./terminal-counters";
 
 export type DbSchema = {
   workflows: typeof workflows;
@@ -461,18 +464,29 @@ export async function discardPhantomRow(
 }
 
 /**
- * KEEP-693: resolve a pre-created phantom or pending row to a user-actionable
- * error (e.g. a billing block) rather than leaving it for the reaper to
- * mis-code as a system failure. Compare-and-set on status IN ('phantom',
- * 'pending') so a row that already advanced is left untouched.
+ * KEEP-693: resolve a pre-created phantom or pending row to its terminal state
+ * rather than leaving it for the reaper to mis-code as a system failure.
+ * Compare-and-set on status IN ('phantom', 'pending') so a row that already
+ * advanced is left untouched.
+ *
+ * The run was refused before it started, so it lands on 'skipped', not 'error':
+ * it never executed, and counting it as a failure skews the success-rate SLI
+ * (in a sampled window, refusals read as a 21% error rate against a real 3%).
+ * The reason is still recorded on the row so its author sees why it did not
+ * fire.
  *
  * Matches 'pending' in addition to 'phantom' because manual-trigger executions
  * are pre-created by the API as 'pending' (not 'phantom') before being enqueued.
  */
-export async function resolvePhantomToError(
+export async function resolveToSkipped(
   db: PostgresJsDatabase<DbSchema>,
   executionId: string | undefined,
-  fields: { error: string; errorCategory: "billing"; errorType: "user" }
+  fields: {
+    error: string;
+    errorCategory: "billing";
+    errorType: "user";
+    reason: string;
+  }
 ): Promise<void> {
   if (!executionId) {
     return;
@@ -480,7 +494,7 @@ export async function resolvePhantomToError(
   const resolved = await db
     .update(workflowExecutions)
     .set({
-      status: "error",
+      status: "skipped",
       error: fields.error,
       errorCategory: fields.errorCategory,
       errorType: fields.errorType,
@@ -498,16 +512,13 @@ export async function resolvePhantomToError(
     )
     .returning({ workflowId: workflowExecutions.workflowId });
 
-  // Same reasoning as failExecutionAsSystemError: the phantom/pending CAS
-  // makes a match the first terminal transition, and billing-blocked rows
-  // never reach any other counted finalize path.
+  // Same reasoning as failExecutionAsSystemError: the phantom/pending CAS makes
+  // a match the first terminal transition, and refused rows never reach any
+  // other counted finalize path.
   if (resolved.length > 0) {
-    await recordTerminalSample(db, {
+    await recordSkippedSample(db, {
       workflowId: resolved[0].workflowId,
-      status: "error",
-      errorMessage: fields.error,
-      errorType: fields.errorType,
-      errorCategory: fields.errorCategory,
+      reason: fields.reason,
     });
   }
 }

--- a/keeperhub-executor/lib/db-helpers.ts
+++ b/keeperhub-executor/lib/db-helpers.ts
@@ -1,5 +1,5 @@
 import { CronExpressionParser } from "cron-parser";
-import { and, eq, inArray, ne, or } from "drizzle-orm";
+import { and, eq, inArray, notInArray, or } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import {
   workflowExecutions,
@@ -225,18 +225,23 @@ export async function updateExecutionStatus(
   // backstop: if the engine's own write landed, the row is already
   // success/error/cancelled and this update is a no-op; if that write was lost
   // (it can throw and only be logged), this closes the row instead of leaving
-  // it stuck "running". Excluding all three terminal states keeps the backstop
-  // from clobbering the engine's richer fields (KEEP-431).
+  // it stuck "running". Excluding every terminal state keeps the backstop from
+  // clobbering the engine's richer fields (KEEP-431). 'skipped' is in the list
+  // for the same reason: a run the platform refused must not be reopened as a
+  // failure by a late backstop write.
   const updated = await db
     .update(workflowExecutions)
     .set(updateData)
     .where(
       and(
         eq(workflowExecutions.id, executionId),
-        ne(workflowExecutions.status, "success"),
-        ne(workflowExecutions.status, "error"),
-        ne(workflowExecutions.status, "system_error"),
-        ne(workflowExecutions.status, "cancelled")
+        notInArray(workflowExecutions.status, [
+          "success",
+          "error",
+          "system_error",
+          "skipped",
+          "cancelled",
+        ])
       )
     )
     .returning({ workflowId: workflowExecutions.workflowId });

--- a/keeperhub-executor/lib/terminal-counters.ts
+++ b/keeperhub-executor/lib/terminal-counters.ts
@@ -17,6 +17,34 @@ import type { DbSchema } from "./db-helpers";
  * actually flipped a non-terminal row, which preserves the emit-once
  * contract. Never throws: metric emission must not break executor DB writes.
  */
+/**
+ * Emit the refusal counter for a run the platform declined before it started.
+ * Deliberately not recordTerminalSample: a refused run is not a failure, so it
+ * must stay out of the error series and the success-rate SLI, while still being
+ * visible in Prometheus. Never throws, same contract as recordTerminalSample.
+ */
+export async function recordSkippedSample(
+  db: PostgresJsDatabase<DbSchema>,
+  args: { workflowId: string; reason: string }
+): Promise<void> {
+  try {
+    const { recordWorkflowExecutionSkipped } = await import(
+      "../../lib/metrics/collectors/prometheus"
+    );
+    const orgSlug = await resolveOrgSlugCached(args.workflowId, (id) =>
+      db
+        .select({ slug: organization.slug })
+        .from(workflows)
+        .leftJoin(organization, eq(workflows.organizationId, organization.id))
+        .where(eq(workflows.id, id))
+        .limit(1)
+    );
+    recordWorkflowExecutionSkipped({ orgSlug, reason: args.reason });
+  } catch {
+    // Metric emission must never break the executor's DB writes.
+  }
+}
+
 export async function recordTerminalSample(
   db: PostgresJsDatabase<DbSchema>,
   args: {

--- a/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
+++ b/keeperhub-scheduler/block-dispatcher/chain-monitor.ts
@@ -797,12 +797,19 @@ export class ChainMonitor {
     // unique index so only one enqueue lands. The in-memory lastProcessedBlock
     // dedup only guards a single instance, so this is what covers 2 replicas.
     const dispatchKey = `block:${wf.id}:${this.chainId}:${blockNumber}`;
-    const { executionId, alreadyExisted } = await createPhantomExecution(
-      wf.id,
-      "block",
-      wf.userId,
-      dispatchKey,
-    );
+    const { executionId, alreadyExisted, refused } =
+      await createPhantomExecution(wf.id, "block", wf.userId, dispatchKey);
+
+    // Refused on plan grounds: the executor would refuse the same run. Skipping
+    // here matters most on a fast chain, where enqueueing would otherwise cost
+    // a message and an executor round-trip on every block, indefinitely.
+    if (refused) {
+      console.log(
+        `[BlockMonitor:${this.chainName}] Skipping refused dispatch for ${dispatchKey} (${refused})`,
+      );
+      metrics.recordDispatchRefused(this.chainName, refused);
+      return;
+    }
 
     if (alreadyExisted) {
       console.log(

--- a/keeperhub-scheduler/lib/metrics.ts
+++ b/keeperhub-scheduler/lib/metrics.ts
@@ -182,6 +182,13 @@ export const sqsEnqueueTotal = new Counter({
   registers: [registry],
 });
 
+export const dispatchRefusedTotal = new Counter({
+  name: `${PREFIX}_dispatch_refused_total`,
+  help: "Block triggers refused at admission (over plan limit or gated action) and skipped without enqueueing, per chain. Not an error: the block matched, the org may not run it.",
+  labelNames: ["chain", "reason"] as const,
+  registers: [registry],
+});
+
 export const unhandledRejectionsTotal = new Counter({
   name: `${PREFIX}_unhandled_rejections_total`,
   help: "Process-level unhandled promise rejections absorbed by the dispatcher's safety-net handler. The most common source is ethers v6 destroyProvider eth_unsubscribe cancellation during reconnect. A sustained increase is fine for those; anything else warrants log investigation.",
@@ -288,6 +295,9 @@ export const metrics = {
   },
   recordSqsEnqueue(chain: string, outcome: "success" | "error"): void {
     sqsEnqueueTotal.inc({ chain, outcome });
+  },
+  recordDispatchRefused(chain: string, reason: string): void {
+    dispatchRefusedTotal.inc({ chain, reason });
   },
   recordUnhandledRejection(): void {
     unhandledRejectionsTotal.inc();

--- a/keeperhub-scheduler/lib/phantom.ts
+++ b/keeperhub-scheduler/lib/phantom.ts
@@ -22,6 +22,9 @@ export type PhantomTriggerSource = "schedule" | "block";
 /** Failure codes the scheduler assigns when an enqueue fails. */
 export type SchedulerErrorCode = "CS-0001" | "BS-0001" | "N-0002";
 
+/** Why the platform refused to create the phantom. */
+export type PhantomRefusalReason = "plan_feature" | "execution_limit";
+
 /** Result of a phantom pre-create attempt. */
 export interface PhantomCreateResult {
   /** Id of the phantom row, or undefined when the call failed. */
@@ -33,6 +36,14 @@ export interface PhantomCreateResult {
    * then skip its own enqueue to avoid a duplicate SQS message.
    */
   alreadyExisted: boolean;
+  /**
+   * Set when the platform refused this dispatch on plan grounds (over the
+   * execution limit, or a gated action). The caller must skip its enqueue: the
+   * executor would refuse the same run, so the SQS message and the round-trip
+   * are pure waste. Distinct from an undefined `executionId` with no refusal,
+   * which is a transport failure and still falls back to the id-less enqueue.
+   */
+  refused?: PhantomRefusalReason;
 }
 
 /**
@@ -53,8 +64,11 @@ export async function createPhantomExecution(
 ): Promise<PhantomCreateResult> {
   try {
     const result = await apiRequest<{
-      executionId: string;
+      executionId?: string;
       alreadyExisted?: boolean;
+      refused?: boolean;
+      reason?: PhantomRefusalReason;
+      error?: string;
     }>("/api/internal/executions", {
       method: "POST",
       body: JSON.stringify({
@@ -65,6 +79,13 @@ export async function createPhantomExecution(
         dispatchKey,
       }),
     });
+    if (result.refused) {
+      const reason: PhantomRefusalReason = result.reason ?? "execution_limit";
+      console.log(
+        `[Phantom] Dispatch refused for workflow ${workflowId} (${reason}): ${result.error ?? ""}`,
+      );
+      return { alreadyExisted: false, refused: reason };
+    }
     return {
       executionId: result.executionId,
       alreadyExisted: result.alreadyExisted ?? false,

--- a/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/dispatch.ts
@@ -24,6 +24,7 @@ import { signSqsMessageAttributes } from "../lib/sqs-message-auth.js";
 import type { Schedule, ScheduleMessage } from "../lib/types.js";
 import {
   errorsTotal,
+  refusedTotal,
   runDurationSeconds,
   runsTotal,
   triggeredTotal,
@@ -325,12 +326,24 @@ export async function dispatch(
         // recomputes this occurrence collides on the unique index and we skip
         // the duplicate enqueue below.
         const dispatchKey = `schedule:${schedule.id}:${occurrence.toISOString()}`;
-        const { executionId, alreadyExisted } = await createPhantomExecution(
-          schedule.workflowId,
-          "schedule",
-          undefined,
-          dispatchKey,
-        );
+        const { executionId, alreadyExisted, refused } =
+          await createPhantomExecution(
+            schedule.workflowId,
+            "schedule",
+            undefined,
+            dispatchKey,
+          );
+
+        // Refused on plan grounds: the executor would refuse the same run, so
+        // enqueueing costs an SQS message and an executor round-trip to reach
+        // the same answer. The refusal is already recorded for the author.
+        if (refused) {
+          console.log(
+            `[${runId}] Skipping refused dispatch for ${dispatchKey} (${refused})`,
+          );
+          refusedTotal.inc({ reason: refused });
+          continue;
+        }
 
         if (alreadyExisted) {
           console.log(

--- a/keeperhub-scheduler/schedule-dispatcher/metrics.ts
+++ b/keeperhub-scheduler/schedule-dispatcher/metrics.ts
@@ -29,6 +29,16 @@ export const triggeredTotal = new Counter({
   registers: [registry],
 });
 
+// Occurrences the platform refused on plan grounds before anything was
+// enqueued. Not an error: the trigger fired, the org may not run it. Rising
+// here with triggered_total flat is an org sitting at its limit, not an outage.
+export const refusedTotal = new Counter({
+  name: `${PREFIX}_refused_total`,
+  help: "Total occurrences refused at admission (over plan limit or gated action), skipped without enqueueing.",
+  labelNames: ["reason"] as const,
+  registers: [registry],
+});
+
 // Per-schedule errors (SQS failure, bad cron caught late, etc.). Distinct from
 // fetch errors which abort the whole pass and are not counted here.
 export const errorsTotal = new Counter({

--- a/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
+++ b/keeperhub-scheduler/tests/unit/chain-monitor.test.ts
@@ -317,6 +317,31 @@ describe("ChainMonitor", () => {
       expect(enqueueBlockTrigger).not.toHaveBeenCalled();
     });
 
+    // A refusal is not a transport failure: it must not fall through to the
+    // id-less enqueue the way a failed create does.
+    it("skips the enqueue when the dispatch is refused on plan grounds", async () => {
+      createPhantomExecution.mockResolvedValueOnce({
+        alreadyExisted: false,
+        refused: "execution_limit",
+      });
+      const monitor = new ChainMonitor({
+        chain: makeChain(),
+        workflows: [makeWorkflow()],
+      });
+
+      await monitor.start();
+
+      const { enqueueBlockTrigger } = await import(
+        "../../block-dispatcher/sqs-enqueue.js"
+      );
+      vi.mocked(enqueueBlockTrigger).mockClear();
+      latestProvider().emitBlock(10);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(enqueueBlockTrigger).not.toHaveBeenCalled();
+      expect(failPhantomExecution).not.toHaveBeenCalled();
+    });
+
     it("marks the phantom failed with BS-0001 when the enqueue fails", async () => {
       createPhantomExecution.mockResolvedValueOnce({
         executionId: "exec_ph",

--- a/keeperhub-scheduler/tests/unit/phantom.test.ts
+++ b/keeperhub-scheduler/tests/unit/phantom.test.ts
@@ -68,6 +68,29 @@ describe("createPhantomExecution", () => {
 
     expect(result).toEqual({ alreadyExisted: false });
   });
+
+  // A transport failure and a refusal must stay distinguishable: the first
+  // still falls back to the id-less enqueue, the second must not enqueue.
+  it("reports a refusal when the platform declines the dispatch", async () => {
+    apiRequest.mockResolvedValue({
+      refused: true,
+      reason: "plan_feature",
+      error: "gated action",
+    });
+
+    const result = await createPhantomExecution("wf_1", "schedule");
+
+    expect(result).toEqual({ alreadyExisted: false, refused: "plan_feature" });
+    expect(result.executionId).toBeUndefined();
+  });
+
+  it("defaults an unlabelled refusal to execution_limit", async () => {
+    apiRequest.mockResolvedValue({ refused: true });
+
+    const result = await createPhantomExecution("wf_1", "schedule");
+
+    expect(result.refused).toBe("execution_limit");
+  });
 });
 
 describe("failPhantomExecution", () => {

--- a/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
+++ b/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
@@ -782,6 +782,30 @@ describe("dispatch", () => {
     expect(failPhantomExecution).not.toHaveBeenCalled();
   });
 
+  // A refusal is not a transport failure: it must not fall through to the
+  // id-less enqueue the way a failed create does.
+  it("skips the enqueue when the dispatch is refused on plan grounds", async () => {
+    createPhantomExecution.mockResolvedValue({
+      alreadyExisted: false,
+      refused: "execution_limit",
+    });
+    stubFetch([
+      {
+        id: "sched-1",
+        workflowId: "wf-1",
+        cronExpression: "0 9 * * *",
+        timezone: "UTC",
+      },
+    ]);
+    mockedSqsSend.mockResolvedValue(sqsOkResponse);
+
+    const result = await dispatch();
+
+    expect(result).toEqual({ evaluated: 1, triggered: 0, errors: 0 });
+    expect(mockedSqsSend).not.toHaveBeenCalled();
+    expect(failPhantomExecution).not.toHaveBeenCalled();
+  });
+
   it("marks the phantom failed with CS-0001 when the enqueue fails", async () => {
     createPhantomExecution.mockResolvedValue({
       executionId: "exec_ph",

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -50,7 +50,7 @@ import type {
 
 /**
  * Normalize workflow execution status to a unified status.
- * workflow_executions uses: pending | running | unconfirmed | success | error | cancelled
+ * workflow_executions uses: pending | running | unconfirmed | success | error | skipped | cancelled
  * direct_executions uses: pending | running | unconfirmed | completed | failed
  * We normalize to: pending | running | success | error
  */
@@ -69,6 +69,9 @@ export function normalizeStatus(
   }
   if (status === "cancelled") {
     return "cancelled";
+  }
+  if (status === "skipped") {
+    return "skipped";
   }
   // Both sources use "unconfirmed" for a broadcast the chain has not confirmed.
   // It is still in flight, not an outcome, so it reads as running in the UI.
@@ -151,6 +154,7 @@ function parseBucketRow(row: {
   success: string;
   error: string;
   cancelled: string;
+  skipped: string;
   pending: string;
   running: string;
 }): TimeSeriesBucket {
@@ -159,6 +163,7 @@ function parseBucketRow(row: {
     success: Number(row.success) || 0,
     error: Number(row.error) || 0,
     cancelled: Number(row.cancelled) || 0,
+    skipped: Number(row.skipped) || 0,
     pending: Number(row.pending) || 0,
     running: Number(row.running) || 0,
   };
@@ -176,6 +181,7 @@ function addBucketToMap(
     existing.success += bucket.success;
     existing.error += bucket.error;
     existing.cancelled += bucket.cancelled;
+    existing.skipped += bucket.skipped;
     existing.pending += bucket.pending;
     existing.running += bucket.running;
   } else {
@@ -279,6 +285,7 @@ async function computeAnalyticsSummary(
   const successCount = workflowStats.success + directStats.success;
   const errorCount = workflowStats.error + directStats.error;
   const cancelledCount = workflowStats.cancelled;
+  const skippedCount = workflowStats.skipped;
   const successRate = totalRuns > 0 ? successCount / totalRuns : 0;
 
   const avgDurationMs = computeAvgDuration(
@@ -293,6 +300,7 @@ async function computeAnalyticsSummary(
     successCount,
     errorCount,
     cancelledCount,
+    skippedCount,
     successRate,
     avgDurationMs,
     totalGasWei,
@@ -312,6 +320,7 @@ async function getWorkflowCounts(
   success: number;
   error: number;
   cancelled: number;
+  skipped: number;
   durationSum: number;
   durationCount: number;
 }> {
@@ -320,6 +329,7 @@ async function getWorkflowCounts(
       success: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'success' THEN 1 ELSE 0 END)`,
       error: sql<number>`SUM(CASE WHEN ${inArray(workflowExecutions.status, [...ERROR_STATUSES])} THEN 1 ELSE 0 END)`,
       cancelled: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'cancelled' THEN 1 ELSE 0 END)`,
+      skipped: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'skipped' THEN 1 ELSE 0 END)`,
       durationSum: sql<number>`COALESCE(SUM(${workflowExecutions.duration}), 0)`,
       durationCount: sql<number>`SUM(CASE WHEN ${workflowExecutions.duration} IS NOT NULL THEN 1 ELSE 0 END)`,
     })
@@ -337,14 +347,16 @@ async function getWorkflowCounts(
   const row = result[0];
   const success = Number(row?.success) || 0;
   const error = Number(row?.error) || 0;
-  // Total counts only completed runs (success + error). Pending, running and
-  // cancelled runs are excluded so the success rate and Total Runs KPI ignore
-  // in-flight and cancelled executions.
+  // Total counts only completed runs (success + error). Pending, running,
+  // cancelled and skipped runs are excluded so the success rate and Total Runs
+  // KPI ignore in-flight runs, cancellations, and runs the platform refused
+  // before they started.
   return {
     total: success + error,
     success,
     error,
     cancelled: Number(row?.cancelled) || 0,
+    skipped: Number(row?.skipped) || 0,
     durationSum: Number(row?.durationSum) || 0,
     durationCount: Number(row?.durationCount) || 0,
   };
@@ -457,6 +469,7 @@ async function getPreviousPeriodSummary(
     successCount: workflowStats.success + directStats.success,
     errorCount: workflowStats.error + directStats.error,
     cancelledCount: workflowStats.cancelled,
+    skippedCount: workflowStats.skipped,
     avgDurationMs: computeAvgDuration(
       workflowStats.durationSum + directStats.durationSum,
       workflowStats.durationCount + directStats.durationCount
@@ -600,6 +613,7 @@ async function computeTimeSeries(
       success: sql<string>`SUM(CASE WHEN ${workflowExecutions.status} = 'success' THEN 1 ELSE 0 END)`,
       error: sql<string>`SUM(CASE WHEN ${inArray(workflowExecutions.status, [...ERROR_STATUSES])} THEN 1 ELSE 0 END)`,
       cancelled: sql<string>`SUM(CASE WHEN ${workflowExecutions.status} = 'cancelled' THEN 1 ELSE 0 END)`,
+      skipped: sql<string>`SUM(CASE WHEN ${workflowExecutions.status} = 'skipped' THEN 1 ELSE 0 END)`,
       pending: sql<string>`SUM(CASE WHEN ${workflowExecutions.status} = 'pending' THEN 1 ELSE 0 END)`,
       running: sql<string>`SUM(CASE WHEN ${workflowExecutions.status} = 'running' THEN 1 ELSE 0 END)`,
     })
@@ -626,6 +640,7 @@ async function computeTimeSeries(
       success: sql<string>`SUM(CASE WHEN ${directExecutions.status} = 'completed' THEN 1 ELSE 0 END)`,
       error: sql<string>`SUM(CASE WHEN ${directExecutions.status} = 'failed' THEN 1 ELSE 0 END)`,
       cancelled: sql<string>`0`,
+      skipped: sql<string>`0`,
       pending: sql<string>`SUM(CASE WHEN ${directExecutions.status} = 'pending' THEN 1 ELSE 0 END)`,
       running: sql<string>`SUM(CASE WHEN ${directExecutions.status} IN ('running', 'unconfirmed') THEN 1 ELSE 0 END)`,
     })
@@ -674,6 +689,7 @@ type BucketRow = {
   success: string;
   error: string;
   cancelled: string;
+  skipped: string;
   pending: string;
   running: string;
 };

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -21,6 +21,7 @@ export type UnifiedStatus =
   | "running"
   | "success"
   | "error"
+  | "skipped"
   | "cancelled"
   | "completed"
   | "failed";
@@ -32,6 +33,10 @@ export type NormalizedStatus =
   | "error"
   | "system_error"
   | "external_error"
+  // Refused before it started (over the plan limit, a gated action, an unpaid
+  // pay-as-you-go charge). Its own status so it stays out of the error count and
+  // the success-rate denominator.
+  | "skipped"
   | "cancelled";
 
 export type UnifiedRun = {
@@ -73,6 +78,7 @@ export type AnalyticsSummary = {
   successCount: number;
   errorCount: number;
   cancelledCount: number;
+  skippedCount: number;
   successRate: number;
   avgDurationMs: number | null;
   /** Every wei the runs burned over the range, sponsored gas included. */
@@ -90,6 +96,7 @@ export type AnalyticsSummary = {
     successCount: number;
     errorCount: number;
     cancelledCount: number;
+    skippedCount: number;
     avgDurationMs: number | null;
     totalGasWei: string;
     sponsoredGasWei: string;
@@ -101,6 +108,7 @@ export type TimeSeriesBucket = {
   success: number;
   error: number;
   cancelled: number;
+  skipped: number;
   pending: number;
   running: number;
 };

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -5,6 +5,7 @@
 
 import type { PlanName } from "@/lib/billing/plans";
 import type { ExecutionErrorType } from "@/lib/errors/execution-error-type";
+import type { NodeExecutionStatus } from "@/lib/errors/execution-status";
 import type { Page } from "@/lib/pagination";
 import type { HeldPaymentView } from "@/lib/tempo/held-payment-view";
 import type { VoteDirection } from "@/lib/workflow/editor/votes";
@@ -829,7 +830,7 @@ export const workflowApi = {
         nodeId: string;
         nodeName: string;
         nodeType: string;
-        status: "pending" | "running" | "success" | "error" | "cancelled";
+        status: NodeExecutionStatus;
         input: unknown;
         output: unknown;
         error: string | null;
@@ -853,7 +854,7 @@ export const workflowApi = {
       status: string;
       nodeStatuses: Array<{
         nodeId: string;
-        status: "pending" | "running" | "success" | "error" | "cancelled";
+        status: NodeExecutionStatus;
       }>;
       progress?: {
         totalSteps: number;

--- a/lib/billing/dispatch-admission.ts
+++ b/lib/billing/dispatch-admission.ts
@@ -1,0 +1,132 @@
+import "server-only";
+
+// Plan admission for pre-created (phantom) dispatches.
+//
+// The executor is still the authoritative gate: it re-runs these checks before
+// it claims a row or creates a runner pod. This runs earlier, at phantom
+// creation, so a dispatch that is already known to be refused never costs a
+// row, an SQS message and an executor round-trip.
+//
+// Only deterministic refusals belong here. A free org past its included limit
+// is admitted on purpose: pay-as-you-go charges it per execution and the charge
+// is settled on the executor after the claim, so refusing it here would drop
+// runs the org is entitled to.
+
+import {
+  extractActionTypeNodes,
+  validateWorkflowFeatures,
+} from "@/lib/features";
+import { isBillingEnabled } from "./feature-flag";
+import type { PlanName } from "./plans";
+import { checkExecutionLimit, getOrgPlan } from "./plans-server";
+
+export type DispatchRefusalReason = "plan_feature" | "execution_limit";
+
+export type DispatchRefusal = {
+  reason: DispatchRefusalReason;
+  message: string;
+};
+
+// Both strings match what the executor writes when it refuses the same run, so
+// a refusal reads identically whether it was caught here or one hop later.
+export const EXECUTION_LIMIT_REFUSAL =
+  "Execution skipped: your plan's monthly execution limit has been reached.";
+
+export function planFeatureRefusalMessage(
+  featureNames: readonly string[]
+): string {
+  return `Workflow uses features that require a paid plan: ${featureNames.join(", ")}`;
+}
+
+/**
+ * Org-level standing: the part of the decision that costs database reads and is
+ * identical for every workflow the org owns.
+ */
+type OrgStanding = { plan: PlanName; limitBlocked: boolean };
+
+// A dispatcher calls this on every occurrence of every trigger, which on a fast
+// block trigger is tens of times a minute for the same org. Without this the
+// admitted path (the common one) would pay three point-lookups per occurrence
+// to spare the refused path its round-trip, which is a net loss at any healthy
+// refusal ratio.
+//
+// Both outcomes are cached. A stale admission is harmless: the executor still
+// refuses. A stale refusal delays the first run after an upgrade by at most the
+// TTL, which is why the TTL is seconds rather than minutes.
+const STANDING_TTL_MS = 30_000;
+
+const standingCache = new Map<
+  string,
+  { expiresAt: number; standing: OrgStanding }
+>();
+
+async function readOrgStanding(organizationId: string): Promise<OrgStanding> {
+  const cached = standingCache.get(organizationId);
+  const now = Date.now();
+  if (cached && cached.expiresAt > now) {
+    return cached.standing;
+  }
+
+  const [plan, limit] = await Promise.all([
+    getOrgPlan(organizationId),
+    checkExecutionLimit(organizationId),
+  ]);
+  const standing: OrgStanding = { plan, limitBlocked: !limit.allowed };
+  standingCache.set(organizationId, {
+    expiresAt: now + STANDING_TTL_MS,
+    standing,
+  });
+  return standing;
+}
+
+/**
+ * Clear the cache. Test-only - throws outside NODE_ENV=test so production code
+ * that calls it by mistake fails loud instead of silently dropping the cache.
+ */
+export function __resetDispatchAdmissionCacheForTest(): void {
+  if (process.env.NODE_ENV !== "test") {
+    throw new Error(
+      "__resetDispatchAdmissionCacheForTest is test-only; do not call in production"
+    );
+  }
+  standingCache.clear();
+}
+
+/**
+ * Decide whether a dispatch may be pre-created. Returns null to admit, or the
+ * refusal to record and report back to the dispatcher.
+ */
+export async function checkDispatchAdmission(params: {
+  organizationId: string | null | undefined;
+  nodes: readonly unknown[];
+}): Promise<DispatchRefusal | null> {
+  if (!isBillingEnabled()) {
+    return null;
+  }
+
+  // Default-deny on plan features: no org context means no paid plan we can
+  // read, so the workflow is validated against free, and there is nothing to
+  // bill. Mirrors enforceWorkflowFeatures and enforceExecutionLimit.
+  const standing: OrgStanding = params.organizationId
+    ? await readOrgStanding(params.organizationId)
+    : { plan: "free", limitBlocked: false };
+
+  // Per-workflow and free: which nodes are gated depends on the definition, so
+  // this part must not be cached per org.
+  const violations = validateWorkflowFeatures(
+    extractActionTypeNodes(params.nodes),
+    standing.plan
+  );
+  if (violations.length > 0) {
+    return {
+      reason: "plan_feature",
+      message: planFeatureRefusalMessage(violations.map((v) => v.feature.name)),
+    };
+  }
+
+  if (standing.limitBlocked) {
+    return { reason: "execution_limit", message: EXECUTION_LIMIT_REFUSAL };
+  }
+
+  return null;
+}

--- a/lib/billing/dispatch-admission.ts
+++ b/lib/billing/dispatch-admission.ts
@@ -55,10 +55,38 @@ type OrgStanding = { plan: PlanName; limitBlocked: boolean };
 // TTL, which is why the TTL is seconds rather than minutes.
 const STANDING_TTL_MS = 30_000;
 
+// Nothing reads an entry back once it has expired, so without a bound the map
+// would retain one entry per org that has ever dispatched for the lifetime of
+// the pod. The cap is well above the number of orgs dispatching inside any one
+// TTL window, so eviction is a safety net rather than part of the hot path.
+const STANDING_CACHE_MAX = 5000;
+
 const standingCache = new Map<
   string,
   { expiresAt: number; standing: OrgStanding }
 >();
+
+/**
+ * Drop expired entries, then the oldest writes if the cap is still exceeded.
+ * Insertion order is write order (every write re-inserts), so the oldest keys
+ * are also the closest to expiring.
+ */
+function evictStandings(now: number): void {
+  for (const [orgId, entry] of standingCache) {
+    if (entry.expiresAt <= now) {
+      standingCache.delete(orgId);
+    }
+  }
+
+  let overflow = standingCache.size - STANDING_CACHE_MAX;
+  for (const orgId of standingCache.keys()) {
+    if (overflow <= 0) {
+      return;
+    }
+    standingCache.delete(orgId);
+    overflow--;
+  }
+}
 
 async function readOrgStanding(organizationId: string): Promise<OrgStanding> {
   const cached = standingCache.get(organizationId);
@@ -72,6 +100,11 @@ async function readOrgStanding(organizationId: string): Promise<OrgStanding> {
     checkExecutionLimit(organizationId),
   ]);
   const standing: OrgStanding = { plan, limitBlocked: !limit.allowed };
+  if (standingCache.size >= STANDING_CACHE_MAX) {
+    evictStandings(now);
+  }
+  // Re-insert so the key moves to the back of the eviction order.
+  standingCache.delete(organizationId);
   standingCache.set(organizationId, {
     expiresAt: now + STANDING_TTL_MS,
     standing,

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -672,6 +672,11 @@ export const workflowExecutions = pgTable(
       | "unconfirmed"
       | "success"
       | "error"
+      // Refused before it started: over the plan's execution limit, a gated
+      // action, or an unpaid pay-as-you-go charge. Terminal, never billable,
+      // and not a failure - the run did not happen, so it belongs outside both
+      // the error count and the success-rate denominator.
+      | "skipped"
       | "cancelled"
       | "phantom"
       | "system_error"

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -13,6 +13,10 @@ import {
 } from "drizzle-orm/pg-core";
 import type { ErrorCode } from "../errors/error-codes";
 import type { ExecutionErrorType } from "../errors/execution-error-type";
+import type {
+  NodeExecutionStatus,
+  WorkflowExecutionStatus,
+} from "../errors/execution-status";
 import type { IntegrationType } from "../types/integration";
 import { generateId } from "../utils/id";
 
@@ -674,23 +678,9 @@ export const workflowExecutions = pgTable(
     userId: text("user_id")
       .notNull()
       .references(() => users.id),
-    status: text("status").notNull().$type<
-      | "pending"
-      | "running"
-      // A run whose claimed transaction hashes could not be read on chain.
-      // Non-terminal: settled to success or error by the reconciler.
-      | "unconfirmed"
-      | "success"
-      | "error"
-      // Refused before it started: over the plan's execution limit, a gated
-      // action, or an unpaid pay-as-you-go charge. Terminal, never billable,
-      // and not a failure - the run did not happen, so it belongs outside both
-      // the error count and the success-rate denominator.
-      | "skipped"
-      | "cancelled"
-      | "phantom"
-      | "system_error"
-    >(),
+    // Values and their meanings live on WorkflowExecutionStatus, so the API,
+    // the client and the executor all name the same set.
+    status: text("status").notNull().$type<WorkflowExecutionStatus>(),
     // biome-ignore lint/suspicious/noExplicitAny: JSONB type - structure validated at application level
     input: jsonb("input").$type<Record<string, any>>(),
     // biome-ignore lint/suspicious/noExplicitAny: JSONB type - structure validated at application level
@@ -846,9 +836,7 @@ export const workflowExecutionLogs = pgTable(
     nodeId: text("node_id").notNull(),
     nodeName: text("node_name").notNull(),
     nodeType: text("node_type").notNull(),
-    status: text("status")
-      .notNull()
-      .$type<"pending" | "running" | "success" | "error" | "cancelled">(),
+    status: text("status").notNull().$type<NodeExecutionStatus>(),
     // biome-ignore lint/suspicious/noExplicitAny: JSONB type - structure validated at application level
     input: jsonb("input").$type<any>(),
     // biome-ignore lint/suspicious/noExplicitAny: JSONB type - structure validated at application level

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -601,6 +601,9 @@ type ExecutionDigestEmailData = {
     total: number;
     success: number;
     error: number;
+    // Runs refused before they started. Rendered in its own neutral section:
+    // they never ran, so they are not failures and carry no rate.
+    skipped: number;
     distinctWorkflows: number;
     transactionCount: number;
     gasUsedWei: string;
@@ -617,6 +620,12 @@ type ExecutionDigestEmailData = {
     workflowId: string;
     name: string;
     runs: number;
+  }[];
+  topSkipped: {
+    workflowId: string;
+    name: string;
+    skipped: number;
+    lastReason: string | null;
   }[];
 };
 
@@ -721,6 +730,7 @@ export async function sendWorkflowExecutionDigestEmail(
     stats,
     topFailing,
     mostExecuted,
+    topSkipped,
   } = data;
   const period = DIGEST_PERIOD_LABEL[cadence];
   const summaryLabel = DIGEST_SUMMARY_LABEL[cadence];
@@ -774,6 +784,21 @@ export async function sendWorkflowExecutionDigestEmail(
       ? ""
       : `\nSponsored transactions: ${stats.sponsoredTransactionCount}`;
 
+  // Omitted entirely when nothing was refused, which is the normal case.
+  const skippedText = stats.skipped
+    ? `
+Skipped: ${stats.skipped} (refused before starting, not failures)
+${topSkipped
+  .map(
+    (w) =>
+      `- ${w.name}: ${w.skipped} skipped${
+        w.lastReason ? ` (${w.lastReason})` : ""
+      } (${workflowUrl(w.workflowId)})`
+  )
+  .join("\n")}
+`
+    : "";
+
   const socialText = DIGEST_SOCIAL_LINKS.map((s) => `${s.name}: ${s.url}`).join(
     "\n"
   );
@@ -795,7 +820,7 @@ ${mostExecutedText}
 Failed: ${stats.error} (${failRate}%)
 Top failing workflows:
 ${failingText}
-
+${skippedText}
 View runs: ${appUrl}/analytics
 
 You're receiving this digest for ${orgName} because you're an owner or admin of that organization.
@@ -875,6 +900,33 @@ ${socialText}
         .join("")
     : `<tr><td style="padding:6px 0;color:#999;">No executions.</td></tr>`;
 
+  // Neutral grey throughout: a skipped run is not an error, and colouring it
+  // like one is the misread this section exists to prevent.
+  const skippedRows = topSkipped
+    .map((w) => {
+      const reasonNote = w.lastReason
+        ? ` <span style="color:#999;" title="${escapeHtml(
+            w.lastReason
+          )}">- ${escapeHtml(truncate(w.lastReason, 42))}</span>`
+        : "";
+      return `<tr><td style="padding:6px 0;">${nameLink(
+        w.workflowId,
+        truncate(w.name, 26),
+        w.name
+      )}${reasonNote}</td><td style="padding:6px 0;text-align:right;color:#666;vertical-align:top;">${
+        w.skipped
+      }</td></tr>`;
+    })
+    .join("");
+
+  const skippedSection = stats.skipped
+    ? `<div style="text-align:left; margin-top:28px;">
+      <p style="margin:0 0 4px;"><span style="color:#666; font-weight:bold; font-size:17px;">Skipped: ${stats.skipped}</span> <span style="color:#999; font-size:13px;">- Runs refused before they started</span></p>
+      <p style="margin:0 0 10px; color:#999; font-size:12px;">These runs never started, so they are not failures and do not count towards your success rate or your usage.</p>
+      <table style="width:100%; border-collapse:collapse;">${tableHeader("Skipped")}${skippedRows}</table>
+    </div>`
+    : "";
+
   const html = `
 <!DOCTYPE html>
 <html>
@@ -905,6 +957,7 @@ ${socialText}
       <p style="margin:0 0 10px;"><span style="color:#c0392b; font-weight:bold; font-size:17px;">Failed: ${stats.error} (${failRate}%)</span> <span style="color:#999; font-size:13px;">- Top failing workflows</span></p>
       <table style="width:100%; border-collapse:collapse;">${tableHeader("Failures", "#c0392b")}${failingRows}</table>
     </div>
+    ${skippedSection}
     <div style="margin:30px 0 0;">
       <a href="${appUrl}/analytics" style="display:inline-block; background:#1a1a2e; color:#fff; padding:12px 24px; border-radius:8px; text-decoration:none;">View runs</a>
     </div>

--- a/lib/errors/execution-status.ts
+++ b/lib/errors/execution-status.ts
@@ -21,6 +21,48 @@ export function isErrorStatus(status: string): status is ErrorStatus {
   return (ERROR_STATUSES as readonly string[]).includes(status);
 }
 
+/**
+ * Every status a row in `workflow_executions` can carry. Declared here rather
+ * than inline on the column so the API, the client and the executor all name
+ * the same set, and so adding a status shows up as a type error everywhere it
+ * has to be handled.
+ *
+ * `skipped` is a run the platform refused before it started: over the plan's
+ * execution limit, a gated action, or an unpaid pay-as-you-go charge. It is
+ * terminal, never billable, and not a failure, so it belongs outside both the
+ * error count and the success-rate denominator.
+ */
+export const WORKFLOW_EXECUTION_STATUSES = [
+  "pending",
+  "running",
+  "unconfirmed",
+  "success",
+  "error",
+  "skipped",
+  "cancelled",
+  "phantom",
+  "system_error",
+] as const;
+
+export type WorkflowExecutionStatus =
+  (typeof WORKFLOW_EXECUTION_STATUSES)[number];
+
+/**
+ * Status of a single node inside a run, as stored on
+ * `workflow_execution_logs.status`. Deliberately narrower than
+ * WorkflowExecutionStatus: a node is dispatched only once the run itself was
+ * admitted, so no node ever carries a run-level outcome such as `skipped`.
+ */
+export const NODE_EXECUTION_STATUSES = [
+  "pending",
+  "running",
+  "success",
+  "error",
+  "cancelled",
+] as const;
+
+export type NodeExecutionStatus = (typeof NODE_EXECUTION_STATUSES)[number];
+
 /** Map an error_type to the execution status that should be persisted. */
 export function statusForErrorType(
   errorType: ExecutionErrorType | null | undefined

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -1024,6 +1024,28 @@ export function recordWorkflowExecutionFinished(labels: {
   });
 }
 
+// Runs the platform refused before they started: over the plan's execution
+// limit, a gated action, or an unpaid pay-as-you-go charge. Deliberately its own
+// series rather than a `finished` status: a refused run never executed, so it
+// belongs in neither the error count nor the success-rate denominator, but it
+// still has to be visible or the refusals become invisible in Prometheus.
+const workflowExecutionsSkipped = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_workflow_executions_skipped_total",
+  "Workflow executions refused before starting, by org_slug and reason (execution_limit, plan_feature, payg_unpaid). Not failures: these runs never executed.",
+  ["org_slug", "reason"]
+);
+
+export function recordWorkflowExecutionSkipped(labels: {
+  orgSlug: string;
+  reason: string;
+}): void {
+  workflowExecutionsSkipped.inc({
+    org_slug: labels.orgSlug,
+    reason: labels.reason,
+  });
+}
+
 // Compensation series for the finished counter. selfHealWorkflowAfterLateStepCommit
 // flips error -> success after finalization has already emitted
 // finished{status="error"|"system_error"}, and a counter cannot be

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -85,6 +85,7 @@ export type WorkflowStats = {
   totalRunning: number;
   totalPending: number;
   totalCancelled: number;
+  totalSkipped: number;
 
   // Per-(status, org_slug, error_type) execution counts. Personal/anonymous
   // workflows are bucketed under ANONYMOUS_ORG_SLUG so the sum of counts for
@@ -128,6 +129,7 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
       totalRunning: 0,
       totalPending: 0,
       totalCancelled: 0,
+      totalSkipped: 0,
       executionsByStatusAndOrgSlug: [],
       durationBuckets: new Array(WORKFLOW_DURATION_BUCKETS.length + 1).fill(0),
       durationSum: 0,
@@ -196,6 +198,11 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
         case "cancelled":
           stats.totalCancelled += c;
           break;
+        // Refused before starting: counted apart from errors so the 30-day
+        // volume gauge does not read a refusal as a failure.
+        case "skipped":
+          stats.totalSkipped += c;
+          break;
         default:
           // Ignore unknown status values
           break;
@@ -258,6 +265,7 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
       totalRunning: 0,
       totalPending: 0,
       totalCancelled: 0,
+      totalSkipped: 0,
       executionsByStatusAndOrgSlug: [],
       durationBuckets: new Array(WORKFLOW_DURATION_BUCKETS.length + 1).fill(0),
       durationSum: 0,

--- a/lib/notifications/execution-digest.ts
+++ b/lib/notifications/execution-digest.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { and, count, desc, eq, gte, inArray, lt, sql } from "drizzle-orm";
+import { and, count, desc, eq, gte, inArray, lt, ne, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
   workflowExecutionLogs,
@@ -109,10 +109,21 @@ export type MostExecutedWorkflow = {
   runs: number;
 };
 
+export type SkippedWorkflow = {
+  workflowId: string;
+  name: string;
+  skipped: number;
+  lastReason: string | null;
+};
+
 export type OrgExecutionDigest = {
   total: number;
   success: number;
   error: number;
+  // Runs the platform refused before they started, over the plan's execution
+  // limit or on a gated action. They never ran, so they are reported on their
+  // own rather than as failures, and they are excluded from `total`.
+  skipped: number;
   // Distinct workflows that ran at least once over the window.
   distinctWorkflows: number;
   // On-chain activity over the window.
@@ -123,10 +134,12 @@ export type OrgExecutionDigest = {
   sponsoredTransactionCount?: number;
   topFailing: FailingWorkflow[];
   mostExecuted: MostExecutedWorkflow[];
+  topSkipped: SkippedWorkflow[];
 };
 
 const TOP_FAILING_LIMIT = 5;
 const TOP_EXECUTED_LIMIT = 3;
+const TOP_SKIPPED_LIMIT = 5;
 
 /**
  * Aggregate an org's workflow executions over [since, until): run totals,
@@ -145,11 +158,16 @@ export async function getOrgExecutionDigest(
     lt(workflowExecutions.startedAt, until)
   );
 
+  // A refused run never executed, so it is excluded from the run total and
+  // from the most-executed ranking, and reported under its own heading below.
+  const ranFilter = and(windowFilter, ne(workflowExecutions.status, "skipped"));
+
   const [totalsRow] = await db
     .select({
-      total: count(),
+      total: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} <> 'skipped' THEN 1 ELSE 0 END)`,
       success: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'success' THEN 1 ELSE 0 END)`,
       error: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'error' THEN 1 ELSE 0 END)`,
+      skipped: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'skipped' THEN 1 ELSE 0 END)`,
       distinctWorkflows: sql<number>`COUNT(DISTINCT ${workflowExecutions.workflowId})`,
       transactionCount: sql<number>`COALESCE(SUM(CASE WHEN jsonb_typeof(${workflowExecutions.transactionHashes}) = 'array' THEN jsonb_array_length(${workflowExecutions.transactionHashes}) ELSE 0 END), 0)`,
       gasUsedWei: sql<string>`COALESCE(SUM(${workflowExecutions.gasUsedWei}), 0)`,
@@ -166,7 +184,7 @@ export async function getOrgExecutionDigest(
     })
     .from(workflowExecutions)
     .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
-    .where(windowFilter)
+    .where(ranFilter)
     .groupBy(workflows.id, workflows.name)
     .orderBy(desc(count()))
     .limit(TOP_EXECUTED_LIMIT);
@@ -205,6 +223,15 @@ export async function getOrgExecutionDigest(
     lastErrorByWorkflow.set(row.workflowId, row.error ?? null);
   }
 
+  // Refused runs, grouped like the failing list so a recipient can see which
+  // workflow stopped firing and why. Only queried when there are any: on a
+  // healthy org this is zero and the email omits the section entirely.
+  const skippedTotal = Number(totalsRow?.skipped) || 0;
+  const topSkipped =
+    skippedTotal > 0
+      ? await getTopSkippedWorkflows(windowFilter)
+      : ([] as SkippedWorkflow[]);
+
   // Sponsored-tx count is only meaningful (and only queried) when gas
   // sponsorship is enabled. Sponsored step runs stamp output_raw.sponsored.
   let sponsoredTransactionCount: number | undefined;
@@ -230,6 +257,7 @@ export async function getOrgExecutionDigest(
     total: Number(totalsRow?.total) || 0,
     success: Number(totalsRow?.success) || 0,
     error: Number(totalsRow?.error) || 0,
+    skipped: skippedTotal,
     distinctWorkflows: Number(totalsRow?.distinctWorkflows) || 0,
     transactionCount: Number(totalsRow?.transactionCount) || 0,
     gasUsedWei: totalsRow?.gasUsedWei ?? "0",
@@ -245,5 +273,55 @@ export async function getOrgExecutionDigest(
       name: row.name,
       runs: Number(row.runs) || 0,
     })),
+    topSkipped,
   };
+}
+
+/**
+ * Workflows whose runs the platform refused over the window, with the reason
+ * carried on the most recent one. Same shape as the failing list, deliberately
+ * kept apart from it: these runs did not fail, they never started.
+ */
+async function getTopSkippedWorkflows(
+  windowFilter: ReturnType<typeof and>
+): Promise<SkippedWorkflow[]> {
+  const skippedFilter = and(
+    windowFilter,
+    eq(workflowExecutions.status, "skipped")
+  );
+
+  const rows = await db
+    .select({
+      workflowId: workflows.id,
+      name: workflows.name,
+      skipped: count(),
+    })
+    .from(workflowExecutions)
+    .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
+    .where(skippedFilter)
+    .groupBy(workflows.id, workflows.name)
+    .orderBy(desc(count()))
+    .limit(TOP_SKIPPED_LIMIT);
+
+  const latestReasonRows = await db
+    .selectDistinctOn([workflowExecutions.workflowId], {
+      workflowId: workflowExecutions.workflowId,
+      error: workflowExecutions.error,
+    })
+    .from(workflowExecutions)
+    .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
+    .where(skippedFilter)
+    .orderBy(workflowExecutions.workflowId, desc(workflowExecutions.startedAt));
+
+  const lastReasonByWorkflow = new Map<string, string | null>();
+  for (const row of latestReasonRows) {
+    lastReasonByWorkflow.set(row.workflowId, row.error ?? null);
+  }
+
+  return rows.map((row) => ({
+    workflowId: row.workflowId,
+    name: row.name,
+    skipped: Number(row.skipped) || 0,
+    lastReason: lastReasonByWorkflow.get(row.workflowId) ?? null,
+  }));
 }

--- a/lib/payments/x402/execution-wait.ts
+++ b/lib/payments/x402/execution-wait.ts
@@ -17,7 +17,12 @@ import { isErrorStatus } from "@/lib/errors/execution-status";
 export const DEFAULT_CALL_WAIT_TIMEOUT_MS = 25_000;
 const DEFAULT_POLL_INTERVAL_MS = 1000;
 
-type TerminalStatus = "success" | "error" | "system_error" | "cancelled";
+type TerminalStatus =
+  | "success"
+  | "error"
+  | "system_error"
+  | "cancelled"
+  | "skipped";
 
 type ExecutionResult = {
   status: TerminalStatus;
@@ -27,7 +32,12 @@ type ExecutionResult = {
 
 function isTerminalStatus(status: string): status is TerminalStatus {
   return (
-    status === "success" || isErrorStatus(status) || status === "cancelled"
+    status === "success" ||
+    isErrorStatus(status) ||
+    status === "cancelled" ||
+    // A refused run never starts, so a caller waiting on it must stop here
+    // rather than poll until the timeout.
+    status === "skipped"
   );
 }
 
@@ -253,6 +263,13 @@ export async function buildCallCompletionResponse(
   }
   if (result.status === "cancelled") {
     return { executionId, status: "error", error: "Execution cancelled" };
+  }
+  if (result.status === "skipped") {
+    return {
+      executionId,
+      status: "error",
+      error: result.error ?? "Execution skipped",
+    };
   }
   return {
     executionId,

--- a/lib/workflow/editor/template-helpers.ts
+++ b/lib/workflow/editor/template-helpers.ts
@@ -1,3 +1,4 @@
+import type { NodeExecutionStatus } from "@/lib/errors/execution-status";
 import { getReadContractOutputFields } from "@/lib/workflow/editor/action-output-fields";
 import { getInputSchemaFields } from "@/lib/workflow/editor/input-schema-fields";
 import { getTriggerOutputFields } from "@/lib/workflow/editor/trigger-output-fields";
@@ -30,7 +31,7 @@ export function buildExecutionLogsMap(
     nodeId: string;
     nodeName: string;
     nodeType: string;
-    status: "pending" | "running" | "success" | "error" | "cancelled";
+    status: NodeExecutionStatus;
     output?: unknown;
   }>
 ): ExecutionLogsByNodeId {

--- a/lib/workflow/execute-in-background.ts
+++ b/lib/workflow/execute-in-background.ts
@@ -1,5 +1,5 @@
 import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
-import { and, eq, isNull, ne } from "drizzle-orm";
+import { and, eq, isNull, ne, notInArray } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { start } from "workflow/api";
 import { db } from "@/lib/db";
@@ -207,7 +207,7 @@ export async function executeWorkflowInBackground(
         and(
           eq(workflowExecutions.id, executionId),
           eq(prevExecution.id, workflowExecutions.id),
-          ne(workflowExecutions.status, "cancelled"),
+          notInArray(workflowExecutions.status, ["cancelled", "skipped"]),
           ne(workflowExecutions.status, "success")
         )
       )

--- a/lib/workflow/execution-access.ts
+++ b/lib/workflow/execution-access.ts
@@ -5,6 +5,7 @@ import { authenticateApiKey } from "@/lib/api-key-auth";
 import { db } from "@/lib/db";
 import type { TransactionHashEntry } from "@/lib/db/schema";
 import { workflowExecutions } from "@/lib/db/schema";
+import type { NodeExecutionStatus } from "@/lib/errors/execution-status";
 import {
   type DualAuthContext,
   getDualAuthContext,
@@ -39,7 +40,7 @@ export type ExecutionViewAccess =
 
 type NodeStatus = {
   nodeId: string;
-  status: "pending" | "running" | "success" | "error" | "cancelled";
+  status: NodeExecutionStatus;
 };
 
 export type ExecutionStatusPayload = {

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -4,7 +4,17 @@
  */
 import "server-only";
 
-import { and, asc, eq, inArray, isNotNull, isNull, ne, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  ne,
+  notInArray,
+  sql,
+} from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { db } from "@/lib/db";
 import {
@@ -53,7 +63,9 @@ import {
 import { getTransactionHashes } from "@/lib/workflow/executor/step-success-tracker";
 import { computeTrulyFailedNodes } from "@/lib/workflow/executor/truly-failed-nodes";
 
-const TERMINAL_STATUSES = new Set(["cancelled"]);
+// Statuses a late step write must never resurrect: the user stopped the run,
+// or the platform refused it before it started.
+const TERMINAL_STATUSES = new Set(["cancelled", "skipped"]);
 
 /**
  * KEEP-431 follow-up: matches the same SDK spurious error shapes that the
@@ -936,7 +948,7 @@ export async function logWorkflowCompleteDb(
       and(
         eq(workflowExecutions.id, params.executionId),
         eq(prevExecution.id, workflowExecutions.id),
-        ne(workflowExecutions.status, "cancelled"),
+        notInArray(workflowExecutions.status, ["cancelled", "skipped"]),
         // KEEP-431 follow-up: defense in depth. If selfHealWorkflowAfterLateStepCommit
         // already CAS-flipped status to 'success', a stray late call to
         // logWorkflowCompleteDb (e.g. a duplicate triggerStep _workflowComplete from
@@ -1041,7 +1053,7 @@ export async function updateCurrentStep(
     .where(
       and(
         eq(workflowExecutions.id, params.executionId),
-        ne(workflowExecutions.status, "cancelled")
+        notInArray(workflowExecutions.status, ["cancelled", "skipped"])
       )
     );
 }
@@ -1086,7 +1098,7 @@ export async function incrementCompletedSteps(
     .where(
       and(
         eq(workflowExecutions.id, params.executionId),
-        ne(workflowExecutions.status, "cancelled")
+        notInArray(workflowExecutions.status, ["cancelled", "skipped"])
       )
     );
 }

--- a/lib/workflow/store.ts
+++ b/lib/workflow/store.ts
@@ -3,6 +3,7 @@ import { applyEdgeChanges, applyNodeChanges } from "@xyflow/react";
 import { atom } from "jotai";
 import { toast } from "sonner";
 import { api } from "@/lib/api-client";
+import type { NodeExecutionStatus } from "@/lib/errors/execution-status";
 import { ErrorCategory, logSystemError, logUserError } from "@/lib/logging";
 import { computeAutoLayout } from "@/lib/workflow/editor/auto-layout";
 import { buildExecutionLogsMap } from "@/lib/workflow/editor/template-helpers";
@@ -189,7 +190,7 @@ export type ExecutionLogEntry = {
   nodeId: string;
   nodeName: string;
   nodeType: string;
-  status: "pending" | "running" | "success" | "error" | "cancelled";
+  status: NodeExecutionStatus;
   output?: unknown;
 };
 

--- a/tests/e2e/vitest/phantom-upgrade.test.ts
+++ b/tests/e2e/vitest/phantom-upgrade.test.ts
@@ -8,7 +8,7 @@ import {
   claimPhantomForExecution,
   type DbSchema,
   discardPhantomRow,
-  resolvePhantomToError,
+  resolveToSkipped,
 } from "../../../keeperhub-executor/lib/db-helpers";
 import {
   organization,
@@ -320,18 +320,22 @@ describe.skipIf(SKIP)("consume-path claim helpers", () => {
     expect((await readExecution(id))?.status).toBe("running");
   });
 
-  it("resolvePhantomToError marks a phantom as a billing/user error", async () => {
+  it("resolveToSkipped marks a phantom as refused, not failed", async () => {
     const id = `${PREFIX}resolve`;
     await seedExecution(id, "phantom");
 
-    await resolvePhantomToError(execDb, id, {
+    await resolveToSkipped(execDb, id, {
       error: "over quota",
       errorCategory: "billing",
       errorType: "user",
+      reason: "execution_limit",
     });
 
     const row = await readExecution(id);
-    expect(row.status).toBe("error");
+    // 'skipped', not 'error': the run never executed, so it must stay out of
+    // the error count and the success-rate denominator.
+    expect(row.status).toBe("skipped");
+    expect(row.billable).toBe(false);
     expect(row.error).toBe("over quota");
     expect(row.errorCategory).toBe("billing");
     expect(row.errorType).toBe("user");
@@ -339,14 +343,15 @@ describe.skipIf(SKIP)("consume-path claim helpers", () => {
     expect(row.errorCode).toBeNull();
   });
 
-  it("resolvePhantomToError leaves a non-phantom row intact", async () => {
+  it("resolveToSkipped leaves a non-phantom row intact", async () => {
     const id = `${PREFIX}resolve_running`;
     await seedExecution(id, "running");
 
-    await resolvePhantomToError(execDb, id, {
+    await resolveToSkipped(execDb, id, {
       error: "x",
       errorCategory: "billing",
       errorType: "user",
+      reason: "execution_limit",
     });
 
     expect((await readExecution(id))?.status).toBe("running");

--- a/tests/integration/internal-executions-route.test.ts
+++ b/tests/integration/internal-executions-route.test.ts
@@ -33,6 +33,16 @@ vi.mock("@/lib/features", () => ({
   extractActionTypeNodes: vi.fn(() => []),
 }));
 
+// Admission for phantom creates: defaults to admitted (null), tests flip it.
+const checkDispatchAdmission = vi.fn(
+  async (..._args: unknown[]) =>
+    null as { reason: string; message: string } | null
+);
+vi.mock("@/lib/billing/dispatch-admission", () => ({
+  checkDispatchAdmission: (...args: unknown[]) =>
+    checkDispatchAdmission(...args),
+}));
+
 // withBackstopCapture wraps the insert; just run the callback.
 vi.mock("@/lib/security/backstop-capture", () => ({
   withBackstopCapture: vi.fn((_ctx: unknown, fn: () => unknown) => fn()),
@@ -192,6 +202,7 @@ describe("POST /api/internal/executions", () => {
     mockSelectResult = [];
     enforceExecutionLimit.mockResolvedValue({ blocked: false });
     enforceWorkflowFeatures.mockResolvedValue({ blocked: false });
+    checkDispatchAdmission.mockResolvedValue(null);
   });
 
   it("creates a running row by default and returns the execution id", async () => {
@@ -207,7 +218,7 @@ describe("POST /api/internal/executions", () => {
     expect(enforceExecutionLimit).toHaveBeenCalledTimes(1);
   });
 
-  it("creates a phantom row and skips the execution-limit guard", async () => {
+  it("creates a phantom row and skips the running-row guards", async () => {
     const response = await POST(
       postRequest({ workflowId: "wf_1", userId: "user_1", status: "phantom" })
     );
@@ -220,6 +231,60 @@ describe("POST /api/internal/executions", () => {
     expect(insertedValues?.billable).toBe(false);
     // Quota is charged when the executor upgrades to running, not now.
     expect(enforceExecutionLimit).not.toHaveBeenCalled();
+    expect(checkDispatchAdmission).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses a phantom the org may not run, without creating one", async () => {
+    checkDispatchAdmission.mockResolvedValue({
+      reason: "execution_limit",
+      message: "limit reached",
+    });
+
+    const response = await POST(
+      postRequest({
+        workflowId: "wf_1",
+        userId: "user_1",
+        status: "phantom",
+        triggerSource: "schedule",
+      })
+    );
+    const data = await response.json();
+
+    // 200, not an error status: a refusal must never look like a transport
+    // failure, which the dispatchers fall back to enqueueing through.
+    expect(response.status).toBe(200);
+    expect(data).toMatchObject({
+      refused: true,
+      reason: "execution_limit",
+      error: "limit reached",
+    });
+    expect(data.executionId).toBeUndefined();
+    // 'skipped', not 'error': the run never executed, so it stays out of the
+    // error count and the success-rate denominator.
+    expect(insertedValues?.status).toBe("skipped");
+  });
+
+  it("records one visible row per workflow, reason and hour for refusals", async () => {
+    checkDispatchAdmission.mockResolvedValue({
+      reason: "plan_feature",
+      message: "gated action",
+    });
+
+    await POST(
+      postRequest({ workflowId: "wf_1", userId: "user_1", status: "phantom" })
+    );
+
+    // The hour-bucketed key is what the unique index collapses, so a fast
+    // trigger writes one row an hour instead of one per occurrence.
+    expect(insertedValues?.dispatchKey).toMatch(
+      /^refused:wf_1:plan_feature:\d{4}-\d{2}-\d{2}T\d{2}$/
+    );
+    expect(insertedValues?.status).toBe("skipped");
+    expect(insertedValues?.error).toBe("gated action");
+    expect(insertedValues?.errorCategory).toBe("billing");
+    expect(insertedValues?.errorType).toBe("user");
+    // Refused before it started, so it consumes no quota.
+    expect(insertedValues?.billable).toBe(false);
   });
 
   it("attributes the row to the supplied trigger source", async () => {

--- a/tests/unit/analytics-status-normalize.test.ts
+++ b/tests/unit/analytics-status-normalize.test.ts
@@ -21,6 +21,13 @@ describe("normalizeStatus", () => {
     expect(normalizeStatus("cancelled", "workflow")).toBe("cancelled");
   });
 
+  // A refused run keeps its own status rather than collapsing into error, which
+  // is what keeps it out of the error count and the success-rate denominator.
+  it("keeps a refused run as skipped", () => {
+    expect(normalizeStatus("skipped", "workflow")).toBe("skipped");
+    expect(normalizeStatus("skipped", "workflow", "user")).toBe("skipped");
+  });
+
   it("maps direct completed/failed onto success/error", () => {
     expect(normalizeStatus("completed", "direct")).toBe("success");
     expect(normalizeStatus("failed", "direct")).toBe("error");

--- a/tests/unit/analytics-stream-start.test.ts
+++ b/tests/unit/analytics-stream-start.test.ts
@@ -11,6 +11,7 @@ const EMPTY_SUMMARY: AnalyticsSummary = {
   successCount: 0,
   errorCount: 0,
   cancelledCount: 0,
+  skippedCount: 0,
   successRate: 0,
   avgDurationMs: null,
   totalGasWei: "0",

--- a/tests/unit/apply-execution-result.test.ts
+++ b/tests/unit/apply-execution-result.test.ts
@@ -19,8 +19,8 @@ vi.mock("../../lib/db/schema", () => ({
 vi.mock("drizzle-orm", () => ({
   eq: () => ({}),
   and: () => ({}),
-  ne: () => ({}),
   inArray: () => ({}),
+  notInArray: () => ({}),
 }));
 
 vi.mock("cron-parser", () => ({

--- a/tests/unit/dispatch-admission.test.ts
+++ b/tests/unit/dispatch-admission.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const isBillingEnabled = vi.fn(() => true);
+vi.mock("@/lib/billing/feature-flag", () => ({
+  isBillingEnabled: () => isBillingEnabled(),
+}));
+
+const getOrgPlan = vi.fn(async (..._args: unknown[]) => "free");
+const checkExecutionLimit = vi.fn(
+  async (..._args: unknown[]) =>
+    ({ allowed: true }) as { allowed: boolean; isOverage?: boolean }
+);
+vi.mock("@/lib/billing/plans-server", () => ({
+  getOrgPlan: (...args: unknown[]) => getOrgPlan(...args),
+  checkExecutionLimit: (...args: unknown[]) => checkExecutionLimit(...args),
+}));
+
+const validateWorkflowFeatures = vi.fn(
+  (..._args: unknown[]) => [] as { feature: { name: string } }[]
+);
+vi.mock("@/lib/features", () => ({
+  extractActionTypeNodes: (nodes: unknown[]) => nodes,
+  validateWorkflowFeatures: (...args: unknown[]) =>
+    validateWorkflowFeatures(...args),
+}));
+
+import {
+  __resetDispatchAdmissionCacheForTest,
+  checkDispatchAdmission,
+} from "@/lib/billing/dispatch-admission";
+
+describe("checkDispatchAdmission", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetDispatchAdmissionCacheForTest();
+    isBillingEnabled.mockReturnValue(true);
+    getOrgPlan.mockResolvedValue("free");
+    checkExecutionLimit.mockResolvedValue({ allowed: true });
+    validateWorkflowFeatures.mockReturnValue([]);
+  });
+
+  it("admits when the org is within its limit and uses no gated feature", async () => {
+    await expect(
+      checkDispatchAdmission({ organizationId: "org_1", nodes: [] })
+    ).resolves.toBeNull();
+  });
+
+  it("refuses a gated action before it costs a queue message", async () => {
+    validateWorkflowFeatures.mockReturnValue([
+      { feature: { name: "Custom ABI" } },
+    ]);
+
+    const refusal = await checkDispatchAdmission({
+      organizationId: "org_1",
+      nodes: [],
+    });
+
+    expect(refusal?.reason).toBe("plan_feature");
+    expect(refusal?.message).toContain("Custom ABI");
+  });
+
+  // Which nodes are gated depends on the workflow, so the per-workflow half of
+  // the decision must not be served from the org-level cache.
+  it("re-validates features per workflow while reusing the org standing", async () => {
+    await checkDispatchAdmission({ organizationId: "org_1", nodes: [] });
+    validateWorkflowFeatures.mockReturnValue([
+      { feature: { name: "Custom ABI" } },
+    ]);
+
+    const refusal = await checkDispatchAdmission({
+      organizationId: "org_1",
+      nodes: [{ id: "n1" }],
+    });
+
+    expect(refusal?.reason).toBe("plan_feature");
+    expect(checkExecutionLimit).toHaveBeenCalledTimes(1);
+  });
+
+  // The admitted path is the common one; it must not pay a database read per
+  // occurrence when a fast trigger fires repeatedly for the same org.
+  it("reads the org standing once for repeated dispatches", async () => {
+    await checkDispatchAdmission({ organizationId: "org_1", nodes: [] });
+    await checkDispatchAdmission({ organizationId: "org_1", nodes: [] });
+    await checkDispatchAdmission({ organizationId: "org_1", nodes: [] });
+
+    expect(checkExecutionLimit).toHaveBeenCalledTimes(1);
+    expect(getOrgPlan).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the standing separate per org", async () => {
+    checkExecutionLimit.mockResolvedValueOnce({ allowed: false });
+
+    const refused = await checkDispatchAdmission({
+      organizationId: "org_blocked",
+      nodes: [],
+    });
+    const admitted = await checkDispatchAdmission({
+      organizationId: "org_ok",
+      nodes: [],
+    });
+
+    expect(refused?.reason).toBe("execution_limit");
+    expect(admitted).toBeNull();
+  });
+
+  it("refuses when the execution limit check blocks the org", async () => {
+    checkExecutionLimit.mockResolvedValue({ allowed: false });
+
+    const refusal = await checkDispatchAdmission({
+      organizationId: "org_1",
+      nodes: [],
+    });
+
+    expect(refusal?.reason).toBe("execution_limit");
+  });
+
+  // Pay-as-you-go admits a free org past its included limit so the executor can
+  // charge it after the claim. Refusing it here would drop paid-for runs.
+  it("admits an org the limit check allows on overage or pay-as-you-go", async () => {
+    checkExecutionLimit.mockResolvedValue({ allowed: true, isOverage: true });
+
+    await expect(
+      checkDispatchAdmission({ organizationId: "org_1", nodes: [] })
+    ).resolves.toBeNull();
+  });
+
+  it("admits everything when billing is disabled", async () => {
+    isBillingEnabled.mockReturnValue(false);
+    validateWorkflowFeatures.mockReturnValue([
+      { feature: { name: "Custom ABI" } },
+    ]);
+
+    await expect(
+      checkDispatchAdmission({ organizationId: "org_1", nodes: [] })
+    ).resolves.toBeNull();
+  });
+
+  // No org context means no plan we can read, so gated nodes are validated
+  // against free rather than waved through.
+  it("validates against the free plan when there is no org", async () => {
+    validateWorkflowFeatures.mockReturnValue([
+      { feature: { name: "Custom ABI" } },
+    ]);
+
+    const refusal = await checkDispatchAdmission({
+      organizationId: null,
+      nodes: [],
+    });
+
+    expect(refusal?.reason).toBe("plan_feature");
+    expect(getOrgPlan).not.toHaveBeenCalled();
+    expect(validateWorkflowFeatures).toHaveBeenCalledWith([], "free");
+  });
+
+  it("skips the limit check when there is no org to bill", async () => {
+    const refusal = await checkDispatchAdmission({
+      organizationId: null,
+      nodes: [],
+    });
+
+    expect(refusal).toBeNull();
+    expect(checkExecutionLimit).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/execution-digest-email.test.ts
+++ b/tests/unit/execution-digest-email.test.ts
@@ -23,6 +23,7 @@ function baseData() {
       total: 5,
       success: 3,
       error: 2,
+      skipped: 0,
       distinctWorkflows: 2,
       transactionCount: 4,
       gasUsedWei: "0",
@@ -36,6 +37,7 @@ function baseData() {
       },
     ],
     mostExecuted: [{ workflowId: "wf-run", name: "Nightly sync", runs: 5 }],
+    topSkipped: [],
   };
 }
 
@@ -110,6 +112,37 @@ describe("sendWorkflowExecutionDigestEmail", () => {
     });
     const content = sentContent();
     expect(content).toContain("Succeeded: 3 (60%)");
+    expect(content).toContain("Failed: 2 (40%)");
+  });
+
+  it("omits the skipped section when nothing was refused", async () => {
+    await sendWorkflowExecutionDigestEmail(baseData());
+    const content = sentContent();
+    expect(content).not.toContain("Skipped:");
+  });
+
+  // A refused run never started, so it must read as its own outcome rather
+  // than inflating the failure count the recipient acts on.
+  it("reports refused runs under their own heading, apart from failures", async () => {
+    const data = baseData();
+    await sendWorkflowExecutionDigestEmail({
+      ...data,
+      stats: { ...data.stats, skipped: 12 },
+      topSkipped: [
+        {
+          workflowId: "wf-skip",
+          name: "Price watcher",
+          skipped: 12,
+          lastReason: "Execution limit reached",
+        },
+      ],
+    });
+    const content = sentContent();
+    expect(content).toContain("Skipped: 12");
+    expect(content).toContain("Price watcher");
+    expect(content).toContain("Execution limit reached");
+    expect(content).toContain("https://app.keeperhub.com/workflows/wf-skip");
+    // The failure count and rate stay untouched by the refusals.
     expect(content).toContain("Failed: 2 (40%)");
   });
 


### PR DESCRIPTION
## Problem

Admission ran on the executor, one hop too late. The dispatcher had already created a `workflow_executions` row and sent an SQS message, and the executor then spent about five queries to reject it, including an uncached `COUNT` aggregate (an org sitting at its limit falls inside the count cache's recount margin, so it re-reads fresh every time).

No runner pod was ever created for a refused run, that part was already correct. The waste was everything before it.

## Per refused occurrence

| Step | Before | Now |
|---|---|---|
| Internal API call | 1 | 1 |
| DB queries | 9, incl. 1 uncached `COUNT` | 2 |
| SQS operations | 2 | 0 |
| Executor message handled | 1 | 0 |
| Execution rows written | 2 | 0 |

One block-triggered workflow on a two-second chain, per hour: ~16,200 queries to ~4,080, 1,800 SQS messages to 0, 3,600 rows to 1.

## Changes

- Admission at phantom creation, refusal reported as `200 {refused, reason}`. An error status would be read as a transport failure, which the dispatchers deliberately fall through to the id-less enqueue, so it would re-queue the run it just refused.
- Org standing cached for 30s, per-workflow feature validation not cached. Without that split the admitted path would pay three point lookups per occurrence to save the refused path a round trip, a net loss at any healthy refusal ratio.
- Pay-as-you-go orgs stay admitted. A free org at its cap is charged per run and settled on the executor after the claim, so refusing it at dispatch would drop runs it paid for.
- Refusals write a new `skipped` terminal status, out of the error count and out of the success-rate denominator, with their own `keeperhub_workflow_executions_skipped_total{org_slug, reason}` series. Terminal everywhere it matters: polling stops, late step writes cannot resurrect it, and x402 callers do not wait out the timeout.
- Visibility rows are bucketed by hour through a synthetic dispatch key, so the existing unique index collapses the rest. A fast trigger writes one row an hour, not one per block.
- New dispatcher counters: `keeperhub_schedule_dispatcher_refused_total` and `keeperhub_block_dispatcher_dispatch_refused_total`.

## Found along the way

Plan-feature violations already returned 402 on phantom creation, which the clients read as a transport error, so gated workflows were dispatching anyway and inserting a fresh error row per occurrence. The refusal contract fixes that too.

## Notes for review

- No migration. `workflow_executions.status` is a text column with a TypeScript union, not a pg enum.
- Existing `error` rows carrying `errorCategory=billing` are left alone. The status change is forward-only from deploy.
- The executor keeps its own guard as the authoritative gate: it covers the race between dispatch and pickup, the legacy id-less path, and manual and webhook triggers.


## Review follow-ups

- The executor's plan-feature refusal and its post-claim pay-as-you-go refusal both wrote `skipped` rows that no Prometheus series counted. Having left the error gauges, those refusals were invisible. Both now emit the skipped counter.
- Analytics surfaces the status: a Skipped filter, a muted series on the timeline, a breakdown line on Total Runs, and tooltips on the skipped, error, external and system badges explaining whose fault each outcome is.
- The digest reports refused runs under their own heading, out of the run total and out of the most-executed ranking. An org whose triggers were all refused still receives the email.
- `skipped` is now treated as terminal where it was missed: log polling in the runs panel, the share view label, icon and badge colour, and the executor's backstop compare-and-set, which could otherwise have reopened a refused row.
- The org standing cache is bounded and evicts on write.
- Both event trackers mark a refused event as processed, so a reconnect does not pay for the admission round-trip to reach the same answer.
- `WorkflowExecutionStatus` and `NodeExecutionStatus` are exported from `lib/errors/execution-status` and replace the eleven copies of those unions, so a new status surfaces as a type error wherever it has to be handled.

## Measured effect

One org on a block trigger had written 11,312 rows in nineteen days, every one a plan-feature refusal that never executed, and every one `billable = true`. Its entire 5,000 included bucket was consumed by runs that did not happen, and it was reported at 226% of quota. After this change those refusals cost one hour-bucketed non-billable row each, so the counted usage is zero and the included bucket stays available for real runs. The change is forward-only; existing rows keep their current status until the month rolls over.

Not covered here: a refusal caused by an unpaid pay-as-you-go charge is still discovered on the executor, so it still costs a full round-trip on every occurrence. Tracked separately.
