### PR TITLE
test: reach organization settings where they now live

### DIFF
--- a/tests/e2e/playwright/invitations.test.ts
+++ b/tests/e2e/playwright/invitations.test.ts
@@ -19,6 +19,7 @@ import {
   openInviteForm,
   sendInvite,
 } from "./utils/invitations";
+import { openOrgSettings } from "./utils/settings";
 
 const ACCEPT_INVITE_URL_REGEX = /\/accept-invite/;
 
@@ -56,13 +57,12 @@ test.describe("Organization Invitations", () => {
       await signInAsInviter(page);
       await openInviteForm(page);
 
-      const dialog = page.locator('[role="dialog"]');
       const inviteEmail = `newinvitee+${Date.now()}@example.com`;
 
-      await dialog
+      await page
         .locator('input[placeholder="colleague@example.com"]')
         .fill(inviteEmail);
-      await dialog.locator('button:has-text("Invite")').click();
+      await page.getByRole("button", { name: "Send invitation" }).click();
 
       await expect(
         page
@@ -70,8 +70,8 @@ test.describe("Organization Invitations", () => {
           .filter({ hasText: `Invitation sent to ${inviteEmail}` })
       ).toBeVisible({ timeout: 10_000 });
 
-      await expect(dialog.locator("text=invited").first()).toBeVisible({
-        timeout: 5000,
+      await expect(page.locator("text=invited").first()).toBeVisible({
+        timeout: 10_000,
       });
     });
 
@@ -88,12 +88,10 @@ test.describe("Organization Invitations", () => {
       await signInAsInviter(page);
       await openInviteForm(page);
 
-      const dialog = page.locator('[role="dialog"]');
-
-      await dialog
+      await page
         .locator('input[placeholder="colleague@example.com"]')
         .fill(existingUserEmail);
-      await dialog.locator('button:has-text("Invite")').click();
+      await page.getByRole("button", { name: "Send invitation" }).click();
 
       await expect(
         page
@@ -101,8 +99,8 @@ test.describe("Organization Invitations", () => {
           .filter({ hasText: `Invitation sent to ${existingUserEmail}` })
       ).toBeVisible({ timeout: 10_000 });
 
-      await expect(dialog.locator("text=invited").first()).toBeVisible({
-        timeout: 5000,
+      await expect(page.locator("text=invited").first()).toBeVisible({
+        timeout: 10_000,
       });
     });
 
@@ -116,27 +114,30 @@ test.describe("Organization Invitations", () => {
       await signInAsInviter(page);
       await openInviteForm(page);
 
-      const dialog = page.locator('[role="dialog"]');
       const inviteEmail = `reinvite+${Date.now()}@example.com`;
       const sentToast = page
         .locator("[data-sonner-toast]")
         .filter({ hasText: `Invitation sent to ${inviteEmail}` });
 
       // First invite succeeds.
-      await dialog
+      await page
         .locator('input[placeholder="colleague@example.com"]')
         .fill(inviteEmail);
-      await dialog.locator('button:has-text("Invite")').click();
+      await page.getByRole("button", { name: "Send invitation" }).click();
       await expect(sentToast).toBeVisible({ timeout: 10_000 });
 
-      // Let the first toast clear so the re-invite toast is unambiguous.
-      await expect(sentToast).toBeHidden({ timeout: 10_000 });
+      // Let the first toast clear so the re-invite toast is unambiguous. The
+      // pointer is parked away from the toaster first: left where the click
+      // landed it keeps the stack expanded, and an expanded toast never times
+      // out on its own.
+      await page.mouse.move(0, 0);
+      await expect(sentToast).toBeHidden({ timeout: 15_000 });
 
       // Re-inviting the same email re-sends (success), not an error.
-      await dialog
+      await page
         .locator('input[placeholder="colleague@example.com"]')
         .fill(inviteEmail);
-      await dialog.locator('button:has-text("Invite")').click();
+      await page.getByRole("button", { name: "Send invitation" }).click();
       await expect(sentToast).toBeVisible({ timeout: 10_000 });
     });
 
@@ -146,12 +147,10 @@ test.describe("Organization Invitations", () => {
       await signInAsInviter(page);
       await openInviteForm(page);
 
-      const dialog = page.locator('[role="dialog"]');
-
-      await dialog
+      await page
         .locator('input[placeholder="colleague@example.com"]')
         .fill(PERSISTENT_INVITER_EMAIL);
-      await dialog.locator('button:has-text("Invite")').click();
+      await page.getByRole("button", { name: "Send invitation" }).click();
 
       await expect(
         page
@@ -361,14 +360,13 @@ test.describe("Organization Invitations", () => {
       const popover = page.locator('[role="listbox"]');
       await expect(popover).toBeVisible({ timeout: 5000 });
       const orgItems = popover.locator('[role="option"]');
-      await expect(orgItems).toHaveCount(3); // 2 orgs + "Manage Organizations"
+      await expect(orgItems).toHaveCount(2); // the member belongs to 2 orgs
 
       const activeItem = orgItems.filter({ hasText: currentOrgName.trim() });
       await expect(activeItem.locator("svg.opacity-100")).toBeVisible();
 
       const otherOrg = orgItems
         .filter({ hasNotText: currentOrgName.trim() })
-        .filter({ hasNotText: "Manage Organizations" })
         .first();
       const otherOrgName = await otherOrg.innerText();
       await otherOrg.click();
@@ -437,37 +435,37 @@ test.describe("Organization Invitations", () => {
         timeout: 15_000,
       });
 
+      // Leaving acts on the organization in scope, so switch to the one this
+      // user is only a member of before opening its settings.
       const orgSwitcher = page.locator('button[role="combobox"]');
+      const startingOrg = (await orgSwitcher.innerText()).trim();
       await orgSwitcher.click();
-      await page.locator("text=Manage Organizations").click();
-
-      const dialog = page.locator('[role="dialog"]');
-      await expect(
-        dialog.locator('h2:has-text("Manage Organizations")')
-      ).toBeVisible({ timeout: 5000 });
-
-      const orgCards = dialog.locator(
-        ".flex.items-center.justify-between.rounded-lg.border.p-3"
-      );
-      const memberOrg = orgCards
-        .filter({ has: page.locator("p.capitalize", { hasText: "Member" }) })
+      const otherOrg = page
+        .locator('[role="option"]')
+        .filter({ hasNotText: startingOrg })
         .first();
-      const orgNameToLeave = await memberOrg
-        .locator(".font-medium.text-sm")
-        .first()
-        .innerText();
-      await memberOrg.locator('button:has-text("Manage")').click();
+      const orgNameToLeave = (await otherOrg.innerText()).trim();
+      await otherOrg.click();
+      await expect(orgSwitcher).toContainText(orgNameToLeave, {
+        timeout: 10_000,
+      });
 
-      await dialog.locator('button:has-text("Leave Organization")').click();
+      await openOrgSettings(page, "organization");
 
+      // Re-click until the dialog opens: straight after navigation the first
+      // click can land before the handler is wired and be dropped, leaving the
+      // page as it was.
+      const leaveButton = page.getByRole("button", {
+        name: "Leave",
+        exact: true,
+      });
       const alertDialog = page.locator('[role="alertdialog"]');
-      await expect(alertDialog).toBeVisible({ timeout: 5000 });
-      await expect(
-        alertDialog.locator("text=Are you sure you want to leave")
-      ).toBeVisible();
-
+      await expect(async () => {
+        await leaveButton.click();
+        await expect(alertDialog).toBeVisible({ timeout: 3000 });
+      }).toPass({ timeout: 30_000 });
       await alertDialog
-        .locator('button:has-text("Leave Organization")')
+        .getByRole("button", { name: "Leave", exact: true })
         .click();
 
       await expect(

--- a/tests/e2e/playwright/org-mfa-enforcement.test.ts
+++ b/tests/e2e/playwright/org-mfa-enforcement.test.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "./fixtures";
+import { openOrgSettings } from "./utils/settings";
 
 const UPDATED_REGEX = /enforcement updated/i;
 const NEEDS_FACTOR_REGEX = /at least one factor/i;
@@ -9,14 +10,7 @@ const NEEDS_FACTOR_REGEX = /at least one factor/i;
 // end-to-end; the wallet-member proxy gate is covered separately.
 
 async function openOrgSecurityTab(page: Page): Promise<void> {
-  await page.goto("/", { waitUntil: "domcontentloaded" });
-  const orgSwitcher = page.locator('button[role="combobox"]');
-  await expect(orgSwitcher).toBeVisible({ timeout: 15_000 });
-  await orgSwitcher.click();
-  await page.locator("text=Manage Organizations").click();
-  const dialog = page.getByRole("dialog");
-  await expect(dialog).toBeVisible();
-  await dialog.getByRole("tab", { name: "Security" }).click();
+  await openOrgSettings(page, "security");
   // The section fetches its current state before rendering; wait for the toggle
   // so callers don't race the loading spinner.
   await expect(page.getByTestId("org-mfa-enforce-toggle")).toBeVisible({

--- a/tests/e2e/playwright/organization-wallet.test.ts
+++ b/tests/e2e/playwright/organization-wallet.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "./fixtures";
 import { signUpAndVerify as signUpAndVerifyBase } from "./utils/auth";
 import { getDbConnection } from "./utils/connection";
 import { PERSISTENT_TEST_USER_EMAIL } from "./utils/db";
+import { openOrgSettings } from "./utils/settings";
 
 // Regex patterns (moved to top level for performance)
 const SLUG_PATTERN = /test-org-/;
@@ -24,29 +25,20 @@ async function signUpAndVerify(
   return { email };
 }
 
-// Open the organization creation form from Manage Organizations modal
+// Open the organization creation form on the General settings page.
 async function openCreateOrgForm(page: Page): Promise<void> {
-  const orgSwitcher = page.locator('button[role="combobox"]');
-  await orgSwitcher.click();
+  await openOrgSettings(page, "organization");
 
-  await page.locator("text=Manage Organizations").click();
-
-  const dialog = page.locator('[role="dialog"]');
-  await expect(
-    dialog.locator('h2:has-text("Manage Organizations")')
-  ).toBeVisible({ timeout: 5000 });
-
-  // Check if form is already visible (may be shown by default)
-  const orgNameInput = dialog.locator("#org-name");
+  const orgNameInput = page.locator("#new-org-name");
   if (await orgNameInput.isVisible({ timeout: 1000 }).catch(() => false)) {
-    return; // Form already visible
+    return;
   }
-
-  // Click the "Create New Organization" button to show the form
-  await dialog.locator('button:has-text("Create New Organization")').click();
-
-  // Wait for the org name input to appear (form is now visible)
-  await expect(orgNameInput).toBeVisible({ timeout: 5000 });
+  // The section header renders before the organization it describes has
+  // loaded, so wait for the control rather than clicking where it will be.
+  const openForm = page.getByRole("button", { name: "New organization" });
+  await expect(openForm).toBeVisible({ timeout: 20_000 });
+  await openForm.click();
+  await expect(orgNameInput).toBeVisible({ timeout: 20_000 });
 }
 
 // Open the wallet overlay from the user menu
@@ -132,18 +124,13 @@ test.describe("Organization Management", () => {
       // Open create organization form
       await openCreateOrgForm(page);
 
-      const dialog = page.locator('[role="dialog"]');
-
-      // Fill in organization details
       const orgName = `Test Org ${Date.now()}`;
-      await dialog.locator("#org-name").fill(orgName);
+      await page.locator("#new-org-name").fill(orgName);
 
       // Verify slug is auto-generated
-      const slugInput = dialog.locator("#org-slug");
-      await expect(slugInput).toHaveValue(SLUG_PATTERN);
+      await expect(page.locator("#new-org-slug")).toHaveValue(SLUG_PATTERN);
 
-      // Submit the form
-      await dialog.locator('button:has-text("Create")').click();
+      await page.getByRole("button", { name: "Create organization" }).click();
 
       // Verify success - should redirect or show the new org
       await expect(
@@ -158,13 +145,11 @@ test.describe("Organization Management", () => {
       });
       await openCreateOrgForm(page);
 
-      const dialog = page.locator('[role="dialog"]');
-
       // Type organization name
-      await dialog.locator("#org-name").fill("My Test Organization");
+      await page.locator("#new-org-name").fill("My Test Organization");
 
       // Verify slug is auto-generated with correct format
-      const slugInput = dialog.locator("#org-slug");
+      const slugInput = page.locator("#new-org-slug");
       await expect(slugInput).toHaveValue("my-test-organization");
     });
 
@@ -175,14 +160,12 @@ test.describe("Organization Management", () => {
       });
       await openCreateOrgForm(page);
 
-      const dialog = page.locator('[role="dialog"]');
-
       // Fill in organization name
-      await dialog.locator("#org-name").fill("My Organization");
+      await page.locator("#new-org-name").fill("My Organization");
 
       // Manually edit the slug with unique timestamp
       const customSlug = `custom-slug-${Date.now()}`;
-      const slugInput = dialog.locator("#org-slug");
+      const slugInput = page.locator("#new-org-slug");
       await slugInput.clear();
       await slugInput.fill(customSlug);
 
@@ -190,7 +173,7 @@ test.describe("Organization Management", () => {
       await expect(slugInput).toHaveValue(customSlug);
 
       // Submit and verify success
-      await dialog.locator('button:has-text("Create")').click();
+      await page.getByRole("button", { name: "Create organization" }).click();
       await expect(
         page.locator("[data-sonner-toast]").filter({ hasText: CREATED_PATTERN })
       ).toBeVisible({ timeout: 10_000 });
@@ -206,22 +189,15 @@ test.describe("Organization Management", () => {
 
       // Create a new organization
       await openCreateOrgForm(page);
-      const dialog = page.locator('[role="dialog"]');
 
       const orgName = `Switcher Test Org ${Date.now()}`;
-      await dialog.locator("#org-name").fill(orgName);
-      await dialog.locator('button:has-text("Create")').click();
+      await page.locator("#new-org-name").fill(orgName);
+      await page.getByRole("button", { name: "Create organization" }).click();
 
       // Wait for creation
       await expect(
         page.locator("[data-sonner-toast]").filter({ hasText: CREATED_PATTERN })
       ).toBeVisible({ timeout: 10_000 });
-
-      // Close any open dialogs by pressing Escape
-      await page.keyboard.press("Escape");
-      await expect(page.locator('[role="dialog"]')).not.toBeVisible({
-        timeout: 5000,
-      });
 
       // Open org switcher
       const orgSwitcher = page.locator('button[role="combobox"]');

--- a/tests/e2e/playwright/utils/invitations.ts
+++ b/tests/e2e/playwright/utils/invitations.ts
@@ -2,6 +2,7 @@ import type { Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 import { getAdminFetchHeaders } from "./admin-fetch";
 import { getDbConnection } from "./connection";
+import { openOrgSettings } from "./settings";
 
 /**
  * Navigate to accept-invite page and wait for it to render.
@@ -93,26 +94,19 @@ async function getInvitationIdViaDb(
 }
 
 /**
- * Navigate to the invite form inside the Manage Organizations modal.
- * Waits for org switcher visibility before interacting.
+ * Open the invite form on the organization's Users settings page.
+ *
+ * Reached through the rail rather than a built URL: the org-scoped route needs
+ * an organization id the test does not hold, and the rail resolves it from the
+ * active organization the way a person would.
  */
 export async function openInviteForm(page: Page): Promise<void> {
-  const orgSwitcher = page.locator('button[role="combobox"]');
-  await expect(orgSwitcher).toBeVisible({ timeout: 15_000 });
-  await orgSwitcher.click();
+  await openOrgSettings(page, "users");
 
-  await page.locator("text=Manage Organizations").click();
-
-  const dialog = page.locator('[role="dialog"]');
+  await page.getByRole("button", { name: "Invite", exact: true }).click();
   await expect(
-    dialog.locator('h2:has-text("Manage Organizations")')
-  ).toBeVisible({ timeout: 5000 });
-
-  await dialog.locator('button:has-text("Manage")').first().click();
-
-  await expect(
-    dialog.locator('input[placeholder="colleague@example.com"]')
-  ).toBeVisible({ timeout: 5000 });
+    page.locator('input[placeholder="colleague@example.com"]')
+  ).toBeVisible({ timeout: 15_000 });
 }
 
 /**
@@ -125,12 +119,11 @@ export async function sendInvite(
 ): Promise<string> {
   await openInviteForm(page);
 
-  const dialog = page.locator('[role="dialog"]');
-  await dialog
+  await page
     .locator('input[placeholder="colleague@example.com"]')
     .fill(inviteeEmail);
 
-  const inviteButton = dialog.locator('button:has-text("Invite")');
+  const inviteButton = page.getByRole("button", { name: "Send invitation" });
   await expect(inviteButton).toBeEnabled({ timeout: 5000 });
   await inviteButton.click();
 

--- a/tests/e2e/playwright/utils/settings.ts
+++ b/tests/e2e/playwright/utils/settings.ts
@@ -1,0 +1,40 @@
+import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+/**
+ * Open an organization-scoped settings section.
+ *
+ * The rail builds its org-scoped links from the active organization, which
+ * loads after the first paint. Following one before it resolves lands on
+ * `/settings/<segment>`, where the app reads the segment as an organization id.
+ * So the link is read back from the page once it carries an id, rather than
+ * clicked on sight or built from an id the test does not hold.
+ */
+export async function openOrgSettings(
+  page: Page,
+  segment: string
+): Promise<void> {
+  await page.goto("/settings/account", { waitUntil: "domcontentloaded" });
+
+  const pattern = new RegExp(`^/settings/[^/]+/${segment}$`);
+  let href: string | null = null;
+  await expect
+    .poll(
+      async () => {
+        const hrefs = await page.$$eval("a[href]", (anchors) =>
+          anchors.map((a) => a.getAttribute("href") ?? "")
+        );
+        href = hrefs.find((h) => pattern.test(h)) ?? null;
+        return href;
+      },
+      { timeout: 20_000 }
+    )
+    .not.toBeNull();
+
+  await page.goto(href as unknown as string, {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(page).toHaveURL(new RegExp(`/settings/[^/]+/${segment}`), {
+    timeout: 20_000,
+  });
+}


### PR DESCRIPTION
Three Playwright suites drive the Manage Organizations modal from the org switcher. The settings hub moved what that modal held into sections and dropped the entry, so they time out clicking text that is no longer on the page.

Currently failing on `staging`:

```
invitations.test.ts:53        INV-SEND-1
org-mfa-enforcement.test.ts:28
org-mfa-enforcement.test.ts:67
```

Two more call sites were broken the same way but had not been reached yet: the switcher option count in ORG-1, and leaving an organization in ORG-3.

## What changed

| was | now |
|---|---|
| invite form inside the modal | Users section, Invite button |
| modal Security tab | Organization security section |
| create org in the modal, `#org-name` | General section, `#new-org-name` |
| 3 switcher options | 2, the manage entry is gone |
| leave via the modal | General section, Leave |

Navigation goes through a shared `openOrgSettings` helper. It reads the link back from the page once it carries an organization id rather than following it on sight: the rail builds org-scoped links from the active organization, which loads after the first paint, and following one early lands on `/settings/<segment>`, where the app reads the segment as an organization id. This was a real failure, not a theoretical one.

Three smaller fixes surfaced while running them:

- **Leaving** re-clicks until its dialog opens, the way `signIn` already re-clicks its submit. After navigation the first click can land before the handler is wired and be dropped.
- **Re-inviting** parks the pointer away from the toaster before waiting for the first toast to clear. On a page rather than in a modal the cursor is left over the stack, and an expanded toast never auto-dismisses.
- **Opening the create-organization form** waits for its control rather than clicking where the control will be.

## Verification

Run locally against a dev server with `LOAD_TEST_BYPASS_TOKEN` set. Every flow touched here passes: both `org-mfa-enforcement` tests, `INV-SEND-1` through `INV-SEND-4`, `ORG-1`, `ORG-3`, and `ORG-CREATE-1` through `ORG-CREATE-4`.

`INV-RECV-1` fails locally on the signup OTP step. It fails identically with this branch stashed, so it is a local environment issue rather than a regression here, and it passes in CI.