### PR TITLE
test: finish moving the invite tests off the removed modal

### DIFF
--- a/tests/e2e/playwright/invitations.test.ts
+++ b/tests/e2e/playwright/invitations.test.ts
@@ -421,7 +421,7 @@ test.describe("Organization Invitations", () => {
       const popover = page.locator('[role="listbox"]');
       await expect(popover).toBeVisible({ timeout: 5000 });
       const orgItems = popover.locator('[role="option"]');
-      await expect(orgItems).toHaveCount(3);
+      await expect(orgItems).toHaveCount(2); // the two organizations, and nothing else
     });
 
     test("ORG-3: user can leave an org", async ({ page, context }) => {

--- a/tests/e2e/playwright/organization-wallet.test.ts
+++ b/tests/e2e/playwright/organization-wallet.test.ts
@@ -33,12 +33,14 @@ async function openCreateOrgForm(page: Page): Promise<void> {
   if (await orgNameInput.isVisible({ timeout: 1000 }).catch(() => false)) {
     return;
   }
-  // The section header renders before the organization it describes has
-  // loaded, so wait for the control rather than clicking where it will be.
+  // Re-click until the form opens: straight after navigation the first click
+  // can land before the handler is wired and be dropped.
   const openForm = page.getByRole("button", { name: "New organization" });
   await expect(openForm).toBeVisible({ timeout: 20_000 });
-  await openForm.click();
-  await expect(orgNameInput).toBeVisible({ timeout: 20_000 });
+  await expect(async () => {
+    await openForm.click();
+    await expect(orgNameInput).toBeVisible({ timeout: 3000 });
+  }).toPass({ timeout: 30_000 });
 }
 
 // Open the wallet overlay from the user menu

--- a/tests/e2e/playwright/wallet-invite.test.ts
+++ b/tests/e2e/playwright/wallet-invite.test.ts
@@ -21,7 +21,7 @@ const INVITE_CREATED_REGEX = /invitation created/i;
 const WELCOME_REGEX = /welcome to/i;
 const SIGN_TO_JOIN_REGEX = /sign to join/i;
 const NOT_FOUND_REGEX = /no keeperhub account signs in with that wallet/i;
-const ADDRESS_INPUT = "0x... (their sign-in wallet)";
+const ADDRESS_INPUT = "0x...";
 
 // The owner invited by address, which resolved to the wallet account's
 // synthetic email; look that email up to find the pending invitation id.
@@ -84,10 +84,11 @@ test.describe("wallet org invite", () => {
       // 2. Owner invites that sign-in address.
       await page.goto("/", { waitUntil: "domcontentloaded" });
       await openInviteForm(page);
-      const dialog = page.locator('[role="dialog"]');
-      await dialog.getByRole("button", { name: "Wallet", exact: true }).click();
-      await dialog.getByPlaceholder(ADDRESS_INPUT).fill(TEST_WALLET_ADDRESS);
-      await dialog.getByRole("button", { name: "Invite" }).click();
+      await page
+        .getByRole("button", { name: "Invite by wallet address instead" })
+        .click();
+      await page.getByPlaceholder(ADDRESS_INPUT).fill(TEST_WALLET_ADDRESS);
+      await page.getByRole("button", { name: "Create invite link" }).click();
       await expect(page.locator("[data-sonner-toast]")).toContainText(
         INVITE_CREATED_REGEX,
         { timeout: 15_000 }
@@ -112,12 +113,13 @@ test.describe("wallet org invite", () => {
   test("inviting an unknown wallet address is rejected", async ({ page }) => {
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await openInviteForm(page);
-    const dialog = page.locator('[role="dialog"]');
-    await dialog.getByRole("button", { name: "Wallet", exact: true }).click();
-    await dialog
+    await page
+      .getByRole("button", { name: "Invite by wallet address instead" })
+      .click();
+    await page
       .getByPlaceholder(ADDRESS_INPUT)
       .fill("0x000000000000000000000000000000000000dEaD");
-    await dialog.getByRole("button", { name: "Invite" }).click();
+    await page.getByRole("button", { name: "Create invite link" }).click();
     await expect(page.locator("[data-sonner-toast]")).toContainText(
       NOT_FOUND_REGEX,
       { timeout: 15_000 }


### PR DESCRIPTION
Follow-up to #2070, which fixed the three suites that named the removed menu entry. Six tests still fail on `staging`, and three of them are the same defect in call sites my sweep missed, because it matched that entry text and these files do not contain it.

## The three that are mine

**`wallet-invite.test.ts`** (2 tests) drives the same invite form and still scoped everything to `[role="dialog"]`. On the settings page there is no dialog. Wallet mode is a text toggle rather than one of a pair of buttons, the address placeholder is `0x...` rather than `0x... (their sign-in wallet)`, and the submit reads `Create invite link` rather than `Invite`.

**`ORG-2`** asserted three rows in the organization switcher. Two were organizations and the third was the manage entry, so the count is two.

**`ORG-CREATE-1`** was the only one I had already touched. Waiting for the button was not enough, so it now re-clicks until the form appears, the way leaving an organization already does. The click was landing before the handler was wired.

## The other two

`INV-SEND-2` and `schedule-trigger` both pass locally and neither touches moved UI. `schedule-trigger` waits on a canvas node. Both look like flakes in that run rather than anything this branch or #2070 changed.

## Verification

Run locally against a dev server with `LOAD_TEST_BYPASS_TOKEN` set. All six pass: both `wallet-invite` tests, `ORG-2`, `ORG-CREATE-1`, `INV-SEND-2`, and the schedule-trigger test.