### PR TITLE
fix(executor): stop wide fan-in runs from stalling or reporting false success

### DIFF
--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -464,10 +464,28 @@ jobs:
     if: needs.check-labels.outputs.should-build-executor == 'true'
     runs-on: ubuntu-latest
     environment: staging
+    # The executor and workflow-runner images each run a full production build
+    # from the same Dockerfile. Building both in one job exhausted the runner
+    # and the VM was terminated mid-build, so they are split across runners the
+    # same way build-images splits app and migrator.
+    strategy:
+      fail-fast: true
+      matrix:
+        image:
+          - name: executor
+            target: executor
+            tag_prefix: executor
+            ecr: keeperhub-executor-staging
+            cache_from_staging: true
+            cache_key: cache-pr
+          - name: workflow-runner
+            target: workflow-runner
+            tag_prefix: workflow-runner
+            ecr: keeperhub-staging
+            cache_from_staging: false
+            cache_key: workflow-runner-cache-pr
     env:
       REGION: ${{ vars.TO_REGION }}
-      EXECUTOR_ECR_NAME: keeperhub-executor-staging
-      RUNNER_ECR_NAME: keeperhub-staging
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -491,69 +509,40 @@ jobs:
         id: vars
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Check if executor image exists
+      - name: Check if image exists
         id: check-image
         run: |
           IMAGE_TAG="${{ steps.vars.outputs.sha_short }}"
           if aws ecr describe-images \
-            --repository-name ${{ env.EXECUTOR_ECR_NAME }} \
-            --image-ids imageTag=executor-${IMAGE_TAG} \
+            --repository-name ${{ matrix.image.ecr }} \
+            --image-ids imageTag=${{ matrix.image.tag_prefix }}-${IMAGE_TAG} \
             --region ${{ env.REGION }} >/dev/null 2>&1; then
             echo "exists=true" >> $GITHUB_OUTPUT
           else
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build and push executor image
+      - name: Build and push image
         if: steps.check-image.outputs.exists != 'true'
-        # Read from staging cache (warm start) and PR cache, but only write to
-        # :cache-pr. Prevents PR builds from poisoning the staging :cache layer
-        # used by deploy-executor.yaml.
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile
-          target: executor
-          push: true
-          provenance: false
-          tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.EXECUTOR_ECR_NAME }}:executor-${{ steps.vars.outputs.sha_short }}
-          cache-from: |
-            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.EXECUTOR_ECR_NAME }}:cache
-            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.EXECUTOR_ECR_NAME }}:cache-pr
-          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.EXECUTOR_ECR_NAME }}:cache-pr,mode=max
-
-      - name: Check if runner image exists
-        id: check-runner-image
-        run: |
-          IMAGE_TAG="${{ steps.vars.outputs.sha_short }}"
-          if aws ecr describe-images \
-            --repository-name ${{ env.RUNNER_ECR_NAME }} \
-            --image-ids imageTag=workflow-runner-${IMAGE_TAG} \
-            --region ${{ env.REGION }} >/dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Build and push runner image
-        if: steps.check-runner-image.outputs.exists != 'true'
         # The workflow steps run in a per-execution Job using RUNNER_IMAGE, so a
-        # PR-specific runner is required to exercise executor.workflow.ts changes.
-        # Same Dockerfile as the executor (target: workflow-runner). Uses a
-        # runner-scoped PR cache so it never writes the app's :cache layer.
+        # PR-specific runner is required alongside the executor to exercise
+        # executor.workflow.ts changes. Both come from the same Dockerfile.
+        # Reads the staging cache for a warm start where one exists, but only
+        # ever writes a PR-scoped cache so a PR build cannot poison the staging
+        # :cache layer used by deploy-executor.yaml.
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
-          target: workflow-runner
+          target: ${{ matrix.image.target }}
           push: true
           provenance: false
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.RUNNER_ECR_NAME }}:workflow-runner-${{ steps.vars.outputs.sha_short }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ matrix.image.ecr }}:${{ matrix.image.tag_prefix }}-${{ steps.vars.outputs.sha_short }}
           cache-from: |
-            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.RUNNER_ECR_NAME }}:workflow-runner-cache-pr
-          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.RUNNER_ECR_NAME }}:workflow-runner-cache-pr,mode=max
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ matrix.image.ecr }}:${{ matrix.image.cache_key }}
+            ${{ matrix.image.cache_from_staging && format('type=registry,ref={0}/{1}:cache', steps.login-ecr.outputs.registry, matrix.image.ecr) || '' }}
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ matrix.image.ecr }}:${{ matrix.image.cache_key }},mode=max
 
   deploy:
     permissions:

--- a/.github/workflows/deploy-pr-environment.yaml
+++ b/.github/workflows/deploy-pr-environment.yaml
@@ -464,28 +464,10 @@ jobs:
     if: needs.check-labels.outputs.should-build-executor == 'true'
     runs-on: ubuntu-latest
     environment: staging
-    # The executor and workflow-runner images each run a full production build
-    # from the same Dockerfile. Building both in one job exhausted the runner
-    # and the VM was terminated mid-build, so they are split across runners the
-    # same way build-images splits app and migrator.
-    strategy:
-      fail-fast: true
-      matrix:
-        image:
-          - name: executor
-            target: executor
-            tag_prefix: executor
-            ecr: keeperhub-executor-staging
-            cache_from_staging: true
-            cache_key: cache-pr
-          - name: workflow-runner
-            target: workflow-runner
-            tag_prefix: workflow-runner
-            ecr: keeperhub-staging
-            cache_from_staging: false
-            cache_key: workflow-runner-cache-pr
     env:
       REGION: ${{ vars.TO_REGION }}
+      EXECUTOR_ECR_NAME: keeperhub-executor-staging
+      RUNNER_ECR_NAME: keeperhub-staging
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -509,40 +491,69 @@ jobs:
         id: vars
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Check if image exists
+      - name: Check if executor image exists
         id: check-image
         run: |
           IMAGE_TAG="${{ steps.vars.outputs.sha_short }}"
           if aws ecr describe-images \
-            --repository-name ${{ matrix.image.ecr }} \
-            --image-ids imageTag=${{ matrix.image.tag_prefix }}-${IMAGE_TAG} \
+            --repository-name ${{ env.EXECUTOR_ECR_NAME }} \
+            --image-ids imageTag=executor-${IMAGE_TAG} \
             --region ${{ env.REGION }} >/dev/null 2>&1; then
             echo "exists=true" >> $GITHUB_OUTPUT
           else
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build and push image
+      - name: Build and push executor image
         if: steps.check-image.outputs.exists != 'true'
-        # The workflow steps run in a per-execution Job using RUNNER_IMAGE, so a
-        # PR-specific runner is required alongside the executor to exercise
-        # executor.workflow.ts changes. Both come from the same Dockerfile.
-        # Reads the staging cache for a warm start where one exists, but only
-        # ever writes a PR-scoped cache so a PR build cannot poison the staging
-        # :cache layer used by deploy-executor.yaml.
+        # Read from staging cache (warm start) and PR cache, but only write to
+        # :cache-pr. Prevents PR builds from poisoning the staging :cache layer
+        # used by deploy-executor.yaml.
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
-          target: ${{ matrix.image.target }}
+          target: executor
           push: true
           provenance: false
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ matrix.image.ecr }}:${{ matrix.image.tag_prefix }}-${{ steps.vars.outputs.sha_short }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.EXECUTOR_ECR_NAME }}:executor-${{ steps.vars.outputs.sha_short }}
           cache-from: |
-            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ matrix.image.ecr }}:${{ matrix.image.cache_key }}
-            ${{ matrix.image.cache_from_staging && format('type=registry,ref={0}/{1}:cache', steps.login-ecr.outputs.registry, matrix.image.ecr) || '' }}
-          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ matrix.image.ecr }}:${{ matrix.image.cache_key }},mode=max
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.EXECUTOR_ECR_NAME }}:cache
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.EXECUTOR_ECR_NAME }}:cache-pr
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.EXECUTOR_ECR_NAME }}:cache-pr,mode=max
+
+      - name: Check if runner image exists
+        id: check-runner-image
+        run: |
+          IMAGE_TAG="${{ steps.vars.outputs.sha_short }}"
+          if aws ecr describe-images \
+            --repository-name ${{ env.RUNNER_ECR_NAME }} \
+            --image-ids imageTag=workflow-runner-${IMAGE_TAG} \
+            --region ${{ env.REGION }} >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push runner image
+        if: steps.check-runner-image.outputs.exists != 'true'
+        # The workflow steps run in a per-execution Job using RUNNER_IMAGE, so a
+        # PR-specific runner is required to exercise executor.workflow.ts changes.
+        # Same Dockerfile as the executor (target: workflow-runner). Uses a
+        # runner-scoped PR cache so it never writes the app's :cache layer.
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: workflow-runner
+          push: true
+          provenance: false
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.RUNNER_ECR_NAME }}:workflow-runner-${{ steps.vars.outputs.sha_short }}
+          cache-from: |
+            type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.RUNNER_ECR_NAME }}:workflow-runner-cache-pr
+          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ env.RUNNER_ECR_NAME }}:workflow-runner-cache-pr,mode=max
 
   deploy:
     permissions:

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -523,6 +523,88 @@ export function evaluateConditionExpression(
   );
 }
 
+type StepFunction = (input: Record<string, unknown>) => Promise<unknown>;
+
+/** Action type -> the step function to invoke for it. */
+export type StepFunctionTable = ReadonlyMap<string, StepFunction>;
+
+/** Resolve the importer for an action type, honoring legacy action renames. */
+function findStepImporter(actionType: string): StepImporter | undefined {
+  const systemAction = (SYSTEM_ACTIONS as Record<string, StepImporter>)[
+    actionType
+  ];
+  if (systemAction) {
+    return systemAction;
+  }
+  const direct = getStepImporter(actionType);
+  if (direct) {
+    return direct;
+  }
+  const mapped = LEGACY_ACTION_MAPPINGS[actionType];
+  return mapped ? getStepImporter(mapped) : undefined;
+}
+
+/**
+ * Resolve every step module the workflow can reach, before any step runs.
+ *
+ * Step identity in the durability layer is assigned by invocation order: the
+ * Nth `useStep` call in a run gets the Nth id, with no name or content
+ * matching. A replay therefore has to invoke steps in exactly the order the
+ * event log recorded, or every id from the divergence point on refers to the
+ * wrong step and the log becomes unreadable.
+ *
+ * `executeActionStep` used to `await importer()` immediately before calling the
+ * step. That await put the step invocation into a racing microtask: on the
+ * first pass the module load is real I/O, on a replay it is an already-resolved
+ * cache hit, so N branches fanned out in parallel reach their step calls in
+ * different orders on different passes. Resolving the modules here -- once, up
+ * front, before any step is invoked -- leaves the fan-out path synchronous from
+ * `executeNode` through to the step call, so invocation order follows the graph
+ * instead of module-load timing.
+ *
+ * Iterating a sorted list keeps this preload itself order-stable. It invokes no
+ * steps, so it contributes nothing to the event log.
+ */
+export async function preloadStepFunctions(
+  nodes: WorkflowNode[]
+): Promise<StepFunctionTable> {
+  const actionTypes = new Set<string>();
+  for (const node of nodes) {
+    if (node.data.type !== "action") {
+      continue;
+    }
+    const actionType = node.data.config?.actionType as string | undefined;
+    if (actionType) {
+      actionTypes.add(actionType);
+    }
+  }
+
+  const table = new Map<string, StepFunction>();
+  for (const actionType of [...actionTypes].sort()) {
+    const importer = findStepImporter(actionType);
+    if (!importer) {
+      continue;
+    }
+    try {
+      const module = await importer.importer();
+      const stepFunction = module[importer.stepFunction];
+      if (typeof stepFunction === "function") {
+        table.set(actionType, stepFunction as StepFunction);
+      }
+    } catch (error) {
+      // A module that fails to load here fails again at call time, where the
+      // error is attributed to the node instead of aborting the whole run.
+      logSystemError(
+        ErrorCategory.WORKFLOW_ENGINE,
+        "[Workflow Executor] Failed to preload step module",
+        error instanceof Error ? error : new Error(String(error)),
+        { action_type: actionType }
+      );
+    }
+  }
+  return table;
+}
+
 /**
  * Execute a single action step with logging via stepHandler
  * IMPORTANT: Steps receive only the integration ID as a reference to fetch credentials.
@@ -533,10 +615,11 @@ async function executeActionStep(input: {
   config: Record<string, unknown>;
   outputs: NodeOutputs;
   context: StepContext;
+  stepFunctions: StepFunctionTable;
   nodeMap?: ReadonlyMap<string, unknown>;
   executionResults?: Record<string, ExecutionResult>;
 }) {
-  const { actionType, config, outputs, context } = input;
+  const { actionType, config, outputs, context, stepFunctions } = input;
 
   // Build step input WITHOUT credentials, but WITH integrationId reference and logging context
   const stepInput: Record<string, unknown> = {
@@ -545,10 +628,19 @@ async function executeActionStep(input: {
     _context: context,
   };
 
+  // Resolved by preloadStepFunctions before any step ran. Looking it up
+  // synchronously is what keeps the step invocation in program order -- an
+  // await here would hand the ordering back to microtask scheduling.
+  const stepFunction = stepFunctions.get(actionType);
+  if (!stepFunction) {
+    return {
+      success: false,
+      error: `Unknown action type: "${actionType}". This action is not registered in the plugin system. Available system actions: ${Object.keys(SYSTEM_ACTIONS).join(", ")}.`,
+    };
+  }
+
   // Special handling for Condition action - needs template evaluation
   if (actionType === "Condition") {
-    const systemAction = SYSTEM_ACTIONS.Condition;
-    const module = await systemAction.importer();
     const originalExpression =
       resolveConditionExpression(stepInput) ?? stepInput.condition;
 
@@ -574,7 +666,7 @@ async function executeActionStep(input: {
 
     console.log("[Condition] Final result:", evaluatedCondition);
 
-    return await module[systemAction.stepFunction]({
+    return await stepFunction({
       condition: evaluatedCondition,
       // Include original expression only when evaluation succeeded (avoid raw template in UI on failure)
       expression:
@@ -589,45 +681,7 @@ async function executeActionStep(input: {
     });
   }
 
-  // Check system actions first (Database Query, HTTP Request)
-  const systemAction = (SYSTEM_ACTIONS as Record<string, StepImporter>)[
-    actionType
-  ];
-  if (systemAction) {
-    const module = await systemAction.importer();
-    const stepFunction = module[systemAction.stepFunction];
-    return await stepFunction(stepInput);
-  }
-
-  // Look up plugin action from the generated step registry
-  let stepImporter = getStepImporter(actionType);
-
-  // Fallback: check legacy action mappings (e.g. "safe-wallet/get-owners" -> "safe/get-owners")
-  if (!stepImporter) {
-    const mapped = LEGACY_ACTION_MAPPINGS[actionType];
-    if (mapped) {
-      stepImporter = getStepImporter(mapped);
-    }
-  }
-
-  if (stepImporter) {
-    const module = await stepImporter.importer();
-    const stepFunction = module[stepImporter.stepFunction];
-    if (stepFunction) {
-      return await stepFunction(stepInput);
-    }
-
-    return {
-      success: false,
-      error: `Step function "${stepImporter.stepFunction}" not found in module for action "${actionType}". Check that the plugin exports the correct function name.`,
-    };
-  }
-
-  // Fallback for unknown action types
-  return {
-    success: false,
-    error: `Unknown action type: "${actionType}". This action is not registered in the plugin system. Available system actions: ${Object.keys(SYSTEM_ACTIONS).join(", ")}.`,
-  };
+  return await stepFunction(stepInput);
 }
 
 /**
@@ -1876,6 +1930,11 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     }
   }
 
+  // Must complete before the first step runs: it invokes no steps itself, and
+  // once it has, every step call downstream is reached synchronously, so the
+  // order they are invoked in follows the graph rather than module-load timing.
+  const stepFunctions = await preloadStepFunctions(nodes);
+
   // Find trigger nodes
   const nodesWithIncoming = new Set(edges.map((e) => e.target));
   const triggerNodes = nodes.filter(
@@ -2089,6 +2148,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           config: processedConfig,
           outputs,
           context: stepContext,
+          stepFunctions,
           nodeMap,
           executionResults: results,
         }),
@@ -2840,6 +2900,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           config: processedConfig,
           outputs: liveOutputs,
           context: stepContext,
+          stepFunctions,
           nodeMap,
           executionResults: results,
         });

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -7,7 +7,12 @@ import {
   applyBigIntConversion,
   needsBigIntMode,
 } from "@/lib/bigint-condition-utils";
-import { ErrorCategory, logSystemError, logUserError } from "@/lib/logging";
+import {
+  ErrorCategory,
+  logSystemError,
+  logSystemWarn,
+  logUserError,
+} from "@/lib/logging";
 import { getMetricsCollector } from "@/lib/metrics";
 import {
   decrementConcurrentExecutions,
@@ -46,6 +51,7 @@ import { enterWorkflowErrorContext } from "@/lib/workflow/executor/error-context
 import {
   computeFinalSuccess,
   type ExecutionResult,
+  findOrphanedNodes,
 } from "@/lib/workflow/executor/final-success";
 import { runBodyNode } from "@/lib/workflow/executor/for-each-body-runner";
 import {
@@ -1828,6 +1834,48 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
   // and failed is never masked as skipped.
   const skippedNodes = new Set<string>();
 
+  // Every node executeNode was entered for, across all branches. The per-branch
+  // `visited` sets cannot answer "was this node ever reached" on their own, and
+  // `results` misses disabled nodes (which return before recording one), so
+  // orphan detection needs its own run-wide record.
+  const attemptedNodes = new Set<string>();
+
+  // Nodes whose execution is gated by a condition's routing decision, excluded
+  // from orphan detection.
+  const conditionNodeIds = new Set(
+    nodes
+      .filter(
+        (n) =>
+          n.data.type === "action" && n.data.config?.actionType === "Condition"
+      )
+      .map((n) => n.id)
+  );
+
+  // For Each body nodes run through runBodyNode, not executeNode, so they never
+  // reach attemptedNodes and would otherwise all read as orphans. Their failures
+  // are already accounted for by the For Each node's failedIterations.
+  const loopBodyNodeIds = new Set<string>();
+  for (const node of nodes) {
+    if (
+      node.data.type !== "action" ||
+      node.data.config?.actionType !== "For Each"
+    ) {
+      continue;
+    }
+    const body = identifyLoopBody(
+      node.id,
+      edgesBySource,
+      nodeMap,
+      edgesBySourceHandle
+    );
+    for (const bodyNodeId of body.bodyNodeIds) {
+      loopBodyNodeIds.add(bodyNodeId);
+    }
+    if (body.collectNodeId) {
+      loopBodyNodeIds.add(body.collectNodeId);
+    }
+  }
+
   // Find trigger nodes
   const nodesWithIncoming = new Set(edges.map((e) => e.target));
   const triggerNodes = nodes.filter(
@@ -2569,6 +2617,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       return; // Prevent cycles
     }
     visited.add(nodeId);
+    attemptedNodes.add(nodeId);
 
     const node = nodeMap.get(nodeId);
     if (!node) {
@@ -2964,15 +3013,31 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       // late-landing success inside a step boundary (DB-backed, replay-safe via
       // memoization) before giving up, so the reconcile path below recovers it
       // instead of nullifying the node and unblocking convergence with no data.
+      // The poll itself is a step and can throw its own max-retries error. An
+      // escape here would abort the rest of this catch, and the convergence
+      // signal at the bottom is what keeps a fan-in join from waiting forever
+      // on an arrival that never comes -- so swallow the failure and fall
+      // through to the normal failure path instead.
       if (isSpuriousMaxRetries && executionId && recordedOutput === undefined) {
-        recordedOutput = (
-          await awaitCompletedStepOutputStep(
-            executionId,
-            nodeId,
-            SPURIOUS_RECOVERY_POLL_TIMEOUT_MS,
-            SPURIOUS_RECOVERY_POLL_INTERVAL_MS
-          )
-        )?.outputRaw;
+        try {
+          recordedOutput = (
+            await awaitCompletedStepOutputStep(
+              executionId,
+              nodeId,
+              SPURIOUS_RECOVERY_POLL_TIMEOUT_MS,
+              SPURIOUS_RECOVERY_POLL_INTERVAL_MS
+            )
+          )?.outputRaw;
+        } catch (pollError) {
+          logSystemWarn(
+            ErrorCategory.WORKFLOW_ENGINE,
+            "[Workflow Executor] Spurious-recovery poll failed; falling back to failure path",
+            pollError instanceof Error
+              ? pollError
+              : new Error(String(pollError)),
+            { ...baseLogLabels, node_id: nodeId }
+          );
+        }
       }
       if (isSpuriousMaxRetries && recordedOutput !== undefined) {
         // Recovered execution: the step body succeeded, only the SDK's
@@ -3177,6 +3242,38 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       organizationId,
       organizationPlan,
     });
+
+    // A node the executor never scheduled is absent from `results`, so on its
+    // own it cannot fail the run. Record one failure per orphan before the
+    // final tally so a fan-in join that never fired -- and the alerting steps
+    // behind it -- surface as an error instead of a green run.
+    const orphanedNodes = findOrphanedNodes({
+      attempted: attemptedNodes,
+      results,
+      skipped: skippedNodes,
+      edgesByTarget,
+      conditionNodeIds,
+      excludedNodeIds: loopBodyNodeIds,
+    });
+    for (const orphanId of orphanedNodes) {
+      const orphanNode = nodeMap.get(orphanId);
+      const upstreamCount = edgesByTarget.get(orphanId)?.length ?? 0;
+      results[orphanId] = {
+        success: false,
+        error: `Node "${orphanNode ? getNodeName(orphanNode) : orphanId}" never executed although all ${upstreamCount} upstream branches completed`,
+      };
+    }
+    if (orphanedNodes.length > 0) {
+      logSystemError(
+        ErrorCategory.WORKFLOW_ENGINE,
+        "[Workflow Executor] Nodes never scheduled despite a clean upstream",
+        new Error(`orphaned_nodes=${orphanedNodes.join(",")}`),
+        {
+          ...baseLogLabels,
+          orphaned_node_count: String(orphanedNodes.length),
+        }
+      );
+    }
 
     // Branch-aware finalSuccess: exclude nodes on dead (not-taken) condition branches.
     // KEEP-395 Bug 2 hardening: re-evaluated AFTER drain so any failures from

--- a/lib/workflow/executor/final-success.ts
+++ b/lib/workflow/executor/final-success.ts
@@ -37,3 +37,75 @@ export function computeFinalSuccess(
   }
   return true;
 }
+
+export type OrphanedNodeScan = {
+  /** Nodes whose whole upstream finished cleanly but which never ran. */
+  attempted: ReadonlySet<string>;
+  results: Record<string, ExecutionResult>;
+  skipped: ReadonlySet<string>;
+  edgesByTarget: ReadonlyMap<string, string[]>;
+  conditionNodeIds: ReadonlySet<string>;
+  /**
+   * Nodes executed by a path other than the main traversal, so absence from
+   * `attempted` proves nothing about them. For Each body nodes run through
+   * runBodyNode and are accounted for by their For Each node's failedIterations.
+   */
+  excludedNodeIds?: ReadonlySet<string>;
+};
+
+/**
+ * Find nodes that should have executed but were never scheduled.
+ *
+ * `computeFinalSuccess` only inspects `results`, so a node the executor never
+ * reached cannot fail the run -- it is simply absent. That is invisible on a
+ * fan-in join: every parallel branch succeeds, the join's arrival count comes
+ * up short by one, the join and everything behind it never run, and the
+ * execution still reports success. For an alerting workflow that means the
+ * alert node silently never fires while the run shows green.
+ *
+ * A node is orphaned when it was never attempted, was not skipped by a
+ * condition branch, and every one of its predecessors completed without
+ * failing. If any predecessor failed, the node legitimately did not run and
+ * the run already reports that failure.
+ *
+ * Nodes fed by a condition are excluded: whether they run is the condition's
+ * routing decision, and on legacy edges that carry no sourceHandle the
+ * not-taken branch leaves no skip record to distinguish from an orphan.
+ */
+export function findOrphanedNodes(scan: OrphanedNodeScan): string[] {
+  const {
+    attempted,
+    results,
+    skipped,
+    edgesByTarget,
+    conditionNodeIds,
+    excludedNodeIds,
+  } = scan;
+  const orphaned: string[] = [];
+
+  for (const [nodeId, predecessors] of edgesByTarget) {
+    if (attempted.has(nodeId) || skipped.has(nodeId)) {
+      continue;
+    }
+    if (excludedNodeIds?.has(nodeId)) {
+      continue;
+    }
+    if (predecessors.length === 0) {
+      continue;
+    }
+    if (predecessors.some((predId) => conditionNodeIds.has(predId))) {
+      continue;
+    }
+    const upstreamClean = predecessors.every(
+      (predId) =>
+        attempted.has(predId) &&
+        !skipped.has(predId) &&
+        results[predId]?.success !== false
+    );
+    if (upstreamClean) {
+      orphaned.push(nodeId);
+    }
+  }
+
+  return orphaned.sort();
+}

--- a/lib/workflow/executor/get-completed-step-output.ts
+++ b/lib/workflow/executor/get-completed-step-output.ts
@@ -202,6 +202,17 @@ export function getCompletedStepOutput(
  * Same kill-switch, error containment, and iteration-row exclusion semantics as
  * getCompletedStepOutput. This is the preferred path for mergeFromAuthority to
  * reduce sequential DB round-trips on cold-pod 9-fan-in convergence.
+ *
+ * Replay determinism: the batch step is issued for the full `nodeIds` list on
+ * every call, never for "the subset the tracker is missing". The tracker is
+ * process-local memory populated by step bodies, and step bodies do not re-run
+ * on replay -- so a cold process sees a miss and creates the step while a warm
+ * replay of the same convergence sees a hit and skips it. The DevKit records
+ * that step_created event on the first pass, finds no matching call on the
+ * second, and aborts the run with "Unconsumed event in event log". Keeping the
+ * call unconditional keeps the step sequence identical across replays. The
+ * tracker is still consulted, but only to fill values the DB has not committed
+ * yet -- never to decide whether the step happens.
  */
 export async function getCompletedStepOutputs(
   executionId: string,
@@ -214,22 +225,26 @@ export async function getCompletedStepOutputs(
 
   const trackerSteps = getSuccessfulSteps(executionId);
 
-  const dbNodeIds: string[] = [];
-  for (const nodeId of nodeIds) {
-    if (trackerSteps?.has(nodeId)) {
-      result.set(nodeId, {
-        output: trackerSteps.get(nodeId),
-        source: "tracker",
-      });
-    } else {
-      dbNodeIds.push(nodeId);
+  const fillFromTracker = (): void => {
+    for (const nodeId of nodeIds) {
+      if (!result.has(nodeId) && trackerSteps?.has(nodeId)) {
+        result.set(nodeId, {
+          output: trackerSteps.get(nodeId),
+          source: "tracker",
+        });
+      }
     }
-  }
+  };
 
-  if (dbNodeIds.length === 0 || !DB_FALLBACK_ENABLED) {
+  // Seeded before the query so tracker entries keep the precedence they had
+  // when they were what decided the query's node list.
+  fillFromTracker();
+
+  if (!DB_FALLBACK_ENABLED) {
     return result;
   }
 
+  const dbNodeIds = [...nodeIds];
   const startMs = Date.now();
   try {
     const rows = await fetchCompletedStepOutputsBatchStep(

--- a/tests/unit/convergence-merge-authority.test.ts
+++ b/tests/unit/convergence-merge-authority.test.ts
@@ -114,8 +114,8 @@ describe("mergeFromAuthority (KEEP-395 cross-process DB fallback)", () => {
     expect(mockFetchBatch).not.toHaveBeenCalled();
   });
 
-  describe("fast path: tracker hit (same process)", () => {
-    it("uses tracker data without querying DB when tracker has the predecessor", async () => {
+  describe("tracker hit (same process)", () => {
+    it("uses tracker data but still issues the batch step so replays match", async () => {
       recordStepSuccess(executionId, "predA", { rate: 4.5 });
 
       const outputs: NodeOutputs = {
@@ -131,7 +131,10 @@ describe("mergeFromAuthority (KEEP-395 cross-process DB fallback)", () => {
       });
 
       expect(result.predA.data).toEqual({ rate: 4.5 });
-      expect(mockFetchBatch).not.toHaveBeenCalled();
+      // The tracker is process-local and empty on a cold pod, so letting it
+      // decide whether the step runs makes the step sequence differ between
+      // replays of the same convergence.
+      expect(mockFetchBatch).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/tests/unit/get-completed-step-output.test.ts
+++ b/tests/unit/get-completed-step-output.test.ts
@@ -425,7 +425,7 @@ describe("getCompletedStepOutputs (batch helper)", () => {
     }
   });
 
-  it("tracker hits are resolved without a DB call; only misses go to DB", async () => {
+  it("DB rows win; tracker fills only what the DB has not committed", async () => {
     recordStepSuccess(executionId, "p1", { fromTracker: true });
     recordStepSuccess(executionId, "p2", { fromTracker: true });
 
@@ -445,13 +445,17 @@ describe("getCompletedStepOutputs (batch helper)", () => {
     expect(mockFetchBatch).toHaveBeenCalledTimes(1);
   });
 
-  it("all tracker hits: no DB call issued", async () => {
+  it("issues the batch step for the full predecessor list even when the tracker has every entry", async () => {
     recordStepSuccess(executionId, "p1", { a: 1 });
     recordStepSuccess(executionId, "p2", { b: 2 });
 
     const result = await getCompletedStepOutputs(executionId, ["p1", "p2"]);
 
-    expect(mockFetchBatch).not.toHaveBeenCalled();
+    // Replay determinism: gating the step on tracker contents made a warm
+    // replay skip a step the cold pass created, which the DevKit rejects as an
+    // unconsumed step_created event and aborts the whole run over.
+    expect(mockFetchBatch).toHaveBeenCalledTimes(1);
+    expect(mockFetchBatch).toHaveBeenCalledWith(executionId, ["p1", "p2"]);
     expect(result.size).toBe(2);
   });
 

--- a/tests/unit/orphaned-fan-in-nodes.test.ts
+++ b/tests/unit/orphaned-fan-in-nodes.test.ts
@@ -181,6 +181,50 @@ describe("findOrphanedNodes", () => {
     expect(orphaned).toEqual([]);
   });
 
+  it("flags a single-predecessor node stranded after its join succeeded", () => {
+    // Observed in prod on a six-branch monitor: the join itself completed, and
+    // the condition hanging off it on one edge never ran. Stranding is not
+    // confined to the join -- any lost continuation leaves the run short.
+    const reads = ["r0", "r1", "r2", "r3", "r4", "r5"];
+    const edges: Edge[] = [
+      ...reads.map((id) => ({ source: "trigger", target: id })),
+      ...reads.map((id) => ({ source: id, target: "join" })),
+      { source: "join", target: "condition" },
+      { source: "condition", target: "alert" },
+    ];
+
+    const orphaned = findOrphanedNodes({
+      attempted: new Set(["trigger", ...reads, "join"]),
+      results: succeeded(["trigger", ...reads, "join"]),
+      skipped: new Set(),
+      edgesByTarget: edgesByTarget(edges),
+      conditionNodeIds: new Set(["condition"]),
+    });
+
+    expect(orphaned).toEqual(["condition"]);
+  });
+
+  it("does not flag an alert the condition legitimately routed away from", () => {
+    // The same workflow on a clean run: the join and condition both ran, the
+    // condition evaluated false, and the alert was correctly never reached.
+    const edges: Edge[] = [
+      { source: "a", target: "join" },
+      { source: "b", target: "join" },
+      { source: "join", target: "condition" },
+      { source: "condition", target: "alert" },
+    ];
+
+    const orphaned = findOrphanedNodes({
+      attempted: new Set(["a", "b", "join", "condition"]),
+      results: succeeded(["a", "b", "join", "condition"]),
+      skipped: new Set(),
+      edgesByTarget: edgesByTarget(edges),
+      conditionNodeIds: new Set(["condition"]),
+    });
+
+    expect(orphaned).toEqual([]);
+  });
+
   it("does not flag For Each body nodes, which run outside the main traversal", () => {
     const edges: Edge[] = [
       { source: "trigger", target: "foreach" },

--- a/tests/unit/orphaned-fan-in-nodes.test.ts
+++ b/tests/unit/orphaned-fan-in-nodes.test.ts
@@ -1,0 +1,220 @@
+/**
+ * A fan-in join is released by an arrival counter: each parallel branch adds
+ * its own id, and the branch that brings the count up to the join's in-degree
+ * is the one that runs it. If a single branch never signals, the join is never
+ * scheduled -- and because computeFinalSuccess only inspects nodes present in
+ * `results`, a node that was never scheduled cannot fail the run.
+ *
+ * That is what let a 14-wide monitor finish with its aggregate and Discord
+ * alert unrun and still report success. These tests pin the detection that
+ * turns the orphan into a real failure.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  computeFinalSuccess,
+  type ExecutionResult,
+  findOrphanedNodes,
+} from "@/lib/workflow/executor/final-success";
+
+type Edge = { source: string; target: string };
+
+function edgesByTarget(edges: Edge[]): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  for (const edge of edges) {
+    const sources = map.get(edge.target) ?? [];
+    if (!sources.includes(edge.source)) {
+      sources.push(edge.source);
+    }
+    map.set(edge.target, sources);
+  }
+  return map;
+}
+
+function succeeded(nodeIds: string[]): Record<string, ExecutionResult> {
+  return Object.fromEntries(nodeIds.map((id) => [id, { success: true }]));
+}
+
+/** trigger -> N parallel reads -> join -> condition -> alert */
+function fanInGraph(width: number): { edges: Edge[]; reads: string[] } {
+  const reads = Array.from({ length: width }, (_, i) => `read-${i}`);
+  const edges: Edge[] = [
+    ...reads.map((id) => ({ source: "trigger", target: id })),
+    ...reads.map((id) => ({ source: id, target: "join" })),
+    { source: "join", target: "condition" },
+    { source: "condition", target: "alert" },
+  ];
+  return { edges, reads };
+}
+
+describe("findOrphanedNodes", () => {
+  it("flags a join that never ran although every upstream branch completed", () => {
+    const { edges, reads } = fanInGraph(14);
+    const attempted = new Set(["trigger", ...reads]);
+
+    const orphaned = findOrphanedNodes({
+      attempted,
+      results: succeeded(["trigger", ...reads]),
+      skipped: new Set(),
+      edgesByTarget: edgesByTarget(edges),
+      conditionNodeIds: new Set(["condition"]),
+    });
+
+    expect(orphaned).toEqual(["join"]);
+  });
+
+  it("turns a silently-green run into a failure", () => {
+    const { edges, reads } = fanInGraph(14);
+    const results = succeeded(["trigger", ...reads]);
+
+    expect(computeFinalSuccess(results, new Set())).toBe(true);
+
+    for (const orphanId of findOrphanedNodes({
+      attempted: new Set(["trigger", ...reads]),
+      results,
+      skipped: new Set(),
+      edgesByTarget: edgesByTarget(edges),
+      conditionNodeIds: new Set(["condition"]),
+    })) {
+      results[orphanId] = { success: false, error: "never executed" };
+    }
+
+    expect(computeFinalSuccess(results, new Set())).toBe(false);
+  });
+
+  it("reports only the join, not the nodes stranded behind it", () => {
+    const { edges, reads } = fanInGraph(10);
+
+    const orphaned = findOrphanedNodes({
+      attempted: new Set(["trigger", ...reads]),
+      results: succeeded(["trigger", ...reads]),
+      skipped: new Set(),
+      edgesByTarget: edgesByTarget(edges),
+      conditionNodeIds: new Set(["condition"]),
+    });
+
+    expect(orphaned).not.toContain("condition");
+    expect(orphaned).not.toContain("alert");
+  });
+
+  it("stays quiet when the join ran", () => {
+    const { edges, reads } = fanInGraph(14);
+    const all = ["trigger", ...reads, "join", "condition", "alert"];
+
+    const orphaned = findOrphanedNodes({
+      attempted: new Set(all),
+      results: succeeded(all),
+      skipped: new Set(),
+      edgesByTarget: edgesByTarget(edges),
+      conditionNodeIds: new Set(["condition"]),
+    });
+
+    expect(orphaned).toEqual([]);
+  });
+
+  it("does not flag a join whose upstream failed", () => {
+    const { edges, reads } = fanInGraph(5);
+    const results = succeeded(["trigger", ...reads]);
+    results["read-2"] = { success: false, error: "rpc down" };
+
+    const orphaned = findOrphanedNodes({
+      attempted: new Set(["trigger", ...reads]),
+      results,
+      skipped: new Set(),
+      edgesByTarget: edgesByTarget(edges),
+      conditionNodeIds: new Set(["condition"]),
+    });
+
+    expect(orphaned).toEqual([]);
+  });
+
+  it("does not flag a node on a not-taken condition branch", () => {
+    const edges: Edge[] = [
+      { source: "trigger", target: "condition" },
+      { source: "condition", target: "alert" },
+    ];
+
+    const orphaned = findOrphanedNodes({
+      attempted: new Set(["trigger", "condition"]),
+      results: succeeded(["trigger", "condition"]),
+      skipped: new Set(["alert"]),
+      edgesByTarget: edgesByTarget(edges),
+      conditionNodeIds: new Set(["condition"]),
+    });
+
+    expect(orphaned).toEqual([]);
+  });
+
+  it("does not flag a condition's target when no skip was recorded", () => {
+    const edges: Edge[] = [
+      { source: "trigger", target: "condition" },
+      { source: "condition", target: "alert" },
+    ];
+
+    // Legacy edges carry no sourceHandle, so the not-taken branch leaves no
+    // skip record and an unrun target is indistinguishable from an orphan.
+    const orphaned = findOrphanedNodes({
+      attempted: new Set(["trigger", "condition"]),
+      results: succeeded(["trigger", "condition"]),
+      skipped: new Set(),
+      edgesByTarget: edgesByTarget(edges),
+      conditionNodeIds: new Set(["condition"]),
+    });
+
+    expect(orphaned).toEqual([]);
+  });
+
+  it("does not flag a disabled node, which is attempted but records no result", () => {
+    const edges: Edge[] = [
+      { source: "trigger", target: "disabled" },
+      { source: "disabled", target: "tail" },
+    ];
+
+    const orphaned = findOrphanedNodes({
+      attempted: new Set(["trigger", "disabled", "tail"]),
+      results: succeeded(["trigger", "tail"]),
+      skipped: new Set(),
+      edgesByTarget: edgesByTarget(edges),
+      conditionNodeIds: new Set(),
+    });
+
+    expect(orphaned).toEqual([]);
+  });
+
+  it("does not flag For Each body nodes, which run outside the main traversal", () => {
+    const edges: Edge[] = [
+      { source: "trigger", target: "foreach" },
+      { source: "foreach", target: "body-1" },
+      { source: "body-1", target: "body-2" },
+      { source: "body-2", target: "collect" },
+    ];
+
+    const orphaned = findOrphanedNodes({
+      attempted: new Set(["trigger", "foreach"]),
+      results: succeeded(["trigger", "foreach"]),
+      skipped: new Set(),
+      edgesByTarget: edgesByTarget(edges),
+      conditionNodeIds: new Set(),
+      excludedNodeIds: new Set(["body-1", "body-2", "collect"]),
+    });
+
+    expect(orphaned).toEqual([]);
+  });
+
+  it("flags a node stranded downstream of a disabled node", () => {
+    const edges: Edge[] = [
+      { source: "trigger", target: "disabled" },
+      { source: "disabled", target: "tail" },
+    ];
+
+    const orphaned = findOrphanedNodes({
+      attempted: new Set(["trigger", "disabled"]),
+      results: succeeded(["trigger"]),
+      skipped: new Set(),
+      edgesByTarget: edgesByTarget(edges),
+      conditionNodeIds: new Set(),
+    });
+
+    expect(orphaned).toEqual(["tail"]);
+  });
+});

--- a/tests/unit/step-function-preload.test.ts
+++ b/tests/unit/step-function-preload.test.ts
@@ -1,0 +1,166 @@
+/**
+ * The durability layer assigns step identity by invocation order: the Nth
+ * `useStep` call in a run gets the Nth id, with no name or content matching. A
+ * replay must therefore invoke steps in exactly the order the event log
+ * recorded, or every id past the divergence point refers to the wrong step.
+ *
+ * `executeActionStep` used to `await importer()` right before calling the step,
+ * which put the invocation into a racing microtask -- real module I/O on the
+ * first pass, a resolved cache hit on replay. With N branches fanned out in
+ * parallel that reorders the step calls between passes.
+ *
+ * Preloading every reachable step module up front removes that await, so the
+ * fan-out path is synchronous from executeNode through to the step call.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const importOrder: string[] = [];
+
+function makeImporter(actionType: string, fnName: string) {
+  return {
+    importer: async () => {
+      importOrder.push(actionType);
+      await Promise.resolve();
+      return { [fnName]: vi.fn() };
+    },
+    stepFunction: fnName,
+  };
+}
+
+vi.mock("@/lib/step-registry", () => ({
+  getStepImporter: (actionType: string) => {
+    if (actionType === "web3/read-contract") {
+      return makeImporter(actionType, "readContractStep");
+    }
+    if (actionType === "web3/query-events") {
+      return makeImporter(actionType, "queryEventsStep");
+    }
+    if (actionType === "discord/send-message") {
+      return makeImporter(actionType, "sendMessageStep");
+    }
+    return;
+  },
+}));
+
+vi.mock("@/plugins/legacy-mappings", () => ({
+  LEGACY_ACTION_MAPPINGS: { "web3/old-read": "web3/read-contract" },
+}));
+
+const { preloadStepFunctions } = await import(
+  "@/lib/workflow/executor/executor.workflow"
+);
+type WorkflowNode = Parameters<typeof preloadStepFunctions>[0][number];
+
+type TestNode = {
+  id: string;
+  data: {
+    type: string;
+    label?: string;
+    config?: { actionType?: string };
+  };
+};
+
+function actionNode(id: string, actionType: string): TestNode {
+  return { id, data: { type: "action", config: { actionType } } };
+}
+
+// WorkflowNode carries position/measured fields this unit never reads.
+const asNodes = (nodes: TestNode[]): WorkflowNode[] =>
+  nodes as unknown as WorkflowNode[];
+
+describe("preloadStepFunctions", () => {
+  beforeEach(() => {
+    importOrder.length = 0;
+  });
+
+  it("resolves a step function for every action type in the graph", async () => {
+    const table = await preloadStepFunctions(
+      asNodes([
+        { id: "trigger", data: { type: "trigger" } },
+        actionNode("r1", "web3/read-contract"),
+        actionNode("r2", "web3/read-contract"),
+        actionNode("alert", "discord/send-message"),
+      ])
+    );
+
+    expect(typeof table.get("web3/read-contract")).toBe("function");
+    expect(typeof table.get("discord/send-message")).toBe("function");
+  });
+
+  it("imports each distinct action type once, however many nodes use it", async () => {
+    await preloadStepFunctions(
+      asNodes(
+        Array.from({ length: 14 }, (_, i) =>
+          actionNode(`read-${i}`, "web3/query-events")
+        )
+      )
+    );
+
+    expect(importOrder).toEqual(["web3/query-events"]);
+  });
+
+  it("resolves in a stable order regardless of node order", async () => {
+    const forward = asNodes([
+      actionNode("a", "web3/read-contract"),
+      actionNode("b", "discord/send-message"),
+      actionNode("c", "web3/query-events"),
+    ]);
+    await preloadStepFunctions(forward);
+    const firstPass = [...importOrder];
+
+    importOrder.length = 0;
+    await preloadStepFunctions(asNodes([...forward].reverse()));
+
+    expect(importOrder).toEqual(firstPass);
+  });
+
+  it("follows legacy action renames", async () => {
+    const table = await preloadStepFunctions(
+      asNodes([actionNode("legacy", "web3/old-read")])
+    );
+
+    expect(typeof table.get("web3/old-read")).toBe("function");
+  });
+
+  it("skips an unknown action type without throwing", async () => {
+    const table = await preloadStepFunctions(
+      asNodes([
+        actionNode("good", "web3/read-contract"),
+        actionNode("bogus", "not-a-real/action"),
+      ])
+    );
+
+    expect(table.has("not-a-real/action")).toBe(false);
+    expect(typeof table.get("web3/read-contract")).toBe("function");
+  });
+
+  it("covers For Each body nodes, which are not reached by graph traversal", async () => {
+    const table = await preloadStepFunctions(
+      asNodes([
+        actionNode("loop", "For Each"),
+        actionNode("body", "web3/read-contract"),
+      ])
+    );
+
+    expect(typeof table.get("web3/read-contract")).toBe("function");
+  });
+
+  it("leaves no import pending, so later step calls need no await to dispatch", async () => {
+    const nodes = asNodes([
+      actionNode("r1", "web3/read-contract"),
+      actionNode("q1", "web3/query-events"),
+    ]);
+
+    const table = await preloadStepFunctions(nodes);
+    importOrder.length = 0;
+
+    // Dispatch is a synchronous Map read; nothing re-enters the importer.
+    for (const actionType of ["web3/read-contract", "web3/query-events"]) {
+      expect(table.get(actionType)).toBeDefined();
+    }
+    expect(importOrder).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

A workflow that fans out into parallel branches and joins them at a downstream node could fail three different ways, all from one cause:

- **Run dies ~1s in** with `Unconsumed event in event log`, leaving the execution stuck at `running` until the no-progress reconciler closes it out as an executor timeout, despite every node completing in well under a second.
- **Steps that succeeded get reported as `exceeded max retries`**, with the node's own execution log showing success in ~100ms.
- **Run reports `success` with the join and everything behind it never executed** (condition, alerting steps). For a monitoring workflow that means it shows green while silently never alerting.

Stranding is not limited to the join. On one six-branch case the join itself completed and the single-predecessor condition hanging off it never ran. Reliability worsened with fan-in width, but there was no safe width: a six-branch workflow failed the same way.

## Cause

Step identity in the durability layer is positional. `correlationId` comes from a monotonic ULID seeded per run with a fixed timestamp, so the Nth step call receives the Nth id, with no name or content matching. A replay must invoke steps in the same order the event log recorded, or every id past the first divergence refers to the wrong step. The runtime then either finds a recorded event no live call claims and aborts the run, or fails to locate a step's completion, re-enqueues it, and trips the max-retries guard on a step whose body already succeeded.

`executeActionStep` awaited a dynamic module import immediately before invoking the step. That await handed ordering to microtask scheduling: on the first pass the import is real module I/O, on a replay it is an already-resolved cache hit. Branches fanned out with `Promise.allSettled` therefore reached their step calls in different orders on different passes. Branches that finish at similar times are the worst case, since their relative order is decided by jitter rather than by anything stable.

## Changes

**Invocation ordering (the cause).** Resolve every step module the graph can reach in one sorted pass up front, before any step runs. Dispatch becomes a synchronous map lookup, leaving the fan-out path from `executeNode` through to the step call free of awaits, so order follows the graph rather than module-load timing. The preload invokes no steps and adds nothing to the event log. A module that fails to load is skipped and reported at call time against its own node instead of aborting the run. For Each body nodes are included, since they invoke steps through the same path without being reached by graph traversal.

**Convergence lookup no longer varies with process memory.** The batch predecessor lookup issued its step only for entries missing from the in-process success tracker, and created no step at all when the tracker held them all. That tracker is process-local memory populated by step bodies, and step bodies do not re-run on replay, so a cold pass created the step while a warm replay of the same convergence skipped it. The batch step is now issued for the full predecessor list every call; the tracker still supplies values and keeps its previous precedence.

**Recovery poll can no longer strand a join.** The spurious-recovery poll is itself a step and can throw its own max-retries error. Unguarded, that escape abandoned the rest of the catch block including the convergence-arrival signal, leaving a join waiting forever on an arrival that never came.

**Never-scheduled nodes now fail the run.** `computeFinalSuccess` only inspected nodes present in `results`, so a node the executor never scheduled could not fail the run and simply vanished from the tally. `findOrphanedNodes` records a failure for any node that was never attempted, was not skipped by a condition branch, and whose every predecessor completed cleanly. Nodes fed by a condition are excluded, since whether they run is the condition's routing decision and legacy edges without a source handle leave no skip record to distinguish from an orphan. For Each body nodes are excluded because they execute through `runBodyNode` rather than `executeNode`, so absence from the attempted set proves nothing about them, and their failures already surface via the For Each node's failed-iteration count.

Note this last change is a safety net for the false-success variant only. When the runtime aborts the run over a corrupted event log the workflow body never reaches finalization, so it cannot fire there.

## CI

`build-executor-image` built both the executor and workflow-runner images in one job. Each runs a full production build from the same Dockerfile, and doing both on one runner exhausted it, terminating the VM mid-build twice. Split into a matrix so each image gets its own runner, matching how `build-images` already separates app and migrator. Image tags, ECR repositories and cache scoping are unchanged.

## Validation

Verified on a PR environment running this branch's executor **and** runner image, against three synthetic fan-in workflows (14, 10 and 6 branches into one join, then a condition and a tail step) with the same node and edge counts as the affected monitors.

Only manual runs count: with `EXECUTION_MODE=isolated`, scheduled runs are dispatched to a k8s Job that calls `executeWorkflow` directly with no event log and no replay, so they cannot exercise this path. Every manual execution produced a durable run.

**43 manual runs, all clean:**

| Signal | Before | After |
|---|---|---|
| `Unconsumed event in event log` | 3 of 10 runs | 0 of 43 |
| `exceeded max retries` on succeeded steps | present | 0 |
| Failed durable runs | 3 | 0 of 43 |
| Join never ran | repeatedly | 0 of 43 |
| Condition never ran | yes | 0 of 43 |

Completed-step counts became perfectly consistent: 17/18, 13/14 and 9/10 on every single run, where the same 14-branch workflow previously alternated between 15 and 17. The one uncounted node is the tail step, correctly skipped when the condition evaluates false. The 14-branch runs alone wrote 304 steps and 960 event-log entries with `max_attempt = 1` and zero retries.

The earlier failure rate was roughly 30% of manual runs, so 43 consecutive clean runs is on the order of one in eight million by chance. The orphan detection also did not misfire on any of the 43, which was the main regression risk.

Unit suite: 531 files, 20841 tests.
