### PR TITLE
fix: stop the getting-started card swallowing clicks on the canvas

### DIFF
--- a/lib/hooks/use-getting-started.ts
+++ b/lib/hooks/use-getting-started.ts
@@ -91,6 +91,13 @@ function readPersisted(userId: string | undefined): Persisted {
   if (typeof window === "undefined") {
     return fallback;
   }
+  // Checked before the stored state, not only in place of it. A saved
+  // Playwright session carries the localStorage written when the launcher
+  // expanded during sign-in, so honouring the cookie only on a missing entry
+  // left the card open in every test that reused that session.
+  if (gettingStartedSuppressed()) {
+    return fallback;
+  }
   try {
     const raw = localStorage.getItem(storageKey(userId));
     if (!raw) {
@@ -101,9 +108,7 @@ function readPersisted(userId: string | undefined): Persisted {
       // (userId undefined) stays collapsed and existing users do not flash open
       // before their stored collapsed state loads. Playwright suppresses the
       // auto-expand by cookie so the card never covers the canvas.
-      return userId && !gettingStartedSuppressed()
-        ? { ...fallback, state: "expanded" }
-        : fallback;
+      return userId ? { ...fallback, state: "expanded" } : fallback;
     }
     const parsed = JSON.parse(raw) as Partial<Persisted>;
     return {

--- a/tests/e2e/playwright/onboarding.test.ts
+++ b/tests/e2e/playwright/onboarding.test.ts
@@ -2,8 +2,9 @@ import { expect, test } from "./fixtures";
 
 // Re-enable the onboarding tours for this file. The rest of the suite disables
 // them by default (see fixtures.ts) so the driver.js overlay never blocks
-// unrelated tests.
-test.use({ disableTours: false });
+// unrelated tests. The launcher comes back too, since the tour starts from its
+// "Take a tour" button.
+test.use({ disableGettingStarted: false, disableTours: false });
 
 const WORKFLOW_EDITOR_URL_REGEX = /\/workflows\/[^/]+/;
 

--- a/tests/e2e/playwright/workflow-io-modal.test.ts
+++ b/tests/e2e/playwright/workflow-io-modal.test.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 import { createWorkflow } from "./utils/workflow";
 
 const VALID_FIXTURE_PATH = join(


### PR DESCRIPTION
Six Playwright tests time out on `staging`, all on the same click:

```
Error: locator.click: Test timeout of 60000ms exceeded.
  - waiting for locator(".react-flow__node-trigger").first()
    - locator resolved to <div ... react-flow__node-trigger ...>
  - attempting click action
    - element is visible, enabled and stable
    - <div class="pointer-events-auto fixed top-[calc(60px+...)] bottom-0 left-0 z-40 ...">
        subtree intercepts pointer events
```

The node is found and reported stable. The click never lands because the first-run **Get started** card expands out of the sidebar, overhangs the canvas, and sits on top of the node. A screenshot from the failing run shows the card covering it.

## Why the existing guard did not hold

`fixtures.ts` already sets a `kh_disable_gs` cookie for this, and `readPersisted` honoured it. But only on the branch where `localStorage` had no entry.

Signing in expands the launcher and persists `state: "expanded"`. `auth.setup.ts` saves `localStorage` into the `storageState` every test reuses. So by the time a test ran, the stored entry existed, the early-return fired, and the cookie was never consulted. The card was open in every test that reused a saved session.

The cookie is now read before the stored state. Nothing outside Playwright sets it, and `getting-started.test.ts` still opts out to exercise the real first-run behaviour.

`workflow-io-modal.test.ts` also imported `test` from `@playwright/test` rather than from `./fixtures`, so it never received the cookie at all.

`onboarding.test.ts` opts back in via `disableGettingStarted: false`, because the walkthrough it tests starts from the launcher own button.

## Verification

Against a database built from scratch in CI order (`db:setup-workflow` → `db:migrate` → `db:seed` → `db:seed-test-wallet`):

- Before: `workflow-io-modal` 4 failed, `schedule-trigger` 1 failed 1 flaky.
- After: `14 passed (41.1s)`, down from six 60-second timeouts.
- `onboarding` + `getting-started` together: `10 passed`.
- Whole suite: 12 failures down to 9, and 33 minutes down to 15 with the timeouts gone.

The 9 that remain are local-environment and pass in CI: signup rate limiting on the OTP step, anonymous-guest session mint failing with `net::ERR_ABORTED`, unseeded analytics fixtures, and two `wallet-org-mfa-enforce` tests that expect a redirect `LOAD_TEST_BYPASS_TOKEN` suppresses. `INV-SEND-2` was already failing on staging before any of this work.