### PR TITLE
fix: let prod use the image it just built

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -46,15 +46,18 @@ jobs:
       caller_action: ${{ github.event.action }}
       has_e2e_label: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-e2e-tests-ephemeral') || false }}
       label_name: ${{ github.event.label.name || '' }}
-      # Pass build outputs only on staging; '' must be the `||` fallthrough since
-      # an empty string is falsy (`cond && '' || x` would always yield x).
-      image_tag: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.image_tag || '') || '' }}
-      # Prebuilt sandbox ref, staging only (same fallthrough rule as image_tag);
-      # empty on PRs/prod makes the e2e jobs build the sandbox locally.
-      sandbox_image: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.sandbox_image || '') || '' }}
-      ecr_registry: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.ecr_registry || '') || '' }}
-      ecr_repo: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.ecr_repo || '') || '' }}
-      ecr_region: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.ecr_region || '') || '' }}
+      # Pass the build outputs whenever build-images produced them, which is
+      # every event except a pull request. Restricting this to staging left prod
+      # rebuilding the app from source on the runner while the image it had just
+      # pushed went unused. '' must be the `||` fallthrough since an empty
+      # string is falsy (`cond && '' || x` would always yield x).
+      image_tag: ${{ github.event_name != 'pull_request' && (needs.build-images.outputs.image_tag || '') || '' }}
+      # Prebuilt sandbox ref (same fallthrough rule as image_tag); empty on PRs
+      # makes the e2e jobs build the sandbox locally.
+      sandbox_image: ${{ github.event_name != 'pull_request' && (needs.build-images.outputs.sandbox_image || '') || '' }}
+      ecr_registry: ${{ github.event_name != 'pull_request' && (needs.build-images.outputs.ecr_registry || '') || '' }}
+      ecr_repo: ${{ github.event_name != 'pull_request' && (needs.build-images.outputs.ecr_repo || '') || '' }}
+      ecr_region: ${{ github.event_name != 'pull_request' && (needs.build-images.outputs.ecr_region || '') || '' }}
     secrets: inherit
 
   # Sentry source-map upload, fanned out from build-images alongside e2e so it


### PR DESCRIPTION
Prod releases are blocked on `e2e-tests / build-app`, which has failed four times in a row.

## Why prod and not staging

`build-images` runs on every push and pushes an image. Its outputs were forwarded to the e2e workflow only when the ref was `staging`:

```yaml
image_tag: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.image_tag || '') || '' }}
```

On prod they arrive empty, and `build-app` runs precisely when `inputs.image_tag == ''`. So prod rebuilt the entire app with `pnpm build` on an `ubuntu-latest` runner while the image it had just pushed went unused. Staging skips that job entirely, which is why only prod is affected.

## Why that build now fails

It reaches its memory peak roughly three minutes in and takes the runner down with it:

```
##[error]The runner has received a shutdown signal
##[error]The operation was canceled
```

Not a compiler error, and not the same step twice: two attempts died inside the TypeScript pass, one before the compile finished. The last time it fit was 2026-08-12, where the TypeScript pass alone ran 79 seconds and completed. Prod has taken a release since. The same build passes locally in 54s compile plus 22s TypeScript, and a cold `tsc` peaks at 3.5 GB against a 7 GB runner.

## The change

Forward the outputs on any non-pull-request event, which is exactly when `build-images` has produced them. Prod then skips `build-app` like staging does, and the e2e jobs run against the image rather than a second copy compiled next to it.

Coverage is unchanged: the same suites still run on prod, against the artifact that actually ships, which is closer to the truth than testing a separately compiled copy.

Ruled out along the way: concurrency cancellation (group is `run_id` for pushes, `cancel-in-progress` only for PRs), cache corruption (both the failing and last-green runs restore cleanly), and the two foundry-pinning commits from the last day, which only touch the anvil image for protocol tests.