### PR TITLE
fix(billing): stop invoice.paid asserting a subscription status

### DIFF
--- a/lib/billing/handle-billing-event.ts
+++ b/lib/billing/handle-billing-event.ts
@@ -53,6 +53,32 @@ function planChangeDirection(
 
 type SubscriptionRow = typeof organizationSubscriptions.$inferSelect;
 
+/**
+ * Count a trial conversion when a row leaves "trialing" for "active".
+ *
+ * Either handler can observe that move. At trial end the provider charges the
+ * card and sends both invoice.paid and subscription.updated, and whichever
+ * arrives first is the one that writes "active". Counting it in only one of
+ * them loses the conversion whenever the other wins the race.
+ *
+ * Each caller reads the row before its own write, so the handler that arrives
+ * second already sees "active" and counts nothing.
+ */
+function recordTrialConversion(
+  previousStatus: string,
+  nextStatus: string | undefined,
+  plan: PlanName,
+  tier: string | null
+): void {
+  if (!(previousStatus === "trialing" && nextStatus === "active")) {
+    return;
+  }
+  getMetricsCollector().incrementCounter(MetricNames.BILLING_TRIAL_CONVERTED, {
+    plan,
+    tier: tier ?? "none",
+  });
+}
+
 async function findSubscriptionByProviderId(
   providerSubscriptionId: string
 ): Promise<SubscriptionRow | undefined> {
@@ -444,12 +470,12 @@ async function handleSubscriptionUpdated(
 
   // Trial conversion: a trialing subscription became active (card charged at
   // trial end). This is the funnel counterpart to billing.trial.started.
-  if (current.status === "trialing" && data.status === "active") {
-    metrics.incrementCounter(MetricNames.BILLING_TRIAL_CONVERTED, {
-      plan: newPlan,
-      tier: (update.tier as string | null) ?? current.tier ?? "none",
-    });
-  }
+  recordTrialConversion(
+    current.status,
+    data.status,
+    newPlan,
+    (update.tier as string | null) ?? current.tier
+  );
 
   // Plan change is signaled by priceChanged in buildSubscriptionUpdate
   // (only present in the update payload when the price differs).
@@ -602,14 +628,18 @@ async function handleSubscriptionDeleted(
   // cannot move below the update.
   await collectFinalPeriodOverageSafely(current);
 
+  // plan and tier drop to free because every entitlement read decides access
+  // from plan alone. providerSubscriptionId and providerPriceId stay: clearing
+  // them left no record that this org ever held this subscription, so the
+  // churned trial fell outside the trials query and could never be counted.
+  // Keeping the id is safe against a late event for the dead subscription,
+  // because invoice.paid now resolves the real status from the provider.
   await db
     .update(organizationSubscriptions)
     .set({
       plan: "free",
       tier: null,
       status: "canceled",
-      providerSubscriptionId: null,
-      providerPriceId: null,
       cancelAtPeriodEnd: false,
       updatedAt: now,
     })
@@ -703,6 +733,39 @@ async function markOverageRecordsPaid(
   }
 }
 
+/**
+ * The status the provider reports for a subscription, or undefined when that
+ * read fails.
+ *
+ * A paid invoice proves an invoice was paid. It does not prove the subscription
+ * is active: the provider issues a paid $0 invoice at trial start, so treating
+ * invoice.paid as an activation overwrote "trialing" whenever the event won its
+ * race with row creation. The subscription object is the only authority for its
+ * own status.
+ *
+ * Returns undefined instead of a guess, so the caller leaves the stored status
+ * alone rather than writing one it cannot support.
+ */
+async function readSubscriptionStatus(
+  providerSubscriptionId: string,
+  provider: BillingProvider
+): Promise<string | undefined> {
+  try {
+    const details = await provider.getSubscriptionDetails(
+      providerSubscriptionId
+    );
+    return details.status;
+  } catch (error) {
+    logSystemWarn(
+      ErrorCategory.BILLING,
+      `${LOG_PREFIX} Could not read the subscription status; leaving the stored status unchanged`,
+      error,
+      { provider_subscription_id: providerSubscriptionId }
+    );
+    return undefined;
+  }
+}
+
 async function handleInvoicePaid(
   data: BillingWebhookEvent["data"],
   provider: BillingProvider
@@ -718,21 +781,38 @@ async function handleInvoicePaid(
     console.info(LOG_PREFIX, "invoice.paid - subId:", providerSubscriptionId);
 
     const sub = await findSubscriptionByProviderId(providerSubscriptionId);
+    const status = await readSubscriptionStatus(
+      providerSubscriptionId,
+      provider
+    );
+
+    const update: Partial<typeof organizationSubscriptions.$inferInsert> = {
+      billingAlert: null,
+      billingAlertUrl: null,
+      updatedAt: new Date(),
+    };
+    if (status !== undefined) {
+      update.status = status;
+    }
 
     await db
       .update(organizationSubscriptions)
-      .set({
-        status: "active",
-        billingAlert: null,
-        billingAlertUrl: null,
-        updatedAt: new Date(),
-      })
+      .set(update)
       .where(
         eq(
           organizationSubscriptions.providerSubscriptionId,
           providerSubscriptionId
         )
       );
+
+    if (sub) {
+      recordTrialConversion(
+        sub.status,
+        status,
+        parsePlanName(sub.plan, "free"),
+        sub.tier
+      );
+    }
 
     if (sub && invoiceId) {
       await markOverageRecordsPaid(sub.organizationId, invoiceId, provider);

--- a/lib/billing/trial.ts
+++ b/lib/billing/trial.ts
@@ -124,10 +124,13 @@ export function isTrialEligible(
   // text and every other read path runs it through parsePlanName, so parse here
   // too: a raw compare calls an org ineligible over a value the rest of the app
   // already treats as free (pay-as-you-go orgs, legacy rows).
-  if (
-    sub.providerSubscriptionId != null ||
-    parsePlanName(sub.plan) !== "free"
-  ) {
+  //
+  // A churned row keeps its providerSubscriptionId so the org's trial history
+  // stays measurable, so the id alone no longer means "subscribed". Pair it
+  // with the status, the way the checkout and preview-proration routes do.
+  const stillSubscribed =
+    sub.providerSubscriptionId != null && sub.status !== "canceled";
+  if (stillSubscribed || parsePlanName(sub.plan) !== "free") {
     return false;
   }
   // First-timer: never trialed, and not a previously-subscribed-then-reset org.

--- a/scripts/reconcile-stripe-subscriptions.ts
+++ b/scripts/reconcile-stripe-subscriptions.ts
@@ -1,0 +1,310 @@
+/**
+ * Reconcile organization_subscriptions against the billing provider.
+ *
+ * The webhook handler keeps the table in step with the provider, but only for
+ * the events that actually arrive. A missed delivery leaves the row behind, and
+ * nothing re-reads the provider afterwards, so a wrong row stays wrong. This
+ * script compares the provider's subscription list against the table and prints
+ * the SQL that repairs it.
+ *
+ * The script reads the provider and prints SQL. It never connects to the
+ * database. The production database is reachable only from inside the cluster
+ * and the provider key must stay there, so one process cannot hold both. The
+ * split also puts the exact statements in front of a person before anything is
+ * written.
+ *
+ * Usage:
+ *   # 1. list the subscriptions from inside the cluster, so the key stays there
+ *   kubectl exec -n keeperhub <app-pod> -- sh -c \
+ *     'curl -sS "https://api.stripe.com/v1/subscriptions?status=all&limit=100" \
+ *       -u "$STRIPE_SECRET_KEY:"' > subscriptions.json
+ *
+ *   # 2. turn the list into SQL (dry run: the script ends the file with ROLLBACK)
+ *   pnpm tsx scripts/reconcile-stripe-subscriptions.ts < subscriptions.json > repair.sql
+ *
+ *   # 3. read repair.sql, then run it and check the reported row counts
+ *   kubectl exec -i -n keeperhub psql-client -- psql "$DATABASE_URL" -f - < repair.sql
+ *
+ *   # 4. re-generate with --apply once the counts look right, then run it again
+ *   pnpm tsx scripts/reconcile-stripe-subscriptions.ts --apply < subscriptions.json
+ *
+ * With STRIPE_SECRET_KEY set and nothing piped in, the script calls the provider
+ * itself. That is the convenient form for a dev or staging database.
+ */
+
+import { Buffer } from "node:buffer";
+import process from "node:process";
+
+type StripeSubscription = {
+  id: string;
+  status: string;
+  customer: string | { id: string };
+  trial_start: number | null;
+  trial_end: number | null;
+  ended_at: number | null;
+  items: { data: { price: { id: string } }[] };
+};
+
+type StripeSubscriptionList = {
+  data?: StripeSubscription[];
+  has_more?: boolean;
+  error?: { message: string };
+};
+
+type Repair = {
+  subscriptionId: string;
+  customerId: string;
+  assignments: string[];
+  // Conditions that are true only while the row still disagrees with the
+  // provider. They make each statement report exactly the rows it had to fix.
+  disagreements: string[];
+};
+
+// Provider ids and statuses are interpolated into SQL, so anything outside this
+// shape aborts the run rather than reaching the database.
+const SAFE_ID = /^[A-Za-z0-9_]+$/;
+const SAFE_STATUS = /^[a-z_]+$/;
+
+const PAGE_SIZE = 100;
+
+// A subscription in one of these states is over. Stripe also stamps ended_at,
+// but only for subscriptions that actually ran, so check both.
+const ENDED_STATUSES = new Set(["canceled", "incomplete_expired"]);
+
+function assertSafeId(value: string, what: string): string {
+  if (!SAFE_ID.test(value)) {
+    throw new Error(`Refusing to build SQL from an unexpected ${what}: ${value}`);
+  }
+  return value;
+}
+
+function assertSafeStatus(value: string): string {
+  if (!SAFE_STATUS.test(value)) {
+    throw new Error(`Refusing to build SQL from an unexpected status: ${value}`);
+  }
+  return value;
+}
+
+function customerIdOf(subscription: StripeSubscription): string | undefined {
+  const { customer } = subscription;
+  return typeof customer === "string" ? customer : customer?.id;
+}
+
+/** Epoch seconds as the naive UTC literal the timestamp columns hold. */
+function toSqlTimestamp(epochSeconds: number): string {
+  const iso = new Date(epochSeconds * 1000).toISOString();
+  return `TIMESTAMP '${iso.slice(0, 19).replace("T", " ")}'`;
+}
+
+function hasEnded(subscription: StripeSubscription): boolean {
+  return (
+    subscription.ended_at !== null || ENDED_STATUSES.has(subscription.status)
+  );
+}
+
+function buildRepair(subscription: StripeSubscription): Repair | undefined {
+  const customerId = customerIdOf(subscription);
+  if (!customerId) {
+    return undefined;
+  }
+
+  const subscriptionId = assertSafeId(subscription.id, "subscription id");
+  assertSafeId(customerId, "customer id");
+  const status = assertSafeStatus(subscription.status);
+  const priceId = subscription.items?.data?.[0]?.price?.id;
+
+  const assignments = [
+    `status = '${status}'`,
+    `provider_subscription_id = '${subscriptionId}'`,
+  ];
+  const disagreements = [
+    `status IS DISTINCT FROM '${status}'`,
+    `provider_subscription_id IS DISTINCT FROM '${subscriptionId}'`,
+  ];
+
+  if (priceId) {
+    assertSafeId(priceId, "price id");
+    assignments.push(`provider_price_id = '${priceId}'`);
+    disagreements.push(`provider_price_id IS DISTINCT FROM '${priceId}'`);
+  }
+
+  // Only ever fill a missing trial stamp. Ours records when our checkout began
+  // and the provider's records when the trial did, so they differ by seconds on
+  // rows that are already correct.
+  if (subscription.trial_start !== null) {
+    const startedAt = toSqlTimestamp(subscription.trial_start);
+    assignments.push(`trial_started_at = COALESCE(trial_started_at, ${startedAt})`);
+    disagreements.push("trial_started_at IS NULL");
+  }
+
+  // A subscription that is over leaves the org on the free plan. Every
+  // entitlement read decides access from plan alone, so this is what actually
+  // revokes it.
+  if (hasEnded(subscription)) {
+    assignments.push("plan = 'free'", "tier = NULL");
+    disagreements.push("plan IS DISTINCT FROM 'free'", "tier IS NOT NULL");
+  }
+
+  assignments.push("updated_at = now()");
+
+  return { subscriptionId, customerId, assignments, disagreements };
+}
+
+function renderUpdate(repair: Repair): string {
+  const { subscriptionId, customerId, assignments, disagreements } = repair;
+  return [
+    `-- ${subscriptionId}`,
+    "UPDATE organization_subscriptions SET",
+    assignments.map((a) => `  ${a}`).join(",\n"),
+    `WHERE provider_customer_id = '${customerId}'`,
+    // Never take a row that already belongs to another subscription: the org
+    // subscribed again, and that newer row is the correct one.
+    `  AND (provider_subscription_id IS NULL OR provider_subscription_id = '${subscriptionId}')`,
+    `  AND (${disagreements.join("\n       OR ")});`,
+  ].join("\n");
+}
+
+function renderUnreachableReport(repairs: Repair[]): string {
+  const values = repairs
+    .map((r) => `    ('${r.subscriptionId}', '${r.customerId}')`)
+    .join(",\n");
+  return [
+    "-- Subscriptions this repair could not reach. Each one needs a decision.",
+    "SELECT v.subscription_id, v.customer_id,",
+    "  CASE WHEN s.id IS NULL THEN 'no organization row for this customer'",
+    "       ELSE 'row already belongs to ' || s.provider_subscription_id END AS reason",
+    "FROM (VALUES",
+    values,
+    "  ) AS v(subscription_id, customer_id)",
+    "LEFT JOIN organization_subscriptions s ON s.provider_customer_id = v.customer_id",
+    "WHERE s.id IS NULL",
+    "   OR (s.provider_subscription_id IS NOT NULL",
+    "       AND s.provider_subscription_id <> v.subscription_id);",
+  ].join("\n");
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function parseList(raw: string): StripeSubscriptionList {
+  const parsed = JSON.parse(raw) as StripeSubscriptionList;
+  if (parsed.error) {
+    throw new Error(`The provider returned an error: ${parsed.error.message}`);
+  }
+  if (!Array.isArray(parsed.data)) {
+    throw new Error("The provider response carries no subscription list");
+  }
+  return parsed;
+}
+
+async function fetchFromProvider(
+  secretKey: string
+): Promise<StripeSubscription[]> {
+  const all: StripeSubscription[] = [];
+  let startingAfter: string | undefined;
+
+  for (;;) {
+    const url = new URL("https://api.stripe.com/v1/subscriptions");
+    url.searchParams.set("status", "all");
+    url.searchParams.set("limit", String(PAGE_SIZE));
+    if (startingAfter) {
+      url.searchParams.set("starting_after", startingAfter);
+    }
+
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Basic ${Buffer.from(`${secretKey}:`).toString("base64")}`,
+      },
+    });
+    const page = parseList(await response.text());
+    const data = page.data ?? [];
+    all.push(...data);
+
+    const last = data.at(-1);
+    if (!(page.has_more && last)) {
+      return all;
+    }
+    startingAfter = last.id;
+  }
+}
+
+async function loadSubscriptions(): Promise<StripeSubscription[]> {
+  if (!process.stdin.isTTY) {
+    const raw = (await readStdin()).trim();
+    if (raw.length > 0) {
+      const page = parseList(raw);
+      if (page.has_more) {
+        throw new Error(
+          `The piped list is truncated (has_more is true). Page through the provider or raise limit above ${PAGE_SIZE}.`
+        );
+      }
+      return page.data ?? [];
+    }
+  }
+
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  if (!secretKey) {
+    throw new Error(
+      "Pipe a subscription list in, or set STRIPE_SECRET_KEY to let the script fetch one"
+    );
+  }
+  return await fetchFromProvider(secretKey);
+}
+
+async function main(): Promise<void> {
+  const apply = process.argv.includes("--apply");
+  const subscriptions = await loadSubscriptions();
+
+  const repairs: Repair[] = [];
+  const skipped: string[] = [];
+  for (const subscription of subscriptions) {
+    const repair = buildRepair(subscription);
+    if (repair) {
+      repairs.push(repair);
+    } else {
+      skipped.push(subscription.id);
+    }
+  }
+
+  const lines = [
+    "-- Generated by scripts/reconcile-stripe-subscriptions.ts",
+    `-- ${subscriptions.length} subscription(s) read from the provider, ${repairs.length} statement(s) below.`,
+    "-- Each UPDATE reports the rows that actually disagreed, so a count of 0 means that",
+    "-- subscription was already correct.",
+    apply
+      ? "-- Ends with COMMIT."
+      : "-- Dry run: ends with ROLLBACK. Re-generate with --apply to keep the changes.",
+    "",
+    "BEGIN;",
+    "",
+  ];
+
+  if (skipped.length > 0) {
+    lines.push(
+      `-- Skipped, no customer on the subscription: ${skipped.join(", ")}`,
+      ""
+    );
+  }
+
+  for (const repair of repairs) {
+    lines.push(renderUpdate(repair), "");
+  }
+
+  if (repairs.length > 0) {
+    lines.push(renderUnreachableReport(repairs), "");
+  }
+
+  lines.push(apply ? "COMMIT;" : "ROLLBACK;");
+
+  console.log(lines.join("\n"));
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`${error instanceof Error ? error.message : error}\n`);
+  process.exitCode = 1;
+});

--- a/tests/unit/billing-handle-event.test.ts
+++ b/tests/unit/billing-handle-event.test.ts
@@ -704,10 +704,33 @@ describe("handleBillingEvent", () => {
           plan: "free",
           tier: null,
           status: "canceled",
-          providerSubscriptionId: null,
-          providerPriceId: null,
         })
       );
+    });
+
+    // Clearing the ids left no record that the org ever held this
+    // subscription, so a churned trial fell outside the trials query.
+    it("keeps the provider ids on the churned row", async () => {
+      const pastDate = new Date(Date.now() - 86_400_000);
+      mockSelectReturning([
+        {
+          providerSubscriptionId: "sub_1",
+          providerPriceId: "price_1",
+          currentPeriodEnd: pastDate,
+          plan: "pro",
+        },
+      ]);
+
+      const provider = createMockProvider();
+      const event = makeEvent("subscription.deleted", {
+        providerSubscriptionId: "sub_1",
+      });
+
+      await handleBillingEvent(event, provider);
+
+      const setArg = mockSet.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg).not.toHaveProperty("providerSubscriptionId");
+      expect(setArg).not.toHaveProperty("providerPriceId");
     });
 
     it("uses event periodEnd over DB periodEnd", async () => {
@@ -893,8 +916,22 @@ describe("handleBillingEvent", () => {
   });
 
   describe("invoice.paid", () => {
-    it("sets status active and clears billing alerts", async () => {
-      const provider = createMockProvider();
+    // A paid invoice proves an invoice was paid, not that the
+    // subscription is active. The provider is the authority for the status.
+    function providerReporting(status: string): BillingProvider {
+      return createMockProvider({
+        getSubscriptionDetails: vi.fn().mockResolvedValue({
+          priceId: process.env.STRIPE_PRICE_PRO_25K_MONTHLY,
+          status,
+          cancelAtPeriodEnd: false,
+          periodStart: new Date("2025-01-01"),
+          periodEnd: new Date("2025-02-01"),
+        }),
+      });
+    }
+
+    it("takes the status from the provider and clears billing alerts", async () => {
+      const provider = providerReporting("active");
       const event = makeEvent("invoice.paid", {
         providerSubscriptionId: "sub_1",
         invoiceId: "inv_1",
@@ -902,6 +939,7 @@ describe("handleBillingEvent", () => {
 
       await handleBillingEvent(event, provider);
 
+      expect(provider.getSubscriptionDetails).toHaveBeenCalledWith("sub_1");
       expect(db.update).toHaveBeenCalled();
       expect(mockSet).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -910,6 +948,115 @@ describe("handleBillingEvent", () => {
           billingAlertUrl: null,
         })
       );
+    });
+
+    // The $0 invoice the provider issues at trial start is paid immediately.
+    // Before the fix that event overwrote "trialing" with "active".
+    it("leaves a trialing subscription trialing", async () => {
+      mockSelectReturning([
+        {
+          organizationId: "org_1",
+          providerSubscriptionId: "sub_1",
+          plan: "pro",
+          tier: "25k",
+          status: "trialing",
+        },
+      ]);
+
+      const provider = providerReporting("trialing");
+      const event = makeEvent("invoice.paid", {
+        providerSubscriptionId: "sub_1",
+        invoiceId: "inv_trial_zero",
+      });
+
+      await handleBillingEvent(event, provider);
+
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "trialing" })
+      );
+      expect(mockIncrementCounter).not.toHaveBeenCalledWith(
+        MetricNames.BILLING_TRIAL_CONVERTED,
+        expect.anything()
+      );
+    });
+
+    it("restores a past_due subscription once its invoice is paid", async () => {
+      mockSelectReturning([
+        {
+          organizationId: "org_1",
+          providerSubscriptionId: "sub_1",
+          plan: "pro",
+          tier: "25k",
+          status: "past_due",
+        },
+      ]);
+
+      const provider = providerReporting("active");
+      const event = makeEvent("invoice.paid", {
+        providerSubscriptionId: "sub_1",
+        invoiceId: "inv_retry",
+      });
+
+      await handleBillingEvent(event, provider);
+
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "active" })
+      );
+    });
+
+    it("counts the conversion when it lands the trialing -> active move", async () => {
+      mockSelectReturning([
+        {
+          organizationId: "org_1",
+          providerSubscriptionId: "sub_1",
+          plan: "pro",
+          tier: "25k",
+          status: "trialing",
+        },
+      ]);
+
+      const provider = providerReporting("active");
+      const event = makeEvent("invoice.paid", {
+        providerSubscriptionId: "sub_1",
+        invoiceId: "inv_first_charge",
+      });
+
+      await handleBillingEvent(event, provider);
+
+      expect(mockIncrementCounter).toHaveBeenCalledWith(
+        MetricNames.BILLING_TRIAL_CONVERTED,
+        { plan: "pro", tier: "25k" }
+      );
+    });
+
+    it("leaves the stored status alone when the provider cannot be read", async () => {
+      mockSelectReturning([
+        {
+          organizationId: "org_1",
+          providerSubscriptionId: "sub_1",
+          plan: "pro",
+          status: "trialing",
+        },
+      ]);
+
+      const provider = createMockProvider({
+        getSubscriptionDetails: vi
+          .fn()
+          .mockRejectedValue(new Error("provider unreachable")),
+      });
+      const event = makeEvent("invoice.paid", {
+        providerSubscriptionId: "sub_1",
+        invoiceId: "inv_1",
+      });
+
+      await handleBillingEvent(event, provider);
+
+      const setArg = mockSet.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg).not.toHaveProperty("status");
+      expect(setArg).toMatchObject({
+        billingAlert: null,
+        billingAlertUrl: null,
+      });
     });
 
     it("clears debt when invoiceId is present", async () => {

--- a/tests/unit/billing-trial.test.ts
+++ b/tests/unit/billing-trial.test.ts
@@ -175,6 +175,23 @@ describe("isTrialEligible", () => {
     );
   });
 
+  // A churned row keeps its providerSubscriptionId so churn stays
+  // measurable, so the id on its own must no longer read as "subscribed".
+  it("does not treat a canceled row as subscribed because it keeps its id", () => {
+    vi.stubEnv("TRIAL_ALLOW_REPEAT", "true");
+    expect(
+      isTrialEligible(
+        makeSub({
+          status: "canceled",
+          providerSubscriptionId: "sub_churned",
+          trialStartedAt: new Date(Date.now() - 200 * DAY_MS),
+        }),
+        "pro",
+        "25k"
+      )
+    ).toBe(true);
+  });
+
   it("is not eligible when the trials feature flag is off", () => {
     vi.stubEnv("TRIALS_ENABLED", "false");
     expect(isTrialEligible(undefined, "pro", "25k")).toBe(false);
@@ -207,9 +224,11 @@ describe("repeat trials (cooldown)", () => {
   });
 
   function trialedSub(daysAgo: number): TrialSub {
-    // Trialed once, converted, then reset back to free (canceled).
+    // Trialed once, converted, then reset back to free (canceled). The
+    // handler keeps the provider id on that row, so carry it here too.
     return makeSub({
       status: "canceled",
+      providerSubscriptionId: "sub_churned",
       trialStartedAt: new Date(Date.now() - daysAgo * DAY_MS),
     });
   }


### PR DESCRIPTION
## Problem

`invoice.paid` wrote `status: "active"` whenever the invoice carried a subscription id. Stripe issues a paid $0 invoice at trial start, so that write overwrote `trialing` whenever the event won its race with the `checkout.completed` row insert.

Verified on production. The `billing_events` arrival time matches each broken row's `updated_at` to within ~10 ms:

| Subscription | checkout.completed | invoice.paid | row updated_at | stored status |
| -- | -- | -- | -- | -- |
| `sub_1U2yJi` | 18:53:01.208 | 18:53:02.046 | 18:53:02.055 | active |
| `sub_1U3aoi` | 11:59:34.818 | 11:59:35.416 | 11:59:35.423 | active |
| `sub_1U3rP9` | 05:42:16.512 | 05:42:16.854 | 05:42:16.856 | active |

All three are `trialing` in Stripe. A fourth trial survived only because its `invoice.paid` arrived 0.19 s after checkout and lost the race. Subscription-cycle invoices started arriving on 2026-08-10, and 3 of the 4 trials since then broke.

Every billing figure on the Growth + Revenue dashboard reads this table, so revenue is overstated today.

## Changes

**`invoice.paid` no longer asserts a status.** It reads the status back from the subscription object. A paid invoice proves an invoice was paid; only the subscription is authoritative for its own status. This is the pattern `handleCheckoutCompleted` already uses. When the provider read fails the handler leaves the stored status alone rather than guessing, and still clears the billing alerts.

**`subscription.deleted` keeps the provider ids on the terminal cancel path.** Clearing `provider_subscription_id` and `provider_price_id` left no record that the org ever held the subscription, so a churned trial fell outside the trials query and could never be counted. `plan` and `tier` still drop to free, which is what actually revokes access: every entitlement read decides from `plan` alone and none of them read `status`.

**`isTrialEligible` pairs the id with the status.** It treated "has a subscription id" as "currently subscribed", so keeping the id would have made every churned org permanently trial-ineligible. It now uses the same phrasing the checkout and preview-proration routes already use.

**The trial-conversion counter moved into a helper both handlers call.** Either event can land the `trialing` to `active` move, and counting it only in `subscription.updated` lost the conversion whenever `invoice.paid` arrived first. So the one bug corrupted the gauge and the counter in opposite directions.

**`scripts/reconcile-stripe-subscriptions.ts`** repairs rows the handler cannot reach. A missed webhook delivery leaves a row behind and nothing re-reads the provider afterwards. The script reads the provider and prints SQL; it never connects to the database, so the key stays in the cluster and a person reviews the statements before they run. It defaults to a dry run that ends in ROLLBACK.

## A second cause the ticket does not name

`billing_events` holds exactly one `subscription.deleted` row, ever. Five of the six cancellations, which ended between 2026-06-27 and 2026-07-20, never reached us at all. The handler fix does not recover those; the reconcile script does. Nothing in this PR prevents the next missed delivery - running the script on a schedule would, and that is worth its own ticket.

## Tests

New cases in `tests/unit/billing-handle-event.test.ts`: a trialing row stays trialing, a `past_due` row still recovers to active, a failed provider read leaves the status untouched, the conversion counter fires when `invoice.paid` lands the move, and the churned row keeps its ids. `tests/unit/billing-trial.test.ts` covers a canceled row that still carries its id.

Every new test was confirmed to fail against the previous code, so none pass vacuously.

## Verification

Local pipeline green: `pnpm check`, `pnpm type-check`, `pnpm check:api-docs`, `pnpm test:unit` (20954 passed), `pnpm test:integration` (937 passed), `pnpm build`.

The reconcile script was dry-run against production. It changes 7 rows and reports the 2 subscriptions whose org rows no longer exist. The resulting state:

| Figure | Now | After repair |
| -- | -- | -- |
| Trialing | 8 | 11 |
| Trials converted | 3 | 0 |
| Trials churned | no data | 2 |
| Past due | 1 | 0 |
| Paid orgs | 9 | 6 |

No trial has converted yet, so 0 is correct. Churn reaches 2 rather than the 5 the ticket estimates, because two of the churned trials have no org row left.

The production repair has not been applied. It waits until this is deployed, so the bug cannot re-break the rows it just fixed.