### PR TITLE
fix: #2093 keep the chain on a run that failed before broadcast

### DIFF
--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -127,21 +127,37 @@ function formatGasAsEth(weiString: string | null): string {
   return `${eth.toFixed(4)} ETH`;
 }
 
-// Run-level gas: multi-network runs can't sum into one token, so they render
-// as "Composed" (per-network amounts live in the expanded steps). A single
-// network shows its total in that network's token.
+// Run-level gas: a run that spent on more than one chain can't sum into one
+// token, so it renders as "Composed" (per-network amounts live in the expanded
+// steps). A single chain shows its total in that chain's token.
+//
+// The question is which chains the gas landed on, not which chains the run
+// touched - `networks` carries the second and answers the first only for a run
+// whose every step spent gas. A workflow that writes on one chain and reads on
+// another has one gas chain and two targeted ones, and its total is perfectly
+// summable. `gasNetworks` is the set this actually needs.
+//
+// Ledger-only gas (a sponsored leg with no step rollup) names no chain of its
+// own, so it borrows the run's, which is unambiguous only when the run touched
+// a single one.
 //
 // The step rollup wins over the sponsorship ledger because it covers every
 // transaction the run made. A run that starts sponsored and falls back to
 // direct signing has only its sponsored leg in the ledger, so preferring the
 // ledger would drop the rest.
-function runGasDisplay(run: UnifiedRun): ReactNode {
-  if (run.networks.length > 1) {
+export function runGasDisplay(run: UnifiedRun): ReactNode {
+  const spentAcrossChains =
+    run.gasNetworks.length > 1 ||
+    (run.gasNetworks.length === 0 && run.networks.length > 1);
+  if (spentAcrossChains) {
     return "Composed";
   }
   const wei = run.gasUsedWei ?? run.gasCostWei;
   if (wei) {
-    return formatGasNative(wei, run.networks[0] ?? run.network);
+    return formatGasNative(
+      wei,
+      run.gasNetworks[0] ?? run.networks[0] ?? run.network
+    );
   }
   return formatGasAsEth(run.gasUsedWei);
 }

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -13,7 +13,7 @@ import {
   sql,
 } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { logInputField } from "@/lib/db/execution-log-fields";
+import { logInputField, logOutputField } from "@/lib/db/execution-log-fields";
 import {
   workflowExecutionLogs,
   workflowExecutions,
@@ -1002,41 +1002,43 @@ async function fetchWorkflowRuns(
   // workflow_execution_logs was a workaround that picked an arbitrary single
   // hash per run; multi-tx workflows (approve+swap, fan-outs) silently lost
   // every hash but one.
-  // Reads the denormalised network / gas_used_wei columns rather than
-  // re-parsing the double-encoded input/output JSONB per row - the cost the
-  // comment above fetchNetworkBreakdown records as the networks-endpoint 524.
-  // That matters more here now that the subquery no longer filters on gas and
-  // so covers every step row of the page. Columns are written by
-  // lib/workflow/executor/logging.ts and backfilled for legacy rows by
-  // scripts/backfill-exec-log-network-gas.ts.
+  // Gas and network are read as COALESCE(denormalised column, JSONB extract).
+  // The columns (migration 0117) are written by lib/workflow/executor/logging.ts
+  // - network at step start, gas_used_wei at step complete - and are NULL on
+  // every row written before it, so a column-only read returns no chain and no
+  // gas for historical runs. scripts/backfill-exec-log-network-gas.ts fills
+  // those rows; the JSONB arm is what keeps this correct while that runs, and on
+  // any row it has not reached. The re-parse cost the comment above
+  // fetchNetworkBreakdown records is not in play here: this subquery is already
+  // restricted to one page of executions (see pagedExecutionIds above), which is
+  // why it could afford the JSONB extract before this change.
+  const logStepNetwork = sql`COALESCE(${workflowExecutionLogs.network}, ${logInputField("network")})`;
+  const logStepHasGas = sql`(${workflowExecutionLogs.gasUsedWei} IS NOT NULL OR ${logOutputField("gasUsed")} IS NOT NULL)`;
+  const logStepGasWei = sql`COALESCE(${workflowExecutionLogs.gasUsedWei}, CAST(${logOutputField("gasUsed")} AS NUMERIC))`;
+
   const logSummary = db
     .select({
       executionId: workflowExecutionLogs.executionId,
-      gasUsedWei:
-        sql<string>`COALESCE(SUM(${workflowExecutionLogs.gasUsedWei}), 0)::text`.as(
-          "gasUsedWei"
-        ),
+      gasUsedWei: sql<string>`COALESCE(SUM(${logStepGasWei}), 0)::text`.as(
+        "gasUsedWei"
+      ),
       // A gas-bearing step names the chain the run actually spent on, so it
       // wins; any step that named one is the fallback. Both arms only matter
       // because this subquery no longer filters on gas: it used to require
-      // gas_used_wei IS NOT NULL, and since WHERE runs before GROUP BY, a run
-      // that never reached broadcast contributed no rows, formed no group, and
-      // left the join NULL - so a pre-flight failure (insufficient balance,
-      // spend cap, a bad address) came back with no chain at all, even when
-      // its own error named one ("Insufficient BASE balance"). A consumer of
-      // the audit trail could not tell which chain a failed run was on.
-      // logging.ts writes network at step start, before any such failure.
+      // gasUsed IS NOT NULL, and since WHERE runs before GROUP BY, a run that
+      // never reached broadcast contributed no rows, formed no group, and left
+      // the join NULL - so a pre-flight failure (insufficient balance, spend
+      // cap, a bad address) came back with no chain at all, even when its own
+      // error named one ("Insufficient BASE balance"). A consumer of the audit
+      // trail could not tell which chain a failed run was on. logging.ts writes
+      // network at step start, before any such failure.
       network: sql<string | null>`COALESCE(
-        MIN(
-          CASE WHEN ${workflowExecutionLogs.gasUsedWei} IS NOT NULL
-          THEN ${workflowExecutionLogs.network}
-          END
-        ),
-        MIN(${workflowExecutionLogs.network})
+        MIN(CASE WHEN ${logStepHasGas} THEN ${logStepNetwork} END),
+        MIN(${logStepNetwork})
       )`.as("network"),
       networks: sql<
         string[]
-      >`COALESCE(ARRAY_AGG(DISTINCT ${workflowExecutionLogs.network}) FILTER (WHERE ${workflowExecutionLogs.network} IS NOT NULL), '{}')`.as(
+      >`COALESCE(ARRAY_AGG(DISTINCT ${logStepNetwork}) FILTER (WHERE ${logStepNetwork} IS NOT NULL), '{}')`.as(
         "networks"
       ),
     })

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -1041,6 +1041,17 @@ async function fetchWorkflowRuns(
       >`COALESCE(ARRAY_AGG(DISTINCT ${logStepNetwork}) FILTER (WHERE ${logStepNetwork} IS NOT NULL), '{}')`.as(
         "networks"
       ),
+      // The subset of `networks` that actually spent gas. The runs table needs
+      // both sets and they are not the same one: the Network column wants every
+      // chain the run touched, while the gas cell can only render an amount
+      // when the wei it is summing landed on a single chain, since two chains'
+      // native tokens do not add. Deriving the second from the first held only
+      // while this subquery filtered on gas.
+      gasNetworks: sql<
+        string[]
+      >`COALESCE(ARRAY_AGG(DISTINCT ${logStepNetwork}) FILTER (WHERE ${logStepNetwork} IS NOT NULL AND ${logStepHasGas}), '{}')`.as(
+        "gasNetworks"
+      ),
     })
     .from(workflowExecutionLogs)
     .where(sql`${workflowExecutionLogs.executionId} IN (${pagedExecutionIds})`)
@@ -1078,6 +1089,7 @@ async function fetchWorkflowRuns(
       gasUsedWei: logSummary.gasUsedWei,
       network: logSummary.network,
       networks: logSummary.networks,
+      gasNetworks: logSummary.gasNetworks,
       gasCostWei: gasCostSummary.gasCostWei,
       transactionHashes: workflowExecutions.transactionHashes,
       error: workflowExecutions.error,
@@ -1110,6 +1122,7 @@ async function fetchWorkflowRuns(
     directType: null,
     network: row.network ?? null,
     networks: row.networks ?? [],
+    gasNetworks: row.gasNetworks ?? [],
     gasCostWei:
       row.gasCostWei && row.gasCostWei !== "0" ? row.gasCostWei : null,
     transactionHashes: row.transactionHashes,
@@ -1184,6 +1197,7 @@ async function fetchDirectRuns(
     directType: row.type as UnifiedRun["directType"],
     network: row.network,
     networks: row.network ? [row.network] : [],
+    gasNetworks: row.network && row.gasUsedWei ? [row.network] : [],
     gasCostWei: row.gasUsedWei,
     // Direct executions are genuinely single-tx. Synthesize the entry so
     // consumers can render workflow + direct runs through the same array

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -1009,10 +1009,20 @@ async function fetchWorkflowRuns(
         sql<string>`COALESCE(SUM(CAST(${logOutputField("gasUsed")} AS NUMERIC)), 0)::text`.as(
           "gasUsedWei"
         ),
-      network: sql<string | null>`MIN(
-        CASE WHEN ${logOutputField("gasUsed")} IS NOT NULL
-        THEN ${logInputField("network")}
-        END
+      // A gas-bearing step names the chain the run actually spent on, so it
+      // wins. Falling back to any step that names one keeps the chain on a run
+      // that never reached broadcast: a pre-flight failure (insufficient
+      // balance, spend cap, a bad address) produces no gasUsed, so the CASE
+      // alone returned NULL and the run came back with no chain at all - even
+      // when its own error names one ("Insufficient BASE balance"). A consumer
+      // of the audit trail could not tell which chain a failed run was on.
+      network: sql<string | null>`COALESCE(
+        MIN(
+          CASE WHEN ${logOutputField("gasUsed")} IS NOT NULL
+          THEN ${logInputField("network")}
+          END
+        ),
+        MIN(${logInputField("network")})
       )`.as("network"),
       networks: sql<
         string[]

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -13,7 +13,7 @@ import {
   sql,
 } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { logInputField, logOutputField } from "@/lib/db/execution-log-fields";
+import { logInputField } from "@/lib/db/execution-log-fields";
 import {
   workflowExecutionLogs,
   workflowExecutions,
@@ -1002,41 +1002,46 @@ async function fetchWorkflowRuns(
   // workflow_execution_logs was a workaround that picked an arbitrary single
   // hash per run; multi-tx workflows (approve+swap, fan-outs) silently lost
   // every hash but one.
+  // Reads the denormalised network / gas_used_wei columns rather than
+  // re-parsing the double-encoded input/output JSONB per row - the cost the
+  // comment above fetchNetworkBreakdown records as the networks-endpoint 524.
+  // That matters more here now that the subquery no longer filters on gas and
+  // so covers every step row of the page. Columns are written by
+  // lib/workflow/executor/logging.ts and backfilled for legacy rows by
+  // scripts/backfill-exec-log-network-gas.ts.
   const logSummary = db
     .select({
       executionId: workflowExecutionLogs.executionId,
       gasUsedWei:
-        sql<string>`COALESCE(SUM(CAST(${logOutputField("gasUsed")} AS NUMERIC)), 0)::text`.as(
+        sql<string>`COALESCE(SUM(${workflowExecutionLogs.gasUsedWei}), 0)::text`.as(
           "gasUsedWei"
         ),
       // A gas-bearing step names the chain the run actually spent on, so it
-      // wins. Falling back to any step that names one keeps the chain on a run
-      // that never reached broadcast: a pre-flight failure (insufficient
-      // balance, spend cap, a bad address) produces no gasUsed, so the CASE
-      // alone returned NULL and the run came back with no chain at all - even
-      // when its own error names one ("Insufficient BASE balance"). A consumer
-      // of the audit trail could not tell which chain a failed run was on.
+      // wins; any step that named one is the fallback. Both arms only matter
+      // because this subquery no longer filters on gas: it used to require
+      // gas_used_wei IS NOT NULL, and since WHERE runs before GROUP BY, a run
+      // that never reached broadcast contributed no rows, formed no group, and
+      // left the join NULL - so a pre-flight failure (insufficient balance,
+      // spend cap, a bad address) came back with no chain at all, even when
+      // its own error named one ("Insufficient BASE balance"). A consumer of
+      // the audit trail could not tell which chain a failed run was on.
+      // logging.ts writes network at step start, before any such failure.
       network: sql<string | null>`COALESCE(
         MIN(
-          CASE WHEN ${logOutputField("gasUsed")} IS NOT NULL
-          THEN ${logInputField("network")}
+          CASE WHEN ${workflowExecutionLogs.gasUsedWei} IS NOT NULL
+          THEN ${workflowExecutionLogs.network}
           END
         ),
-        MIN(${logInputField("network")})
+        MIN(${workflowExecutionLogs.network})
       )`.as("network"),
       networks: sql<
         string[]
-      >`COALESCE(ARRAY_AGG(DISTINCT ${logInputField("network")}) FILTER (WHERE ${logInputField("network")} IS NOT NULL), '{}')`.as(
+      >`COALESCE(ARRAY_AGG(DISTINCT ${workflowExecutionLogs.network}) FILTER (WHERE ${workflowExecutionLogs.network} IS NOT NULL), '{}')`.as(
         "networks"
       ),
     })
     .from(workflowExecutionLogs)
-    .where(
-      and(
-        sql`${workflowExecutionLogs.executionId} IN (${pagedExecutionIds})`,
-        sql`${logOutputField("gasUsed")} IS NOT NULL`
-      )
-    )
+    .where(sql`${workflowExecutionLogs.executionId} IN (${pagedExecutionIds})`)
     .groupBy(workflowExecutionLogs.executionId)
     .as("log_summary");
 

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -53,6 +53,14 @@ export type UnifiedRun = {
    * runs, where a read-only step on another chain now joins the list.
    */
   networks: string[];
+  /**
+   * The subset of `networks` the run actually spent gas on. Distinct from
+   * `networks` because the runs table asks two different questions of the same
+   * run: which chains it touched (the Network column) and which chains its gas
+   * landed on (the Gas cell, which can only render an amount when that is one
+   * chain - two chains' native tokens do not add).
+   */
+  gasNetworks: string[];
   /** Total native gas cost (wei) sponsored across the run's transactions. */
   gasCostWei: string | null;
   /**

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -45,7 +45,13 @@ export type UnifiedRun = {
   workflowName: string | null;
   directType: DirectType | null;
   network: string | null;
-  /** Distinct networks (chain ids) the run produced on-chain writes on. */
+  /**
+   * Distinct networks (chain ids) the run's steps targeted - not only the ones
+   * it produced on-chain writes on. A run that fails before broadcast still
+   * names its chain here, which is the point: a chainless failed run is
+   * unattributable in the audit trail. The widening is visible on mixed-chain
+   * runs, where a read-only step on another chain now joins the list.
+   */
   networks: string[];
   /** Total native gas cost (wei) sponsored across the run's transactions. */
   gasCostWei: string | null;

--- a/scripts/backfill-exec-log-network-gas.ts
+++ b/scripts/backfill-exec-log-network-gas.ts
@@ -4,23 +4,33 @@
  *
  * Migration 0117 adds the columns null. New rows are populated at write time by
  * lib/workflow/executor/logging.ts (network at step start, gas_used_wei at step
- * complete). This script fills historical rows so the /analytics per-network
- * gas breakdown can move off the per-row input/output JSONB re-parse (the cost
- * behind the networks-endpoint 524) without the breakdown totals changing.
+ * complete). This script fills historical rows so the /analytics read paths can
+ * move off the per-row input/output JSONB re-parse (the cost behind the
+ * networks-endpoint 524) without any total or attribution changing.
  *
- * Scope: only gas-bearing rows. The per-network breakdown reads network and
- * gas_used_wei exclusively for rows where gas_used_wei IS NOT NULL, so those are
- * the only historical rows that need denormalising. Gas steps are a tiny
- * fraction of the table (most rows are reads with no on-chain gas), so this
- * touches a handful of rows rather than the whole multi-GB table. network on
- * non-gas rows stays null on purpose; nothing reads it.
+ * Scope: every row whose JSONB carries a value the matching column does not.
+ * That is wider than the original KEEP-857 scope, which took gas-bearing rows
+ * only on the reasoning that nothing read `network` on a gas-free row. That is
+ * no longer true - fetchWorkflowRuns reads `network` per step so a run that
+ * failed before broadcast keeps its chain (#2093), and a pre-flight failure is
+ * exactly a row with a network in `input` and no `gasUsed` in `output`. Gas
+ * steps are a small fraction of the table but network-bearing steps are not, so
+ * this walk is over most web3 step rows rather than a handful; it is keyset
+ * batched, idempotent and resumable via --after-id, so a long run is fine to
+ * interrupt and continue.
  *
- * Approach: keyset batches over the gas-bearing rows, each re-extracting
- * network/gasUsed from the JSONB via the shared logInputField/logOutputField
- * builders, the same expressions the executor writer mirrors in JS and the
- * /analytics reads used to use, so all paths agree value-for-value. COALESCE
- * preserves any value the live writer already set (no clobber race on hot
- * recent rows). Idempotent and resumable via --after-id.
+ * Correctness does not depend on this having run. lib/analytics/queries.ts reads
+ * COALESCE(column, JSONB extract), so an unbackfilled row still resolves; the
+ * backfill is what retires the JSONB arm, not what makes it right.
+ *
+ * Approach: keyset batches, each re-extracting network/gasUsed from the JSONB
+ * via the shared logInputField/logOutputField builders - the same expressions
+ * the executor writer mirrors in JS and the /analytics reads use as their
+ * fallback arm, so all paths agree value-for-value. COALESCE preserves any value
+ * the live writer already set (no clobber race on hot recent rows).
+ *
+ * The SQL lives in scripts/lib/exec-log-network-gas-backfill.ts so
+ * tests/e2e/vitest/analytics-run-network.db.test.ts can run a batch directly.
  *
  * A LIVE run against a non-local DB requires --yes; dry-runs and local DBs do
  * not. This is a guard against an accidental prod write, not a security
@@ -34,15 +44,12 @@
  *   pnpm tsx scripts/backfill-exec-log-network-gas.ts --dry-run --max-batches 5
  */
 
-import { sql } from "drizzle-orm";
-import { db } from "@/lib/db";
 import {
-  logInputField,
-  logOutputField,
-} from "@/lib/db/execution-log-fields";
-import { workflowExecutionLogs } from "@/lib/db/schema";
-
-const DEFAULT_BATCH_SIZE = 1000;
+  applyBatch,
+  countBatch,
+  DEFAULT_BATCH_SIZE,
+  fetchLogIdBatch,
+} from "@/scripts/lib/exec-log-network-gas-backfill";
 
 type CliArgs = {
   dryRun: boolean;
@@ -89,77 +96,6 @@ function parseArgs(argv: string[]): CliArgs {
     }
   }
   return args;
-}
-
-const networkExpr = logInputField("network");
-const gasExpr = logOutputField("gasUsed");
-
-/**
- * Keyset page of the gas-bearing log ids still needing a backfill; the cursor
- * for the next batch is the last id. Filtering to gas rows here keeps the walk
- * over the handful of rows that matter instead of the whole table.
- */
-async function fetchLogIdBatch(
-  afterId: string,
-  batchSize: number
-): Promise<string[]> {
-  const rows = await db
-    .select({ id: workflowExecutionLogs.id })
-    .from(workflowExecutionLogs)
-    .where(
-      sql`${workflowExecutionLogs.id} > ${afterId} AND ${workflowExecutionLogs.gasUsedWei} IS NULL AND ${gasExpr} IS NOT NULL`
-    )
-    .orderBy(workflowExecutionLogs.id)
-    .limit(batchSize);
-  return rows.map((r) => r.id);
-}
-
-/**
- * Backfill one keyset batch of gas-bearing rows. Re-selects the same batch
- * inside a CTE (deterministic for a fixed cursor) so no id array has to be
- * marshalled into the statement. COALESCE keeps any value the live writer
- * already set; re-runs skip rows whose gas_used_wei is already populated.
- * Returns the number of rows written.
- */
-async function applyBatch(afterId: string, batchSize: number): Promise<number> {
-  const result = await db.execute(sql`
-    WITH batch AS (
-      SELECT id FROM workflow_execution_logs
-      WHERE id > ${afterId}
-        AND gas_used_wei IS NULL
-        AND ${gasExpr} IS NOT NULL
-      ORDER BY id
-      LIMIT ${batchSize}
-    )
-    UPDATE workflow_execution_logs
-    SET network = COALESCE(workflow_execution_logs.network, ${networkExpr}),
-        gas_used_wei = COALESCE(
-          workflow_execution_logs.gas_used_wei,
-          CAST(${gasExpr} AS NUMERIC)
-        )
-    FROM batch
-    WHERE workflow_execution_logs.id = batch.id
-    RETURNING workflow_execution_logs.id
-  `);
-  // postgres-js: db.execute resolves to the RETURNING rows array.
-  return result.length;
-}
-
-/** Dry-run: count how many gas-bearing rows in the batch WOULD be written. */
-async function countBatch(afterId: string, batchSize: number): Promise<number> {
-  const result = await db.execute(sql`
-    WITH batch AS (
-      SELECT id FROM workflow_execution_logs
-      WHERE id > ${afterId}
-        AND gas_used_wei IS NULL
-        AND ${gasExpr} IS NOT NULL
-      ORDER BY id
-      LIMIT ${batchSize}
-    )
-    SELECT COUNT(*) AS n FROM batch
-  `);
-  // postgres-js: db.execute resolves to the rows array.
-  return Number(result[0]?.n ?? 0);
 }
 
 function dbHost(): string {

--- a/scripts/lib/exec-log-network-gas-backfill.ts
+++ b/scripts/lib/exec-log-network-gas-backfill.ts
@@ -1,0 +1,104 @@
+/**
+ * KEEP-857 backfill query logic for the denormalised `network` / `gas_used_wei`
+ * columns on `workflow_execution_logs`, extracted from
+ * scripts/backfill-exec-log-network-gas.ts so a database-backed test can run a
+ * batch directly instead of shelling out to the CLI.
+ *
+ * The CLI wrapper owns argument parsing, the non-local-write guard and the
+ * progress logging; everything that touches SQL lives here.
+ */
+
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { logInputField, logOutputField } from "@/lib/db/execution-log-fields";
+import { workflowExecutionLogs } from "@/lib/db/schema";
+
+export const DEFAULT_BATCH_SIZE = 1000;
+
+const networkExpr = logInputField("network");
+const gasExpr = logOutputField("gasUsed");
+
+/**
+ * A row still needs denormalising if either column is unset while the JSONB it
+ * mirrors carries a value.
+ *
+ * The gas arm is the original KEEP-857 scope. The network arm was added when
+ * fetchWorkflowRuns started reading `network` on rows that spend no gas: a
+ * read-only or pre-flight-failed step has a network in `input` and no `gasUsed`
+ * in `output`, so the gas arm alone never reaches it. Keeping both arms means a
+ * partially-backfilled row (network filled by an earlier run, gas still null, or
+ * the reverse) is still picked up.
+ */
+const needsBackfill = sql`(
+  (${workflowExecutionLogs.network} IS NULL AND ${networkExpr} IS NOT NULL)
+  OR (${workflowExecutionLogs.gasUsedWei} IS NULL AND ${gasExpr} IS NOT NULL)
+)`;
+
+/**
+ * Keyset page of the log ids still needing a backfill; the cursor for the next
+ * batch is the last id returned.
+ */
+export async function fetchLogIdBatch(
+  afterId: string,
+  batchSize: number
+): Promise<string[]> {
+  const rows = await db
+    .select({ id: workflowExecutionLogs.id })
+    .from(workflowExecutionLogs)
+    .where(sql`${workflowExecutionLogs.id} > ${afterId} AND ${needsBackfill}`)
+    .orderBy(workflowExecutionLogs.id)
+    .limit(batchSize);
+  return rows.map((r) => r.id);
+}
+
+/**
+ * Backfill one keyset batch. Re-selects the same batch inside a CTE
+ * (deterministic for a fixed cursor) so no id array has to be marshalled into
+ * the statement. COALESCE keeps any value the live writer already set, so there
+ * is no clobber race on hot recent rows and a re-run is a no-op on rows already
+ * populated. Returns the number of rows written.
+ */
+export async function applyBatch(
+  afterId: string,
+  batchSize: number
+): Promise<number> {
+  const result = await db.execute(sql`
+    WITH batch AS (
+      SELECT id FROM workflow_execution_logs
+      WHERE id > ${afterId}
+        AND ${needsBackfill}
+      ORDER BY id
+      LIMIT ${batchSize}
+    )
+    UPDATE workflow_execution_logs
+    SET network = COALESCE(workflow_execution_logs.network, ${networkExpr}),
+        gas_used_wei = COALESCE(
+          workflow_execution_logs.gas_used_wei,
+          CAST(${gasExpr} AS NUMERIC)
+        )
+    FROM batch
+    WHERE workflow_execution_logs.id = batch.id
+    RETURNING workflow_execution_logs.id
+  `);
+  // postgres-js: db.execute resolves to the RETURNING rows array.
+  return result.length;
+}
+
+/** Dry-run: count how many rows in the batch WOULD be written. */
+export async function countBatch(
+  afterId: string,
+  batchSize: number
+): Promise<number> {
+  const result = await db.execute(sql`
+    WITH batch AS (
+      SELECT id FROM workflow_execution_logs
+      WHERE id > ${afterId}
+        AND ${needsBackfill}
+      ORDER BY id
+      LIMIT ${batchSize}
+    )
+    SELECT COUNT(*) AS n FROM batch
+  `);
+  // postgres-js: db.execute resolves to the rows array.
+  return Number(result[0]?.n ?? 0);
+}

--- a/tests/e2e/vitest/analytics-run-network.db.test.ts
+++ b/tests/e2e/vitest/analytics-run-network.db.test.ts
@@ -1,0 +1,186 @@
+import "dotenv/config";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { UnifiedRun } from "../../../lib/analytics/types";
+import {
+  organization,
+  users,
+  workflowExecutionLogs,
+  workflowExecutions,
+  workflows,
+} from "../../../lib/db/schema";
+
+// vitest runs in Node, not an SSR context.
+vi.mock("server-only", () => ({}));
+
+// tests/setup.ts globally stubs @/lib/db; this suite needs getUnifiedRuns to
+// hit Postgres, because the behaviour under test is which rows survive the
+// log-summary subquery's WHERE clause - not the shape of the generated SQL.
+vi.unmock("@/lib/db");
+
+const SKIP =
+  !process.env.DATABASE_URL || process.env.SKIP_INFRA_TESTS === "true";
+const DATABASE_URL = process.env.DATABASE_URL ?? "";
+
+const PREFIX = "test_run_network_";
+const ORG_ID = `${PREFIX}org`;
+const USER_ID = `${PREFIX}user`;
+const WORKFLOW_ID = `${PREFIX}wf`;
+
+/** A run that failed before broadcast: its step named a chain, spent no gas. */
+const PREFLIGHT_ID = `${PREFIX}exec_preflight`;
+/** A run whose gas-bearing step and read-only step sit on different chains. */
+const MIXED_ID = `${PREFIX}exec_mixed`;
+
+describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
+  let queryClient: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  let getUnifiedRuns: (
+    organizationId: string,
+    range: "7d",
+    options?: { limit?: number }
+  ) => Promise<{ runs: UnifiedRun[] }>;
+
+  async function cleanup(): Promise<void> {
+    await queryClient`DELETE FROM workflow_execution_logs WHERE execution_id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM workflow_executions WHERE id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM workflows WHERE id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM member WHERE organization_id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM users WHERE id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM organization WHERE id LIKE ${`${PREFIX}%`}`;
+  }
+
+  beforeAll(async () => {
+    queryClient = postgres(DATABASE_URL);
+    db = drizzle(queryClient);
+    await cleanup();
+
+    const now = new Date();
+
+    await db.insert(organization).values({
+      id: ORG_ID,
+      name: "run network org",
+      slug: ORG_ID,
+      createdAt: now,
+    });
+    await db.insert(users).values({
+      id: USER_ID,
+      email: `${USER_ID}@keeperhub.test`,
+      emailVerified: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(workflows).values({
+      id: WORKFLOW_ID,
+      name: "run network workflow",
+      userId: USER_ID,
+      organizationId: ORG_ID,
+      enabled: true,
+      nodes: [],
+      edges: [],
+    });
+
+    await db.insert(workflowExecutions).values({
+      id: PREFLIGHT_ID,
+      workflowId: WORKFLOW_ID,
+      userId: USER_ID,
+      status: "error" as const,
+      error: "Insufficient BASE balance",
+      startedAt: now,
+      completedAt: now,
+      totalSteps: "1",
+      completedSteps: "0",
+    });
+    await db.insert(workflowExecutions).values({
+      id: MIXED_ID,
+      workflowId: WORKFLOW_ID,
+      userId: USER_ID,
+      status: "success" as const,
+      startedAt: now,
+      completedAt: now,
+      totalSteps: "2",
+      completedSteps: "2",
+    });
+
+    // logging.ts writes network/gas into both the JSONB and the denormalised
+    // columns, so the fixture populates both: the failure this suite asserts
+    // must come from the subquery's gas predicate, not from a half-seeded row
+    // that only the column-reading variant can see.
+    await db.insert(workflowExecutionLogs).values([
+      {
+        id: `${PREFIX}log_preflight`,
+        executionId: PREFLIGHT_ID,
+        nodeId: "send-1",
+        nodeName: "Send",
+        nodeType: "web3",
+        status: "error",
+        input: { network: "base" },
+        error: "Insufficient BASE balance",
+        startedAt: now,
+        network: "base",
+        gasUsedWei: null,
+      },
+      {
+        id: `${PREFIX}log_mixed_write`,
+        executionId: MIXED_ID,
+        nodeId: "swap-1",
+        nodeName: "Swap",
+        nodeType: "web3",
+        status: "success",
+        input: { network: "base" },
+        output: { gasUsed: "21000" },
+        startedAt: now,
+        network: "base",
+        gasUsedWei: "21000",
+      },
+      {
+        id: `${PREFIX}log_mixed_read`,
+        executionId: MIXED_ID,
+        nodeId: "read-1",
+        nodeName: "Read balance",
+        nodeType: "web3",
+        status: "success",
+        input: { network: "optimism" },
+        startedAt: now,
+        network: "optimism",
+        gasUsedWei: null,
+      },
+    ]);
+
+    ({ getUnifiedRuns } = await import("@/lib/analytics/queries"));
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await queryClient.end();
+  });
+
+  async function runById(id: string): Promise<UnifiedRun> {
+    const { runs } = await getUnifiedRuns(ORG_ID, "7d", { limit: 50 });
+    const run = runs.find((r) => r.id === id);
+    if (!run) {
+      throw new Error(`seeded run ${id} missing from getUnifiedRuns`);
+    }
+    return run;
+  }
+
+  it("keeps the chain on a run that spent no gas", async () => {
+    const run = await runById(PREFLIGHT_ID);
+    expect(run.network).toBe("base");
+    expect(run.networks).toEqual(["base"]);
+    // No gas was spent, and that must stay distinguishable from "no chain".
+    expect(run.gasUsedWei).toBeNull();
+  });
+
+  it("still prefers the gas-bearing step's chain as the run's network", async () => {
+    const run = await runById(MIXED_ID);
+    expect(run.network).toBe("base");
+    expect(run.gasUsedWei).toBe("21000");
+  });
+
+  it("lists every chain the run's steps targeted, gas-bearing or not", async () => {
+    const run = await runById(MIXED_ID);
+    expect([...run.networks].sort()).toEqual(["base", "optimism"]);
+  });
+});

--- a/tests/e2e/vitest/analytics-run-network.db.test.ts
+++ b/tests/e2e/vitest/analytics-run-network.db.test.ts
@@ -242,6 +242,7 @@ describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
     expect(run.networks).toEqual(["base"]);
     // No gas was spent, and that must stay distinguishable from "no chain".
     expect(run.gasUsedWei).toBeNull();
+    expect(run.gasNetworks).toEqual([]);
   });
 
   it("still prefers the gas-bearing step's chain as the run's network", async () => {
@@ -253,6 +254,9 @@ describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
   it("lists every chain the run's steps targeted, gas-bearing or not", async () => {
     const run = await runById(MIXED_ID);
     expect([...run.networks].sort()).toEqual(["base", "optimism"]);
+    // ...while the gas cell reads gasNetworks, which stays the one chain the
+    // run actually spent on, so its total is still summable into one token.
+    expect(run.gasNetworks).toEqual(["base"]);
   });
 
   it("reads the chain from the JSONB when the column was never backfilled", async () => {
@@ -266,6 +270,8 @@ describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
     const run = await runById(LEGACY_GAS_ID);
     expect(run.gasUsedWei).toBe("31000");
     expect(run.network).toBe("base");
+    // The COALESCE arm feeds gasNetworks too, not just the scalar network.
+    expect(run.gasNetworks).toEqual(["base"]);
   });
 
   it("backfills a gas-free legacy row, so the read moves onto the column", async () => {

--- a/tests/e2e/vitest/analytics-run-network.db.test.ts
+++ b/tests/e2e/vitest/analytics-run-network.db.test.ts
@@ -32,6 +32,22 @@ const WORKFLOW_ID = `${PREFIX}wf`;
 const PREFLIGHT_ID = `${PREFIX}exec_preflight`;
 /** A run whose gas-bearing step and read-only step sit on different chains. */
 const MIXED_ID = `${PREFIX}exec_mixed`;
+/** Pre-migration-0117 pre-flight failure: chain in the JSONB, columns null. */
+const LEGACY_ID = `${PREFIX}exec_legacy`;
+/** Pre-migration-0117 gas-bearing run: gas in the JSONB, columns null. */
+const LEGACY_GAS_ID = `${PREFIX}exec_legacy_gas`;
+/** Same shape as LEGACY_ID, reserved for the backfill to repair in place. */
+const BACKFILL_ID = `${PREFIX}exec_backfill`;
+
+// Log ids are the backfill's keyset cursor, so they are chosen, not incidental:
+// the backfill case runs one batch from the cursor below, and every other
+// unbackfilled fixture row sorts before it and is therefore out of that batch's
+// reach. Without that the batch would repair the legacy rows too and the cases
+// above it would stop testing the unbackfilled path.
+const LEGACY_LOG_ID = `${PREFIX}log_za_legacy`;
+const LEGACY_GAS_LOG_ID = `${PREFIX}log_zb_legacy_gas`;
+const BACKFILL_CURSOR = `${PREFIX}log_zy`;
+const BACKFILL_LOG_ID = `${BACKFILL_CURSOR}_backfill`;
 
 describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
   let queryClient: ReturnType<typeof postgres>;
@@ -41,6 +57,7 @@ describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
     range: "7d",
     options?: { limit?: number }
   ) => Promise<{ runs: UnifiedRun[] }>;
+  let applyBatch: (afterId: string, batchSize: number) => Promise<number>;
 
   async function cleanup(): Promise<void> {
     await queryClient`DELETE FROM workflow_execution_logs WHERE execution_id LIKE ${`${PREFIX}%`}`;
@@ -49,6 +66,12 @@ describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
     await queryClient`DELETE FROM member WHERE organization_id LIKE ${`${PREFIX}%`}`;
     await queryClient`DELETE FROM users WHERE id LIKE ${`${PREFIX}%`}`;
     await queryClient`DELETE FROM organization WHERE id LIKE ${`${PREFIX}%`}`;
+  }
+
+  async function logNetworkColumn(logId: string): Promise<string | null> {
+    const rows =
+      await queryClient`SELECT network FROM workflow_execution_logs WHERE id = ${logId}`;
+    return (rows[0]?.network as string | null) ?? null;
   }
 
   beforeAll(async () => {
@@ -81,32 +104,38 @@ describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
       edges: [],
     });
 
-    await db.insert(workflowExecutions).values({
-      id: PREFLIGHT_ID,
+    const execution = (id: string, error?: string) => ({
+      id,
       workflowId: WORKFLOW_ID,
       userId: USER_ID,
-      status: "error" as const,
-      error: "Insufficient BASE balance",
+      status: (error ? "error" : "success") as "error" | "success",
+      error,
       startedAt: now,
       completedAt: now,
       totalSteps: "1",
-      completedSteps: "0",
-    });
-    await db.insert(workflowExecutions).values({
-      id: MIXED_ID,
-      workflowId: WORKFLOW_ID,
-      userId: USER_ID,
-      status: "success" as const,
-      startedAt: now,
-      completedAt: now,
-      totalSteps: "2",
-      completedSteps: "2",
+      completedSteps: error ? "0" : "1",
     });
 
-    // logging.ts writes network/gas into both the JSONB and the denormalised
-    // columns, so the fixture populates both: the failure this suite asserts
-    // must come from the subquery's gas predicate, not from a half-seeded row
-    // that only the column-reading variant can see.
+    await db
+      .insert(workflowExecutions)
+      .values([
+        execution(PREFLIGHT_ID, "Insufficient BASE balance"),
+        { ...execution(MIXED_ID), totalSteps: "2", completedSteps: "2" },
+        execution(LEGACY_ID, "Insufficient BASE balance"),
+        execution(LEGACY_GAS_ID),
+        execution(BACKFILL_ID, "Insufficient BASE balance"),
+      ]);
+
+    // Two row shapes matter here, and they are seeded separately on purpose.
+    //
+    // Post-0117 rows carry the value in both the JSONB and the denormalised
+    // column, because logging.ts writes both; the first three rows are those.
+    //
+    // Pre-0117 rows carry it only in the JSONB - migration 0117 added the
+    // columns null and no writer ever went back over the history. Those are the
+    // za/zb/zy rows, and they are what makes a column-only read regress: they
+    // are seeded with the column NULL so a read that ignores the JSONB returns
+    // nothing for them.
     await db.insert(workflowExecutionLogs).values([
       {
         id: `${PREFIX}log_preflight`,
@@ -146,9 +175,51 @@ describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
         network: "optimism",
         gasUsedWei: null,
       },
+      {
+        id: LEGACY_LOG_ID,
+        executionId: LEGACY_ID,
+        nodeId: "send-1",
+        nodeName: "Send",
+        nodeType: "web3",
+        status: "error",
+        input: { network: "base" },
+        error: "Insufficient BASE balance",
+        startedAt: now,
+        network: null,
+        gasUsedWei: null,
+      },
+      {
+        id: LEGACY_GAS_LOG_ID,
+        executionId: LEGACY_GAS_ID,
+        nodeId: "swap-1",
+        nodeName: "Swap",
+        nodeType: "web3",
+        status: "success",
+        input: { network: "base" },
+        output: { gasUsed: "31000" },
+        startedAt: now,
+        network: null,
+        gasUsedWei: null,
+      },
+      {
+        id: BACKFILL_LOG_ID,
+        executionId: BACKFILL_ID,
+        nodeId: "send-1",
+        nodeName: "Send",
+        nodeType: "web3",
+        status: "error",
+        input: { network: "base" },
+        error: "Insufficient BASE balance",
+        startedAt: now,
+        network: null,
+        gasUsedWei: null,
+      },
     ]);
 
     ({ getUnifiedRuns } = await import("@/lib/analytics/queries"));
+    ({ applyBatch } = await import(
+      "@/scripts/lib/exec-log-network-gas-backfill"
+    ));
   });
 
   afterAll(async () => {
@@ -182,5 +253,34 @@ describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
   it("lists every chain the run's steps targeted, gas-bearing or not", async () => {
     const run = await runById(MIXED_ID);
     expect([...run.networks].sort()).toEqual(["base", "optimism"]);
+  });
+
+  it("reads the chain from the JSONB when the column was never backfilled", async () => {
+    expect(await logNetworkColumn(LEGACY_LOG_ID)).toBeNull();
+    const run = await runById(LEGACY_ID);
+    expect(run.network).toBe("base");
+    expect(run.networks).toEqual(["base"]);
+  });
+
+  it("reads historical gas from the JSONB when the column was never backfilled", async () => {
+    const run = await runById(LEGACY_GAS_ID);
+    expect(run.gasUsedWei).toBe("31000");
+    expect(run.network).toBe("base");
+  });
+
+  it("backfills a gas-free legacy row, so the read moves onto the column", async () => {
+    expect(await logNetworkColumn(BACKFILL_LOG_ID)).toBeNull();
+
+    // One batch, scoped by cursor to this row alone: the gas-only predicate the
+    // backfill used to carry never selects it, since it has no gasUsed.
+    expect(await applyBatch(BACKFILL_CURSOR, 1)).toBe(1);
+    expect(await logNetworkColumn(BACKFILL_LOG_ID)).toBe("base");
+
+    const run = await runById(BACKFILL_ID);
+    expect(run.network).toBe("base");
+    expect(run.networks).toEqual(["base"]);
+
+    // Idempotent: the row no longer matches, so a re-run writes nothing.
+    expect(await applyBatch(BACKFILL_CURSOR, 1)).toBe(0);
   });
 });

--- a/tests/unit/analytics-run-gas-display.test.ts
+++ b/tests/unit/analytics-run-gas-display.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { runGasDisplay } from "@/components/analytics/runs-table";
+import type { UnifiedRun } from "@/lib/analytics/types";
+
+const BASE = "8453"; // ETH
+const POLYGON = "137"; // POL
+
+const ONE_TENTH = "100000000000000000"; // 0.1e18
+
+function run(overrides: Partial<UnifiedRun>): UnifiedRun {
+  return {
+    id: "run",
+    source: "workflow",
+    status: "success",
+    startedAt: new Date(0).toISOString(),
+    completedAt: null,
+    durationMs: null,
+    workflowId: "wf",
+    workflowName: "wf",
+    directType: null,
+    network: null,
+    networks: [],
+    gasNetworks: [],
+    gasCostWei: null,
+    transactionHashes: [],
+    gasUsedWei: null,
+    totalSteps: null,
+    completedSteps: null,
+    error: null,
+    errorCode: null,
+    errorType: null,
+    errorCategory: null,
+    ...overrides,
+  };
+}
+
+describe("runGasDisplay", () => {
+  it("shows the amount for a run that wrote on one chain and read on another", () => {
+    // The case the targeted-chains reading got wrong: two chains touched, gas
+    // on one, so the total is summable and must not collapse to "Composed".
+    expect(
+      runGasDisplay(
+        run({
+          networks: [BASE, POLYGON],
+          gasNetworks: [BASE],
+          gasUsedWei: ONE_TENTH,
+          network: BASE,
+        })
+      )
+    ).toBe("0.10 ETH");
+  });
+
+  it("denominates in the chain the gas landed on, not an arbitrary targeted one", () => {
+    // networks[0] is Base here; keying the symbol off it would print ETH
+    // against an amount that was actually spent in POL.
+    expect(
+      runGasDisplay(
+        run({
+          networks: [BASE, POLYGON],
+          gasNetworks: [POLYGON],
+          gasUsedWei: ONE_TENTH,
+          network: POLYGON,
+        })
+      )
+    ).toBe("0.10 POL");
+  });
+
+  it("composes a run that genuinely spent on two chains", () => {
+    expect(
+      runGasDisplay(
+        run({
+          networks: [BASE, POLYGON],
+          gasNetworks: [BASE, POLYGON],
+          gasUsedWei: ONE_TENTH,
+          network: BASE,
+        })
+      )
+    ).toBe("Composed");
+  });
+
+  it("composes ledger-only gas that cannot be attributed to one chain", () => {
+    // No step rollup names a chain, and the run touched two, so there is no
+    // token to render the sponsored amount in.
+    expect(
+      runGasDisplay(
+        run({
+          networks: [BASE, POLYGON],
+          gasNetworks: [],
+          gasCostWei: ONE_TENTH,
+          network: BASE,
+        })
+      )
+    ).toBe("Composed");
+  });
+
+  it("borrows the run's chain for ledger-only gas on a single-chain run", () => {
+    expect(
+      runGasDisplay(
+        run({
+          networks: [POLYGON],
+          gasNetworks: [],
+          gasCostWei: ONE_TENTH,
+          network: POLYGON,
+        })
+      )
+    ).toBe("0.10 POL");
+  });
+
+  it("renders no amount for a run that failed before broadcast", () => {
+    expect(
+      runGasDisplay(
+        run({
+          status: "error",
+          networks: [BASE],
+          gasNetworks: [],
+          network: BASE,
+        })
+      )
+    ).toBe("--");
+  });
+});


### PR DESCRIPTION
Fixes the `network: null` / `networks: []` that `/api/analytics/runs` returns for any run that failed before broadcast. Issue: #2093.

### The cause

The `logSummary` subquery in `fetchWorkflowRuns` filtered on `gasUsed IS NOT NULL`. `WHERE` is evaluated before `GROUP BY`, so a run whose steps all lack gas contributed zero rows, formed no group, and left the `leftJoin` NULL - no expression in the select list could recover it. `lib/workflow/executor/logging.ts:566` writes the chain at step start, so the value was on disk the whole time; only the read dropped it.

In the UI that meant `--` under Network on exactly the runs an operator opens when something broke, and no way to match those runs by chain in the search filter. `runs-table.tsx:417-419` renders `run.networks`, so both aggregates had to be repaired, not just `network`.

### Changes

- Drop the gas predicate from the subquery. `gasUsedWei` is unaffected - `SUM` skips NULLs, and the resulting `0` still maps to `null` downstream, so "spent no gas" stays distinguishable from "chain unknown".
- Read each step's chain and gas as `COALESCE(denormalised column, JSONB extract)`. The columns (migration `0117`) are the cheap source, but they are NULL on every row written before that migration, and no writer went back over the history - so a column-only read loses the chain on exactly the old failed runs this fixes, and loses gas on old successful ones. The COALESCE arm makes correctness independent of the backfill having run.
- Widen `scripts/backfill-exec-log-network-gas.ts` so the columns can eventually carry every row. It keyed on gas-bearing rows only, on the stated reasoning that nothing read `network` on a gas-free row; this change makes that false, since a pre-flight failure is exactly a row with a network in `input` and no `gasUsed` in `output`. The predicate is now "either column unset while its JSONB carries a value", which also picks up partially-backfilled rows.
- Move the backfill's SQL to `scripts/lib/exec-log-network-gas-backfill.ts` so the database-backed test can run a batch, instead of asserting the widening in prose. The CLI keeps argument parsing, the non-local-write guard and progress logging.
- Restate the `networks` contract in `lib/analytics/types.ts`, and add `gasNetworks` beside it - the subset that actually spent gas. See the section below.
- Key the runs table's Gas cell off `gasNetworks` rather than `networks`, for both the "Composed" guard and the token symbol.
- `tests/e2e/vitest/analytics-run-network.db.test.ts` covers six cases against real Postgres.

### On the re-parse cost

The comment above `fetchNetworkBreakdown` records that per-row JSONB re-parsing pushed the networks endpoint past the edge timeout, which is why the columns exist. That cost is not in play in this subquery: `logSummary` is restricted to `pagedExecutionIds`, one page of executions, and has been since the comment at `queries.ts:975-981`. Reading JSONB here was already affordable, which is what makes the COALESCE arm the cheaper trade than a hard dependency on a backfill run.

### Two chain sets, because the table asks two questions

`networks` widens from "chains the run produced on-chain writes on" to "chains the run's steps targeted". That is what makes a pre-broadcast failure legible, and it is also what `types.ts` should always have said: `queries.ts` builds a *direct* run's `networks` from `directExecutions.network`, which is recorded whether or not gas landed, so the old contract was already false for half the union.

The widening did surface a second bug. `runs-table.tsx` decided "Composed" from `networks.length`, and its own comment states the criterion it means to apply - a run that spent on more than one chain cannot sum into one token. That is a claim about which chains bore gas. The two sets coincided only while this subquery gated `networks` behind `gasUsed IS NOT NULL`, so the guard was reading the right values through the wrong field. Ungate `networks` and a workflow that writes on Base and reads on Optimism renders "Composed" instead of a total that is perfectly summable.

Narrowing `networks` back would re-hide that rather than fix it. Instead the payload now carries both sets: `networks` for the Network column and the search filter, `gasNetworks` for the Gas cell. The subquery builds the second from fragments already in scope.

The token symbol matters independently of the guard. `runs-table.tsx:144` picked an arbitrary element of `networks`, which under the widened contract can be the read-only chain - so a Base amount could have printed with another chain's token. The old guard short-circuited before that line, so it was latent rather than live, but it was correct by accident either way. It now reads the gas chain.

Tracked as KEEP-1241.

### Scope

Covers every failure reaching `logStepCompleteDb` without gas: pre-flight balance and spend-cap rejections, simulation revert, wallet/config error, RPC unreachable, and cancelled runs whose log stays at `status='running'`.

Deliberately **not** covered, and tracked in #2093 rather than silently missed:
- `status='unconfirmed'`, where broadcast happened but no receipt was read. Its chain lives in `workflow_executions.transaction_hashes[].network`, a different read path.
- Runs that fail before any step log row exists. Nothing to read; needs run-level chain resolution and reopens the `schema.ts:733-737` decision.

### Verification

Six cases in `tests/e2e/vitest/analytics-run-network.db.test.ts` against Postgres 16:

| Case | On `61039ab` | On `6245e1c` | On head |
|---|---|---|---|
| gas-free run keeps its chain | fail | pass | pass |
| gas-bearing step's chain wins | pass | pass | pass |
| `networks` lists every targeted chain | fail | pass | pass |
| legacy row: chain read from JSONB | fail | fail | pass |
| legacy row: gas read from JSONB | pass | fail | pass |
| widened backfill repairs a gas-free legacy row | n/a | n/a | pass |

The two legacy cases fail on `6245e1c` with `expected null to be 'base'` and `expected null to be '31000'` - the second is the historical-gas regression the column-only read introduced. The backfill case returns 0 rows written under the old gas-only predicate and 1 under the widened one, so the widening is load-bearing rather than asserted.

Six more in `tests/unit/analytics-run-gas-display.test.ts` pin the Gas cell. Against the old `networks.length` guard, two fail: `expected 'Composed' to be '0.10 ETH'` and `expected 'Composed' to be '0.10 POL'` - the second being the token-symbol case.

`biome check` clean on the touched files. `tsc --noEmit` exits 0 with no diagnostics.

### Before merge

The backfill is no longer a correctness prerequisite, but it should still be run on staging and prod to retire the JSONB arm. It is keyset-batched, idempotent and resumable via `--after-id`; the widened scope walks most web3 step rows rather than the previous handful, so expect it to take longer.
