### PR TITLE
fix: split node template refs on the label, not the first dot

### DIFF
--- a/lib/utils/template.ts
+++ b/lib/utils/template.ts
@@ -12,6 +12,7 @@ import {
   recordUnresolved,
   type TemplateResolutionTracker,
 } from "@/lib/workflow/executor/template-resolution";
+import { splitTemplateRef } from "@/lib/workflow/template-ref";
 
 // Regex constants for performance
 const TEMPLATE_PATTERN = /\{\{([^}]+)\}\}/g;
@@ -73,8 +74,7 @@ function processNewFormatReference(
 
   const nodeId = withoutAt.substring(0, colonIndex);
   const rest = withoutAt.substring(colonIndex + 1);
-  const dotIndex = rest.indexOf(".");
-  const fieldPath = dotIndex === -1 ? "" : rest.substring(dotIndex + 1);
+  const { fieldPath } = splitTemplateRef(rest, nodeOutputs[nodeId]?.label);
 
   if (!fieldPath) {
     const nodeOutput = nodeOutputs[nodeId];

--- a/lib/workflow/codegen/codegen.ts
+++ b/lib/workflow/codegen/codegen.ts
@@ -3,6 +3,7 @@ import { resolveConditionExpression } from "@/lib/workflow/nodes/condition/resol
 import { isSafeConditionExpression } from "@/lib/workflow/nodes/condition/safe-eval";
 import { DEFAULT_HTTP_METHOD } from "@/lib/workflow/nodes/http-request/constants";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
+import { splitTemplateRef } from "@/lib/workflow/template-ref";
 import { findActionById, flattenConfigFields } from "@/plugins/registry";
 import {
   analyzeNodeUsage,
@@ -98,6 +99,9 @@ export function generateWorkflowCode(
 
   // Build a map of nodeId to variable name for template references
   const nodeIdToVarName = new Map<string, string>();
+  const nodeIdToLabel = new Map<string, string>(
+    nodes.map((n) => [n.id, n.data.label ?? ""])
+  );
   const usedVarNames = new Set<string>();
 
   for (const node of nodes) {
@@ -134,8 +138,7 @@ export function generateWorkflowCode(
 
     const nodeId = withoutAt.substring(0, colonIndex);
     const rest = withoutAt.substring(colonIndex + 1);
-    const dotIndex = rest.indexOf(".");
-    const fieldPath = dotIndex === -1 ? "" : rest.substring(dotIndex + 1);
+    const { fieldPath } = splitTemplateRef(rest, nodeIdToLabel.get(nodeId));
 
     const varName = nodeIdToVarName.get(nodeId);
     if (!varName) {
@@ -183,8 +186,7 @@ export function generateWorkflowCode(
 
     const nodeId = withoutAt.substring(0, colonIndex);
     const rest = withoutAt.substring(colonIndex + 1);
-    const dotIndex = rest.indexOf(".");
-    const fieldPath = dotIndex === -1 ? "" : rest.substring(dotIndex + 1);
+    const { fieldPath } = splitTemplateRef(rest, nodeIdToLabel.get(nodeId));
 
     const varName = nodeIdToVarName.get(nodeId);
     if (!varName) {

--- a/lib/workflow/codegen/sdk.ts
+++ b/lib/workflow/codegen/sdk.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { DEFAULT_HTTP_METHOD } from "@/lib/workflow/nodes/http-request/constants";
+import { splitTemplateRef } from "@/lib/workflow/template-ref";
 import { findActionById } from "@/plugins/registry";
 import { synthesiseProtocolForSDK } from "./protocol-synthesiser";
 // System action codegen templates (not in plugin registry)
@@ -67,7 +68,11 @@ function loadStepImplementation(actionType: string): string | null {
 /**
  * Process new format ID references (@nodeId:DisplayName)
  */
-function processNewFormatID(trimmed: string, match: string): string {
+function processNewFormatID(
+  trimmed: string,
+  match: string,
+  nodeLabels?: ReadonlyMap<string, string>
+): string {
   const withoutAt = trimmed.substring(1);
   const colonIndex = withoutAt.indexOf(":");
 
@@ -77,8 +82,7 @@ function processNewFormatID(trimmed: string, match: string): string {
 
   const nodeId = withoutAt.substring(0, colonIndex);
   const rest = withoutAt.substring(colonIndex + 1);
-  const dotIndex = rest.indexOf(".");
-  const fieldPath = dotIndex === -1 ? "" : rest.substring(dotIndex + 1);
+  const { fieldPath } = splitTemplateRef(rest, nodeLabels?.get(nodeId));
 
   const sanitizedNodeId = nodeId.replace(/[^a-zA-Z0-9]/g, "_");
 
@@ -138,7 +142,10 @@ function processLegacyDollarRef(trimmed: string): string {
  * Convert template variables to JavaScript expressions
  * Converts {{@nodeId:DisplayName.field}} to ${outputs?.['nodeId']?.data?.field}
  */
-function convertTemplateToJS(template: string): string {
+function convertTemplateToJSWithLabels(
+  template: string,
+  nodeLabels?: ReadonlyMap<string, string>
+): string {
   if (!template || typeof template !== "string") {
     return template;
   }
@@ -149,7 +156,7 @@ function convertTemplateToJS(template: string): string {
     const trimmed = expression.trim();
 
     if (trimmed.startsWith("@")) {
-      return processNewFormatID(trimmed, match);
+      return processNewFormatID(trimmed, match, nodeLabels);
     }
 
     if (trimmed.startsWith("$")) {
@@ -229,6 +236,11 @@ export function generateWorkflowSDKCode(
   // Build a map of node connections
   const nodeMap = new Map(nodes.map((n) => [n.id, n]));
   const edgesBySource = buildEdgeMap(edges);
+
+  // Labels are needed to split `Label.field` refs whose label contains dots.
+  const nodeLabels = new Map(nodes.map((n) => [n.id, n.data.label ?? ""]));
+  const convertTemplateToJS = (template: string): string =>
+    convertTemplateToJSWithLabels(template, nodeLabels);
 
   // Find trigger nodes
   const triggerNodes = findTriggerNodes(nodes, edges);

--- a/lib/workflow/editor/template-utils.ts
+++ b/lib/workflow/editor/template-utils.ts
@@ -1,3 +1,4 @@
+import { splitTemplateRef } from "@/lib/workflow/template-ref";
 import { findActionById } from "@/plugins/registry";
 import { BUILTIN_NODE_ID } from "./builtin-variables";
 
@@ -64,17 +65,15 @@ export function getDisplayTextForTemplate(
     }
   }
 
-  const dotIndex = rest.indexOf(".");
+  const { fieldPath } = splitTemplateRef(rest, displayLabel);
 
-  if (dotIndex === -1) {
+  if (!fieldPath) {
     return displayLabel ?? rest;
   }
-
-  const field = rest.substring(dotIndex + 1);
 
   if (!displayLabel) {
     return rest;
   }
 
-  return `${displayLabel}.${field}`;
+  return `${displayLabel}.${fieldPath}`;
 }

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -86,6 +86,7 @@ import {
 import { ARRAY_SOURCE_RE } from "@/lib/workflow/nodes/for-each/utils";
 import { triggerStep } from "@/lib/workflow/nodes/trigger/step";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
+import { splitTemplateRef } from "@/lib/workflow/template-ref";
 import { LEGACY_ACTION_MAPPINGS } from "@/plugins/legacy-mappings";
 
 // System actions that don't have plugins - maps to module import functions.
@@ -264,10 +265,10 @@ function replaceTemplateVariable(
     );
   }
 
-  const dotIndex = rest.indexOf(".");
+  const { fieldPath } = splitTemplateRef(rest, output.label);
   let value: unknown;
 
-  if (dotIndex === -1) {
+  if (!fieldPath) {
     value = output.data;
   } else if (output.data === null || output.data === undefined) {
     // KEEP-1284: Throw error when node data is null/undefined
@@ -275,8 +276,6 @@ function replaceTemplateVariable(
       `Condition references "${rest}" but the node output data is ${output.data === null ? "null" : "undefined"}. Ensure the referenced node produces valid output.`
     );
   } else {
-    const fieldPath = rest.substring(dotIndex + 1);
-
     // Wrapper-aware lookup: matches resolveFromOutputData's three-shape walk
     // (top-level → { data: ... } → { result: ... }) so paths like
     // "args.value" resolve through the trigger node's

--- a/lib/workflow/template-ref.ts
+++ b/lib/workflow/template-ref.ts
@@ -1,0 +1,40 @@
+/**
+ * Splitting for the `Label.field` half of a `{{@nodeId:Label.field}}` reference.
+ */
+
+export type TemplateRefParts = {
+  label: string;
+  fieldPath: string;
+};
+
+/**
+ * Split `Label.field` into its label and field path.
+ *
+ * The label is baked into the token at authoring time and may itself contain
+ * dots (a node named "check app.keeperhub.com"), so splitting on the first dot
+ * reads part of the label as the field path. Prefer the node's known label and
+ * fall back to the first dot when it is absent or stale, which is what a
+ * reference stored before the node was renamed carries.
+ */
+export function splitTemplateRef(
+  rest: string,
+  nodeLabel?: string
+): TemplateRefParts {
+  if (nodeLabel) {
+    if (rest === nodeLabel) {
+      return { label: nodeLabel, fieldPath: "" };
+    }
+    if (rest.startsWith(`${nodeLabel}.`)) {
+      return { label: nodeLabel, fieldPath: rest.slice(nodeLabel.length + 1) };
+    }
+  }
+
+  const dotIndex = rest.indexOf(".");
+  if (dotIndex === -1) {
+    return { label: rest, fieldPath: "" };
+  }
+  return {
+    label: rest.slice(0, dotIndex),
+    fieldPath: rest.slice(dotIndex + 1),
+  };
+}

--- a/tests/unit/template-ref-split.test.ts
+++ b/tests/unit/template-ref-split.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { splitTemplateRef } from "@/lib/workflow/template-ref";
+
+describe("splitTemplateRef", () => {
+  it("keeps a dotted label intact and takes the field after it", () => {
+    expect(
+      splitTemplateRef(
+        "check app.keeperhub.com.status",
+        "check app.keeperhub.com"
+      )
+    ).toEqual({ label: "check app.keeperhub.com", fieldPath: "status" });
+  });
+
+  it("returns no field path when the ref is the dotted label alone", () => {
+    expect(
+      splitTemplateRef("check app.keeperhub.com", "check app.keeperhub.com")
+    ).toEqual({ label: "check app.keeperhub.com", fieldPath: "" });
+  });
+
+  it("keeps nested field paths under a dotted label", () => {
+    expect(
+      splitTemplateRef("api.example.com.data.items[0].price", "api.example.com")
+    ).toEqual({ label: "api.example.com", fieldPath: "data.items[0].price" });
+  });
+
+  it("splits on the first dot for an ordinary label", () => {
+    expect(splitTemplateRef("HTTP Request.status", "HTTP Request")).toEqual({
+      label: "HTTP Request",
+      fieldPath: "status",
+    });
+  });
+
+  it("falls back to the first dot when no label is known", () => {
+    expect(splitTemplateRef("HTTP Request.data.value")).toEqual({
+      label: "HTTP Request",
+      fieldPath: "data.value",
+    });
+  });
+
+  it("falls back to the first dot when the stored label is stale", () => {
+    expect(splitTemplateRef("Old Name.status", "New Name")).toEqual({
+      label: "Old Name",
+      fieldPath: "status",
+    });
+  });
+
+  it("returns an empty field path when there is no dot at all", () => {
+    expect(splitTemplateRef("Trigger")).toEqual({
+      label: "Trigger",
+      fieldPath: "",
+    });
+  });
+
+  it("does not treat a label that merely shares a prefix as a match", () => {
+    expect(splitTemplateRef("HTTP Request.status", "HTTP")).toEqual({
+      label: "HTTP Request",
+      fieldPath: "status",
+    });
+  });
+});


### PR DESCRIPTION
## Problem

A stored template reference has the shape `{{@nodeId:Label.field}}`, and the label is written into the token at authoring time. Every reader split that token on the **first** dot to separate the label from the field path, which assumes a label can never contain a dot.

Naming a node after a host breaks that assumption. With a node called `check app.keeperhub.com`, the token is `{{@abc123:check app.keeperhub.com.status}}`, and the first-dot split yields a field path of `keeperhub.com.status`. A following condition then fails:

```
Condition references field "app.keeperhub.com.status" but "keeperhub" does not exist on the data.
Available fields: success, data, status
```

## Fix

Split on the node's known label when it matches, and fall back to the first dot when the label is absent or stale, so a reference stored before a rename keeps resolving exactly as it does today. The rule lives in one helper, `lib/workflow/template-ref.ts`.

The same first-dot split existed at six places, so fixing only the condition evaluator would have moved the bug rather than removed it:

| Site | Effect of the bug |
| --- | --- |
| `lib/workflow/executor/executor.workflow.ts` | condition evaluation fails at runtime (the reported symptom) |
| `lib/utils/template.ts` | action config templates resolve to the wrong field at runtime |
| `lib/workflow/editor/template-utils.ts` | reference badge renders the wrong display text |
| `lib/workflow/codegen/codegen.ts` (x2) | generated code emits a wrong access path |
| `lib/workflow/codegen/sdk.ts` | generated SDK code emits a wrong access path |

The two codegen modules only serve the generated-code viewer, not execution. The executor and `lib/utils/template.ts` are the live paths.

`sdk.ts` reaches labels through a local alias inside `generateWorkflowSDKCode` so its nineteen existing call sites are unchanged.

## Behaviour

No change for labels without dots: those still take the first-dot path and resolve as before. A node whose label contains dots now resolves its fields instead of erroring.

One case stays as it is today: a reference stored while a node had a dotted label, after that node is renamed to something else. The stored label no longer matches, so it falls back to the first-dot split. That is the existing behaviour, not a regression.