### PR TITLE
fix: surface the attributed preflight shortfall in the workflow builder

### DIFF
--- a/docs/api/direct-execution.md
+++ b/docs/api/direct-execution.md
@@ -806,7 +806,7 @@ Broadcasting requires `mcp:write`. A dry run (`simulate: true`) neither signs no
 
 Before an interactive Run, the workflow editor calls `POST /api/workflows/{workflowId}/simulate` to perform a read-only preflight of reachable EVM write nodes.
 
-The simulation is advisory and never blocks execution. Reverts, invalid simulation inputs, unsupported signers, RPC failures, timeouts, and unavailable simulation services are shown in the issues overlay with **Run Anyway** available.
+The simulation is advisory and never blocks execution. Reverts, funding shortfalls, invalid simulation inputs, unsupported signers, RPC failures, timeouts, and unavailable simulation services are shown in the issues overlay with **Run Anyway** available. A funding shortfall reports the account to fund and the amount it is short by, and names no configured field, because no configured field is wrong.
 
 Only write nodes reachable from a trigger are simulated. Disconnected write nodes are ignored.
 

--- a/lib/workflow/run-simulation.ts
+++ b/lib/workflow/run-simulation.ts
@@ -312,11 +312,11 @@ function simulationPreflightMessage(
   label: string,
   reason: string
 ): string {
-  if (!context.hasEarlierReachableWrite) {
-    return `${label} cannot run: ${reason}`;
-  }
-
   const sentence = reason.endsWith(".") ? reason : `${reason}.`;
+
+  if (!context.hasEarlierReachableWrite) {
+    return `${label} cannot run: ${sentence}`;
+  }
 
   return `${label} may not run: ${sentence} This may depend on an earlier step in this workflow.`;
 }
@@ -673,11 +673,14 @@ async function simulateNode(
   // than the revert arm above - but the configured inputs are not what is
   // wrong with it, and its reason is the actionable answer.
   if (result.code !== undefined) {
+    // No fieldKey: the shortfall is a fact about the funding account, not
+    // about any configured field. Naming one would point the issues overlay's
+    // parameter path and its Fix button at an input that is not wrong, which
+    // is the misdirection this branch exists to remove.
     return {
       status: "failed",
       issue: makeIssue(context, {
         code: "SIMULATION_PREFLIGHT_FAILED",
-        fieldKey: failureField(context),
         message: simulationPreflightMessage(
           context,
           label,

--- a/lib/workflow/run-simulation.ts
+++ b/lib/workflow/run-simulation.ts
@@ -295,6 +295,32 @@ function simulationRevertMessage(
   return `${label} would revert. ${revertGuidance(context.actionType)}`;
 }
 
+/**
+ * Message for a preflight failure the simulator attributed to a specific
+ * cause, such as a native-value shortfall.
+ *
+ * The attributed reason names the account to fund and the amount it is short
+ * by, neither of which the editor can derive on its own, so it is surfaced
+ * verbatim rather than replaced with generic input guidance.
+ *
+ * An earlier reachable write may be what funds the account. Simulation reads
+ * current state, not the state the workflow will have produced by the time
+ * this node runs, so the claim is softened the same way a revert is.
+ */
+function simulationPreflightMessage(
+  context: NodeSimulationContext,
+  label: string,
+  reason: string
+): string {
+  if (!context.hasEarlierReachableWrite) {
+    return `${label} cannot run: ${reason}`;
+  }
+
+  const sentence = reason.endsWith(".") ? reason : `${reason}.`;
+
+  return `${label} may not run: ${sentence} This may depend on an earlier step in this workflow.`;
+}
+
 function makeIssue(
   context: NodeSimulationContext,
   input: {
@@ -636,6 +662,27 @@ async function simulateNode(
         code: "SIMULATION_WOULD_REVERT",
         fieldKey: failureField(context),
         message: simulationRevertMessage(context, label, reason),
+      }),
+    };
+  }
+
+  // A machine-readable `code` means the simulator attributed the failure to a
+  // specific cause it could name, currently a native-value shortfall. Such a
+  // failure keeps `failureKind: "validation"` because gas estimation rejects
+  // the call before the EVM returns revert data, so it reaches here rather
+  // than the revert arm above - but the configured inputs are not what is
+  // wrong with it, and its reason is the actionable answer.
+  if (result.code !== undefined) {
+    return {
+      status: "failed",
+      issue: makeIssue(context, {
+        code: "SIMULATION_PREFLIGHT_FAILED",
+        fieldKey: failureField(context),
+        message: simulationPreflightMessage(
+          context,
+          label,
+          result.revertReason
+        ),
       }),
     };
   }

--- a/tests/unit/workflow-run-simulation.test.ts
+++ b/tests/unit/workflow-run-simulation.test.ts
@@ -682,7 +682,6 @@ describe("runWorkflowSimulation", () => {
 
     expect(result.warnings[0]).toMatchObject({
       code: "SIMULATION_PREFLIGHT_FAILED",
-      fieldKey: "amount",
     });
     // The address to fund and the amount to fund it by are the two facts the
     // editor cannot derive on its own, so both have to survive.
@@ -692,20 +691,18 @@ describe("runWorkflowSimulation", () => {
     expect(result.warnings[0]?.message).not.toContain(
       "has invalid transaction inputs"
     );
-    // Not a revert: nothing reached the EVM.
-    expect(result.warnings[0]?.message).not.toContain("revert");
+    // The wallet is short; no configured field is wrong. The overlay renders
+    // parameterPath under the message and points its Fix button at fieldKey,
+    // so naming a field here would send the user to an input that is fine.
+    expect(result.warnings[0]?.fieldKey).toBeUndefined();
+    expect(result.warnings[0]?.parameterPath).toBe("nodes[0].data.config");
+    // Gas estimation rejected the call, so it is not reported as a revert.
+    expect(result.warnings[0]?.message).not.toContain("would revert");
   });
 
   it("softens an attributed shortfall when an earlier step may fund it", async () => {
     spies.simulateNativeTransfer
-      .mockResolvedValueOnce({
-        success: true,
-        status: "simulated",
-        from: "0xaa0000000000000000000000000000000000aa00",
-        to: "0xbb0000000000000000000000000000000000bb00",
-        value: "1",
-        wouldRevert: false,
-      })
+      .mockResolvedValueOnce(SUCCESS_RESULT)
       .mockResolvedValueOnce({
         success: false,
         status: "simulated",

--- a/tests/unit/workflow-run-simulation.test.ts
+++ b/tests/unit/workflow-run-simulation.test.ts
@@ -641,6 +641,118 @@ describe("runWorkflowSimulation", () => {
       code: "SIMULATION_INVALID_TRANSACTION",
       fieldKey: "amount",
     });
+    // An uncoded validation failure has no attributed cause to report, so the
+    // generic input guidance is still the right answer for it.
+    expect(result.warnings[0]?.message).toContain(
+      "has invalid transaction inputs"
+    );
+  });
+
+  it("surfaces an attributed shortfall instead of generic input guidance", async () => {
+    // The real underfunded-sender shape: gas estimation rejects the call
+    // before the EVM returns revert data, so failureKind stays "validation"
+    // while `code` carries the attributed cause.
+    spies.simulateNativeTransfer.mockResolvedValueOnce({
+      success: false,
+      status: "simulated",
+      from: "0xaa0000000000000000000000000000000000aa00",
+      to: "0xbb0000000000000000000000000000000000bb00",
+      value: "1000000000000000000",
+      failureKind: "validation",
+      wouldRevert: true,
+      revertReason:
+        "Insufficient ETH balance. Have: 0.25, Need: 1.0. Fund 0xaa0000000000000000000000000000000000aa00 with at least 0.75 ETH on this chain and retry.",
+      error: "Insufficient ETH balance. Have: 0.25, Need: 1.0.",
+      code: "insufficient_balance",
+      balanceWei: "250000000000000000",
+      requiredWei: "1000000000000000000",
+      shortfallWei: "750000000000000000",
+      nativeSymbol: "ETH",
+    });
+
+    const result = await runWorkflowSimulation({
+      organizationId: "org_test",
+      nodes: [
+        actionNode("transfer-1", "web3/transfer-funds", {
+          amount: "1",
+          recipientAddress: "0xbb0000000000000000000000000000000000bb00",
+        }),
+      ],
+    });
+
+    expect(result.warnings[0]).toMatchObject({
+      code: "SIMULATION_PREFLIGHT_FAILED",
+      fieldKey: "amount",
+    });
+    // The address to fund and the amount to fund it by are the two facts the
+    // editor cannot derive on its own, so both have to survive.
+    expect(result.warnings[0]?.message).toContain(
+      "Fund 0xaa0000000000000000000000000000000000aa00 with at least 0.75 ETH"
+    );
+    expect(result.warnings[0]?.message).not.toContain(
+      "has invalid transaction inputs"
+    );
+    // Not a revert: nothing reached the EVM.
+    expect(result.warnings[0]?.message).not.toContain("revert");
+  });
+
+  it("softens an attributed shortfall when an earlier step may fund it", async () => {
+    spies.simulateNativeTransfer
+      .mockResolvedValueOnce({
+        success: true,
+        status: "simulated",
+        from: "0xaa0000000000000000000000000000000000aa00",
+        to: "0xbb0000000000000000000000000000000000bb00",
+        value: "1",
+        wouldRevert: false,
+      })
+      .mockResolvedValueOnce({
+        success: false,
+        status: "simulated",
+        from: "0xaa0000000000000000000000000000000000aa00",
+        to: "0xcc0000000000000000000000000000000000cc00",
+        value: "2000000000000000000",
+        failureKind: "validation",
+        wouldRevert: true,
+        revertReason:
+          "Insufficient ETH balance. Have: 0.25, Need: 2.0. Fund 0xaa0000000000000000000000000000000000aa00 with at least 1.75 ETH on this chain and retry.",
+        error: "Insufficient ETH balance. Have: 0.25, Need: 2.0.",
+        code: "insufficient_balance",
+        balanceWei: "250000000000000000",
+        requiredWei: "2000000000000000000",
+        shortfallWei: "1750000000000000000",
+        nativeSymbol: "ETH",
+      });
+
+    const result = await runWorkflowSimulation({
+      organizationId: "org_test",
+      nodes: [
+        triggerNode(),
+        actionNode("write-1", "web3/transfer-funds", {
+          amount: "1",
+          recipientAddress: "0xbb0000000000000000000000000000000000bb00",
+        }),
+        actionNode("write-2", "web3/transfer-funds", {
+          amount: "2",
+          recipientAddress: "0xcc0000000000000000000000000000000000cc00",
+        }),
+      ],
+      edges: [
+        { source: "trigger-1", target: "write-1" },
+        { source: "write-1", target: "write-2" },
+      ],
+    });
+
+    expect(result.warnings[0]).toMatchObject({
+      code: "SIMULATION_PREFLIGHT_FAILED",
+      nodeId: "write-2",
+    });
+    expect(result.warnings[0]?.message).toContain(
+      "This may depend on an earlier step in this workflow."
+    );
+    // The shortfall reason already ends in a period, so the appended sentence
+    // must not double it.
+    expect(result.warnings[0]?.message).not.toContain("retry.. This may");
   });
 
   it("warns that a later write may depend on an earlier workflow step", async () => {


### PR DESCRIPTION
## Problem

The workflow editor's pre-run simulation computes an actionable funding diagnosis and then throws it away.

`nativeShortfallFailure` attributes a native-value shortfall, returning `code: "insufficient_balance"` and the reason:

```
Insufficient ETH balance. Have: 0.25, Need: 1.0.
Fund 0x...orgWallet with at least 0.75 ETH on this chain and retry.
```

That failure keeps `failureKind: "validation"`, because gas estimation rejects the call before the EVM produces revert data. `simulationOutcome` branched only on `failureKind`, so the shortfall fell past the `unavailable` and `revert` arms into the fallback, which replaced the reason with:

```
<Node> has invalid transaction inputs.
Check the configured network, addresses, amount, and function parameters.
```

The user is told to check inputs that are fine, while the address to fund and the amount to fund it by, both already computed, are discarded. Reachable for any node sending native value: `web3/transfer-funds`, and `web3/write-contract` with a non-zero value. Zero-value calls skip the attribution entirely and are unaffected.

## Change

Branch on the attributed `code` before the fallback arm and report the simulator's own reason under a new `SIMULATION_PREFLIGHT_FAILED` issue code.

This follows the classification settled on the direct-execution dry-run diagnostics work: `failureKind` says where a failure came from, `code` is the actionable layer, and consumers branch on `code`. The shared discriminator is not touched, so no REST response shape changes and no simulator semantics move.

An earlier reachable write may be what funds the account. Simulation reads current state, not the state the workflow will have produced by the time the node runs, so that case is softened to "may not run" rather than asserting the node cannot run, matching how the revert arm already handles it.

Uncoded validation failures are unchanged and keep their generic input guidance, which is the right answer when there is no attributed cause to report.

## User-facing result

Before:

```
Transfer Native Token has invalid transaction inputs. Check the configured
network, addresses, amount, and function parameters.
```

After:

```
Transfer Native Token cannot run: Insufficient ETH balance. Have: 0.25,
Need: 1.0. Fund 0xaa...aa00 with at least 0.75 ETH on this chain and retry.
```

## Risk

Nothing branches on the issue `code` string today, so the added code value is inert for consumers.

The message is not the only observable field, though: the issues overlay also renders `parameterPath` beneath it and wires its **Fix** button to `fieldKey`. A shortfall therefore carries neither - it is a fact about the funding account, not about a configured field, and naming one would send the user to an input that is fine. `issuePath` drops the suffix, so the path is `nodes[N].data.config` and Fix opens the step without focusing a field.

## Tests

Two added to `tests/unit/workflow-run-simulation.test.ts`, both built on the real underfunded-sender payload shape rather than a synthetic one:

- an attributed shortfall reports `SIMULATION_PREFLIGHT_FAILED`, keeps the address and amount in the message, drops the generic guidance, is not labelled a revert, and carries no `fieldKey` so the overlay's path stays `nodes[N].data.config`;
- with an earlier reachable write, the claim is softened and the appended sentence does not double the reason's terminal period.

Both were confirmed to fail against the unmodified source and pass with it. The existing uncoded-validation test gains an assertion pinning the generic guidance, so the fallback cannot be widened by accident.

## Validation

- `tests/unit/workflow-run-simulation.test.ts`: 24/24
- `tests/unit/workflow-run-validation.test.ts`, `tests/integration/workflow-simulation-route.test.ts`, `tests/unit/execute-simulate.test.ts`: 55/55
- `tsc --noEmit`: clean
- Biome on both changed files: clean
