### PR TITLE
docs: sync CLI reference from v0.15.0

### DIFF
--- a/docs/cli/commands/kh_auth_login.md
+++ b/docs/cli/commands/kh_auth_login.md
@@ -8,7 +8,10 @@ Authenticate with KeeperHub using the device code flow.
 Prints a URL and a one-time code. Open the URL in any browser (the browser
 does not open automatically — copy the URL from the terminal) and enter the
 code to complete sign-in. Codes expire after 15 minutes.
-Use --with-token to read an API key from stdin for non-interactive automation.
+Use --with-token to supply an API key. In a terminal it is prompted for without
+echo; piped or redirected input is read from stdin for non-interactive
+automation. Passing the key inline records it in your shell history, where it
+stays after the session ends.
 
 See also: kh auth status, kh auth logout
 
@@ -22,8 +25,13 @@ kh auth login [flags]
   # Log in (device code flow)
   kh auth login
 
-  # Log in with an API key (non-interactive)
-  echo "kh_xxx" | kh auth login --with-token
+  # Log in with an API key (prompted, not echoed)
+  kh auth login --with-token
+
+  # Non-interactive, for CI. Use a variable or a file so the key stays out of
+  # shell history.
+  printf '%s' "$KEEPERHUB_API_KEY" | kh auth login --with-token
+  kh auth login --with-token < api-key.txt
 ```
 
 ### Options

--- a/docs/cli/commands/kh_execute_contract-call.md
+++ b/docs/cli/commands/kh_execute_contract-call.md
@@ -19,14 +19,15 @@ kh execute contract-call [flags]
 ### Options
 
 ```
-      --abi-file string    Path to local ABI JSON file
-      --args string        Method arguments as JSON array: '["arg1","arg2"]'
-      --chain string       Chain ID (required)
-      --contract string    Contract address (required)
-  -h, --help               help for contract-call
-      --method string      Method name (required)
-      --timeout duration   Timeout when using --wait (default 5m0s)
-      --wait               Wait for completion
+      --abi-file string          Path to local ABI JSON file
+      --args string              Method arguments as JSON array: '["arg1","arg2"]'
+      --chain string             Chain ID (required)
+      --contract string          Contract address (required)
+  -h, --help                     help for contract-call
+      --idempotency-key string   Stable Idempotency-Key for write intents (auto-generated if empty)
+      --method string            Method name (required)
+      --timeout duration         Timeout when using --wait (default 5m0s)
+      --wait                     Wait for completion
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/commands/kh_execute_status.md
+++ b/docs/cli/commands/kh_execute_status.md
@@ -5,7 +5,15 @@ Show the status of an execution
 ### Synopsis
 
 Show the status of a direct blockchain execution (transfer or contract call).
-Use --watch to poll until the execution reaches a terminal state.
+Use --watch to poll until the execution reaches a terminal state. Unconfirmed
+is terminal: the transaction was broadcast but no receipt could be read yet,
+and the reconciler keeps watching it, so re-check the execution later.
+
+Use --require-verified to fail unless the execution completed AND every
+onchain receipt is chain-verified with receiptStatus "success". A completed
+status without receipts exits non-zero: nothing was submitted, so there is
+nothing to chain-verify. An unconfirmed status exits non-zero as well: a
+broadcast with no readable receipt is not proof the transaction landed.
 
 See also: kh r st, kh ex transfer, kh ex cc
 
@@ -21,13 +29,19 @@ kh execute status <execution-id> [flags]
 
   # Watch until completion
   kh ex st abc123 --watch
+
+  # Gate a script on chain-verified success. --watch polls until the
+  # execution reaches a terminal status and has no deadline of its own,
+  # so bound it externally when running unattended.
+  kh ex st abc123 --watch --require-verified && ./next-step.sh
 ```
 
 ### Options
 
 ```
-  -h, --help    help for status
-      --watch   Live-update until complete
+  -h, --help               help for status
+      --require-verified   Exit non-zero unless completed with chain-verified success receipts
+      --watch              Live-update until complete
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/commands/kh_execute_transfer.md
+++ b/docs/cli/commands/kh_execute_transfer.md
@@ -19,14 +19,15 @@ kh execute transfer [flags]
 ### Options
 
 ```
-      --amount string          Amount to transfer (required)
-      --chain string           Chain ID (required)
-  -h, --help                   help for transfer
-      --timeout duration       Timeout when using --wait (default 5m0s)
-      --to string              Recipient address (required)
-      --token string           Token symbol (default "ETH")
-      --token-address string   ERC-20 token contract address
-      --wait                   Wait for completion
+      --amount string            Amount to transfer (required)
+      --chain string             Chain ID (required)
+  -h, --help                     help for transfer
+      --idempotency-key string   Stable Idempotency-Key for this write intent (auto-generated if empty)
+      --timeout duration         Timeout when using --wait (default 5m0s)
+      --to string                Recipient address (required)
+      --token string             Token symbol (default "ETH")
+      --token-address string     ERC-20 token contract address
+      --wait                     Wait for completion
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/execution-recovery.md
+++ b/docs/cli/execution-recovery.md
@@ -1,0 +1,82 @@
+---
+title: "Execution recovery"
+description: "KeeperHub CLI Execution recovery"
+---
+
+# Execution recovery
+
+Agents and adapters that submit KeeperHub **direct-execution** writes
+(`POST /api/execute/transfer`, `POST /api/execute/contract-call`) must recover
+safely when the network flakes, a status read races ahead of persistence, or
+an on-chain receipt is not successful.
+
+This guide is the published summary of the normative contract in
+[`execution-recovery-v1/contract.md`](./execution-recovery-v1/contract.md).
+
+It does **not** describe `POST /api/workflows/<id>/webhook`. That is a
+different surface.
+
+## Safe first-write sequence
+
+1. Simulate when available and continue only if the call would not revert.
+2. Broadcast once with a stable `Idempotency-Key` that names the **work**, not the attempt.
+3. Save `executionId`.
+4. Poll `GET /api/execute/{executionId}/status`.
+5. Do not infer on-chain success from `status=completed` alone. Treat
+   `receipts[].receiptStatus` as the receipt evidence: only `success` is a
+   successful receipt. `reverted` and `safe_inner_failure` are conclusive
+   failures. `not_found` and `timeout` mean the receipt was unreadable; the
+   server settles those rows as `unconfirmed`, not `failed`.
+
+KEEP-966 on the server re-verifies every claimed hash before writing
+`completed`. A reverted receipt is stored `verified: false` and the row
+settles as `failed`. A client that still sees `completed` plus a non-success
+receipt must fail closed — that combination is a defensive invariant, not an
+observed production envelope.
+
+## Direct-execution status vocabulary
+
+`pending | running | unconfirmed | completed | failed`
+
+(`app/api/execute/_lib/types.ts`. There is no `queued` status on this endpoint.)
+
+Poll while a row is `pending` or `running`. Stop on `unconfirmed`, `completed`
+or `failed`. `unconfirmed` means the transaction was broadcast but no receipt
+could be read; the server keeps reconciling that row, so treat it as "stop
+waiting and report", not as a failure, and read the settled status later
+against the same execution ID.
+
+Workflow run status uses a different vocabulary (`success` / `error` /
+`cancelled`) — do not mix it with direct-execution statuses.
+
+## CLI behaviour
+
+- `kh ex transfer` / `kh ex cc` attach `Idempotency-Key` on every write.
+  Override with `--idempotency-key` to pin a key across process restarts.
+- HTTP 5xx retries reuse that key.
+- HTTP 409 `idempotency_in_progress`: retry the **same** key until `--timeout`.
+  Do not mint a new key.
+- HTTP 409 `idempotency_conflict`: fail. Do not rotate the key (that would
+  broadcast a second transaction).
+- `--wait` polls the same execution ID and tolerates a **bounded** initial HTTP
+  404 until `--timeout` (default 5m). Persistent 404 (wrong id, other org) is
+  a timeout error.
+- `--watch` does **not** treat 404 as pending. A mistyped or foreign-org id
+  exits with an error instead of looping.
+- `--wait` and `--watch` stop on `unconfirmed` and report it. `--wait` exits
+  **zero** there, printing the status and transaction hash, because a non-zero
+  exit invites a re-run that would broadcast a second transaction.
+- Wait paths fail when `status=failed`, when a receipt is `reverted` or
+  `safe_inner_failure`, and when `status=completed` carries any non-success
+  receipt.
+- `kh ex status --require-verified` additionally demands chain proof: it exits
+  non-zero unless the execution completed carrying at least one receipt and
+  every receipt is `verified: true` with `receiptStatus: success`. `unconfirmed`
+  fails that gate, and so does a completion with an empty `receipts` array,
+  which is treated as success without the flag.
+
+## Fixtures
+
+Golden responses live under `testdata/execution_recovery_v1/` (`version: 1`)
+and are loaded by `go test ./internal/execrecovery/...`. Each fixture is
+labeled `observed`, `defensive`, or `classifier`.

--- a/docs/cli/quickstart.md
+++ b/docs/cli/quickstart.md
@@ -1,0 +1,100 @@
+---
+title: "Quickstart"
+description: "KeeperHub CLI Quickstart"
+---
+
+# Quickstart
+
+## Install
+
+**Homebrew (macOS/Linux with Homebrew):**
+```
+brew install keeperhub/tap/kh
+```
+
+**Linux (no Homebrew / headless):**
+```bash
+mkdir -p ~/.local/bin && cd "$(mktemp -d)"
+curl -fsSL https://api.github.com/repos/keeperhub/cli/releases/latest \
+  | grep browser_download_url | cut -d '"' -f 4 \
+  | grep -E 'linux_amd64\.tar\.gz|checksums\.txt' \
+  | xargs -n1 curl -fsSLO
+sha256sum --ignore-missing -c checksums.txt
+tar -xzf kh_*_linux_amd64.tar.gz -C ~/.local/bin kh
+```
+Replace `linux_amd64` with `linux_arm64` on ARM. Ensure `~/.local/bin` is on your `PATH`.
+The unauthenticated GitHub API is rate-limited to 60 requests per hour per IP; if you hit that limit, download directly from [GitHub Releases](https://github.com/keeperhub/cli/releases).
+
+**Go install:**
+```
+go install github.com/keeperhub/cli/cmd/kh@latest
+```
+
+**Binary download:** Download from [GitHub Releases](https://github.com/keeperhub/cli/releases) and add to your PATH.
+
+## Authenticate
+
+```
+kh auth login
+```
+
+This uses the **device code flow**: it prints a URL and a short code. Open the URL in any browser (including on a different machine) and enter the code to complete sign-in. On headless or remote boxes the browser will not open automatically — copy the URL from the terminal. Codes expire after 15 minutes; re-run `kh auth login` if yours expires. Your token is stored in the OS keyring.
+
+To authenticate non-interactively (CI/CD), set `KH_API_KEY` instead.
+
+## Common Commands
+
+**List workflows:**
+```
+kh workflow list
+```
+
+**Run a workflow and wait for completion:**
+```
+kh workflow run <workflow-id> --wait
+```
+
+**Check a run's status:**
+```
+kh run status <run-id>
+```
+
+**View run logs:**
+```
+kh run logs <run-id>
+```
+
+**Execute a contract call:**
+```
+kh execute contract-call --protocol aave --action supply --args '{"amount":"1000000"}'
+```
+
+**List available protocols:**
+```
+kh protocol list
+```
+
+## MCP Server Mode
+
+KeeperHub exposes its actions as tools to AI assistants via the [Model Context Protocol](https://modelcontextprotocol.io).
+
+**Recommended: remote HTTP endpoint (no local server required):**
+```
+claude mcp add --transport http --scope user keeperhub https://app.keeperhub.com/mcp
+```
+
+**Add to Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+```json
+{ "mcpServers": { "keeperhub": { "type": "http", "url": "https://app.keeperhub.com/mcp" } } }
+```
+
+Restart Claude Desktop. KeeperHub tools will appear in the tool list.
+
+**Legacy: local stdio server (deprecated):**
+
+`kh serve --mcp` starts a local MCP stdio server. This mode is deprecated. Prefer the remote HTTP endpoint above.
+
+## Next Steps
+
+- [Concepts](./concepts) -- authentication, output formats, configuration
+- [Command reference](./commands/kh) -- full documentation for every command


### PR DESCRIPTION
Auto-synced CLI command reference from cli@v0.15.0. Changes generated by go generate ./docs/... and copied to docs/cli/.