### PR TITLE
docs: #2055 point agent/API consumers at wallet and address discovery

### DIFF
--- a/docs/getting-started/agent.md
+++ b/docs/getting-started/agent.md
@@ -75,6 +75,12 @@ four above. Treat anything other than `success` as a failure. Checking only for 
 For a one-off transfer or contract call with no workflow around it, use the direct execution
 tools: `execute_transfer`, `execute_contract_call`, `execute_protocol_action`.
 
+**Know the wallet that signs.** Broadcasts come from your organization's Turnkey wallet, not your
+own. Discover it over REST with `GET /api/user/wallet` (`walletAddress` for EVM, `solanaAddress`
+for Solana) or `GET /api/integrations` (canonical EIP-55 checksummed `address`), or over MCP with
+`list_integrations` and `get_wallet_integration`. Fund that address on the target network before a
+first write. See [User API](/api/user) and [Integrations](/api/integrations).
+
 Always preflight:
 
 1. Call the tool with `simulate: true`.

--- a/docs/getting-started/api.md
+++ b/docs/getting-started/api.md
@@ -47,6 +47,13 @@ from wallet sign-in instead. See [Headless Onboarding](/api/headless-onboarding)
 Your organization's Turnkey wallet is provisioned on signup. Eligible transactions on supported
 EVM mainnets and testnets may use the organization's monthly sponsored-gas allowance.
 
+To find the address that signs and funds your executions, `GET /api/user/wallet` returns the
+Turnkey wallet for your organization, including `walletAddress` (EVM) and `solanaAddress`
+(Solana). `GET /api/integrations` returns the same signer as a web3 integration with a canonical
+EIP-55 checksummed `address` field, which API consumers should prefer when an address must be
+compared exactly. Both endpoints accept the same `Authorization: Bearer $KEEPERHUB_KEY` header as
+every other agent route. See [User API](/api/user) and [Integrations](/api/integrations).
+
 Sponsorship pays the **network fee**, not the value moved. A workflow that sends 0.1 ETH still
 needs 0.1 ETH in the wallet, and an ERC-20 transfer still needs the token balance. Sponsorship
 also requires the sender to be the wallet rather than a Safe, the transaction to use the public


### PR DESCRIPTION
docs: point agent and API consumers at wallet/address discovery (#2055)

## What

`docs/getting-started/agent.md` and `docs/getting-started/api.md` tell a new
integration that broadcasts come from the organization's Turnkey wallet, but
never say how to discover that wallet's address over the API. An agent has to
guess between the dashboard, the MCP, and undocumented REST routes.

This adds two short pointers:

- `docs/getting-started/api.md` (section 2, "Fund the wallet"): how to find the
  signer address via `GET /api/user/wallet` (`walletAddress` / `solanaAddress`)
  and via `GET /api/integrations` (canonical EIP-55 checksummed `address`).
- `docs/getting-started/agent.md` (section 4, "Write onchain, safely"): a "Know
  the wallet that signs" note covering the same REST routes plus the MCP tools
  `list_integrations` / `get_wallet_integration`.

Both endpoints already exist and accept a `kh_` API key (verified live). The
reference already documents them (`docs/api/user.md`, `docs/api/integrations.md`);
these onboarding pages just did not link to them.

## Why

A REST-only or MCP-only integration cannot discover its funding address without
leaving the docs: the dashboard exposes it, and `docs/api/headless-onboarding.md`
reaches it via `GET /api/user`, but the primary getting-started pages for agents
and API consumers stay silent. This closes the documented gap from #2055.

Contributes to #1869.
