### PR TITLE
fix: #1959 reject simulate query param on transfer instead of silently executing

### DIFF
--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -64,6 +64,23 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 
+  // The dry-run flag lives in the request body (`simulate: true`), never in
+  // the query string. A `?simulate=...` parameter is rejected rather than
+  // silently ignored: a caller that believes the query made a dry run could
+  // otherwise broadcast for real. #1959
+  const query = new URL(request.url).searchParams;
+  if (query.has("simulate")) {
+    return NextResponse.json(
+      {
+        error: "unsupported_param",
+        details:
+          '`simulate` is only accepted in the request body (`{"simulate":true}`), not as a query parameter. A query flag is never honoured.',
+        field: "simulate",
+      },
+      { status: HttpStatus.BAD_REQUEST }
+    );
+  }
+
   const simulateFlag = parseSimulateFlag(body);
   if (!simulateFlag.ok) {
     return NextResponse.json(


### PR DESCRIPTION
fix: #1959 reject a `simulate` query param on /api/execute/transfer instead of silently executing

## What

`POST /api/execute/transfer?simulate=true` silently ignored the query flag and
broadcast a real transfer. The dry-run flag is only ever read from the request
body (`{"simulate":true}`); a caller who believed `?simulate=` made a dry run
had no way to find out otherwise until funds moved.

This adds a guard at the top of the transfer route that rejects a `simulate`
query parameter with a `400 unsupported_param`, naming the correct (body) form.
It never reaches the broadcast path.

## Why this is the right shape

- The request-body `simulate: true` path already works and is the canonical,
  documented dry-run (verified live: returns `status:"simulated"` /
  `wouldRevert`, nothing broadcast). The remaining hole from #1959 is the query
  parameter being ignored.
- This matches the `simulate`-uniformity invariant tracked in #2004: an execute
  route either honours a dry-run or refuses it, and never accepts the flag and
  broadcasts. Rejecting the query param removes the silent-broadcast hazard
  today, the smaller and safer option.
- Consistent with `lib/execute/simulate-flag.ts`'s strict-boolean philosophy: a
  flag in the wrong place is the same hazard as a flag of the wrong type.

## Repro (pre-fix, observed on app.keeperhub.com)

```
POST /api/execute/transfer?simulate=true
{"chainId":"11155111","recipientAddress":"0x...dEaD","amount":"0.001"}
```
post-fix expectation: `400 {"error":"unsupported_param", ...}` instead of a
broadcast.

Contributes to #2004.
