### PR TITLE
fix: keep the sign-in dialog open across a tab switch

### DIFF
--- a/components/auth/connect-auth-panel.tsx
+++ b/components/auth/connect-auth-panel.tsx
@@ -172,13 +172,15 @@ export function ConnectAuthPanel({
   const [captchaToken, setCaptchaToken] = useState("");
   const captchaRef = useRef<TurnstileInstance | null>(null);
 
-  const inCodeStep =
-    view === "verify" || view === "mfa-email" || view === "mfa-totp";
-
+  // While this panel is on screen the visitor is mid auth flow. Better Auth
+  // refetches the session on tab focus and UserMenu drops to a skeleton while
+  // that is pending, which unmounts the dialog owning this panel and discards
+  // whatever was typed. Users leave the tab to copy an emailed code, so the
+  // panel has to survive that round trip on every view, not just code steps.
   useEffect(() => {
-    setConnectPanelActive(loading || inCodeStep);
+    setConnectPanelActive(true);
     return () => setConnectPanelActive(false);
-  }, [loading, inCodeStep]);
+  }, []);
 
   const contentRef = useRef<HTMLDivElement>(null);
   const [height, setHeight] = useState<number | "auto">("auto");

--- a/components/auth/dialog.tsx
+++ b/components/auth/dialog.tsx
@@ -17,7 +17,7 @@ export type AuthPromptIntent = {
 };
 
 // --- Auth-flow-in-progress tracking --------------------------------------
-// ConnectAuthPanel flips connectPanelActive during its email / OTP steps so
+// ConnectAuthPanel flips connectPanelActive for as long as it is mounted so
 // surfaces like the user menu know an auth flow is mid-air and must not be
 // torn down by a session refetch. Kept here so importers have one source.
 let connectPanelActive = false;

--- a/tests/e2e/playwright/auth-dialog-tab-switch.test.ts
+++ b/tests/e2e/playwright/auth-dialog-tab-switch.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "./fixtures";
+
+// Unique per run: the reset request allows only 5 per address per 15 minutes,
+// so a constant address throttles on repeated runs.
+const uniqueEmail = (): string => `tab-switch+${Date.now()}@techops.services`;
+
+/**
+ * The in-app sign-in dialog must survive a tab switch. Better Auth refetches the
+ * session on tab focus and UserMenu drops to a skeleton while that is pending,
+ * which unmounts ConnectButton and the dialog state it owns. Users leave the tab
+ * to copy an emailed code, so losing the dialog there strands them mid-flow.
+ */
+test.describe("auth dialog lifecycle", () => {
+  test("survives a tab switch while awaiting an emailed reset code", async ({
+    page,
+    context,
+  }) => {
+    await context.clearCookies();
+    const dialog = await openSignInDialog(page);
+
+    // The request leg answers success for unknown emails so it cannot be used to
+    // enumerate accounts, so the reset view is reachable without a real user.
+    await dialog.locator("#auth-email").fill(uniqueEmail());
+    await dialog.getByRole("button", { name: "Forgot password?" }).click();
+    await dialog.getByRole("button", { name: "Send reset code" }).click();
+
+    const resetHeading = dialog.getByRole("heading", {
+      name: "Enter your reset code",
+    });
+    await expect(resetHeading).toBeVisible({ timeout: 20_000 });
+
+    await switchAwayAndBack(page);
+
+    await expect(resetHeading).toBeVisible({ timeout: 20_000 });
+    await expect(dialog.getByPlaceholder("Reset code")).toBeVisible();
+  });
+
+  test("keeps a typed email across a tab switch on the sign-in view", async ({
+    page,
+    context,
+  }) => {
+    await context.clearCookies();
+    const dialog = await openSignInDialog(page);
+    const typed = uniqueEmail();
+    await dialog.locator("#auth-email").fill(typed);
+
+    await switchAwayAndBack(page);
+
+    await expect(dialog.locator("#auth-email")).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(dialog.locator("#auth-email")).toHaveValue(typed);
+  });
+});
+
+/**
+ * A real tab switch, which is what Better Auth's focus manager listens for.
+ * bringToFront does not change visibilityState in headless Chromium, so it
+ * would not exercise this path.
+ */
+async function switchAwayAndBack(
+  page: import("@playwright/test").Page
+): Promise<void> {
+  await page.evaluate(() => {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+  await page.evaluate(() => {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+
+/**
+ * Open the in-app sign-in dialog as a visitor with no session at all. Guests
+ * hold an anonymous session, which UserMenu already exempts from the skeleton,
+ * so the teardown only reproduces here. /hub is public; "/" would redirect to
+ * /welcome, where the panel renders inline and is never unmounted.
+ */
+async function openSignInDialog(
+  page: import("@playwright/test").Page
+): Promise<import("@playwright/test").Locator> {
+  await page.goto("/hub", { waitUntil: "domcontentloaded" });
+  await page
+    .getByRole("button", { name: "Sign in", exact: true })
+    .first()
+    .click();
+  const dialog = page.locator('[role="dialog"]');
+  await expect(dialog.locator("#auth-email")).toBeVisible({ timeout: 20_000 });
+  return dialog;
+}


### PR DESCRIPTION
## Problem

The in-app sign-in dialog closes when you switch to another tab and come back. Anyone leaving the tab to read an emailed code returns to a dismissed modal with their input gone, which makes the code impossible to complete without a second device.

## Cause

Better Auth's focus manager listens for `visibilitychange` and refreshes the session whenever the document becomes visible again. While that refresh is pending, `UserMenu` renders a skeleton. For a signed-out visitor the dialog is owned by `ConnectButton`, which that skeleton replaces, so the dialog unmounts and its state is discarded.

A guard for this already existed, but it only marked the panel active on the code steps. Sign-up, both password-reset legs and the sign-in view itself were unprotected. The reset view was the most common way to hit it, since that is exactly when people go read their email.

Visitors holding an anonymous session were already exempt from the skeleton, so this only affected visitors with no session at all. That is why it reproduces on a public page such as the hub rather than through the guest entry.

## Fix

Mark the panel active for as long as it is mounted rather than only on code steps.

## Tests

Two Playwright tests covering the dialog surviving a tab switch, one on the reset view awaiting an emailed code and one preserving typed input on the sign-in view.

The tests drive `visibilitychange` directly, because that is the event Better Auth listens for and `bringToFront` does not change `visibilityState` in headless Chromium. Verified against a real app and database: both tests fail against the current code and pass with the fix.