### PR TITLE
fix: clear the inherited session in the auth flow e2e tests

### DIFF
--- a/tests/e2e/playwright/email-password-auth-flow.test.ts
+++ b/tests/e2e/playwright/email-password-auth-flow.test.ts
@@ -18,6 +18,13 @@ const CHANGED_PASSWORD = "ChangedPass789!";
  * tests cannot see a form wired to a field that no longer renders.
  */
 test.describe("email and password auth flow", () => {
+  // The chromium project loads a signed-in storageState. These tests create
+  // their own users and start from /welcome, which only serves the sign-up view
+  // to logged-out visitors, so the inherited session has to go first.
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+  });
+
   test("signup verifies email and enrolls TOTP before granting a session", async ({
     page,
   }) => {


### PR DESCRIPTION
## Problem

The staging pipeline is red on `e2e-playwright-ephemeral`. All three tests in `email-password-auth-flow.test.ts` fail, through both CI retries, so this is a real failure rather than flake.

Each fails the same way, waiting on the sign-up toggle:

```
Locator: getByRole('heading', { name: 'Create your account' })
Error: element(s) not found
```

## Cause

The `chromium` project loads a signed-in `storageState` produced by `auth.setup`. These tests create their own users, and `signUp` starts at `/welcome`, which only serves the sign-up view to logged-out visitors. With a session present `/welcome` redirects to `/`, so the toggle never renders. None of the three cleared the inherited session first.

This did not show up when the tests were written because that run reused a stale `storageState` whose session was no longer valid, leaving the browser effectively logged out. The signed-in path only appears on a runner where `auth.setup` succeeds.

## Fix

Clear cookies before each test, matching the pattern already used in `auth.test.ts`.

## Verification

Reproduced and fixed locally against a real app and database. Confirmed directly that a signed-in context lands on `/` with no sign-up toggle, and that clearing the session restores it. Then minted a genuine signed-in `storageState`, which is the condition that broke CI, and ran the suite against it: all three pass, and both auth spec files pass together.

## Not included

`invitations.test.ts` INV-SEND-2 also appeared in that run but passed on retry and is reported as flaky, not failed. It is unrelated to these tests and left alone here.