### PR TITLE
fix: open billing and plans to members, close restricted settings routes

### DIFF
--- a/components/billing/payg-section.tsx
+++ b/components/billing/payg-section.tsx
@@ -248,8 +248,11 @@ function PaygWalletFunding({
  */
 export function PaygSection({
   plan,
+  canManageCaps = true,
 }: {
   plan: PlanName;
+  /** The caps are the owner's to set, so everyone else reads usage only. */
+  canManageCaps?: boolean;
 }): React.ReactElement | null {
   const { organization } = useOrganization();
   const orgId = organization?.id;
@@ -393,40 +396,48 @@ export function PaygSection({
         />
       </div>
 
-      <div className="flex flex-wrap items-end gap-3">
-        <CapField
-          hint="Resets daily at 00:00 UTC"
-          id="payg-daily-cap"
-          label="Daily spend cap"
-          onChange={setDaily}
-          value={daily}
-        />
-        <CapField
-          hint="Resets at the start of each billing month"
-          id="payg-period-cap"
-          label="Monthly spend cap"
-          onChange={setPeriod}
-          value={period}
-        />
-        <Button
-          disabled={saving || !(dirty && available)}
-          onClick={() => {
-            saveCaps().catch(() => undefined);
-          }}
-          size="sm"
-          type="button"
-          variant="outline"
-        >
-          {saving && <Loader2 className="size-4 animate-spin" />}
-          Save caps
-        </Button>
-      </div>
+      {canManageCaps ? (
+        <>
+          <div className="flex flex-wrap items-end gap-3">
+            <CapField
+              hint="Resets daily at 00:00 UTC"
+              id="payg-daily-cap"
+              label="Daily spend cap"
+              onChange={setDaily}
+              value={daily}
+            />
+            <CapField
+              hint="Resets at the start of each billing month"
+              id="payg-period-cap"
+              label="Monthly spend cap"
+              onChange={setPeriod}
+              value={period}
+            />
+            <Button
+              disabled={saving || !(dirty && available)}
+              onClick={() => {
+                saveCaps().catch(() => undefined);
+              }}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              {saving && <Loader2 className="size-4 animate-spin" />}
+              Save caps
+            </Button>
+          </div>
 
-      <p className="text-muted-foreground text-xs">
-        Amounts in USDC. A cap of 0 spends nothing. Executions that would exceed
-        a cap are blocked with a clear reason and recorded as a billing error on
-        the run.
-      </p>
+          <p className="text-muted-foreground text-xs">
+            Amounts in USDC. A cap of 0 spends nothing. Executions that would
+            exceed a cap are blocked with a clear reason and recorded as a
+            billing error on the run.
+          </p>
+        </>
+      ) : (
+        <p className="text-muted-foreground text-xs">
+          Spend caps are set by the owner of this organization.
+        </p>
+      )}
 
       <PaygChargesTable key={orgId} />
     </div>

--- a/components/billing/pricing-table/index.tsx
+++ b/components/billing/pricing-table/index.tsx
@@ -11,7 +11,7 @@ import {
   type PricingCtaContext,
 } from "keeperhub-pricing-ui";
 import "keeperhub-pricing-ui/styles.css";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { BILLING_API } from "@/lib/billing/constants";
 import {
@@ -676,9 +676,85 @@ function buildComparisonColumns(): PkgComparisonColumn[] {
   }));
 }
 
-/** A card nobody can act on: the price and what it includes still read. */
+const OWNER_ONLY_HINT = "Available to the owner";
+
+/**
+ * A card nobody can act on: the price and what it includes still read. The
+ * handler goes with the button, which leaves the package rendering an inert
+ * link -- and a link, unlike a disabled button, still reports the hover the
+ * hint is anchored to.
+ */
 function withoutCta(card: PkgPricingCard): PkgPricingCard {
-  return { ...card, cta: { ...card.cta, disabled: true } };
+  return {
+    ...card,
+    cta: { ...card.cta, disabled: true, href: undefined, onClick: undefined },
+  };
+}
+
+type HintSpot = { left: number; top: number };
+
+/** The read-only table, with a word on why the cards cannot be acted on. */
+function ReadOnlyCards({
+  cards,
+  interval,
+  onIntervalChange,
+  onTierChange,
+}: {
+  cards: PkgPricingCard[];
+  interval: PkgBillingInterval;
+  onIntervalChange: (next: PkgBillingInterval) => void;
+  onTierChange: (cardId: string, tierKey: string) => void;
+}): React.ReactElement {
+  const frame = useRef<HTMLDivElement>(null);
+  const [hint, setHint] = useState<HintSpot | null>(null);
+
+  // The cards come from a package, so there is no element of ours to hang a
+  // tooltip on. The frame listens for the hover instead and places the hint
+  // over whichever card button the pointer is on.
+  useEffect(() => {
+    const node = frame.current;
+    if (!node) {
+      return;
+    }
+    const show = (event: MouseEvent): void => {
+      const cta = (event.target as HTMLElement | null)?.closest(".khp-cta");
+      if (!cta) {
+        return;
+      }
+      const box = cta.getBoundingClientRect();
+      const frameBox = node.getBoundingClientRect();
+      setHint({
+        left: box.left - frameBox.left + box.width / 2,
+        top: box.top - frameBox.top,
+      });
+    };
+    const hide = (): void => setHint(null);
+    node.addEventListener("mouseover", show);
+    node.addEventListener("mouseout", hide);
+    return () => {
+      node.removeEventListener("mouseover", show);
+      node.removeEventListener("mouseout", hide);
+    };
+  }, []);
+
+  return (
+    <div className="relative" ref={frame}>
+      <PricingCards
+        cards={cards}
+        interval={interval}
+        onIntervalChange={onIntervalChange}
+        onTierChange={onTierChange}
+      />
+      {hint && (
+        <span
+          className="-translate-x-1/2 -translate-y-full pointer-events-none absolute z-50 w-fit whitespace-nowrap rounded-md bg-foreground px-3 py-1.5 text-background text-xs"
+          style={{ left: hint.left, top: hint.top - 8 }}
+        >
+          {OWNER_ONLY_HINT}
+        </span>
+      )}
+    </div>
+  );
 }
 
 // -- Confirm dialog derived data --
@@ -850,12 +926,21 @@ export function PricingTable({
 
   return (
     <div className="space-y-8">
-      <PricingCards
-        cards={cards}
-        interval={appIntervalToPkg(interval)}
-        onIntervalChange={(next) => setInterval(pkgIntervalToApp(next))}
-        onTierChange={onCardTierChange}
-      />
+      {canManage ? (
+        <PricingCards
+          cards={cards}
+          interval={appIntervalToPkg(interval)}
+          onIntervalChange={(next) => setInterval(pkgIntervalToApp(next))}
+          onTierChange={onCardTierChange}
+        />
+      ) : (
+        <ReadOnlyCards
+          cards={cards}
+          interval={appIntervalToPkg(interval)}
+          onIntervalChange={(next) => setInterval(pkgIntervalToApp(next))}
+          onTierChange={onCardTierChange}
+        />
+      )}
 
       <PricingComparisonTable
         collapsible

--- a/components/billing/pricing-table/index.tsx
+++ b/components/billing/pricing-table/index.tsx
@@ -676,6 +676,11 @@ function buildComparisonColumns(): PkgComparisonColumn[] {
   }));
 }
 
+/** A card nobody can act on: the price and what it includes still read. */
+function withoutCta(card: PkgPricingCard): PkgPricingCard {
+  return { ...card, cta: { ...card.cta, disabled: true } };
+}
+
 // -- Confirm dialog derived data --
 
 type DialogData = ConfirmTarget & {
@@ -741,6 +746,7 @@ export function PricingTable({
   gasCreditCaps,
   trial,
   onPlanUpdated,
+  canManage = true,
 }: PricingTableProps): React.ReactElement {
   const [interval, setInterval] = useState<BillingInterval>("monthly");
   const [selectedTierByCard, setSelectedTierByCard] = useState<
@@ -819,7 +825,7 @@ export function PricingTable({
   const proTrialDays = isTrialSelection(trial, "pro", selectedTierByCard.pro)
     ? (trial?.days ?? null)
     : null;
-  const cards = buildCards({
+  const builtCards = buildCards({
     currentPlan,
     currentTier,
     currentInterval,
@@ -832,6 +838,7 @@ export function PricingTable({
     proTrialDays,
     onSelect: onCardCta,
   });
+  const cards = canManage ? builtCards : builtCards.map(withoutCta);
 
   const comparisonColumns = buildComparisonColumns();
   const comparisonRows = buildComparisonRows(

--- a/components/billing/pricing-table/types.ts
+++ b/components/billing/pricing-table/types.ts
@@ -18,6 +18,7 @@ export type TrialInfo = {
 
 export type PricingTableProps = {
   currentPlan?: PlanName;
+  canManage?: boolean;
   currentTier?: TierKey | null;
   currentInterval?: BillingInterval | null;
   gasCreditCaps?: GasCreditCapsMap;

--- a/components/settings/hub/billing-section.tsx
+++ b/components/settings/hub/billing-section.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 import { PAYG_PLAN_NAME } from "@/lib/billing/plans";
 import { UsageMeter } from "./billing/usage-meter";
 import { useBillingSummary } from "./hooks/use-billing-summary";
-import { SectionHeader, SettingsCard, StatTile } from "./section";
+import { EmptyState, SectionHeader, SettingsCard, StatTile } from "./section";
 import { useSettingsContext } from "./settings-context";
 import { FormSkeleton } from "./skeletons";
 
@@ -42,8 +42,16 @@ function formatDate(value: string | null): string {
   return value ? new Date(value).toLocaleDateString() : "--";
 }
 
+/** Only the owner can act on a plan, so everyone else is offered a look. */
+function changePlanLabel(isOwner: boolean, isPaid: boolean): string {
+  if (!isOwner) {
+    return "View plans";
+  }
+  return isPaid ? "Change plan" : "Upgrade";
+}
+
 export function BillingSection(): React.ReactElement {
-  const { organizationId } = useSettingsContext();
+  const { organizationId, isOwner } = useSettingsContext();
   const { summary, loading } = useBillingSummary();
   const isPaid = summary ? summary.plan !== "free" : false;
   const pending = loading || !summary;
@@ -54,7 +62,7 @@ export function BillingSection(): React.ReactElement {
         action={
           <Button asChild>
             <Link href={`/settings/${organizationId}/plans`}>
-              {isPaid ? "Change plan" : "Upgrade"}
+              {changePlanLabel(isOwner, isPaid)}
             </Link>
           </Button>
         }
@@ -116,7 +124,7 @@ export function BillingSection(): React.ReactElement {
         )}
       </SettingsCard>
 
-      {isPaid && (
+      {isPaid && isOwner && (
         <>
           {/* One under the other, each the full width: side by side left the
               history table too narrow to show its first column. */}
@@ -125,12 +133,21 @@ export function BillingSection(): React.ReactElement {
         </>
       )}
 
+      {isPaid && !isOwner && (
+        <SettingsCard title="Payment and invoices">
+          <EmptyState>
+            The card on file and the invoices are visible to the owner of this
+            organization only.
+          </EmptyState>
+        </SettingsCard>
+      )}
+
       {summary?.plan === PAYG_PLAN_NAME && (
         <SettingsCard
           description="Keep a balance in USDC and spend it per execution, with no subscription. Top it up here."
           title="Pay as you go"
         >
-          <PaygSection plan={summary.plan} />
+          <PaygSection canManageCaps={isOwner} plan={summary.plan} />
         </SettingsCard>
       )}
     </>

--- a/components/settings/hub/nav.ts
+++ b/components/settings/hub/nav.ts
@@ -284,6 +284,11 @@ export const SETTINGS_NAV: readonly SettingsNavGroup[] = [
               "usage",
               "quota",
               "gas sponsorship credits",
+            ],
+          },
+          {
+            title: "Payment and invoices",
+            tags: [
               "invoices",
               "receipts",
               "payment method",
@@ -300,11 +305,11 @@ export const SETTINGS_NAV: readonly SettingsNavGroup[] = [
               "balance",
               "per execution",
               "auto recharge",
+              "spend cap",
             ],
           },
         ],
         tags: ["pricing", "cost", "pay"],
-        ownerOnly: true,
       },
       {
         segment: "plans",
@@ -325,7 +330,6 @@ export const SETTINGS_NAV: readonly SettingsNavGroup[] = [
           "monthly",
           "yearly",
         ],
-        ownerOnly: true,
       },
       {
         segment: "wallets",

--- a/components/settings/hub/plans-section.tsx
+++ b/components/settings/hub/plans-section.tsx
@@ -3,14 +3,20 @@
 import { PricingTable } from "@/components/billing/pricing-table";
 import { useBillingPlan } from "./hooks/use-billing-plan";
 import { SectionHeader } from "./section";
+import { useSettingsContext } from "./settings-context";
 
 export function PlansSection(): React.ReactElement {
   const billing = useBillingPlan();
+  const { isOwner } = useSettingsContext();
 
   return (
     <>
       <SectionHeader
-        description="What this organization is on, and what it could move to."
+        description={
+          isOwner
+            ? "What this organization is on, and what it could move to."
+            : "What this organization is on, and what it could move to. Only the owner can change the plan."
+        }
         title="Plans"
       />
 
@@ -18,6 +24,7 @@ export function PlansSection(): React.ReactElement {
           comes from a package with no loading state of its own, so it renders
           straight away and only the highlighted plan arrives late. */}
       <PricingTable
+        canManage={isOwner}
         currentInterval={billing.interval}
         currentPlan={billing.plan}
         currentTier={billing.tier}

--- a/components/settings/hub/settings-access-gate.tsx
+++ b/components/settings/hub/settings-access-gate.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+import {
+  findSettingsItem,
+  isSettingsItemVisible,
+  type SettingsNavItem,
+} from "./nav";
+import { EmptyState, SectionHeader, SettingsCard } from "./section";
+import { useSettingsContext } from "./settings-context";
+import { FormSkeleton } from "./skeletons";
+
+function accessMessage(item: SettingsNavItem): string {
+  return item.ownerOnly
+    ? "Only the owner of this organization can see this section."
+    : "Only admins and owners of this organization can see this section.";
+}
+
+/**
+ * The rail hides sections a role cannot use, but the routes behind them stay
+ * reachable by URL, and switching organizations keeps the path while the role
+ * changes underneath it. The gate answers for the organization in the path, so
+ * a restricted section stays closed however it was reached.
+ */
+export function SettingsAccessGate({
+  children,
+}: {
+  children: ReactNode;
+}): React.ReactElement {
+  const pathname = usePathname();
+  const { isAdmin, isOwner, roleLoading } = useSettingsContext();
+  const item = findSettingsItem(pathname);
+
+  if (!(item?.ownerOnly || item?.adminOnly)) {
+    return <>{children}</>;
+  }
+  // Rendering the section before the role lands would show it to everyone for
+  // a frame, so hold the page until the answer is in.
+  if (roleLoading) {
+    return <FormSkeleton rows={3} />;
+  }
+  if (isSettingsItemVisible(item, { isAdmin, isOwner })) {
+    return <>{children}</>;
+  }
+
+  return (
+    <>
+      <SectionHeader description={item.description} title={item.label} />
+      <SettingsCard>
+        <EmptyState>{accessMessage(item)}</EmptyState>
+      </SettingsCard>
+    </>
+  );
+}

--- a/components/settings/hub/settings-shell.tsx
+++ b/components/settings/hub/settings-shell.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
+import { SettingsAccessGate } from "./settings-access-gate";
 import { SettingsRail } from "./settings-rail";
 
 export function SettingsShell({
@@ -33,7 +34,7 @@ export function SettingsShell({
               wide ? "max-w-7xl" : "max-w-5xl"
             )}
           >
-            {children}
+            <SettingsAccessGate>{children}</SettingsAccessGate>
           </div>
         </main>
       </div>

--- a/tests/unit/settings-nav-search.test.ts
+++ b/tests/unit/settings-nav-search.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { findSettingsMatches } from "@/components/settings/hub/nav";
+import {
+  findSettingsItem,
+  findSettingsMatches,
+  isSettingsItemVisible,
+  type SettingsNavItem,
+} from "@/components/settings/hub/nav";
 
 const OWNER = { isAdmin: true, isOwner: true };
 const MEMBER = { isAdmin: false, isOwner: false };
@@ -40,17 +45,67 @@ describe("findSettingsMatches", () => {
   it("lists everything in a section when the section itself is named", () => {
     expect(results("billing")).toEqual([
       "Billing > This month",
+      "Billing > Payment and invoices",
       "Billing > Pay as you go",
     ]);
   });
 
   it("leaves out sections the member cannot open", () => {
-    expect(results("spend", MEMBER)).toEqual([]);
-    expect(results("spend")).toEqual(["Spending limits > Daily value caps"]);
+    expect(results("daily value caps", MEMBER)).toEqual([]);
+    expect(results("daily value caps")).toEqual([
+      "Spending limits > Daily value caps",
+    ]);
+  });
+
+  it("offers billing and plans to a member", () => {
+    expect(results("plans", MEMBER)).toEqual([]);
+    expect(
+      findSettingsMatches("plans", MEMBER).map((m) => m.item.segment)
+    ).toEqual(["plans"]);
+    expect(results("gas sponsorship credits", MEMBER)).toEqual([
+      "Billing > This month",
+    ]);
   });
 
   it("returns nothing for an empty or unmatched query", () => {
     expect(results("  ")).toEqual([]);
     expect(results("zzzz")).toEqual([]);
+  });
+});
+
+describe("isSettingsItemVisible", () => {
+  const item = (pathname: string): SettingsNavItem => {
+    const found = findSettingsItem(pathname);
+    if (!found) {
+      throw new Error(`no settings item for ${pathname}`);
+    }
+    return found;
+  };
+
+  it("opens billing and plans to every member of the organization", () => {
+    expect(isSettingsItemVisible(item("/settings/org-1/billing"), MEMBER)).toBe(
+      true
+    );
+    expect(isSettingsItemVisible(item("/settings/org-1/plans"), MEMBER)).toBe(
+      true
+    );
+  });
+
+  it("keeps the admin sections closed to a member", () => {
+    for (const segment of ["security", "notifications", "limits"]) {
+      expect(
+        isSettingsItemVisible(item(`/settings/org-1/${segment}`), MEMBER)
+      ).toBe(false);
+      expect(
+        isSettingsItemVisible(item(`/settings/org-1/${segment}`), OWNER)
+      ).toBe(true);
+    }
+  });
+
+  it("tells the account security page from the organization one", () => {
+    expect(item("/settings/security").scope).toBe("user");
+    expect(isSettingsItemVisible(item("/settings/security"), MEMBER)).toBe(
+      true
+    );
   });
 });


### PR DESCRIPTION
## Problem

Billing and Plans were hidden from the settings rail for anyone but the owner, but the routes stayed reachable. Opening the billing page of an organization you own and then switching organizations in the dropdown left the page on screen for an organization where you are only a member.

Almost nothing on those two pages is owner-only. The current plan, the executions used and the gas sponsorship credits are useful to everyone in the organization. The card on file, the invoices and the spend caps are not.

## What changed

Billing and Plans are visible in the rail to every member of the organization.

Inside Billing, three things stay with the owner:

- the payment method
- the invoices
- the pay-as-you-go spend cap fields

Members see the plan, the status, the executions used, the monthly meters, the gas sponsorship credits and the pay-as-you-go usage, plus a line saying who sets the caps. On Plans everyone reads the pricing table and only the owner can act on a card; the plan buttons render disabled for everyone else.

The route hole is closed for every restricted section, not only these two. A gate around the settings pages resolves the nav entry from the path and renders a short message where the role does not allow the section, so Organization security, Notifications and Spending limits are no longer readable by URL either. It holds the page while the role is still resolving, so a restricted section never renders for a frame first.

## On the exposure

The endpoints were already correct. Billing details, invoices, the portal, checkout, cancel, proration and the pay-as-you-go cap write all require an owner, and every one of them resolves the organization from the session rather than the URL. The newly visible figures come from endpoints any member of the organization may read. The fix is in what the pages show, not in what the API serves.

## Verified

Signed in as a plain member of an organization owned by someone else:

- Billing and Plans appear in the rail; usage, meters and gas credits render
- the spend cap fields are gone, replaced by a line naming the owner
- all four plan buttons come back disabled
- `/limits` and `/security` render the restricted panel instead of their contents

`pnpm check`, `pnpm type-check` and the settings nav unit tests pass.