### PR TITLE
fix(e2e): refill the sign-in form on retry and wait on the import request

### DIFF
--- a/tests/e2e/playwright/utils/auth.ts
+++ b/tests/e2e/playwright/utils/auth.ts
@@ -455,23 +455,35 @@ export async function signIn(
 
   // The email/password form renders inline (no chooser step on the landing).
   const emailField = page.locator("#auth-email");
-  await expect(emailField).toBeVisible({ timeout: 15_000 });
-  await emailField.fill(email);
-  await page.locator("#auth-password").fill(password);
+  const passwordField = page.locator("#auth-password");
+  const orgSwitcher = page.locator('button[role="combobox"]');
 
-  // Retry the submit: right after navigation the first click can land before
-  // the client handler is wired and be dropped, leaving the form in place.
-  // toPass re-clicks until the org switcher (canvas) resolves.
+  // An existing session redirects /welcome straight into the app, so there is
+  // no form to fill. Wait for whichever of the two lands and take that branch.
+  await expect(emailField.or(orgSwitcher).first()).toBeVisible({
+    timeout: 15_000,
+  });
+  if (await orgSwitcher.isVisible()) {
+    return;
+  }
+
+  // Retry the fill and the submit together: a fill that lands before hydration
+  // is wiped when React mounts the controlled inputs, and a click that lands
+  // before the handler is wired is dropped. Re-filling every attempt keeps the
+  // loop from clicking an empty form against native required validation.
   const signInButton = page.getByRole("button", {
     name: "Sign in",
     exact: true,
   });
-  const orgSwitcher = page.locator('button[role="combobox"]');
   await expect(async () => {
     if (await signInButton.isVisible()) {
+      await emailField.fill(email);
+      await passwordField.fill(password);
       await signInButton.click();
     }
-    await expect(orgSwitcher).toBeVisible({ timeout: 4000 });
+    // Give a submit that did land time to resolve before re-clicking, so a slow
+    // sign-in is not mistaken for a dropped click and re-submitted needlessly.
+    await expect(orgSwitcher).toBeVisible({ timeout: 10_000 });
   }).toPass({ timeout: 30_000 });
 }
 

--- a/tests/e2e/playwright/workflow-io-modal.test.ts
+++ b/tests/e2e/playwright/workflow-io-modal.test.ts
@@ -14,6 +14,7 @@ const DOWNLOAD_BUTTON_NAME_REGEX = /export workflow as json/i;
 const SELECTED_TEXT_REGEX = /Selected:/i;
 const IMPORT_BUTTON_NAME_REGEX = /import workflow/i;
 const WORKFLOW_URL_REGEX = /\/workflows?\/[^/]+/;
+const IMPORT_ENDPOINT = "/api/workflows/import";
 
 // MODAL-06 imports a fixture containing an HTTP Request action, which is
 // Pro-gated (lib/features/registry.ts) and otherwise blocked at import for a
@@ -109,7 +110,17 @@ test.describe("Workflow I/O modal (MODAL-04, MODAL-05, MODAL-06, MODAL-08)", () 
       name: IMPORT_BUTTON_NAME_REGEX,
     });
     await expect(importButton).toBeEnabled({ timeout: 10_000 });
+
+    // Wait on the import request itself rather than guessing how long a cold
+    // route takes under CI load, so a slow import does not read as a missing toast.
+    const importResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes(IMPORT_ENDPOINT) &&
+        response.request().method() === "POST",
+      { timeout: 60_000 }
+    );
     await importButton.click();
+    expect((await importResponse).ok()).toBe(true);
 
     // The component contract (plan 42-07) is: toast.success -> onOpenChange(false)
     // -> router.push. We assert all three end states are reached.


### PR DESCRIPTION
Two Playwright specs have been failing on staging across unrelated commits. Both fail through all three retries, so they block the pipeline rather than self-healing.

## Sign-in retry loop submitted an empty form

`signIn` filled the email and password once, then entered a `toPass` loop that only re-clicked Sign in. When the fill landed before hydration finished, React reset the controlled inputs as it mounted them, and every later click hit the browser's native required-field validation instead of reaching the server. The loop then burned its full 30s budget clicking an empty form and reported `locator('button[role="combobox"]') not found`, which points nowhere near the real cause.

The failure screenshot from the run shows the empty form with the native "Please fill out this field" bubble on the email input.

Changes:
- Fill both fields inside the retry block, so a wiped fill is restored on the next attempt.
- Return early when an existing session has already redirected `/welcome` into the app, instead of waiting 15s for a form that will never render.
- Raise the inner wait from 4s to 10s so a submit that did land has time to resolve, which also cuts the number of redundant sign-in requests per call.

`invitations.test.ts` INV-SEND-2 is the test that hits this most often, since it is the one that clears cookies and does a real credential sign-in rather than reusing stored state.

## Import assertion was tighter than the request

MODAL-06 asserted the success toast within 15s of clicking Import. The failure screenshot shows the button still reading "Importing...", so the request was in flight and correct, just slower than the budget on a loaded runner. The test now waits on the import response and checks it succeeded before asserting the toast, close, and navigate ordering.

## Verification

Run locally against a dedicated `keeperhub_test` database with a fresh schema and seed.

- `workflow-io-modal.test.ts`: 8 passed, MODAL-06 included.
- `invitations.test.ts` on unmodified staging in the same environment: INV-SEND-2 failed through all retries, 8 passed, 5 did not run.
- `invitations.test.ts` with this change: INV-SEND-2 passes, 11 passed.
- `pnpm check` and `pnpm type-check` clean.

ORG-2 fails in the local environment because the hand-built test database lacks the seeded test wallet that CI provisions. It passes in CI and is untouched by this change.