### PR TITLE
feat: add read-only Solana account actions

### DIFF
--- a/lib/web3/solana-account-reader.ts
+++ b/lib/web3/solana-account-reader.ts
@@ -1,0 +1,68 @@
+import "server-only";
+
+import { type AccountInfo, PublicKey } from "@solana/web3.js";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { isSolanaChain } from "@/lib/rpc/provider-factory";
+import { getErrorMessage } from "@/lib/utils";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
+import type { SolanaChainAdapter } from "@/lib/web3/chain-adapter/solana";
+
+function parsePublicKey(value: string): PublicKey | null {
+  try {
+    return new PublicKey(value);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolves a network + base58 address into a Solana chain adapter and pubkey.
+ * Shared by the read-solana-account and read-solana-program-anchor steps.
+ */
+export function resolveSolanaAccountAddress(
+  network: string,
+  address: string
+):
+  | { chainId: number; adapter: SolanaChainAdapter; pubkey: PublicKey }
+  | { error: string } {
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(network);
+  } catch (error) {
+    return { error: getErrorMessage(error) };
+  }
+
+  if (!isSolanaChain(chainId)) {
+    return { error: `Only supported on Solana networks, got: ${network}` };
+  }
+
+  const pubkey = parsePublicKey(address);
+  if (!pubkey) {
+    return { error: `Invalid Solana address: ${address}` };
+  }
+
+  return {
+    chainId,
+    adapter: getChainAdapter(chainId) as SolanaChainAdapter,
+    pubkey,
+  };
+}
+
+/**
+ * Fetches raw account info via the chain's RPC failover. A null accountInfo
+ * means the account does not exist - that is a valid outcome, not an error.
+ */
+export async function fetchSolanaAccountInfo(
+  adapter: SolanaChainAdapter,
+  pubkey: PublicKey
+): Promise<{ accountInfo: AccountInfo<Buffer> | null } | { error: string }> {
+  try {
+    const accountInfo = await adapter.executeWithSolanaFailover(
+      (connection) => connection.getAccountInfo(pubkey, "confirmed"),
+      "read"
+    );
+    return { accountInfo };
+  } catch (error) {
+    return { error: `Failed to read account: ${getErrorMessage(error)}` };
+  }
+}

--- a/lib/web3/solana-account-reader.ts
+++ b/lib/web3/solana-account-reader.ts
@@ -7,7 +7,7 @@ import { getErrorMessage } from "@/lib/utils";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import type { SolanaChainAdapter } from "@/lib/web3/chain-adapter/solana";
 
-function parsePublicKey(value: string): PublicKey | null {
+export function parsePublicKey(value: string): PublicKey | null {
   try {
     return new PublicKey(value);
   } catch {

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -657,6 +657,10 @@ const web3Plugin: IntegrationPlugin = {
           description: "Length of the account's raw data in bytes",
         },
         {
+          field: "addressLink",
+          description: "Explorer link to view the account",
+        },
+        {
           field: "error",
           description: "Error message if the read failed",
         },
@@ -704,6 +708,10 @@ const web3Plugin: IntegrationPlugin = {
         {
           field: "lamports",
           description: "Number of lamports assigned to the account",
+        },
+        {
+          field: "addressLink",
+          description: "Explorer link to view the account",
         },
         {
           field: "error",

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -616,6 +616,150 @@ const web3Plugin: IntegrationPlugin = {
       ],
     },
     {
+      slug: "read-solana-account",
+      label: "Read Solana Account",
+      description:
+        "Read the raw account info (owner, lamports, data) for a Solana address. Read-only - no wallet or credentials required.",
+      category: "Web3",
+      stepFunction: "readSolanaAccountStep",
+      stepImportPath: "read-solana-account",
+      outputFields: [
+        {
+          field: "success",
+          description: "Whether the read succeeded",
+        },
+        {
+          field: "exists",
+          description: "Whether the account exists on-chain",
+        },
+        {
+          field: "owner",
+          description: "The base58 address of the program that owns the account",
+        },
+        {
+          field: "lamports",
+          description: "Number of lamports assigned to the account",
+        },
+        {
+          field: "executable",
+          description: "Whether the account's data contains a loaded program",
+        },
+        {
+          field: "rentEpoch",
+          description: "The account's rent epoch, if applicable",
+        },
+        {
+          field: "dataBase64",
+          description: "The account's raw data, base64-encoded",
+        },
+        {
+          field: "dataLength",
+          description: "Length of the account's raw data in bytes",
+        },
+        {
+          field: "error",
+          description: "Error message if the read failed",
+        },
+      ],
+      configFields: [
+        {
+          key: "network",
+          label: "Network",
+          type: "chain-select",
+          chainTypeFilter: "solana",
+          placeholder: "Select network",
+          required: true,
+        },
+        {
+          key: "accountAddress",
+          label: "Account Address",
+          type: "template-input",
+          placeholder: "Solana address or {{NodeName.address}}",
+          example: "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+          required: true,
+        },
+      ],
+    },
+    {
+      slug: "read-solana-program-anchor",
+      label: "Read Solana Program (Anchor)",
+      description:
+        "Read a Solana account and decode it against an Anchor program's IDL. Read-only - no wallet or credentials required.",
+      category: "Web3",
+      stepFunction: "readSolanaProgramStep",
+      stepImportPath: "read-solana-program",
+      outputFields: [
+        {
+          field: "success",
+          description: "Whether the read succeeded",
+        },
+        {
+          field: "result",
+          description: "The decoded account fields, per the IDL's account type",
+        },
+        {
+          field: "owner",
+          description: "The base58 address of the program that owns the account",
+        },
+        {
+          field: "lamports",
+          description: "Number of lamports assigned to the account",
+        },
+        {
+          field: "error",
+          description: "Error message if the read or decode failed",
+        },
+      ],
+      configFields: [
+        {
+          key: "network",
+          label: "Network",
+          type: "chain-select",
+          chainTypeFilter: "solana",
+          placeholder: "Select network",
+          required: true,
+        },
+        {
+          key: "accountAddress",
+          label: "Account Address",
+          type: "template-input",
+          placeholder: "Solana address or {{NodeName.address}}",
+          example: "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+          helpTip: "The data account to read and decode - not the program's own address.",
+          required: true,
+        },
+        {
+          key: "programId",
+          label: "Program ID",
+          type: "template-input",
+          placeholder: "Program address (base58) or {{NodeName.programId}}",
+          example: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          helpTip:
+            "The base58 address of the Anchor program that owns this account. Verified against the account's actual owner before decoding.",
+          required: true,
+        },
+        {
+          key: "idl",
+          label: "Anchor IDL",
+          type: "json-editor",
+          placeholder:
+            '{ "address": "...", "metadata": {...}, "instructions": [...], "accounts": [...], "types": [...] }',
+          helpTip:
+            "The program's Anchor IDL as JSON (Anchor 0.30 or newer, with per-account discriminators). Paste the published IDL. Used to decode the account's raw data.",
+          required: true,
+        },
+        {
+          key: "accountType",
+          label: "Account Type",
+          type: "template-input",
+          placeholder: "Account type name, e.g. Vault",
+          helpTip:
+            "The name of the account type to decode as, exactly as it appears in the IDL's accounts array.",
+          required: true,
+        },
+      ],
+    },
+    {
       slug: "read-contract",
       label: "Read Contract",
       description: "Read data from a smart contract (view/pure functions)",

--- a/plugins/web3/steps/read-solana-account-core.ts
+++ b/plugins/web3/steps/read-solana-account-core.ts
@@ -40,15 +40,23 @@ export async function readSolanaAccountCore(
   if ("error" in resolved) {
     return { success: false, error: resolved.error };
   }
-  const { adapter, pubkey } = resolved;
+  const { adapter, pubkey, chainId } = resolved;
 
-  const fetched = await fetchSolanaAccountInfo(adapter, pubkey);
+  const [fetched, addressLink] = await Promise.all([
+    fetchSolanaAccountInfo(adapter, pubkey),
+    adapter.getAddressUrl(accountAddress),
+  ]);
+
   if ("error" in fetched) {
     logUserError(
       ErrorCategory.NETWORK_RPC,
       "[Read Solana Account] Failed to read account",
       fetched.error,
-      { plugin_name: "web3", action_name: "read-solana-account" }
+      {
+        plugin_name: "web3",
+        action_name: "read-solana-account",
+        chain_id: String(chainId),
+      }
     );
     return { success: false, error: fetched.error };
   }
@@ -59,7 +67,6 @@ export async function readSolanaAccountCore(
 
   const { executable, owner, lamports, data, rentEpoch } =
     fetched.accountInfo;
-  const addressLink = await adapter.getAddressUrl(accountAddress);
 
   return {
     success: true,

--- a/plugins/web3/steps/read-solana-account-core.ts
+++ b/plugins/web3/steps/read-solana-account-core.ts
@@ -1,0 +1,75 @@
+/**
+ * Core read-solana-account logic.
+ *
+ * IMPORTANT: This file must NOT contain "use step" or be a step file.
+ */
+import "server-only";
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import {
+  fetchSolanaAccountInfo,
+  resolveSolanaAccountAddress,
+} from "@/lib/web3/solana-account-reader";
+
+export type ReadSolanaAccountCoreInput = {
+  network: string;
+  accountAddress: string;
+  _context?: { executionId?: string };
+};
+
+export type ReadSolanaAccountResult =
+  | { success: true; exists: false }
+  | {
+      success: true;
+      exists: true;
+      owner: string;
+      lamports: number;
+      executable: boolean;
+      rentEpoch: number | null;
+      dataBase64: string;
+      dataLength: number;
+      addressLink: string;
+    }
+  | { success: false; error: string };
+
+export async function readSolanaAccountCore(
+  input: ReadSolanaAccountCoreInput
+): Promise<ReadSolanaAccountResult> {
+  const { network, accountAddress } = input;
+
+  const resolved = resolveSolanaAccountAddress(network, accountAddress);
+  if ("error" in resolved) {
+    return { success: false, error: resolved.error };
+  }
+  const { adapter, pubkey } = resolved;
+
+  const fetched = await fetchSolanaAccountInfo(adapter, pubkey);
+  if ("error" in fetched) {
+    logUserError(
+      ErrorCategory.NETWORK_RPC,
+      "[Read Solana Account] Failed to read account",
+      fetched.error,
+      { plugin_name: "web3", action_name: "read-solana-account" }
+    );
+    return { success: false, error: fetched.error };
+  }
+
+  if (!fetched.accountInfo) {
+    return { success: true, exists: false };
+  }
+
+  const { executable, owner, lamports, data, rentEpoch } =
+    fetched.accountInfo;
+  const addressLink = await adapter.getAddressUrl(accountAddress);
+
+  return {
+    success: true,
+    exists: true,
+    owner: owner.toBase58(),
+    lamports,
+    executable,
+    rentEpoch: rentEpoch ?? null,
+    dataBase64: data.toString("base64"),
+    dataLength: data.length,
+    addressLink,
+  };
+}

--- a/plugins/web3/steps/read-solana-account.ts
+++ b/plugins/web3/steps/read-solana-account.ts
@@ -1,0 +1,39 @@
+import "server-only";
+
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
+import {
+  type ReadSolanaAccountCoreInput,
+  type ReadSolanaAccountResult,
+  readSolanaAccountCore,
+} from "./read-solana-account-core";
+
+export type {
+  ReadSolanaAccountCoreInput,
+  ReadSolanaAccountResult,
+} from "./read-solana-account-core";
+
+export type ReadSolanaAccountInput = StepInput & ReadSolanaAccountCoreInput;
+
+/**
+ * Read Solana Account Step
+ * Reads the raw account info (owner, lamports, data) for a Solana address.
+ */
+export async function readSolanaAccountStep(
+  input: ReadSolanaAccountInput
+): Promise<ReadSolanaAccountResult> {
+  "use step";
+
+  return withPluginMetrics(
+    {
+      pluginName: "web3",
+      actionName: "read-solana-account",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => readSolanaAccountCore(input))
+  );
+}
+
+readSolanaAccountStep.maxRetries = 0;
+
+export const _integrationType = "web3";

--- a/plugins/web3/steps/read-solana-program-core.ts
+++ b/plugins/web3/steps/read-solana-program-core.ts
@@ -1,0 +1,161 @@
+/**
+ * Core read-solana-program-anchor logic.
+ *
+ * IMPORTANT: This file must NOT contain "use step" or be a step file.
+ */
+import "server-only";
+import { BN, BorshAccountsCoder } from "@coral-xyz/anchor";
+import { PublicKey } from "@solana/web3.js";
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import { getErrorMessage } from "@/lib/utils";
+import { parseAnchorIdl } from "@/lib/web3/anchor-idl";
+import {
+  fetchSolanaAccountInfo,
+  resolveSolanaAccountAddress,
+} from "@/lib/web3/solana-account-reader";
+
+export type ReadSolanaProgramCoreInput = {
+  network: string;
+  accountAddress: string;
+  programId: string;
+  idl: string | object;
+  accountType: string;
+  _context?: { executionId?: string };
+};
+
+export type ReadSolanaProgramResult =
+  | {
+      success: true;
+      result: unknown;
+      owner: string;
+      lamports: number;
+      addressLink: string;
+    }
+  | { success: false; error: string };
+
+function parsePublicKey(value: string): PublicKey | null {
+  try {
+    return new PublicKey(value);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Recursively converts Anchor's decoded value tree into JSON-safe values:
+ * PublicKey -> base58, BN -> decimal string, byte arrays -> base64. Anchor's
+ * decoder resolves defined/vec/option types into plain objects/arrays/nulls,
+ * so a generic walk covers every IDL shape without needing the type layout.
+ */
+function serializeAnchorValue(value: unknown): unknown {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (value instanceof PublicKey) {
+    return value.toBase58();
+  }
+  if (value instanceof BN) {
+    // bn.js ships no type declarations; TypeScript's JS-inference for it
+    // (via allowJs) misses the toString(base) overload, so the base-10
+    // argument is omitted here - toString() with no argument already
+    // defaults to base 10.
+    return value.toString();
+  }
+  if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+    return Buffer.from(value).toString("base64");
+  }
+  if (Array.isArray(value)) {
+    return value.map(serializeAnchorValue);
+  }
+  if (typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = serializeAnchorValue(entry);
+    }
+    return out;
+  }
+  return value;
+}
+
+export async function readSolanaProgramCore(
+  input: ReadSolanaProgramCoreInput
+): Promise<ReadSolanaProgramResult> {
+  const { network, accountAddress, programId, idl, accountType } = input;
+
+  const resolved = resolveSolanaAccountAddress(network, accountAddress);
+  if ("error" in resolved) {
+    return { success: false, error: resolved.error };
+  }
+  const { adapter, pubkey } = resolved;
+
+  const programPk = parsePublicKey(programId);
+  if (!programPk) {
+    return {
+      success: false,
+      error: `Invalid Solana program address: ${programId}`,
+    };
+  }
+
+  const idlResult = parseAnchorIdl(idl);
+  if ("error" in idlResult) {
+    return { success: false, error: idlResult.error };
+  }
+
+  if (!accountType || accountType.trim() === "") {
+    return { success: false, error: "Missing account type" };
+  }
+
+  const accountDef = idlResult.idl.accounts?.find(
+    (entry) => entry.name === accountType
+  );
+  if (!accountDef) {
+    const available =
+      idlResult.idl.accounts?.map((entry) => entry.name).join(", ") || "none";
+    return {
+      success: false,
+      error: `Account type "${accountType}" not found in IDL. Available: ${available}`,
+    };
+  }
+
+  const fetched = await fetchSolanaAccountInfo(adapter, pubkey);
+  if ("error" in fetched) {
+    logUserError(
+      ErrorCategory.NETWORK_RPC,
+      "[Read Solana Program] Failed to read account",
+      fetched.error,
+      { plugin_name: "web3", action_name: "read-solana-program-anchor" }
+    );
+    return { success: false, error: fetched.error };
+  }
+  if (!fetched.accountInfo) {
+    return { success: false, error: `Account not found: ${accountAddress}` };
+  }
+
+  const { owner, lamports, data } = fetched.accountInfo;
+  if (!owner.equals(programPk)) {
+    return {
+      success: false,
+      error: `Account ${accountAddress} is owned by ${owner.toBase58()}, not the expected program ${programPk.toBase58()}`,
+    };
+  }
+
+  let decoded: unknown;
+  try {
+    decoded = new BorshAccountsCoder(idlResult.idl).decode(accountType, data);
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to decode account as "${accountType}": ${getErrorMessage(error)}`,
+    };
+  }
+
+  const addressLink = await adapter.getAddressUrl(accountAddress);
+
+  return {
+    success: true,
+    result: serializeAnchorValue(decoded),
+    owner: owner.toBase58(),
+    lamports,
+    addressLink,
+  };
+}

--- a/plugins/web3/steps/read-solana-program-core.ts
+++ b/plugins/web3/steps/read-solana-program-core.ts
@@ -11,6 +11,7 @@ import { getErrorMessage } from "@/lib/utils";
 import { parseAnchorIdl } from "@/lib/web3/anchor-idl";
 import {
   fetchSolanaAccountInfo,
+  parsePublicKey,
   resolveSolanaAccountAddress,
 } from "@/lib/web3/solana-account-reader";
 
@@ -32,14 +33,6 @@ export type ReadSolanaProgramResult =
       addressLink: string;
     }
   | { success: false; error: string };
-
-function parsePublicKey(value: string): PublicKey | null {
-  try {
-    return new PublicKey(value);
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Recursively converts Anchor's decoded value tree into JSON-safe values:
@@ -86,7 +79,7 @@ export async function readSolanaProgramCore(
   if ("error" in resolved) {
     return { success: false, error: resolved.error };
   }
-  const { adapter, pubkey } = resolved;
+  const { adapter, pubkey, chainId } = resolved;
 
   const programPk = parsePublicKey(programId);
   if (!programPk) {
@@ -101,19 +94,22 @@ export async function readSolanaProgramCore(
     return { success: false, error: idlResult.error };
   }
 
-  if (!accountType || accountType.trim() === "") {
+  const trimmedAccountType = accountType?.trim() ?? "";
+  if (trimmedAccountType === "") {
     return { success: false, error: "Missing account type" };
   }
 
-  const accountDef = idlResult.idl.accounts?.find(
-    (entry) => entry.name === accountType
+  const idlAccounts = Array.isArray(idlResult.idl.accounts)
+    ? idlResult.idl.accounts
+    : [];
+  const accountDef = idlAccounts.find(
+    (entry) => entry.name === trimmedAccountType
   );
   if (!accountDef) {
-    const available =
-      idlResult.idl.accounts?.map((entry) => entry.name).join(", ") || "none";
+    const available = idlAccounts.map((entry) => entry.name).join(", ") || "none";
     return {
       success: false,
-      error: `Account type "${accountType}" not found in IDL. Available: ${available}`,
+      error: `Account type "${trimmedAccountType}" not found in IDL. Available: ${available}`,
     };
   }
 
@@ -123,7 +119,11 @@ export async function readSolanaProgramCore(
       ErrorCategory.NETWORK_RPC,
       "[Read Solana Program] Failed to read account",
       fetched.error,
-      { plugin_name: "web3", action_name: "read-solana-program-anchor" }
+      {
+        plugin_name: "web3",
+        action_name: "read-solana-program-anchor",
+        chain_id: String(chainId),
+      }
     );
     return { success: false, error: fetched.error };
   }
@@ -139,13 +139,17 @@ export async function readSolanaProgramCore(
     };
   }
 
-  let decoded: unknown;
+  let result: unknown;
   try {
-    decoded = new BorshAccountsCoder(idlResult.idl).decode(accountType, data);
+    const decoded = new BorshAccountsCoder(idlResult.idl).decode(
+      trimmedAccountType,
+      data
+    );
+    result = serializeAnchorValue(decoded);
   } catch (error) {
     return {
       success: false,
-      error: `Failed to decode account as "${accountType}": ${getErrorMessage(error)}`,
+      error: `Failed to decode account as "${trimmedAccountType}": ${getErrorMessage(error)}`,
     };
   }
 
@@ -153,7 +157,7 @@ export async function readSolanaProgramCore(
 
   return {
     success: true,
-    result: serializeAnchorValue(decoded),
+    result,
     owner: owner.toBase58(),
     lamports,
     addressLink,

--- a/plugins/web3/steps/read-solana-program.ts
+++ b/plugins/web3/steps/read-solana-program.ts
@@ -1,0 +1,39 @@
+import "server-only";
+
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
+import {
+  type ReadSolanaProgramCoreInput,
+  type ReadSolanaProgramResult,
+  readSolanaProgramCore,
+} from "./read-solana-program-core";
+
+export type {
+  ReadSolanaProgramCoreInput,
+  ReadSolanaProgramResult,
+} from "./read-solana-program-core";
+
+export type ReadSolanaProgramInput = StepInput & ReadSolanaProgramCoreInput;
+
+/**
+ * Read Solana Program (Anchor) Step
+ * Reads a Solana account and decodes it against a supplied Anchor IDL.
+ */
+export async function readSolanaProgramStep(
+  input: ReadSolanaProgramInput
+): Promise<ReadSolanaProgramResult> {
+  "use step";
+
+  return withPluginMetrics(
+    {
+      pluginName: "web3",
+      actionName: "read-solana-program-anchor",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => readSolanaProgramCore(input))
+  );
+}
+
+readSolanaProgramStep.maxRetries = 0;
+
+export const _integrationType = "web3";

--- a/tests/unit/read-solana-account.test.ts
+++ b/tests/unit/read-solana-account.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { PublicKey } from "@solana/web3.js";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
+import { readSolanaAccountCore } from "@/plugins/web3/steps/read-solana-account-core";
+
+vi.mock("@/lib/web3/chain-adapter", () => ({
+  getChainAdapter: vi.fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { NETWORK_RPC: "network_rpc" },
+  logUserError: vi.fn(),
+}));
+
+const ADDRESS = "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU";
+const OWNER = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+
+describe("readSolanaAccountCore", () => {
+  let mockAdapter: {
+    executeWithSolanaFailover: ReturnType<typeof vi.fn>;
+    getAddressUrl: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockAdapter = {
+      executeWithSolanaFailover: vi.fn(),
+      getAddressUrl: vi
+        .fn()
+        .mockResolvedValue(`https://solscan.io/account/${ADDRESS}`),
+    };
+
+    vi.mocked(getChainAdapter).mockReturnValue(mockAdapter as never);
+  });
+
+  it("returns exists:false for a missing account", async () => {
+    mockAdapter.executeWithSolanaFailover.mockResolvedValue(null);
+
+    const result = await readSolanaAccountCore({
+      network: "solana-devnet",
+      accountAddress: ADDRESS,
+    });
+
+    expect(result).toEqual({ success: true, exists: false });
+  });
+
+  it("returns raw account info for an existing account", async () => {
+    mockAdapter.executeWithSolanaFailover.mockResolvedValue({
+      executable: false,
+      owner: new PublicKey(OWNER),
+      lamports: 2_039_280,
+      data: Buffer.from([1, 2, 3, 4]),
+      rentEpoch: 361,
+    });
+
+    const result = await readSolanaAccountCore({
+      network: "solana-devnet",
+      accountAddress: ADDRESS,
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      exists: true,
+      owner: OWNER,
+      lamports: 2_039_280,
+      executable: false,
+      rentEpoch: 361,
+      dataBase64: Buffer.from([1, 2, 3, 4]).toString("base64"),
+      dataLength: 4,
+    });
+    expect((result as { addressLink: string }).addressLink).toBe(
+      `https://solscan.io/account/${ADDRESS}`
+    );
+  });
+
+  it("defaults a missing rentEpoch to null", async () => {
+    mockAdapter.executeWithSolanaFailover.mockResolvedValue({
+      executable: false,
+      owner: new PublicKey(OWNER),
+      lamports: 100,
+      data: Buffer.alloc(0),
+      rentEpoch: undefined,
+    });
+
+    const result = await readSolanaAccountCore({
+      network: "solana-devnet",
+      accountAddress: ADDRESS,
+    });
+
+    expect(result).toMatchObject({ success: true, rentEpoch: null });
+  });
+
+  it("rejects a non-Solana network without touching the adapter", async () => {
+    const result = await readSolanaAccountCore({
+      network: "ethereum",
+      accountAddress: ADDRESS,
+    });
+
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toContain(
+      "Only supported on Solana networks"
+    );
+    expect(getChainAdapter).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid address", async () => {
+    const result = await readSolanaAccountCore({
+      network: "solana-devnet",
+      accountAddress: "not-a-pubkey!!",
+    });
+
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toContain(
+      "Invalid Solana address"
+    );
+  });
+
+  it("surfaces an RPC failure", async () => {
+    mockAdapter.executeWithSolanaFailover.mockRejectedValue(
+      new Error("RPC down")
+    );
+
+    const result = await readSolanaAccountCore({
+      network: "solana-devnet",
+      accountAddress: ADDRESS,
+    });
+
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toContain(
+      "Failed to read account"
+    );
+  });
+});

--- a/tests/unit/read-solana-program.test.ts
+++ b/tests/unit/read-solana-program.test.ts
@@ -196,4 +196,38 @@ describe("readSolanaProgramCore", () => {
       'Failed to decode account as "Vault"'
     );
   });
+
+  it("tolerates whitespace around accountType", async () => {
+    mockAdapter.executeWithSolanaFailover.mockResolvedValue({
+      executable: false,
+      owner: new PublicKey(PROGRAM),
+      lamports: 2_039_280,
+      data: await encodedVault(AUTHORITY, "1000000"),
+      rentEpoch: 1,
+    });
+
+    const result = await readSolanaProgramCore({
+      ...validInput,
+      accountType: "  Vault\n",
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      result: { authority: AUTHORITY, amount: "1000000" },
+    });
+  });
+
+  it("rejects a malformed IDL where accounts is not an array, without throwing", async () => {
+    const idl = { ...fixtureIdl(), accounts: {} };
+
+    const result = await readSolanaProgramCore({
+      ...validInput,
+      idl: JSON.stringify(idl),
+    });
+
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toContain(
+      'Account type "Vault" not found'
+    );
+  });
 });

--- a/tests/unit/read-solana-program.test.ts
+++ b/tests/unit/read-solana-program.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { BN, BorshAccountsCoder } from "@coral-xyz/anchor";
+import { PublicKey } from "@solana/web3.js";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
+import { readSolanaProgramCore } from "@/plugins/web3/steps/read-solana-program-core";
+
+vi.mock("@/lib/web3/chain-adapter", () => ({
+  getChainAdapter: vi.fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { NETWORK_RPC: "network_rpc" },
+  logUserError: vi.fn(),
+}));
+
+const ADDRESS = "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU";
+const PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+const AUTHORITY = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+// A minimal Anchor 0.30+ IDL with one account type (per-account discriminator).
+function fixtureIdl() {
+  return {
+    address: PROGRAM,
+    metadata: { name: "fixture", version: "0.1.0", spec: "0.1.0" },
+    instructions: [
+      {
+        name: "do_thing",
+        discriminator: [1, 2, 3, 4, 5, 6, 7, 8],
+        accounts: [],
+        args: [],
+      },
+    ],
+    accounts: [
+      { name: "Vault", discriminator: [10, 20, 30, 40, 50, 60, 70, 80] },
+    ],
+    types: [
+      {
+        name: "Vault",
+        type: {
+          kind: "struct",
+          fields: [
+            { name: "authority", type: "pubkey" },
+            { name: "amount", type: "u64" },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+async function encodedVault(
+  authority: string,
+  amount: string
+): Promise<Buffer> {
+  const coder = new BorshAccountsCoder(fixtureIdl() as never);
+  return coder.encode("Vault", {
+    authority: new PublicKey(authority),
+    amount: new BN(amount),
+  });
+}
+
+describe("readSolanaProgramCore", () => {
+  let mockAdapter: {
+    executeWithSolanaFailover: ReturnType<typeof vi.fn>;
+    getAddressUrl: ReturnType<typeof vi.fn>;
+  };
+
+  const validInput = {
+    network: "solana-devnet",
+    accountAddress: ADDRESS,
+    programId: PROGRAM,
+    idl: JSON.stringify(fixtureIdl()),
+    accountType: "Vault",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockAdapter = {
+      executeWithSolanaFailover: vi.fn(),
+      getAddressUrl: vi
+        .fn()
+        .mockResolvedValue(`https://solscan.io/account/${ADDRESS}`),
+    };
+
+    vi.mocked(getChainAdapter).mockReturnValue(mockAdapter as never);
+  });
+
+  it("decodes an existing account against the IDL", async () => {
+    mockAdapter.executeWithSolanaFailover.mockResolvedValue({
+      executable: false,
+      owner: new PublicKey(PROGRAM),
+      lamports: 2_039_280,
+      data: await encodedVault(AUTHORITY, "1000000"),
+      rentEpoch: 1,
+    });
+
+    const result = await readSolanaProgramCore(validInput);
+
+    expect(result).toMatchObject({
+      success: true,
+      owner: PROGRAM,
+      lamports: 2_039_280,
+      result: { authority: AUTHORITY, amount: "1000000" },
+    });
+  });
+
+  it("rejects a non-Solana network without touching the adapter", async () => {
+    const result = await readSolanaProgramCore({
+      ...validInput,
+      network: "ethereum",
+    });
+
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toContain(
+      "Only supported on Solana networks"
+    );
+    expect(getChainAdapter).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid program id", async () => {
+    const result = await readSolanaProgramCore({
+      ...validInput,
+      programId: "not-a-program!!",
+    });
+
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toContain(
+      "Invalid Solana program address"
+    );
+  });
+
+  it("rejects an IDL that is not valid JSON", async () => {
+    const result = await readSolanaProgramCore({ ...validInput, idl: "{bad" });
+
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toContain("not valid JSON");
+  });
+
+  it("rejects an unknown account type, listing what is available", async () => {
+    const result = await readSolanaProgramCore({
+      ...validInput,
+      accountType: "Nope",
+    });
+
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toContain(
+      'Account type "Nope" not found'
+    );
+    expect((result as { error: string }).error).toContain("Vault");
+  });
+
+  it("errors when the account does not exist", async () => {
+    mockAdapter.executeWithSolanaFailover.mockResolvedValue(null);
+
+    const result = await readSolanaProgramCore(validInput);
+
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toContain("Account not found");
+  });
+
+  it("errors when the account is not owned by the given program", async () => {
+    mockAdapter.executeWithSolanaFailover.mockResolvedValue({
+      executable: false,
+      owner: new PublicKey(AUTHORITY),
+      lamports: 100,
+      data: await encodedVault(AUTHORITY, "1"),
+      rentEpoch: 1,
+    });
+
+    const result = await readSolanaProgramCore(validInput);
+
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toContain("is owned by");
+    expect((result as { error: string }).error).toContain(
+      "not the expected program"
+    );
+  });
+
+  it("errors when the account data does not match the account type's discriminator", async () => {
+    mockAdapter.executeWithSolanaFailover.mockResolvedValue({
+      executable: false,
+      owner: new PublicKey(PROGRAM),
+      lamports: 100,
+      data: Buffer.alloc(16, 0),
+      rentEpoch: 1,
+    });
+
+    const result = await readSolanaProgramCore(validInput);
+
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toContain(
+      'Failed to decode account as "Vault"'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add `web3/read-solana-account`: reads raw account info (owner, lamports, executable, rent epoch, raw data) for a Solana address. Read-only, no wallet or credentials required.
- Add `web3/read-solana-program-anchor`: reads a Solana account and decodes it against a supplied Anchor IDL via `BorshAccountsCoder`, mirroring the write-side `call-solana-program-anchor` action but for reads. Verifies the account's owner matches the given program before decoding.
- Add shared `lib/web3/solana-account-reader.ts` helper (network/chain resolution, pubkey parsing, account fetch) used by both actions' core files.

## Changes

- `plugins/web3/index.ts`: register both new actions
- `plugins/web3/steps/read-solana-account.ts` + `read-solana-account-core.ts`
- `plugins/web3/steps/read-solana-program.ts` + `read-solana-program-core.ts`
- `lib/web3/solana-account-reader.ts`
- `tests/unit/read-solana-account.test.ts`, `tests/unit/read-solana-program.test.ts`

## Test Plan

- [x] `pnpm type-check` passes
- [x] `pnpm check` (biome) passes on changed files
- [x] `pnpm test:unit` - 14/14 new unit tests pass (account exists/missing, invalid address, RPC failure, IDL decode success, unknown account type, owner mismatch, discriminator mismatch)
- [ ] Manually exercised in a running workflow