### PR TITLE
feat: Solana support for check-token-balance and get-transaction

### DIFF
--- a/app/api/validate-token/route.ts
+++ b/app/api/validate-token/route.ts
@@ -1,21 +1,27 @@
+import { PublicKey } from "@solana/web3.js";
 import { ethers } from "ethers";
 import { NextResponse } from "next/server";
 import { normalizeAddressForStorage } from "@/lib/address-utils";
 import ERC20_ABI from "@/lib/contracts/abis/erc20.json";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
-import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
+import type { SolanaChainAdapter } from "@/lib/web3/chain-adapter/solana";
+import { parseSolanaMintAccount } from "@/lib/web3/solana-mint";
+import { validateChainAddress } from "@/lib/web3/validate-chain-address";
 
 /**
  * Validate Token API
  *
- * Validates that an address is a valid ERC20 token and fetches its metadata.
+ * Validates that an address is a valid ERC20 or SPL token and fetches its
+ * metadata.
  *
  * Query params:
- * - address: The token contract address
- * - network: Network name (e.g., "eth-mainnet", "base")
+ * - address: The token contract/mint address
+ * - network: Network name (e.g., "eth-mainnet", "base", "solana-mainnet")
  */
-export async function GET(request: Request) {
+export function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const address = searchParams.get("address");
   const network = searchParams.get("network");
@@ -34,28 +40,44 @@ export async function GET(request: Request) {
     );
   }
 
-  // Validate address format
-  if (!ethers.isAddress(address)) {
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(network);
+  } catch {
+    return NextResponse.json(
+      { valid: false, error: "Network not supported" },
+      { status: 200 }
+    );
+  }
+
+  // Validate address format for the chain family.
+  if (!validateChainAddress(address, chainId)) {
     return NextResponse.json(
       { valid: false, error: "Invalid address format" },
       { status: 200 }
     );
   }
 
+  return isSolanaChain(chainId)
+    ? validateSolanaToken(address, chainId)
+    : validateEvmToken(address, chainId);
+}
+
+async function validateEvmToken(
+  address: string,
+  chainId: number
+): Promise<NextResponse> {
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
   try {
-    // Get chain ID and RPC provider
-    const chainId = getChainIdFromNetwork(network);
+    rpcManager = await getRpcProvider({ chainId });
+  } catch {
+    return NextResponse.json(
+      { valid: false, error: "Network not supported" },
+      { status: 200 }
+    );
+  }
 
-    let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
-    try {
-      rpcManager = await getRpcProvider({ chainId });
-    } catch {
-      return NextResponse.json(
-        { valid: false, error: "Network not supported" },
-        { status: 200 }
-      );
-    }
-
+  try {
     // Fetch ERC20 metadata with retry/failover
     const [symbol, name, decimals] = await rpcManager.executeWithFailover(
       (provider) => {
@@ -84,6 +106,59 @@ export async function GET(request: Request) {
     });
     return NextResponse.json(
       { valid: false, error: "Not a valid ERC20 token" },
+      { status: 200 }
+    );
+  }
+}
+
+/**
+ * Solana has no on-chain equivalent of ERC20's symbol()/name() (that lives in
+ * a separate Metaplex metadata account this endpoint does not integrate with
+ * - same limitation noted in check-token-balance.ts), so a valid mint
+ * validates with placeholder symbol/name rather than failing outright.
+ */
+async function validateSolanaToken(
+  address: string,
+  chainId: number
+): Promise<NextResponse> {
+  const mintPubkey = new PublicKey(address);
+  const adapter = getChainAdapter(chainId) as SolanaChainAdapter;
+
+  try {
+    const mintInfo = await adapter.executeWithSolanaFailover((connection) =>
+      connection.getAccountInfo(mintPubkey, "confirmed")
+    );
+    if (!mintInfo) {
+      return NextResponse.json(
+        { valid: false, error: "Mint account not found" },
+        { status: 200 }
+      );
+    }
+
+    const resolved = parseSolanaMintAccount(mintPubkey, mintInfo);
+    if ("error" in resolved) {
+      return NextResponse.json(
+        { valid: false, error: resolved.error },
+        { status: 200 }
+      );
+    }
+
+    return NextResponse.json({
+      valid: true,
+      token: {
+        address,
+        symbol: "???",
+        name: "Unknown",
+        decimals: resolved.mint.decimals,
+      },
+    });
+  } catch (error) {
+    logSystemError(ErrorCategory.NETWORK_RPC, "Validate token error", error, {
+      endpoint: "/api/validate-token",
+      operation: "get",
+    });
+    return NextResponse.json(
+      { valid: false, error: "Not a valid SPL token" },
       { status: 200 }
     );
   }

--- a/components/address-book/save-address-bookmark.tsx
+++ b/components/address-book/save-address-bookmark.tsx
@@ -11,7 +11,10 @@ import {
   ADDRESS_BOOK_SELECTION_KEY,
   parseAddressBookSelection,
 } from "@/lib/address-book-selection";
-import { normalizeAddressForStorage } from "@/lib/address-utils";
+import {
+  isSolanaAddressFormat,
+  normalizeAddressForStorage,
+} from "@/lib/address-utils";
 import { addressBookApi, api } from "@/lib/api-client";
 import { useSession } from "@/lib/auth-client";
 import {
@@ -214,8 +217,13 @@ export function SaveAddressBookmark({
   }, [selectedBookmarkId]);
 
   const handleSaveClick = () => {
-    if (!(address && ethers.isAddress(address))) {
-      toast.error("Please enter a valid Ethereum address first");
+    if (
+      !(
+        address &&
+        (ethers.isAddress(address) || isSolanaAddressFormat(address))
+      )
+    ) {
+      toast.error("Please enter a valid address first");
       return;
     }
 

--- a/components/workflow/config/token-select-field.tsx
+++ b/components/workflow/config/token-select-field.tsx
@@ -14,7 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { toChecksumAddress } from "@/lib/address-utils";
+import { isSolanaAddressFormat, toChecksumAddress } from "@/lib/address-utils";
 import type {
   CustomToken,
   SupportedToken,
@@ -137,10 +137,14 @@ export function TokenSelectField({
       return;
     }
 
-    // If same token already selected, just clear input
-    if (
-      currentValue.customToken?.address.toLowerCase() === trimmed.toLowerCase()
-    ) {
+    // If same token already selected, just clear input. Solana addresses are
+    // case-sensitive base58 (lowercasing can decode to a different, valid key
+    // with no error), so only EVM addresses compare case-insensitively.
+    const currentCustomAddress = currentValue.customToken?.address;
+    const alreadySelected = isSolanaAddressFormat(trimmed)
+      ? currentCustomAddress === trimmed
+      : currentCustomAddress?.toLowerCase() === trimmed.toLowerCase();
+    if (alreadySelected) {
       setCustomInputValue("");
       setValidationError(null);
       return;

--- a/lib/address-utils.ts
+++ b/lib/address-utils.ts
@@ -8,6 +8,20 @@
 
 import { ethers } from "ethers";
 
+// Solana base58 addresses are 32-44 chars. Client-safe (no @solana/web3.js
+// import) - excludes 0/O/I/l so it never collides with 0x-prefixed EVM hex.
+// Format check only; full validation (32-byte decode) happens server-side
+// via lib/web3/validate-chain-address.ts.
+const SOLANA_BASE58_ADDRESS_PATTERN = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+
+/**
+ * True when the value is shaped like a Solana base58 address. Does not
+ * decode or validate the key - see the pattern comment above.
+ */
+export function isSolanaAddressFormat(address: string): boolean {
+  return SOLANA_BASE58_ADDRESS_PATTERN.test(address);
+}
+
 /**
  * Returns the EIP-55 checksummed form of an EVM address.
  * If the address is invalid or corrupt, returns it unchanged so UI never crashes.

--- a/lib/db/schema-extensions.ts
+++ b/lib/db/schema-extensions.ts
@@ -469,7 +469,11 @@ export const supportedTokens = pgTable(
       .primaryKey()
       .$defaultFn(() => generateId()),
     chainId: integer("chain_id").notNull(),
-    tokenAddress: text("token_address").notNull(), // ERC20 contract address (lowercase)
+    // ERC20 contract address, stored lowercase - this convention is EVM-only.
+    // A Solana row (SPL mint) MUST be stored with its exact base58 case: base58
+    // has no checksum, so lowercasing can silently decode to a different, still
+    // -valid 32-byte key rather than failing loudly.
+    tokenAddress: text("token_address").notNull(),
     symbol: text("symbol").notNull(), // e.g., "USDC", "USDT", "DAI"
     name: text("name").notNull(), // e.g., "USD Coin", "Tether USD"
     decimals: integer("decimals").notNull(),

--- a/lib/mcp/validate-workflow-web3.ts
+++ b/lib/mcp/validate-workflow-web3.ts
@@ -8,6 +8,8 @@ import {
   VALIDATION_ERROR_CODES,
   type ValidationErrorCode,
 } from "@/lib/mcp/validate-workflow-codes";
+import { isSolanaChain } from "@/lib/rpc/provider-factory";
+import { validateChainAddress } from "@/lib/web3/validate-chain-address";
 
 type Web3Issue = {
   code: ValidationErrorCode;
@@ -87,12 +89,56 @@ export function chainExists(
 }
 
 /**
+ * Resolves a node's `network` config to a chain ID for format-checking
+ * purposes, or null when it can't be determined statically (missing, or a
+ * template reference resolved at execution time - same skip condition
+ * chainExists above uses). A null result means the address format check
+ * below falls back to accepting either EVM or Solana shape, since the
+ * chain family that will actually validate it is unknown here.
+ */
+function resolveNodeChainId(rawNode: NodeLike): number | null {
+  const network = readStringConfig(rawNode, "network");
+  if (network === null || isWholeTemplateReference(network)) {
+    return null;
+  }
+  const parsed = Number(network);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+// validateChainAddress only branches on isSolanaChain(chainId), never on the
+// specific chain ID within a family, so any Solana chain ID stands in for
+// "check base58 shape" when a node's actual chain is unknown (see the null
+// branch of isValidAddressForNode below).
+const ANY_SOLANA_CHAIN_ID = 101;
+
+/**
+ * Format-checks an address against the chain family resolved for this node.
+ * When the chain can't be determined statically, accepts either EVM or
+ * Solana shape rather than defaulting to EVM-only and false-positiving on
+ * every Solana workflow this validator has no chain context for.
+ */
+function isValidAddressForNode(
+  address: string,
+  chainId: number | null
+): boolean {
+  if (chainId !== null) {
+    return validateChainAddress(address, chainId);
+  }
+  return (
+    ethers.isAddress(address) ||
+    validateChainAddress(address, ANY_SOLANA_CHAIN_ID)
+  );
+}
+
+/**
  * VALID-06: per-node token / contract address format.
  *
  * Walks every node config; for any string-typed `contractAddress` (and
- * any address inside `tokenConfig` JSON), validates with ethers.isAddress.
- * Empty strings and missing fields are SKIPPED (those are a different
- * validation surface — required-field checks belong to the editor).
+ * any address inside `tokenConfig` JSON), validates against the node's
+ * resolved chain family (EVM 0x-hex or Solana base58 - see
+ * lib/web3/validate-chain-address.ts). Empty strings and missing fields are
+ * SKIPPED (those are a different validation surface — required-field checks
+ * belong to the editor).
  */
 export function tokenAddressFormat(nodes: unknown): Web3Issue[] {
   const issues: Web3Issue[] = [];
@@ -100,6 +146,10 @@ export function tokenAddressFormat(nodes: unknown): Web3Issue[] {
     return issues;
   }
   for (const [idx, rawNode] of nodes.entries()) {
+    const chainId = resolveNodeChainId(rawNode as NodeLike);
+    const formatLabel =
+      chainId !== null && isSolanaChain(chainId) ? "Solana" : "EVM";
+
     const contractAddress = readStringConfig(
       rawNode as NodeLike,
       "contractAddress"
@@ -108,11 +158,11 @@ export function tokenAddressFormat(nodes: unknown): Web3Issue[] {
       contractAddress !== null &&
       contractAddress.length > 0 &&
       !isTemplateReference(contractAddress) &&
-      !ethers.isAddress(contractAddress)
+      !isValidAddressForNode(contractAddress, chainId)
     ) {
       issues.push({
         code: VALIDATION_ERROR_CODES.INVALID_TOKEN_ADDRESS,
-        message: `nodes[${idx}].config.contractAddress "${contractAddress}" is not a valid EVM address`,
+        message: `nodes[${idx}].config.contractAddress "${contractAddress}" is not a valid ${formatLabel} address`,
         parameterPath: `nodes[${idx}].config.contractAddress`,
       });
     }
@@ -134,11 +184,11 @@ export function tokenAddressFormat(nodes: unknown): Web3Issue[] {
     if (
       embeddedAddress !== null &&
       !isTemplateReference(embeddedAddress) &&
-      !ethers.isAddress(embeddedAddress)
+      !isValidAddressForNode(embeddedAddress, chainId)
     ) {
       issues.push({
         code: VALIDATION_ERROR_CODES.INVALID_TOKEN_ADDRESS,
-        message: `nodes[${idx}].config.tokenConfig.customToken.address "${embeddedAddress}" is not a valid EVM address`,
+        message: `nodes[${idx}].config.tokenConfig.customToken.address "${embeddedAddress}" is not a valid ${formatLabel} address`,
         parameterPath: `nodes[${idx}].config.tokenConfig.customToken.address`,
       });
     }

--- a/lib/web3/solana-mint.ts
+++ b/lib/web3/solana-mint.ts
@@ -1,0 +1,50 @@
+import "server-only";
+
+import {
+  type Mint,
+  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+  unpackMint,
+} from "@solana/spl-token";
+import type { AccountInfo, PublicKey } from "@solana/web3.js";
+import { getErrorMessage } from "@/lib/utils";
+
+/** True for the legacy SPL Token program or Token-2022 (Token Extensions). */
+export function isSolanaTokenProgram(programId: PublicKey): boolean {
+  return (
+    programId.equals(TOKEN_PROGRAM_ID) ||
+    programId.equals(TOKEN_2022_PROGRAM_ID)
+  );
+}
+
+/**
+ * Parses an already-fetched mint account, resolving which token program owns
+ * it (legacy SPL Token or Token-2022) so callers don't hardcode TOKEN_PROGRAM_ID
+ * and silently reject Token-2022 mints (transfer-fee, confidential-transfer,
+ * interest-bearing).
+ *
+ * Deliberately takes the account info rather than a Connection: the RPC read
+ * and its failover/retry policy belong to the caller (some retry via a
+ * SolanaChainAdapter's executeWithSolanaFailover, some don't), while parsing
+ * a fetched account is synchronous and must never be retried - unpackMint
+ * throwing means the data is malformed, not that the network blipped.
+ */
+export function parseSolanaMintAccount(
+  mintPubkey: PublicKey,
+  mintInfo: AccountInfo<Buffer>
+): { mint: Mint; programId: PublicKey } | { error: string } {
+  const programId = mintInfo.owner;
+  if (!isSolanaTokenProgram(programId)) {
+    return {
+      error: `${mintPubkey.toBase58()} is not an SPL token mint (owned by ${programId.toBase58()})`,
+    };
+  }
+
+  try {
+    return { mint: unpackMint(mintPubkey, mintInfo, programId), programId };
+  } catch (error) {
+    return {
+      error: `${mintPubkey.toBase58()} is not a valid SPL mint: ${getErrorMessage(error)}`,
+    };
+  }
+}

--- a/lib/web3/validate-chain-address.ts
+++ b/lib/web3/validate-chain-address.ts
@@ -42,3 +42,17 @@ export function validateChainTxHash(hash: string, chainId: number): boolean {
   }
   return EVM_TX_HASH_PATTERN.test(hash);
 }
+
+/**
+ * Guard for actions that only understand EVM (ABI-decoded logs/calls have no
+ * Solana equivalent). Returns a ready-to-return failure result for a Solana
+ * chainId, or null when the chain is fine - shared so the guard condition and
+ * message live in one place instead of being copy-pasted per action.
+ */
+export function evmOnlyGuard(
+  chainId: number
+): { success: false; error: string } | null {
+  return isSolanaChain(chainId)
+    ? { success: false, error: "Solana is not supported for this action yet" }
+    : null;
+}

--- a/lib/web3/validate-chain-address.ts
+++ b/lib/web3/validate-chain-address.ts
@@ -1,0 +1,44 @@
+import { PublicKey } from "@solana/web3.js";
+import bs58 from "bs58";
+import { ethers } from "ethers";
+import { isSolanaChain } from "@/lib/rpc/provider-factory";
+
+const EVM_TX_HASH_PATTERN = /^0x[a-fA-F0-9]{64}$/;
+const SOLANA_SIGNATURE_BYTE_LENGTH = 64;
+
+/**
+ * Validates an address against the format the chain actually uses: base58
+ * for Solana, 0x-hex for EVM. A chain-agnostic address check rejects valid
+ * input from the "other" family, so callers must resolve chainId before
+ * validating - see check-balance.ts for the reference pattern this mirrors.
+ */
+export function validateChainAddress(
+  address: string,
+  chainId: number
+): boolean {
+  if (isSolanaChain(chainId)) {
+    try {
+      // Throws on non-base58 / wrong-length input.
+      new PublicKey(address);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return ethers.isAddress(address);
+}
+
+/**
+ * Validates a transaction hash/signature against the chain's format: a
+ * 64-byte base58 signature for Solana, a 32-byte 0x-hex hash for EVM.
+ */
+export function validateChainTxHash(hash: string, chainId: number): boolean {
+  if (isSolanaChain(chainId)) {
+    try {
+      return bs58.decode(hash).length === SOLANA_SIGNATURE_BYTE_LENGTH;
+    } catch {
+      return false;
+    }
+  }
+  return EVM_TX_HASH_PATTERN.test(hash);
+}

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -720,7 +720,13 @@ const web3Plugin: IntegrationPlugin = {
         },
         {
           field: "gasLimit",
-          description: "Gas limit for the transaction",
+          description:
+            "Gas limit for the transaction (EVM only; 0 for Solana, which has no comparable ceiling)",
+        },
+        {
+          field: "computeUnitsConsumed",
+          description:
+            "Solana only: actual compute units consumed by the transaction",
         },
         {
           field: "blockNumber",

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -79,7 +79,7 @@ const web3Plugin: IntegrationPlugin = {
     {
       slug: "check-token-balance",
       label: "Get ERC20 Token Balance",
-      description: "Get ERC20 token balance of any address",
+      description: "Get the token balance (ERC20 or SPL) of any address",
       category: "Web3",
       stepFunction: "checkTokenBalanceStep",
       stepImportPath: "check-token-balance",
@@ -134,7 +134,7 @@ const web3Plugin: IntegrationPlugin = {
           key: "network",
           label: "Network",
           type: "chain-select",
-          chainTypeFilter: "evm",
+          // No chainType filter: supports EVM (ERC20) and Solana (SPL) tokens.
           placeholder: "Select network",
           required: true,
         },
@@ -142,7 +142,7 @@ const web3Plugin: IntegrationPlugin = {
           key: "address",
           label: "Address",
           type: "template-input",
-          placeholder: "0x... or {{NodeName.address}}",
+          placeholder: "0x... / Solana address / {{NodeName.address}}",
           example: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb",
           required: true,
         },
@@ -748,7 +748,7 @@ const web3Plugin: IntegrationPlugin = {
           key: "network",
           label: "Network",
           type: "chain-select",
-          chainTypeFilter: "evm",
+          // No chainType filter: supports EVM and Solana transaction lookups.
           placeholder: "Select network",
           required: true,
         },
@@ -756,7 +756,7 @@ const web3Plugin: IntegrationPlugin = {
           key: "transactionHash",
           label: "Transaction Hash",
           type: "template-input",
-          placeholder: "0x... or {{NodeName.transactionHash}}",
+          placeholder: "0x... / Solana signature / {{NodeName.transactionHash}}",
           example:
             "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060",
           required: true,

--- a/plugins/web3/steps/check-balance.ts
+++ b/plugins/web3/steps/check-balance.ts
@@ -1,6 +1,5 @@
 import "server-only";
 
-import { PublicKey } from "@solana/web3.js";
 import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { db } from "@/lib/db";
@@ -14,6 +13,7 @@ import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
+import { validateChainAddress } from "@/lib/web3/validate-chain-address";
 
 /**
  * Get userId from executionId by querying the workflowExecutions table
@@ -99,35 +99,20 @@ async function stepHandler(
   const isSolana = isSolanaChain(chainId);
 
   // Validate the address for the chain family.
-  if (isSolana) {
-    try {
-      // Throws on non-base58 / wrong-length input.
-      new PublicKey(address);
-    } catch {
-      logUserError(
-        ErrorCategory.VALIDATION,
-        "[Check Balance] Invalid Solana address:",
-        address,
-        { plugin_name: "web3", action_name: "check-balance" }
-      );
-      return {
-        success: false,
-        error: `Invalid Solana address: ${address}`,
-      };
-    }
-  } else if (!ethers.isAddress(address)) {
+  if (!validateChainAddress(address, chainId)) {
     logUserError(
       ErrorCategory.VALIDATION,
-      "[Check Balance] Invalid address:",
+      isSolana
+        ? "[Check Balance] Invalid Solana address:"
+        : "[Check Balance] Invalid address:",
       address,
-      {
-        plugin_name: "web3",
-        action_name: "check-balance",
-      }
+      { plugin_name: "web3", action_name: "check-balance" }
     );
     return {
       success: false,
-      error: `Invalid Ethereum address: ${address}`,
+      error: isSolana
+        ? `Invalid Solana address: ${address}`
+        : `Invalid Ethereum address: ${address}`,
     };
   }
 

--- a/plugins/web3/steps/check-token-balance.ts
+++ b/plugins/web3/steps/check-token-balance.ts
@@ -1,5 +1,12 @@
 import "server-only";
 
+import {
+  getAccount,
+  getAssociatedTokenAddress,
+  getMint,
+  TokenAccountNotFoundError,
+} from "@solana/spl-token";
+import { type Connection, PublicKey } from "@solana/web3.js";
 import { and, eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import ERC20_ABI from "@/lib/contracts/abis/erc20.json";
@@ -7,11 +14,14 @@ import { db } from "@/lib/db";
 import { supportedTokens, workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
-import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
+import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 import type { CustomToken, TokenFieldValue } from "@/lib/wallet/types";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
+import type { SolanaChainAdapter } from "@/lib/web3/chain-adapter/solana";
+import { validateChainAddress } from "@/lib/web3/validate-chain-address";
 
 /**
  * Get userId from executionId by querying the workflowExecutions table
@@ -305,6 +315,85 @@ async function fetchTokenBalance(
 }
 
 /**
+ * Resolve a display symbol/name for an SPL mint. Solana has no on-chain
+ * equivalent of ERC20's symbol()/name() (that lives in a separate Metaplex
+ * metadata account this action does not integrate with), so this falls back
+ * to whatever the caller already told us: the custom-token symbol supplied
+ * in tokenConfig, or a matching row in supportedTokens if one exists.
+ */
+async function getSolanaTokenDisplayInfo(
+  tokenConfig: TokenFieldValue,
+  chainId: number,
+  tokenAddress: string
+): Promise<{ symbol: string; name: string }> {
+  if (tokenConfig.customToken?.symbol) {
+    return {
+      symbol: tokenConfig.customToken.symbol,
+      name: tokenConfig.customToken.symbol,
+    };
+  }
+
+  const tokens = await db
+    .select({ symbol: supportedTokens.symbol, name: supportedTokens.name })
+    .from(supportedTokens)
+    .where(
+      and(
+        eq(supportedTokens.chainId, chainId),
+        eq(supportedTokens.tokenAddress, tokenAddress)
+      )
+    )
+    .limit(1);
+
+  return {
+    symbol: tokens[0]?.symbol ?? "???",
+    name: tokens[0]?.name ?? "Unknown",
+  };
+}
+
+/**
+ * Fetch an SPL token balance for a wallet. A wallet with no associated
+ * token account for this mint has never held the token, which is a zero
+ * balance (matching ERC20 balanceOf() on an unfunded holder), not an error.
+ */
+async function fetchSolanaTokenBalance(
+  connection: Connection,
+  walletAddress: string,
+  tokenAddress: string,
+  symbol: string,
+  name: string
+): Promise<TokenBalance> {
+  const mintPubkey = new PublicKey(tokenAddress);
+  const ownerPubkey = new PublicKey(walletAddress);
+
+  const mint = await getMint(connection, mintPubkey);
+  const associatedTokenAddress = await getAssociatedTokenAddress(
+    mintPubkey,
+    ownerPubkey
+  );
+
+  let balanceRaw = BigInt(0);
+  try {
+    const account = await getAccount(connection, associatedTokenAddress);
+    balanceRaw = account.amount;
+  } catch (error) {
+    if (!(error instanceof TokenAccountNotFoundError)) {
+      throw error;
+    }
+  }
+
+  const balance = ethers.formatUnits(balanceRaw, mint.decimals);
+
+  return {
+    balance,
+    balanceRaw: balanceRaw.toString(),
+    symbol,
+    decimals: mint.decimals,
+    name,
+    tokenAddress,
+  };
+}
+
+/**
  * Core check token balance logic
  */
 async function stepHandler(
@@ -329,24 +418,8 @@ async function stepHandler(
     );
   }
 
-  // Validate wallet address
-  if (!ethers.isAddress(address)) {
-    logUserError(
-      ErrorCategory.VALIDATION,
-      "[Check Token Balance] Invalid wallet address:",
-      address,
-      {
-        plugin_name: "web3",
-        action_name: "check-token-balance",
-      }
-    );
-    return {
-      success: false,
-      error: `Invalid wallet address: ${address}`,
-    };
-  }
-
-  // Get chain ID from network name
+  // Resolve the chain first so address validation can branch on the chain
+  // family (EVM vs Solana) - see lib/web3/validate-chain-address.ts.
   let chainId: number;
   try {
     chainId = getChainIdFromNetwork(network);
@@ -367,6 +440,25 @@ async function stepHandler(
     };
   }
 
+  const isSolana = isSolanaChain(chainId);
+
+  // Validate wallet address
+  if (!validateChainAddress(address, chainId)) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[Check Token Balance] Invalid wallet address:",
+      address,
+      {
+        plugin_name: "web3",
+        action_name: "check-token-balance",
+      }
+    );
+    return {
+      success: false,
+      error: `Invalid wallet address: ${address}`,
+    };
+  }
+
   // Get token address to check
   const tokenAddress = await getTokenAddress(tokenConfig, chainId);
 
@@ -383,7 +475,7 @@ async function stepHandler(
   );
 
   // Validate token address
-  if (!ethers.isAddress(tokenAddress)) {
+  if (!validateChainAddress(tokenAddress, chainId)) {
     logUserError(
       ErrorCategory.VALIDATION,
       "[Check Token Balance] Invalid token address:",
@@ -399,35 +491,58 @@ async function stepHandler(
     };
   }
 
-  // Resolve RPC provider with failover support
-  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
-  try {
-    rpcManager = await getRpcProvider({ chainId, userId });
-  } catch (error) {
-    logUserError(
-      ErrorCategory.VALIDATION,
-      "[Check Token Balance] Failed to resolve RPC config:",
-      error,
-      {
-        plugin_name: "web3",
-        action_name: "check-token-balance",
-        chain_id: String(chainId),
-      }
-    );
-    return {
-      success: false,
-      error: getErrorMessage(error),
-    };
+  // Resolve RPC provider with failover support (EVM only). SolanaChainAdapter
+  // owns its own provider manager, so the Solana path skips this entirely.
+  let rpcManager: RpcProviderManager | undefined;
+  if (!isSolana) {
+    try {
+      rpcManager = await getRpcProvider({ chainId, userId });
+    } catch (error) {
+      logUserError(
+        ErrorCategory.VALIDATION,
+        "[Check Token Balance] Failed to resolve RPC config:",
+        error,
+        {
+          plugin_name: "web3",
+          action_name: "check-token-balance",
+          chain_id: String(chainId),
+        }
+      );
+      return {
+        success: false,
+        error: getErrorMessage(error),
+      };
+    }
   }
 
   const adapter = getChainAdapter(chainId);
 
   // Check balance for the token
   try {
-    const balance = await adapter.executeWithFailover(
-      rpcManager,
-      async (provider) => fetchTokenBalance(provider, address, tokenAddress)
-    );
+    let balance: TokenBalance;
+    if (isSolana) {
+      const displayInfo = await getSolanaTokenDisplayInfo(
+        tokenConfig,
+        chainId,
+        tokenAddress
+      );
+      balance = await (
+        adapter as SolanaChainAdapter
+      ).executeWithSolanaFailover((connection) =>
+        fetchSolanaTokenBalance(
+          connection,
+          address,
+          tokenAddress,
+          displayInfo.symbol,
+          displayInfo.name
+        )
+      );
+    } else {
+      balance = await adapter.executeWithFailover(
+        rpcManager as RpcProviderManager,
+        async (provider) => fetchTokenBalance(provider, address, tokenAddress)
+      );
+    }
 
     const addressLink = await adapter.getAddressUrl(address);
 

--- a/plugins/web3/steps/check-token-balance.ts
+++ b/plugins/web3/steps/check-token-balance.ts
@@ -1,26 +1,31 @@
 import "server-only";
 
 import {
-  getAccount,
-  getAssociatedTokenAddress,
-  getMint,
-  TokenAccountNotFoundError,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  getAssociatedTokenAddressSync,
+  unpackAccount,
 } from "@solana/spl-token";
 import { type Connection, PublicKey } from "@solana/web3.js";
 import { and, eq } from "drizzle-orm";
 import { ethers } from "ethers";
+import { isSolanaAddressFormat } from "@/lib/address-utils";
 import ERC20_ABI from "@/lib/contracts/abis/erc20.json";
 import { db } from "@/lib/db";
 import { supportedTokens, workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
-import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
+import {
+  getRpcProvider,
+  getSolanaProvider,
+  isSolanaChain,
+} from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 import type { CustomToken, TokenFieldValue } from "@/lib/wallet/types";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
-import type { SolanaChainAdapter } from "@/lib/web3/chain-adapter/solana";
+import { SolanaChainAdapter } from "@/lib/web3/chain-adapter/solana";
+import { parseSolanaMintAccount } from "@/lib/web3/solana-mint";
 import { validateChainAddress } from "@/lib/web3/validate-chain-address";
 
 /**
@@ -210,8 +215,12 @@ function parseTokenConfig(input: CheckTokenBalanceInput): TokenFieldValue {
       customToken: extractCustomToken(parsed),
     };
   } catch {
-    // If parsing fails and it looks like an address, treat as custom
-    if (input.tokenConfig.startsWith("0x")) {
+    // If parsing fails and it looks like an address (EVM 0x-hex or Solana
+    // base58), treat as custom.
+    if (
+      input.tokenConfig.startsWith("0x") ||
+      isSolanaAddressFormat(input.tokenConfig)
+    ) {
       return {
         mode: "custom",
         customToken: { address: input.tokenConfig, symbol: "???" },
@@ -326,7 +335,10 @@ async function getSolanaTokenDisplayInfo(
   chainId: number,
   tokenAddress: string
 ): Promise<{ symbol: string; name: string }> {
-  if (tokenConfig.customToken?.symbol) {
+  // "???" is this file's own unknown-symbol sentinel (see extractCustomToken /
+  // parseTokenConfig's legacy fallbacks above) - it is not a real symbol, so
+  // it must fall through to the DB lookup below rather than short-circuit it.
+  if (tokenConfig.customToken?.symbol && tokenConfig.customToken.symbol !== "???") {
     return {
       symbol: tokenConfig.customToken.symbol,
       name: tokenConfig.customToken.symbol,
@@ -365,21 +377,34 @@ async function fetchSolanaTokenBalance(
   const mintPubkey = new PublicKey(tokenAddress);
   const ownerPubkey = new PublicKey(walletAddress);
 
-  const mint = await getMint(connection, mintPubkey);
-  const associatedTokenAddress = await getAssociatedTokenAddress(
+  const mintInfo = await connection.getAccountInfo(mintPubkey, "confirmed");
+  if (!mintInfo) {
+    throw new Error(`Mint account not found: ${mintPubkey.toBase58()}`);
+  }
+  const resolved = parseSolanaMintAccount(mintPubkey, mintInfo);
+  if ("error" in resolved) {
+    throw new Error(resolved.error);
+  }
+  const { mint, programId } = resolved;
+
+  // Off-curve owners (PDA/program-owned wallets, e.g. a multisig treasury)
+  // are legitimate holders to check - matching transfer-spl-token-core.ts's
+  // handling of off-curve recipients. Derivation is synchronous (no RPC).
+  const associatedTokenAddress = getAssociatedTokenAddressSync(
     mintPubkey,
-    ownerPubkey
+    ownerPubkey,
+    true,
+    programId,
+    ASSOCIATED_TOKEN_PROGRAM_ID
   );
 
-  let balanceRaw = BigInt(0);
-  try {
-    const account = await getAccount(connection, associatedTokenAddress);
-    balanceRaw = account.amount;
-  } catch (error) {
-    if (!(error instanceof TokenAccountNotFoundError)) {
-      throw error;
-    }
-  }
+  const accountInfo = await connection.getAccountInfo(
+    associatedTokenAddress,
+    "confirmed"
+  );
+  const balanceRaw = accountInfo
+    ? unpackAccount(associatedTokenAddress, accountInfo, programId).amount
+    : BigInt(0);
 
   const balance = ethers.formatUnits(balanceRaw, mint.decimals);
 
@@ -391,6 +416,116 @@ async function fetchSolanaTokenBalance(
     name,
     tokenAddress,
   };
+}
+
+/**
+ * EVM branch: resolve an RPC provider and read the ERC20 balance/metadata.
+ */
+async function checkEvmTokenBalance(
+  address: string,
+  tokenAddress: string,
+  chainId: number,
+  userId: string | undefined
+): Promise<CheckTokenBalanceResult> {
+  let rpcManager: RpcProviderManager;
+  try {
+    rpcManager = await getRpcProvider({ chainId, userId });
+  } catch (error) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[Check Token Balance] Failed to resolve RPC config:",
+      error,
+      {
+        plugin_name: "web3",
+        action_name: "check-token-balance",
+        chain_id: String(chainId),
+      }
+    );
+    return {
+      success: false,
+      error: getErrorMessage(error),
+    };
+  }
+
+  const adapter = getChainAdapter(chainId);
+
+  try {
+    const balance = await adapter.executeWithFailover(
+      rpcManager,
+      async (provider) => fetchTokenBalance(provider, address, tokenAddress)
+    );
+    const addressLink = await adapter.getAddressUrl(address);
+
+    return { success: true, balance, address, addressLink };
+  } catch (error) {
+    logUserError(
+      ErrorCategory.NETWORK_RPC,
+      "[Check Token Balance] Failed to check token balance:",
+      error,
+      {
+        plugin_name: "web3",
+        action_name: "check-token-balance",
+        chain_id: String(chainId),
+      }
+    );
+    return {
+      success: false,
+      error: `Failed to check token balance: ${getErrorMessage(error)}`,
+    };
+  }
+}
+
+/**
+ * Solana branch: a fresh, userId-aware adapter is constructed directly
+ * (bypassing getChainAdapter's chainId-only cache) so a user's custom RPC
+ * preference is actually honored here, the same way getRpcProvider({chainId,
+ * userId}) already honors it on the EVM branch above.
+ */
+async function checkSolanaTokenBalance(
+  address: string,
+  tokenAddress: string,
+  chainId: number,
+  userId: string | undefined,
+  tokenConfig: TokenFieldValue
+): Promise<CheckTokenBalanceResult> {
+  const adapter = new SolanaChainAdapter(chainId, () =>
+    getSolanaProvider({ chainId, userId })
+  );
+
+  try {
+    const displayInfo = await getSolanaTokenDisplayInfo(
+      tokenConfig,
+      chainId,
+      tokenAddress
+    );
+    const balance = await adapter.executeWithSolanaFailover((connection) =>
+      fetchSolanaTokenBalance(
+        connection,
+        address,
+        tokenAddress,
+        displayInfo.symbol,
+        displayInfo.name
+      )
+    );
+    const addressLink = await adapter.getAddressUrl(address);
+
+    return { success: true, balance, address, addressLink };
+  } catch (error) {
+    logUserError(
+      ErrorCategory.NETWORK_RPC,
+      "[Check Token Balance] Failed to check token balance:",
+      error,
+      {
+        plugin_name: "web3",
+        action_name: "check-token-balance",
+        chain_id: String(chainId),
+      }
+    );
+    return {
+      success: false,
+      error: `Failed to check token balance: ${getErrorMessage(error)}`,
+    };
+  }
 }
 
 /**
@@ -439,8 +574,6 @@ async function stepHandler(
       error: getErrorMessage(error),
     };
   }
-
-  const isSolana = isSolanaChain(chainId);
 
   // Validate wallet address
   if (!validateChainAddress(address, chainId)) {
@@ -491,83 +624,9 @@ async function stepHandler(
     };
   }
 
-  // Resolve RPC provider with failover support (EVM only). SolanaChainAdapter
-  // owns its own provider manager, so the Solana path skips this entirely.
-  let rpcManager: RpcProviderManager | undefined;
-  if (!isSolana) {
-    try {
-      rpcManager = await getRpcProvider({ chainId, userId });
-    } catch (error) {
-      logUserError(
-        ErrorCategory.VALIDATION,
-        "[Check Token Balance] Failed to resolve RPC config:",
-        error,
-        {
-          plugin_name: "web3",
-          action_name: "check-token-balance",
-          chain_id: String(chainId),
-        }
-      );
-      return {
-        success: false,
-        error: getErrorMessage(error),
-      };
-    }
-  }
-
-  const adapter = getChainAdapter(chainId);
-
-  // Check balance for the token
-  try {
-    let balance: TokenBalance;
-    if (isSolana) {
-      const displayInfo = await getSolanaTokenDisplayInfo(
-        tokenConfig,
-        chainId,
-        tokenAddress
-      );
-      balance = await (
-        adapter as SolanaChainAdapter
-      ).executeWithSolanaFailover((connection) =>
-        fetchSolanaTokenBalance(
-          connection,
-          address,
-          tokenAddress,
-          displayInfo.symbol,
-          displayInfo.name
-        )
-      );
-    } else {
-      balance = await adapter.executeWithFailover(
-        rpcManager as RpcProviderManager,
-        async (provider) => fetchTokenBalance(provider, address, tokenAddress)
-      );
-    }
-
-    const addressLink = await adapter.getAddressUrl(address);
-
-    return {
-      success: true,
-      balance,
-      address,
-      addressLink,
-    };
-  } catch (error) {
-    logUserError(
-      ErrorCategory.NETWORK_RPC,
-      "[Check Token Balance] Failed to check token balance:",
-      error,
-      {
-        plugin_name: "web3",
-        action_name: "check-token-balance",
-        chain_id: String(chainId),
-      }
-    );
-    return {
-      success: false,
-      error: `Failed to check token balance: ${getErrorMessage(error)}`,
-    };
-  }
+  return isSolanaChain(chainId)
+    ? checkSolanaTokenBalance(address, tokenAddress, chainId, userId, tokenConfig)
+    : checkEvmTokenBalance(address, tokenAddress, chainId, userId);
 }
 
 /**

--- a/plugins/web3/steps/get-transaction.ts
+++ b/plugins/web3/steps/get-transaction.ts
@@ -8,12 +8,15 @@ import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getAddressUrl, getTransactionUrl } from "@/lib/explorer";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
-import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
+import {
+  getRpcProvider,
+  getSolanaProvider,
+  isSolanaChain,
+} from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
-import { getChainAdapter } from "@/lib/web3/chain-adapter";
-import type { SolanaChainAdapter } from "@/lib/web3/chain-adapter/solana";
+import { SolanaChainAdapter } from "@/lib/web3/chain-adapter/solana";
 import { validateChainTxHash } from "@/lib/web3/validate-chain-address";
 
 /**
@@ -59,6 +62,11 @@ type GetTransactionResult =
       input: string;
       nonce: number;
       gasLimit: string;
+      // Solana only: actual compute units consumed. Not comparable to
+      // gasLimit (an EVM ceiling the transaction was allowed to spend, not
+      // what it used), so it is reported as its own field rather than
+      // overloading gasLimit with a different quantity.
+      computeUnitsConsumed?: string;
       blockNumber: number | null;
       transactionLink: string;
       fromLink: string;
@@ -72,6 +80,116 @@ export type GetTransactionCoreInput = {
 };
 
 export type GetTransactionInput = StepInput & GetTransactionCoreInput;
+
+/**
+ * EVM branch: resolve an RPC provider and fetch the transaction.
+ */
+async function fetchEvmTransaction(
+  hash: string,
+  chainId: number,
+  userId: string | undefined
+): Promise<GetTransactionResult> {
+  let rpcManager: RpcProviderManager;
+  try {
+    rpcManager = await getRpcProvider({ chainId, userId });
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  const tx = await rpcManager.executeWithFailover(async (provider) =>
+    provider.getTransaction(hash)
+  );
+
+  if (!tx) {
+    return { success: false, error: `Transaction not found: ${hash}` };
+  }
+
+  const explorerConfig = await db.query.explorerConfigs.findFirst({
+    where: eq(explorerConfigs.chainId, chainId),
+  });
+  const transactionLink = explorerConfig
+    ? getTransactionUrl(explorerConfig, hash)
+    : "";
+  const fromLink = explorerConfig
+    ? getAddressUrl(explorerConfig, tx.from)
+    : "";
+  const toLink =
+    explorerConfig && tx.to ? getAddressUrl(explorerConfig, tx.to) : "";
+
+  return {
+    success: true,
+    hash: tx.hash,
+    from: tx.from,
+    to: tx.to,
+    value: ethers.formatEther(tx.value),
+    input: tx.data,
+    nonce: tx.nonce,
+    gasLimit: tx.gasLimit.toString(),
+    blockNumber: tx.blockNumber,
+    transactionLink,
+    fromLink,
+    toLink,
+  };
+}
+
+/**
+ * Solana branch: a fresh, userId-aware adapter is constructed directly
+ * (bypassing getChainAdapter's chainId-only cache) so a user's custom RPC
+ * preference is actually honored here, the same way getRpcProvider({chainId,
+ * userId}) already honors it on the EVM branch above.
+ */
+async function fetchSolanaTransaction(
+  hash: string,
+  chainId: number,
+  userId: string | undefined
+): Promise<GetTransactionResult> {
+  const adapter = new SolanaChainAdapter(chainId, () =>
+    getSolanaProvider({ chainId, userId })
+  );
+  const tx = await adapter.executeWithSolanaFailover((connection) =>
+    connection.getTransaction(hash, {
+      commitment: "confirmed",
+      maxSupportedTransactionVersion: 0,
+    })
+  );
+
+  if (!tx) {
+    return { success: false, error: `Transaction not found: ${hash}` };
+  }
+
+  const feePayer = getSolanaFeePayer(tx);
+  const explorerConfig = await db.query.explorerConfigs.findFirst({
+    where: eq(explorerConfigs.chainId, chainId),
+  });
+  const transactionLink = explorerConfig
+    ? getTransactionUrl(explorerConfig, hash)
+    : "";
+  const fromLink = explorerConfig
+    ? getAddressUrl(explorerConfig, feePayer)
+    : "";
+
+  return {
+    success: true,
+    hash,
+    from: feePayer,
+    // Solana has no single recipient: a transaction is a list of
+    // instructions, each with its own accounts.
+    to: null,
+    // Solana has no single top-level transfer amount the way an EVM
+    // transaction does.
+    value: "0",
+    input: "",
+    nonce: 0,
+    // No fixed compute ceiling is reported by this RPC call; actual usage is
+    // reported separately via computeUnitsConsumed below.
+    gasLimit: "0",
+    computeUnitsConsumed: String(tx.meta?.computeUnitsConsumed ?? 0),
+    blockNumber: tx.slot,
+    transactionLink,
+    fromLink,
+    toLink: "",
+  };
+}
 
 async function stepHandler(
   input: GetTransactionInput
@@ -106,107 +224,12 @@ async function stepHandler(
     };
   }
 
-  const isSolana = isSolanaChain(chainId);
   const userId = await getUserIdFromExecution(_context?.executionId);
 
-  // Resolve RPC provider with failover support (EVM only). SolanaChainAdapter
-  // owns its own provider manager, so the Solana path skips this entirely.
-  let rpcManager: RpcProviderManager | undefined;
-  if (!isSolana) {
-    try {
-      rpcManager = await getRpcProvider({ chainId, userId });
-    } catch (error) {
-      return {
-        success: false,
-        error: getErrorMessage(error),
-      };
-    }
-  }
-
   try {
-    const explorerConfig = await db.query.explorerConfigs.findFirst({
-      where: eq(explorerConfigs.chainId, chainId),
-    });
-
-    if (isSolana) {
-      const adapter = getChainAdapter(chainId) as SolanaChainAdapter;
-      const tx = await adapter.executeWithSolanaFailover((connection) =>
-        connection.getTransaction(hash, {
-          commitment: "confirmed",
-          maxSupportedTransactionVersion: 0,
-        })
-      );
-
-      if (!tx) {
-        return {
-          success: false,
-          error: `Transaction not found: ${hash}`,
-        };
-      }
-
-      const feePayer = getSolanaFeePayer(tx);
-      const transactionLink = explorerConfig
-        ? getTransactionUrl(explorerConfig, hash)
-        : "";
-      const fromLink = explorerConfig
-        ? getAddressUrl(explorerConfig, feePayer)
-        : "";
-
-      return {
-        success: true,
-        hash,
-        from: feePayer,
-        // Solana has no single recipient: a transaction is a list of
-        // instructions, each with its own accounts.
-        to: null,
-        // Solana has no single top-level transfer amount the way an EVM
-        // transaction does.
-        value: "0",
-        input: "",
-        nonce: 0,
-        // Compute units are the closest Solana analogue to an EVM gas limit.
-        gasLimit: String(tx.meta?.computeUnitsConsumed ?? 0),
-        blockNumber: tx.slot,
-        transactionLink,
-        fromLink,
-        toLink: "",
-      };
-    }
-
-    const tx = await (rpcManager as RpcProviderManager).executeWithFailover(
-      async (provider) => provider.getTransaction(hash)
-    );
-
-    if (!tx) {
-      return {
-        success: false,
-        error: `Transaction not found: ${hash}`,
-      };
-    }
-
-    const transactionLink = explorerConfig
-      ? getTransactionUrl(explorerConfig, hash)
-      : "";
-    const fromLink = explorerConfig
-      ? getAddressUrl(explorerConfig, tx.from)
-      : "";
-    const toLink =
-      explorerConfig && tx.to ? getAddressUrl(explorerConfig, tx.to) : "";
-
-    return {
-      success: true,
-      hash: tx.hash,
-      from: tx.from,
-      to: tx.to,
-      value: ethers.formatEther(tx.value),
-      input: tx.data,
-      nonce: tx.nonce,
-      gasLimit: tx.gasLimit.toString(),
-      blockNumber: tx.blockNumber,
-      transactionLink,
-      fromLink,
-      toLink,
-    };
+    return isSolanaChain(chainId)
+      ? await fetchSolanaTransaction(hash, chainId, userId)
+      : await fetchEvmTransaction(hash, chainId, userId);
   } catch (error) {
     return {
       success: false,

--- a/plugins/web3/steps/get-transaction.ts
+++ b/plugins/web3/steps/get-transaction.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import type { VersionedTransactionResponse } from "@solana/web3.js";
 import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { db } from "@/lib/db";
@@ -7,12 +8,30 @@ import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getAddressUrl, getTransactionUrl } from "@/lib/explorer";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
-import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
+import type { SolanaChainAdapter } from "@/lib/web3/chain-adapter/solana";
+import { validateChainTxHash } from "@/lib/web3/validate-chain-address";
 
-const TX_HASH_PATTERN = /^0x[a-fA-F0-9]{64}$/;
+/**
+ * Index 0 of a transaction's account keys is always the fee payer - the
+ * same convention SolanaChainAdapter relies on when reading back simulated
+ * fee-payer state (see solana.ts's buildSignAndSimulate).
+ */
+function getSolanaFeePayer(tx: VersionedTransactionResponse): string {
+  const feePayer = tx.transaction.message
+    .getAccountKeys({ accountKeysFromLookups: tx.meta?.loadedAddresses })
+    .get(0);
+  if (!feePayer) {
+    throw new Error(
+      "[Get Transaction] Transaction has no fee payer account key"
+    );
+  }
+  return feePayer.toBase58();
+}
 
 async function getUserIdFromExecution(
   executionId: string | undefined
@@ -67,15 +86,9 @@ async function stepHandler(
   }
 
   const hash = transactionHash.trim();
-  if (!TX_HASH_PATTERN.test(hash)) {
-    return {
-      success: false,
-      error: `Invalid transaction hash format: ${hash}`,
-    };
-  }
 
-  const userId = await getUserIdFromExecution(_context?.executionId);
-
+  // Resolve the chain first so hash-format validation can branch on the
+  // chain family (EVM vs Solana) - see lib/web3/validate-chain-address.ts.
   let chainId: number;
   try {
     chainId = getChainIdFromNetwork(network);
@@ -86,19 +99,82 @@ async function stepHandler(
     };
   }
 
-  let rpcManager: RpcProviderManager;
-  try {
-    rpcManager = await getRpcProvider({ chainId, userId });
-  } catch (error) {
+  if (!validateChainTxHash(hash, chainId)) {
     return {
       success: false,
-      error: getErrorMessage(error),
+      error: `Invalid transaction hash format: ${hash}`,
     };
   }
 
+  const isSolana = isSolanaChain(chainId);
+  const userId = await getUserIdFromExecution(_context?.executionId);
+
+  // Resolve RPC provider with failover support (EVM only). SolanaChainAdapter
+  // owns its own provider manager, so the Solana path skips this entirely.
+  let rpcManager: RpcProviderManager | undefined;
+  if (!isSolana) {
+    try {
+      rpcManager = await getRpcProvider({ chainId, userId });
+    } catch (error) {
+      return {
+        success: false,
+        error: getErrorMessage(error),
+      };
+    }
+  }
+
   try {
-    const tx = await rpcManager.executeWithFailover(async (provider) =>
-      provider.getTransaction(hash)
+    const explorerConfig = await db.query.explorerConfigs.findFirst({
+      where: eq(explorerConfigs.chainId, chainId),
+    });
+
+    if (isSolana) {
+      const adapter = getChainAdapter(chainId) as SolanaChainAdapter;
+      const tx = await adapter.executeWithSolanaFailover((connection) =>
+        connection.getTransaction(hash, {
+          commitment: "confirmed",
+          maxSupportedTransactionVersion: 0,
+        })
+      );
+
+      if (!tx) {
+        return {
+          success: false,
+          error: `Transaction not found: ${hash}`,
+        };
+      }
+
+      const feePayer = getSolanaFeePayer(tx);
+      const transactionLink = explorerConfig
+        ? getTransactionUrl(explorerConfig, hash)
+        : "";
+      const fromLink = explorerConfig
+        ? getAddressUrl(explorerConfig, feePayer)
+        : "";
+
+      return {
+        success: true,
+        hash,
+        from: feePayer,
+        // Solana has no single recipient: a transaction is a list of
+        // instructions, each with its own accounts.
+        to: null,
+        // Solana has no single top-level transfer amount the way an EVM
+        // transaction does.
+        value: "0",
+        input: "",
+        nonce: 0,
+        // Compute units are the closest Solana analogue to an EVM gas limit.
+        gasLimit: String(tx.meta?.computeUnitsConsumed ?? 0),
+        blockNumber: tx.slot,
+        transactionLink,
+        fromLink,
+        toLink: "",
+      };
+    }
+
+    const tx = await (rpcManager as RpcProviderManager).executeWithFailover(
+      async (provider) => provider.getTransaction(hash)
     );
 
     if (!tx) {
@@ -107,10 +183,6 @@ async function stepHandler(
         error: `Transaction not found: ${hash}`,
       };
     }
-
-    const explorerConfig = await db.query.explorerConfigs.findFirst({
-      where: eq(explorerConfigs.chainId, chainId),
-    });
 
     const transactionLink = explorerConfig
       ? getTransactionUrl(explorerConfig, hash)

--- a/plugins/web3/steps/query-events.ts
+++ b/plugins/web3/steps/query-events.ts
@@ -7,7 +7,7 @@ import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
-import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
@@ -293,6 +293,24 @@ async function stepHandler(
 
   const { contractAddress, network, abi, eventName, _context } = input;
 
+  // Resolve the chain first so the address check and the Solana guard below
+  // can branch on the chain family.
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(network);
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  if (isSolanaChain(chainId)) {
+    // Event querying decodes EVM ABI logs, which have no Solana equivalent
+    // (Solana program logs are untyped and unindexed) - not yet supported.
+    return {
+      success: false,
+      error: "Solana is not supported for this action yet",
+    };
+  }
+
   if (!ethers.isAddress(contractAddress)) {
     return {
       success: false,
@@ -310,13 +328,6 @@ async function stepHandler(
   );
   if (!eventAbiEntry) {
     return { success: false, error: `Event '${eventName}' not found in ABI` };
-  }
-
-  let chainId: number;
-  try {
-    chainId = getChainIdFromNetwork(network);
-  } catch (error) {
-    return { success: false, error: getErrorMessage(error) };
   }
 
   const userId = await getUserIdFromExecution(_context?.executionId);

--- a/plugins/web3/steps/query-events.ts
+++ b/plugins/web3/steps/query-events.ts
@@ -7,10 +7,11 @@ import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
-import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
+import { evmOnlyGuard } from "@/lib/web3/validate-chain-address";
 import {
   type AbiEntry,
   isNearHeadBatch,
@@ -302,13 +303,11 @@ async function stepHandler(
     return { success: false, error: getErrorMessage(error) };
   }
 
-  if (isSolanaChain(chainId)) {
-    // Event querying decodes EVM ABI logs, which have no Solana equivalent
-    // (Solana program logs are untyped and unindexed) - not yet supported.
-    return {
-      success: false,
-      error: "Solana is not supported for this action yet",
-    };
+  // Event querying decodes EVM ABI logs, which have no Solana equivalent
+  // (Solana program logs are untyped and unindexed) - not yet supported.
+  const evmOnlyResult = evmOnlyGuard(chainId);
+  if (evmOnlyResult) {
+    return evmOnlyResult;
   }
 
   if (!ethers.isAddress(contractAddress)) {

--- a/plugins/web3/steps/query-transactions-core.ts
+++ b/plugins/web3/steps/query-transactions-core.ts
@@ -12,7 +12,7 @@ import {
   resolveExplorerUrlConfig,
 } from "@/lib/explorer";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
-import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { serializeArg } from "@/lib/web3/serialize-arg";
 import { getErrorMessage } from "@/lib/utils";
@@ -356,6 +356,24 @@ function validateInputs(
 ): { success: true; data: ValidatedInput } | { success: false; error: string } {
   const { contractAddress, abi, abiFunction } = input;
 
+  // Resolve the chain first so the address check and the Solana guard below
+  // can branch on the chain family.
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(input.network);
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  if (isSolanaChain(chainId)) {
+    // Transaction querying decodes calls via an EVM ABI function selector,
+    // which has no Solana equivalent - not yet supported.
+    return {
+      success: false,
+      error: "Solana is not supported for this action yet",
+    };
+  }
+
   if (!ethers.isAddress(contractAddress)) {
     return {
       success: false,
@@ -375,13 +393,6 @@ function validateInputs(
       success: false,
       error: `Function '${abiFunction}' not found in ABI`,
     };
-  }
-
-  let chainId: number;
-  try {
-    chainId = getChainIdFromNetwork(input.network);
-  } catch (error) {
-    return { success: false, error: getErrorMessage(error) };
   }
 
   return {

--- a/plugins/web3/steps/query-transactions-core.ts
+++ b/plugins/web3/steps/query-transactions-core.ts
@@ -12,9 +12,10 @@ import {
   resolveExplorerUrlConfig,
 } from "@/lib/explorer";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
-import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { serializeArg } from "@/lib/web3/serialize-arg";
+import { evmOnlyGuard } from "@/lib/web3/validate-chain-address";
 import { getErrorMessage } from "@/lib/utils";
 
 const DEFAULT_BLOCK_LOOKBACK = 6500;
@@ -365,13 +366,11 @@ function validateInputs(
     return { success: false, error: getErrorMessage(error) };
   }
 
-  if (isSolanaChain(chainId)) {
-    // Transaction querying decodes calls via an EVM ABI function selector,
-    // which has no Solana equivalent - not yet supported.
-    return {
-      success: false,
-      error: "Solana is not supported for this action yet",
-    };
+  // Transaction querying decodes calls via an EVM ABI function selector,
+  // which has no Solana equivalent - not yet supported.
+  const evmOnlyResult = evmOnlyGuard(chainId);
+  if (evmOnlyResult) {
+    return evmOnlyResult;
   }
 
   if (!ethers.isAddress(contractAddress)) {

--- a/plugins/web3/steps/transfer-funds-core.ts
+++ b/plugins/web3/steps/transfer-funds-core.ts
@@ -28,7 +28,7 @@ import { rpcRelayErrorClass } from "@/lib/rpc/providers";
 import type { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 import { getErrorMessage } from "@/lib/utils";
 import { generateId } from "@/lib/utils/id";
-import { PublicKey } from "@solana/web3.js";
+import { validateChainAddress } from "@/lib/web3/validate-chain-address";
 import type { SolanaTransactionSigner } from "@/lib/web3/chain-adapter/types";
 import type { NonceSession } from "@/lib/web3/nonce-manager";
 import {
@@ -552,9 +552,7 @@ async function transferFundsSolana(args: {
   }
 
   // 2. Validate recipient address (must be valid Solana base58 address)
-  try {
-    new PublicKey(recipientAddress);
-  } catch {
+  if (!validateChainAddress(recipientAddress, chainId)) {
     return {
       success: false,
       error: `Invalid Solana recipient address: ${recipientAddress}`,

--- a/tests/integration/check-token-balance-solana.test.ts
+++ b/tests/integration/check-token-balance-solana.test.ts
@@ -1,3 +1,4 @@
+import { PublicKey } from "@solana/web3.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
@@ -11,39 +12,81 @@ vi.mock("ethers", () => ({
   },
 }));
 
-const {
-  mockGetMint,
-  mockGetAssociatedTokenAddress,
-  mockGetAccount,
-  MockTokenAccountNotFoundError,
-} = vi.hoisted(() => {
-  class TokenAccountNotFoundErrorStub extends Error {}
+// Real, well-known program IDs - needed so parseSolanaMintAccount's
+// programId.equals(TOKEN_PROGRAM_ID) checks behave like the real library.
+const TOKEN_PROGRAM_ID = new PublicKey(
+  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+);
+const TOKEN_2022_PROGRAM_ID = new PublicKey(
+  "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+);
+const ASSOCIATED_TOKEN_PROGRAM_ID = new PublicKey(
+  "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+);
+
+const { mockUnpackMint, mockUnpackAccount, mockGetAssociatedTokenAddressSync } =
+  vi.hoisted(() => ({
+    mockUnpackMint: vi.fn(),
+    mockUnpackAccount: vi.fn(),
+    mockGetAssociatedTokenAddressSync: vi.fn(),
+  }));
+
+vi.mock("@solana/spl-token", async () => {
+  const actual =
+    await vi.importActual<typeof import("@solana/spl-token")>(
+      "@solana/spl-token"
+    );
   return {
-    mockGetMint: vi.fn(),
-    mockGetAssociatedTokenAddress: vi.fn(),
-    mockGetAccount: vi.fn(),
-    MockTokenAccountNotFoundError: TokenAccountNotFoundErrorStub,
+    TOKEN_PROGRAM_ID: actual.TOKEN_PROGRAM_ID,
+    TOKEN_2022_PROGRAM_ID: actual.TOKEN_2022_PROGRAM_ID,
+    ASSOCIATED_TOKEN_PROGRAM_ID: actual.ASSOCIATED_TOKEN_PROGRAM_ID,
+    unpackMint: (...args: unknown[]) => mockUnpackMint(...args),
+    unpackAccount: (...args: unknown[]) => mockUnpackAccount(...args),
+    getAssociatedTokenAddressSync: (...args: unknown[]) =>
+      mockGetAssociatedTokenAddressSync(...args),
   };
 });
 
-vi.mock("@solana/spl-token", () => ({
-  getMint: (...args: unknown[]) => mockGetMint(...args),
-  getAssociatedTokenAddress: (...args: unknown[]) =>
-    mockGetAssociatedTokenAddress(...args),
-  getAccount: (...args: unknown[]) => mockGetAccount(...args),
-  TokenAccountNotFoundError: MockTokenAccountNotFoundError,
-}));
-
-const { mockGetAddressUrl } = vi.hoisted(() => ({
+const {
+  mockConnectionGetAccountInfo,
+  mockGetAddressUrl,
+  mockGetSolanaProvider,
+} = vi.hoisted(() => ({
+  mockConnectionGetAccountInfo: vi.fn(),
   mockGetAddressUrl: vi.fn(),
+  mockGetSolanaProvider: vi.fn(),
 }));
 
-// Fake Solana adapter: the real one would resolve an on-chain RPC connection.
+// check-token-balance.ts's (unexercised here) EVM branch still imports the
+// real registry, which pulls in EvmChainAdapter -> nonce-manager -> schema's
+// drizzle sql() helper. Stub it so that module-load chain never runs.
 vi.mock("@/lib/web3/chain-adapter", () => ({
-  getChainAdapter: () => ({
-    executeWithSolanaFailover: (fn: (connection: unknown) => unknown) => fn({}),
-    getAddressUrl: (...args: unknown[]) => mockGetAddressUrl(...args),
-  }),
+  getChainAdapter: vi.fn(),
+}));
+
+// Fake adapter: constructed directly (not via the shared registry) so the
+// step can thread userId into getSolanaProvider - see checkSolanaTokenBalance
+// in check-token-balance.ts. The real adapter would resolve an on-chain RPC
+// connection; here executeWithSolanaFailover both exercises the
+// userId-carrying provider factory (for assertions below) and hands back a
+// fake connection.
+vi.mock("@/lib/web3/chain-adapter/solana", () => ({
+  SolanaChainAdapter: class MockSolanaChainAdapter {
+    private readonly providerFactory: () => unknown;
+    constructor(_chainId: number, providerFactory: () => unknown) {
+      this.providerFactory = providerFactory;
+    }
+    async executeWithSolanaFailover(fn: (connection: unknown) => unknown) {
+      await this.providerFactory();
+      return fn({
+        getAccountInfo: (...args: unknown[]) =>
+          mockConnectionGetAccountInfo(...args),
+      });
+    }
+    getAddressUrl(...args: unknown[]) {
+      return mockGetAddressUrl(...args);
+    }
+  },
 }));
 
 vi.mock("@/lib/rpc/network-utils", () => ({
@@ -57,6 +100,7 @@ vi.mock("@/lib/rpc/network-utils", () => ({
 
 vi.mock("@/lib/rpc/provider-factory", () => ({
   getRpcProvider: vi.fn(),
+  getSolanaProvider: (...args: unknown[]) => mockGetSolanaProvider(...args),
   isSolanaChain: (chainId: number) => chainId === 101 || chainId === 103,
 }));
 
@@ -101,8 +145,13 @@ vi.mock("@/lib/utils", () => ({
 import { checkTokenBalanceStep } from "@/plugins/web3/steps/check-token-balance";
 
 const WALLET = "4zYdhhTJJKbYJ3Yqa2WGpBi25V1JcZVVBQWYKAY9tegL";
+const OFF_CURVE_WALLET = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
 const MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
-const ATA = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+const ATA = "4gZfWA6UftMD8W3XqPB8p7cN8G2p9J4ELuTFCe4gTaeM";
+
+function fakeAccountInfo(owner: PublicKey) {
+  return { owner, data: Buffer.alloc(0), lamports: 0, executable: false };
+}
 
 const context = () => ({
   executionId: "exec_1",
@@ -124,15 +173,21 @@ const input = () => ({
 describe("checkTokenBalanceStep - Solana", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetAssociatedTokenAddress.mockResolvedValue(ATA);
+    mockGetSolanaProvider.mockResolvedValue({
+      executeWithFailover: vi.fn(),
+    });
+    mockGetAssociatedTokenAddressSync.mockReturnValue(new PublicKey(ATA));
     mockGetAddressUrl.mockResolvedValue(
       "https://solscan.io/account/x?cluster=devnet"
     );
   });
 
-  it("fetches an SPL token balance for a funded associated token account", async () => {
-    mockGetMint.mockResolvedValue({ decimals: 6 });
-    mockGetAccount.mockResolvedValue({ amount: BigInt(5_000_000) });
+  it("fetches a legacy SPL token balance for a funded associated token account", async () => {
+    mockConnectionGetAccountInfo
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_PROGRAM_ID)) // mint account
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_PROGRAM_ID)); // ATA account
+    mockUnpackMint.mockReturnValue({ decimals: 6 });
+    mockUnpackAccount.mockReturnValue({ amount: BigInt(5_000_000) });
 
     const result = await checkTokenBalanceStep(input());
 
@@ -143,13 +198,43 @@ describe("checkTokenBalanceStep - Solana", () => {
       expect(result.balance.decimals).toBe(6);
       expect(result.balance.symbol).toBe("TEST");
       expect(result.balance.tokenAddress).toBe(MINT);
-      expect(result.address).toBe(WALLET);
     }
+    // getAssociatedTokenAddressSync's allowOwnerOffCurve argument (3rd) must
+    // be true - checking a PDA-owned wallet's balance is legitimate.
+    expect(mockGetAssociatedTokenAddressSync).toHaveBeenCalledWith(
+      expect.any(PublicKey),
+      expect.any(PublicKey),
+      true,
+      TOKEN_PROGRAM_ID,
+      ASSOCIATED_TOKEN_PROGRAM_ID
+    );
+  });
+
+  it("fetches a Token-2022 mint's balance instead of failing with an owner-mismatch error", async () => {
+    mockConnectionGetAccountInfo
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_2022_PROGRAM_ID))
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_2022_PROGRAM_ID));
+    mockUnpackMint.mockReturnValue({ decimals: 9 });
+    mockUnpackAccount.mockReturnValue({ amount: BigInt(1_000_000_000) });
+
+    const result = await checkTokenBalanceStep(input());
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.balance.balance).toBe("1");
+    }
+    expect(mockUnpackMint).toHaveBeenCalledWith(
+      expect.any(PublicKey),
+      expect.anything(),
+      TOKEN_2022_PROGRAM_ID
+    );
   });
 
   it("returns a zero balance when the wallet has no associated token account", async () => {
-    mockGetMint.mockResolvedValue({ decimals: 9 });
-    mockGetAccount.mockRejectedValue(new MockTokenAccountNotFoundError());
+    mockConnectionGetAccountInfo
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_PROGRAM_ID)) // mint account
+      .mockResolvedValueOnce(null); // no ATA yet
+    mockUnpackMint.mockReturnValue({ decimals: 9 });
 
     const result = await checkTokenBalanceStep(input());
 
@@ -158,15 +243,60 @@ describe("checkTokenBalanceStep - Solana", () => {
       expect(result.balance.balance).toBe("0");
       expect(result.balance.balanceRaw).toBe("0");
     }
+    expect(mockUnpackAccount).not.toHaveBeenCalled();
+  });
+
+  it("fetches the balance of an off-curve (PDA-owned) wallet address", async () => {
+    mockConnectionGetAccountInfo
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_PROGRAM_ID))
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_PROGRAM_ID));
+    mockUnpackMint.mockReturnValue({ decimals: 6 });
+    mockUnpackAccount.mockReturnValue({ amount: BigInt(2_000_000) });
+
+    const result = await checkTokenBalanceStep({
+      ...input(),
+      address: OFF_CURVE_WALLET,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("threads the caller's userId into the Solana RPC provider", async () => {
+    mockConnectionGetAccountInfo
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_PROGRAM_ID))
+      .mockResolvedValueOnce(null);
+    mockUnpackMint.mockReturnValue({ decimals: 6 });
+
+    await checkTokenBalanceStep(input());
+
+    expect(mockGetSolanaProvider).toHaveBeenCalledWith({
+      chainId: 103,
+      userId: "user_1",
+    });
   });
 
   it("propagates a real RPC error instead of treating it as a zero balance", async () => {
-    mockGetMint.mockResolvedValue({ decimals: 9 });
-    mockGetAccount.mockRejectedValue(new Error("RPC timeout"));
+    mockConnectionGetAccountInfo.mockRejectedValue(new Error("RPC timeout"));
 
     const result = await checkTokenBalanceStep(input());
 
     expect(result.success).toBe(false);
+  });
+
+  it("rejects a mint that is not owned by an SPL token program", async () => {
+    const NOT_A_TOKEN_PROGRAM = new PublicKey(
+      "11111111111111111111111111111111"
+    );
+    mockConnectionGetAccountInfo.mockResolvedValueOnce(
+      fakeAccountInfo(NOT_A_TOKEN_PROGRAM)
+    );
+
+    const result = await checkTokenBalanceStep(input());
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("not an SPL token mint");
+    }
   });
 
   it("rejects an invalid Solana wallet address before touching the chain", async () => {
@@ -179,7 +309,6 @@ describe("checkTokenBalanceStep - Solana", () => {
     if (!result.success) {
       expect(result.error).toContain("Invalid wallet address");
     }
-    expect(mockGetMint).not.toHaveBeenCalled();
-    expect(mockGetAccount).not.toHaveBeenCalled();
+    expect(mockConnectionGetAccountInfo).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/check-token-balance-solana.test.ts
+++ b/tests/integration/check-token-balance-solana.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("ethers", () => ({
+  ethers: {
+    isAddress: vi.fn((a: string) => a.startsWith("0x") && a.length === 42),
+    formatUnits: vi.fn((value: bigint, decimals: number) =>
+      (Number(value) / 10 ** decimals).toString()
+    ),
+  },
+}));
+
+const {
+  mockGetMint,
+  mockGetAssociatedTokenAddress,
+  mockGetAccount,
+  MockTokenAccountNotFoundError,
+} = vi.hoisted(() => {
+  class TokenAccountNotFoundErrorStub extends Error {}
+  return {
+    mockGetMint: vi.fn(),
+    mockGetAssociatedTokenAddress: vi.fn(),
+    mockGetAccount: vi.fn(),
+    MockTokenAccountNotFoundError: TokenAccountNotFoundErrorStub,
+  };
+});
+
+vi.mock("@solana/spl-token", () => ({
+  getMint: (...args: unknown[]) => mockGetMint(...args),
+  getAssociatedTokenAddress: (...args: unknown[]) =>
+    mockGetAssociatedTokenAddress(...args),
+  getAccount: (...args: unknown[]) => mockGetAccount(...args),
+  TokenAccountNotFoundError: MockTokenAccountNotFoundError,
+}));
+
+const { mockGetAddressUrl } = vi.hoisted(() => ({
+  mockGetAddressUrl: vi.fn(),
+}));
+
+// Fake Solana adapter: the real one would resolve an on-chain RPC connection.
+vi.mock("@/lib/web3/chain-adapter", () => ({
+  getChainAdapter: () => ({
+    executeWithSolanaFailover: (fn: (connection: unknown) => unknown) => fn({}),
+    getAddressUrl: (...args: unknown[]) => mockGetAddressUrl(...args),
+  }),
+}));
+
+vi.mock("@/lib/rpc/network-utils", () => ({
+  getChainIdFromNetwork: vi.fn((network: string) => {
+    if (network === "solana-devnet") {
+      return 103;
+    }
+    throw new Error(`Unsupported network: ${network}`);
+  }),
+}));
+
+vi.mock("@/lib/rpc/provider-factory", () => ({
+  getRpcProvider: vi.fn(),
+  isSolanaChain: (chainId: number) => chainId === 101 || chainId === 103,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve([{ userId: "user_1" }]) }),
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  supportedTokens: {
+    chainId: "chainId",
+    id: "id",
+    tokenAddress: "tokenAddress",
+  },
+  workflowExecutions: { id: "id", userId: "userId" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: () => ({}),
+  and: () => ({}),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { VALIDATION: "validation", NETWORK_RPC: "network_rpc" },
+  logUserError: vi.fn(),
+}));
+
+vi.mock("@/lib/workflow/executor/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/utils", () => ({
+  getErrorMessage: (error: { message?: string }) =>
+    error?.message ?? String(error),
+}));
+
+import { checkTokenBalanceStep } from "@/plugins/web3/steps/check-token-balance";
+
+const WALLET = "4zYdhhTJJKbYJ3Yqa2WGpBi25V1JcZVVBQWYKAY9tegL";
+const MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const ATA = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+
+const context = () => ({
+  executionId: "exec_1",
+  nodeId: "node_1",
+  nodeName: "Get SPL Balance",
+  nodeType: "check-token-balance" as const,
+});
+
+const input = () => ({
+  network: "solana-devnet",
+  address: WALLET,
+  tokenConfig: {
+    mode: "custom",
+    customToken: { address: MINT, symbol: "TEST" },
+  },
+  _context: context(),
+});
+
+describe("checkTokenBalanceStep - Solana", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAssociatedTokenAddress.mockResolvedValue(ATA);
+    mockGetAddressUrl.mockResolvedValue(
+      "https://solscan.io/account/x?cluster=devnet"
+    );
+  });
+
+  it("fetches an SPL token balance for a funded associated token account", async () => {
+    mockGetMint.mockResolvedValue({ decimals: 6 });
+    mockGetAccount.mockResolvedValue({ amount: BigInt(5_000_000) });
+
+    const result = await checkTokenBalanceStep(input());
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.balance.balance).toBe("5");
+      expect(result.balance.balanceRaw).toBe("5000000");
+      expect(result.balance.decimals).toBe(6);
+      expect(result.balance.symbol).toBe("TEST");
+      expect(result.balance.tokenAddress).toBe(MINT);
+      expect(result.address).toBe(WALLET);
+    }
+  });
+
+  it("returns a zero balance when the wallet has no associated token account", async () => {
+    mockGetMint.mockResolvedValue({ decimals: 9 });
+    mockGetAccount.mockRejectedValue(new MockTokenAccountNotFoundError());
+
+    const result = await checkTokenBalanceStep(input());
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.balance.balance).toBe("0");
+      expect(result.balance.balanceRaw).toBe("0");
+    }
+  });
+
+  it("propagates a real RPC error instead of treating it as a zero balance", async () => {
+    mockGetMint.mockResolvedValue({ decimals: 9 });
+    mockGetAccount.mockRejectedValue(new Error("RPC timeout"));
+
+    const result = await checkTokenBalanceStep(input());
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an invalid Solana wallet address before touching the chain", async () => {
+    const result = await checkTokenBalanceStep({
+      ...input(),
+      address: "not a valid base58 address",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Invalid wallet address");
+    }
+    expect(mockGetMint).not.toHaveBeenCalled();
+    expect(mockGetAccount).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/get-transaction-solana.test.ts
+++ b/tests/integration/get-transaction-solana.test.ts
@@ -8,19 +8,32 @@ vi.mock("ethers", () => ({
   },
 }));
 
-const { mockConnectionGetTransaction } = vi.hoisted(() => ({
-  mockConnectionGetTransaction: vi.fn(),
-}));
+const { mockConnectionGetTransaction, mockGetSolanaProvider } = vi.hoisted(
+  () => ({
+    mockConnectionGetTransaction: vi.fn(),
+    mockGetSolanaProvider: vi.fn(),
+  })
+);
 
-// Fake Solana adapter: the real one would resolve an on-chain RPC connection.
-vi.mock("@/lib/web3/chain-adapter", () => ({
-  getChainAdapter: () => ({
-    executeWithSolanaFailover: (fn: (connection: unknown) => unknown) =>
-      fn({
+// Fake adapter: constructed directly (not via the shared registry) so the
+// step can thread userId into getSolanaProvider - see fetchSolanaTransaction
+// in get-transaction.ts. executeWithSolanaFailover both exercises the
+// userId-carrying provider factory (for assertions below) and hands back a
+// fake connection.
+vi.mock("@/lib/web3/chain-adapter/solana", () => ({
+  SolanaChainAdapter: class MockSolanaChainAdapter {
+    private readonly providerFactory: () => unknown;
+    constructor(_chainId: number, providerFactory: () => unknown) {
+      this.providerFactory = providerFactory;
+    }
+    async executeWithSolanaFailover(fn: (connection: unknown) => unknown) {
+      await this.providerFactory();
+      return fn({
         getTransaction: (...args: unknown[]) =>
           mockConnectionGetTransaction(...args),
-      }),
-  }),
+      });
+    }
+  },
 }));
 
 vi.mock("@/lib/rpc/network-utils", () => ({
@@ -34,6 +47,7 @@ vi.mock("@/lib/rpc/network-utils", () => ({
 
 vi.mock("@/lib/rpc/provider-factory", () => ({
   getRpcProvider: vi.fn(),
+  getSolanaProvider: (...args: unknown[]) => mockGetSolanaProvider(...args),
   isSolanaChain: (chainId: number) => chainId === 101 || chainId === 103,
 }));
 
@@ -122,6 +136,7 @@ const context = () => ({
 describe("getTransactionStep - Solana", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetSolanaProvider.mockResolvedValue({ executeWithFailover: vi.fn() });
   });
 
   it("fetches a Solana transaction and maps fee payer, slot, and compute units", async () => {
@@ -139,8 +154,25 @@ describe("getTransactionStep - Solana", () => {
       expect(result.from).toBe(FEE_PAYER);
       expect(result.to).toBeNull();
       expect(result.blockNumber).toBe(12_345);
-      expect(result.gasLimit).toBe("5000");
+      // gasLimit has no Solana equivalent; actual usage is a separate field.
+      expect(result.gasLimit).toBe("0");
+      expect(result.computeUnitsConsumed).toBe("5000");
     }
+  });
+
+  it("threads the caller's userId into the Solana RPC provider", async () => {
+    mockConnectionGetTransaction.mockResolvedValue(fakeSolanaTx());
+
+    await getTransactionStep({
+      network: "solana-devnet",
+      transactionHash: VALID_SIGNATURE,
+      _context: context(),
+    });
+
+    expect(mockGetSolanaProvider).toHaveBeenCalledWith({
+      chainId: 103,
+      userId: "user_1",
+    });
   });
 
   it("returns not-found when the signature doesn't resolve to a transaction", async () => {

--- a/tests/integration/get-transaction-solana.test.ts
+++ b/tests/integration/get-transaction-solana.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("ethers", () => ({
+  ethers: {
+    formatEther: vi.fn((value: bigint) => value.toString()),
+  },
+}));
+
+const { mockConnectionGetTransaction } = vi.hoisted(() => ({
+  mockConnectionGetTransaction: vi.fn(),
+}));
+
+// Fake Solana adapter: the real one would resolve an on-chain RPC connection.
+vi.mock("@/lib/web3/chain-adapter", () => ({
+  getChainAdapter: () => ({
+    executeWithSolanaFailover: (fn: (connection: unknown) => unknown) =>
+      fn({
+        getTransaction: (...args: unknown[]) =>
+          mockConnectionGetTransaction(...args),
+      }),
+  }),
+}));
+
+vi.mock("@/lib/rpc/network-utils", () => ({
+  getChainIdFromNetwork: vi.fn((network: string) => {
+    if (network === "solana-devnet") {
+      return 103;
+    }
+    throw new Error(`Unsupported network: ${network}`);
+  }),
+}));
+
+vi.mock("@/lib/rpc/provider-factory", () => ({
+  getRpcProvider: vi.fn(),
+  isSolanaChain: (chainId: number) => chainId === 101 || chainId === 103,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve([{ userId: "user_1" }]) }),
+      }),
+    }),
+    query: {
+      explorerConfigs: {
+        findFirst: () =>
+          Promise.resolve({
+            id: "cfg_1",
+            chainId: 103,
+            explorerUrl: "https://solscan.io",
+          }),
+      },
+    },
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  explorerConfigs: { id: "id", chainId: "chainId" },
+  workflowExecutions: { id: "id", userId: "userId" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: () => ({}),
+}));
+
+vi.mock("@/lib/explorer", () => ({
+  getTransactionUrl: (_config: unknown, hash: string) =>
+    `https://solscan.io/tx/${hash}`,
+  getAddressUrl: (_config: unknown, address: string) =>
+    `https://solscan.io/account/${address}`,
+}));
+
+vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
+  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/workflow/executor/step-handler", () => ({
+  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/lib/utils", () => ({
+  getErrorMessage: (error: { message?: string }) =>
+    error?.message ?? String(error),
+}));
+
+import { getTransactionStep } from "@/plugins/web3/steps/get-transaction";
+
+const VALID_SIGNATURE =
+  "4XR92Zct9ZodXzisJ4kov3upmTvMotYVrg65MHP8aoCjSPJwUa7vjaXK5VhDF7ZiiF16v7cY5BPazCLnVqZ3yzb";
+const FEE_PAYER = "4zYdhhTJJKbYJ3Yqa2WGpBi25V1JcZVVBQWYKAY9tegL";
+
+function fakeSolanaTx(
+  overrides: { computeUnits?: number; slot?: number } = {}
+) {
+  return {
+    slot: overrides.slot ?? 12_345,
+    meta: {
+      computeUnitsConsumed: overrides.computeUnits ?? 5000,
+      loadedAddresses: undefined,
+    },
+    transaction: {
+      message: {
+        getAccountKeys: () => ({
+          get: (i: number) =>
+            i === 0 ? { toBase58: () => FEE_PAYER } : undefined,
+        }),
+      },
+    },
+  };
+}
+
+const context = () => ({
+  executionId: "exec_1",
+  nodeId: "node_1",
+  nodeName: "Get Transaction",
+  nodeType: "get-transaction" as const,
+});
+
+describe("getTransactionStep - Solana", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches a Solana transaction and maps fee payer, slot, and compute units", async () => {
+    mockConnectionGetTransaction.mockResolvedValue(fakeSolanaTx());
+
+    const result = await getTransactionStep({
+      network: "solana-devnet",
+      transactionHash: VALID_SIGNATURE,
+      _context: context(),
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.hash).toBe(VALID_SIGNATURE);
+      expect(result.from).toBe(FEE_PAYER);
+      expect(result.to).toBeNull();
+      expect(result.blockNumber).toBe(12_345);
+      expect(result.gasLimit).toBe("5000");
+    }
+  });
+
+  it("returns not-found when the signature doesn't resolve to a transaction", async () => {
+    mockConnectionGetTransaction.mockResolvedValue(null);
+
+    const result = await getTransactionStep({
+      network: "solana-devnet",
+      transactionHash: VALID_SIGNATURE,
+      _context: context(),
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Transaction not found");
+    }
+  });
+
+  it("rejects an invalid Solana signature before touching the chain", async () => {
+    const result = await getTransactionStep({
+      network: "solana-devnet",
+      transactionHash: "not a valid base58 signature",
+      _context: context(),
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Invalid transaction hash format");
+    }
+    expect(mockConnectionGetTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/query-transactions.test.ts
+++ b/tests/integration/query-transactions.test.ts
@@ -147,6 +147,7 @@ vi.mock("@/lib/rpc/network-utils", () => ({
 // ---------------------------------------------------------------------------
 vi.mock("@/lib/rpc/provider-factory", () => ({
   getRpcProvider: mockGetRpcProvider,
+  isSolanaChain: (chainId: number) => chainId === 101 || chainId === 103,
 }));
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/validate-workflow-21-smoke.test.ts
+++ b/tests/integration/validate-workflow-21-smoke.test.ts
@@ -16,7 +16,10 @@
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
 import {
   type ValidatorWorkflow,
   validateWorkflow,

--- a/tests/unit/query-transactions-core.test.ts
+++ b/tests/unit/query-transactions-core.test.ts
@@ -52,6 +52,7 @@ const mockExecuteWithFailover = vi.fn();
 vi.mock("@/lib/rpc/provider-factory", () => ({
   getRpcProvider: () =>
     Promise.resolve({ executeWithFailover: mockExecuteWithFailover }),
+  isSolanaChain: (chainId: number) => chainId === 101 || chainId === 103,
 }));
 
 const mockFetch = vi.fn();

--- a/tests/unit/scan-factory.test.ts
+++ b/tests/unit/scan-factory.test.ts
@@ -4,7 +4,10 @@
  * Requirements covered: PREFILL-01..07 + HF condition coercion (SC#1)
  * Wave 0 scaffold; Wave 2 (52-03) implementation turns all tests GREEN.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
 import {
   type ValidatorWorkflow,
   validateWorkflow,

--- a/tests/unit/validate-chain-address.test.ts
+++ b/tests/unit/validate-chain-address.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  validateChainAddress,
+  validateChainTxHash,
+} from "@/lib/web3/validate-chain-address";
+
+const EVM_CHAIN_ID = 1;
+const SOLANA_CHAIN_ID = 101;
+
+const VALID_EVM_ADDRESS = "0x9464020b645A9206a12b19f7c1155966BE4f4aAE";
+const VALID_SOLANA_ADDRESS = "4zYdhhTJJKbYJ3Yqa2WGpBi25V1JcZVVBQWYKAY9tegL";
+const VALID_EVM_TX_HASH =
+  "0x72edaf73d90ecd9f4fa701e5c16de7ecd6df1e05b3df7240e1a1ea70a44557e8";
+const VALID_SOLANA_SIGNATURE =
+  "4XR92Zct9ZodXzisJ4kov3upmTvMotYVrg65MHP8aoCjSPJwUa7vjaXK5VhDF7ZiiF16v7cY5BPazCLnVqZ3yzb";
+
+describe("validateChainAddress", () => {
+  it("accepts a valid EVM address on an EVM chain", () => {
+    expect(validateChainAddress(VALID_EVM_ADDRESS, EVM_CHAIN_ID)).toBe(true);
+  });
+
+  it("rejects a Solana address on an EVM chain", () => {
+    expect(validateChainAddress(VALID_SOLANA_ADDRESS, EVM_CHAIN_ID)).toBe(
+      false
+    );
+  });
+
+  it("accepts a valid Solana address on a Solana chain", () => {
+    expect(validateChainAddress(VALID_SOLANA_ADDRESS, SOLANA_CHAIN_ID)).toBe(
+      true
+    );
+  });
+
+  it("rejects an EVM address on a Solana chain", () => {
+    expect(validateChainAddress(VALID_EVM_ADDRESS, SOLANA_CHAIN_ID)).toBe(
+      false
+    );
+  });
+
+  it("rejects garbage input on either chain family", () => {
+    expect(validateChainAddress("not an address", EVM_CHAIN_ID)).toBe(false);
+    expect(validateChainAddress("not an address", SOLANA_CHAIN_ID)).toBe(false);
+  });
+});
+
+describe("validateChainTxHash", () => {
+  it("accepts a valid EVM tx hash on an EVM chain", () => {
+    expect(validateChainTxHash(VALID_EVM_TX_HASH, EVM_CHAIN_ID)).toBe(true);
+  });
+
+  it("rejects a Solana signature on an EVM chain", () => {
+    expect(validateChainTxHash(VALID_SOLANA_SIGNATURE, EVM_CHAIN_ID)).toBe(
+      false
+    );
+  });
+
+  it("accepts a valid Solana signature on a Solana chain", () => {
+    expect(validateChainTxHash(VALID_SOLANA_SIGNATURE, SOLANA_CHAIN_ID)).toBe(
+      true
+    );
+  });
+
+  it("rejects an EVM tx hash on a Solana chain", () => {
+    expect(validateChainTxHash(VALID_EVM_TX_HASH, SOLANA_CHAIN_ID)).toBe(false);
+  });
+
+  it("rejects garbage input on either chain family", () => {
+    expect(validateChainTxHash("not a hash", EVM_CHAIN_ID)).toBe(false);
+    expect(validateChainTxHash("not a hash", SOLANA_CHAIN_ID)).toBe(false);
+  });
+});

--- a/tests/unit/validate-chain-address.test.ts
+++ b/tests/unit/validate-chain-address.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 import {
+  evmOnlyGuard,
   validateChainAddress,
   validateChainTxHash,
 } from "@/lib/web3/validate-chain-address";
@@ -70,5 +71,18 @@ describe("validateChainTxHash", () => {
   it("rejects garbage input on either chain family", () => {
     expect(validateChainTxHash("not a hash", EVM_CHAIN_ID)).toBe(false);
     expect(validateChainTxHash("not a hash", SOLANA_CHAIN_ID)).toBe(false);
+  });
+});
+
+describe("evmOnlyGuard", () => {
+  it("returns null for an EVM chain", () => {
+    expect(evmOnlyGuard(EVM_CHAIN_ID)).toBeNull();
+  });
+
+  it("returns a failure result for a Solana chain", () => {
+    const result = evmOnlyGuard(SOLANA_CHAIN_ID);
+    expect(result).not.toBeNull();
+    expect(result?.success).toBe(false);
+    expect(result?.error).toContain("Solana is not supported");
   });
 });

--- a/tests/unit/validate-workflow-allowance.test.ts
+++ b/tests/unit/validate-workflow-allowance.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
 
 import { validateWorkflow } from "@/lib/mcp/validate-workflow";
 import {

--- a/tests/unit/validate-workflow-structural.test.ts
+++ b/tests/unit/validate-workflow-structural.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
 import {
   type ValidatorWorkflow,
   validateWorkflow,

--- a/tests/unit/validate-workflow-web3.test.ts
+++ b/tests/unit/validate-workflow-web3.test.ts
@@ -2,7 +2,9 @@
 // (token / contract address format). All tests must FAIL before
 // validate-workflow-web3.ts is created.
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
 
 import {
   type ValidatorWorkflow,
@@ -338,6 +340,56 @@ describe("validateWorkflow — invalid-token-address (VALID-06)", () => {
     const result = validateWorkflow(wf);
     const err = result.errors.find((e) => e.code === "invalid-token-address");
     expect(err).toBeUndefined();
+  });
+
+  it("passes for a valid Solana base58 contractAddress on a Solana network", () => {
+    const wf = makeWorkflow({
+      nodes: [
+        triggerNode(),
+        actionNode("a1", {
+          network: "101",
+          contractAddress: "4zYdhhTJJKbYJ3Yqa2WGpBi25V1JcZVVBQWYKAY9tegL",
+        }),
+      ],
+      edges: [edge("e1", "trigger-1", "a1")],
+    });
+    const result = validateWorkflow(wf);
+    const err = result.errors.find((e) => e.code === "invalid-token-address");
+    expect(err).toBeUndefined();
+  });
+
+  it("errors for an EVM contractAddress on a Solana network, naming the Solana format", () => {
+    const wf = makeWorkflow({
+      nodes: [
+        triggerNode(),
+        actionNode("a1", {
+          network: "101",
+          contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+        }),
+      ],
+      edges: [edge("e1", "trigger-1", "a1")],
+    });
+    const result = validateWorkflow(wf);
+    const err = result.errors.find((e) => e.code === "invalid-token-address");
+    expect(err).toBeDefined();
+    expect(err?.message).toContain("not a valid Solana address");
+  });
+
+  it("errors for a Solana contractAddress on an EVM network, naming the EVM format", () => {
+    const wf = makeWorkflow({
+      nodes: [
+        triggerNode(),
+        actionNode("a1", {
+          network: "1",
+          contractAddress: "4zYdhhTJJKbYJ3Yqa2WGpBi25V1JcZVVBQWYKAY9tegL",
+        }),
+      ],
+      edges: [edge("e1", "trigger-1", "a1")],
+    });
+    const result = validateWorkflow(wf);
+    const err = result.errors.find((e) => e.code === "invalid-token-address");
+    expect(err).toBeDefined();
+    expect(err?.message).toContain("not a valid EVM address");
   });
 
   it("errors for an invalid address embedded in tokenConfig JSON (custom mode)", () => {


### PR DESCRIPTION
## Summary
- check-token-balance, get-transaction, query-events, and query-transactions validated addresses/hashes with EVM-only checks before the chain was resolved, so any Solana input was rejected outright regardless of whether the action could otherwise handle it
- Adds a shared chain-aware validator (lib/web3/validate-chain-address.ts) and reorders each action to resolve chainId before validating, mirroring check-balance's existing pattern
- check-token-balance and get-transaction get full Solana support: SPL token balance lookup via the associated token account, and transaction lookup by signature, both routed through SolanaChainAdapter's failover-wrapped connection
- query-events and query-transactions are ABI/EVM-log-shaped with no Solana equivalent, so they get the validator fix plus an explicit "not supported yet" result instead of a misleading "Invalid contract address" error
- Removes the workflow-builder chainTypeFilter: "evm" restriction on the network field for the two now-Solana-capable actions, so Solana can actually be selected in the UI (query-events/query-transactions keep the filter, since they remain EVM-only)

## Test plan
- [x] `pnpm check` clean
- [x] `pnpm type-check` clean
- [x] New unit tests for the shared validator (tests/unit/validate-chain-address.test.ts)
- [x] New integration tests for check-token-balance Solana path: funded SPL balance, zero balance for unfunded associated token account, real RPC error propagation, invalid address rejection
- [x] New integration tests for get-transaction Solana path: fetch by signature, not-found, invalid signature rejection
- [x] Full unit suite (`pnpm test:unit`): 540 files / 21055 tests passing
- [x] Full integration suite (`pnpm test:integration`): 94 files / 947 tests passing, no regressions