### PR TITLE
fix: soft-delete execution logs and stamp the owning org on runs

### DIFF
--- a/app/api/internal/executions/route.ts
+++ b/app/api/internal/executions/route.ts
@@ -62,6 +62,7 @@ function resolveTriggerSource(value: unknown): TriggerSource {
 async function recordRefusedDispatch(params: {
   request: Request;
   workflowId: string;
+  organizationId: string;
   userId: string;
   source: TriggerSource;
   refusal: DispatchRefusal;
@@ -75,6 +76,7 @@ async function recordRefusedDispatch(params: {
       .insert(workflowExecutions)
       .values({
         workflowId: params.workflowId,
+        organizationId: params.organizationId,
         userId: params.userId,
         // Refused before it started, so it is neither a failure nor billable.
         // Matches what the executor writes when it refuses the same run.
@@ -180,6 +182,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       await recordRefusedDispatch({
         request,
         workflowId,
+        organizationId: workflow.organizationId,
         userId: ownerId,
         source,
         refusal,
@@ -213,6 +216,7 @@ export async function POST(request: Request): Promise<NextResponse> {
         .insert(workflowExecutions)
         .values({
           workflowId,
+          organizationId: workflow.organizationId,
           userId: ownerId,
           status: isPhantom ? "phantom" : "running",
           // KEEP-693: a phantom has not run yet, so it must not count toward the

--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -161,6 +161,7 @@ async function prepareExecution(
         .insert(workflowExecutions)
         .values({
           workflowId: workflow.id,
+          organizationId: workflow.organizationId,
           userId: workflow.userId,
           status: "running",
           input: body,

--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -266,6 +266,7 @@ export async function POST(
             db.insert(workflowExecutions).values({
               id: executionId,
               workflowId,
+              organizationId: workflow.organizationId,
               userId,
               status: "pending",
               input,
@@ -285,6 +286,7 @@ export async function POST(
             .insert(workflowExecutions)
             .values({
               workflowId,
+              organizationId: workflow.organizationId,
               userId,
               status: "pending",
               input,

--- a/app/api/workflows/[workflowId]/executions/route.ts
+++ b/app/api/workflows/[workflowId]/executions/route.ts
@@ -7,6 +7,10 @@ import { requireScope } from "@/lib/middleware/require-scope";
 import { db } from "@/lib/db";
 import { workflowExecutions, workflowHistory, workflows } from "@/lib/db/schema";
 import { getWorkflowAccess } from "@/lib/workflow/access";
+import {
+  executionLogNotDeleted,
+  executionLogSoftDeleteValues,
+} from "@/lib/workflow/soft-delete";
 
 function parseIntOrNull(value: string | null): number | null {
   if (value === null) {
@@ -207,11 +211,11 @@ export async function DELETE(
       // org-level total does not share and nothing can reconcile.
       await db
         .update(workflowExecutionLogs)
-        .set({ deletedAt: purgedAt })
+        .set(executionLogSoftDeleteValues(purgedAt))
         .where(
           and(
             inArray(workflowExecutionLogs.executionId, executionIds),
-            isNull(workflowExecutionLogs.deletedAt)
+            executionLogNotDeleted()
           )
         );
 

--- a/app/api/workflows/[workflowId]/executions/route.ts
+++ b/app/api/workflows/[workflowId]/executions/route.ts
@@ -200,19 +200,27 @@ export async function DELETE(
 
     if (executionIds.length > 0) {
       const { workflowExecutionLogs } = await import("@/lib/db/schema");
+      const purgedAt = new Date();
 
-      // Per-step logs are the bulky payloads and are not billing-relevant, so
-      // hard-delete them to reclaim storage.
+      // Soft-delete the per-step logs. They carry the per-network gas the
+      // analytics breakdown aggregates, so erasing them leaves a gap the
+      // org-level total does not share and nothing can reconcile.
       await db
-        .delete(workflowExecutionLogs)
-        .where(inArray(workflowExecutionLogs.executionId, executionIds));
+        .update(workflowExecutionLogs)
+        .set({ deletedAt: purgedAt })
+        .where(
+          and(
+            inArray(workflowExecutionLogs.executionId, executionIds),
+            isNull(workflowExecutionLogs.deletedAt)
+          )
+        );
 
       // Soft-delete the runs themselves: usage counters count every row, so the
       // billing total cannot be reset by purging history. Listings filter
       // deleted_at IS NULL.
       await db
         .update(workflowExecutions)
-        .set({ deletedAt: new Date() })
+        .set({ deletedAt: purgedAt })
         .where(inArray(workflowExecutions.id, executionIds));
     }
 

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -977,8 +977,13 @@ export async function DELETE(
       const { workflowExecutionLogs } = await import("@/lib/db/schema");
 
       await db.transaction(async (tx) => {
+        // Only the runs not already purged, so a second pass cannot restamp
+        // a run to a later instant than the logs it was purged with.
         const executions = await tx.query.workflowExecutions.findMany({
-          where: eq(workflowExecutions.workflowId, workflowId),
+          where: and(
+            eq(workflowExecutions.workflowId, workflowId),
+            isNull(workflowExecutions.deletedAt)
+          ),
           columns: { id: true },
         });
 
@@ -997,10 +1002,13 @@ export async function DELETE(
               )
             );
 
+          // Same set the logs update used. Re-reading by workflow_id here would
+          // catch a run that committed after the snapshot and mark it deleted
+          // while its logs stay visible, with nothing left to stamp them.
           await tx
             .update(workflowExecutions)
             .set({ deletedAt: purgedAt })
-            .where(eq(workflowExecutions.workflowId, workflowId));
+            .where(inArray(workflowExecutions.id, executionIds));
         }
 
         await tx

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -33,7 +33,11 @@ import { getWorkflowAccess } from "@/lib/workflow/access";
 import { hashWorkflowDefinition } from "@/lib/workflow/content-hash";
 import { recordWorkflowSnapshot } from "@/lib/workflow/history";
 import { sanitizeWorkflowData } from "@/lib/workflow/editor/sanitize-nodes";
-import { softDeleteValues } from "@/lib/workflow/soft-delete";
+import {
+  executionLogNotDeleted,
+  executionLogSoftDeleteValues,
+  softDeleteValues,
+} from "@/lib/workflow/soft-delete";
 import { isReservedSlug } from "@/lib/workflow/reserved-slugs";
 import {
   formatActionConfigValidationResponse,
@@ -985,11 +989,11 @@ export async function DELETE(
 
           await tx
             .update(workflowExecutionLogs)
-            .set({ deletedAt: purgedAt })
+            .set(executionLogSoftDeleteValues(purgedAt))
             .where(
               and(
                 inArray(workflowExecutionLogs.executionId, executionIds),
-                isNull(workflowExecutionLogs.deletedAt)
+                executionLogNotDeleted()
               )
             );
 

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError, logSystemWarn } from "@/lib/logging";
@@ -962,17 +962,15 @@ export async function DELETE(
 
     // KEEP-440: soft-delete the workflow row instead of hard-deleting it. The
     // surviving row keeps its listedSlug bound in idx_workflows_listed_slug, so
-    // the slug can never be re-claimed by another workflow. On force, the bulky
-    // per-step logs are hard-deleted to reclaim storage but the execution runs
-    // are soft-deleted (deleted_at) so usage counters, which count every row,
-    // stay accurate; schedules are removed explicitly -- the ON DELETE CASCADE
-    // that used to clean them up no longer fires now that the row is not
-    // actually deleted.
+    // the slug can never be re-claimed by another workflow. On force, the runs
+    // and their per-step logs are soft-deleted (deleted_at) so usage counters
+    // and the analytics gas history, which both count every row, stay whole;
+    // schedules are removed explicitly -- the ON DELETE CASCADE that used to
+    // clean them up no longer fires now that the row is not actually deleted.
     const softDelete = softDeleteValues();
 
     if (hasExecutions && force) {
       const { workflowExecutionLogs } = await import("@/lib/db/schema");
-      const { inArray } = await import("drizzle-orm");
 
       await db.transaction(async (tx) => {
         const executions = await tx.query.workflowExecutions.findMany({
@@ -983,13 +981,21 @@ export async function DELETE(
         const executionIds = executions.map((e) => e.id);
 
         if (executionIds.length > 0) {
+          const purgedAt = new Date();
+
           await tx
-            .delete(workflowExecutionLogs)
-            .where(inArray(workflowExecutionLogs.executionId, executionIds));
+            .update(workflowExecutionLogs)
+            .set({ deletedAt: purgedAt })
+            .where(
+              and(
+                inArray(workflowExecutionLogs.executionId, executionIds),
+                isNull(workflowExecutionLogs.deletedAt)
+              )
+            );
 
           await tx
             .update(workflowExecutions)
-            .set({ deletedAt: new Date() })
+            .set({ deletedAt: purgedAt })
             .where(eq(workflowExecutions.workflowId, workflowId));
         }
 

--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -401,6 +401,7 @@ export async function POST(
           .insert(workflowExecutions)
           .values({
             workflowId,
+            organizationId: workflow.organizationId,
             userId: workflow.userId,
             status: "pending",
             input: body,

--- a/app/api/workflows/executions/[executionId]/logs/route.ts
+++ b/app/api/workflows/executions/[executionId]/logs/route.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNull } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
@@ -6,6 +6,7 @@ import { workflowExecutionLogs } from "@/lib/db/schema";
 import { redactAllUrls, redactSecretUrls } from "@/lib/rpc/scrub-rpc-urls";
 import { redactSensitiveData } from "@/lib/utils/redact";
 import { resolveAuthorizedExecution } from "@/lib/workflow/execution-access";
+import { executionLogNotDeleted } from "@/lib/workflow/soft-delete";
 
 type TruncatedMarker = {
   _truncated: true;
@@ -78,7 +79,7 @@ export async function GET(
     const logs = await db.query.workflowExecutionLogs.findMany({
       where: and(
         eq(workflowExecutionLogs.executionId, executionId),
-        isNull(workflowExecutionLogs.deletedAt)
+        executionLogNotDeleted()
       ),
       orderBy: [desc(workflowExecutionLogs.timestamp)],
     });

--- a/app/api/workflows/executions/[executionId]/logs/route.ts
+++ b/app/api/workflows/executions/[executionId]/logs/route.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
@@ -76,7 +76,10 @@ export async function GET(
     };
 
     const logs = await db.query.workflowExecutionLogs.findMany({
-      where: eq(workflowExecutionLogs.executionId, executionId),
+      where: and(
+        eq(workflowExecutionLogs.executionId, executionId),
+        isNull(workflowExecutionLogs.deletedAt)
+      ),
       orderBy: [desc(workflowExecutionLogs.timestamp)],
     });
 

--- a/app/api/workflows/executions/[executionId]/status/route.ts
+++ b/app/api/workflows/executions/[executionId]/status/route.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { workflowExecutionLogs } from "@/lib/db/schema";
@@ -18,6 +18,7 @@ import {
   redactExecutionStatusForPublicView,
   resolveExecutionViewAccess,
 } from "@/lib/workflow/execution-access";
+import { executionLogNotDeleted } from "@/lib/workflow/soft-delete";
 import { checkExecutionStatusRateLimit } from "@/lib/workflow/execution-status-rate-limit";
 
 type NodeStatus = {
@@ -133,7 +134,11 @@ export async function GET(
     const { execution } = viewAccess;
 
     const logs = await db.query.workflowExecutionLogs.findMany({
-      where: eq(workflowExecutionLogs.executionId, executionId),
+      // Per-step detail of one run, so a purge hides it here too.
+      where: and(
+        eq(workflowExecutionLogs.executionId, executionId),
+        executionLogNotDeleted()
+      ),
     });
 
     const nodeStatuses: NodeStatus[] = logs.map((log) => ({

--- a/drizzle/0147_keep_1199_soft_delete_execution_logs.sql
+++ b/drizzle/0147_keep_1199_soft_delete_execution_logs.sql
@@ -1,3 +1,7 @@
-ALTER TABLE "workflow_execution_logs" ADD COLUMN IF NOT EXISTS "deleted_at" timestamp;--> statement-breakpoint
-ALTER TABLE "workflow_executions" ADD COLUMN IF NOT EXISTS "organization_id" text;--> statement-breakpoint
-ALTER TABLE "workflow_executions" ADD CONSTRAINT "workflow_executions_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action NOT VALID;
+ALTER TABLE "workflow_execution_logs" ADD COLUMN "deleted_at" timestamp;--> statement-breakpoint
+ALTER TABLE "workflow_executions" ADD COLUMN "organization_id" text;--> statement-breakpoint
+ALTER TABLE "workflow_executions" ADD CONSTRAINT "workflow_executions_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action NOT VALID;
+-- NOT VALID skips the validation scan, which would take a SHARE ROW EXCLUSIVE
+-- lock on workflow_executions during deploy. The constraint still enforces on
+-- every new insert; only pre-existing rows go unchecked, and those are all
+-- NULL until the backfill runs. Operator runs VALIDATE CONSTRAINT after it.

--- a/drizzle/0147_keep_1199_soft_delete_execution_logs.sql
+++ b/drizzle/0147_keep_1199_soft_delete_execution_logs.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "workflow_execution_logs" ADD COLUMN IF NOT EXISTS "deleted_at" timestamp;--> statement-breakpoint
+ALTER TABLE "workflow_executions" ADD COLUMN IF NOT EXISTS "organization_id" text;--> statement-breakpoint
+ALTER TABLE "workflow_executions" ADD CONSTRAINT "workflow_executions_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action NOT VALID;

--- a/drizzle/0147_keep_1199_soft_delete_execution_logs.sql
+++ b/drizzle/0147_keep_1199_soft_delete_execution_logs.sql
@@ -1,15 +1,29 @@
 -- @requires-db-prep
-ALTER TABLE "workflow_execution_logs" ADD COLUMN "deleted_at" timestamp;--> statement-breakpoint
-ALTER TABLE "workflow_executions" ADD COLUMN "organization_id" text;--> statement-breakpoint
-ALTER TABLE "workflow_executions" ADD CONSTRAINT "workflow_executions_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action NOT VALID;--> statement-breakpoint
+-- Every statement is idempotent because the operator applies this whole file
+-- to the target DB by hand before merge. The index needs organization_id to
+-- exist, so the column and the constraint have to be run out of band with it,
+-- and the deploy then re-runs all four statements as a no-op.
+ALTER TABLE "workflow_execution_logs" ADD COLUMN IF NOT EXISTS "deleted_at" timestamp;--> statement-breakpoint
+ALTER TABLE "workflow_executions" ADD COLUMN IF NOT EXISTS "organization_id" text;--> statement-breakpoint
 -- NOT VALID skips the validation scan, which would take a SHARE ROW EXCLUSIVE
 -- lock on workflow_executions during deploy. The constraint still enforces on
 -- every new insert; only pre-existing rows go unchecked, and those are all
 -- NULL until the backfill runs. Operator runs VALIDATE CONSTRAINT after it.
---
+-- Postgres has no ADD CONSTRAINT IF NOT EXISTS, hence the guard.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'workflow_executions_organization_id_organization_id_fk'
+      AND conrelid = 'public.workflow_executions'::regclass
+  ) THEN
+    ALTER TABLE "workflow_executions" ADD CONSTRAINT "workflow_executions_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action NOT VALID;
+  END IF;
+END $$;--> statement-breakpoint
 -- The index backs that FK. Without it the RI check on an organization delete
 -- or key change scans workflow_executions, the largest table, under lock. The
--- operator creates it CONCURRENTLY before merge, so IF NOT EXISTS makes this
--- statement a no-op on deploy and it never takes the ACCESS EXCLUSIVE lock a
--- plain CREATE INDEX would hold for the length of the build.
+-- operator creates it CONCURRENTLY, so IF NOT EXISTS makes this statement a
+-- no-op on deploy and it never takes the ACCESS EXCLUSIVE lock a plain
+-- CREATE INDEX would hold for the length of the build.
 CREATE INDEX IF NOT EXISTS "idx_workflow_executions_organization_id" ON "workflow_executions" ("organization_id");

--- a/drizzle/0147_keep_1199_soft_delete_execution_logs.sql
+++ b/drizzle/0147_keep_1199_soft_delete_execution_logs.sql
@@ -1,7 +1,15 @@
+-- @requires-db-prep
 ALTER TABLE "workflow_execution_logs" ADD COLUMN "deleted_at" timestamp;--> statement-breakpoint
 ALTER TABLE "workflow_executions" ADD COLUMN "organization_id" text;--> statement-breakpoint
-ALTER TABLE "workflow_executions" ADD CONSTRAINT "workflow_executions_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action NOT VALID;
+ALTER TABLE "workflow_executions" ADD CONSTRAINT "workflow_executions_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action NOT VALID;--> statement-breakpoint
 -- NOT VALID skips the validation scan, which would take a SHARE ROW EXCLUSIVE
 -- lock on workflow_executions during deploy. The constraint still enforces on
 -- every new insert; only pre-existing rows go unchecked, and those are all
 -- NULL until the backfill runs. Operator runs VALIDATE CONSTRAINT after it.
+--
+-- The index backs that FK. Without it the RI check on an organization delete
+-- or key change scans workflow_executions, the largest table, under lock. The
+-- operator creates it CONCURRENTLY before merge, so IF NOT EXISTS makes this
+-- statement a no-op on deploy and it never takes the ACCESS EXCLUSIVE lock a
+-- plain CREATE INDEX would hold for the length of the build.
+CREATE INDEX IF NOT EXISTS "idx_workflow_executions_organization_id" ON "workflow_executions" ("organization_id");

--- a/drizzle/meta/0147_snapshot.json
+++ b/drizzle/meta/0147_snapshot.json
@@ -1,0 +1,9056 @@
+{
+  "id": "39750404-418c-40f9-a389-8a13f5083611",
+  "prevId": "e350c1fc-b899-4e8f-ac3d-de6514a78e03",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_accounts_user_id": {
+          "name": "idx_accounts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.address_book_entry": {
+      "name": "address_book_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_address_book_org": {
+          "name": "idx_address_book_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_address_book_org_address": {
+          "name": "idx_address_book_org_address",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "address_book_entry_organization_id_organization_id_fk": {
+          "name": "address_book_entry_organization_id_organization_id_fk",
+          "tableFrom": "address_book_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "address_book_entry_created_by_users_id_fk": {
+          "name": "address_book_entry_created_by_users_id_fk",
+          "tableFrom": "address_book_entry",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_registrations": {
+      "name": "agent_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "registry_address": {
+          "name": "registry_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentic_wallet_credits": {
+      "name": "agentic_wallet_credits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sub_org_id": {
+          "name": "sub_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_usdc_cents": {
+          "name": "amount_usdc_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocation_reason": {
+          "name": "allocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'onboard_initial'"
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentic_wallet_credits_sub_org": {
+          "name": "idx_agentic_wallet_credits_sub_org",
+          "columns": [
+            {
+              "expression": "sub_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_agentic_wallet_credits_sub_org_reason": {
+          "name": "uq_agentic_wallet_credits_sub_org_reason",
+          "columns": [
+            {
+              "expression": "sub_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "allocation_reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentic_wallet_credits_sub_org_id_agentic_wallets_sub_org_id_fk": {
+          "name": "agentic_wallet_credits_sub_org_id_agentic_wallets_sub_org_id_fk",
+          "tableFrom": "agentic_wallet_credits",
+          "tableTo": "agentic_wallets",
+          "columnsFrom": [
+            "sub_org_id"
+          ],
+          "columnsTo": [
+            "sub_org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentic_wallet_daily_spend": {
+      "name": "agentic_wallet_daily_spend",
+      "schema": "",
+      "columns": {
+        "sub_org_id": {
+          "name": "sub_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_utc": {
+          "name": "day_utc",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spent_micros": {
+          "name": "spent_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        }
+      },
+      "indexes": {
+        "idx_agentic_wallet_daily_spend_day": {
+          "name": "idx_agentic_wallet_daily_spend_day",
+          "columns": [
+            {
+              "expression": "day_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentic_wallet_daily_spend_sub_org_id_agentic_wallets_sub_org_id_fk": {
+          "name": "agentic_wallet_daily_spend_sub_org_id_agentic_wallets_sub_org_id_fk",
+          "tableFrom": "agentic_wallet_daily_spend",
+          "tableTo": "agentic_wallets",
+          "columnsFrom": [
+            "sub_org_id"
+          ],
+          "columnsTo": [
+            "sub_org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agentic_wallet_daily_spend_sub_org_id_day_utc_pk": {
+          "name": "agentic_wallet_daily_spend_sub_org_id_day_utc_pk",
+          "columns": [
+            "sub_org_id",
+            "day_utc"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentic_wallet_hmac_secrets": {
+      "name": "agentic_wallet_hmac_secrets",
+      "schema": "",
+      "columns": {
+        "sub_org_id": {
+          "name": "sub_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_ciphertext": {
+          "name": "secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agentic_wallet_hmac_secrets_sub_org_id_agentic_wallets_sub_org_id_fk": {
+          "name": "agentic_wallet_hmac_secrets_sub_org_id_agentic_wallets_sub_org_id_fk",
+          "tableFrom": "agentic_wallet_hmac_secrets",
+          "tableTo": "agentic_wallets",
+          "columnsFrom": [
+            "sub_org_id"
+          ],
+          "columnsTo": [
+            "sub_org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agentic_wallet_hmac_secrets_sub_org_id_key_version_pk": {
+          "name": "agentic_wallet_hmac_secrets_sub_org_id_key_version_pk",
+          "columns": [
+            "sub_org_id",
+            "key_version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentic_wallet_rate_limits": {
+      "name": "agentic_wallet_rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_agentic_wallet_rate_limits_bucket": {
+          "name": "idx_agentic_wallet_rate_limits_bucket",
+          "columns": [
+            {
+              "expression": "bucket_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agentic_wallet_rate_limits_key_bucket_start_pk": {
+          "name": "agentic_wallet_rate_limits_key_bucket_start_pk",
+          "columns": [
+            "key",
+            "bucket_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentic_wallets": {
+      "name": "agentic_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sub_org_id": {
+          "name": "sub_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address_base": {
+          "name": "wallet_address_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address_tempo": {
+          "name": "wallet_address_tempo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hmac_secret": {
+          "name": "hmac_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_user_id": {
+          "name": "linked_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentic_wallets_linked_user": {
+          "name": "idx_agentic_wallets_linked_user",
+          "columns": [
+            {
+              "expression": "linked_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentic_wallets_wallet_base": {
+          "name": "idx_agentic_wallets_wallet_base",
+          "columns": [
+            {
+              "expression": "wallet_address_base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentic_wallets_wallet_tempo": {
+          "name": "idx_agentic_wallets_wallet_tempo",
+          "columns": [
+            {
+              "expression": "wallet_address_tempo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentic_wallets_linked_user_id_users_id_fk": {
+          "name": "agentic_wallets_linked_user_id_users_id_fk",
+          "tableFrom": "agentic_wallets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linked_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agentic_wallets_sub_org_id_unique": {
+          "name": "agentic_wallets_sub_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sub_org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.beta_access_requests": {
+      "name": "beta_access_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_events": {
+      "name": "billing_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed": {
+          "name": "processed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_events_provider_event_id_unique": {
+          "name": "billing_events_provider_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chains": {
+      "name": "chains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_payment_rail": {
+          "name": "is_payment_rail",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "chain_type": {
+          "name": "chain_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'evm'"
+        },
+        "default_primary_rpc": {
+          "name": "default_primary_rpc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_fallback_rpc": {
+          "name": "default_fallback_rpc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_primary_wss": {
+          "name": "default_primary_wss",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_fallback_wss": {
+          "name": "default_fallback_wss",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_private_mempool_rpc": {
+          "name": "use_private_mempool_rpc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "default_private_rpc_url": {
+          "name": "default_private_rpc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_testnet": {
+          "name": "is_testnet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stable'"
+        },
+        "gas_config": {
+          "name": "gas_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chains_chain_id": {
+          "name": "idx_chains_chain_id",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chains_chain_id_unique": {
+          "name": "chains_chain_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chain_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_code_user_id_users_id_fk": {
+          "name": "device_code_user_id_users_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.direct_executions": {
+      "name": "direct_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "transaction_hash": {
+          "name": "transaction_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipts": {
+          "name": "receipts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_used_wei": {
+          "name": "gas_used_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_price_wei": {
+          "name": "gas_price_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_wei": {
+          "name": "value_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_lamports": {
+          "name": "value_lamports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_direct_executions_org": {
+          "name": "idx_direct_executions_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_direct_executions_status": {
+          "name": "idx_direct_executions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "direct_executions_organization_id_organization_id_fk": {
+          "name": "direct_executions_organization_id_organization_id_fk",
+          "tableFrom": "direct_executions",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.execution_debt": {
+      "name": "execution_debt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_record_id": {
+          "name": "overage_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_invoice_id": {
+          "name": "provider_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debt_executions": {
+          "name": "debt_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "enforced_at": {
+          "name": "enforced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cleared_at": {
+          "name": "cleared_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_execution_debt_org_status": {
+          "name": "idx_execution_debt_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_execution_debt_invoice": {
+          "name": "idx_execution_debt_invoice",
+          "columns": [
+            {
+              "expression": "provider_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "execution_debt_organization_id_organization_id_fk": {
+          "name": "execution_debt_organization_id_organization_id_fk",
+          "tableFrom": "execution_debt",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "execution_debt_overage_record_id_overage_billing_records_id_fk": {
+          "name": "execution_debt_overage_record_id_overage_billing_records_id_fk",
+          "tableFrom": "execution_debt",
+          "tableTo": "overage_billing_records",
+          "columnsFrom": [
+            "overage_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "execution_debt_overage_record_id_unique": {
+          "name": "execution_debt_overage_record_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "overage_record_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.execution_quota_notifications": {
+      "name": "execution_quota_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_percent": {
+          "name": "usage_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executions_used": {
+          "name": "executions_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_limit": {
+          "name": "execution_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_count": {
+          "name": "recipient_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_execution_quota_notif_org": {
+          "name": "idx_execution_quota_notif_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "execution_quota_notif_org_fk": {
+          "name": "execution_quota_notif_org_fk",
+          "tableFrom": "execution_quota_notifications",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "execution_quota_notif_org_period_threshold": {
+          "name": "execution_quota_notif_org_period_threshold",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "period_start",
+            "threshold"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.explorer_configs": {
+      "name": "explorer_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_type": {
+          "name": "chain_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'evm'"
+        },
+        "explorer_url": {
+          "name": "explorer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explorer_api_type": {
+          "name": "explorer_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explorer_api_url": {
+          "name": "explorer_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backup_explorer_api_type": {
+          "name": "backup_explorer_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backup_explorer_api_url": {
+          "name": "backup_explorer_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backup_explorer_api_key_needed": {
+          "name": "backup_explorer_api_key_needed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backup_explorer_api_key": {
+          "name": "backup_explorer_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backup_explorer_url": {
+          "name": "backup_explorer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backup_explorer_tx_path": {
+          "name": "backup_explorer_tx_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backup_explorer_address_path": {
+          "name": "backup_explorer_address_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backup_explorer_contract_path": {
+          "name": "backup_explorer_contract_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explorer_tx_path": {
+          "name": "explorer_tx_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/tx/{hash}'"
+        },
+        "explorer_address_path": {
+          "name": "explorer_address_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/address/{address}'"
+        },
+        "explorer_contract_path": {
+          "name": "explorer_contract_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_explorer_configs_chain_id": {
+          "name": "idx_explorer_configs_chain_id",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "explorer_configs_chain_id_chains_chain_id_fk": {
+          "name": "explorer_configs_chain_id_chains_chain_id_fk",
+          "tableFrom": "explorer_configs",
+          "tableTo": "chains",
+          "columnsFrom": [
+            "chain_id"
+          ],
+          "columnsTo": [
+            "chain_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "explorer_configs_chain_id_unique": {
+          "name": "explorer_configs_chain_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chain_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_registry": {
+          "name": "agent_registry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'erc-8004'"
+        },
+        "agent_chain_id": {
+          "name": "agent_chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_wallet": {
+          "name": "payer_wallet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_decimals": {
+          "name": "value_decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_hash": {
+          "name": "feedback_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_chain_id": {
+          "name": "tx_chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "feedback_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "broadcast_at": {
+          "name": "broadcast_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_feedback_execution": {
+          "name": "idx_feedback_execution",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_payer": {
+          "name": "idx_feedback_payer",
+          "columns": [
+            {
+              "expression": "payer_wallet",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_agent": {
+          "name": "idx_feedback_agent",
+          "columns": [
+            {
+              "expression": "agent_registry",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_status": {
+          "name": "idx_feedback_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_execution_id_workflow_executions_id_fk": {
+          "name": "feedback_execution_id_workflow_executions_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "workflow_executions",
+          "columnsFrom": [
+            "execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "feedback_workflow_id_workflows_id_fk": {
+          "name": "feedback_workflow_id_workflows_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gas_credit_allocations": {
+      "name": "gas_credit_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocated_cents": {
+          "name": "allocated_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gas_credit_alloc_org": {
+          "name": "idx_gas_credit_alloc_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gas_credit_allocations_organization_id_organization_id_fk": {
+          "name": "gas_credit_allocations_organization_id_organization_id_fk",
+          "tableFrom": "gas_credit_allocations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gas_credit_alloc_org_period": {
+          "name": "gas_credit_alloc_org_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "period_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gas_credit_usage": {
+      "name": "gas_credit_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_used": {
+          "name": "gas_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gas_price_wei": {
+          "name": "gas_price_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gas_cost_wei": {
+          "name": "gas_cost_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gas_cost_micro_usd": {
+          "name": "gas_cost_micro_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eth_price_usd": {
+          "name": "eth_price_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gas_usage_org_created": {
+          "name": "idx_gas_usage_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gas_credit_usage_organization_id_organization_id_fk": {
+          "name": "gas_credit_usage_organization_id_organization_id_fk",
+          "tableFrom": "gas_credit_usage",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gas_usage_org_tx": {
+          "name": "gas_usage_org_tx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "tx_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gas_sponsorship_delegations": {
+      "name": "gas_sponsorship_delegations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegation_tx_hash": {
+          "name": "delegation_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "implementation_address": {
+          "name": "implementation_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "delegated_at": {
+          "name": "delegated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gas_delegation_org": {
+          "name": "idx_gas_delegation_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gas_sponsorship_delegations_organization_id_organization_id_fk": {
+          "name": "gas_sponsorship_delegations_organization_id_organization_id_fk",
+          "tableFrom": "gas_sponsorship_delegations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gas_delegation_org_chain": {
+          "name": "gas_delegation_org_chain",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "chain_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gas_sponsorship_monthly": {
+      "name": "gas_sponsorship_monthly",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month_start": {
+          "name": "month_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sponsored_wei": {
+          "name": "sponsored_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sponsored_micro_usd": {
+          "name": "sponsored_micro_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_count": {
+          "name": "tx_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gas_sponsorship_monthly_org_month": {
+          "name": "idx_gas_sponsorship_monthly_org_month",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gas_sponsorship_monthly_organization_id_organization_id_fk": {
+          "name": "gas_sponsorship_monthly_organization_id_organization_id_fk",
+          "tableFrom": "gas_sponsorship_monthly",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gas_sponsorship_monthly_org_month_chain": {
+          "name": "gas_sponsorship_monthly_org_month_chain",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "month_start",
+            "chain_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_grants": {
+      "name": "integration_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integration_grants_integration_user": {
+          "name": "idx_integration_grants_integration_user",
+          "columns": [
+            {
+              "expression": "integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_grants_user": {
+          "name": "idx_integration_grants_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_grants_integration_id_integrations_id_fk": {
+          "name": "integration_grants_integration_id_integrations_id_fk",
+          "tableFrom": "integration_grants",
+          "tableTo": "integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_grants_user_id_users_id_fk": {
+          "name": "integration_grants_user_id_users_id_fk",
+          "tableFrom": "integration_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_grants_granted_by_users_id_fk": {
+          "name": "integration_grants_granted_by_users_id_fk",
+          "tableFrom": "integration_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_managed": {
+          "name": "is_managed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "integration_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integrations_org_web3": {
+          "name": "idx_integrations_org_web3",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"integrations\".\"type\" = 'web3' AND \"integrations\".\"organization_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_created_by": {
+          "name": "idx_integrations_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integrations_created_by_users_id_fk": {
+          "name": "integrations_created_by_users_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "integrations_organization_id_organization_id_fk": {
+          "name": "integrations_organization_id_organization_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.internal_service_hmac_secrets": {
+      "name": "internal_service_hmac_secrets",
+      "schema": "",
+      "columns": {
+        "caller": {
+          "name": "caller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_ciphertext": {
+          "name": "secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "internal_service_hmac_secrets_caller_key_version_pk": {
+          "name": "internal_service_hmac_secrets_caller_key_version_pk",
+          "columns": [
+            "caller",
+            "key_version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_users_id_fk": {
+          "name": "invitation_inviter_id_users_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.key_export_codes": {
+      "name": "key_export_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "key_export_codes_organization_id_organization_id_fk": {
+          "name": "key_export_codes_organization_id_organization_id_fk",
+          "tableFrom": "key_export_codes",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_auth_codes": {
+      "name": "mcp_oauth_auth_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_auth_codes_code_unique": {
+          "name": "mcp_oauth_auth_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_clients_client_id_unique": {
+          "name": "mcp_oauth_clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_refresh_tokens": {
+      "name": "mcp_oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mcp_refresh_tokens_client": {
+          "name": "idx_mcp_refresh_tokens_client",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_refresh_tokens_user": {
+          "name": "idx_mcp_refresh_tokens_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_refresh_tokens_org": {
+          "name": "idx_mcp_refresh_tokens_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_refresh_tokens_token_hash_unique": {
+          "name": "mcp_oauth_refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "mcp_max_scope": {
+          "name": "mcp_max_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_member_user_id": {
+          "name": "idx_member_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_member_organization_id": {
+          "name": "idx_member_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_org_single_owner": {
+          "name": "member_org_single_owner",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"member\".\"role\" = 'owner'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_users_id_fk": {
+          "name": "member_user_id_users_id_fk",
+          "tableFrom": "member",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforce_mfa": {
+          "name": "enforce_mfa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enforced_mfa_factors": {
+          "name": "enforced_mfa_factors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_max_scope": {
+          "name": "mcp_max_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_api_keys": {
+      "name": "organization_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_org_api_keys_org_id": {
+          "name": "idx_org_api_keys_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_api_keys_created_by": {
+          "name": "idx_org_api_keys_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_api_keys_organization_id_organization_id_fk": {
+          "name": "organization_api_keys_organization_id_organization_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_api_keys_created_by_users_id_fk": {
+          "name": "organization_api_keys_created_by_users_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_api_keys_key_hash_unique": {
+          "name": "organization_api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_spend_caps": {
+      "name": "organization_spend_caps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_cap_wei": {
+          "name": "daily_cap_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_value_cap_wei": {
+          "name": "daily_value_cap_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_solana_value_cap_lamports": {
+          "name": "daily_solana_value_cap_lamports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_spend_caps_organization_id_organization_id_fk": {
+          "name": "organization_spend_caps_organization_id_organization_id_fk",
+          "tableFrom": "organization_spend_caps",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_spend_caps_organization_id_unique": {
+          "name": "organization_spend_caps_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_subscriptions": {
+      "name": "organization_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_customer_id": {
+          "name": "provider_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_subscription_id": {
+          "name": "provider_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_price_id": {
+          "name": "provider_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "billing_alert": {
+          "name": "billing_alert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_alert_url": {
+          "name": "billing_alert_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_started_at": {
+          "name": "trial_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_overrides": {
+          "name": "plan_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_subscriptions_org": {
+          "name": "idx_org_subscriptions_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_subscriptions_provider_sub": {
+          "name": "idx_org_subscriptions_provider_sub",
+          "columns": [
+            {
+              "expression": "provider_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_subscriptions_organization_id_organization_id_fk": {
+          "name": "organization_subscriptions_organization_id_organization_id_fk",
+          "tableFrom": "organization_subscriptions",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_subscriptions_organization_id_unique": {
+          "name": "organization_subscriptions_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        },
+        "organization_subscriptions_provider_customer_id_unique": {
+          "name": "organization_subscriptions_provider_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_tokens": {
+      "name": "organization_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "safe_wallet_id": {
+          "name": "safe_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decimals": {
+          "name": "decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_tokens_org_chain": {
+          "name": "idx_org_tokens_org_chain",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_tokens_safe": {
+          "name": "idx_org_tokens_safe",
+          "columns": [
+            {
+              "expression": "safe_wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tokens_organization_id_organization_id_fk": {
+          "name": "organization_tokens_organization_id_organization_id_fk",
+          "tableFrom": "organization_tokens",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_tokens_safe_wallet_id_safe_wallets_id_fk": {
+          "name": "organization_tokens_safe_wallet_id_safe_wallets_id_fk",
+          "tableFrom": "organization_tokens",
+          "tableTo": "safe_wallets",
+          "columnsFrom": [
+            "safe_wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_wallets": {
+      "name": "organization_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turnkey_sub_org_id": {
+          "name": "turnkey_sub_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turnkey_wallet_id": {
+          "name": "turnkey_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turnkey_private_key_id": {
+          "name": "turnkey_private_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "solana_address": {
+          "name": "solana_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_wallets_org_active_unique": {
+          "name": "organization_wallets_org_active_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organization_wallets\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_wallets_user_id_users_id_fk": {
+          "name": "organization_wallets_user_id_users_id_fk",
+          "tableFrom": "organization_wallets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_wallets_organization_id_organization_id_fk": {
+          "name": "organization_wallets_organization_id_organization_id_fk",
+          "tableFrom": "organization_wallets",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.overage_billing_records": {
+      "name": "overage_billing_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_limit": {
+          "name": "execution_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_executions": {
+          "name": "total_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_count": {
+          "name": "overage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_rate_cents": {
+          "name": "overage_rate_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_charge_cents": {
+          "name": "total_charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_invoice_item_id": {
+          "name": "provider_invoice_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_invoice_id": {
+          "name": "provider_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_overage_billing_org": {
+          "name": "idx_overage_billing_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_overage_billing_status": {
+          "name": "idx_overage_billing_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "overage_billing_records_organization_id_organization_id_fk": {
+          "name": "overage_billing_records_organization_id_organization_id_fk",
+          "tableFrom": "overage_billing_records",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "overage_billing_org_period": {
+          "name": "overage_billing_org_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "period_start",
+            "period_end"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payg_config": {
+      "name": "payg_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "daily_cap_raw": {
+          "name": "daily_cap_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "period_cap_raw": {
+          "name": "period_cap_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8453
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payg_config_org": {
+          "name": "idx_payg_config_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payg_config_organization_id_organization_id_fk": {
+          "name": "payg_config_organization_id_organization_id_fk",
+          "tableFrom": "payg_config",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "payg_config_organization_id_unique": {
+          "name": "payg_config_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payg_payments": {
+      "name": "payg_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_raw": {
+          "name": "amount_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_address": {
+          "name": "payer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "treasury_address": {
+          "name": "treasury_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'settled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payg_payments_org_created": {
+          "name": "idx_payg_payments_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payg_payments_organization_id_organization_id_fk": {
+          "name": "payg_payments_organization_id_organization_id_fk",
+          "tableFrom": "payg_payments",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "payg_payments_org_execution": {
+          "name": "payg_payments_org_execution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "execution_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_transactions": {
+      "name": "pending_transactions",
+      "schema": "",
+      "columns": {
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_price": {
+          "name": "gas_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "idx_pending_tx_status": {
+          "name": "idx_pending_tx_status",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_tx_execution": {
+          "name": "idx_pending_tx_execution",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pending_transactions_wallet_address_chain_id_nonce_pk": {
+          "name": "pending_transactions_wallet_address_chain_id_nonce_pk",
+          "columns": [
+            "wallet_address",
+            "chain_id",
+            "nonce"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_org": {
+          "name": "idx_projects_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organization_id_fk": {
+          "name": "projects_organization_id_organization_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_user_id_users_id_fk": {
+          "name": "projects_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.public_tags": {
+      "name": "public_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "public_tags_name_unique": {
+          "name": "public_tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "public_tags_slug_unique": {
+          "name": "public_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.safe_role_allowances": {
+      "name": "safe_role_allowances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol_slug": {
+          "name": "protocol_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowance_key": {
+          "name": "allowance_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_symbol": {
+          "name": "token_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_decimals": {
+          "name": "token_decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_refill_wei": {
+          "name": "max_refill_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_wei": {
+          "name": "refill_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_seconds": {
+          "name": "period_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_chain_balance_wei": {
+          "name": "last_chain_balance_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_chain_timestamp": {
+          "name": "last_chain_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reconciled_at": {
+          "name": "last_reconciled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_applied_tx_hash": {
+          "name": "last_applied_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "safe_role_allowances_role_key_unique": {
+          "name": "safe_role_allowances_role_key_unique",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "allowance_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_safe_role_allowances_role": {
+          "name": "idx_safe_role_allowances_role",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "safe_role_allowances_role_id_safe_roles_id_fk": {
+          "name": "safe_role_allowances_role_id_safe_roles_id_fk",
+          "tableFrom": "safe_role_allowances",
+          "tableTo": "safe_roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.safe_role_direct_rules": {
+      "name": "safe_role_direct_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_symbol": {
+          "name": "token_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_decimals": {
+          "name": "token_decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty": {
+          "name": "counterparty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_human": {
+          "name": "amount_human",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_seconds": {
+          "name": "period_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'allowed'"
+        },
+        "last_applied_tx_hash": {
+          "name": "last_applied_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "safe_role_direct_rules_role_kind_token_cp_unique": {
+          "name": "safe_role_direct_rules_role_kind_token_cp_unique",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_safe_role_direct_rules_role": {
+          "name": "idx_safe_role_direct_rules_role",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "safe_role_direct_rules_role_id_safe_roles_id_fk": {
+          "name": "safe_role_direct_rules_role_id_safe_roles_id_fk",
+          "tableFrom": "safe_role_direct_rules",
+          "tableTo": "safe_roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.safe_role_protocols": {
+      "name": "safe_role_protocols",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol_slug": {
+          "name": "protocol_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_slug": {
+          "name": "template_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_token_symbols": {
+          "name": "allowed_token_symbols",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_addresses": {
+          "name": "target_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_selectors": {
+          "name": "allowed_selectors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'allowed'"
+        },
+        "last_applied_tx_hash": {
+          "name": "last_applied_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "safe_role_protocols_role_slug_unique": {
+          "name": "safe_role_protocols_role_slug_unique",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "protocol_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_safe_role_protocols_role": {
+          "name": "idx_safe_role_protocols_role",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "safe_role_protocols_role_id_safe_roles_id_fk": {
+          "name": "safe_role_protocols_role_id_safe_roles_id_fk",
+          "tableFrom": "safe_role_protocols",
+          "tableTo": "safe_roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.safe_roles": {
+      "name": "safe_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "safe_wallet_id": {
+          "name": "safe_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_type": {
+          "name": "role_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'automation'"
+        },
+        "role_key": {
+          "name": "role_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles_modifier_address": {
+          "name": "roles_modifier_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegate_address": {
+          "name": "delegate_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_tx_hash": {
+          "name": "installed_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reconciled_at": {
+          "name": "last_reconciled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "safe_roles_safe_type_unique": {
+          "name": "safe_roles_safe_type_unique",
+          "columns": [
+            {
+              "expression": "safe_wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_safe_roles_safe": {
+          "name": "idx_safe_roles_safe",
+          "columns": [
+            {
+              "expression": "safe_wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "safe_roles_safe_wallet_id_safe_wallets_id_fk": {
+          "name": "safe_roles_safe_wallet_id_safe_wallets_id_fk",
+          "tableFrom": "safe_roles",
+          "tableTo": "safe_wallets",
+          "columnsFrom": [
+            "safe_wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.safe_wallets": {
+      "name": "safe_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "safe_address": {
+          "name": "safe_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_wallet_id": {
+          "name": "owner_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owners": {
+          "name": "owners",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salt_nonce": {
+          "name": "salt_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "safe_version": {
+          "name": "safe_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.4.1'"
+        },
+        "singleton_address": {
+          "name": "singleton_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "factory_address": {
+          "name": "factory_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_tx_hash": {
+          "name": "deployment_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_block": {
+          "name": "deployment_block",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "deployed_at": {
+          "name": "deployed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_signing_active": {
+          "name": "is_signing_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "safe_wallets_org_chain_unique": {
+          "name": "safe_wallets_org_chain_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_safe_wallets_org": {
+          "name": "idx_safe_wallets_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "safe_wallets_organization_id_organization_id_fk": {
+          "name": "safe_wallets_organization_id_organization_id_fk",
+          "tableFrom": "safe_wallets",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "safe_wallets_owner_wallet_id_organization_wallets_id_fk": {
+          "name": "safe_wallets_owner_wallet_id_organization_wallets_id_fk",
+          "tableFrom": "safe_wallets",
+          "tableTo": "organization_wallets",
+          "columnsFrom": [
+            "owner_wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_label": {
+          "name": "actor_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_label": {
+          "name": "organization_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'succeeded'"
+        },
+        "diff": {
+          "name": "diff",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_security_audit_org_created": {
+          "name": "idx_security_audit_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_actor_created": {
+          "name": "idx_security_audit_actor_created",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_resource_created": {
+          "name": "idx_security_audit_resource_created",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_action_created": {
+          "name": "idx_security_audit_action_created",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_correlation_created": {
+          "name": "idx_security_audit_correlation_created",
+          "columns": [
+            {
+              "expression": "correlation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_audit_log_actor_user_id_users_id_fk": {
+          "name": "security_audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "security_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "security_audit_log_organization_id_organization_id_fk": {
+          "name": "security_audit_log_organization_id_organization_id_fk",
+          "tableFrom": "security_audit_log",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_mfa": {
+          "name": "requires_mfa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mfa_verified_at": {
+          "name": "mfa_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_flags_json": {
+          "name": "risk_flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supported_tokens": {
+      "name": "supported_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decimals": {
+          "name": "decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_stablecoin": {
+          "name": "is_stablecoin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_supported_tokens_chain": {
+          "name": "idx_supported_tokens_chain",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "supported_tokens_chain_address": {
+          "name": "supported_tokens_chain_address",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chain_id",
+            "token_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tags_org": {
+          "name": "idx_tags_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_organization_id_organization_id_fk": {
+          "name": "tags_organization_id_organization_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tags_user_id_users_id_fk": {
+          "name": "tags_user_id_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tempo_held_payments": {
+      "name": "tempo_held_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_address": {
+          "name": "to_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_raw": {
+          "name": "amount_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_symbol": {
+          "name": "token_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_decimals": {
+          "name": "token_decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_display": {
+          "name": "amount_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serialized_tx": {
+          "name": "serialized_tx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precomputed_hash": {
+          "name": "precomputed_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce_key": {
+          "name": "nonce_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_fee_per_gas": {
+          "name": "max_fee_per_gas",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_after": {
+          "name": "valid_after",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_before": {
+          "name": "valid_before",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "broadcast_at": {
+          "name": "broadcast_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "tempo_held_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "broadcast_tx_hash": {
+          "name": "broadcast_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_key": {
+          "name": "dispatch_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tempo_held_payments_org": {
+          "name": "idx_tempo_held_payments_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tempo_held_payments_org_created": {
+          "name": "idx_tempo_held_payments_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tempo_held_payments_status": {
+          "name": "idx_tempo_held_payments_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tempo_held_payments_due": {
+          "name": "idx_tempo_held_payments_due",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "broadcast_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tempo_held_payments_expiry": {
+          "name": "idx_tempo_held_payments_expiry",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_before",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_tempo_held_payments_hash": {
+          "name": "uq_tempo_held_payments_hash",
+          "columns": [
+            {
+              "expression": "precomputed_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_tempo_held_payments_dispatch_key": {
+          "name": "uq_tempo_held_payments_dispatch_key",
+          "columns": [
+            {
+              "expression": "dispatch_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tempo_held_payments_organization_id_organization_id_fk": {
+          "name": "tempo_held_payments_organization_id_organization_id_fk",
+          "tableFrom": "tempo_held_payments",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tempo_held_payments_created_by_user_id_users_id_fk": {
+          "name": "tempo_held_payments_created_by_user_id_users_id_fk",
+          "tableFrom": "tempo_held_payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor": {
+      "name": "two_factor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "failed_verification_count": {
+          "name": "failed_verification_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_two_factor_user_id": {
+          "name": "idx_two_factor_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_users_id_fk": {
+          "name": "two_factor_user_id_users_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "two_factor_user_id_unique": {
+          "name": "two_factor_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_rpc_preferences": {
+      "name": "user_rpc_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_rpc_url": {
+          "name": "primary_rpc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fallback_rpc_url": {
+          "name": "fallback_rpc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_wss_url": {
+          "name": "primary_wss_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fallback_wss_url": {
+          "name": "fallback_wss_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_rpc_user_chain": {
+          "name": "idx_user_rpc_user_chain",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_rpc_user_id": {
+          "name": "idx_user_rpc_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_rpc_preferences_user_id_users_id_fk": {
+          "name": "user_rpc_preferences_user_id_users_id_fk",
+          "tableFrom": "user_rpc_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_trusted_countries": {
+      "name": "user_trusted_countries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_trusted_countries_user_id": {
+          "name": "idx_user_trusted_countries_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_trusted_countries_user_country": {
+          "name": "idx_user_trusted_countries_user_country",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_trusted_countries_user_id_users_id_fk": {
+          "name": "user_trusted_countries_user_id_users_id_fk",
+          "tableFrom": "user_trusted_countries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_trusted_devices": {
+      "name": "user_trusted_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_trusted_devices_user_id": {
+          "name": "idx_user_trusted_devices_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_trusted_devices_user_device": {
+          "name": "idx_user_trusted_devices_user_device",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_trusted_devices_user_id_users_id_fk": {
+          "name": "user_trusted_devices_user_id_users_id_fk",
+          "tableFrom": "user_trusted_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_trusted_ips": {
+      "name": "user_trusted_ips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_trusted_ips_user_id": {
+          "name": "idx_user_trusted_ips_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_trusted_ips_user_ip": {
+          "name": "idx_user_trusted_ips_user_ip",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_trusted_ips_user_id_users_id_fk": {
+          "name": "user_trusted_ips_user_id_users_id_fk",
+          "tableFrom": "user_trusted_ips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "display_name_confirmed": {
+          "name": "display_name_confirmed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "step_up_policy": {
+          "name": "step_up_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_up_email": {
+          "name": "step_up_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signup_notified_at": {
+          "name": "signup_notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_address": {
+      "name": "wallet_address",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wallet_address_user_id": {
+          "name": "idx_wallet_address_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wallet_address_address_unique": {
+          "name": "idx_wallet_address_address_unique",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_address_user_id_users_id_fk": {
+          "name": "wallet_address_user_id_users_id_fk",
+          "tableFrom": "wallet_address",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_approval_requests": {
+      "name": "wallet_approval_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sub_org_id": {
+          "name": "sub_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload": {
+          "name": "operation_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "approval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "risk_level": {
+          "name": "risk_level",
+          "type": "approval_risk_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bound_recipient": {
+          "name": "bound_recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bound_amount_micro": {
+          "name": "bound_amount_micro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bound_chain": {
+          "name": "bound_chain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bound_contract": {
+          "name": "bound_contract",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now() + interval '15 minutes'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_wallet_approval_sub_org": {
+          "name": "idx_wallet_approval_sub_org",
+          "columns": [
+            {
+              "expression": "sub_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wallet_approval_status": {
+          "name": "idx_wallet_approval_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wallet_approval_created": {
+          "name": "idx_wallet_approval_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wallet_approval_resolved_by": {
+          "name": "idx_wallet_approval_resolved_by",
+          "columns": [
+            {
+              "expression": "resolved_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_approval_requests_sub_org_id_agentic_wallets_sub_org_id_fk": {
+          "name": "wallet_approval_requests_sub_org_id_agentic_wallets_sub_org_id_fk",
+          "tableFrom": "wallet_approval_requests",
+          "tableTo": "agentic_wallets",
+          "columnsFrom": [
+            "sub_org_id"
+          ],
+          "columnsTo": [
+            "sub_org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_approval_requests_resolved_by_user_id_users_id_fk": {
+          "name": "wallet_approval_requests_resolved_by_user_id_users_id_fk",
+          "tableFrom": "wallet_approval_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_locks": {
+      "name": "wallet_locks",
+      "schema": "",
+      "columns": {
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "wallet_locks_wallet_address_chain_id_pk": {
+          "name": "wallet_locks_wallet_address_chain_id_pk",
+          "columns": [
+            "wallet_address",
+            "chain_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_execution_digest_settings": {
+      "name": "workflow_execution_digest_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cadences": {
+          "name": "cadences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"weekly\"]'::jsonb"
+        },
+        "subscriber_user_ids": {
+          "name": "subscriber_user_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_sent": {
+          "name": "last_sent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_execution_digest_enabled": {
+          "name": "idx_execution_digest_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_execution_digest_settings_organization_id_organization_id_fk": {
+          "name": "workflow_execution_digest_settings_organization_id_organization_id_fk",
+          "tableFrom": "workflow_execution_digest_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_execution_logs": {
+      "name": "workflow_execution_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_name": {
+          "name": "node_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_type": {
+          "name": "node_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_raw": {
+          "name": "output_raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "iteration_index": {
+          "name": "iteration_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "for_each_node_id": {
+          "name": "for_each_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_used_wei": {
+          "name": "gas_used_wei",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_exec_logs_started_at": {
+          "name": "idx_exec_logs_started_at",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_execution_logs_execution_id_workflow_executions_id_fk": {
+          "name": "workflow_execution_logs_execution_id_workflow_executions_id_fk",
+          "tableFrom": "workflow_execution_logs",
+          "tableTo": "workflow_executions",
+          "columnsFrom": [
+            "execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_executions": {
+      "name": "workflow_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_category": {
+          "name": "error_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_steps": {
+          "name": "total_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_steps": {
+          "name": "completed_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "current_node_id": {
+          "name": "current_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_node_name": {
+          "name": "current_node_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_successful_node_id": {
+          "name": "last_successful_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_successful_node_name": {
+          "name": "last_successful_node_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_trace": {
+          "name": "execution_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_hashes": {
+          "name": "transaction_hashes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "gas_used_wei": {
+          "name": "gas_used_wei",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billable": {
+          "name": "billable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "triggered_by_user_api_key_id": {
+          "name": "triggered_by_user_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_org_api_key_id": {
+          "name": "triggered_by_org_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_ip": {
+          "name": "triggered_by_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_country": {
+          "name": "triggered_by_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_credential_type": {
+          "name": "triggered_by_credential_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_credential_label": {
+          "name": "triggered_by_credential_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_workflow_hash": {
+          "name": "executed_workflow_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_key": {
+          "name": "dispatch_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_workflow_executions_status": {
+          "name": "idx_workflow_executions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_executions_user_id": {
+          "name": "idx_workflow_executions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_executions_executed_hash": {
+          "name": "idx_workflow_executions_executed_hash",
+          "columns": [
+            {
+              "expression": "executed_workflow_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_executions_dispatch_key": {
+          "name": "idx_workflow_executions_dispatch_key",
+          "columns": [
+            {
+              "expression": "dispatch_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_executions_workflow_id_workflows_id_fk": {
+          "name": "workflow_executions_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_executions",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_executions_organization_id_organization_id_fk": {
+          "name": "workflow_executions_organization_id_organization_id_fk",
+          "tableFrom": "workflow_executions",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_executions_user_id_users_id_fk": {
+          "name": "workflow_executions_user_id_users_id_fk",
+          "tableFrom": "workflow_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_executions_triggered_by_user_api_key_id_api_keys_id_fk": {
+          "name": "workflow_executions_triggered_by_user_api_key_id_api_keys_id_fk",
+          "tableFrom": "workflow_executions",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "triggered_by_user_api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_history": {
+      "name": "workflow_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change": {
+          "name": "change",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_workflow_history_workflow_version": {
+          "name": "uq_workflow_history_workflow_version",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_history_content_hash": {
+          "name": "idx_workflow_history_content_hash",
+          "columns": [
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_history_workflow_id_workflows_id_fk": {
+          "name": "workflow_history_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_history",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_history_organization_id_organization_id_fk": {
+          "name": "workflow_history_organization_id_organization_id_fk",
+          "tableFrom": "workflow_history",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workflow_history_changed_by_user_id_users_id_fk": {
+          "name": "workflow_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "workflow_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_payments": {
+      "name": "workflow_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_hash": {
+          "name": "payment_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'execution'"
+        },
+        "deliverable": {
+          "name": "deliverable",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_usdc": {
+          "name": "amount_usdc",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_address": {
+          "name": "payer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_wallet_address": {
+          "name": "creator_wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'x402'"
+        },
+        "chain": {
+          "name": "chain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'base'"
+        }
+      },
+      "indexes": {
+        "idx_workflow_payments_hash": {
+          "name": "idx_workflow_payments_hash",
+          "columns": [
+            {
+              "expression": "payment_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_payments_workflow": {
+          "name": "idx_workflow_payments_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_public_tags": {
+      "name": "workflow_public_tags",
+      "schema": "",
+      "columns": {
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_tag_id": {
+          "name": "public_tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_workflow_public_tags_workflow": {
+          "name": "idx_workflow_public_tags_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_public_tags_tag": {
+          "name": "idx_workflow_public_tags_tag",
+          "columns": [
+            {
+              "expression": "public_tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_public_tags_workflow_id_workflows_id_fk": {
+          "name": "workflow_public_tags_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_public_tags",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_public_tags_public_tag_id_public_tags_id_fk": {
+          "name": "workflow_public_tags_public_tag_id_public_tags_id_fk",
+          "tableFrom": "workflow_public_tags",
+          "tableTo": "public_tags",
+          "columnsFrom": [
+            "public_tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_public_tags_workflow_id_public_tag_id_pk": {
+          "name": "workflow_public_tags_workflow_id_public_tag_id_pk",
+          "columns": [
+            "workflow_id",
+            "public_tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_ratings": {
+      "name": "workflow_ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_ratings_workflow": {
+          "name": "idx_workflow_ratings_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_ratings_workflow_id_workflows_id_fk": {
+          "name": "workflow_ratings_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_ratings",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_ratings_user_id_users_id_fk": {
+          "name": "workflow_ratings_user_id_users_id_fk",
+          "tableFrom": "workflow_ratings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_workflow_ratings_workflow_user": {
+          "name": "uq_workflow_ratings_workflow_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workflow_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_schedules": {
+      "name": "workflow_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anchor_at": {
+          "name": "anchor_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_schedules_enabled": {
+          "name": "idx_workflow_schedules_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_schedules_workflow": {
+          "name": "idx_workflow_schedules_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_schedules_workflow_id_workflows_id_fk": {
+          "name": "workflow_schedules_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_schedules",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_schedules_workflow_id_unique": {
+          "name": "workflow_schedules_workflow_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workflow_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "featured_order": {
+          "name": "featured_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "featured_protocol": {
+          "name": "featured_protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured_protocol_order": {
+          "name": "featured_protocol_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nodes": {
+          "name": "nodes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edges": {
+          "name": "edges",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_workflow_id": {
+          "name": "source_workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "seeded_at": {
+          "name": "seeded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "listed_slug": {
+          "name": "listed_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listed_at": {
+          "name": "listed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_execution_status": {
+          "name": "share_execution_status",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_mapping": {
+          "name": "output_mapping",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_usdc_per_call": {
+          "name": "price_usdc_per_call",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_type": {
+          "name": "workflow_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain": {
+          "name": "chain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_version": {
+          "name": "listing_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_workflows_listed_slug": {
+          "name": "idx_workflows_listed_slug",
+          "columns": [
+            {
+              "expression": "listed_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflows\".\"listed_slug\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflows_user_id": {
+          "name": "idx_workflows_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflows_tag_id": {
+          "name": "idx_workflows_tag_id",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflows_project_id": {
+          "name": "idx_workflows_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_user_id_users_id_fk": {
+          "name": "workflows_user_id_users_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflows_organization_id_organization_id_fk": {
+          "name": "workflows_organization_id_organization_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_project_id_projects_id_fk": {
+          "name": "workflows_project_id_projects_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workflows_tag_id_tags_id_fk": {
+          "name": "workflows_tag_id_tags_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.approval_risk_level": {
+      "name": "approval_risk_level",
+      "schema": "public",
+      "values": [
+        "auto",
+        "ask",
+        "block"
+      ]
+    },
+    "public.approval_status": {
+      "name": "approval_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.feedback_status": {
+      "name": "feedback_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "broadcast",
+        "confirmed",
+        "failed"
+      ]
+    },
+    "public.integration_visibility": {
+      "name": "integration_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "specific_members",
+        "organization"
+      ]
+    },
+    "public.tempo_held_payment_status": {
+      "name": "tempo_held_payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "broadcasting",
+        "broadcast",
+        "confirmed",
+        "failed",
+        "expired",
+        "canceled"
+      ]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.step_status": {
+      "name": "step_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.wait_status": {
+      "name": "wait_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "completed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0147_snapshot.json
+++ b/drizzle/meta/0147_snapshot.json
@@ -7892,6 +7892,21 @@
           "method": "btree",
           "with": {}
         },
+        "idx_workflow_executions_organization_id": {
+          "name": "idx_workflow_executions_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
         "idx_workflow_executions_executed_hash": {
           "name": "idx_workflow_executions_executed_hash",
           "columns": [

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1030,6 +1030,13 @@
       "when": 1786974522606,
       "tag": "0146_keep_1175_execution_quota_notifications",
       "breakpoints": true
+    },
+    {
+      "idx": 147,
+      "version": "7",
+      "when": 1787065022606,
+      "tag": "0147_keep_1199_soft_delete_execution_logs",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1034,7 +1034,7 @@
     {
       "idx": 147,
       "version": "7",
-      "when": 1787065022606,
+      "when": 1787253008362,
       "tag": "0147_keep_1199_soft_delete_execution_logs",
       "breakpoints": true
     }

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -481,6 +481,7 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
           db.insert(workflowExecutions).values({
             id: blockedExecutionId,
             workflowId,
+            organizationId: workflow.organizationId,
             userId: blockedUserId,
             status: "skipped",
             billable: false,
@@ -648,6 +649,7 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
       db.insert(workflowExecutions).values({
         id: executionId,
         workflowId,
+        organizationId: workflow.organizationId,
         userId,
         status: "pending",
         input: serializedInput,

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -8,6 +8,7 @@ import {
   gte,
   inArray,
   isNotNull,
+  isNull,
   lt,
   type SQL,
   sql,
@@ -980,6 +981,9 @@ async function fetchWorkflowRuns(
     sql`${workflowExecutions.workflowId} IN (${orgWorkflowIds})`,
     gte(workflowExecutions.startedAt, rangeStart),
     lt(workflowExecutions.startedAt, rangeEnd),
+    // A purged run leaves the listing. Its gas stays in the summary tiles and
+    // the network breakdown, which count every row on purpose.
+    isNull(workflowExecutions.deletedAt),
   ];
 
   if (status) {
@@ -1222,6 +1226,9 @@ async function getWorkflowRunsTotal(
     eq(workflows.organizationId, organizationId),
     gte(workflowExecutions.startedAt, rangeStart),
     lt(workflowExecutions.startedAt, rangeEnd),
+    // Must match fetchWorkflowRuns: a total that counts rows the listing drops
+    // leaves the last page short and the cursor pointing at nothing.
+    isNull(workflowExecutions.deletedAt),
   ];
   if (projectId) {
     conditions.push(eq(workflows.projectId, projectId));

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -8,6 +8,7 @@ import {
   gte,
   inArray,
   isNotNull,
+  isNull,
   lt,
   type SQL,
   sql,
@@ -1351,7 +1352,10 @@ export async function getStepLogs(
     .where(
       and(
         eq(workflowExecutionLogs.executionId, executionId),
-        eq(workflows.organizationId, organizationId)
+        eq(workflows.organizationId, organizationId),
+        // Purged steps stay in the table for the gas aggregates, but this is
+        // the run detail a user reads, so it shows what they kept.
+        isNull(workflowExecutionLogs.deletedAt)
       )
     )
     .orderBy(workflowExecutionLogs.startedAt);

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -8,7 +8,6 @@ import {
   gte,
   inArray,
   isNotNull,
-  isNull,
   lt,
   type SQL,
   sql,
@@ -32,6 +31,7 @@ import {
   sumOrgValueTodayWei,
 } from "@/lib/execute/value-ledger";
 import { redactAllUrls, redactSecretUrls } from "@/lib/rpc/scrub-rpc-urls";
+import { executionLogNotDeleted } from "@/lib/workflow/soft-delete";
 import { analyticsCacheKey, cachedAnalytics } from "./cache";
 import {
   getBucketInterval,
@@ -1355,7 +1355,7 @@ export async function getStepLogs(
         eq(workflows.organizationId, organizationId),
         // Purged steps stay in the table for the gas aggregates, but this is
         // the run detail a user reads, so it shows what they kept.
-        isNull(workflowExecutionLogs.deletedAt)
+        executionLogNotDeleted()
       )
     )
     .orderBy(workflowExecutionLogs.startedAt);

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -672,6 +672,19 @@ export const workflowExecutions = pgTable(
     workflowId: text("workflow_id")
       .notNull()
       .references(() => workflows.id),
+    /**
+     * Owning organisation, denormalised off `workflows.organization_id` at
+     * insert. Every org-scoped read used to reach the org only by joining
+     * `workflows`, so the run's billing and analytics attribution lived in a
+     * row the run does not control. This column holds the attribution on the
+     * run itself, so quota counts and gas history survive whatever happens to
+     * the workflow.
+     *
+     * Nullable on rows written before the column existed, until
+     * scripts/backfill-execution-organization-id.ts has run. Read it through
+     * getOrganizationIdFromExecution, which falls back to the join.
+     */
+    organizationId: text("organization_id").references(() => organization.id),
     // Audit lineage only (the workflow's createdBy, or the triggering user
     // where one exists). Execution AUTHORITY - quotas, billing, credentials -
     // is the owning org: resolve it via getOrganizationIdFromExecution.
@@ -865,6 +878,18 @@ export const workflowExecutionLogs = pgTable(
      */
     network: text("network"),
     gasUsedWei: numeric("gas_used_wei"),
+    /**
+     * Set when a user purges run history or force-deletes a workflow. These
+     * rows carry the per-step network and gas that the analytics gas
+     * breakdown aggregates, so erasing them tore a hole in historical spend
+     * that no query could explain. Soft-deleting keeps the history whole and
+     * hides the steps from the run detail views.
+     *
+     * Aggregate readers count every row, matching how the billing quota
+     * counters already treat soft-deleted runs. Only the views that show a
+     * user their own steps filter on it.
+     */
+    deletedAt: timestamp("deleted_at"),
   },
   (table) => [index("idx_exec_logs_started_at").on(table.startedAt)]
 );

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -826,6 +826,9 @@ export const workflowExecutions = pgTable(
   (table) => [
     index("idx_workflow_executions_status").on(table.status),
     index("idx_workflow_executions_user_id").on(table.userId),
+    // Backs the FK to organization: without it the RI check on an organization
+    // delete or key change scans this table, the largest one, under lock.
+    index("idx_workflow_executions_organization_id").on(table.organizationId),
     // Resolve "which runs executed this snapshot" / join to workflow_history.
     index("idx_workflow_executions_executed_hash").on(
       table.executedWorkflowHash

--- a/lib/workflow/executor/helpers.ts
+++ b/lib/workflow/executor/helpers.ts
@@ -8,7 +8,8 @@ import { workflowExecutions, workflows } from "@/lib/db/schema";
  * Get organizationId from executionId
  *
  * Workflow executions are scoped to organizations, not individual users.
- * This helper joins workflow_executions → workflows to get the organizationId.
+ * Reads the run's own `organization_id`, written at insert, and falls back to
+ * the workflow join for rows that predate the column.
  *
  * @param executionId - Execution ID (passed via _context in workflow steps)
  * @returns organizationId - Organization that owns the workflow
@@ -21,11 +22,10 @@ export async function getOrganizationIdFromExecution(
     throw new Error("Execution ID is required to get organization ID");
   }
 
-  // Join workflow_executions with workflows to get organizationId
   const result = await db
     .select({
-      organizationId: workflows.organizationId,
-      workflowId: workflowExecutions.workflowId,
+      executionOrganizationId: workflowExecutions.organizationId,
+      workflowOrganizationId: workflows.organizationId,
     })
     .from(workflowExecutions)
     .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
@@ -36,7 +36,8 @@ export async function getOrganizationIdFromExecution(
     throw new Error(`Execution not found: ${executionId}`);
   }
 
-  const { organizationId } = result[0];
+  const { executionOrganizationId, workflowOrganizationId } = result[0];
+  const organizationId = executionOrganizationId ?? workflowOrganizationId;
 
   if (!organizationId) {
     throw new Error(

--- a/lib/workflow/soft-delete.ts
+++ b/lib/workflow/soft-delete.ts
@@ -1,5 +1,5 @@
 import { isNull, type SQL } from "drizzle-orm";
-import { workflows } from "@/lib/db/schema";
+import { workflowExecutionLogs, workflows } from "@/lib/db/schema";
 
 /**
  * KEEP-440: Drizzle predicate that excludes soft-deleted workflow rows.
@@ -39,6 +39,29 @@ export function softDeleteValues(): {
     isListed: false,
     shareExecutionStatus: false,
   };
+}
+
+/**
+ * Drizzle predicate that excludes soft-deleted step logs.
+ *
+ * Step logs are soft-deleted instead of erased because they carry the per-step
+ * network and gas the analytics breakdown aggregates. Compose this into the
+ * WHERE of any read that shows a user their own steps. Aggregate readers
+ * deliberately omit it and count every row, the same way the billing quota
+ * counters already treat soft-deleted runs, and so does the executor resume
+ * path, which must still read `output_raw` for a run purged mid-flight.
+ */
+export function executionLogNotDeleted(): SQL {
+  return isNull(workflowExecutionLogs.deletedAt);
+}
+
+/**
+ * The column write that retires a step log. Takes the timestamp so every row
+ * in one purge shares a single instant, which is what makes a purge
+ * identifiable after the fact.
+ */
+export function executionLogSoftDeleteValues(at: Date): { deletedAt: Date } {
+  return { deletedAt: at };
 }
 
 /**

--- a/scripts/backfill-execution-organization-id.ts
+++ b/scripts/backfill-execution-organization-id.ts
@@ -1,0 +1,236 @@
+/**
+ * KEEP-1199: one-time backfill of the denormalised `organization_id` column on
+ * `workflow_executions`.
+ *
+ * Migration 0147 adds the column null. New rows are populated at insert by
+ * every trigger path (the API execute/webhook/mcp/internal routes and the
+ * executor). This script fills historical rows so a run resolves its owning
+ * org from itself rather than from a join through `workflows`, which is what
+ * getOrganizationIdFromExecution falls back to while rows are still null.
+ *
+ * Scope: every row where organization_id IS NULL. The value comes from the
+ * workflow the run belongs to; `workflows.organization_id` is NOT NULL, so
+ * every row resolves and none are skipped.
+ *
+ * Approach: keyset batches over the null rows, joining `workflows` for the
+ * value. COALESCE preserves anything the live writer already set, so there is
+ * no clobber race on hot recent rows. Idempotent and resumable via --after-id.
+ *
+ * A LIVE run against a non-local DB requires --yes; dry-runs and local DBs do
+ * not. This is a guard against an accidental prod write, not a security
+ * boundary.
+ *
+ * Usage:
+ *   pnpm tsx scripts/backfill-execution-organization-id.ts --dry-run
+ *   pnpm tsx scripts/backfill-execution-organization-id.ts                # local DB
+ *   pnpm tsx scripts/backfill-execution-organization-id.ts --yes          # staging/prod
+ *   pnpm tsx scripts/backfill-execution-organization-id.ts --yes --batch-size 2000 --after-id <id>
+ *   pnpm tsx scripts/backfill-execution-organization-id.ts --dry-run --max-batches 5
+ */
+
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { workflowExecutions } from "@/lib/db/schema";
+
+const DEFAULT_BATCH_SIZE = 1000;
+const LOG_PREFIX = "[backfill-execution-organization-id]";
+
+type CliArgs = {
+  dryRun: boolean;
+  batchSize: number;
+  afterId: string;
+  maxBatches: number | null;
+  yes: boolean;
+};
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    dryRun: false,
+    batchSize: DEFAULT_BATCH_SIZE,
+    afterId: "",
+    maxBatches: null,
+    yes: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") {
+      args.dryRun = true;
+    } else if (a === "--yes") {
+      args.yes = true;
+    } else if (a === "--batch-size" && argv[i + 1]) {
+      const parsed = Number.parseInt(argv[i + 1], 10);
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        args.batchSize = parsed;
+      }
+      i++;
+    } else if (a === "--after-id" && argv[i + 1]) {
+      args.afterId = argv[i + 1];
+      i++;
+    } else if (a === "--max-batches" && argv[i + 1]) {
+      const parsed = Number.parseInt(argv[i + 1], 10);
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        args.maxBatches = parsed;
+      }
+      i++;
+    } else if (a === "--help" || a === "-h") {
+      console.log(
+        "Usage: pnpm tsx scripts/backfill-execution-organization-id.ts [--dry-run] [--batch-size N] [--after-id ID] [--max-batches N] [--yes]"
+      );
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+/**
+ * Keyset page of the execution ids still needing a backfill; the cursor for the
+ * next batch is the last id.
+ */
+async function fetchExecutionIdBatch(
+  afterId: string,
+  batchSize: number
+): Promise<string[]> {
+  const rows = await db
+    .select({ id: workflowExecutions.id })
+    .from(workflowExecutions)
+    .where(
+      sql`${workflowExecutions.id} > ${afterId} AND ${workflowExecutions.organizationId} IS NULL`
+    )
+    .orderBy(workflowExecutions.id)
+    .limit(batchSize);
+  return rows.map((r) => r.id);
+}
+
+/**
+ * Backfill one keyset batch. Re-selects the same batch inside a CTE
+ * (deterministic for a fixed cursor) so no id array has to be marshalled into
+ * the statement. COALESCE keeps any value the live writer already set.
+ * Returns the number of rows written.
+ */
+async function applyBatch(afterId: string, batchSize: number): Promise<number> {
+  const result = await db.execute(sql`
+    WITH batch AS (
+      SELECT we.id, w.organization_id
+      FROM workflow_executions we
+      JOIN workflows w ON w.id = we.workflow_id
+      WHERE we.id > ${afterId}
+        AND we.organization_id IS NULL
+      ORDER BY we.id
+      LIMIT ${batchSize}
+    )
+    UPDATE workflow_executions
+    SET organization_id = COALESCE(
+      workflow_executions.organization_id,
+      batch.organization_id
+    )
+    FROM batch
+    WHERE workflow_executions.id = batch.id
+    RETURNING workflow_executions.id
+  `);
+  // postgres-js: db.execute resolves to the RETURNING rows array.
+  return result.length;
+}
+
+/** Dry-run: count how many rows in the batch WOULD be written. */
+async function countBatch(afterId: string, batchSize: number): Promise<number> {
+  const result = await db.execute(sql`
+    WITH batch AS (
+      SELECT we.id
+      FROM workflow_executions we
+      JOIN workflows w ON w.id = we.workflow_id
+      WHERE we.id > ${afterId}
+        AND we.organization_id IS NULL
+      ORDER BY we.id
+      LIMIT ${batchSize}
+    )
+    SELECT COUNT(*) AS n FROM batch
+  `);
+  // postgres-js: db.execute resolves to the rows array.
+  return Number(result[0]?.n ?? 0);
+}
+
+function dbHost(): string {
+  try {
+    return new URL(process.env.DATABASE_URL ?? "").host || "(unknown)";
+  } catch {
+    return "(unparseable DATABASE_URL)";
+  }
+}
+
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "db", "postgres"]);
+
+function isLocalDb(): boolean {
+  try {
+    // URL.hostname drops the port; strip the IPv6 brackets it keeps.
+    const hostname = new URL(process.env.DATABASE_URL ?? "").hostname.replace(
+      /^\[|\]$/g,
+      ""
+    );
+    return LOCAL_HOSTS.has(hostname);
+  } catch {
+    return false;
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  console.log(
+    `${LOG_PREFIX} mode=${args.dryRun ? "DRY-RUN" : "LIVE"} host=${dbHost()} batchSize=${args.batchSize} afterId=${args.afterId || "(start)"} maxBatches=${args.maxBatches ?? "all"}`
+  );
+
+  // A LIVE run against a non-local DB (staging/prod) writes immediately. Require
+  // an explicit --yes so an operator cannot kick one off by reflex. Dry-runs and
+  // local DBs are unguarded.
+  if (!(args.dryRun || args.yes || isLocalDb())) {
+    console.error(
+      `${LOG_PREFIX} refusing LIVE run against non-local host ${dbHost()} without --yes. Re-run with --yes to confirm, or add --dry-run.`
+    );
+    process.exit(1);
+  }
+
+  let cursor = args.afterId;
+  let batches = 0;
+  let totalScanned = 0;
+  let totalWritten = 0;
+
+  for (;;) {
+    const ids = await fetchExecutionIdBatch(cursor, args.batchSize);
+    if (ids.length === 0) {
+      break;
+    }
+
+    const written = args.dryRun
+      ? await countBatch(cursor, args.batchSize)
+      : await applyBatch(cursor, args.batchSize);
+
+    batches += 1;
+    totalScanned += ids.length;
+    totalWritten += written;
+    cursor = ids[ids.length - 1];
+
+    console.log(
+      `${LOG_PREFIX} batch=${batches} scanned=${ids.length} written=${written} cursor=${cursor} cumulative_scanned=${totalScanned} cumulative_written=${totalWritten}`
+    );
+
+    if (ids.length < args.batchSize) {
+      break;
+    }
+    if (args.maxBatches !== null && batches >= args.maxBatches) {
+      console.log(
+        `${LOG_PREFIX} stopping at --max-batches=${args.maxBatches}; resume with --after-id ${cursor}`
+      );
+      break;
+    }
+  }
+
+  console.log(
+    `${LOG_PREFIX} done. mode=${args.dryRun ? "DRY-RUN" : "LIVE"} batches=${batches} scanned=${totalScanned} written=${totalWritten} last_cursor=${cursor || "(none)"}`
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(`${LOG_PREFIX} failed:`, err);
+    process.exit(1);
+  });

--- a/tests/e2e/vitest/execution-log-soft-delete.test.ts
+++ b/tests/e2e/vitest/execution-log-soft-delete.test.ts
@@ -1,0 +1,259 @@
+import "dotenv/config";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  organization,
+  users,
+  workflowExecutionLogs,
+  workflowExecutions,
+  workflows,
+} from "../../../lib/db/schema";
+
+// Bypass the Next.js server-only guard - vitest runs in Node, not SSR context.
+vi.mock("server-only", () => ({}));
+
+// tests/setup.ts globally stubs @/lib/db. This suite needs real SQL to verify
+// that the delete paths write deleted_at instead of removing the rows.
+vi.unmock("@/lib/db");
+
+const PREFIX = "test_keep1199_";
+const ORG_ID = `${PREFIX}org`;
+const USER_ID = `${PREFIX}user`;
+
+// Auth is not what this suite exercises. Grant full access to the seeded org so
+// both handlers reach the delete branch.
+vi.mock("@/lib/middleware/auth-helpers", () => ({
+  getDualAuthContext: () =>
+    Promise.resolve({
+      userId: USER_ID,
+      organizationId: ORG_ID,
+      authMethod: "session",
+      apiKeyId: null,
+      scope: null,
+    }),
+  authFailureResponse: () => new Response(null, { status: 401 }),
+}));
+
+vi.mock("@/lib/middleware/require-scope", () => ({
+  requireScope: () => null,
+}));
+
+vi.mock("@/lib/workflow/access", () => ({
+  getWorkflowAccess: () =>
+    Promise.resolve({ hasFullAccess: true, isDeleted: false }),
+  validateWorkflowAccess: () => Promise.resolve({ authorized: true }),
+}));
+
+// security_audit_log is append-only at the DB level (BEFORE DELETE OR UPDATE
+// trigger), and its FK to users is ON DELETE SET NULL, so a real audit write
+// here would make the suite impossible to clean up after itself.
+vi.mock("@/lib/security/audit-log", () => ({
+  recordAuditEvent: vi.fn(() => Promise.resolve()),
+  buildAuditMetadata: vi.fn(() => ({})),
+}));
+
+const SKIP =
+  !process.env.DATABASE_URL || process.env.SKIP_INFRA_TESTS === "true";
+const DATABASE_URL = process.env.DATABASE_URL ?? "";
+
+type LogRow = { id: string; deleted_at: Date | null; gas_used_wei: string };
+
+describe.skipIf(SKIP)("execution log soft delete - real-DB integration", () => {
+  let queryClient: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+
+  // One workflow per delete path so the two runs cannot mask each other.
+  const purgeWorkflowId = `${PREFIX}wf_purge`;
+  const cascadeWorkflowId = `${PREFIX}wf_cascade`;
+  const purgeExecutionId = `${PREFIX}exec_purge`;
+  const cascadeExecutionId = `${PREFIX}exec_cascade`;
+
+  async function cleanup(): Promise<void> {
+    await queryClient`DELETE FROM workflow_execution_logs WHERE execution_id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM workflow_executions WHERE id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM workflow_schedules WHERE workflow_id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM workflows WHERE id LIKE ${`${PREFIX}%`}`;
+    // The org and user are left in place on purpose. security_audit_log is
+    // append-only at the DB level and its FKs are ON DELETE SET NULL, so once
+    // any run has written an audit row the user can never be deleted again.
+    // Both are prefixed and re-seeded idempotently instead.
+  }
+
+  async function logsFor(executionId: string): Promise<LogRow[]> {
+    return (await queryClient`
+      SELECT id, deleted_at, gas_used_wei
+      FROM workflow_execution_logs
+      WHERE execution_id = ${executionId}
+      ORDER BY id
+    `) as unknown as LogRow[];
+  }
+
+  beforeAll(async () => {
+    queryClient = postgres(DATABASE_URL);
+    db = drizzle(queryClient);
+    await cleanup();
+
+    const now = new Date();
+
+    await db
+      .insert(organization)
+      .values({
+        id: ORG_ID,
+        name: "keep1199 test org",
+        slug: ORG_ID,
+        createdAt: now,
+      })
+      .onConflictDoNothing();
+
+    await db
+      .insert(users)
+      .values({
+        id: USER_ID,
+        email: `${USER_ID}@keep1199.test`,
+        emailVerified: false,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoNothing();
+
+    for (const id of [purgeWorkflowId, cascadeWorkflowId]) {
+      await db.insert(workflows).values({
+        id,
+        name: `keep1199 ${id}`,
+        userId: USER_ID,
+        organizationId: ORG_ID,
+        nodes: [],
+        edges: [],
+      });
+    }
+
+    // Two gas-bearing steps per run: the per-network breakdown aggregates these
+    // columns, so they are what must survive a delete.
+    const runs: [string, string][] = [
+      [purgeExecutionId, purgeWorkflowId],
+      [cascadeExecutionId, cascadeWorkflowId],
+    ];
+
+    for (const [executionId, workflowId] of runs) {
+      await db.insert(workflowExecutions).values({
+        id: executionId,
+        workflowId,
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        status: "success",
+        startedAt: now,
+        completedAt: now,
+      });
+
+      for (const step of [1, 2]) {
+        await db.insert(workflowExecutionLogs).values({
+          id: `${executionId}_step${step}`,
+          executionId,
+          nodeId: `node-${step}`,
+          nodeName: `Node ${step}`,
+          nodeType: "web3/read-contract",
+          status: "success",
+          startedAt: now,
+          completedAt: now,
+          network: "1",
+          gasUsedWei: "21000",
+        });
+      }
+    }
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await queryClient.end();
+  });
+
+  it("seeds two gas-bearing log rows per run", async () => {
+    expect(await logsFor(purgeExecutionId)).toHaveLength(2);
+    expect(await logsFor(cascadeExecutionId)).toHaveLength(2);
+  });
+
+  it("purging run history soft-deletes the step logs instead of erasing them", async () => {
+    const { DELETE } = await import(
+      "@/app/api/workflows/[workflowId]/executions/route"
+    );
+
+    const response = await DELETE(
+      new Request(
+        `http://localhost/api/workflows/${purgeWorkflowId}/executions`,
+        { method: "DELETE" }
+      ),
+      { params: Promise.resolve({ workflowId: purgeWorkflowId }) }
+    );
+    expect(response.status).toBe(200);
+
+    const logs = await logsFor(purgeExecutionId);
+    expect(logs).toHaveLength(2);
+    for (const log of logs) {
+      expect(log.deleted_at).not.toBeNull();
+      // The gas the analytics breakdown sums is still on the row.
+      expect(log.gas_used_wei).toBe("21000");
+    }
+
+    const [execution] = (await queryClient`
+      SELECT deleted_at FROM workflow_executions WHERE id = ${purgeExecutionId}
+    `) as unknown as Array<{ deleted_at: Date | null }>;
+    expect(execution.deleted_at).not.toBeNull();
+  });
+
+  it("force-deleting a workflow soft-deletes the step logs instead of erasing them", async () => {
+    const { DELETE } = await import("@/app/api/workflows/[workflowId]/route");
+
+    const response = await DELETE(
+      new Request(
+        `http://localhost/api/workflows/${cascadeWorkflowId}?force=true`,
+        { method: "DELETE" }
+      ),
+      { params: Promise.resolve({ workflowId: cascadeWorkflowId }) }
+    );
+    expect(response.status).toBe(200);
+
+    const logs = await logsFor(cascadeExecutionId);
+    expect(logs).toHaveLength(2);
+    for (const log of logs) {
+      expect(log.deleted_at).not.toBeNull();
+      expect(log.gas_used_wei).toBe("21000");
+    }
+  });
+
+  it("keeps purged gas in the per-network breakdown the analytics page reads", async () => {
+    // Drives the real production query rather than a hand-written copy of it,
+    // so the assertion cannot drift from what the page actually shows. A
+    // "custom" range bypasses the analytics cache (see isCacheableRange).
+    const { getNetworkBreakdown } = await import("@/lib/analytics/queries");
+
+    const start = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const end = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const breakdown = await getNetworkBreakdown(ORG_ID, "custom", start, end);
+
+    const mainnet = breakdown.find((n) => n.network === "1");
+    expect(mainnet).toBeDefined();
+    // Four steps at 21000 across the two purged runs. Zero here would mean the
+    // gas history died with the purge, which is the whole point of the change.
+    expect(mainnet?.totalGasWei).toBe("84000");
+  });
+
+  it("hides purged steps from the run detail view", async () => {
+    const [row] = (await queryClient`
+      SELECT COUNT(*)::int AS n
+      FROM workflow_execution_logs
+      WHERE execution_id = ${purgeExecutionId}
+        AND deleted_at IS NULL
+    `) as unknown as Array<{ n: number }>;
+
+    expect(row.n).toBe(0);
+  });
+
+  it("stamps the owning org on the execution row itself", async () => {
+    const [row] = (await queryClient`
+      SELECT organization_id FROM workflow_executions WHERE id = ${purgeExecutionId}
+    `) as unknown as Array<{ organization_id: string | null }>;
+
+    expect(row.organization_id).toBe(ORG_ID);
+  });
+});

--- a/tests/unit/executions-route-soft-delete.test.ts
+++ b/tests/unit/executions-route-soft-delete.test.ts
@@ -7,7 +7,9 @@ const findManyMock = vi.fn();
 const deleteWhereMock = vi.fn();
 const deleteMock = vi.fn(() => ({ where: deleteWhereMock }));
 const updateWhereMock = vi.fn();
-const updateSetMock = vi.fn(() => ({ where: updateWhereMock }));
+const updateSetMock = vi.fn((_values: Record<string, unknown>) => ({
+  where: updateWhereMock,
+}));
 const updateMock = vi.fn(() => ({ set: updateSetMock }));
 
 vi.mock("@/lib/db", () => ({
@@ -49,11 +51,11 @@ beforeEach(() => {
   updateWhereMock.mockResolvedValue(undefined);
 });
 
-// Purging execution history must not reduce the billable count, so runs are
-// soft-deleted (deleted_at) rather than hard-deleted; only the bulky per-step
-// logs are hard-deleted to reclaim storage.
+// Purging execution history must not reduce the billable count, and must not
+// tear a hole in the analytics gas history, so the runs and their per-step logs
+// are both soft-deleted (deleted_at) rather than erased.
 describe("executions DELETE route soft-deletes runs", () => {
-  it("soft-deletes the runs and hard-deletes only their logs", async () => {
+  it("soft-deletes the runs and their logs, erasing neither", async () => {
     findFirstMock.mockResolvedValueOnce({
       id: "wf_1",
       userId: "user_1",
@@ -73,15 +75,22 @@ describe("executions DELETE route soft-deletes runs", () => {
     expect(response.status).toBe(200);
     expect(body.deletedCount).toBe(2);
 
-    // Runs are soft-deleted (deleted_at stamped), never hard-deleted.
+    // Runs are soft-deleted (deleted_at stamped), never erased.
     expect(updateMock).toHaveBeenCalledWith(workflowExecutions);
-    expect(updateSetMock).toHaveBeenCalledWith(
-      expect.objectContaining({ deletedAt: expect.any(Date) })
-    );
     expect(deleteMock).not.toHaveBeenCalledWith(workflowExecutions);
 
-    // Only the per-step logs are hard-deleted.
-    expect(deleteMock).toHaveBeenCalledWith(workflowExecutionLogs);
+    // The per-step logs take the same treatment: stamped, not erased. They
+    // carry the gas the analytics breakdown aggregates.
+    expect(updateMock).toHaveBeenCalledWith(workflowExecutionLogs);
+    expect(deleteMock).not.toHaveBeenCalledWith(workflowExecutionLogs);
+
+    // Both updates stamp a deletion time.
+    expect(updateSetMock).toHaveBeenCalledTimes(2);
+    for (const call of updateSetMock.mock.calls) {
+      expect(call[0]).toEqual(
+        expect.objectContaining({ deletedAt: expect.any(Date) })
+      );
+    }
   });
 
   it("does not touch executions when there are none", async () => {

--- a/tests/unit/get-execution-logs-backward-compat.test.ts
+++ b/tests/unit/get-execution-logs-backward-compat.test.ts
@@ -25,12 +25,15 @@ vi.mock("@/lib/db/schema", () => ({
   workflowExecutionLogs: {
     executionId: "executionId",
     timestamp: "timestamp",
+    deletedAt: "deletedAt",
   },
 }));
 
 vi.mock("drizzle-orm", () => ({
   eq: () => ({}),
   desc: () => ({}),
+  and: () => ({}),
+  isNull: () => ({}),
 }));
 
 vi.mock("@/lib/middleware/auth-helpers", () => ({


### PR DESCRIPTION
## Problem

Purging run history and force-deleting a workflow both hard-deleted `workflow_execution_logs`. Those rows carry the per-step `network` and `gas_used_wei` that the analytics per-network breakdown aggregates (`lib/analytics/queries.ts:790-812`), while the org-level gas total reads `workflow_executions.gas_used_wei` (`:560`) and survived.

After a purge the analytics page contradicted itself: the total stayed whole, the network breakdown summed to less, and nothing in the data explained the gap. The loss covered every past month, not only the current one.

## What changed

**Both delete paths stamp `deleted_at` instead of erasing rows.** Aggregate readers keep counting every row, matching how the billing quota counters already treat soft-deleted runs. Only the two views that show a user their own steps filter it out: the execution logs route and `getStepLogs`.

**`workflow_executions` now carries `organization_id`.** A run previously reached its owning org only by joining `workflows`, so its billing and analytics attribution lived in a row the run does not control. Written at insert by all eight trigger paths, with `getOrganizationIdFromExecution` falling back to the join until the backfill has run.

The executor resume path (`get-completed-step-output.step.ts`) is deliberately left unfiltered. Neither delete path has a status filter, so a purge can land on an in-flight run; keeping `output_raw` readable means that run still resumes.

## Verification

Migrated a scratch database from empty through all 148 migrations, then ran against it.

| Check | Result |
| -- | -- |
| `pnpm db:migrate` from empty | all 148 applied |
| `pnpm type-check` | clean |
| `pnpm check` | clean |
| `tests/unit` | 539 files, 21054 passed |
| New DB-backed suite | 6 passed, repeatable |

The new suite binds to the fix rather than restating it. Reverting either delete path drops the per-network gas total from `84000` to `0` and fails three of the six cases. The aggregate assertion calls the real `getNetworkBreakdown` rather than a hand-written copy of its SQL, so it cannot drift from what the page shows.

Two existing tests asserted the old contract and were updated: `executions-route-soft-delete.test.ts` expected logs to be erased, and `get-execution-logs-backward-compat.test.ts` mocked `drizzle-orm` with only `eq` and `desc`, so the route's new `and`/`isNull` calls threw a 500.

## Trade-offs, measured

Benchmarked on 200k step-log rows with multi-KB payloads.

| Purge strategy | Time | Heap after |
| -- | -- | -- |
| `DELETE` (before) | 165 ms | no growth |
| `UPDATE deleted_at` (this PR) | 2792 ms | +97% |

**Purging is roughly 17x slower** and rewrites every row rather than marking it dead. This is the cost of keeping the data. Worth knowing: the force-cascade path runs its update inside a transaction, so a workflow with millions of step logs will hold that transaction for tens of seconds. The previous `DELETE` had the same unbounded shape, just faster. Batching it is a reasonable follow-up if it bites.

**Storage growth is one-time, not compounding.** `pgstattuple` after vacuum shows 69.5% reusable free space and zero dead tuples, so the file roughly doubles once during a large purge and subsequent writes reuse the space.

**The gas aggregate gets slower because it now has data to sum:** 92 ms before a purge, 129 ms after. The old path's 0.05 ms came from having destroyed the rows, which is the bug rather than a benchmark.

**Backfill is cheap:** 200k rows in 7 seconds (about 35 s per million), keyset-batched, resumable, idempotent (a second run reports 0 batches). It refuses a live run against a non-local host without `--yes`.

## Deploy notes

1. Migration `0147` adds two nullable columns. Both are instant on PG11+ (no rewrite, no default).
2. The FK ships `NOT VALID` to skip the validation scan. It still enforces on new inserts; only pre-existing rows are unvalidated, and those are all null. Run `VALIDATE CONSTRAINT` after the backfill.
3. **Run the backfill after the code deploy**, not before, so rows written in the gap are caught.

The FK is `ON DELETE NO ACTION` rather than `CASCADE` on purpose. Org deletion is already blocked today by the `workflows` to `workflow_executions` chain, so this preserves current behaviour rather than quietly enabling deletion of billing rows. The policy for winding an org down belongs in the separate org-deletion work.

## Out of scope

Reclaiming the storage the old hard delete bought back. A retention job is the likely answer and needs a decision on retention period first. Nothing here blocks it.
