### PR TITLE
fix(workflows): exclude soft-deleted rows from the workflow list route

### DIFF
--- a/app/api/workflows/route.ts
+++ b/app/api/workflows/route.ts
@@ -6,6 +6,7 @@ import { ApiErrorCodes, apiError } from "@/lib/errors/api-envelope";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { authFailureResponse, getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { MAX_PAGE_SIZE } from "@/lib/pagination";
+import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
 
 /**
  * The largest offset worth forwarding. Past Number.MAX_SAFE_INTEGER a parsed
@@ -114,7 +115,14 @@ export async function GET(request: Request): Promise<NextResponse> {
       });
     }
 
-    const conditions = [eq(workflows.organizationId, organizationId)];
+    // A soft-deleted workflow is gone as far as every listing surface is
+    // concerned. Filtering here rather than in the client keeps this route in
+    // step with the other reads and covers the non-browser callers (MCP,
+    // API keys) that never ran the client-side filter.
+    const conditions = [
+      eq(workflows.organizationId, organizationId),
+      workflowNotDeleted(),
+    ];
 
     if (projectIdFilter) {
       conditions.push(eq(workflows.projectId, projectIdFilter));

--- a/components/navigation-sidebar.tsx
+++ b/components/navigation-sidebar.tsx
@@ -60,10 +60,9 @@ type WorkflowEntry = {
   updatedAt: string;
   projectId?: string | null;
   tagId?: string | null;
-  // Soft-delete timestamp. Hidden from the sidebar picker via
-  // filterPickerVisible(), but the API still returns these rows so audit /
-  // recovery surfaces (executions history, marketplace listings) can render
-  // them.
+  // Soft-delete timestamp. The list route already excludes these rows;
+  // filterPickerVisible() re-checks it so a stale cached payload cannot put
+  // one back in the picker.
   deletedAt?: string | null;
   // The trigger type drives whether the "Disabled" label is meaningful --
   // see shouldShowDisabledBadge. Derived once at the SavedWorkflow boundary

--- a/lib/workflow/soft-delete.ts
+++ b/lib/workflow/soft-delete.ts
@@ -7,9 +7,7 @@ import { workflows } from "@/lib/db/schema";
  * Workflows are soft-deleted (`deletedAt` set) instead of hard-deleted so the
  * listed slug stays bound to the row and cannot be re-claimed by another
  * workflow. Every read that should treat a deleted workflow as gone must
- * compose this into its WHERE clause. The owner-facing workflow list is the
- * deliberate exception -- it keeps showing deleted rows so the UI can mark
- * them as deleted.
+ * compose this into its WHERE clause, the owner-facing list included.
  */
 export function workflowNotDeleted(): SQL {
   return isNull(workflows.deletedAt);
@@ -43,10 +41,10 @@ export function softDeleteValues(): {
 
 /**
  * Filter the owner-facing workflow list down to entries that belong in the
- * sidebar picker. Soft-deleted rows are dropped (audit/recovery still keeps
- * them in the API payload for other surfaces) and the internal `__current__`
- * stub is excluded. Disabled rows are intentionally kept -- the picker greys
- * them out and tags them rather than hiding them.
+ * sidebar picker: the internal `__current__` stub is excluded, and the
+ * deletedAt check is a second line of defence behind the route's own
+ * workflowNotDeleted() filter. Disabled rows are intentionally kept -- the
+ * picker greys them out and tags them rather than hiding them.
  */
 export function filterPickerVisible<
   T extends { name: string; deletedAt?: Date | string | null },

--- a/tests/unit/workflows-list-soft-delete.test.ts
+++ b/tests/unit/workflows-list-soft-delete.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { mockAuth, mockSelect } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockSelect: vi.fn(),
+}));
+
+vi.mock("@/lib/middleware/auth-helpers", () => ({
+  getDualAuthContext: (...args: unknown[]) => mockAuth(...args),
+  authFailureResponse: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: { select: (...args: unknown[]) => mockSelect(...args) },
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "database" },
+  logSystemError: vi.fn(),
+}));
+
+import { GET } from "@/app/api/workflows/route";
+
+/** Chainable drizzle stub that records the predicate handed to where(). */
+function queryStub(rows: unknown[]) {
+  const calls: { where?: unknown } = {};
+  const builder: Record<string, unknown> = {
+    from: () => builder,
+    where: (predicate: unknown) => {
+      calls.where = predicate;
+      return builder;
+    },
+    orderBy: () => builder,
+    limit: () => builder,
+    offset: () => builder,
+    // biome-ignore lint/suspicious/noThenProperty: drizzle's builder is itself a thenable and the route awaits it, so the stub has to be one too.
+    then: (resolve: (value: unknown) => unknown) => resolve(rows),
+  };
+  return { builder, calls };
+}
+
+/** Every column referenced anywhere in a drizzle SQL predicate tree. */
+function columnsIn(node: unknown, found: string[] = []): string[] {
+  if (node === null || typeof node !== "object") {
+    return found;
+  }
+  const candidate = node as { name?: unknown; queryChunks?: unknown };
+  if (typeof candidate.name === "string" && "table" in candidate) {
+    found.push(candidate.name);
+  }
+  const chunks = candidate.queryChunks;
+  if (Array.isArray(chunks)) {
+    for (const chunk of chunks) {
+      columnsIn(chunk, found);
+    }
+  }
+  return found;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.mockResolvedValue({ organizationId: "org_1" });
+});
+
+describe("GET /api/workflows soft-delete", () => {
+  it("filters deleted rows in the query rather than leaving it to the caller", async () => {
+    const { builder, calls } = queryStub([]);
+    mockSelect.mockReturnValue(builder);
+
+    await GET(new Request("http://localhost/api/workflows"));
+
+    const columns = columnsIn(calls.where);
+    expect(columns).toContain("deleted_at");
+    expect(columns).toContain("organization_id");
+  });
+
+  it("keeps filtering deleted rows when a project filter narrows the list", async () => {
+    const { builder, calls } = queryStub([]);
+    mockSelect.mockReturnValue(builder);
+
+    await GET(new Request("http://localhost/api/workflows?projectId=proj_1"));
+
+    const columns = columnsIn(calls.where);
+    expect(columns).toContain("deleted_at");
+    expect(columns).toContain("project_id");
+  });
+});


### PR DESCRIPTION
## Problem

`GET /api/workflows` was the only workflow read path in the codebase not composing `workflowNotDeleted()`. Every other read applies it: `workflows/public`, `workflows/events`, `mcp/workflows`, `openapi`, `x402`, `duplicate`, `create`, `internal/block-workflows`, `lib/mcp/listing.ts`, `lib/workflow/executable.ts`, `lib/agentic-wallet/workflow-binding.ts`.

The owner-facing list opted out and pushed the job to the client, where only the sidebar ran `filterPickerVisible()`. Every other consumer of the same endpoint received soft-deleted rows:

- `app/workflows/page.tsx`
- `components/workflow/workflow-toolbar.tsx` (the workflow switcher, two call sites)
- `components/welcome/steps/connect-agent-step.tsx`
- `components/navigation-sidebar.tsx` anonymous one-workflow cap, which counted deleted rows toward the cap and could redirect the user into one
- non-browser callers: MCP `list_workflows` and API-key clients, which never had a client filter to run

Deleted workflows were therefore listed by the API while the sidebar hid them, so the two surfaces disagreed about what exists.

## Change

- `app/api/workflows/route.ts`: `workflowNotDeleted()` added to the WHERE conditions, so it holds across the project filter, the tag filter and the paging path.
- `lib/workflow/soft-delete.ts` and `components/navigation-sidebar.tsx`: the comments documenting the list as a deliberate exception now describe the client-side check as second-line defence, which is what it now is.
- `tests/unit/workflows-list-soft-delete.test.ts`: new, asserts the predicate handed to the query references `deleted_at`, both bare and alongside a project filter.

Reading a single workflow is deliberately untouched. `GET /api/workflows/[workflowId]` still serves a deleted row to its owning org and 404s for everyone else, and the page metadata stays redacted for private workflows.

## Verification

- Both new tests fail with the route hunk reverted and pass with it.
- Full unit suite: 540 files, 21056 passed, 1 skipped.
- `pnpm type-check` clean. `pnpm check` clean, with one pre-existing `info` about an oversized test fixture unrelated to this branch.