### PR TITLE
docs: register the MCP server at user scope in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Users and Agents can build and deploy Web3 automation workflows through a visual
 **Quick setup (no install needed):**
 
 ```bash
-claude mcp add --transport http keeperhub https://app.keeperhub.com/mcp
+claude mcp add --transport http --scope user keeperhub https://app.keeperhub.com/mcp
 ```
 
 Then run `/mcp` inside Claude Code to authorize via browser. That's it.


### PR DESCRIPTION
## Problem

The README tells readers to run:

```
claude mcp add --transport http keeperhub https://app.keeperhub.com/mcp
```

Without `--scope user` the server is registered at project scope, so it disappears the moment the reader changes directory. Onboarding assumes user scope: every page under `docs/` carries the flag, `lib/agent-connect-commands.ts` emits it, and a unit test asserts it. The README was the last copy without it.

## Change

One line in `README.md`, bringing it in line with the rest of the repo.

The CLI repo carries the same defect in its own README and is fixed separately in KeeperHub/cli. Its `docs/quickstart.md`, which the docs sync copies into `docs/cli/`, already has the flag, so no sync will revert this.