### PR TITLE
test(wallet): guard the org-scoped wallet refetch

### DIFF
--- a/tests/unit/org-scoped-atoms.test.ts
+++ b/tests/unit/org-scoped-atoms.test.ts
@@ -1,0 +1,104 @@
+import { createStore } from "jotai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api-client", () => ({
+  api: {
+    project: { getAll: vi.fn().mockResolvedValue([]) },
+    tag: { getAll: vi.fn().mockResolvedValue([]) },
+  },
+}));
+
+import {
+  activeOrgScopeAtom,
+  orgDataReadyAtom,
+  walletAtom,
+  walletRefreshAtom,
+} from "@/lib/atoms/organization";
+
+const WALLETS: Record<string, string> = {
+  "org-a": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "org-b": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+};
+
+// The route reads the active organization from the session, so the stub is
+// keyed on whichever org the store currently says is in scope.
+let servedOrg = "org-a";
+const fetchMock = vi.fn(() =>
+  Promise.resolve({
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        hasWallet: true,
+        walletAddress: WALLETS[servedOrg],
+      }),
+  } as unknown as Response)
+);
+
+async function scopeTo(
+  store: ReturnType<typeof createStore>,
+  orgId: string
+): Promise<string | null | undefined> {
+  servedOrg = orgId;
+  store.set(activeOrgScopeAtom, orgId);
+  const summary = await store.get(walletAtom);
+  return summary?.walletAddress;
+}
+
+describe("organization-scoped wallet atom", () => {
+  let store: ReturnType<typeof createStore>;
+
+  beforeEach(() => {
+    fetchMock.mockClear();
+    servedOrg = "org-a";
+    vi.stubGlobal("fetch", fetchMock);
+    store = createStore();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not fetch before the client marks the store ready", async () => {
+    store.set(activeOrgScopeAtom, "org-a");
+    expect(await store.get(walletAtom)).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch until an organization is in scope", async () => {
+    store.set(orgDataReadyAtom, true);
+    expect(await store.get(walletAtom)).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("refetches the wallet when the active organization changes", async () => {
+    store.set(orgDataReadyAtom, true);
+
+    expect(await scopeTo(store, "org-a")).toBe(WALLETS["org-a"]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // The regression this guards: the address kept showing the previous
+    // organization's wallet because nothing re-ran on the switch.
+    expect(await scopeTo(store, "org-b")).toBe(WALLETS["org-b"]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    expect(await scopeTo(store, "org-a")).toBe(WALLETS["org-a"]);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("refetches when the refresh counter is bumped", async () => {
+    store.set(orgDataReadyAtom, true);
+    await scopeTo(store, "org-a");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    store.set(walletRefreshAtom, (n) => n + 1);
+    await store.get(walletAtom);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports no wallet when the route rejects the request", async () => {
+    store.set(orgDataReadyAtom, true);
+    fetchMock.mockResolvedValueOnce({ ok: false } as unknown as Response);
+    store.set(activeOrgScopeAtom, "org-a");
+    expect(await store.get(walletAtom)).toEqual({ hasWallet: false });
+  });
+});


### PR DESCRIPTION
## Context

Report: switching organizations left the previous org's wallet address in the top panel, so transactions checked against it on a block explorer did not match.

## What I found

The bug was real and is already fixed on `staging` and `prod`, but it was fixed by accident.

The old `useWalletInfo` computed the active org id and never used it:

```ts
const _activeOrgId = activeOrg?.id ?? null;
const refresh = useCallback(async () => { ... }, [isAuthed]);
useEffect(() => { refresh(); }, [refresh]);
```

The comment above the effect claimed it refetched on an org switch. It did not: `refresh` only changed identity when `isAuthed` changed, so switching organizations never re-ran the fetch and the pill kept the old address. The same held for the invalidation counter.

The `perf: fetch the organization wallet once` refactor moved that fetch into `walletAtom`, which reads `activeOrgScopeAtom`, and the symptom went away as a side effect. Nothing asserts that dependency, so the next refactor of this store can reintroduce it silently.

## Verification

Reproduced against the local stack with a user in eight organizations, each with a distinct wallet, driving the real org switcher and comparing the pill against `/api/user/wallet`. Current `staging` matches on every switch, on `/` and on workflow-to-workflow client-side navigation.

## Change

A unit test over the atom graph: no fetch before the client marks the store ready, no fetch without an org in scope, a fresh fetch on every scope change, a fetch on a refresh bump, and `hasWallet: false` when the route rejects.

Confirmed the guard bites: removing the scope dependency from `walletAtom` fails two of the five cases, one of them with exactly the reported symptom, the previous org's address where the new one belongs.

No production code changes.