### PR TITLE
feat: split SPL token balance into its own action

### DIFF
--- a/docs/agent/mcp-server.md
+++ b/docs/agent/mcp-server.md
@@ -399,6 +399,7 @@ Conditions reference previous node outputs using template syntax: `{{@nodeId:Lab
 |--------|----------------|
 | `web3/check-balance` | `network`, `address` |
 | `web3/check-token-balance` | `network`, `address`, `tokenConfig` |
+| `web3/get-spl-token-balance` | `network`, `address`, `tokenConfig` |
 | `web3/read-contract` | `network`, `contractAddress`, `abi`, `abiFunction` |
 
 ### Write Actions (require a wallet integration)

--- a/docs/plugins/web3.md
+++ b/docs/plugins/web3.md
@@ -12,7 +12,8 @@ Interact with EVM-compatible blockchain networks and Solana. Read-only actions w
 | Action | Category | Credentials | Description |
 |--------|----------|-------------|-------------|
 | Get Native Token Balance | Web3 | No | Check ETH/MATIC/etc. balance of any address |
-| Get ERC20 Token Balance | Web3 | No | Check token balance of any address |
+| Get ERC20 Token Balance | Web3 | No | Check ERC20 token balance of any address |
+| Get SPL Token Balance | Web3 | No | Check SPL token balance of any Solana address |
 | Read Contract | Web3 | No | Call view/pure functions on smart contracts |
 | Batch Read Contract | Web3 | No | Batch multiple contract reads into one RPC call via Multicall3 |
 | Get Transaction | Web3 | No | Fetch full transaction details by hash |
@@ -53,13 +54,25 @@ Schedule (every hour)
 
 ## Get ERC20 Token Balance
 
-Check the balance of any ERC20 token for a given address.
+Check the balance of any ERC20 token for a given address on EVM chains. For SPL tokens on Solana, use Get SPL Token Balance.
 
 **Inputs:** Network, Address, Token (select from supported tokens or enter custom contract)
 
 **Outputs:** `success`, `balance.balance`, `balance.symbol`, `balance.decimals`, `balance.name`, `address`, `error`
 
 **When to use:** Track token holdings, monitor protocol positions, alert on balance changes.
+
+---
+
+## Get SPL Token Balance
+
+Check the balance of any SPL token for a given Solana address. Supports Token-2022 mints and program-owned (off-curve) wallet addresses. A wallet with no associated token account for the mint reports a zero balance. Token symbol and name resolve from the mint's on-chain metadata when the token is not in the supported list.
+
+**Inputs:** Network (Solana), Address, Token (select from supported tokens or enter a mint address)
+
+**Outputs:** `success`, `balance.balance`, `balance.symbol`, `balance.decimals`, `balance.name`, `address`, `error`
+
+**When to use:** Track SPL token holdings, monitor treasury balances on Solana, alert on balance changes.
 
 ---
 

--- a/lib/action-schemas/builder.ts
+++ b/lib/action-schemas/builder.ts
@@ -77,7 +77,7 @@ function mapFieldType(field: ActionConfigFieldBase): string {
     case "chain-select":
       return "string (chain ID)";
     case "token-select":
-      return 'string (JSON) - Token selection config. Use: {"mode":"custom","customToken":{"address":"0x...","symbol":"USDC"}} for a known token address';
+      return 'string (JSON) - Token selection config. Use: {"mode":"custom","customToken":{"address":"0x...","symbol":"USDC"}} for a known token address. On Solana actions the address is the base58 mint, not a 0x address';
     case "abi-function-select":
       return "string (function name from ABI)";
     case "abi-function-args":
@@ -353,7 +353,7 @@ export async function buildActionSchemasResponse(
       "web3 read actions (check-balance, read-contract) don't require wallet integration",
       "web3 write actions (transfer-funds, write-contract) require wallet integration",
       "web3/query-transactions queries historical transactions by function call using block explorer APIs. Use it when the contract does not emit events for the operations you need to monitor. Provide functionArgs as a JSON array where empty strings are wildcards.",
-      'tokenConfig must be a JSON string with format: {"mode":"custom","customToken":{"address":"0x...","symbol":"USDC"}}. Do NOT use a flat {address, symbol, decimals} object',
+      'tokenConfig must be a JSON string with format: {"mode":"custom","customToken":{"address":"0x...","symbol":"USDC"}}. On Solana actions (get-spl-token-balance, transfer-spl-token) customToken.address is the base58 mint address. Do NOT use a flat {address, symbol, decimals} object',
       "Use projectId to organize related workflows into a project (e.g., all Sky ESM workflows in one project)",
       "Use tagId to label a workflow with a single tag (e.g., 'production', 'monitoring'). Each workflow supports one tag. Fetch available tags from GET /api/tags first.",
       `Use {{@${BUILTIN_NODE_ID}:${BUILTIN_NODE_LABEL}.unixTimestamp}} for current time comparisons in conditions (e.g., checking if a contract timestamp has passed)`,

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -79,7 +79,7 @@ const web3Plugin: IntegrationPlugin = {
     {
       slug: "check-token-balance",
       label: "Get ERC20 Token Balance",
-      description: "Get the token balance (ERC20 or SPL) of any address",
+      description: "Get ERC20 token balance of any address",
       category: "Web3",
       stepFunction: "checkTokenBalanceStep",
       stepImportPath: "check-token-balance",
@@ -134,7 +134,7 @@ const web3Plugin: IntegrationPlugin = {
           key: "network",
           label: "Network",
           type: "chain-select",
-          // No chainType filter: supports EVM (ERC20) and Solana (SPL) tokens.
+          chainTypeFilter: "evm",
           placeholder: "Select network",
           required: true,
         },
@@ -142,8 +142,87 @@ const web3Plugin: IntegrationPlugin = {
           key: "address",
           label: "Address",
           type: "template-input",
-          placeholder: "0x... / Solana address / {{NodeName.address}}",
+          placeholder: "0x... or {{NodeName.address}}",
           example: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb",
+          required: true,
+        },
+        {
+          key: "tokenConfig",
+          label: "Token",
+          type: "token-select",
+          networkField: "network",
+          required: true,
+        },
+      ],
+    },
+    {
+      slug: "get-spl-token-balance",
+      label: "Get SPL Token Balance",
+      description: "Get SPL token balance of any Solana address",
+      category: "Web3",
+      stepFunction: "getSplTokenBalanceStep",
+      stepImportPath: "get-spl-token-balance",
+      outputFields: [
+        {
+          field: "success",
+          description: "Whether the balance check succeeded",
+        },
+        {
+          field: "balance",
+          description: "Token balance object",
+        },
+        {
+          field: "balance.balance",
+          description: "The token balance amount (human-readable string)",
+        },
+        {
+          field: "balance.balanceRaw",
+          description: "The token balance in raw units (string)",
+        },
+        {
+          field: "balance.symbol",
+          description: "The token symbol (e.g., USDC)",
+        },
+        {
+          field: "balance.decimals",
+          description: "The token decimals",
+        },
+        {
+          field: "balance.name",
+          description: "The token name",
+        },
+        {
+          field: "balance.tokenAddress",
+          description: "The token mint address",
+        },
+        {
+          field: "address",
+          description: "The wallet address that was checked",
+        },
+        {
+          field: "addressLink",
+          description: "Explorer link to the wallet address",
+        },
+        {
+          field: "error",
+          description: "Error message if the check failed",
+        },
+      ],
+      configFields: [
+        {
+          key: "network",
+          label: "Network",
+          type: "chain-select",
+          chainTypeFilter: "solana",
+          placeholder: "Select network",
+          required: true,
+        },
+        {
+          key: "address",
+          label: "Address",
+          type: "template-input",
+          placeholder: "Solana address or {{NodeName.address}}",
+          example: "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
           required: true,
         },
         {

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -71,7 +71,7 @@ const web3Plugin: IntegrationPlugin = {
           label: "Address",
           type: "template-input",
           placeholder: "0x... / Solana address / {{NodeName.address}}",
-          example: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb",
+          example: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
           required: true,
         },
       ],
@@ -143,7 +143,7 @@ const web3Plugin: IntegrationPlugin = {
           label: "Address",
           type: "template-input",
           placeholder: "0x... or {{NodeName.address}}",
-          example: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb",
+          example: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
           required: true,
         },
         {
@@ -230,6 +230,8 @@ const web3Plugin: IntegrationPlugin = {
           label: "Token",
           type: "token-select",
           networkField: "network",
+          example:
+            '{"mode":"custom","customToken":{"address":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC"}}',
           required: true,
         },
       ],
@@ -286,7 +288,7 @@ const web3Plugin: IntegrationPlugin = {
           label: "Recipient Address",
           type: "template-input",
           placeholder: "0x... or {{NodeName.address}}",
-          example: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb",
+          example: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
           required: true,
         },
         {
@@ -401,7 +403,7 @@ const web3Plugin: IntegrationPlugin = {
           label: "Recipient Address",
           type: "template-input",
           placeholder: "0x... or {{NodeName.address}}",
-          example: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb",
+          example: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
           required: true,
         },
         {
@@ -1932,7 +1934,7 @@ const web3Plugin: IntegrationPlugin = {
           label: "Owner Address",
           type: "template-input",
           placeholder: "0x... or {{NodeName.address}}",
-          example: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb",
+          example: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
           required: true,
         },
         {

--- a/plugins/web3/steps/check-token-balance.ts
+++ b/plugins/web3/steps/check-token-balance.ts
@@ -6,6 +6,7 @@ import ERC20_ABI from "@/lib/contracts/abis/erc20.json";
 import { db } from "@/lib/db";
 import { workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logUserError } from "@/lib/logging";
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
@@ -16,7 +17,7 @@ import { validateChainAddress } from "@/lib/web3/validate-chain-address";
 import {
   getTokenAddress,
   parseTokenConfig,
-  type TokenBalance,
+  type TokenBalanceInfo,
   type TokenConfigSource,
 } from "./token-config-core";
 
@@ -42,7 +43,7 @@ async function getUserIdFromExecution(
 type CheckTokenBalanceResult =
   | {
       success: true;
-      balance: TokenBalance;
+      balance: TokenBalanceInfo;
       address: string;
       addressLink: string;
     }
@@ -90,7 +91,7 @@ async function fetchTokenBalance(
   provider: ethers.JsonRpcProvider,
   walletAddress: string,
   tokenAddress: string
-): Promise<TokenBalance> {
+): Promise<TokenBalanceInfo> {
   const contract = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
 
   const [balanceRaw, decimals, symbol, name] = await Promise.all([
@@ -285,7 +286,14 @@ export async function checkTokenBalanceStep(
 ): Promise<CheckTokenBalanceResult> {
   "use step";
 
-  return withStepLogging(input, () => stepHandler(input));
+  return withPluginMetrics(
+    {
+      pluginName: "web3",
+      actionName: "check-token-balance",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => stepHandler(input))
+  );
 }
 
 checkTokenBalanceStep.maxRetries = 0;

--- a/plugins/web3/steps/check-token-balance.ts
+++ b/plugins/web3/steps/check-token-balance.ts
@@ -1,32 +1,24 @@
 import "server-only";
 
-import {
-  ASSOCIATED_TOKEN_PROGRAM_ID,
-  getAssociatedTokenAddressSync,
-  unpackAccount,
-} from "@solana/spl-token";
-import { type Connection, PublicKey } from "@solana/web3.js";
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
-import { isSolanaAddressFormat } from "@/lib/address-utils";
 import ERC20_ABI from "@/lib/contracts/abis/erc20.json";
 import { db } from "@/lib/db";
-import { supportedTokens, workflowExecutions } from "@/lib/db/schema";
+import { workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
-import {
-  getRpcProvider,
-  getSolanaProvider,
-  isSolanaChain,
-} from "@/lib/rpc/provider-factory";
+import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
-import type { CustomToken, TokenFieldValue } from "@/lib/wallet/types";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
-import { SolanaChainAdapter } from "@/lib/web3/chain-adapter/solana";
-import { parseSolanaMintAccount } from "@/lib/web3/solana-mint";
 import { validateChainAddress } from "@/lib/web3/validate-chain-address";
+import {
+  getTokenAddress,
+  parseTokenConfig,
+  type TokenBalance,
+  type TokenConfigSource,
+} from "./token-config-core";
 
 /**
  * Get userId from executionId by querying the workflowExecutions table
@@ -47,15 +39,6 @@ async function getUserIdFromExecution(
   return execution[0]?.userId;
 }
 
-type TokenBalance = {
-  balance: string;
-  balanceRaw: string;
-  symbol: string;
-  decimals: number;
-  name: string;
-  tokenAddress: string;
-};
-
 type CheckTokenBalanceResult =
   | {
       success: true;
@@ -65,205 +48,12 @@ type CheckTokenBalanceResult =
     }
   | { success: false; error: string };
 
-export type CheckTokenBalanceCoreInput = {
+export type CheckTokenBalanceCoreInput = TokenConfigSource & {
   network: string;
   address: string;
-  tokenConfig: string | Record<string, unknown>;
-  // Legacy support
-  tokenAddress?: string;
 };
 
 export type CheckTokenBalanceInput = StepInput & CheckTokenBalanceCoreInput;
-
-/**
- * Extract mode from parsed config, defaulting to "supported"
- */
-function extractMode(parsed: unknown): "supported" | "custom" {
-  if (typeof parsed !== "object" || parsed === null) {
-    return "supported";
-  }
-
-  const config = parsed as Record<string, unknown>;
-  return config.mode === "supported" || config.mode === "custom"
-    ? (config.mode as "supported" | "custom")
-    : "supported";
-}
-
-/**
- * Extract supported token ID from parsed config
- * Handles both new (single) and legacy (array) formats
- */
-function extractSupportedTokenId(parsed: unknown): string | undefined {
-  if (typeof parsed !== "object" || parsed === null) {
-    return;
-  }
-
-  const config = parsed as Record<string, unknown>;
-
-  // New format: single token ID
-  if (typeof config.supportedTokenId === "string") {
-    return config.supportedTokenId;
-  }
-
-  // Legacy format: array - use first element
-  if (
-    Array.isArray(config.supportedTokenIds) &&
-    config.supportedTokenIds.length > 0
-  ) {
-    const firstId = config.supportedTokenIds[0];
-    return typeof firstId === "string" ? firstId : undefined;
-  }
-
-  return;
-}
-
-/**
- * Extract custom token from parsed config
- * Handles both new (single) and legacy (array/string) formats
- */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Handles multiple legacy formats for backwards compatibility
-function extractCustomToken(parsed: unknown): CustomToken | undefined {
-  if (typeof parsed !== "object" || parsed === null) {
-    return;
-  }
-
-  const config = parsed as Record<string, unknown>;
-
-  // New format: single custom token object
-  if (
-    config.customToken &&
-    typeof config.customToken === "object" &&
-    config.customToken !== null
-  ) {
-    const token = config.customToken as Record<string, unknown>;
-    if (typeof token.address === "string" && typeof token.symbol === "string") {
-      return { address: token.address, symbol: token.symbol };
-    }
-  }
-
-  // Legacy format: array of custom tokens - use first element
-  if (Array.isArray(config.customTokens) && config.customTokens.length > 0) {
-    const firstToken = config.customTokens[0];
-    if (
-      firstToken &&
-      typeof firstToken === "object" &&
-      typeof firstToken.address === "string" &&
-      typeof firstToken.symbol === "string"
-    ) {
-      return {
-        address: firstToken.address,
-        symbol: firstToken.symbol,
-      };
-    }
-  }
-
-  // Legacy format: array of addresses - convert first address to token
-  if (
-    Array.isArray(config.customTokenAddresses) &&
-    config.customTokenAddresses.length > 0
-  ) {
-    const address = config.customTokenAddresses.find(
-      (a): a is string => typeof a === "string" && a.trim() !== ""
-    );
-    if (address) {
-      return { address, symbol: "???" };
-    }
-  }
-
-  // Legacy format: single address string
-  if (typeof config.customTokenAddress === "string") {
-    return { address: config.customTokenAddress, symbol: "???" };
-  }
-
-  return;
-}
-
-/**
- * Parse token config from input
- * Supports both new (single token) and legacy (array) formats
- */
-function parseTokenConfig(input: CheckTokenBalanceInput): TokenFieldValue {
-  // Legacy support: if tokenAddress is provided directly, use custom mode
-  if (input.tokenAddress && !input.tokenConfig) {
-    return {
-      mode: "custom",
-      customToken: { address: input.tokenAddress, symbol: "???" },
-    };
-  }
-
-  if (!input.tokenConfig) {
-    return {
-      mode: "supported",
-    };
-  }
-
-  // Object values from API/MCP-created workflows
-  if (typeof input.tokenConfig === "object") {
-    return {
-      mode: extractMode(input.tokenConfig),
-      supportedTokenId: extractSupportedTokenId(input.tokenConfig),
-      customToken: extractCustomToken(input.tokenConfig),
-    };
-  }
-
-  try {
-    const parsed = JSON.parse(input.tokenConfig);
-
-    return {
-      mode: extractMode(parsed),
-      supportedTokenId: extractSupportedTokenId(parsed),
-      customToken: extractCustomToken(parsed),
-    };
-  } catch {
-    // If parsing fails and it looks like an address (EVM 0x-hex or Solana
-    // base58), treat as custom.
-    if (
-      input.tokenConfig.startsWith("0x") ||
-      isSolanaAddressFormat(input.tokenConfig)
-    ) {
-      return {
-        mode: "custom",
-        customToken: { address: input.tokenConfig, symbol: "???" },
-      };
-    }
-    return {
-      mode: "supported",
-    };
-  }
-}
-
-/**
- * Get token address to check based on config
- * Returns a single token address (either supported or custom)
- */
-async function getTokenAddress(
-  config: TokenFieldValue,
-  chainId: number
-): Promise<string | null> {
-  // Get supported token address from database
-  if (config.supportedTokenId) {
-    const tokens = await db
-      .select({ tokenAddress: supportedTokens.tokenAddress })
-      .from(supportedTokens)
-      .where(
-        and(
-          eq(supportedTokens.chainId, chainId),
-          eq(supportedTokens.id, config.supportedTokenId)
-        )
-      )
-      .limit(1);
-    if (tokens[0]?.tokenAddress) {
-      return tokens[0].tokenAddress;
-    }
-  }
-
-  // Get custom token address
-  if (config.customToken?.address) {
-    return config.customToken.address;
-  }
-
-  return null;
-}
 
 /**
  * Fetch a string metadata field from a token contract, handling non-standard
@@ -324,102 +114,7 @@ async function fetchTokenBalance(
 }
 
 /**
- * Resolve a display symbol/name for an SPL mint. Solana has no on-chain
- * equivalent of ERC20's symbol()/name() (that lives in a separate Metaplex
- * metadata account this action does not integrate with), so this falls back
- * to whatever the caller already told us: the custom-token symbol supplied
- * in tokenConfig, or a matching row in supportedTokens if one exists.
- */
-async function getSolanaTokenDisplayInfo(
-  tokenConfig: TokenFieldValue,
-  chainId: number,
-  tokenAddress: string
-): Promise<{ symbol: string; name: string }> {
-  // "???" is this file's own unknown-symbol sentinel (see extractCustomToken /
-  // parseTokenConfig's legacy fallbacks above) - it is not a real symbol, so
-  // it must fall through to the DB lookup below rather than short-circuit it.
-  if (tokenConfig.customToken?.symbol && tokenConfig.customToken.symbol !== "???") {
-    return {
-      symbol: tokenConfig.customToken.symbol,
-      name: tokenConfig.customToken.symbol,
-    };
-  }
-
-  const tokens = await db
-    .select({ symbol: supportedTokens.symbol, name: supportedTokens.name })
-    .from(supportedTokens)
-    .where(
-      and(
-        eq(supportedTokens.chainId, chainId),
-        eq(supportedTokens.tokenAddress, tokenAddress)
-      )
-    )
-    .limit(1);
-
-  return {
-    symbol: tokens[0]?.symbol ?? "???",
-    name: tokens[0]?.name ?? "Unknown",
-  };
-}
-
-/**
- * Fetch an SPL token balance for a wallet. A wallet with no associated
- * token account for this mint has never held the token, which is a zero
- * balance (matching ERC20 balanceOf() on an unfunded holder), not an error.
- */
-async function fetchSolanaTokenBalance(
-  connection: Connection,
-  walletAddress: string,
-  tokenAddress: string,
-  symbol: string,
-  name: string
-): Promise<TokenBalance> {
-  const mintPubkey = new PublicKey(tokenAddress);
-  const ownerPubkey = new PublicKey(walletAddress);
-
-  const mintInfo = await connection.getAccountInfo(mintPubkey, "confirmed");
-  if (!mintInfo) {
-    throw new Error(`Mint account not found: ${mintPubkey.toBase58()}`);
-  }
-  const resolved = parseSolanaMintAccount(mintPubkey, mintInfo);
-  if ("error" in resolved) {
-    throw new Error(resolved.error);
-  }
-  const { mint, programId } = resolved;
-
-  // Off-curve owners (PDA/program-owned wallets, e.g. a multisig treasury)
-  // are legitimate holders to check - matching transfer-spl-token-core.ts's
-  // handling of off-curve recipients. Derivation is synchronous (no RPC).
-  const associatedTokenAddress = getAssociatedTokenAddressSync(
-    mintPubkey,
-    ownerPubkey,
-    true,
-    programId,
-    ASSOCIATED_TOKEN_PROGRAM_ID
-  );
-
-  const accountInfo = await connection.getAccountInfo(
-    associatedTokenAddress,
-    "confirmed"
-  );
-  const balanceRaw = accountInfo
-    ? unpackAccount(associatedTokenAddress, accountInfo, programId).amount
-    : BigInt(0);
-
-  const balance = ethers.formatUnits(balanceRaw, mint.decimals);
-
-  return {
-    balance,
-    balanceRaw: balanceRaw.toString(),
-    symbol,
-    decimals: mint.decimals,
-    name,
-    tokenAddress,
-  };
-}
-
-/**
- * EVM branch: resolve an RPC provider and read the ERC20 balance/metadata.
+ * Resolve an RPC provider and read the ERC20 balance/metadata.
  */
 async function checkEvmTokenBalance(
   address: string,
@@ -476,59 +171,6 @@ async function checkEvmTokenBalance(
 }
 
 /**
- * Solana branch: a fresh, userId-aware adapter is constructed directly
- * (bypassing getChainAdapter's chainId-only cache) so a user's custom RPC
- * preference is actually honored here, the same way getRpcProvider({chainId,
- * userId}) already honors it on the EVM branch above.
- */
-async function checkSolanaTokenBalance(
-  address: string,
-  tokenAddress: string,
-  chainId: number,
-  userId: string | undefined,
-  tokenConfig: TokenFieldValue
-): Promise<CheckTokenBalanceResult> {
-  const adapter = new SolanaChainAdapter(chainId, () =>
-    getSolanaProvider({ chainId, userId })
-  );
-
-  try {
-    const displayInfo = await getSolanaTokenDisplayInfo(
-      tokenConfig,
-      chainId,
-      tokenAddress
-    );
-    const balance = await adapter.executeWithSolanaFailover((connection) =>
-      fetchSolanaTokenBalance(
-        connection,
-        address,
-        tokenAddress,
-        displayInfo.symbol,
-        displayInfo.name
-      )
-    );
-    const addressLink = await adapter.getAddressUrl(address);
-
-    return { success: true, balance, address, addressLink };
-  } catch (error) {
-    logUserError(
-      ErrorCategory.NETWORK_RPC,
-      "[Check Token Balance] Failed to check token balance:",
-      error,
-      {
-        plugin_name: "web3",
-        action_name: "check-token-balance",
-        chain_id: String(chainId),
-      }
-    );
-    return {
-      success: false,
-      error: `Failed to check token balance: ${getErrorMessage(error)}`,
-    };
-  }
-}
-
-/**
  * Core check token balance logic
  */
 async function stepHandler(
@@ -553,8 +195,6 @@ async function stepHandler(
     );
   }
 
-  // Resolve the chain first so address validation can branch on the chain
-  // family (EVM vs Solana) - see lib/web3/validate-chain-address.ts.
   let chainId: number;
   try {
     chainId = getChainIdFromNetwork(network);
@@ -572,6 +212,14 @@ async function stepHandler(
     return {
       success: false,
       error: getErrorMessage(error),
+    };
+  }
+
+  if (isSolanaChain(chainId)) {
+    return {
+      success: false,
+      error:
+        "Solana chains are not supported by this action. Use the Get SPL Token Balance action for SPL tokens.",
     };
   }
 
@@ -624,9 +272,7 @@ async function stepHandler(
     };
   }
 
-  return isSolanaChain(chainId)
-    ? checkSolanaTokenBalance(address, tokenAddress, chainId, userId, tokenConfig)
-    : checkEvmTokenBalance(address, tokenAddress, chainId, userId);
+  return checkEvmTokenBalance(address, tokenAddress, chainId, userId);
 }
 
 /**

--- a/plugins/web3/steps/get-spl-token-balance.ts
+++ b/plugins/web3/steps/get-spl-token-balance.ts
@@ -1,0 +1,379 @@
+import "server-only";
+
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  getAssociatedTokenAddressSync,
+  unpackAccount,
+} from "@solana/spl-token";
+import { type Connection, PublicKey } from "@solana/web3.js";
+import { and, eq } from "drizzle-orm";
+import { ethers } from "ethers";
+import { db } from "@/lib/db";
+import { supportedTokens, workflowExecutions } from "@/lib/db/schema";
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { getSolanaProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
+import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
+import { getErrorMessage } from "@/lib/utils";
+import type { TokenFieldValue } from "@/lib/wallet/types";
+import { SolanaChainAdapter } from "@/lib/web3/chain-adapter/solana";
+import { parseSolanaMintAccount } from "@/lib/web3/solana-mint";
+import { validateChainAddress } from "@/lib/web3/validate-chain-address";
+import {
+  getTokenAddress,
+  parseTokenConfig,
+  type TokenBalance,
+  type TokenConfigSource,
+} from "./token-config-core";
+
+const METAPLEX_METADATA_PROGRAM_ID = new PublicKey(
+  "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+);
+const METADATA_SEED = Buffer.from("metadata");
+// Metadata layout before the name field: key (1) + updateAuthority (32) +
+// mint (32).
+const METADATA_NAME_OFFSET = 65;
+const TRAILING_NULLS = /\0+$/;
+
+export type GetSplTokenBalanceCoreInput = TokenConfigSource & {
+  network: string;
+  address: string;
+};
+
+export type GetSplTokenBalanceInput = StepInput & GetSplTokenBalanceCoreInput;
+
+type GetSplTokenBalanceResult =
+  | {
+      success: true;
+      balance: TokenBalance;
+      address: string;
+      addressLink: string;
+    }
+  | { success: false; error: string };
+
+/**
+ * Get userId from executionId by querying the workflowExecutions table
+ */
+async function getUserIdFromExecution(
+  executionId: string | undefined
+): Promise<string | undefined> {
+  if (!executionId) {
+    return;
+  }
+
+  const execution = await db
+    .select({ userId: workflowExecutions.userId })
+    .from(workflowExecutions)
+    .where(eq(workflowExecutions.id, executionId))
+    .limit(1);
+
+  return execution[0]?.userId;
+}
+
+/**
+ * Read a borsh string (u32 LE length prefix + utf8 bytes) at offset,
+ * trimming the trailing null padding Metaplex writes inside the declared
+ * length. Returns null when the declared length runs past the buffer.
+ */
+function readBorshString(
+  data: Buffer,
+  offset: number
+): { value: string; nextOffset: number } | null {
+  if (offset + 4 > data.length) {
+    return null;
+  }
+  const length = data.readUInt32LE(offset);
+  const start = offset + 4;
+  if (start + length > data.length) {
+    return null;
+  }
+  const value = data
+    .subarray(start, start + length)
+    .toString("utf8")
+    .replace(TRAILING_NULLS, "")
+    .trim();
+  return { value, nextOffset: start + length };
+}
+
+/**
+ * Resolve symbol/name from the mint's Metaplex token metadata PDA. Returns
+ * null when no metadata account exists or its data does not parse - callers
+ * fall back to the unknown-token sentinels.
+ */
+async function fetchMetaplexDisplayInfo(
+  connection: Connection,
+  mintPubkey: PublicKey
+): Promise<{ symbol: string; name: string } | null> {
+  const [metadataAddress] = PublicKey.findProgramAddressSync(
+    [METADATA_SEED, METAPLEX_METADATA_PROGRAM_ID.toBuffer(), mintPubkey.toBuffer()],
+    METAPLEX_METADATA_PROGRAM_ID
+  );
+
+  const accountInfo = await connection.getAccountInfo(
+    metadataAddress,
+    "confirmed"
+  );
+  if (!accountInfo) {
+    return null;
+  }
+
+  const name = readBorshString(accountInfo.data, METADATA_NAME_OFFSET);
+  if (!name) {
+    return null;
+  }
+  const symbol = readBorshString(accountInfo.data, name.nextOffset);
+  if (!symbol || (!name.value && !symbol.value)) {
+    return null;
+  }
+
+  return {
+    symbol: symbol.value || "???",
+    name: name.value || "Unknown",
+  };
+}
+
+/**
+ * Resolve a display symbol/name without touching the chain: the custom-token
+ * symbol supplied in tokenConfig, or a matching supportedTokens row. Returns
+ * null when neither knows the token, so the caller can try Metaplex metadata.
+ */
+async function getOffChainDisplayInfo(
+  tokenConfig: TokenFieldValue,
+  chainId: number,
+  tokenAddress: string
+): Promise<{ symbol: string; name: string } | null> {
+  // "???" is the token-config parser's own unknown-symbol sentinel (see
+  // token-config-core.ts) - it is not a real symbol, so it must fall through
+  // to the DB lookup rather than short-circuit it.
+  if (
+    tokenConfig.customToken?.symbol &&
+    tokenConfig.customToken.symbol !== "???"
+  ) {
+    return {
+      symbol: tokenConfig.customToken.symbol,
+      name: tokenConfig.customToken.symbol,
+    };
+  }
+
+  const tokens = await db
+    .select({ symbol: supportedTokens.symbol, name: supportedTokens.name })
+    .from(supportedTokens)
+    .where(
+      and(
+        eq(supportedTokens.chainId, chainId),
+        eq(supportedTokens.tokenAddress, tokenAddress)
+      )
+    )
+    .limit(1);
+
+  if (tokens[0]) {
+    return { symbol: tokens[0].symbol, name: tokens[0].name };
+  }
+  return null;
+}
+
+/**
+ * Fetch an SPL token balance for a wallet. A wallet with no associated
+ * token account for this mint has never held the token, which is a zero
+ * balance (matching ERC20 balanceOf() on an unfunded holder), not an error.
+ */
+async function fetchSplBalance(
+  connection: Connection,
+  walletAddress: string,
+  tokenAddress: string
+): Promise<{ balanceRaw: bigint; decimals: number; mintPubkey: PublicKey }> {
+  const mintPubkey = new PublicKey(tokenAddress);
+  const ownerPubkey = new PublicKey(walletAddress);
+
+  const mintInfo = await connection.getAccountInfo(mintPubkey, "confirmed");
+  if (!mintInfo) {
+    throw new Error(`Mint account not found: ${mintPubkey.toBase58()}`);
+  }
+  const resolved = parseSolanaMintAccount(mintPubkey, mintInfo);
+  if ("error" in resolved) {
+    throw new Error(resolved.error);
+  }
+  const { mint, programId } = resolved;
+
+  // Off-curve owners (PDA/program-owned wallets, e.g. a multisig treasury)
+  // are legitimate holders to check - matching transfer-spl-token-core.ts's
+  // handling of off-curve recipients. Derivation is synchronous (no RPC).
+  const associatedTokenAddress = getAssociatedTokenAddressSync(
+    mintPubkey,
+    ownerPubkey,
+    true,
+    programId,
+    ASSOCIATED_TOKEN_PROGRAM_ID
+  );
+
+  const accountInfo = await connection.getAccountInfo(
+    associatedTokenAddress,
+    "confirmed"
+  );
+  const balanceRaw = accountInfo
+    ? unpackAccount(associatedTokenAddress, accountInfo, programId).amount
+    : BigInt(0);
+
+  return { balanceRaw, decimals: mint.decimals, mintPubkey };
+}
+
+/**
+ * Core get SPL token balance logic
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: linear validation ladder mirroring check-token-balance
+async function stepHandler(
+  input: GetSplTokenBalanceInput
+): Promise<GetSplTokenBalanceResult> {
+  const { network, address, _context } = input;
+  const tokenConfig = parseTokenConfig(input);
+
+  // Get userId from execution context (for user RPC preferences)
+  const userId = await getUserIdFromExecution(_context?.executionId);
+
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(network);
+  } catch (error) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[Get SPL Token Balance] Failed to resolve network:",
+      error,
+      {
+        plugin_name: "web3",
+        action_name: "get-spl-token-balance",
+      }
+    );
+    return {
+      success: false,
+      error: getErrorMessage(error),
+    };
+  }
+
+  if (!isSolanaChain(chainId)) {
+    return {
+      success: false,
+      error:
+        "This action only supports Solana chains. Use the Get ERC20 Token Balance action for EVM tokens.",
+    };
+  }
+
+  if (!validateChainAddress(address, chainId)) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[Get SPL Token Balance] Invalid wallet address:",
+      address,
+      {
+        plugin_name: "web3",
+        action_name: "get-spl-token-balance",
+      }
+    );
+    return {
+      success: false,
+      error: `Invalid wallet address: ${address}`,
+    };
+  }
+
+  const tokenAddress = await getTokenAddress(tokenConfig, chainId);
+  if (!tokenAddress) {
+    return {
+      success: false,
+      error: "No token selected to check",
+    };
+  }
+
+  if (!validateChainAddress(tokenAddress, chainId)) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[Get SPL Token Balance] Invalid token address:",
+      tokenAddress,
+      {
+        plugin_name: "web3",
+        action_name: "get-spl-token-balance",
+      }
+    );
+    return {
+      success: false,
+      error: `Invalid token address: ${tokenAddress}`,
+    };
+  }
+
+  // A fresh, userId-aware adapter is constructed directly (bypassing
+  // getChainAdapter's chainId-only cache) so a user's custom RPC preference
+  // is honored, matching the other Solana steps.
+  const adapter = new SolanaChainAdapter(chainId, () =>
+    getSolanaProvider({ chainId, userId })
+  );
+
+  try {
+    const offChainDisplay = await getOffChainDisplayInfo(
+      tokenConfig,
+      chainId,
+      tokenAddress
+    );
+    const balance = await adapter.executeWithSolanaFailover(
+      async (connection) => {
+        const { balanceRaw, decimals, mintPubkey } = await fetchSplBalance(
+          connection,
+          address,
+          tokenAddress
+        );
+        const display =
+          offChainDisplay ??
+          (await fetchMetaplexDisplayInfo(connection, mintPubkey)) ?? {
+            symbol: "???",
+            name: "Unknown",
+          };
+        return {
+          balance: ethers.formatUnits(balanceRaw, decimals),
+          balanceRaw: balanceRaw.toString(),
+          symbol: display.symbol,
+          decimals,
+          name: display.name,
+          tokenAddress,
+        };
+      }
+    );
+    const addressLink = await adapter.getAddressUrl(address);
+
+    return { success: true, balance, address, addressLink };
+  } catch (error) {
+    logUserError(
+      ErrorCategory.NETWORK_RPC,
+      "[Get SPL Token Balance] Failed to check token balance:",
+      error,
+      {
+        plugin_name: "web3",
+        action_name: "get-spl-token-balance",
+        chain_id: String(chainId),
+      }
+    );
+    return {
+      success: false,
+      error: `Failed to check token balance: ${getErrorMessage(error)}`,
+    };
+  }
+}
+
+/**
+ * Get SPL Token Balance Step
+ * Checks the SPL token balance of a Solana address for a single mint.
+ */
+export async function getSplTokenBalanceStep(
+  input: GetSplTokenBalanceInput
+): Promise<GetSplTokenBalanceResult> {
+  "use step";
+
+  return withPluginMetrics(
+    {
+      pluginName: "web3",
+      actionName: "get-spl-token-balance",
+      executionId: input._context?.executionId,
+    },
+    () => withStepLogging(input, () => stepHandler(input))
+  );
+}
+
+getSplTokenBalanceStep.maxRetries = 0;
+
+export const _integrationType = "web3";

--- a/plugins/web3/steps/get-spl-token-balance.ts
+++ b/plugins/web3/steps/get-spl-token-balance.ts
@@ -23,7 +23,7 @@ import { validateChainAddress } from "@/lib/web3/validate-chain-address";
 import {
   getTokenAddress,
   parseTokenConfig,
-  type TokenBalance,
+  type TokenBalanceInfo,
   type TokenConfigSource,
 } from "./token-config-core";
 
@@ -34,7 +34,16 @@ const METADATA_SEED = Buffer.from("metadata");
 // Metadata layout before the name field: key (1) + updateAuthority (32) +
 // mint (32).
 const METADATA_NAME_OFFSET = 65;
-const TRAILING_NULLS = /\0+$/;
+// Metaplex convention caps the name at 32 bytes and the symbol at 10.
+const MAX_METADATA_NAME_LENGTH = 32;
+const MAX_METADATA_SYMBOL_LENGTH = 10;
+// Metadata strings are attacker-authored on-chain bytes that flow into the
+// step output and downstream notification templates, so control characters
+// (embedded NULs included), bidi overrides, and zero-width characters are
+// stripped rather than passed through.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping control characters is the point
+const DISALLOWED_METADATA_CHARS =
+  /[\u0000-\u001f\u007f-\u009f\u200b-\u200f\u202a-\u202e\u2066-\u2069\ufeff]/g;
 
 export type GetSplTokenBalanceCoreInput = TokenConfigSource & {
   network: string;
@@ -46,14 +55,18 @@ export type GetSplTokenBalanceInput = StepInput & GetSplTokenBalanceCoreInput;
 type GetSplTokenBalanceResult =
   | {
       success: true;
-      balance: TokenBalance;
+      balance: TokenBalanceInfo;
       address: string;
       addressLink: string;
     }
   | { success: false; error: string };
 
 /**
- * Get userId from executionId by querying the workflowExecutions table
+ * Get userId from executionId by querying the workflowExecutions table.
+ *
+ * Non-throwing by design: RPC preferences are a per-user convenience, not an
+ * authority signal, so a lookup failure falls back to the chain's default RPC
+ * config rather than failing the balance check.
  */
 async function getUserIdFromExecution(
   executionId: string | undefined
@@ -62,23 +75,29 @@ async function getUserIdFromExecution(
     return;
   }
 
-  const execution = await db
-    .select({ userId: workflowExecutions.userId })
-    .from(workflowExecutions)
-    .where(eq(workflowExecutions.id, executionId))
-    .limit(1);
+  try {
+    const execution = await db
+      .select({ userId: workflowExecutions.userId })
+      .from(workflowExecutions)
+      .where(eq(workflowExecutions.id, executionId))
+      .limit(1);
 
-  return execution[0]?.userId;
+    return execution[0]?.userId;
+  } catch {
+    return;
+  }
 }
 
 /**
  * Read a borsh string (u32 LE length prefix + utf8 bytes) at offset,
- * trimming the trailing null padding Metaplex writes inside the declared
- * length. Returns null when the declared length runs past the buffer.
+ * stripping the null padding Metaplex writes inside the declared length
+ * along with any other disallowed characters, and capping the result at
+ * maxLength. Returns null when the declared length runs past the buffer.
  */
 function readBorshString(
   data: Buffer,
-  offset: number
+  offset: number,
+  maxLength: number
 ): { value: string; nextOffset: number } | null {
   if (offset + 4 > data.length) {
     return null;
@@ -91,46 +110,64 @@ function readBorshString(
   const value = data
     .subarray(start, start + length)
     .toString("utf8")
-    .replace(TRAILING_NULLS, "")
-    .trim();
+    .replace(DISALLOWED_METADATA_CHARS, "")
+    .trim()
+    .slice(0, maxLength);
   return { value, nextOffset: start + length };
 }
 
 /**
  * Resolve symbol/name from the mint's Metaplex token metadata PDA. Returns
- * null when no metadata account exists or its data does not parse - callers
- * fall back to the unknown-token sentinels.
+ * null when no metadata account exists, its data does not parse, or the
+ * lookup itself fails - the metadata read is cosmetic, so it must never
+ * fail a balance check; callers fall back to the unknown-token sentinels.
  */
 async function fetchMetaplexDisplayInfo(
   connection: Connection,
   mintPubkey: PublicKey
 ): Promise<{ symbol: string; name: string } | null> {
-  const [metadataAddress] = PublicKey.findProgramAddressSync(
-    [METADATA_SEED, METAPLEX_METADATA_PROGRAM_ID.toBuffer(), mintPubkey.toBuffer()],
-    METAPLEX_METADATA_PROGRAM_ID
-  );
+  try {
+    const [metadataAddress] = PublicKey.findProgramAddressSync(
+      [
+        METADATA_SEED,
+        METAPLEX_METADATA_PROGRAM_ID.toBuffer(),
+        mintPubkey.toBuffer(),
+      ],
+      METAPLEX_METADATA_PROGRAM_ID
+    );
 
-  const accountInfo = await connection.getAccountInfo(
-    metadataAddress,
-    "confirmed"
-  );
-  if (!accountInfo) {
+    const accountInfo = await connection.getAccountInfo(
+      metadataAddress,
+      "confirmed"
+    );
+    if (!accountInfo) {
+      return null;
+    }
+
+    const name = readBorshString(
+      accountInfo.data,
+      METADATA_NAME_OFFSET,
+      MAX_METADATA_NAME_LENGTH
+    );
+    if (!name) {
+      return null;
+    }
+    const symbol = readBorshString(
+      accountInfo.data,
+      name.nextOffset,
+      MAX_METADATA_SYMBOL_LENGTH
+    );
+    if (!name.value && !symbol?.value) {
+      return null;
+    }
+
+    return {
+      symbol: symbol?.value || "???",
+      name: name.value || "Unknown",
+    };
+  } catch {
     return null;
   }
-
-  const name = readBorshString(accountInfo.data, METADATA_NAME_OFFSET);
-  if (!name) {
-    return null;
-  }
-  const symbol = readBorshString(accountInfo.data, name.nextOffset);
-  if (!symbol || (!name.value && !symbol.value)) {
-    return null;
-  }
-
-  return {
-    symbol: symbol.value || "???",
-    name: name.value || "Unknown",
-  };
 }
 
 /**
@@ -221,7 +258,6 @@ async function fetchSplBalance(
 /**
  * Core get SPL token balance logic
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: linear validation ladder mirroring check-token-balance
 async function stepHandler(
   input: GetSplTokenBalanceInput
 ): Promise<GetSplTokenBalanceResult> {

--- a/plugins/web3/steps/query-solana-program-events-core.ts
+++ b/plugins/web3/steps/query-solana-program-events-core.ts
@@ -124,6 +124,14 @@ function parseSignatureLookback(
       };
     }
     parsed = Number.parseInt(trimmed, 10);
+    // The regex only admits digit strings, so the remaining invalid case is
+    // "0" - reject it like the number branch rejects 0.
+    if (parsed <= 0) {
+      return {
+        success: false,
+        error: `Invalid signatureLookback value: ${input}`,
+      };
+    }
   }
 
   return { success: true, value: Math.min(parsed, MAX_SIGNATURE_LOOKBACK) };

--- a/plugins/web3/steps/query-solana-program-events-core.ts
+++ b/plugins/web3/steps/query-solana-program-events-core.ts
@@ -116,6 +116,14 @@ function parseSignatureLookback(
     }
     parsed = input;
   } else {
+    // Node config is untyped JSON at runtime - a boolean/array/object here
+    // must fail as invalid input, not throw on .trim().
+    if (typeof input !== "string") {
+      return {
+        success: false,
+        error: `Invalid signatureLookback value: ${String(input)}`,
+      };
+    }
     const trimmed = input.trim();
     if (!INTEGER_STRING_RE.test(trimmed)) {
       return {

--- a/plugins/web3/steps/token-config-core.ts
+++ b/plugins/web3/steps/token-config-core.ts
@@ -1,0 +1,217 @@
+/**
+ * Shared token-config parsing for the token balance steps.
+ *
+ * IMPORTANT: This file must NOT contain "use step" or be a step file.
+ */
+import "server-only";
+
+import { and, eq } from "drizzle-orm";
+import { isSolanaAddressFormat } from "@/lib/address-utils";
+import { db } from "@/lib/db";
+import { supportedTokens } from "@/lib/db/schema";
+import type { CustomToken, TokenFieldValue } from "@/lib/wallet/types";
+
+export type TokenBalance = {
+  balance: string;
+  balanceRaw: string;
+  symbol: string;
+  decimals: number;
+  name: string;
+  tokenAddress: string;
+};
+
+export type TokenConfigSource = {
+  tokenConfig: string | Record<string, unknown>;
+  // Legacy support
+  tokenAddress?: string;
+};
+
+/**
+ * Extract mode from parsed config, defaulting to "supported"
+ */
+function extractMode(parsed: unknown): "supported" | "custom" {
+  if (typeof parsed !== "object" || parsed === null) {
+    return "supported";
+  }
+
+  const config = parsed as Record<string, unknown>;
+  return config.mode === "supported" || config.mode === "custom"
+    ? (config.mode as "supported" | "custom")
+    : "supported";
+}
+
+/**
+ * Extract supported token ID from parsed config
+ * Handles both new (single) and legacy (array) formats
+ */
+function extractSupportedTokenId(parsed: unknown): string | undefined {
+  if (typeof parsed !== "object" || parsed === null) {
+    return;
+  }
+
+  const config = parsed as Record<string, unknown>;
+
+  // New format: single token ID
+  if (typeof config.supportedTokenId === "string") {
+    return config.supportedTokenId;
+  }
+
+  // Legacy format: array - use first element
+  if (
+    Array.isArray(config.supportedTokenIds) &&
+    config.supportedTokenIds.length > 0
+  ) {
+    const firstId = config.supportedTokenIds[0];
+    return typeof firstId === "string" ? firstId : undefined;
+  }
+
+  return;
+}
+
+/**
+ * Extract custom token from parsed config
+ * Handles both new (single) and legacy (array/string) formats
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Handles multiple legacy formats for backwards compatibility
+function extractCustomToken(parsed: unknown): CustomToken | undefined {
+  if (typeof parsed !== "object" || parsed === null) {
+    return;
+  }
+
+  const config = parsed as Record<string, unknown>;
+
+  // New format: single custom token object
+  if (
+    config.customToken &&
+    typeof config.customToken === "object" &&
+    config.customToken !== null
+  ) {
+    const token = config.customToken as Record<string, unknown>;
+    if (typeof token.address === "string" && typeof token.symbol === "string") {
+      return { address: token.address, symbol: token.symbol };
+    }
+  }
+
+  // Legacy format: array of custom tokens - use first element
+  if (Array.isArray(config.customTokens) && config.customTokens.length > 0) {
+    const firstToken = config.customTokens[0];
+    if (
+      firstToken &&
+      typeof firstToken === "object" &&
+      typeof firstToken.address === "string" &&
+      typeof firstToken.symbol === "string"
+    ) {
+      return {
+        address: firstToken.address,
+        symbol: firstToken.symbol,
+      };
+    }
+  }
+
+  // Legacy format: array of addresses - convert first address to token
+  if (
+    Array.isArray(config.customTokenAddresses) &&
+    config.customTokenAddresses.length > 0
+  ) {
+    const address = config.customTokenAddresses.find(
+      (a): a is string => typeof a === "string" && a.trim() !== ""
+    );
+    if (address) {
+      return { address, symbol: "???" };
+    }
+  }
+
+  // Legacy format: single address string
+  if (typeof config.customTokenAddress === "string") {
+    return { address: config.customTokenAddress, symbol: "???" };
+  }
+
+  return;
+}
+
+/**
+ * Parse token config from input
+ * Supports both new (single token) and legacy (array) formats
+ */
+export function parseTokenConfig(input: TokenConfigSource): TokenFieldValue {
+  // Legacy support: if tokenAddress is provided directly, use custom mode
+  if (input.tokenAddress && !input.tokenConfig) {
+    return {
+      mode: "custom",
+      customToken: { address: input.tokenAddress, symbol: "???" },
+    };
+  }
+
+  if (!input.tokenConfig) {
+    return {
+      mode: "supported",
+    };
+  }
+
+  // Object values from API/MCP-created workflows
+  if (typeof input.tokenConfig === "object") {
+    return {
+      mode: extractMode(input.tokenConfig),
+      supportedTokenId: extractSupportedTokenId(input.tokenConfig),
+      customToken: extractCustomToken(input.tokenConfig),
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(input.tokenConfig);
+
+    return {
+      mode: extractMode(parsed),
+      supportedTokenId: extractSupportedTokenId(parsed),
+      customToken: extractCustomToken(parsed),
+    };
+  } catch {
+    // If parsing fails and it looks like an address (EVM 0x-hex or Solana
+    // base58), treat as custom.
+    if (
+      input.tokenConfig.startsWith("0x") ||
+      isSolanaAddressFormat(input.tokenConfig)
+    ) {
+      return {
+        mode: "custom",
+        customToken: { address: input.tokenConfig, symbol: "???" },
+      };
+    }
+    return {
+      mode: "supported",
+    };
+  }
+}
+
+/**
+ * Get token address to check based on config
+ * Returns a single token address (either supported or custom)
+ */
+export async function getTokenAddress(
+  config: TokenFieldValue,
+  chainId: number
+): Promise<string | null> {
+  // Get supported token address from database
+  if (config.supportedTokenId) {
+    const tokens = await db
+      .select({ tokenAddress: supportedTokens.tokenAddress })
+      .from(supportedTokens)
+      .where(
+        and(
+          eq(supportedTokens.chainId, chainId),
+          eq(supportedTokens.id, config.supportedTokenId)
+        )
+      )
+      .limit(1);
+    if (tokens[0]?.tokenAddress) {
+      return tokens[0].tokenAddress;
+    }
+  }
+
+  // Get custom token address
+  if (config.customToken?.address) {
+    return config.customToken.address;
+  }
+
+  return null;
+}

--- a/plugins/web3/steps/token-config-core.ts
+++ b/plugins/web3/steps/token-config-core.ts
@@ -11,7 +11,9 @@ import { db } from "@/lib/db";
 import { supportedTokens } from "@/lib/db/schema";
 import type { CustomToken, TokenFieldValue } from "@/lib/wallet/types";
 
-export type TokenBalance = {
+// Named TokenBalanceInfo rather than TokenBalance to avoid colliding with
+// the structurally different wallet-UI TokenBalance in lib/wallet/types.ts.
+export type TokenBalanceInfo = {
   balance: string;
   balanceRaw: string;
   symbol: string;
@@ -21,7 +23,8 @@ export type TokenBalance = {
 };
 
 export type TokenConfigSource = {
-  tokenConfig: string | Record<string, unknown>;
+  // Optional: legacy stored node configs can omit it entirely.
+  tokenConfig?: string | Record<string, unknown>;
   // Legacy support
   tokenAddress?: string;
 };

--- a/tests/integration/get-spl-token-balance.test.ts
+++ b/tests/integration/get-spl-token-balance.test.ts
@@ -65,8 +65,8 @@ vi.mock("@/lib/web3/chain-adapter", () => ({
 }));
 
 // Fake adapter: constructed directly (not via the shared registry) so the
-// step can thread userId into getSolanaProvider - see checkSolanaTokenBalance
-// in check-token-balance.ts. The real adapter would resolve an on-chain RPC
+// step can thread userId into getSolanaProvider - see stepHandler in
+// get-spl-token-balance.ts. The real adapter would resolve an on-chain RPC
 // connection; here executeWithSolanaFailover both exercises the
 // userId-carrying provider factory (for assertions below) and hands back a
 // fake connection.
@@ -94,6 +94,9 @@ vi.mock("@/lib/rpc/network-utils", () => ({
     if (network === "solana-devnet") {
       return 103;
     }
+    if (network === "sepolia") {
+      return 11_155_111;
+    }
     throw new Error(`Unsupported network: ${network}`);
   }),
 }));
@@ -104,11 +107,17 @@ vi.mock("@/lib/rpc/provider-factory", () => ({
   isSolanaChain: (chainId: number) => chainId === 101 || chainId === 103,
 }));
 
+// The workflowExecutions lookup (selects userId) resolves a caller; the
+// supportedTokens display-info lookup (selects symbol/name) finds no row, so
+// the Metaplex fallback is reachable.
 vi.mock("@/lib/db", () => ({
   db: {
-    select: () => ({
+    select: (shape: Record<string, unknown>) => ({
       from: () => ({
-        where: () => ({ limit: () => Promise.resolve([{ userId: "user_1" }]) }),
+        where: () => ({
+          limit: () =>
+            Promise.resolve("userId" in shape ? [{ userId: "user_1" }] : []),
+        }),
       }),
     }),
   },
@@ -119,6 +128,8 @@ vi.mock("@/lib/db/schema", () => ({
     chainId: "chainId",
     id: "id",
     tokenAddress: "tokenAddress",
+    symbol: "symbol",
+    name: "name",
   },
   workflowExecutions: { id: "id", userId: "userId" },
 }));
@@ -137,12 +148,17 @@ vi.mock("@/lib/workflow/executor/step-handler", () => ({
   withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
 }));
 
+vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
+  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
+}));
+
 vi.mock("@/lib/utils", () => ({
   getErrorMessage: (error: { message?: string }) =>
     error?.message ?? String(error),
 }));
 
 import { checkTokenBalanceStep } from "@/plugins/web3/steps/check-token-balance";
+import { getSplTokenBalanceStep } from "@/plugins/web3/steps/get-spl-token-balance";
 
 const WALLET = "4zYdhhTJJKbYJ3Yqa2WGpBi25V1JcZVVBQWYKAY9tegL";
 const OFF_CURVE_WALLET = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
@@ -153,11 +169,37 @@ function fakeAccountInfo(owner: PublicKey) {
   return { owner, data: Buffer.alloc(0), lamports: 0, executable: false };
 }
 
+/**
+ * Builds a Metaplex metadata account payload the way the on-chain program
+ * writes it: key (1) + updateAuthority (32) + mint (32), then borsh strings
+ * whose declared length includes trailing null padding.
+ */
+function fakeMetadataAccountInfo(name: string, symbol: string) {
+  const paddedName = Buffer.alloc(32);
+  paddedName.write(name, "utf8");
+  const paddedSymbol = Buffer.alloc(10);
+  paddedSymbol.write(symbol, "utf8");
+
+  const nameLen = Buffer.alloc(4);
+  nameLen.writeUInt32LE(paddedName.length);
+  const symbolLen = Buffer.alloc(4);
+  symbolLen.writeUInt32LE(paddedSymbol.length);
+
+  const data = Buffer.concat([
+    Buffer.alloc(65),
+    nameLen,
+    paddedName,
+    symbolLen,
+    paddedSymbol,
+  ]);
+  return { owner: TOKEN_PROGRAM_ID, data, lamports: 0, executable: false };
+}
+
 const context = () => ({
   executionId: "exec_1",
   nodeId: "node_1",
   nodeName: "Get SPL Balance",
-  nodeType: "check-token-balance" as const,
+  nodeType: "get-spl-token-balance" as const,
 });
 
 const input = () => ({
@@ -170,7 +212,7 @@ const input = () => ({
   _context: context(),
 });
 
-describe("checkTokenBalanceStep - Solana", () => {
+describe("getSplTokenBalanceStep", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetSolanaProvider.mockResolvedValue({
@@ -189,7 +231,7 @@ describe("checkTokenBalanceStep - Solana", () => {
     mockUnpackMint.mockReturnValue({ decimals: 6 });
     mockUnpackAccount.mockReturnValue({ amount: BigInt(5_000_000) });
 
-    const result = await checkTokenBalanceStep(input());
+    const result = await getSplTokenBalanceStep(input());
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -213,11 +255,15 @@ describe("checkTokenBalanceStep - Solana", () => {
   it("fetches a Token-2022 mint's balance instead of failing with an owner-mismatch error", async () => {
     mockConnectionGetAccountInfo
       .mockResolvedValueOnce(fakeAccountInfo(TOKEN_2022_PROGRAM_ID))
-      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_2022_PROGRAM_ID));
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_2022_PROGRAM_ID))
+      .mockResolvedValueOnce(null); // no metadata account
     mockUnpackMint.mockReturnValue({ decimals: 9 });
     mockUnpackAccount.mockReturnValue({ amount: BigInt(1_000_000_000) });
 
-    const result = await checkTokenBalanceStep(input());
+    const result = await getSplTokenBalanceStep({
+      ...input(),
+      tokenConfig: MINT,
+    });
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -236,7 +282,7 @@ describe("checkTokenBalanceStep - Solana", () => {
       .mockResolvedValueOnce(null); // no ATA yet
     mockUnpackMint.mockReturnValue({ decimals: 9 });
 
-    const result = await checkTokenBalanceStep(input());
+    const result = await getSplTokenBalanceStep(input());
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -253,12 +299,66 @@ describe("checkTokenBalanceStep - Solana", () => {
     mockUnpackMint.mockReturnValue({ decimals: 6 });
     mockUnpackAccount.mockReturnValue({ amount: BigInt(2_000_000) });
 
-    const result = await checkTokenBalanceStep({
+    const result = await getSplTokenBalanceStep({
       ...input(),
       address: OFF_CURVE_WALLET,
     });
 
     expect(result.success).toBe(true);
+  });
+
+  it("resolves symbol and name from the Metaplex metadata account when the config supplies none", async () => {
+    mockConnectionGetAccountInfo
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_PROGRAM_ID)) // mint
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_PROGRAM_ID)) // ATA
+      .mockResolvedValueOnce(fakeMetadataAccountInfo("USD Coin", "USDC"));
+    mockUnpackMint.mockReturnValue({ decimals: 6 });
+    mockUnpackAccount.mockReturnValue({ amount: BigInt(1_000_000) });
+
+    const result = await getSplTokenBalanceStep({
+      ...input(),
+      tokenConfig: MINT, // bare address - parser records the "???" sentinel
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.balance.symbol).toBe("USDC");
+      expect(result.balance.name).toBe("USD Coin");
+    }
+  });
+
+  it("falls back to unknown-token sentinels when no metadata account exists", async () => {
+    mockConnectionGetAccountInfo
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_PROGRAM_ID))
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_PROGRAM_ID))
+      .mockResolvedValueOnce(null); // no metadata PDA
+    mockUnpackMint.mockReturnValue({ decimals: 6 });
+    mockUnpackAccount.mockReturnValue({ amount: BigInt(1_000_000) });
+
+    const result = await getSplTokenBalanceStep({
+      ...input(),
+      tokenConfig: MINT,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.balance.symbol).toBe("???");
+      expect(result.balance.name).toBe("Unknown");
+    }
+  });
+
+  it("does not fetch metadata when the config already carries a real symbol", async () => {
+    mockConnectionGetAccountInfo
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_PROGRAM_ID))
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_PROGRAM_ID));
+    mockUnpackMint.mockReturnValue({ decimals: 6 });
+    mockUnpackAccount.mockReturnValue({ amount: BigInt(1_000_000) });
+
+    const result = await getSplTokenBalanceStep(input());
+
+    expect(result.success).toBe(true);
+    // mint + ATA only - no third getAccountInfo for the metadata PDA
+    expect(mockConnectionGetAccountInfo).toHaveBeenCalledTimes(2);
   });
 
   it("threads the caller's userId into the Solana RPC provider", async () => {
@@ -267,7 +367,7 @@ describe("checkTokenBalanceStep - Solana", () => {
       .mockResolvedValueOnce(null);
     mockUnpackMint.mockReturnValue({ decimals: 6 });
 
-    await checkTokenBalanceStep(input());
+    await getSplTokenBalanceStep(input());
 
     expect(mockGetSolanaProvider).toHaveBeenCalledWith({
       chainId: 103,
@@ -278,7 +378,7 @@ describe("checkTokenBalanceStep - Solana", () => {
   it("propagates a real RPC error instead of treating it as a zero balance", async () => {
     mockConnectionGetAccountInfo.mockRejectedValue(new Error("RPC timeout"));
 
-    const result = await checkTokenBalanceStep(input());
+    const result = await getSplTokenBalanceStep(input());
 
     expect(result.success).toBe(false);
   });
@@ -291,7 +391,7 @@ describe("checkTokenBalanceStep - Solana", () => {
       fakeAccountInfo(NOT_A_TOKEN_PROGRAM)
     );
 
-    const result = await checkTokenBalanceStep(input());
+    const result = await getSplTokenBalanceStep(input());
 
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -300,7 +400,7 @@ describe("checkTokenBalanceStep - Solana", () => {
   });
 
   it("rejects an invalid Solana wallet address before touching the chain", async () => {
-    const result = await checkTokenBalanceStep({
+    const result = await getSplTokenBalanceStep({
       ...input(),
       address: "not a valid base58 address",
     });
@@ -308,6 +408,41 @@ describe("checkTokenBalanceStep - Solana", () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error).toContain("Invalid wallet address");
+    }
+    expect(mockConnectionGetAccountInfo).not.toHaveBeenCalled();
+  });
+
+  it("rejects an EVM chain with a pointer to the ERC20 action", async () => {
+    const result = await getSplTokenBalanceStep({
+      ...input(),
+      network: "sepolia",
+      address: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("only supports Solana chains");
+    }
+    expect(mockConnectionGetAccountInfo).not.toHaveBeenCalled();
+  });
+});
+
+describe("checkTokenBalanceStep - Solana rejection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects a Solana chain with a pointer to the SPL action", async () => {
+    const result = await checkTokenBalanceStep({
+      network: "solana-devnet",
+      address: WALLET,
+      tokenConfig: MINT,
+      _context: { ...context(), nodeType: "check-token-balance" },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Get SPL Token Balance");
     }
     expect(mockConnectionGetAccountInfo).not.toHaveBeenCalled();
   });

--- a/tests/integration/get-spl-token-balance.test.ts
+++ b/tests/integration/get-spl-token-balance.test.ts
@@ -23,6 +23,9 @@ const TOKEN_2022_PROGRAM_ID = new PublicKey(
 const ASSOCIATED_TOKEN_PROGRAM_ID = new PublicKey(
   "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
 );
+const METAPLEX_METADATA_PROGRAM_ID = new PublicKey(
+  "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+);
 
 const { mockUnpackMint, mockUnpackAccount, mockGetAssociatedTokenAddressSync } =
   vi.hoisted(() => ({
@@ -108,15 +111,27 @@ vi.mock("@/lib/rpc/provider-factory", () => ({
 }));
 
 // The workflowExecutions lookup (selects userId) resolves a caller; the
-// supportedTokens display-info lookup (selects symbol/name) finds no row, so
-// the Metaplex fallback is reachable.
+// supportedTokens address lookup (selects tokenAddress) resolves the mint for
+// supported-token configs; the supportedTokens display-info lookup (selects
+// symbol/name) finds no row, so the Metaplex fallback is reachable.
 vi.mock("@/lib/db", () => ({
   db: {
     select: (shape: Record<string, unknown>) => ({
       from: () => ({
         where: () => ({
-          limit: () =>
-            Promise.resolve("userId" in shape ? [{ userId: "user_1" }] : []),
+          limit: () => {
+            if ("userId" in shape) {
+              return Promise.resolve([{ userId: "user_1" }]);
+            }
+            if ("tokenAddress" in shape) {
+              return Promise.resolve([
+                {
+                  tokenAddress: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                },
+              ]);
+            }
+            return Promise.resolve([]);
+          },
         }),
       }),
     }),
@@ -192,7 +207,12 @@ function fakeMetadataAccountInfo(name: string, symbol: string) {
     symbolLen,
     paddedSymbol,
   ]);
-  return { owner: TOKEN_PROGRAM_ID, data, lamports: 0, executable: false };
+  return {
+    owner: METAPLEX_METADATA_PROGRAM_ID,
+    data,
+    lamports: 0,
+    executable: false,
+  };
 }
 
 const context = () => ({
@@ -325,6 +345,20 @@ describe("getSplTokenBalanceStep", () => {
       expect(result.balance.symbol).toBe("USDC");
       expect(result.balance.name).toBe("USD Coin");
     }
+
+    // The third read must target the canonical Metaplex metadata PDA - a
+    // wrong seed order or program id would silently resolve to sentinels.
+    const [expectedMetadataAddress] = PublicKey.findProgramAddressSync(
+      [
+        Buffer.from("metadata"),
+        METAPLEX_METADATA_PROGRAM_ID.toBuffer(),
+        new PublicKey(MINT).toBuffer(),
+      ],
+      METAPLEX_METADATA_PROGRAM_ID
+    );
+    const metadataCallArg = mockConnectionGetAccountInfo.mock
+      .calls[2][0] as PublicKey;
+    expect(metadataCallArg.equals(expectedMetadataAddress)).toBe(true);
   });
 
   it("falls back to unknown-token sentinels when no metadata account exists", async () => {
@@ -344,6 +378,69 @@ describe("getSplTokenBalanceStep", () => {
     if (result.success) {
       expect(result.balance.symbol).toBe("???");
       expect(result.balance.name).toBe("Unknown");
+    }
+  });
+
+  it("resolves a supported token id to its mint address via the DB", async () => {
+    mockConnectionGetAccountInfo
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_PROGRAM_ID)) // mint
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_PROGRAM_ID)) // ATA
+      .mockResolvedValueOnce(null); // no metadata account
+    mockUnpackMint.mockReturnValue({ decimals: 6 });
+    mockUnpackAccount.mockReturnValue({ amount: BigInt(3_000_000) });
+
+    const result = await getSplTokenBalanceStep({
+      ...input(),
+      tokenConfig: { mode: "supported", supportedTokenId: "tok_1" },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.balance.tokenAddress).toBe(MINT);
+      expect(result.balance.balance).toBe("3");
+    }
+  });
+
+  it("keeps a successful balance when the metadata lookup itself errors", async () => {
+    mockConnectionGetAccountInfo
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_PROGRAM_ID)) // mint
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_PROGRAM_ID)) // ATA
+      .mockRejectedValueOnce(new Error("429 rate limited")); // metadata PDA
+    mockUnpackMint.mockReturnValue({ decimals: 6 });
+    mockUnpackAccount.mockReturnValue({ amount: BigInt(1_000_000) });
+
+    const result = await getSplTokenBalanceStep({
+      ...input(),
+      tokenConfig: MINT,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.balance.balance).toBe("1");
+      expect(result.balance.symbol).toBe("???");
+      expect(result.balance.name).toBe("Unknown");
+    }
+  });
+
+  it("strips control and bidi characters from on-chain metadata strings", async () => {
+    mockConnectionGetAccountInfo
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_PROGRAM_ID))
+      .mockResolvedValueOnce(fakeAccountInfo(TOKEN_PROGRAM_ID))
+      .mockResolvedValueOnce(
+        fakeMetadataAccountInfo("USD\u0000 Coin\u202e", "US\u0000DC")
+      );
+    mockUnpackMint.mockReturnValue({ decimals: 6 });
+    mockUnpackAccount.mockReturnValue({ amount: BigInt(1_000_000) });
+
+    const result = await getSplTokenBalanceStep({
+      ...input(),
+      tokenConfig: MINT,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.balance.symbol).toBe("USDC");
+      expect(result.balance.name).toBe("USD Coin");
     }
   });
 
@@ -376,7 +473,11 @@ describe("getSplTokenBalanceStep", () => {
   });
 
   it("propagates a real RPC error instead of treating it as a zero balance", async () => {
-    mockConnectionGetAccountInfo.mockRejectedValue(new Error("RPC timeout"));
+    // Once, not persistent: vi.clearAllMocks() does not clear implementations,
+    // so a persistent mockRejectedValue would leak into later tests.
+    mockConnectionGetAccountInfo.mockRejectedValueOnce(
+      new Error("RPC timeout")
+    );
 
     const result = await getSplTokenBalanceStep(input());
 

--- a/tests/unit/query-solana-program-events-core.test.ts
+++ b/tests/unit/query-solana-program-events-core.test.ts
@@ -543,6 +543,20 @@ describe("queryProgramEventsCore", () => {
     expect(mockGetSignaturesForAddress).not.toHaveBeenCalled();
   });
 
+  it("rejects a non-string, non-number signatureLookback instead of throwing", async () => {
+    const result = await queryProgramEventsCore({
+      network: "solana",
+      programId: PROGRAM_ID,
+      signatureLookback: true as unknown as number,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Invalid signatureLookback value");
+    }
+    expect(mockGetSignaturesForAddress).not.toHaveBeenCalled();
+  });
+
   it("rejects a non-integer numeric signatureLookback", async () => {
     const result = await queryProgramEventsCore({
       network: "solana",

--- a/tests/unit/query-solana-program-events-core.test.ts
+++ b/tests/unit/query-solana-program-events-core.test.ts
@@ -529,6 +529,20 @@ describe("queryProgramEventsCore", () => {
     expect(mockGetSignaturesForAddress).not.toHaveBeenCalled();
   });
 
+  it("rejects a zero string signatureLookback instead of silently scanning nothing", async () => {
+    const result = await queryProgramEventsCore({
+      network: "solana",
+      programId: PROGRAM_ID,
+      signatureLookback: "0",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Invalid signatureLookback value");
+    }
+    expect(mockGetSignaturesForAddress).not.toHaveBeenCalled();
+  });
+
   it("rejects a non-integer numeric signatureLookback", async () => {
     const result = await queryProgramEventsCore({
       network: "solana",


### PR DESCRIPTION
## Summary

Follow-ups from the staging verification pass on the recent Solana web3 actions, resolved together:

- **Split SPL balance fetching out of Get ERC20 Token Balance.** The unified action's label said ERC-20 while accepting SPL mints, and the token selector, placeholders, and validation had to straddle both chain families. New Solana-only `get-spl-token-balance` action (chain filter `solana`) carries the SPL logic: associated-token-account lookup, zero balance for a missing ATA (matching `balanceOf` on an unfunded holder), Token-2022 mints, off-curve (PDA) owners, and per-user RPC preferences. `check-token-balance` reverts to EVM-only - `evm` chain filter and ERC-20 wording restored - and a Solana network now returns an explicit error pointing at the new action instead of silently working with a misleading label. `get-transaction` deliberately stays unified: a transaction hash self-identifies its chain family, unlike the balance action's config surface. Shared token-config parsing moves to `token-config-core.ts` (no behavior change).
- **Resolve SPL symbol/name from Metaplex metadata.** Balances for well-known mints (e.g. mainnet USDC by raw address) previously came back `??? / Unknown` unless the caller supplied a symbol or a `supportedTokens` row existed. The new action now falls back to reading the mint's Metaplex token-metadata PDA (borsh name/symbol, null-padding trimmed) inside the same RPC failover wrapper, keeping the sentinels only when no metadata account exists.
- **Reject `signatureLookback: "0"` in Query Solana Program Events.** The numeric branch already rejected 0, but the string branch - which is what the template-input UI always sends - only regex-checked digits, so "0" was accepted and silently scanned nothing.

No live workflows depend on the removed unified behavior: it reached staging only hours before this change.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Biome clean on lint-scoped changed files
- [x] `tests/integration/get-spl-token-balance.test.ts` (ported from the check-token-balance Solana suite, 13 tests): funded ATA, Token-2022, zero-balance missing ATA, off-curve owner, Metaplex symbol resolution + no-metadata fallback + no-fetch-when-symbol-known, userId threading, RPC error propagation, non-mint rejection, invalid wallet, EVM-chain rejection, and check-token-balance's Solana rejection
- [x] `tests/unit/query-solana-program-events-core.test.ts` (23 tests): new zero-string-lookback rejection alongside the existing invalid-lookback cases
- [ ] CI