### PR TITLE
fix: #2116 exclude soft-deleted executions from workflow delete pre-check

### DIFF
--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError, logSystemWarn } from "@/lib/logging";
@@ -944,8 +944,13 @@ export async function DELETE(
     const { searchParams } = new URL(request.url);
     const force = searchParams.get("force") === "true";
 
+    // Soft-deleted runs (history already purged, see the executions DELETE
+    // route) are not "execution history" for this guard's purpose.
     const hasExecutions = await db.query.workflowExecutions.findFirst({
-      where: eq(workflowExecutions.workflowId, workflowId),
+      where: and(
+        eq(workflowExecutions.workflowId, workflowId),
+        isNull(workflowExecutions.deletedAt)
+      ),
       columns: { id: true },
     });
 

--- a/tests/integration/workflow-delete-precheck-soft-delete.test.ts
+++ b/tests/integration/workflow-delete-precheck-soft-delete.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Pulls in the same server-only-gated modules as the other route tests in
+// this directory (history -> version-diff -> step-registry).
+vi.mock("server-only", () => ({}));
+
+const {
+  mockGetDualAuthContext,
+  mockWorkflowsFindFirst,
+  mockExecutionsFindFirst,
+  mockExecutionsFindMany,
+  mockTopLevelUpdateSet,
+  mockRecordAuditEvent,
+} = vi.hoisted(() => ({
+  mockGetDualAuthContext: vi.fn(),
+  mockWorkflowsFindFirst: vi.fn(),
+  mockExecutionsFindFirst: vi.fn(),
+  mockExecutionsFindMany: vi.fn(),
+  mockTopLevelUpdateSet: vi.fn(),
+  mockRecordAuditEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/middleware/auth-helpers", () => ({
+  getDualAuthContext: mockGetDualAuthContext,
+  authFailureResponse: vi.fn(),
+}));
+
+vi.mock("@/lib/middleware/require-scope", () => ({
+  requireScope: vi.fn(() => null),
+}));
+
+// getWorkflowAccess's own DB reads (org-membership lookup) are orthogonal to
+// the pre-check this fix touches, so the collaborator is stubbed directly
+// rather than re-driving it through the mocked db below.
+vi.mock("@/lib/workflow/access", () => ({
+  getWorkflowAccess: vi.fn().mockResolvedValue({
+    isCreatorWithCurrentAccess: true,
+    isSameOrg: true,
+    hasFullAccess: true,
+    isDeleted: false,
+  }),
+}));
+
+vi.mock("@/lib/security/audit-log", () => ({
+  recordAuditEvent: mockRecordAuditEvent,
+  buildAuditMetadata: vi.fn(() => ({})),
+}));
+
+const txStub = {
+  delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+  update: vi.fn(() => ({
+    set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+  })),
+  query: {
+    workflowExecutions: { findMany: vi.fn().mockResolvedValue([]) },
+  },
+};
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      workflows: { findFirst: mockWorkflowsFindFirst },
+      workflowExecutions: {
+        findFirst: mockExecutionsFindFirst,
+        findMany: mockExecutionsFindMany,
+      },
+    },
+    delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    update: vi.fn(() => ({
+      set: vi.fn((data: Record<string, unknown>) => ({
+        where: vi.fn(() => mockTopLevelUpdateSet(data)),
+      })),
+    })),
+    transaction: vi.fn(async (cb: (tx: typeof txStub) => Promise<void>) => {
+      await cb(txStub);
+    }),
+  },
+}));
+
+import { DELETE as purgeExecutions } from "@/app/api/workflows/[workflowId]/executions/route";
+import { DELETE as deleteWorkflow } from "@/app/api/workflows/[workflowId]/route";
+
+/** Every column referenced anywhere in a drizzle SQL predicate tree -- same
+ * helper, copied verbatim from
+ * tests/unit/workflows-list-soft-delete.test.ts, which uses it to prove a
+ * query filters on a given column without a live database. */
+function columnsIn(node: unknown, found: string[] = []): string[] {
+  if (node === null || typeof node !== "object") {
+    return found;
+  }
+  const candidate = node as { name?: unknown; queryChunks?: unknown };
+  if (typeof candidate.name === "string" && "table" in candidate) {
+    found.push(candidate.name);
+  }
+  const chunks = candidate.queryChunks;
+  if (Array.isArray(chunks)) {
+    for (const chunk of chunks) {
+      columnsIn(chunk, found);
+    }
+  }
+  return found;
+}
+
+function createDeleteRequest(): Request {
+  return new Request("http://localhost:3000/api/workflows/wf-1", {
+    method: "DELETE",
+  });
+}
+
+function createPurgeRequest(): Request {
+  return new Request("http://localhost:3000/api/workflows/wf-1/executions", {
+    method: "DELETE",
+  });
+}
+
+const mockParams = Promise.resolve({ workflowId: "wf-1" });
+
+const AUTH_CONTEXT = {
+  userId: "user-1",
+  organizationId: "org-1",
+  authMethod: "session" as const,
+  apiKeyId: null,
+  scope: "mcp:write",
+};
+
+const WORKFLOW_ROW = {
+  id: "wf-1",
+  userId: "user-1",
+  organizationId: "org-1",
+  isAnonymous: false,
+  deletedAt: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetDualAuthContext.mockResolvedValue(AUTH_CONTEXT);
+  mockWorkflowsFindFirst.mockResolvedValue(WORKFLOW_ROW);
+});
+
+describe("DELETE /api/workflows/[workflowId] — soft-deleted execution pre-check", () => {
+  it("builds a predicate that references deleted_at, not just workflow_id", async () => {
+    mockExecutionsFindFirst.mockResolvedValue(undefined);
+
+    await deleteWorkflow(createDeleteRequest(), { params: mockParams });
+
+    const [{ where }] = mockExecutionsFindFirst.mock.calls[0];
+    const columns = columnsIn(where);
+    expect(columns).toContain("workflow_id");
+    expect(columns).toContain("deleted_at");
+  });
+
+  it("returns 409 when a live execution is found", async () => {
+    mockExecutionsFindFirst.mockResolvedValue({ id: "exec-1" });
+
+    const response = await deleteWorkflow(createDeleteRequest(), {
+      params: mockParams,
+    });
+
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.hasExecutions).toBe(true);
+  });
+
+  it("deletes without force when no live execution is found (e.g. all soft-deleted)", async () => {
+    mockExecutionsFindFirst.mockResolvedValue(undefined);
+
+    const response = await deleteWorkflow(createDeleteRequest(), {
+      params: mockParams,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+  });
+
+  it(
+    "mirrors the reported dead end: purging run history via the executions " +
+      "route, then deleting the workflow without force, now succeeds",
+    async () => {
+      // Shared fixture: both routes read/write the same in-memory rows, the
+      // way both read/write the same table in production.
+      const rows = [{ id: "exec-1", deletedAt: null as Date | null }];
+
+      mockExecutionsFindMany.mockImplementation(async () =>
+        rows
+          .filter((row) => row.deletedAt === null)
+          .map((row) => ({ id: row.id }))
+      );
+      // The purge route soft-deletes exactly the runs its own findMany just
+      // selected -- mirrored here by closing over that same result.
+      mockTopLevelUpdateSet.mockImplementation((data: { deletedAt: Date }) => {
+        for (const row of rows) {
+          row.deletedAt = data.deletedAt;
+        }
+        return Promise.resolve(undefined);
+      });
+
+      const purgeResponse = await purgeExecutions(createPurgeRequest(), {
+        params: mockParams,
+      });
+      expect(purgeResponse.status).toBe(200);
+      const purgeBody = await purgeResponse.json();
+      expect(purgeBody.deletedCount).toBe(1);
+      expect(rows[0].deletedAt).not.toBeNull();
+
+      // The purge left no live execution, so the pre-check's findFirst
+      // (real query semantics aside) resolves to nothing.
+      mockExecutionsFindFirst.mockResolvedValue(undefined);
+
+      const deleteResponse = await deleteWorkflow(createDeleteRequest(), {
+        params: mockParams,
+      });
+
+      expect(deleteResponse.status).toBe(200);
+      const deleteBody = await deleteResponse.json();
+      expect(deleteBody.success).toBe(true);
+    }
+  );
+});

--- a/tests/integration/workflow-delete-precheck-soft-delete.test.ts
+++ b/tests/integration/workflow-delete-precheck-soft-delete.test.ts
@@ -1,3 +1,5 @@
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Pulls in the same server-only-gated modules as the other route tests in
@@ -80,25 +82,31 @@ vi.mock("@/lib/db", () => ({
 import { DELETE as purgeExecutions } from "@/app/api/workflows/[workflowId]/executions/route";
 import { DELETE as deleteWorkflow } from "@/app/api/workflows/[workflowId]/route";
 
-/** Every column referenced anywhere in a drizzle SQL predicate tree -- same
- * helper, copied verbatim from
- * tests/unit/workflows-list-soft-delete.test.ts, which uses it to prove a
- * query filters on a given column without a live database. */
-function columnsIn(node: unknown, found: string[] = []): string[] {
-  if (node === null || typeof node !== "object") {
-    return found;
-  }
-  const candidate = node as { name?: unknown; queryChunks?: unknown };
-  if (typeof candidate.name === "string" && "table" in candidate) {
-    found.push(candidate.name);
-  }
-  const chunks = candidate.queryChunks;
-  if (Array.isArray(chunks)) {
-    for (const chunk of chunks) {
-      columnsIn(chunk, found);
-    }
-  }
-  return found;
+/** The predicate the route hands to findFirst, compiled to SQL. This test
+ * mocks @/lib/db, so db.dialect is not reachable -- a standalone dialect
+ * compiles the same predicate tree. */
+function compiledPredicate(where: SQL): string {
+  return new PgDialect().sqlToQuery(where).sql;
+}
+
+/** Whether the predicate excludes purged runs, i.e. constrains this table's
+ * deleted_at to null rather than merely mentioning the column. */
+function excludesPurgedRuns(where: SQL): boolean {
+  return /"workflow_executions"\."deleted_at"\s+is\s+null/.test(
+    compiledPredicate(where)
+  );
+}
+
+/** Stands in for the real findFirst over `rows`. It is not a SQL engine; it is
+ * honest about the one thing under test -- a predicate that constrains
+ * deleted_at to null can only match rows that were never purged, and any other
+ * predicate matches this workflow's rows regardless of deleted_at. */
+function findFirstOver(rows: { id: string; deletedAt: Date | null }[]) {
+  return ({ where }: { where: SQL }) => {
+    const liveOnly = excludesPurgedRuns(where);
+    const match = rows.find((row) => !liveOnly || row.deletedAt === null);
+    return Promise.resolve(match ? { id: match.id } : undefined);
+  };
 }
 
 function createDeleteRequest(): Request {
@@ -138,19 +146,24 @@ beforeEach(() => {
 });
 
 describe("DELETE /api/workflows/[workflowId] — soft-deleted execution pre-check", () => {
-  it("builds a predicate that references deleted_at, not just workflow_id", async () => {
-    mockExecutionsFindFirst.mockResolvedValue(undefined);
+  it("builds a predicate that constrains deleted_at, not just workflow_id", async () => {
+    mockExecutionsFindFirst.mockImplementation(findFirstOver([]));
 
     await deleteWorkflow(createDeleteRequest(), { params: mockParams });
 
     const [{ where }] = mockExecutionsFindFirst.mock.calls[0];
-    const columns = columnsIn(where);
-    expect(columns).toContain("workflow_id");
-    expect(columns).toContain("deleted_at");
+    const predicate = compiledPredicate(where);
+    expect(predicate).toMatch(/"workflow_executions"\."workflow_id"\s*=/);
+    expect(predicate).toMatch(
+      /"workflow_executions"\."deleted_at"\s+is\s+null/
+    );
+    expect(predicate).not.toMatch(/is\s+not\s+null/);
   });
 
   it("returns 409 when a live execution is found", async () => {
-    mockExecutionsFindFirst.mockResolvedValue({ id: "exec-1" });
+    mockExecutionsFindFirst.mockImplementation(
+      findFirstOver([{ id: "exec-1", deletedAt: null }])
+    );
 
     const response = await deleteWorkflow(createDeleteRequest(), {
       params: mockParams,
@@ -161,8 +174,10 @@ describe("DELETE /api/workflows/[workflowId] — soft-deleted execution pre-chec
     expect(body.hasExecutions).toBe(true);
   });
 
-  it("deletes without force when no live execution is found (e.g. all soft-deleted)", async () => {
-    mockExecutionsFindFirst.mockResolvedValue(undefined);
+  it("deletes without force when every execution is soft-deleted", async () => {
+    mockExecutionsFindFirst.mockImplementation(
+      findFirstOver([{ id: "exec-1", deletedAt: new Date() }])
+    );
 
     const response = await deleteWorkflow(createDeleteRequest(), {
       params: mockParams,
@@ -203,9 +218,9 @@ describe("DELETE /api/workflows/[workflowId] — soft-deleted execution pre-chec
       expect(purgeBody.deletedCount).toBe(1);
       expect(rows[0].deletedAt).not.toBeNull();
 
-      // The purge left no live execution, so the pre-check's findFirst
-      // (real query semantics aside) resolves to nothing.
-      mockExecutionsFindFirst.mockResolvedValue(undefined);
+      // The pre-check reads the same rows the purge just stamped, through
+      // its own predicate -- nothing about the outcome is fixed up front.
+      mockExecutionsFindFirst.mockImplementation(findFirstOver(rows));
 
       const deleteResponse = await deleteWorkflow(createDeleteRequest(), {
         params: mockParams,


### PR DESCRIPTION
Fixes #2116

`DELETE /api/workflows/{workflowId}`'s non-force pre-check (`hasExecutions`) matched executions on `workflowId` alone, so a workflow whose run history had already been purged (soft-deleted via the executions DELETE route, not hard-deleted) still hit the 409 "has execution history" response. The only way past it was `force=true`, which is unreachable for MCP callers (#2109) and triggers a heavier cascade than a workflow with no live runs actually needs.

Regression source: 658bc515 (2026-07-24, "fix(billing): soft-delete executions so history purges keep the usage count") moved the executions purge from a hard delete to `deleted_at`, but did not update this pre-check to match, so it kept counting rows the purge route itself no longer treats as live.

Fix: add `isNull(workflowExecutions.deletedAt)` to the guard's `where` clause.

Caller-visible behavior change (one, and it is the intended one): a workflow whose executions are all soft-deleted is now deletable without `force=true` (previously 409). No response shape, status code, or other behavior changes. The only other 409 in this handler is an unrelated FK-race catch block, not a second instance of this guard.

Tests: this pre-check had no coverage before this PR. Added, following the pattern in tests/unit/workflows-list-soft-delete.test.ts: a column assertion that the pre-check predicate filters on `deleted_at` (this is the test that fails without the fix); handler-branch coverage for the 409 and 200 outcomes; and an end-to-end test that runs the executions-purge route then this route against a shared fixture, mirroring the reported dead end.

Scope: this narrows what remains of #2109 by restoring the 409 message's truth for plain REST callers in the soft-deleted-only case, but does not duplicate it. #2109 covers exposing `force=true` to the MCP `delete_workflow` tool and the message text, both still open and unrelated to this pre-check.

Acknowledged, out of scope: the UI at `components/workflow/node-config-panel.tsx:248` has a separate escalation-path inconsistency around this same delete flow; not touched here.