### PR TITLE
refactor: deduplicate step user lookup and standard test mock preamble

### DIFF
--- a/lib/workflow/executor/helpers.ts
+++ b/lib/workflow/executor/helpers.ts
@@ -74,3 +74,29 @@ export async function getUserIdFromExecution(
 
   return execution[0].userId;
 }
+
+/**
+ * Lenient variant of getUserIdFromExecution for per-user RPC preference
+ * lookups in read steps. RPC preferences are a per-user convenience, not an
+ * authority signal, so a missing context, an unknown execution, or a
+ * transient DB failure all resolve to undefined and the step falls back to
+ * the chain's default RPC config rather than failing. Same retirement note
+ * as above: once RPC preferences move to the org this helper goes with them.
+ */
+export async function getRpcPreferenceUserId(
+  executionId: string | undefined
+): Promise<string | undefined> {
+  if (!executionId) {
+    return;
+  }
+  try {
+    const execution = await db
+      .select({ userId: workflowExecutions.userId })
+      .from(workflowExecutions)
+      .where(eq(workflowExecutions.id, executionId))
+      .limit(1);
+    return execution[0]?.userId;
+  } catch {
+    return;
+  }
+}

--- a/plugins/web3/steps/batch-read-contract.ts
+++ b/plugins/web3/steps/batch-read-contract.ts
@@ -1,15 +1,13 @@
 import "server-only";
 
-import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { MULTICALL3_ABI, MULTICALL3_ADDRESS } from "@/lib/contracts/multicall3";
-import { db } from "@/lib/db";
-import { workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
+import { getRpcPreferenceUserId } from "@/lib/workflow/executor/helpers";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 import {
@@ -21,25 +19,6 @@ const LOG_PREFIX = "[Batch Read Contract]";
 const DEFAULT_BATCH_SIZE = 100;
 const MAX_BATCH_SIZE = 500;
 const MAX_TOTAL_CALLS = 5000;
-
-/**
- * Get userId from executionId by querying the workflowExecutions table
- */
-async function getUserIdFromExecution(
-  executionId: string | undefined
-): Promise<string | undefined> {
-  if (!executionId) {
-    return;
-  }
-
-  const execution = await db
-    .select({ userId: workflowExecutions.userId })
-    .from(workflowExecutions)
-    .where(eq(workflowExecutions.id, executionId))
-    .limit(1);
-
-  return execution[0]?.userId;
-}
 
 type CallResult = {
   success: boolean;
@@ -775,7 +754,7 @@ async function executeMixedMode(
 async function stepHandler(
   input: BatchReadContractInput
 ): Promise<BatchReadContractResult> {
-  const userId = await getUserIdFromExecution(input._context?.executionId);
+  const userId = await getRpcPreferenceUserId(input._context?.executionId);
   const isUniform = input.inputMode !== "mixed";
 
   if (isUniform) {

--- a/plugins/web3/steps/check-allowance.ts
+++ b/plugins/web3/steps/check-allowance.ts
@@ -1,13 +1,11 @@
 import "server-only";
 
-import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import ERC20_ABI from "@/lib/contracts/abis/erc20.json";
-import { db } from "@/lib/db";
-import { workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { getRpcPreferenceUserId } from "@/lib/workflow/executor/helpers";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
@@ -31,22 +29,6 @@ type CheckAllowanceResult =
       symbol: string;
     }
   | { success: false; error: string };
-
-async function getUserIdFromExecution(
-  executionId: string | undefined
-): Promise<string | undefined> {
-  if (!executionId) {
-    return;
-  }
-
-  const execution = await db
-    .select({ userId: workflowExecutions.userId })
-    .from(workflowExecutions)
-    .where(eq(workflowExecutions.id, executionId))
-    .limit(1);
-
-  return execution[0]?.userId;
-}
 
 async function stepHandler(
   input: CheckAllowanceInput
@@ -96,7 +78,7 @@ async function stepHandler(
   }
 
   // Get userId from execution context (for user RPC preferences)
-  const userId = await getUserIdFromExecution(_context?.executionId);
+  const userId = await getRpcPreferenceUserId(_context?.executionId);
 
   // Resolve RPC provider with failover support
   let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;

--- a/plugins/web3/steps/check-balance.ts
+++ b/plugins/web3/steps/check-balance.ts
@@ -3,36 +3,18 @@ import "server-only";
 import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { db } from "@/lib/db";
-import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
+import { explorerConfigs } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
+import { getRpcPreferenceUserId } from "@/lib/workflow/executor/helpers";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import { validateChainAddress } from "@/lib/web3/validate-chain-address";
-
-/**
- * Get userId from executionId by querying the workflowExecutions table
- */
-async function getUserIdFromExecution(
-  executionId: string | undefined
-): Promise<string | undefined> {
-  if (!executionId) {
-    return;
-  }
-
-  const execution = await db
-    .select({ userId: workflowExecutions.userId })
-    .from(workflowExecutions)
-    .where(eq(workflowExecutions.id, executionId))
-    .limit(1);
-
-  return execution[0]?.userId;
-}
 
 type CheckBalanceResult =
   | {
@@ -66,7 +48,7 @@ async function stepHandler(
   const { network, address, _context } = input;
 
   // Get userId from execution context (for user RPC preferences)
-  const userId = await getUserIdFromExecution(_context?.executionId);
+  const userId = await getRpcPreferenceUserId(_context?.executionId);
   if (userId) {
     console.log(
       "[Check Balance] Using user RPC preferences for userId:",

--- a/plugins/web3/steps/check-token-balance.ts
+++ b/plugins/web3/steps/check-token-balance.ts
@@ -1,15 +1,13 @@
 import "server-only";
 
-import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import ERC20_ABI from "@/lib/contracts/abis/erc20.json";
-import { db } from "@/lib/db";
-import { workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
+import { getRpcPreferenceUserId } from "@/lib/workflow/executor/helpers";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
@@ -20,25 +18,6 @@ import {
   type TokenBalanceInfo,
   type TokenConfigSource,
 } from "./token-config-core";
-
-/**
- * Get userId from executionId by querying the workflowExecutions table
- */
-async function getUserIdFromExecution(
-  executionId: string | undefined
-): Promise<string | undefined> {
-  if (!executionId) {
-    return;
-  }
-
-  const execution = await db
-    .select({ userId: workflowExecutions.userId })
-    .from(workflowExecutions)
-    .where(eq(workflowExecutions.id, executionId))
-    .limit(1);
-
-  return execution[0]?.userId;
-}
 
 type CheckTokenBalanceResult =
   | {
@@ -188,7 +167,7 @@ async function stepHandler(
   const tokenConfig = parseTokenConfig(input);
 
   // Get userId from execution context (for user RPC preferences)
-  const userId = await getUserIdFromExecution(_context?.executionId);
+  const userId = await getRpcPreferenceUserId(_context?.executionId);
   if (userId) {
     console.log(
       "[Check Token Balance] Using user RPC preferences for userId:",

--- a/plugins/web3/steps/get-spl-token-balance.ts
+++ b/plugins/web3/steps/get-spl-token-balance.ts
@@ -9,11 +9,12 @@ import { type Connection, PublicKey } from "@solana/web3.js";
 import { and, eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { db } from "@/lib/db";
-import { supportedTokens, workflowExecutions } from "@/lib/db/schema";
+import { supportedTokens } from "@/lib/db/schema";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getSolanaProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
+import { getRpcPreferenceUserId } from "@/lib/workflow/executor/helpers";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 import type { TokenFieldValue } from "@/lib/wallet/types";
@@ -60,33 +61,6 @@ type GetSplTokenBalanceResult =
       addressLink: string;
     }
   | { success: false; error: string };
-
-/**
- * Get userId from executionId by querying the workflowExecutions table.
- *
- * Non-throwing by design: RPC preferences are a per-user convenience, not an
- * authority signal, so a lookup failure falls back to the chain's default RPC
- * config rather than failing the balance check.
- */
-async function getUserIdFromExecution(
-  executionId: string | undefined
-): Promise<string | undefined> {
-  if (!executionId) {
-    return;
-  }
-
-  try {
-    const execution = await db
-      .select({ userId: workflowExecutions.userId })
-      .from(workflowExecutions)
-      .where(eq(workflowExecutions.id, executionId))
-      .limit(1);
-
-    return execution[0]?.userId;
-  } catch {
-    return;
-  }
-}
 
 /**
  * Read a borsh string (u32 LE length prefix + utf8 bytes) at offset,
@@ -265,7 +239,7 @@ async function stepHandler(
   const tokenConfig = parseTokenConfig(input);
 
   // Get userId from execution context (for user RPC preferences)
-  const userId = await getUserIdFromExecution(_context?.executionId);
+  const userId = await getRpcPreferenceUserId(_context?.executionId);
 
   let chainId: number;
   try {

--- a/plugins/web3/steps/get-transaction.ts
+++ b/plugins/web3/steps/get-transaction.ts
@@ -4,7 +4,7 @@ import type { VersionedTransactionResponse } from "@solana/web3.js";
 import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { db } from "@/lib/db";
-import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
+import { explorerConfigs } from "@/lib/db/schema";
 import { getAddressUrl, getTransactionUrl } from "@/lib/explorer";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
@@ -14,6 +14,7 @@ import {
   isSolanaChain,
 } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
+import { getRpcPreferenceUserId } from "@/lib/workflow/executor/helpers";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 import { SolanaChainAdapter } from "@/lib/web3/chain-adapter/solana";
@@ -34,22 +35,6 @@ function getSolanaFeePayer(tx: VersionedTransactionResponse): string {
     );
   }
   return feePayer.toBase58();
-}
-
-async function getUserIdFromExecution(
-  executionId: string | undefined
-): Promise<string | undefined> {
-  if (!executionId) {
-    return;
-  }
-
-  const execution = await db
-    .select({ userId: workflowExecutions.userId })
-    .from(workflowExecutions)
-    .where(eq(workflowExecutions.id, executionId))
-    .limit(1);
-
-  return execution[0]?.userId;
 }
 
 type GetTransactionResult =
@@ -224,7 +209,7 @@ async function stepHandler(
     };
   }
 
-  const userId = await getUserIdFromExecution(_context?.executionId);
+  const userId = await getRpcPreferenceUserId(_context?.executionId);
 
   try {
     return isSolanaChain(chainId)

--- a/plugins/web3/steps/query-events.ts
+++ b/plugins/web3/steps/query-events.ts
@@ -3,12 +3,13 @@ import "server-only";
 import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { db } from "@/lib/db";
-import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
+import { explorerConfigs } from "@/lib/db/schema";
 import { getAddressUrl } from "@/lib/explorer";
 import { withPluginMetrics } from "@/lib/metrics/instrumentation/plugin";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
+import { getRpcPreferenceUserId } from "@/lib/workflow/executor/helpers";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 import { evmOnlyGuard } from "@/lib/web3/validate-chain-address";
@@ -20,22 +21,6 @@ import {
 
 const DEFAULT_BATCH_SIZE = 2000;
 const DEFAULT_BLOCK_LOOKBACK = 6500;
-
-async function getUserIdFromExecution(
-  executionId: string | undefined
-): Promise<string | undefined> {
-  if (!executionId) {
-    return;
-  }
-
-  const execution = await db
-    .select({ userId: workflowExecutions.userId })
-    .from(workflowExecutions)
-    .where(eq(workflowExecutions.id, executionId))
-    .limit(1);
-
-  return execution[0]?.userId;
-}
 
 type DecodedEvent = {
   blockNumber: number;
@@ -329,7 +314,7 @@ async function stepHandler(
     return { success: false, error: `Event '${eventName}' not found in ABI` };
   }
 
-  const userId = await getUserIdFromExecution(_context?.executionId);
+  const userId = await getRpcPreferenceUserId(_context?.executionId);
 
   // Validate event exists in ABI using ethers Interface (no provider needed)
   const iface = new ethers.Interface(abiResult.parsed);

--- a/plugins/web3/steps/query-solana-program-events-core.ts
+++ b/plugins/web3/steps/query-solana-program-events-core.ts
@@ -1,13 +1,11 @@
 import "server-only";
+import { getRpcPreferenceUserId } from "@/lib/workflow/executor/helpers";
 
 import type {
   ConfirmedSignatureInfo,
   VersionedTransactionResponse,
 } from "@solana/web3.js";
 import { PublicKey } from "@solana/web3.js";
-import { eq } from "drizzle-orm";
-import { db } from "@/lib/db";
-import { workflowExecutions } from "@/lib/db/schema";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getSolanaProvider } from "@/lib/rpc/provider-factory";
 import type { SolanaProviderManager } from "@/lib/rpc/providers/solana";
@@ -76,27 +74,6 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
-}
-
-// Non-throwing by design: RPC preferences are a per-user convenience, not an
-// authority signal, so a lookup failure falls back to the chain's default RPC
-// config rather than failing the query.
-async function getUserIdFromExecution(
-  executionId: string | undefined
-): Promise<string | undefined> {
-  if (!executionId) {
-    return;
-  }
-  try {
-    const execution = await db
-      .select({ userId: workflowExecutions.userId })
-      .from(workflowExecutions)
-      .where(eq(workflowExecutions.id, executionId))
-      .limit(1);
-    return execution[0]?.userId;
-  } catch {
-    return;
-  }
 }
 
 function parseSignatureLookback(
@@ -439,7 +416,7 @@ export async function queryProgramEventsCore(
   const { programKey, decoder, lookback, chainId } = resolved.value;
   const eventName = input.eventName;
 
-  const userId = await getUserIdFromExecution(input._context?.executionId);
+  const userId = await getRpcPreferenceUserId(input._context?.executionId);
 
   let rpcManager: SolanaProviderManager;
   try {

--- a/plugins/web3/steps/query-transactions-core.ts
+++ b/plugins/web3/steps/query-transactions-core.ts
@@ -1,9 +1,10 @@
 import "server-only";
+import { getRpcPreferenceUserId } from "@/lib/workflow/executor/helpers";
 
 import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { db } from "@/lib/db";
-import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
+import { explorerConfigs } from "@/lib/db/schema";
 import {
   fetchContractTransactions,
   getAddressUrl,
@@ -59,22 +60,6 @@ export type QueryTransactionsCoreInput = {
   blockCount?: number | string;
   _context?: { executionId?: string; organizationId?: string };
 };
-
-async function getUserIdFromExecution(
-  executionId: string | undefined
-): Promise<string | undefined> {
-  if (!executionId) {
-    return;
-  }
-
-  const execution = await db
-    .select({ userId: workflowExecutions.userId })
-    .from(workflowExecutions)
-    .where(eq(workflowExecutions.id, executionId))
-    .limit(1);
-
-  return execution[0]?.userId;
-}
 
 function parseAbi(
   abi: string
@@ -410,7 +395,7 @@ export async function queryTransactionsCore(
 
   const { iface, functionFragment, chainId } = validation.data;
 
-  const userId = await getUserIdFromExecution(input._context?.executionId);
+  const userId = await getRpcPreferenceUserId(input._context?.executionId);
 
   let rpcManager: RpcProviderManager;
   try {

--- a/plugins/web3/steps/read-contract-core.ts
+++ b/plugins/web3/steps/read-contract-core.ts
@@ -6,14 +6,12 @@
  * exporting functions from "use step" files (which breaks the workflow bundler).
  */
 import "server-only";
+import { getRpcPreferenceUserId } from "@/lib/workflow/executor/helpers";
 import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 
-import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { coerceArgsForAbi, reshapeArgsForAbi } from "@/lib/abi/struct-args";
 import { validateArgsForAbi } from "@/lib/abi/validate-args";
-import { db } from "@/lib/db";
-import { workflowExecutions } from "@/lib/db/schema";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
@@ -39,22 +37,6 @@ export type ReadContractCoreInput = {
 export type ReadContractResult =
   | { success: true; result: unknown; addressLink: string }
   | { success: false; error: string; errorClass?: ExecutionErrorType };
-
-async function getUserIdFromExecution(
-  executionId: string | undefined
-): Promise<string | undefined> {
-  if (!executionId) {
-    return;
-  }
-
-  const execution = await db
-    .select({ userId: workflowExecutions.userId })
-    .from(workflowExecutions)
-    .where(eq(workflowExecutions.id, executionId))
-    .limit(1);
-
-  return execution[0]?.userId;
-}
 
 /**
  * Core read contract logic
@@ -84,7 +66,7 @@ export async function readContractCore(
 
   const userId = _context?.organizationId
     ? undefined
-    : await getUserIdFromExecution(_context?.executionId);
+    : await getRpcPreferenceUserId(_context?.executionId);
 
   // Validate contract address
   if (!ethers.isAddress(contractAddress)) {

--- a/tests/integration/check-balance-solana.test.ts
+++ b/tests/integration/check-balance-solana.test.ts
@@ -54,13 +54,13 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
-vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
-  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
 
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
 
 vi.mock("@/lib/utils", () => ({
   getErrorMessage: (error: { message?: string }) =>

--- a/tests/integration/get-spl-token-balance.test.ts
+++ b/tests/integration/get-spl-token-balance.test.ts
@@ -159,13 +159,13 @@ vi.mock("@/lib/logging", () => ({
   logUserError: vi.fn(),
 }));
 
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
 
-vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
-  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
 
 vi.mock("@/lib/utils", () => ({
   getErrorMessage: (error: { message?: string }) =>

--- a/tests/integration/get-transaction-solana.test.ts
+++ b/tests/integration/get-transaction-solana.test.ts
@@ -87,13 +87,13 @@ vi.mock("@/lib/explorer", () => ({
     `https://solscan.io/account/${address}`,
 }));
 
-vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
-  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
 
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
 
 vi.mock("@/lib/utils", () => ({
   getErrorMessage: (error: { message?: string }) =>

--- a/tests/mocks/step-mocks.ts
+++ b/tests/mocks/step-mocks.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared vi.mock factories for step-file tests (the standard preamble from
+ * plugins/CLAUDE.md). Use the async-import form so vitest's mock hoisting
+ * stays correct - the factory resolves this module lazily, after hoisting:
+ *
+ *   vi.mock("@/lib/workflow/executor/step-handler", async () =>
+ *     (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+ *   );
+ *
+ * Only the invariant passthrough shapes live here. Mocks whose bodies differ
+ * per test (db row shapes, logging spies with per-test categories) stay local
+ * to their test files.
+ */
+
+export function stepHandlerPassthrough() {
+  return {
+    withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
+  };
+}
+
+export function pluginMetricsPassthrough() {
+  return {
+    withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
+  };
+}
+
+export function utilsGetErrorMessage() {
+  return {
+    getErrorMessage: (e: unknown) =>
+      e instanceof Error ? e.message : String(e),
+  };
+}

--- a/tests/unit/approve-token.test.ts
+++ b/tests/unit/approve-token.test.ts
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
 
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: {

--- a/tests/unit/batch-read-contract.test.ts
+++ b/tests/unit/batch-read-contract.test.ts
@@ -2,13 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
 
-vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
-  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
 
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: { VALIDATION: "validation", NETWORK_RPC: "network_rpc" },

--- a/tests/unit/batch-write-contract.test.ts
+++ b/tests/unit/batch-write-contract.test.ts
@@ -2,13 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
 
-vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
-  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
 
 const { mockDbWhere } = vi.hoisted(() => ({ mockDbWhere: vi.fn() }));
 vi.mock("@/lib/db", () => ({

--- a/tests/unit/blockscout-ssrf.test.ts
+++ b/tests/unit/blockscout-ssrf.test.ts
@@ -2,13 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
 
-vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
-  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
 
 const mockFetchCredentials = vi.fn();
 vi.mock("@/lib/credential-fetcher", () => ({

--- a/tests/unit/blockscout-steps.test.ts
+++ b/tests/unit/blockscout-steps.test.ts
@@ -2,13 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
 
-vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
-  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
 
 const mockFetchCredentials = vi.fn();
 vi.mock("@/lib/credential-fetcher", () => ({

--- a/tests/unit/check-allowance.test.ts
+++ b/tests/unit/check-allowance.test.ts
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
 
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: {

--- a/tests/unit/check-and-execute-routing.test.ts
+++ b/tests/unit/check-and-execute-routing.test.ts
@@ -18,9 +18,9 @@ vi.mock("@/lib/abi/cache", () => ({
   resolveAbi: vi.fn().mockResolvedValue({ abi: "[]" }),
 }));
 
-vi.mock("@/lib/utils", () => ({
-  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
-}));
+vi.mock("@/lib/utils", async () =>
+  (await import("../mocks/step-mocks")).utilsGetErrorMessage()
+);
 
 // Use @/ aliases so Vitest resolves the same module the route does
 const mockValidateApiKey = vi.fn();

--- a/tests/unit/code-run-code.test.ts
+++ b/tests/unit/code-run-code.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
 
-vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
-  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
 
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: { VALIDATION: "VALIDATION" },

--- a/tests/unit/discord-send-message.test.ts
+++ b/tests/unit/discord-send-message.test.ts
@@ -2,13 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
 
-vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
-  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
 
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: {

--- a/tests/unit/math-aggregate.test.ts
+++ b/tests/unit/math-aggregate.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
 
-vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
-  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
 
 import {
   type AggregateCoreInput,

--- a/tests/unit/query-transactions-core.test.ts
+++ b/tests/unit/query-transactions-core.test.ts
@@ -2,13 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
 
-vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
-  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
 
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: {

--- a/tests/unit/send-webhook-ssrf.test.ts
+++ b/tests/unit/send-webhook-ssrf.test.ts
@@ -2,13 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
 
-vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
-  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
 
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: {

--- a/tests/unit/tempo-batch-payout.test.ts
+++ b/tests/unit/tempo-batch-payout.test.ts
@@ -1,19 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
-vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
-  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: { TRANSACTION: "transaction" },
   logUserError: vi.fn(),
 }));
-vi.mock("@/lib/utils", () => ({
-  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
-}));
+vi.mock("@/lib/utils", async () =>
+  (await import("../mocks/step-mocks")).utilsGetErrorMessage()
+);
 
 const mockGetChainIdFromNetwork = vi.fn();
 vi.mock("@/lib/rpc/network-utils", () => ({

--- a/tests/unit/tempo-broadcast-due.test.ts
+++ b/tests/unit/tempo-broadcast-due.test.ts
@@ -6,9 +6,9 @@ vi.mock("@/lib/logging", () => ({
   logInfo: vi.fn(),
   logSystemWarn: vi.fn(),
 }));
-vi.mock("@/lib/utils", () => ({
-  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
-}));
+vi.mock("@/lib/utils", async () =>
+  (await import("../mocks/step-mocks")).utilsGetErrorMessage()
+);
 
 const broker = {
   expireDueHeldPayments: vi.fn(),

--- a/tests/unit/tempo-dex-swap.test.ts
+++ b/tests/unit/tempo-dex-swap.test.ts
@@ -1,19 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
-vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
-  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: { TRANSACTION: "transaction" },
   logUserError: vi.fn(),
 }));
-vi.mock("@/lib/utils", () => ({
-  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
-}));
+vi.mock("@/lib/utils", async () =>
+  (await import("../mocks/step-mocks")).utilsGetErrorMessage()
+);
 
 const mockGetChainIdFromNetwork = vi.fn();
 vi.mock("@/lib/rpc/network-utils", () => ({

--- a/tests/unit/tempo-hold-payment.test.ts
+++ b/tests/unit/tempo-hold-payment.test.ts
@@ -1,19 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
-vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
-  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: { TRANSACTION: "transaction" },
   logUserError: vi.fn(),
 }));
-vi.mock("@/lib/utils", () => ({
-  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
-}));
+vi.mock("@/lib/utils", async () =>
+  (await import("../mocks/step-mocks")).utilsGetErrorMessage()
+);
 
 const mockGetChainIdFromNetwork = vi.fn();
 vi.mock("@/lib/rpc/network-utils", () => ({

--- a/tests/unit/tempo-transfer-with-memo.test.ts
+++ b/tests/unit/tempo-transfer-with-memo.test.ts
@@ -1,19 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
-vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
-  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: { TRANSACTION: "transaction" },
   logUserError: vi.fn(),
 }));
-vi.mock("@/lib/utils", () => ({
-  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
-}));
+vi.mock("@/lib/utils", async () =>
+  (await import("../mocks/step-mocks")).utilsGetErrorMessage()
+);
 
 const mockGetChainIdFromNetwork = vi.fn();
 vi.mock("@/lib/rpc/network-utils", () => ({

--- a/tests/unit/transfer-token-core.test.ts
+++ b/tests/unit/transfer-token-core.test.ts
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
 
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: {
@@ -48,9 +48,9 @@ vi.mock("drizzle-orm", () => ({
   inArray: () => ({}),
 }));
 
-vi.mock("@/lib/utils", () => ({
-  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
-}));
+vi.mock("@/lib/utils", async () =>
+  (await import("../mocks/step-mocks")).utilsGetErrorMessage()
+);
 
 vi.mock("@/lib/utils/id", () => ({
   generateId: vi.fn().mockReturnValue("test-unique-id"),

--- a/tests/unit/write-contract-core.test.ts
+++ b/tests/unit/write-contract-core.test.ts
@@ -4,13 +4,13 @@ const DIRECT_ID_PREFIX_REGEX = /^direct-/;
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
 
-vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
-  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
 
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: {
@@ -54,9 +54,9 @@ vi.mock("@/lib/utils/id", () => ({
   generateId: () => mockGenerateId(),
 }));
 
-vi.mock("@/lib/utils", () => ({
-  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
-}));
+vi.mock("@/lib/utils", async () =>
+  (await import("../mocks/step-mocks")).utilsGetErrorMessage()
+);
 
 vi.mock("@/lib/rpc/network-utils", () => ({
   getChainIdFromNetwork: vi.fn().mockReturnValue(1),

--- a/tests/unit/write-contract-fail-on-error.test.ts
+++ b/tests/unit/write-contract-fail-on-error.test.ts
@@ -9,13 +9,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
 
-vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
-  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
 
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: {

--- a/tests/unit/write-contract-value-cap.test.ts
+++ b/tests/unit/write-contract-value-cap.test.ts
@@ -8,13 +8,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/metrics/instrumentation/plugin", () => ({
-  withPluginMetrics: (_opts: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
 
-vi.mock("@/lib/workflow/executor/step-handler", () => ({
-  withStepLogging: (_input: unknown, fn: () => unknown) => fn(),
-}));
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
 
 vi.mock("drizzle-orm", () => ({ eq: () => ({}) }));
 


### PR DESCRIPTION
## Summary

First mechanical pass of the compile-surface reduction work: consolidate the two largest byte-identical duplications with no behavior change on the happy path.

- **One user-lookup helper instead of ten.** Every web3 read step carried its own copy of `getUserIdFromExecution`, all existing solely to thread the audit user into per-user RPC preference lookups - and the copies had drifted: eight threw on transient DB errors (failing a read-only step on a blip), two swallowed them. They are replaced by a single `getRpcPreferenceUserId` in `lib/workflow/executor/helpers.ts`, standardized on the non-throwing contract (missing context, unknown execution, or a DB failure resolve to `undefined` and the step falls back to the chain default RPC config - the behavior the recent SPL-balance review established as correct). The strict `getUserIdFromExecution` consumed by the codegen registry keeps its throwing contract, unchanged. Imports the deleted copies held (`eq`/`db`/`workflowExecutions` across eight files) are removed where now unused.
- **One test-mock preamble instead of 49 copies.** `tests/mocks/step-mocks.ts` (following the existing `tests/mocks/` convention) now owns the three invariant factories from the standard step-test preamble - step-handler passthrough, plugin-metrics passthrough, `getErrorMessage` - consumed via the hoisting-safe async-import form. 49 byte-identical blocks across 24 test files migrate to it; variant and spy-based mocks stay local, as do per-test db/schema shapes. Line-neutral by design: the point is that a `withStepLogging` signature change is now a one-file edit.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Biome clean on all lint-scoped changed files (25)
- [x] 969 tests across the 48 step-related suites pass
- [x] 421 tests across the 24 migrated test files pass
- [x] Full unit suite: 21211/21212 - the single failure (`agent-identity.test.ts`) reproduces identically on a clean checkout (pre-existing environment artifact, unrelated)
- [ ] CI