### PR TITLE
perf: reduce the root type-check program - hotspot annotations and executor isolation

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -221,6 +221,12 @@ jobs:
       - name: Run type check
         run: pnpm type-check
 
+      # keeperhub-executor is excluded from the root program (it is the sole
+      # importer of @kubernetes/client-node, 816 .d.ts files) and checked as
+      # its own smaller program, like keeperhub-scheduler/keeperhub-events.
+      - name: Run executor type check
+        run: pnpm type-check:executor
+
   build:
     runs-on: ubuntu-latest
     environment: staging

--- a/components/ai-elements/shimmer.tsx
+++ b/components/ai-elements/shimmer.tsx
@@ -25,9 +25,14 @@ const ShimmerComponent = ({
   duration = 2,
   spread = 2,
 }: TextShimmerProps) => {
+  // The cast keeps type-checking cheap: motion.create over the full
+  // JSX.IntrinsicElements union instantiates motion's generics for every
+  // intrinsic element (~1.7s of tsc check measured via --generateTrace).
+  // Runtime is unchanged; the props used below are common to all elements,
+  // so checking them against the default element's motion component is sound.
   const MotionComponent = motion.create(
     Component as keyof JSX.IntrinsicElements
-  );
+  ) as typeof motion.p;
 
   const dynamicSpread = useMemo(
     () => (children?.length ?? 0) * spread,

--- a/keeperhub-executor/tsconfig.json
+++ b/keeperhub-executor/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "plugins": []
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/lib/web3/sponsored-transaction-manager.ts
+++ b/lib/web3/sponsored-transaction-manager.ts
@@ -1,6 +1,12 @@
 import "server-only";
 import type { Hex, TransactionReceipt } from "viem";
-import { BaseError, createPublicClient, encodeFunctionData, http } from "viem";
+import {
+  BaseError,
+  createPublicClient,
+  encodeFunctionData,
+  http,
+  type PublicClient,
+} from "viem";
 import {
   checkGasCredits,
   getGasTokenPriceUsd,
@@ -223,7 +229,10 @@ const VIEM_REVERT_REASON_RE = /reverted with reason:\s*(.+?)\.?\s*$/i;
  * message.
  */
 async function decodeSponsoredRevertReason(
-  publicClient: ReturnType<typeof createPublicClient>,
+  // Concrete PublicClient rather than ReturnType<typeof createPublicClient>:
+  // the un-instantiated generic return type was the single most expensive
+  // comparison in the whole type-check (measured via tsc --generateTrace).
+  publicClient: PublicClient,
   txHash: Hex,
   blockNumber: bigint
 ): Promise<string | undefined> {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "pnpm discover-plugins && next build",
     "start": "next start",
     "type-check": "tsc --noEmit",
+    "type-check:executor": "tsc -p keeperhub-executor --noEmit",
     "check": "biome check",
     "check:api-docs": "tsx scripts/check-api-docs-routes.ts",
     "fix": "biome check --write",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,6 +40,7 @@
     "docs-site/**/*",
     "keeperhub-events/**/*",
     "keeperhub-scheduler/**/*",
+    "keeperhub-executor/**/*",
     "sandbox/**/*",
     "scripts/seed/dev-bootstrap.ts",
     "scripts/seed/fixtures/dev-workflows.ts",


### PR DESCRIPTION
## Summary

Phase 1 of the compile-surface work (both halves in one PR - the second builds on the first's measurements):

**Commit 1 - the two measured hotspots**, fixed with type annotations only, zero runtime change:
- `lib/web3/sponsored-transaction-manager.ts`: `decodeSponsoredRevertReason` typed its client param as `ReturnType<typeof createPublicClient>` - comparing that un-instantiated generic was the single most expensive operation in the whole check. Now the concrete viem `PublicClient` (the function only uses `.getTransaction` and `.call`).
- `components/ai-elements/shimmer.tsx`: `motion.create(Component as keyof JSX.IntrinsicElements)` instantiated motion's generics over the entire intrinsic-elements union; the result is now cast to `typeof motion.p`. Runtime identical; the props passed are common to all elements.

**Commit 2 - keeperhub-executor checked as its own program.** It is the sole importer of `@kubernetes/client-node` (816 `.d.ts` files). The root tsconfig now excludes it, following the existing scheduler/events precedent, and a new `type-check:executor` script + CI step checks it separately - it extends the root config, so `@/*` paths and strictness carry over and its deliberate `../lib` imports remain fully type-checked.

Measured cold on one machine (`tsc --noEmit --incremental false --extendedDiagnostics`):

| Metric | Baseline | After annotations | After isolation |
|---|---|---|---|
| Root check time | 44.80s | 40.50s | 38.46s (-14%) |
| Root memory | 3.53 GB | 3.28 GB | 2.72 GB (-23%) |
| Root program files | 9,004 | 9,004 | 8,148 |
| Instantiations | 4.04M | 3.28M | - |
| Executor program | - | - | 5,047 files, 7.19s, clean |

## Test plan

- [x] Root `tsc --noEmit` clean; executor `tsc -p keeperhub-executor` clean
- [x] Biome clean on changed files
- [x] 64 tests across the sponsored-transaction suites pass
- [ ] CI (including the new executor type-check step)