### PR TITLE
fix: KEEP-1206 stop the prod release path rebuilding the app on a runner

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -86,6 +86,22 @@ jobs:
             echo "INCLUDE_TEST_ENDPOINTS=true" >> "$GITHUB_ENV"
           fi
 
+      # docker-bake.hcl reads the repo names under different variable names than
+      # the job env above uses. Export them once, derived from the *_ECR_NAME
+      # values so there is a single source of truth for each repo, and every
+      # later step (both bake attempts) inherits them. KEEP-1206: doing this here
+      # rather than on the bake step means the build and its retry cannot drift
+      # apart, and no repo name is written down twice.
+      - name: Export bake repository variables
+        run: |
+          {
+            echo "ECR_REPO=${AWS_ECR_NAME}"
+            echo "EXECUTOR_ECR_REPO=${EXECUTOR_ECR_NAME}"
+            echo "SCHEDULER_ECR_REPO=${SCHEDULER_ECR_NAME}"
+            echo "METRICS_COLLECTOR_ECR_REPO=${COLLECTOR_ECR_NAME}"
+            echo "SANDBOX_ECR_REPO=${SANDBOX_ECR_NAME}"
+          } >> "$GITHUB_ENV"
+
       - name: Check commit message for skip flags
         id: skip
         run: |
@@ -105,9 +121,14 @@ jobs:
       - name: Extract commit hash and ECR coordinates
         id: vars
         run: |
-          SHA=$(git rev-parse --short HEAD)
-          if [[ -z "$SHA" || ${#SHA} -lt 7 ]]; then
-            echo "::error::Failed to resolve commit SHA (got '${SHA}')"
+          # --short=7 is pinned, NOT left to `git rev-parse --short`. That
+          # abbreviates to whatever length the local object count needs (7 in
+          # this shallow checkout, 9 in a full clone), which would silently move
+          # every image tag. ci-pipeline.yml's resolve-e2e-image job pins the
+          # same 7 so it can find the image this job pushed. KEEP-1206.
+          SHA=$(git rev-parse --short=7 HEAD)
+          if [[ ${#SHA} -ne 7 ]]; then
+            echo "::error::Expected a 7-character commit SHA, got '${SHA}'. Image tags would move; fix this before building."
             exit 1
           fi
           {
@@ -167,60 +188,46 @@ jobs:
         if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
         uses: docker/setup-buildx-action@v4
 
-      # Persist the Next.js incremental-compile cache (.next/cache) across runs.
-      # BuildKit type=cache mounts are not carried by the registry layer cache,
-      # so on ephemeral runners the mount starts empty and next build runs cold
-      # every time. actions/cache stores the mount contents; buildkit-cache-dance
-      # injects them into the BuildKit builder before the build (and extracts
-      # them again in its post step, before actions/cache saves). Keyed per
-      # environment so staging and prod never share a lineage.
-      - name: Restore Next.js build cache
-        id: next-cache
-        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
-        uses: actions/cache@v6
-        with:
-          path: .next-cache
-          key: next-build-cache-${{ env.ENVIRONMENT_TAG }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
-          restore-keys: |
-            next-build-cache-${{ env.ENVIRONMENT_TAG }}-${{ hashFiles('pnpm-lock.yaml') }}-
-            next-build-cache-${{ env.ENVIRONMENT_TAG }}-
+      # KEEP-1206: the `actions/cache` + `buildkit-cache-dance` pair that used to
+      # sit here is gone. Both existed to carry `.next/cache` across ephemeral
+      # runners so `next build` would run warm. Turbopack (the build default
+      # since Next 16) writes no persistent compile cache, so there was never
+      # anything to carry. Measured on 2026-08-24: after a full production build
+      # `.next/cache` holds only `.tsbuildinfo` plus the workflow DevKit
+      # manifests. The saved cache bore that out - 495 KB, every run. The
+      # Dockerfile keeps its `nextjs-build-cache` mount, which still serialises
+      # targets that share the builder stage within one bake; only the
+      # cross-run persistence is dropped. Restore this only alongside a Next
+      # version that actually persists a build cache, and confirm a cache
+      # larger than a megabyte really appears before trusting it.
 
-      - name: Inject Next.js build cache into BuildKit
-        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
-        uses: reproducible-containers/buildkit-cache-dance@v3
-        with:
-          cache-map: |
-            {
-              ".next-cache": {
-                "target": "/app/.next/cache",
-                "id": "nextjs-build-cache"
-              }
-            }
-          skip-extraction: ${{ steps.next-cache.outputs.cache-hit }}
-
+      # KEEP-1206. `pnpm build` inside this bake needs more than 16 GiB and at
+      # most 20 GiB (measured 2026-08-24: OOM-killed under a 16 GiB hard limit,
+      # clean at 20 GiB, peak 20.1 GiB, 4 CPUs, swap off). A standard runner has
+      # 16 GiB of RAM plus roughly 4 GiB of swap, so this build only just fits
+      # and it fits by swapping - which is why it takes 17-19 minutes rather than
+      # the ~6 it takes with real headroom, and why it dies outright when
+      # anything else on the runner wants memory. Measured rate: 4 failures in
+      # the last 40 push runs, staging and prod alike, all
+      # `ResourceExhausted: ... cannot allocate memory`.
+      #
+      # The retry below is a STOPGAP, not a fix. It works because BuildKit keeps
+      # the layers the first attempt completed, so the retry resumes rather than
+      # starting cold. It does not reduce the 20 GiB. Upgrading Next is NOT the
+      # way out: 16.3.2 was measured at ~30 GiB on this codebase, half again
+      # worse, and would break this build outright. The real fixes are more
+      # memory for this job or a smaller module graph.
+      #
+      # The verdict step below deliberately shouts when the retry was needed, so
+      # the failure rate stays visible instead of being hidden by the retry.
       - name: Build and push all images to ECR
+        id: bake
         if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
+        continue-on-error: true
         uses: docker/bake-action@v7
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPO: ${{ env.AWS_ECR_NAME }}
-          EXECUTOR_ECR_REPO: ${{ env.EXECUTOR_ECR_NAME }}
-          SCHEDULER_ECR_REPO: ${{ env.SCHEDULER_ECR_NAME }}
-          METRICS_COLLECTOR_ECR_REPO: ${{ env.COLLECTOR_ECR_NAME }}
-          SANDBOX_ECR_REPO: ${{ env.SANDBOX_ECR_NAME }}
           IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
-          NEXT_PUBLIC_AUTH_PROVIDERS: ${{ env.NEXT_PUBLIC_AUTH_PROVIDERS }}
-          NEXT_PUBLIC_GITHUB_CLIENT_ID: ${{ env.NEXT_PUBLIC_GITHUB_CLIENT_ID }}
-          NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ env.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
-          NEXT_PUBLIC_BILLING_ENABLED: ${{ env.NEXT_PUBLIC_BILLING_ENABLED }}
-          NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED: ${{ env.NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED }}
-          NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ env.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
-          ENVIRONMENT_TAG: ${{ env.ENVIRONMENT_TAG }}
-          INCLUDE_TEST_ENDPOINTS: ${{ env.INCLUDE_TEST_ENDPOINTS }}
-          NEXT_PUBLIC_SENTRY_DSN: ${{ env.NEXT_PUBLIC_SENTRY_DSN }}
-          SENTRY_ORG: ${{ env.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ env.SENTRY_PROJECT }}
-          SENTRY_AUTH_TOKEN: ${{ env.SENTRY_AUTH_TOKEN }}
           SENTRY_RELEASE: ${{ steps.vars.outputs.sha_short }}
         with:
           files: docker-bake.hcl
@@ -232,6 +239,40 @@ jobs:
             pipeline
             sandbox
           push: true
+
+      - name: Retry the image build once
+        id: bake-retry
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true' && steps.bake.outcome == 'failure'
+        continue-on-error: true
+        uses: docker/bake-action@v7
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
+          SENTRY_RELEASE: ${{ steps.vars.outputs.sha_short }}
+        with:
+          files: docker-bake.hcl
+          targets: |
+            pipeline
+            sandbox
+          push: true
+
+      - name: Image build verdict
+        if: steps.skip.outputs.skip_build != 'true' && steps.check-image.outputs.exists != 'true'
+        env:
+          FIRST: ${{ steps.bake.outcome }}
+          RETRY: ${{ steps.bake-retry.outcome }}
+        run: |
+          set -euo pipefail
+          if [[ "${FIRST}" == "success" ]]; then
+            echo "Image build succeeded on the first attempt."
+            exit 0
+          fi
+          if [[ "${RETRY}" == "success" ]]; then
+            echo "::warning title=KEEP-1206 image build retried::The image build failed on its first attempt and succeeded on the retry. This is the known memory ceiling, not a random flake - the build needs up to 20 GiB and a standard runner has about 20 GiB including swap. Track how often this warning appears; if it becomes common the job needs more memory or the module graph needs to shrink."
+            exit 0
+          fi
+          echo "::error title=KEEP-1206 image build failed twice::The image build failed on both attempts. If the logs show 'cannot allocate memory' or 'ResourceExhausted', the runner ran out of memory and re-running will not reliably help - this job needs more memory than a standard runner has."
+          exit 1
 
       # Sentry source-map upload moved out to its own sentry-upload.yml job,
       # fanned out from build-images in ci-pipeline.yml so it runs parallel to

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -36,9 +36,142 @@ jobs:
     uses: ./.github/workflows/build-images.yml
     secrets: inherit
 
+  # KEEP-1206. Prod pushes used to hand e2e an empty image_tag, which made both
+  # build-app and e2e-playwright-ephemeral run their own bare `pnpm build` on the
+  # runner. That build needs more than 16 GiB and at most 20 GiB (measured
+  # 2026-08-24: OOM-killed under a 16 GiB hard limit, clean at 20 GiB, peak
+  # 20.1 GiB, 4 CPUs, swap off), so it does not fit a standard runner and died on
+  # every release since 2026-08-18.
+  #
+  # A prod release is a merge of staging into prod, so the merge commit's tree is
+  # identical to its staging parent's tree. The staging image for that parent
+  # already exists and is built with INCLUDE_TEST_ENDPOINTS=true, which is what
+  # the e2e jobs need and which the prod image deliberately never carries. Point
+  # e2e at that image instead of rebuilding it.
+  #
+  # CONTRACT, do not break either half:
+  #   * This job reads the STAGING environment on purpose. Every ECR coordinate
+  #     comes from `environment: staging`, never from a literal.
+  #   * Its outputs feed `e2e-tests` ONLY. `deploy` keeps using
+  #     `needs.build-images.outputs.image_tag`, the prod tag. A staging tag
+  #     reaching the deploy input would ship staging images to production.
+  #
+  # Every check fails the run rather than falling back to a bare build: the
+  # fallback is the OOM this job exists to remove.
+  resolve-e2e-image:
+    if: ${{ github.event_name == 'push' && github.ref_name == 'prod' }}
+    runs-on: ubuntu-latest
+    environment: staging
+    outputs:
+      image_tag: ${{ steps.resolve.outputs.image_tag }}
+      sandbox_image: ${{ steps.resolve.outputs.sandbox_image }}
+      ecr_registry: ${{ steps.login-ecr.outputs.registry }}
+      ecr_repo: ${{ steps.resolve.outputs.ecr_repo }}
+      ecr_region: ${{ steps.resolve.outputs.ecr_region }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          # Both parents of the release merge commit, so the tree comparison
+          # below has the staging-side tree object available locally.
+          fetch-depth: 2
+
+      - name: Resolve the staging commit this release merges
+        id: staging-sha
+        run: |
+          set -euo pipefail
+          if ! git rev-parse --verify --quiet HEAD^2 >/dev/null; then
+            echo "::error::HEAD is not a merge commit, so there is no staging parent to source an e2e image from. A release must reach prod as a merge of staging. Push this as a staging->prod merge, or run the pipeline again once one exists."
+            exit 1
+          fi
+          MERGE_TREE=$(git rev-parse "HEAD^{tree}")
+          STAGING_TREE=$(git rev-parse "HEAD^2^{tree}")
+          if [[ "${MERGE_TREE}" != "${STAGING_TREE}" ]]; then
+            echo "::error::This release merge changed the tree relative to its staging parent (merge ${MERGE_TREE}, staging ${STAGING_TREE}). The staging image would not match the code being released, so e2e must not reuse it. Land the difference on staging first."
+            exit 1
+          fi
+          # --short=7 is pinned, NOT left to `git rev-parse --short`. That
+          # abbreviates to whatever length the local object count needs, so the
+          # same commit yields 7 characters in CI's shallow clone and 9 in a
+          # full one. build-images.yml pins the same 7 when it tags the image, so
+          # the two stay locked together. If that convention ever changes, the
+          # ECR existence check below fails loudly rather than silently looking
+          # for the wrong tag.
+          SHA=$(git rev-parse --short=7 "HEAD^2")
+          if [[ ${#SHA} -ne 7 ]]; then
+            echo "::error::Expected a 7-character staging SHA, got '${SHA}'. The image tag convention has changed; update this job and build-images.yml together."
+            exit 1
+          fi
+          echo "Release tree matches staging parent ${SHA}; e2e will reuse that build."
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.TO_REGION }}
+
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Confirm the staging images exist
+        id: resolve
+        env:
+          SHA: ${{ steps.staging-sha.outputs.sha }}
+          # Both resolve from `environment: staging` above. Never hard-code
+          # either: this job is the one place the pipeline reads across
+          # environments, so the values must come from the environment itself.
+          APP_ECR_NAME: ${{ vars.TO_ECR_NAME }}
+          REGION: ${{ vars.TO_REGION }}
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${APP_ECR_NAME}" || -z "${REGION}" ]]; then
+            echo "::error::The staging environment did not supply TO_ECR_NAME/TO_REGION. Refusing to guess an ECR coordinate."
+            exit 1
+          fi
+          # Same repo-naming convention build-images.yml uses for the satellite
+          # repos, pinned to the staging suffix because this job only ever reads
+          # staging. It is derived from APP_ECR_NAME so the account and prefix
+          # still come from the environment.
+          SANDBOX_ECR_NAME="keeperhub-sandbox-${APP_ECR_NAME##*-}"
+          MISSING=false
+          for pair in "${APP_ECR_NAME}:app" "${SANDBOX_ECR_NAME}:sandbox"; do
+            repo="${pair%%:*}"; prefix="${pair##*:}"
+            if aws ecr describe-images \
+                 --repository-name "${repo}" \
+                 --image-ids "imageTag=${prefix}-${SHA}" \
+                 --region "${REGION}" >/dev/null 2>&1; then
+              echo "${repo}:${prefix}-${SHA} found"
+            else
+              echo "::error::${repo}:${prefix}-${SHA} is absent. e2e cannot reuse the staging build for this release. Re-run the staging pipeline for ${SHA} so the image is rebuilt, then re-run this release."
+              MISSING=true
+            fi
+          done
+          if [[ "${MISSING}" == "true" ]]; then
+            exit 1
+          fi
+          {
+            echo "image_tag=${SHA}"
+            echo "ecr_repo=${APP_ECR_NAME}"
+            echo "ecr_region=${REGION}"
+            echo "sandbox_image=${REGISTRY}/${SANDBOX_ECR_NAME}:sandbox-${SHA}"
+          } >> "$GITHUB_OUTPUT"
+
   # Ephemeral e2e tests.
+  #
+  # Image source per ref (KEEP-1206):
+  #   staging -> build-images, the staging image it just baked.
+  #   prod    -> resolve-e2e-image, the STAGING image for the commit this
+  #              release merges. The prod image is never used here: it is built
+  #              without INCLUDE_TEST_ENDPOINTS, which the e2e suites require.
+  #   PR      -> empty, so build-app produces a bare .next as before.
+  # A failed resolve-e2e-image blocks this job rather than falling through to an
+  # empty image_tag, because that fallback is the bare build that OOMs.
   e2e-tests:
-    needs: [build-images]
+    needs: [build-images, resolve-e2e-image]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/e2e-tests-ephemeral.yml
     with:
@@ -46,15 +179,14 @@ jobs:
       caller_action: ${{ github.event.action }}
       has_e2e_label: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-e2e-tests-ephemeral') || false }}
       label_name: ${{ github.event.label.name || '' }}
-      # Pass build outputs only on staging; '' must be the `||` fallthrough since
-      # an empty string is falsy (`cond && '' || x` would always yield x).
-      image_tag: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.image_tag || '') || '' }}
-      # Prebuilt sandbox ref, staging only (same fallthrough rule as image_tag);
-      # empty on PRs/prod makes the e2e jobs build the sandbox locally.
-      sandbox_image: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.sandbox_image || '') || '' }}
-      ecr_registry: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.ecr_registry || '') || '' }}
-      ecr_repo: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.ecr_repo || '') || '' }}
-      ecr_region: ${{ github.ref_name == 'staging' && (needs.build-images.outputs.ecr_region || '') || '' }}
+      # '' must be the final `||` fallthrough since an empty string is falsy
+      # (`cond && '' || x` would always yield x). Each ref picks exactly one
+      # source; PRs reach the trailing ''.
+      image_tag: ${{ github.ref_name == 'staging' && needs.build-images.outputs.image_tag || github.ref_name == 'prod' && needs.resolve-e2e-image.outputs.image_tag || '' }}
+      sandbox_image: ${{ github.ref_name == 'staging' && needs.build-images.outputs.sandbox_image || github.ref_name == 'prod' && needs.resolve-e2e-image.outputs.sandbox_image || '' }}
+      ecr_registry: ${{ github.ref_name == 'staging' && needs.build-images.outputs.ecr_registry || github.ref_name == 'prod' && needs.resolve-e2e-image.outputs.ecr_registry || '' }}
+      ecr_repo: ${{ github.ref_name == 'staging' && needs.build-images.outputs.ecr_repo || github.ref_name == 'prod' && needs.resolve-e2e-image.outputs.ecr_repo || '' }}
+      ecr_region: ${{ github.ref_name == 'staging' && needs.build-images.outputs.ecr_region || github.ref_name == 'prod' && needs.resolve-e2e-image.outputs.ecr_region || '' }}
     secrets: inherit
 
   # Sentry source-map upload, fanned out from build-images alongside e2e so it
@@ -72,15 +204,25 @@ jobs:
     secrets: inherit
 
   # Deploy runs after build-images and e2e-tests.
-  # Blocked if e2e tests fail — no deployment without passing tests.
+  # Blocked if e2e tests fail - no deployment without passing tests.
   # Deploys the whole execution pipeline (app + executor + schedule + block +
   # metrics-collector) as one atomic keeperhub-stack release, so every component
   # rolls together. This replaces the previously separate app/executor/scheduler/
   # metrics-collector deploys and removes the staggered-rollover window that left
   # in-flight executions orphaned mid-deploy.
+  #
+  # KEEP-1206: the gate is the explicit `passed` output of the e2e workflow, not
+  # `!failure()`. The implicit form let three prod releases (2026-08-18, 08-20
+  # and 08-21) deploy with build-app in `failure`. Comparing against the literal
+  # string "true" fails closed: a skipped or crashed e2e-gate yields an empty
+  # output, which is not "true", so the deploy stops.
+  #
+  # When ENABLE_E2E_EPHEMERAL_TESTS is false every e2e job skips, e2e-gate reads
+  # those as legitimate skips and still emits "true". The kill switch keeps
+  # working exactly as before.
   deploy:
     needs: [build-images, e2e-tests]
-    if: ${{ github.event_name != 'pull_request' && !failure() && !cancelled() }}
+    if: ${{ github.event_name != 'pull_request' && !cancelled() && needs.e2e-tests.outputs.passed == 'true' }}
     uses: ./.github/workflows/deploy-keeperhub.yaml
     with:
       image_tag: ${{ needs.build-images.outputs.image_tag }}

--- a/.github/workflows/deploy-keeperhub.yaml
+++ b/.github/workflows/deploy-keeperhub.yaml
@@ -129,6 +129,55 @@ jobs:
         run: |
           kubectl apply -f deploy/keeperhub-stack/${{ vars.TO_HELM_VALUES_DIR }}/runner-sa.yaml
 
+      # KEEP-1206. A helm upgrade that is killed mid-flight leaves its release
+      # record in `pending-upgrade` forever, and every later upgrade then dies on
+      # "another operation (install/upgrade/rollback) is in progress". That
+      # happened on 2026-08-23: run 32670866140 attempt 4 started the upgrade,
+      # attempt 5 was launched three minutes later, GitHub cancelled attempt 4
+      # mid-helm, and prod deploys stayed blocked until the record was deleted by
+      # hand. The concurrency group above cannot prevent it, because the killer
+      # is a re-run of the same run rather than a second run.
+      #
+      # Deleting an abandoned record is safe: the pods it rolled are already
+      # live, and dropping it just makes the previous revision the current one
+      # again, which the next upgrade then diffs against. Deleting a record whose
+      # helm is still running is NOT safe, so anything younger than the helm
+      # timeout stops the deploy instead of being cleaned up.
+      - name: Reconcile an abandoned helm release lock
+        if: steps.skip.outputs.skip_deploy != 'true'
+        env:
+          # Helm's own --timeout below is 15m; allow it to elapse in full plus a
+          # margin before calling a record abandoned.
+          STALE_AFTER_SECONDS: "1200"
+        run: |
+          set -euo pipefail
+          PENDING=$(kubectl get secret -n "${NAMESPACE}" \
+            -l "owner=helm,name=${SERVICE_NAME},status in (pending-install,pending-upgrade,pending-rollback)" \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.labels.status}{"\t"}{.metadata.creationTimestamp}{"\n"}{end}')
+
+          if [[ -z "${PENDING}" ]]; then
+            echo "No pending helm release record for ${SERVICE_NAME}; nothing to reconcile."
+            exit 0
+          fi
+
+          NOW=$(date -u +%s)
+          BLOCKED=false
+          while IFS=$'\t' read -r NAME STATUS CREATED; do
+            [[ -z "${NAME}" ]] && continue
+            AGE=$(( NOW - $(date -u -d "${CREATED}" +%s) ))
+            if (( AGE < STALE_AFTER_SECONDS )); then
+              echo "::error::${NAME} is ${STATUS} and only ${AGE}s old, which is inside helm's ${STALE_AFTER_SECONDS}s window. Another deploy may still be running it. Refusing to touch it - wait for that deploy to finish, then re-run."
+              BLOCKED=true
+              continue
+            fi
+            echo "::warning::${NAME} is ${STATUS} and ${AGE}s old, past the ${STALE_AFTER_SECONDS}s window, so its helm process is gone. Deleting the abandoned record so this upgrade can proceed. The workloads it rolled are untouched."
+            kubectl delete secret "${NAME}" -n "${NAMESPACE}"
+          done <<< "${PENDING}"
+
+          if [[ "${BLOCKED}" == "true" ]]; then
+            exit 1
+          fi
+
       - name: Deploying Service to Kubernetes with Helm
         id: deploy
         if: steps.skip.outputs.skip_deploy != 'true'

--- a/.github/workflows/e2e-tests-ephemeral.yml
+++ b/.github/workflows/e2e-tests-ephemeral.yml
@@ -3,6 +3,14 @@ name: E2E Tests Ephemeral
 
 on:
   workflow_call:
+    outputs:
+      passed:
+        description: >-
+          "true" only when every e2e job reached an acceptable terminal state.
+          Callers MUST gate deployment on this equalling the string "true" and
+          must treat any other value, including an empty one, as a failure.
+          See the e2e-gate job for why `!failure()` is not enough.
+        value: ${{ jobs.e2e-gate.outputs.passed }}
     inputs:
       caller_event:
         description: "Event name from the calling workflow (push, pull_request)"
@@ -121,12 +129,25 @@ jobs:
             fi
           fi
 
-  # Production build for the bare-metal path (PRs, workflow_dispatch,
-  # schedule, prod pushes), done once and shared: the e2e vitest and
-  # protocol-coverage jobs download the artifact and start the app from
-  # it instead of each running its own pnpm build. Docker-path runs
-  # (staging pushes provide image_tag) skip this job; those jobs pull
-  # the prebuilt ECR image instead.
+  # Production build for the bare-metal path, done once and shared: the e2e
+  # vitest and protocol-coverage jobs download the artifact and start the app
+  # from it instead of each running its own pnpm build. Docker-path runs skip
+  # this job and pull the prebuilt ECR image instead.
+  #
+  # WARNING (KEEP-1206). This bare build does NOT fit a standard runner. It needs
+  # more than 16 GiB and at most 20 GiB (measured 2026-08-24: OOM-killed under a
+  # 16 GiB hard limit, clean at 20 GiB, peak 20.1 GiB, 4 CPUs, swap off), while
+  # ubuntu-latest offers 16 GiB of RAM plus roughly 4 GiB of swap. It died on
+  # every prod release from 2026-08-18 onward.
+  #
+  # Staging and prod pushes no longer reach this job: both now supply an
+  # image_tag, staging from build-images and prod from ci-pipeline's
+  # resolve-e2e-image (the staging image for the commit the release merges).
+  # The only caller left is a pull request carrying the run-e2e-tests-ephemeral
+  # label, and there is no prebuilt image to hand a PR. So that label is
+  # currently unusable: adding it makes this job OOM. Nothing has hit it because
+  # no recent PR used the label. Before relying on PR e2e again, either give this
+  # job a runner with real memory or build a PR image for it to reuse.
   build-app:
     needs: should-run
     if: ${{ needs.should-run.outputs.run-e2e == 'true' && inputs.image_tag == '' }}
@@ -141,14 +162,17 @@ jobs:
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
 
-      - name: Cache Next.js build
-        uses: actions/cache@v6
-        with:
-          path: .next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.ts', '**/*.tsx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
-            ${{ runner.os }}-nextjs-
+      # KEEP-1206: the `actions/cache` step that used to sit here is gone.
+      # It was added on the premise that a warm `.next/cache` makes a
+      # GitHub-hosted build cheap. Turbopack (the build default since Next 16)
+      # writes no persistent compile cache, so that premise never held. Measured
+      # on 2026-08-24: after a full production build `.next/cache` holds only
+      # `.tsbuildinfo` plus the workflow DevKit manifests - nothing Turbopack
+      # can reuse. In practice nothing was restored either: zero
+      # `Linux-nextjs-*` caches existed at all, because this job's key embeds
+      # `hashFiles('**/*.ts','**/*.tsx')` and busts on every commit. Restore
+      # this only alongside a Next version that actually persists a build cache,
+      # and verify a cache larger than a megabyte really appears before trusting it.
 
       # Same env the start-app action's bare-metal build step used when it
       # lived inside the e2e vitest job, except DATABASE_URL, which must be
@@ -1491,3 +1515,65 @@ jobs:
           name: playwright-screenshots-ephemeral
           path: test-results/**/*.png
           retention-days: 7
+
+  # KEEP-1206. The deploy gate used to be `!failure() && !cancelled()` over this
+  # workflow in ci-pipeline.yml. That did not hold: on 2026-08-18 (run
+  # 32126673288), 2026-08-20 (32329142935) and 2026-08-21 (32507444096) the
+  # build-app job ended `failure` and deploy + release still ran to success, so
+  # three prod releases shipped without a passing e2e suite. On attempt 3 of run
+  # 32670866140 the same failure did skip deploy, so the bypass rides on the
+  # re-run path. The exact GitHub semantics behind it are not pinned down, and
+  # the gate should not depend on knowing them.
+  #
+  # This job replaces that implicit gate with an explicit one. It reads every
+  # sibling job's `result` directly and emits a single string. `always()` makes
+  # it run even when a sibling failed, so a caller that sees no output at all is
+  # looking at an infrastructure failure and must also treat that as not-passed.
+  #
+  # `skipped` is accepted because several jobs skip legitimately: build-app skips
+  # on the Docker path, and every job skips when should-run says run-e2e=false
+  # (the ENABLE_E2E_EPHEMERAL_TESTS kill switch or a [skip e2e] commit). Only
+  # `failure` and `cancelled` are rejected.
+  e2e-gate:
+    needs:
+      - should-run
+      - build-app
+      - tier1-simulations
+      - tier1-simulations-l2
+      - e2e-vitest-ephemeral
+      - protocol-coverage-ephemeral
+      - protocol-coverage-floor
+      - e2e-playwright-ephemeral
+    if: always()
+    runs-on: ubuntu-latest
+    outputs:
+      passed: ${{ steps.gate.outputs.passed }}
+    steps:
+      - name: Evaluate every e2e job result
+        id: gate
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          # Write `passed` exactly once. Emitting it twice would leave two
+          # values in $GITHUB_OUTPUT and make the gate depend on which one the
+          # runner keeps. Any exit before the write leaves the output unset,
+          # which the caller already treats as not-passed.
+          BAD=""
+          while IFS=$'\t' read -r job result; do
+            case "${result}" in
+              success|skipped)
+                echo "ok       ${job}: ${result}" ;;
+              *)
+                echo "NOT OK   ${job}: ${result}"
+                BAD="${BAD} ${job}(${result})" ;;
+            esac
+          done < <(echo "${RESULTS}" | jq -r 'to_entries[] | "\(.key)\t\(.value.result)"')
+
+          if [[ -n "${BAD}" ]]; then
+            echo "passed=false" >> "$GITHUB_OUTPUT"
+            echo "::error::E2E gate is closed. Not acceptable:${BAD}. Deployment must not proceed."
+            exit 1
+          fi
+          echo "passed=true" >> "$GITHUB_OUTPUT"
+          echo "E2E gate is open: every job succeeded or skipped legitimately."


### PR DESCRIPTION
Closes the prod release blockage in KEEP-1206. The ticket's framing is corrected below - several of its claims did not hold once measured.

## What was actually wrong

Prod is **not** stuck on Aug 12 code and releases were **not** blocked. On 2026-08-18, 08-20 and 08-21 the `e2e-tests / build-app` job ended `failure` and `deploy` plus `release` still ran to success (runs 32126673288, 32329142935, 32507444096; helm revisions 257, 259, 260 all "Upgrade complete"). Three prod releases shipped **without a passing e2e suite**. That is the real severity.

What blocked the 2026-08-23 release was a stuck helm record, which the ticket does not mention. Attempt 4 started the upgrade, attempt 5 was launched three minutes later, GitHub cancelled attempt 4 mid-`helm upgrade`, and revision 262 sat in `pending-upgrade`. Every later deploy then failed on `another operation (install/upgrade/rollback) is in progress`. That record has been cleared; prod runs `app-273e31c` at full readiness.

## The measurement

Cold `next build` at staging HEAD, Dockerfile `source` stage, 4 CPUs to match the runner, swap disabled, cgroup v2 `memory.peak`:

| Config | Limit | Result | Peak |
|---|---|---|---|
| next 16.2.11 | 16 GiB | OOM-killed @109s | hit ceiling |
| next 16.2.11 | 16 GiB, 2 CPUs | OOM-killed @209s | hit ceiling |
| next 16.2.11 | 20 GiB | pass, 344s | no OOM |
| next 16.2.11 | 32 GiB | pass, 335s | **20.1 GiB** |
| next 16.3.2 | 32 GiB | **OOM-killed** | hit ceiling |
| next 16.3.2, build cache off | 32 GiB | pass, 427s | **30.0 GiB** |

So the build needs >16 and <=20 GiB. A standard runner is 16 GiB of RAM plus roughly 4 GiB of swap, which is why the Docker build only just fits, takes 17-19 min rather than ~6, and fails about 1 push in 10.

**Upgrading Next is not the way out.** 16.3.2 measures ~30 GiB on this codebase, half again worse, and would break `build-images` outright. `turbopackFileSystemCacheForBuild` already defaults to `true` in 16.3.2 and is not the cause. Halving CPUs does not help either.

## What this changes

- **Prod pushes reuse the staging image.** A release reaches prod as a merge of staging, so the merge tree is identical to its staging parent's (verified on the last three releases). That parent's image is already built with `INCLUDE_TEST_ENDPOINTS`, which e2e needs and the prod image never carries. A new `resolve-e2e-image` job resolves it and **fails the run** rather than falling back to the bare build. This removes both bare builds from the release path - `build-app` and the second one inside `e2e-playwright-ephemeral` via `start-app`, which had been dying since Aug 14.
- **`deploy` gates on an explicit `passed` output** from the e2e workflow instead of `!failure()`, which is what let those three releases through. Fails closed: an empty output is not `"true"`.
- **The deploy job reconciles an abandoned helm record** before upgrading, encoding the manual fix. A record younger than the helm timeout stops the deploy instead of being cleaned up.
- **The image bake retries once** and says so loudly when the retry was needed, so the failure rate stays visible. This is a stopgap for the memory ceiling, not a fix.
- **The `.next` cache steps and `buildkit-cache-dance` are removed.** Turbopack writes no persistent build cache - verified directly: after a full build `.next/cache` holds only `.tsbuildinfo` and the workflow manifests. The saved cache was 495 KB every run.
- **`git rev-parse --short=7` is pinned** in both the tagger and the resolver. Left to itself it abbreviates by local object count - 7 in CI's shallow clone, 9 in a full one - which would have made the resolver look for a tag that does not exist.

### Contract to preserve on review

`deploy` and `sentry-upload` must keep using `needs.build-images.outputs.image_tag`, the **prod** tag. `resolve-e2e-image` reads the **staging** environment on purpose and its outputs feed `e2e-tests` only. A staging tag reaching the deploy input would ship staging images to production.

## Known gap, deliberately left

`build-images` still needs ~20 GiB and will keep failing occasionally; the retry masks it rather than fixing it. The durable fix is more memory for that job or a smaller module graph. The `run-e2e-tests-ephemeral` PR label is now the only caller of the bare build, so adding it to a PR will OOM - documented in the workflow rather than left as a trap.

## Verification

Local CI green: actionlint, `pnpm check`, `pnpm type-check`, `pnpm test:unit` (21,337), `pnpm test:integration` (963), sandbox suite (39). The resolver, the gate and the helm preflight were each exercised against real data - the resolver against the last three prod releases and the live ECR, the gate against all five job-result scenarios including the exact bypass, the preflight against the real Aug 23 record.

Not verified: end-to-end behaviour on a real prod release. That can only be confirmed on the next `staging`->`prod` promotion.