### PR TITLE
perf: KEEP-1088 batch eth_getLogs for sub-second block chains

### DIFF
--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -830,14 +830,25 @@ export class ChainProviderManager {
     entry.provider.on("block", listener);
   }
 
-  private detachBlockListener(entry: ChainEntry): void {
+  /**
+   * Stop delivering blocks on this connection.
+   *
+   * `retainWindow` decides the fate of an open coalescing window, and the two
+   * cases are not alike. Unsubscribe and destroy leave no subscriber to
+   * dispatch to, so the buffered numbers are discarded. A reconnect does not:
+   * its subscribers are still attached and still expect those logs, and
+   * discarding them would lose events that per-block dispatch never could.
+   * The numbers are just block heights, not provider state, so the reconnect
+   * carries them and the replacement connection serves them.
+   */
+  private detachBlockListener(entry: ChainEntry, retainWindow = false): void {
     entry.blockListenerAttachedAt = null;
-    // Drop any open window. Detach happens when the last subscriber leaves
-    // (nothing left to dispatch to) or when the connection is being replaced
-    // (the buffered numbers belong to the old provider, and a reconnect has
-    // already lost blocks for its downtime). Flushing here would issue a
-    // request against a provider that is about to be destroyed.
-    this.clearBatchWindow(entry);
+    // The timer always goes: it must not fire against a provider that is
+    // being torn down.
+    this.stopBatchTimer(entry);
+    if (!retainWindow) {
+      entry.pendingBlocks = [];
+    }
     if (!(entry.provider && entry.blockListener)) {
       entry.blockListener = null;
       return;
@@ -911,7 +922,8 @@ export class ChainProviderManager {
    */
   private async flushBatchWindow(entry: ChainEntry): Promise<void> {
     const blocks = entry.pendingBlocks;
-    this.clearBatchWindow(entry);
+    this.stopBatchTimer(entry);
+    entry.pendingBlocks = [];
     if (blocks.length === 0) {
       return;
     }
@@ -926,12 +938,11 @@ export class ChainProviderManager {
     );
   }
 
-  private clearBatchWindow(entry: ChainEntry): void {
+  private stopBatchTimer(entry: ChainEntry): void {
     if (entry.batchTimer) {
       clearTimeout(entry.batchTimer);
       entry.batchTimer = null;
     }
-    entry.pendingBlocks = [];
   }
 
   private attachErrorListener(entry: ChainEntry): void {
@@ -1084,6 +1095,13 @@ export class ChainProviderManager {
     }
     entry.isReconnecting = true;
     this.stopHeartbeat(entry);
+    // Disarm the coalescing window here rather than in `reconnect()`, which
+    // does not run until the backoff has elapsed. The window is the same
+    // width as the initial backoff, so leaving it armed lets it fire against
+    // the connection that just failed: the request throws, and the buffered
+    // blocks are lost to a logged warning. The blocks themselves are kept -
+    // `reconnect()` carries them to the replacement.
+    this.stopBatchTimer(entry);
 
     // Publish the reconnect promise on the entry BEFORE any `await`
     // yields. `getOrCreateProvider` awaits this to avoid creating a
@@ -1179,7 +1197,7 @@ export class ChainProviderManager {
     // the old provider cannot trigger another reconnect while we are
     // building the new one.
     if (entry.provider) {
-      this.detachBlockListener(entry);
+      this.detachBlockListener(entry, true);
       this.detachErrorListener(entry);
       try {
         await entry.provider.destroy();
@@ -1233,6 +1251,10 @@ export class ChainProviderManager {
     if (entry.subscribers.size > 0) {
       this.attachBlockListener(entry);
       this.startHeartbeat(entry);
+      // Serve the window the dropped connection was holding. These heights
+      // are historical by now, so the replacement answers for them as well as
+      // the original would have.
+      await this.flushBatchWindow(entry);
     }
   }
 

--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -122,6 +122,15 @@ const BLOCK_INTERVAL_EWMA_ALPHA = 0.2;
  * That leaves the log stream. `logger` emits canonical single-line JSON
  * precisely so Loki can aggregate across the app and its satellites, so a
  * periodic line is the one channel that makes calls-per-day observable.
+ *
+ * The counters are packed as key=value inside `msg` rather than as JSON
+ * fields, because the logger has no structured-field API. Querying them
+ * therefore needs the inner parse as well:
+ *
+ *   {namespace="keeperhub"} |= "getlogs-stats"
+ *     | json | line_format "{{.msg}}" | logfmt
+ *
+ * `| json` alone yields `msg` as one string, not the individual counters.
  */
 const STATS_LOG_INTERVAL_MS = 60_000;
 const INITIAL_RECONNECT_DELAY_MS = 1_000;
@@ -1360,9 +1369,6 @@ export class ChainProviderManager {
     const { addresses, topic0s } = this.collectFilter(subscribers);
     const fromHex = `0x${fromBlock.toString(16)}`;
     const toHex = `0x${toBlock.toString(16)}`;
-    entry.stats.ranges += 1;
-    entry.stats.blocksCovered += toBlock - fromBlock + 1;
-
     try {
       const logs: ethers.Log[] = [];
       for (let i = 0; i < addresses.length; i += GETLOGS_ADDRESS_BATCH) {
@@ -1386,6 +1392,14 @@ export class ChainProviderManager {
       for (const log of logs) {
         await this.dispatchLog(entry, log);
       }
+      // Counted only once every request for the range returned. A throw
+      // leaves the range out of `blocksCovered` entirely, so a failing chain
+      // cannot report blocks it never fetched logs for - which would make
+      // the blocks-per-call ratio look most efficient exactly when the chain
+      // is least working. The calls themselves are counted at issue, since a
+      // request that fails was still made and still billed.
+      entry.stats.ranges += 1;
+      entry.stats.blocksCovered += toBlock - fromBlock + 1;
       entry.stats.logsDispatched += logs.length;
     } catch (err) {
       entry.stats.getLogsErrors += 1;
@@ -1403,11 +1417,12 @@ export class ChainProviderManager {
     if (this.statsTimer || this.isDestroyed) {
       return;
     }
-    const timer = setInterval(() => {
+    // Not unref'd, matching every other timer in this class: `destroy`
+    // clears it, and `unref` is not on `setInterval`'s return type under
+    // every lib configuration this package compiles against.
+    this.statsTimer = setInterval(() => {
       this.logStats();
     }, STATS_LOG_INTERVAL_MS);
-    timer.unref?.();
-    this.statsTimer = timer;
   }
 
   private stopStatsTimer(): void {

--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -14,13 +14,18 @@ import { logger } from "../../lib/utils/logger";
  * typically ~1000 per WSS).
  *
  * Request volume is driven by block rate, so a sub-second chain costs orders
- * of magnitude more than a 12 s one for the same subscriptions. Blocks from a
- * chain observed to be producing them faster than
- * `BATCHING_BLOCK_INTERVAL_THRESHOLD_MS` are coalesced into a
- * `BATCH_WINDOW_MS` window and served by a single ranged request. Cadence is
- * measured per connection rather than configured, and every chain starts out
- * dispatching per block, so a chain only leaves the historical behaviour once
- * it has demonstrated it needs to.
+ * of magnitude more than a 12 s one for the same subscriptions. Requests are
+ * therefore rate limited rather than issued per block: each chain keeps a
+ * high-water mark of the last block it has served, and a drain fetches
+ * `(mark, head]` at most once per `GETLOGS_MIN_INTERVAL_MS`.
+ *
+ * Nothing branches on how fast a chain is. A chain whose blocks arrive
+ * further apart than that interval always finds it already elapsed and
+ * dispatches immediately - one request per block, as before - while a faster
+ * one accumulates against the mark and is served in one ranged request. The
+ * range is contiguous, so blocks the subscription never pushed are covered
+ * too, and the mark survives a reconnect so a replacement connection resumes
+ * rather than starting blind.
  *
  * Per-chain reconnect + heartbeat are owned here. Drop detection uses two
  * signals:
@@ -42,7 +47,7 @@ import { logger } from "../../lib/utils/logger";
 
 // Address list cap on `eth_getLogs` varies by provider (Alchemy ~500,
 // Infura ~1000). Chunk defensively; multiple calls per block are cheap.
-const GETLOGS_ADDRESS_BATCH = 500;
+export const GETLOGS_ADDRESS_BATCH = 500;
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const HEARTBEAT_TIMEOUT_MS = 10_000;
@@ -58,53 +63,84 @@ const HEARTBEAT_TIMEOUT_MS = 10_000;
  * time so a slow-but-healthy chain is never reconnected for a normal
  * inter-block gap; overridable per-manager for tests.
  */
-const BLOCK_STALENESS_TIMEOUT_MS = 120_000;
+export const BLOCK_STALENESS_TIMEOUT_MS = 120_000;
 /**
  * Floor on the derived staleness threshold for a batching chain. A chain
  * producing blocks every 100 ms would otherwise derive a 1 s threshold and
  * reconnect on any brief upstream hiccup. 30 s is ~300 blocks of slack there,
  * still three orders of magnitude tighter than the fixed default.
  */
-const BLOCK_STALENESS_FLOOR_MS = 30_000;
-/** Blocks of slack the derived staleness threshold allows. */
-const BLOCK_STALENESS_BLOCK_MULTIPLIER = 10;
+export const BLOCK_STALENESS_FLOOR_MS = 30_000;
+/**
+ * Blocks of slack the derived staleness threshold allows.
+ *
+ * Chosen so that no chain running today changes: at 60 blocks, Base's 2 s
+ * cadence derives 120 s and Ethereum's 12 s clamps to the same, which is what
+ * both had before any of this existed. A 100 ms chain derives 6 s and takes
+ * the 30 s floor instead. The value is live between those - a 1 s chain
+ * derives 60 s - so tuning it has an effect rather than being absorbed by a
+ * bound, which is what a multiplier of 10 was: every reachable cadence
+ * produced a value below the floor, making the constant dead and the
+ * documented `max(floor, interval x N)` rule unobservable.
+ */
+export const BLOCK_STALENESS_BLOCK_MULTIPLIER = 60;
 
 /**
- * Batching engages only below this observed inter-block interval. Every chain
- * supported today produces blocks at 2 s or slower, so all of them keep the
- * historical one-`eth_getLogs`-per-block behaviour and its latency; batching
- * is reachable only by a sub-second chain, where per-block calls are the
- * problem (a 100 ms chain issues 864,000 calls/day/address-batch against
- * Base's 43,200).
+ * Minimum wall-clock gap between `eth_getLogs` requests for one chain.
  *
- * Set well clear of both sides rather than at the 1 s round number: the
- * integration rig runs anvil at `--block-time 1`, and a chain sitting exactly
- * on the threshold would drift across it on timer jitter alone and batch
- * nondeterministically. 500 ms leaves 5x margin below to the chain this
- * exists for and 2x above to the fastest cadence anything here produces.
+ * Request volume is driven by block rate, so a sub-second chain costs orders
+ * of magnitude more than a 12 s one for the same subscriptions: at 100 ms a
+ * chain issues 864,000 calls/day/address-batch against Base's 43,200. Rate
+ * limiting the request rather than measuring the chain bounds that directly -
+ * one call per second per chain, whatever the cadence.
+ *
+ * Nothing here is conditional on a chain being fast. A chain whose blocks
+ * arrive further apart than this always finds the interval already elapsed
+ * and dispatches immediately, so every chain supported today - 2 s at the
+ * fastest - keeps one request per block and its current latency without a
+ * threshold deciding anything. A 100 ms chain finds it has not, and its
+ * blocks accumulate against the high-water mark until it has.
+ *
+ * The gap is well inside the 0-10 s jitter `EventListener` already applies
+ * before forwarding a matched event, so it is not the binding term in
+ * end-to-end trigger latency on any chain.
  */
-const BATCHING_BLOCK_INTERVAL_THRESHOLD_MS = 500;
+export const GETLOGS_MIN_INTERVAL_MS = 1_000;
 /**
- * Width of the coalescing window, measured from the first buffered block.
- * Well inside the 0-10 s jitter `EventListener` already applies before
- * forwarding a matched event, so it is not the binding term in end-to-end
- * trigger latency.
+ * Ceiling on the block span of a single request, so a wide gap - a long
+ * reconnect, a slow drain, a chain that ran ahead - cannot produce one
+ * oversized response or trip a provider's block-range limit. A remainder is
+ * left for the next drain rather than dropped.
  */
-const BATCH_WINDOW_MS = 1_000;
+export const GETLOGS_MAX_BLOCK_SPAN = 25;
 /**
- * Ceiling on blocks per windowed request, so a burst (catch-up after a slow
- * flush) cannot widen the range without bound and produce an oversized
- * response or trip a provider's block-range limit.
+ * Ceiling on how far behind the head the mark may fall before the gap is
+ * abandoned rather than walked.
+ *
+ * The mark survives a reconnect, which is what lets a drain recover blocks
+ * the subscription missed while it was down. Left unbounded, a long outage on
+ * a fast chain would queue hours of catch-up at one request per second and
+ * starve current blocks behind history nobody is waiting for. Past this the
+ * mark jumps to the head and the skip is logged, so the loss is recorded
+ * rather than silent.
  */
-const BATCH_MAX_BLOCKS = 25;
-/**
- * Inter-block intervals folded into the EWMA before its value is trusted.
- * Until then a chain dispatches per block, so a misjudged cadence at startup
- * can only fail towards today's behaviour.
- */
-const BLOCK_INTERVAL_WARMUP_SAMPLES = 20;
+export const GETLOGS_MAX_CATCHUP_BLOCKS = 5_000;
 /** EWMA smoothing factor for the inter-block interval. */
 const BLOCK_INTERVAL_EWMA_ALPHA = 0.2;
+/**
+ * Inter-block intervals required before the cadence estimate is trusted.
+ */
+export const BLOCK_INTERVAL_MIN_SAMPLES = 20;
+/**
+ * Wall-clock the samples must also span before the estimate is trusted.
+ *
+ * A sample count alone is not evidence of cadence. Twenty `newHeads` messages
+ * drained back-to-back out of a socket buffer after an event-loop stall are
+ * twenty samples milliseconds apart, and would read a 12 s chain as a 1 ms
+ * one. Requiring the samples to cover real time as well makes that
+ * impossible: a burst cannot manufacture a minute.
+ */
+export const BLOCK_INTERVAL_MIN_SPAN_MS = 60_000;
 /**
  * Cadence of the per-chain `getlogs-stats` line.
  *
@@ -132,7 +168,7 @@ const BLOCK_INTERVAL_EWMA_ALPHA = 0.2;
  *
  * `| json` alone yields `msg` as one string, not the individual counters.
  */
-const STATS_LOG_INTERVAL_MS = 60_000;
+export const STATS_LOG_INTERVAL_MS = 60_000;
 const INITIAL_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 60_000;
 const MAX_RECONNECT_ATTEMPTS = 10;
@@ -200,17 +236,19 @@ export interface ChainHealth {
    */
   blockIntervalMs: number | null;
   /**
-   * Whether this chain is coalescing blocks into windowed ranged requests
-   * rather than dispatching one request per block.
+   * How many blocks the head is ahead of the last block served, or null
+   * before the first block arrives. Zero on a chain keeping up; a persistently
+   * positive value means requests are being rate limited behind the head.
    */
-  batching: boolean;
+  blocksBehindHead: number | null;
   /**
-   * Cumulative `eth_getLogs` calls issued for this chain since the entry
-   * was created, across reconnects. The same counter reported by the
-   * periodic `getlogs-stats` line, surfaced here so the number is reachable
-   * without log search if this endpoint ever becomes reachable.
+   * Cumulative `eth_getLogs` calls issued for this chain since the entry was
+   * created, across reconnects. Named to match `getLogsCallsTotal` on the
+   * `getlogs-stats` line, which is its source: the line's `getLogsCalls` is
+   * the per-interval count, a different quantity, and giving the two the same
+   * name invited reading a rate as a counter.
    */
-  getLogsCalls: number;
+  getLogsCallsTotal: number;
   /**
    * If the most recent `createProvider` attempt rejected, the error
    * message captured at rejection time. Cleared on the next successful
@@ -304,20 +342,34 @@ interface ChainEntry {
   lastBlockIntervalAt: number | null;
   /**
    * EWMA of inter-block arrival intervals in ms, or null before the first
-   * interval is observed. Measured rather than configured: no per-chain block
-   * time reaches this process, and an observed value needs no migration when
-   * a chain is added or its cadence changes.
+   * interval is observed. Used only to size the block-staleness threshold -
+   * dispatch does not consult it, so a wrong estimate cannot change which
+   * logs are fetched.
    */
   blockIntervalEwmaMs: number | null;
   /** Intervals folded into `blockIntervalEwmaMs` since the last attach. */
   blockIntervalSamples: number;
+  /** When the first interval since the last attach was recorded. */
+  blockIntervalFirstSampleAt: number | null;
   /**
-   * Block numbers awaiting a windowed ranged `eth_getLogs`. Non-empty only
-   * while batching is engaged.
+   * Highest block whose logs have been fetched and dispatched. The drain
+   * queries forward from here, so it is the one piece of state that decides
+   * what is owed. Survives a reconnect: a replacement connection resumes
+   * where the old one stopped rather than starting blind.
    */
-  pendingBlocks: number[];
-  /** Open coalescing window, started by the first block buffered into it. */
-  batchTimer: ReturnType<typeof setTimeout> | null;
+  lastProcessedBlock: number | null;
+  /** Highest block number the subscription has reported. */
+  headBlock: number | null;
+  /** When the last `eth_getLogs` request for this chain was issued. */
+  lastRequestAt: number | null;
+  /** Armed when blocks are owed but the minimum interval has not elapsed. */
+  catchUpTimer: ReturnType<typeof setTimeout> | null;
+  /**
+   * True while a drain is in flight. Blocks keep arriving during a request,
+   * and each one calls `drain`; without this they would issue overlapping
+   * requests for overlapping ranges.
+   */
+  draining: boolean;
   /**
    * Populated when `createProvider` rejects (most often the
    * subscription probe). Cleared on the next successful creation.
@@ -336,11 +388,18 @@ interface ChainEntry {
  * None of it resets on reconnect. The cadence estimate is per connection
  * because a new socket may be a different upstream; cost is per chain.
  *
- * `blocksCovered` against `getLogsCalls` is the ratio the batching exists to
- * move, and it is self-comparing: a per-block chain reports them roughly
- * equal, a batching chain reports blocks far ahead of calls. That matters
- * because there is no historical baseline for this quantity to compare a
- * later reading against - nothing has ever counted it.
+ * `blocksCovered / ranges` is the ratio the rate limiting exists to move, and
+ * it is self-comparing: a chain dispatching one request per block reports
+ * exactly 1, a rate-limited chain reports the average blocks served per
+ * request. That matters because there is no historical baseline for this
+ * quantity to compare a later reading against - nothing has ever counted it.
+ *
+ * Read it against `ranges`, not `getLogsCalls`. `getLogsCalls` counts one per
+ * address chunk, so a chain with more than `GETLOGS_ADDRESS_BATCH` subscribed
+ * addresses issues several calls per range and the blocks-per-call figure
+ * halves for a reason that has nothing to do with coalescing. `getLogsCalls`
+ * is the cost number - it is what a provider bills - and `ranges` is the
+ * denominator that isolates the behaviour.
  */
 interface ChainStats {
   getLogsCalls: number;
@@ -434,8 +493,8 @@ export class ChainProviderManager {
   private readonly blockStalenessTimeoutOverrideMs: number | null;
   /**
    * Manager-wide timer for the periodic per-chain counter line. Started with
-   * the first block listener and stopped in `destroy`. Unreferenced so a
-   * reporting-only timer can never hold the process open.
+   * the first block listener and cleared by `destroy`, which the shutdown
+   * path calls. Not unref'd, matching every other timer in this class.
    */
   private statsTimer: ReturnType<typeof setInterval> | null = null;
   private isDestroyed = false;
@@ -627,8 +686,11 @@ export class ChainProviderManager {
       lastBlockAt: entry.lastBlockAt,
       subscriberCount: entry.subscribers.size,
       blockIntervalMs: entry.blockIntervalEwmaMs,
-      batching: this.isBatching(entry),
-      getLogsCalls: entry.stats.getLogsCallsTotal,
+      blocksBehindHead:
+        entry.headBlock !== null && entry.lastProcessedBlock !== null
+          ? Math.max(0, entry.headBlock - entry.lastProcessedBlock)
+          : null,
+      getLogsCallsTotal: entry.stats.getLogsCallsTotal,
       lastCreateError: entry.lastCreateError,
     };
   }
@@ -712,8 +774,12 @@ export class ChainProviderManager {
       lastBlockIntervalAt: null,
       blockIntervalEwmaMs: null,
       blockIntervalSamples: 0,
-      pendingBlocks: [],
-      batchTimer: null,
+      blockIntervalFirstSampleAt: null,
+      lastProcessedBlock: null,
+      headBlock: null,
+      lastRequestAt: null,
+      catchUpTimer: null,
+      draining: false,
       lastCreateError: null,
       disconnectHandlers: new Set(),
       stats: newChainStats(),
@@ -902,46 +968,35 @@ export class ChainProviderManager {
       const now = Date.now();
       this.recordBlockInterval(entry, now);
       entry.lastBlockAt = now;
-      if (!this.isBatching(entry)) {
-        await this.processBlockRange(entry, blockNumber, blockNumber);
-        return;
+      if (entry.headBlock === null || blockNumber > entry.headBlock) {
+        entry.headBlock = blockNumber;
       }
-      await this.bufferBlock(entry, blockNumber);
+      await this.drain(entry);
     };
     entry.blockListener = listener;
     // Baseline for the block-staleness watchdog: until the first block
     // arrives, staleness is measured from attach time so a subscription that
     // never delivers a block is still caught.
     entry.blockListenerAttachedAt = Date.now();
-    // A fresh connection re-learns the chain's cadence. Carrying the previous
-    // connection's estimate across a reconnect would let a stale value decide
-    // batching for a provider that may be a different upstream entirely.
+    // A fresh connection re-measures cadence: the replacement may be a
+    // different upstream, and the downtime gap is not an inter-block
+    // interval. `lastProcessedBlock` deliberately does NOT reset - what is
+    // owed is a property of the chain, not of the socket that was serving it.
     entry.lastBlockIntervalAt = null;
     entry.blockIntervalEwmaMs = null;
     entry.blockIntervalSamples = 0;
+    entry.blockIntervalFirstSampleAt = null;
     entry.provider.on("block", listener);
     this.startStatsTimer();
   }
 
-  /**
-   * Stop delivering blocks on this connection.
-   *
-   * `retainWindow` decides the fate of an open coalescing window, and the two
-   * cases are not alike. Unsubscribe and destroy leave no subscriber to
-   * dispatch to, so the buffered numbers are discarded. A reconnect does not:
-   * its subscribers are still attached and still expect those logs, and
-   * discarding them would lose events that per-block dispatch never could.
-   * The numbers are just block heights, not provider state, so the reconnect
-   * carries them and the replacement connection serves them.
-   */
-  private detachBlockListener(entry: ChainEntry, retainWindow = false): void {
+  private detachBlockListener(entry: ChainEntry): void {
     entry.blockListenerAttachedAt = null;
-    // The timer always goes: it must not fire against a provider that is
-    // being torn down.
-    this.stopBatchTimer(entry);
-    if (!retainWindow) {
-      entry.pendingBlocks = [];
-    }
+    // The timer must not fire against a provider that is being torn down.
+    // Nothing is lost by dropping it: the timer only ever schedules another
+    // drain, and `lastProcessedBlock` still records exactly what is owed, so
+    // whatever this connection did not serve the next one starts from.
+    this.stopCatchUpTimer(entry);
     if (!(entry.provider && entry.blockListener)) {
       entry.blockListener = null;
       return;
@@ -954,6 +1009,10 @@ export class ChainProviderManager {
    * Fold this block's arrival into the chain's inter-block interval estimate.
    * The first block after an attach establishes the baseline only - there is
    * no prior arrival on this connection to measure against.
+   *
+   * This drives the staleness threshold and nothing else. Dispatch does not
+   * consult it, so an estimate that is wrong - or never settles - cannot
+   * change which logs are fetched or when.
    */
   private recordBlockInterval(entry: ChainEntry, now: number): void {
     const previous = entry.lastBlockIntervalAt;
@@ -967,6 +1026,9 @@ export class ChainProviderManager {
     if (interval <= 0) {
       return;
     }
+    if (entry.blockIntervalFirstSampleAt === null) {
+      entry.blockIntervalFirstSampleAt = now;
+    }
     entry.blockIntervalEwmaMs =
       entry.blockIntervalEwmaMs === null
         ? interval
@@ -976,65 +1038,124 @@ export class ChainProviderManager {
   }
 
   /**
-   * Whether this chain has proven itself fast enough to coalesce blocks.
-   * False until the estimate is warm, so a chain always starts out dispatching
-   * per block and only changes behaviour once its cadence is established.
+   * Whether the cadence estimate can be trusted, which needs both enough
+   * samples and enough elapsed time. The time condition is what makes a burst
+   * harmless: twenty messages drained out of a socket buffer are twenty
+   * samples, but they cannot span a minute.
    */
-  private isBatching(entry: ChainEntry): boolean {
+  private hasSettledCadence(entry: ChainEntry): boolean {
+    if (
+      entry.blockIntervalEwmaMs === null ||
+      entry.blockIntervalFirstSampleAt === null ||
+      entry.blockIntervalSamples < BLOCK_INTERVAL_MIN_SAMPLES
+    ) {
+      return false;
+    }
+    // The span the samples cover, not the time since the first one. Measuring
+    // to `Date.now()` would let silence supply the span: a burst of twenty
+    // millisecond-apart samples followed by a quiet minute would read as
+    // settled, and the quiet minute is exactly when the threshold it produced
+    // gets used.
+    const lastSampleAt = entry.lastBlockIntervalAt ?? 0;
     return (
-      entry.blockIntervalSamples >= BLOCK_INTERVAL_WARMUP_SAMPLES &&
-      entry.blockIntervalEwmaMs !== null &&
-      entry.blockIntervalEwmaMs < BATCHING_BLOCK_INTERVAL_THRESHOLD_MS
+      lastSampleAt - entry.blockIntervalFirstSampleAt >=
+      BLOCK_INTERVAL_MIN_SPAN_MS
     );
   }
 
   /**
-   * Add a block to the open window, opening one if needed. The window is
-   * measured from its first block, so it bounds the delay any single block
-   * waits rather than sliding forward as blocks keep arriving.
+   * Fetch and dispatch everything owed between the high-water mark and the
+   * head, subject to one request per `GETLOGS_MIN_INTERVAL_MS` per chain.
+   *
+   * Called on every block. On a chain slower than the interval the gap has
+   * always already elapsed, so this is one immediate request per block - the
+   * historical behaviour, with no threshold deciding it. On a faster chain the
+   * interval has not elapsed, the head runs ahead of the mark, and the next
+   * drain serves the accumulated range in one request.
+   *
+   * The range is contiguous from the mark, so blocks the subscription never
+   * pushed are covered too, and the dedup layer absorbs anything redelivered
+   * as a result.
    */
-  private async bufferBlock(
-    entry: ChainEntry,
-    blockNumber: number,
-  ): Promise<void> {
-    entry.pendingBlocks.push(blockNumber);
-    if (entry.pendingBlocks.length >= BATCH_MAX_BLOCKS) {
-      await this.flushBatchWindow(entry);
+  private async drain(entry: ChainEntry): Promise<void> {
+    if (
+      entry.draining ||
+      entry.isReconnecting ||
+      this.isDestroyed ||
+      !entry.provider ||
+      entry.subscribers.size === 0 ||
+      entry.headBlock === null
+    ) {
       return;
     }
-    if (!entry.batchTimer) {
-      entry.batchTimer = setTimeout(() => {
-        void this.flushBatchWindow(entry);
-      }, BATCH_WINDOW_MS);
+
+    // The first block on a chain establishes the mark rather than triggering a
+    // backfill: history before the first subscriber is not owed to anyone.
+    if (entry.lastProcessedBlock === null) {
+      entry.lastProcessedBlock = entry.headBlock - 1;
+    }
+
+    const behind = entry.headBlock - entry.lastProcessedBlock;
+    if (behind <= 0) {
+      return;
+    }
+    if (behind > GETLOGS_MAX_CATCHUP_BLOCKS) {
+      logger.warn(
+        `[ChainProviderManager] chain=${entry.chainId} ${behind} blocks behind head; skipping to ${entry.headBlock} without fetching logs for the gap`,
+      );
+      entry.lastProcessedBlock = entry.headBlock - 1;
+    }
+
+    const waitMs =
+      entry.lastRequestAt === null
+        ? 0
+        : GETLOGS_MIN_INTERVAL_MS - (Date.now() - entry.lastRequestAt);
+    if (waitMs > 0) {
+      this.armCatchUp(entry, waitMs);
+      return;
+    }
+
+    const from = entry.lastProcessedBlock + 1;
+    const to = Math.min(entry.headBlock, from + GETLOGS_MAX_BLOCK_SPAN - 1);
+
+    entry.draining = true;
+    try {
+      entry.lastRequestAt = Date.now();
+      // The mark advances only on success. A failed range stays owed, so the
+      // next drain re-queries it instead of losing every event in it.
+      if (await this.processBlockRange(entry, from, to)) {
+        entry.lastProcessedBlock = to;
+      }
+    } finally {
+      entry.draining = false;
+    }
+
+    // More owed than one request could take, the head moved while the request
+    // was in flight, or the range failed and is still owed.
+    if (
+      entry.headBlock !== null &&
+      entry.lastProcessedBlock !== null &&
+      entry.lastProcessedBlock < entry.headBlock
+    ) {
+      this.armCatchUp(entry, GETLOGS_MIN_INTERVAL_MS);
     }
   }
 
-  /**
-   * Issue one ranged `eth_getLogs` covering every block buffered in the open
-   * window, then close it.
-   */
-  private async flushBatchWindow(entry: ChainEntry): Promise<void> {
-    const blocks = entry.pendingBlocks;
-    this.stopBatchTimer(entry);
-    entry.pendingBlocks = [];
-    if (blocks.length === 0) {
+  /** Schedule the next drain. Idempotent: an armed timer is left alone. */
+  private armCatchUp(entry: ChainEntry, delayMs: number): void {
+    if (entry.catchUpTimer || this.isDestroyed) {
       return;
     }
-    // Span the extremes rather than the arrival order. A ranged request also
-    // covers any block the subscription skipped inside the window, which
-    // recovers logs a per-block loop would have missed; the dedup layer
-    // absorbs anything that arrives twice as a result.
-    await this.processBlockRange(
-      entry,
-      Math.min(...blocks),
-      Math.max(...blocks),
-    );
+    entry.catchUpTimer = setTimeout(() => {
+      entry.catchUpTimer = null;
+      void this.drain(entry);
+    }, delayMs);
   }
 
-  private stopBatchTimer(entry: ChainEntry): void {
-    if (entry.batchTimer) {
-      clearTimeout(entry.batchTimer);
-      entry.batchTimer = null;
+  private stopCatchUpTimer(entry: ChainEntry): void {
+    if (entry.catchUpTimer) {
+      clearTimeout(entry.catchUpTimer);
+      entry.catchUpTimer = null;
     }
   }
 
@@ -1124,12 +1245,21 @@ export class ChainProviderManager {
       return this.blockStalenessTimeoutOverrideMs;
     }
     const ewma = entry.blockIntervalEwmaMs;
-    if (!this.isBatching(entry) || ewma === null) {
+    if (ewma === null || !this.hasSettledCadence(entry)) {
       return BLOCK_STALENESS_TIMEOUT_MS;
     }
-    return Math.max(
-      BLOCK_STALENESS_FLOOR_MS,
-      ewma * BLOCK_STALENESS_BLOCK_MULTIPLIER,
+    // Clamped at both ends: never tighter than the floor, so no chain is
+    // reconnected over an ordinary upstream hiccup, and never looser than the
+    // historical default, so no chain gains slack it did not have. Both
+    // bounds bind for real chains - a 100 ms chain takes the floor, a 12 s
+    // chain takes the default - and the multiplier decides everything
+    // between.
+    return Math.min(
+      BLOCK_STALENESS_TIMEOUT_MS,
+      Math.max(
+        BLOCK_STALENESS_FLOOR_MS,
+        ewma * BLOCK_STALENESS_BLOCK_MULTIPLIER,
+      ),
     );
   }
 
@@ -1188,13 +1318,12 @@ export class ChainProviderManager {
     }
     entry.isReconnecting = true;
     this.stopHeartbeat(entry);
-    // Disarm the coalescing window here rather than in `reconnect()`, which
-    // does not run until the backoff has elapsed. The window is the same
-    // width as the initial backoff, so leaving it armed lets it fire against
-    // the connection that just failed: the request throws, and the buffered
-    // blocks are lost to a logged warning. The blocks themselves are kept -
-    // `reconnect()` carries them to the replacement.
-    this.stopBatchTimer(entry);
+    // Disarm the pending drain. `drain` also refuses to run while
+    // `isReconnecting`, so a block arriving during the backoff cannot re-arm
+    // it either - the guard is on the work, not just on the timer. Nothing is
+    // lost: `lastProcessedBlock` still records what is owed, and the
+    // replacement connection serves it.
+    this.stopCatchUpTimer(entry);
 
     // Publish the reconnect promise on the entry BEFORE any `await`
     // yields. `getOrCreateProvider` awaits this to avoid creating a
@@ -1290,7 +1419,7 @@ export class ChainProviderManager {
     // the old provider cannot trigger another reconnect while we are
     // building the new one.
     if (entry.provider) {
-      this.detachBlockListener(entry, true);
+      this.detachBlockListener(entry);
       this.detachErrorListener(entry);
       try {
         await entry.provider.destroy();
@@ -1344,26 +1473,34 @@ export class ChainProviderManager {
     if (entry.subscribers.size > 0) {
       this.attachBlockListener(entry);
       this.startHeartbeat(entry);
-      // Serve the window the dropped connection was holding. These heights
-      // are historical by now, so the replacement answers for them as well as
-      // the original would have.
-      await this.flushBatchWindow(entry);
+      // Schedule rather than await. Anything owed from before the drop is
+      // still owed - `lastProcessedBlock` survived - and a drain dispatches
+      // logs to handlers that may each sleep seconds of jitter, so awaiting
+      // it here would hold `isReconnecting` true long after the connection
+      // was healthy, reporting the chain degraded and blocking every
+      // `getOrCreateProvider` behind it.
+      this.armCatchUp(entry, GETLOGS_MIN_INTERVAL_MS);
     }
   }
 
   /**
-   * Fetch and dispatch the logs in `[fromBlock, toBlock]`. The two are equal
-   * on a per-block dispatch and span the window on a batched one, so both
-   * paths issue the same shape of request.
+   * Fetch and dispatch the logs in `[fromBlock, toBlock]`.
+   *
+   * Returns whether the whole range was served. A range spanning more than
+   * `GETLOGS_ADDRESS_BATCH` addresses takes several requests, and a failure in
+   * any of them means the range is incomplete - so nothing from it is
+   * dispatched and the caller leaves the high-water mark where it was, which
+   * makes the next drain re-query it. Dispatching the chunks that did return
+   * would deliver a partial view of the range and then never fetch the rest.
    */
   private async processBlockRange(
     entry: ChainEntry,
     fromBlock: number,
     toBlock: number,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const subscribers = [...entry.subscribers];
     if (subscribers.length === 0 || !entry.provider) {
-      return;
+      return false;
     }
 
     const { addresses, topic0s } = this.collectFilter(subscribers);
@@ -1395,12 +1532,13 @@ export class ChainProviderManager {
       // Counted only once every request for the range returned. A throw
       // leaves the range out of `blocksCovered` entirely, so a failing chain
       // cannot report blocks it never fetched logs for - which would make
-      // the blocks-per-call ratio look most efficient exactly when the chain
+      // the blocks-per-range ratio look most efficient exactly when the chain
       // is least working. The calls themselves are counted at issue, since a
       // request that fails was still made and still billed.
       entry.stats.ranges += 1;
       entry.stats.blocksCovered += toBlock - fromBlock + 1;
       entry.stats.logsDispatched += logs.length;
+      return true;
     } catch (err) {
       entry.stats.getLogsErrors += 1;
       const range =
@@ -1408,8 +1546,9 @@ export class ChainProviderManager {
           ? `block=${fromBlock}`
           : `blocks=${fromBlock}-${toBlock}`;
       logger.warn(
-        `[ChainProviderManager] chain=${entry.chainId} ${range} getLogs failed: ${String(err)}`,
+        `[ChainProviderManager] chain=${entry.chainId} ${range} getLogs failed, will retry: ${String(err)}`,
       );
+      return false;
     }
   }
 
@@ -1447,8 +1586,12 @@ export class ChainProviderManager {
         entry.blockIntervalEwmaMs === null
           ? "null"
           : String(Math.round(entry.blockIntervalEwmaMs));
+      const behind =
+        entry.headBlock !== null && entry.lastProcessedBlock !== null
+          ? Math.max(0, entry.headBlock - entry.lastProcessedBlock)
+          : 0;
       logger.log(
-        `[ChainProviderManager] getlogs-stats chain=${entry.chainId} batching=${this.isBatching(entry)} blockIntervalMs=${interval} windowMs=${BATCH_WINDOW_MS} intervalMs=${STATS_LOG_INTERVAL_MS} getLogsCalls=${stats.getLogsCalls} getLogsErrors=${stats.getLogsErrors} blocksCovered=${stats.blocksCovered} ranges=${stats.ranges} logsDispatched=${stats.logsDispatched} getLogsCallsTotal=${stats.getLogsCallsTotal}`,
+        `[ChainProviderManager] getlogs-stats chain=${entry.chainId} blockIntervalMs=${interval} minRequestIntervalMs=${GETLOGS_MIN_INTERVAL_MS} statsIntervalMs=${STATS_LOG_INTERVAL_MS} getLogsCalls=${stats.getLogsCalls} getLogsErrors=${stats.getLogsErrors} blocksCovered=${stats.blocksCovered} ranges=${stats.ranges} blocksBehindHead=${behind} logsDispatched=${stats.logsDispatched} getLogsCallsTotal=${stats.getLogsCallsTotal}`,
       );
       stats.getLogsCalls = 0;
       stats.getLogsErrors = 0;

--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -13,6 +13,15 @@ import { logger } from "../../lib/utils/logger";
  * subscription count from workflow count (provider subscription caps are
  * typically ~1000 per WSS).
  *
+ * Request volume is driven by block rate, so a sub-second chain costs orders
+ * of magnitude more than a 12 s one for the same subscriptions. Blocks from a
+ * chain observed to be producing them faster than
+ * `BATCHING_BLOCK_INTERVAL_THRESHOLD_MS` are coalesced into a
+ * `BATCH_WINDOW_MS` window and served by a single ranged request. Cadence is
+ * measured per connection rather than configured, and every chain starts out
+ * dispatching per block, so a chain only leaves the historical behaviour once
+ * it has demonstrated it needs to.
+ *
  * Per-chain reconnect + heartbeat are owned here. Drop detection uses two
  * signals:
  *   - `provider.on("error")` for transport-level errors surfaced by ethers
@@ -50,6 +59,52 @@ const HEARTBEAT_TIMEOUT_MS = 10_000;
  * inter-block gap; overridable per-manager for tests.
  */
 const BLOCK_STALENESS_TIMEOUT_MS = 120_000;
+/**
+ * Floor on the derived staleness threshold for a batching chain. A chain
+ * producing blocks every 100 ms would otherwise derive a 1 s threshold and
+ * reconnect on any brief upstream hiccup. 30 s is ~300 blocks of slack there,
+ * still three orders of magnitude tighter than the fixed default.
+ */
+const BLOCK_STALENESS_FLOOR_MS = 30_000;
+/** Blocks of slack the derived staleness threshold allows. */
+const BLOCK_STALENESS_BLOCK_MULTIPLIER = 10;
+
+/**
+ * Batching engages only below this observed inter-block interval. Every chain
+ * supported today produces blocks at 2 s or slower, so all of them keep the
+ * historical one-`eth_getLogs`-per-block behaviour and its latency; batching
+ * is reachable only by a sub-second chain, where per-block calls are the
+ * problem (a 100 ms chain issues 864,000 calls/day/address-batch against
+ * Base's 43,200).
+ *
+ * Set well clear of both sides rather than at the 1 s round number: the
+ * integration rig runs anvil at `--block-time 1`, and a chain sitting exactly
+ * on the threshold would drift across it on timer jitter alone and batch
+ * nondeterministically. 500 ms leaves 5x margin below to the chain this
+ * exists for and 2x above to the fastest cadence anything here produces.
+ */
+const BATCHING_BLOCK_INTERVAL_THRESHOLD_MS = 500;
+/**
+ * Width of the coalescing window, measured from the first buffered block.
+ * Well inside the 0-10 s jitter `EventListener` already applies before
+ * forwarding a matched event, so it is not the binding term in end-to-end
+ * trigger latency.
+ */
+const BATCH_WINDOW_MS = 1_000;
+/**
+ * Ceiling on blocks per windowed request, so a burst (catch-up after a slow
+ * flush) cannot widen the range without bound and produce an oversized
+ * response or trip a provider's block-range limit.
+ */
+const BATCH_MAX_BLOCKS = 25;
+/**
+ * Inter-block intervals folded into the EWMA before its value is trusted.
+ * Until then a chain dispatches per block, so a misjudged cadence at startup
+ * can only fail towards today's behaviour.
+ */
+const BLOCK_INTERVAL_WARMUP_SAMPLES = 20;
+/** EWMA smoothing factor for the inter-block interval. */
+const BLOCK_INTERVAL_EWMA_ALPHA = 0.2;
 const INITIAL_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 60_000;
 const MAX_RECONNECT_ATTEMPTS = 10;
@@ -195,6 +250,29 @@ interface ChainEntry {
    */
   blockListenerAttachedAt: number | null;
   /**
+   * Arrival time of the previous block, used only to measure inter-block
+   * intervals. Distinct from `lastBlockAt`, which survives a reconnect as the
+   * staleness baseline: folding the downtime gap into the cadence estimate
+   * would read a fast chain as slow. Reset on every block-listener attach.
+   */
+  lastBlockIntervalAt: number | null;
+  /**
+   * EWMA of inter-block arrival intervals in ms, or null before the first
+   * interval is observed. Measured rather than configured: no per-chain block
+   * time reaches this process, and an observed value needs no migration when
+   * a chain is added or its cadence changes.
+   */
+  blockIntervalEwmaMs: number | null;
+  /** Intervals folded into `blockIntervalEwmaMs` since the last attach. */
+  blockIntervalSamples: number;
+  /**
+   * Block numbers awaiting a windowed ranged `eth_getLogs`. Non-empty only
+   * while batching is engaged.
+   */
+  pendingBlocks: number[];
+  /** Open coalescing window, started by the first block buffered into it. */
+  batchTimer: ReturnType<typeof setTimeout> | null;
+  /**
    * Populated when `createProvider` rejects (most often the
    * subscription probe). Cleared on the next successful creation.
    * Surfaced through `getAllHealth` for `/healthz` consumers.
@@ -268,7 +346,11 @@ export class ChainProviderManager {
   private readonly chains = new Map<number, ChainEntry>();
   private readonly factory: ProviderFactory;
   private readonly onPermanentFailure: (chainId: number) => void;
-  private readonly blockStalenessTimeoutMs: number;
+  /**
+   * Explicit override for the block-staleness threshold. Null means derive it
+   * per chain; tests set a small value to exercise the watchdog.
+   */
+  private readonly blockStalenessTimeoutOverrideMs: number | null;
   private isDestroyed = false;
   // Wake-up signal for in-flight reconnect sleeps: `destroy()` resolves
   // this promise, racing any pending backoff sleep so the reconnect loop
@@ -284,8 +366,7 @@ export class ChainProviderManager {
     this.factory = opts.factory ?? defaultFactory;
     this.onPermanentFailure =
       opts.onPermanentFailure ?? defaultOnPermanentFailure;
-    this.blockStalenessTimeoutMs =
-      opts.blockStalenessTimeoutMs ?? BLOCK_STALENESS_TIMEOUT_MS;
+    this.blockStalenessTimeoutOverrideMs = opts.blockStalenessTimeoutMs ?? null;
     let resolve!: () => void;
     const promise = new Promise<void>((r) => {
       resolve = r;
@@ -537,6 +618,11 @@ export class ChainProviderManager {
       isReconnecting: false,
       lastBlockAt: null,
       blockListenerAttachedAt: null,
+      lastBlockIntervalAt: null,
+      blockIntervalEwmaMs: null,
+      blockIntervalSamples: 0,
+      pendingBlocks: [],
+      batchTimer: null,
       lastCreateError: null,
       disconnectHandlers: new Set(),
     };
@@ -721,25 +807,131 @@ export class ChainProviderManager {
       );
     }
     const listener = async (blockNumber: number): Promise<void> => {
-      entry.lastBlockAt = Date.now();
-      await this.processBlock(entry, blockNumber);
+      const now = Date.now();
+      this.recordBlockInterval(entry, now);
+      entry.lastBlockAt = now;
+      if (!this.isBatching(entry)) {
+        await this.processBlockRange(entry, blockNumber, blockNumber);
+        return;
+      }
+      await this.bufferBlock(entry, blockNumber);
     };
     entry.blockListener = listener;
     // Baseline for the block-staleness watchdog: until the first block
     // arrives, staleness is measured from attach time so a subscription that
     // never delivers a block is still caught.
     entry.blockListenerAttachedAt = Date.now();
+    // A fresh connection re-learns the chain's cadence. Carrying the previous
+    // connection's estimate across a reconnect would let a stale value decide
+    // batching for a provider that may be a different upstream entirely.
+    entry.lastBlockIntervalAt = null;
+    entry.blockIntervalEwmaMs = null;
+    entry.blockIntervalSamples = 0;
     entry.provider.on("block", listener);
   }
 
   private detachBlockListener(entry: ChainEntry): void {
     entry.blockListenerAttachedAt = null;
+    // Drop any open window. Detach happens when the last subscriber leaves
+    // (nothing left to dispatch to) or when the connection is being replaced
+    // (the buffered numbers belong to the old provider, and a reconnect has
+    // already lost blocks for its downtime). Flushing here would issue a
+    // request against a provider that is about to be destroyed.
+    this.clearBatchWindow(entry);
     if (!(entry.provider && entry.blockListener)) {
       entry.blockListener = null;
       return;
     }
     entry.provider.off("block", entry.blockListener);
     entry.blockListener = null;
+  }
+
+  /**
+   * Fold this block's arrival into the chain's inter-block interval estimate.
+   * The first block after an attach establishes the baseline only - there is
+   * no prior arrival on this connection to measure against.
+   */
+  private recordBlockInterval(entry: ChainEntry, now: number): void {
+    const previous = entry.lastBlockIntervalAt;
+    entry.lastBlockIntervalAt = now;
+    if (previous === null) {
+      return;
+    }
+    const interval = now - previous;
+    // A duplicate or out-of-order push can report a non-positive gap; it
+    // carries no cadence information, so it is not a sample.
+    if (interval <= 0) {
+      return;
+    }
+    entry.blockIntervalEwmaMs =
+      entry.blockIntervalEwmaMs === null
+        ? interval
+        : BLOCK_INTERVAL_EWMA_ALPHA * interval +
+          (1 - BLOCK_INTERVAL_EWMA_ALPHA) * entry.blockIntervalEwmaMs;
+    entry.blockIntervalSamples += 1;
+  }
+
+  /**
+   * Whether this chain has proven itself fast enough to coalesce blocks.
+   * False until the estimate is warm, so a chain always starts out dispatching
+   * per block and only changes behaviour once its cadence is established.
+   */
+  private isBatching(entry: ChainEntry): boolean {
+    return (
+      entry.blockIntervalSamples >= BLOCK_INTERVAL_WARMUP_SAMPLES &&
+      entry.blockIntervalEwmaMs !== null &&
+      entry.blockIntervalEwmaMs < BATCHING_BLOCK_INTERVAL_THRESHOLD_MS
+    );
+  }
+
+  /**
+   * Add a block to the open window, opening one if needed. The window is
+   * measured from its first block, so it bounds the delay any single block
+   * waits rather than sliding forward as blocks keep arriving.
+   */
+  private async bufferBlock(
+    entry: ChainEntry,
+    blockNumber: number,
+  ): Promise<void> {
+    entry.pendingBlocks.push(blockNumber);
+    if (entry.pendingBlocks.length >= BATCH_MAX_BLOCKS) {
+      await this.flushBatchWindow(entry);
+      return;
+    }
+    if (!entry.batchTimer) {
+      entry.batchTimer = setTimeout(() => {
+        void this.flushBatchWindow(entry);
+      }, BATCH_WINDOW_MS);
+    }
+  }
+
+  /**
+   * Issue one ranged `eth_getLogs` covering every block buffered in the open
+   * window, then close it.
+   */
+  private async flushBatchWindow(entry: ChainEntry): Promise<void> {
+    const blocks = entry.pendingBlocks;
+    this.clearBatchWindow(entry);
+    if (blocks.length === 0) {
+      return;
+    }
+    // Span the extremes rather than the arrival order. A ranged request also
+    // covers any block the subscription skipped inside the window, which
+    // recovers logs a per-block loop would have missed; the dedup layer
+    // absorbs anything that arrives twice as a result.
+    await this.processBlockRange(
+      entry,
+      Math.min(...blocks),
+      Math.max(...blocks),
+    );
+  }
+
+  private clearBatchWindow(entry: ChainEntry): void {
+    if (entry.batchTimer) {
+      clearTimeout(entry.batchTimer);
+      entry.batchTimer = null;
+    }
+    entry.pendingBlocks = [];
   }
 
   private attachErrorListener(entry: ChainEntry): void {
@@ -814,8 +1006,32 @@ export class ChainProviderManager {
   }
 
   /**
+   * Block-staleness threshold for one chain.
+   *
+   * The fixed default is slack measured in wall-clock, not in blocks: 120 s is
+   * ten blocks on Ethereum but 1.2 million on a 100 ms chain, where a dead
+   * subscription would go unnoticed far longer in the terms that matter. Only
+   * a chain fast enough to be batching derives its own threshold, so every
+   * chain dispatching per block keeps the historical value exactly and this
+   * cannot introduce reconnect churn on a chain that behaves today.
+   */
+  private stalenessTimeoutFor(entry: ChainEntry): number {
+    if (this.blockStalenessTimeoutOverrideMs !== null) {
+      return this.blockStalenessTimeoutOverrideMs;
+    }
+    const ewma = entry.blockIntervalEwmaMs;
+    if (!this.isBatching(entry) || ewma === null) {
+      return BLOCK_STALENESS_TIMEOUT_MS;
+    }
+    return Math.max(
+      BLOCK_STALENESS_FLOOR_MS,
+      ewma * BLOCK_STALENESS_BLOCK_MULTIPLIER,
+    );
+  }
+
+  /**
    * Reconnect a chain whose connection is answering the heartbeat but has
-   * stopped delivering blocks past `blockStalenessTimeoutMs`. Runs on each
+   * stopped delivering blocks past its staleness threshold. Runs on each
    * heartbeat tick (after a successful ping) so it inherits the heartbeat's
    * subscriber-scoped lifecycle. Measures staleness from the last delivered
    * block, or - before any block has arrived - from when the block listener
@@ -844,7 +1060,8 @@ export class ChainProviderManager {
       return;
     }
     const age = Date.now() - reference;
-    if (age <= this.blockStalenessTimeoutMs) {
+    const timeout = this.stalenessTimeoutFor(entry);
+    if (age <= timeout) {
       return;
     }
     logger.warn(
@@ -1019,9 +1236,15 @@ export class ChainProviderManager {
     }
   }
 
-  private async processBlock(
+  /**
+   * Fetch and dispatch the logs in `[fromBlock, toBlock]`. The two are equal
+   * on a per-block dispatch and span the window on a batched one, so both
+   * paths issue the same shape of request.
+   */
+  private async processBlockRange(
     entry: ChainEntry,
-    blockNumber: number,
+    fromBlock: number,
+    toBlock: number,
   ): Promise<void> {
     const subscribers = [...entry.subscribers];
     if (subscribers.length === 0 || !entry.provider) {
@@ -1029,7 +1252,8 @@ export class ChainProviderManager {
     }
 
     const { addresses, topic0s } = this.collectFilter(subscribers);
-    const blockHex = `0x${blockNumber.toString(16)}`;
+    const fromHex = `0x${fromBlock.toString(16)}`;
+    const toHex = `0x${toBlock.toString(16)}`;
 
     try {
       const logs: ethers.Log[] = [];
@@ -1037,8 +1261,8 @@ export class ChainProviderManager {
         const chunk = addresses.slice(i, i + GETLOGS_ADDRESS_BATCH);
         const batch = (await entry.provider.send("eth_getLogs", [
           {
-            fromBlock: blockHex,
-            toBlock: blockHex,
+            fromBlock: fromHex,
+            toBlock: toHex,
             address: chunk,
             topics: [topic0s],
           },
@@ -1050,8 +1274,12 @@ export class ChainProviderManager {
         await this.dispatchLog(entry, log);
       }
     } catch (err) {
+      const range =
+        fromBlock === toBlock
+          ? `block=${fromBlock}`
+          : `blocks=${fromBlock}-${toBlock}`;
       logger.warn(
-        `[ChainProviderManager] chain=${entry.chainId} block=${blockNumber} getLogs failed: ${String(err)}`,
+        `[ChainProviderManager] chain=${entry.chainId} ${range} getLogs failed: ${String(err)}`,
       );
     }
   }

--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -105,6 +105,25 @@ const BATCH_MAX_BLOCKS = 25;
 const BLOCK_INTERVAL_WARMUP_SAMPLES = 20;
 /** EWMA smoothing factor for the inter-block interval. */
 const BLOCK_INTERVAL_EWMA_ALPHA = 0.2;
+/**
+ * Cadence of the per-chain `getlogs-stats` line.
+ *
+ * Batching is a cost change, so it has to be measurable to be worth
+ * trusting, and nothing outside this process can measure it. The package
+ * ships no prom-client, no OpenTelemetry and no `/metrics` route, and the
+ * health server binds `HEALTH_PORT` (default 3001) while the deployment
+ * declares only 3000, so an endpoint added here would not be reachable.
+ * Aetherlay cannot stand in either: its
+ * `aetherlay_endpoint_proxy_requests_total` increments once per WebSocket
+ * *connection* and only per request on the HTTP path, so calls tunnelled
+ * through a long-lived socket - which is every call this class makes -
+ * never move it, on any cluster.
+ *
+ * That leaves the log stream. `logger` emits canonical single-line JSON
+ * precisely so Loki can aggregate across the app and its satellites, so a
+ * periodic line is the one channel that makes calls-per-day observable.
+ */
+const STATS_LOG_INTERVAL_MS = 60_000;
 const INITIAL_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 60_000;
 const MAX_RECONNECT_ATTEMPTS = 10;
@@ -165,6 +184,24 @@ export interface ChainHealth {
   reconnecting: boolean;
   lastBlockAt: number | null;
   subscriberCount: number;
+  /**
+   * Smoothed inter-block interval in milliseconds, or null before the
+   * current connection has observed enough intervals to estimate one.
+   * Per connection, like the estimate that drives batching.
+   */
+  blockIntervalMs: number | null;
+  /**
+   * Whether this chain is coalescing blocks into windowed ranged requests
+   * rather than dispatching one request per block.
+   */
+  batching: boolean;
+  /**
+   * Cumulative `eth_getLogs` calls issued for this chain since the entry
+   * was created, across reconnects. The same counter reported by the
+   * periodic `getlogs-stats` line, surfaced here so the number is reachable
+   * without log search if this endpoint ever becomes reachable.
+   */
+  getLogsCalls: number;
   /**
    * If the most recent `createProvider` attempt rejected, the error
    * message captured at rejection time. Cleared on the next successful
@@ -279,6 +316,41 @@ interface ChainEntry {
    */
   lastCreateError: string | null;
   disconnectHandlers: Set<DisconnectHandler>;
+  stats: ChainStats;
+}
+
+/**
+ * Per-chain request counters behind the `getlogs-stats` line. Everything
+ * except `getLogsCallsTotal` is reset once reported, so a line describes the
+ * interval it covers rather than needing two lines differenced.
+ *
+ * None of it resets on reconnect. The cadence estimate is per connection
+ * because a new socket may be a different upstream; cost is per chain.
+ *
+ * `blocksCovered` against `getLogsCalls` is the ratio the batching exists to
+ * move, and it is self-comparing: a per-block chain reports them roughly
+ * equal, a batching chain reports blocks far ahead of calls. That matters
+ * because there is no historical baseline for this quantity to compare a
+ * later reading against - nothing has ever counted it.
+ */
+interface ChainStats {
+  getLogsCalls: number;
+  getLogsErrors: number;
+  blocksCovered: number;
+  ranges: number;
+  logsDispatched: number;
+  getLogsCallsTotal: number;
+}
+
+function newChainStats(): ChainStats {
+  return {
+    getLogsCalls: 0,
+    getLogsErrors: 0,
+    blocksCovered: 0,
+    ranges: 0,
+    logsDispatched: 0,
+    getLogsCallsTotal: 0,
+  };
 }
 
 /**
@@ -351,6 +423,12 @@ export class ChainProviderManager {
    * per chain; tests set a small value to exercise the watchdog.
    */
   private readonly blockStalenessTimeoutOverrideMs: number | null;
+  /**
+   * Manager-wide timer for the periodic per-chain counter line. Started with
+   * the first block listener and stopped in `destroy`. Unreferenced so a
+   * reporting-only timer can never hold the process open.
+   */
+  private statsTimer: ReturnType<typeof setInterval> | null = null;
   private isDestroyed = false;
   // Wake-up signal for in-flight reconnect sleeps: `destroy()` resolves
   // this promise, racing any pending backoff sleep so the reconnect loop
@@ -539,12 +617,16 @@ export class ChainProviderManager {
       reconnecting: entry.isReconnecting,
       lastBlockAt: entry.lastBlockAt,
       subscriberCount: entry.subscribers.size,
+      blockIntervalMs: entry.blockIntervalEwmaMs,
+      batching: this.isBatching(entry),
+      getLogsCalls: entry.stats.getLogsCallsTotal,
       lastCreateError: entry.lastCreateError,
     };
   }
 
   async destroy(): Promise<void> {
     this.isDestroyed = true;
+    this.stopStatsTimer();
     // Wake every reconnect loop that is currently sleeping. The loop
     // resumes, checks `isDestroyed`, and bails via its `finally`.
     this.destroyed.resolve();
@@ -625,6 +707,7 @@ export class ChainProviderManager {
       batchTimer: null,
       lastCreateError: null,
       disconnectHandlers: new Set(),
+      stats: newChainStats(),
     };
     this.chains.set(chainId, entry);
     return entry;
@@ -828,6 +911,7 @@ export class ChainProviderManager {
     entry.blockIntervalEwmaMs = null;
     entry.blockIntervalSamples = 0;
     entry.provider.on("block", listener);
+    this.startStatsTimer();
   }
 
   /**
@@ -1276,11 +1360,18 @@ export class ChainProviderManager {
     const { addresses, topic0s } = this.collectFilter(subscribers);
     const fromHex = `0x${fromBlock.toString(16)}`;
     const toHex = `0x${toBlock.toString(16)}`;
+    entry.stats.ranges += 1;
+    entry.stats.blocksCovered += toBlock - fromBlock + 1;
 
     try {
       const logs: ethers.Log[] = [];
       for (let i = 0; i < addresses.length; i += GETLOGS_ADDRESS_BATCH) {
         const chunk = addresses.slice(i, i + GETLOGS_ADDRESS_BATCH);
+        // Counted at the call rather than the range: one range over more
+        // than GETLOGS_ADDRESS_BATCH addresses is still several requests,
+        // and requests are the quantity the provider bills.
+        entry.stats.getLogsCalls += 1;
+        entry.stats.getLogsCallsTotal += 1;
         const batch = (await entry.provider.send("eth_getLogs", [
           {
             fromBlock: fromHex,
@@ -1295,7 +1386,9 @@ export class ChainProviderManager {
       for (const log of logs) {
         await this.dispatchLog(entry, log);
       }
+      entry.stats.logsDispatched += logs.length;
     } catch (err) {
+      entry.stats.getLogsErrors += 1;
       const range =
         fromBlock === toBlock
           ? `block=${fromBlock}`
@@ -1303,6 +1396,50 @@ export class ChainProviderManager {
       logger.warn(
         `[ChainProviderManager] chain=${entry.chainId} ${range} getLogs failed: ${String(err)}`,
       );
+    }
+  }
+
+  private startStatsTimer(): void {
+    if (this.statsTimer || this.isDestroyed) {
+      return;
+    }
+    const timer = setInterval(() => {
+      this.logStats();
+    }, STATS_LOG_INTERVAL_MS);
+    timer.unref?.();
+    this.statsTimer = timer;
+  }
+
+  private stopStatsTimer(): void {
+    if (this.statsTimer) {
+      clearInterval(this.statsTimer);
+      this.statsTimer = null;
+    }
+  }
+
+  /**
+   * Emit one line per chain that issued a request this interval, then reset
+   * the per-interval counters. Chains that did nothing stay silent so an idle
+   * tracker does not emit a line per chain per minute forever.
+   */
+  private logStats(): void {
+    for (const entry of this.chains.values()) {
+      const stats = entry.stats;
+      if (stats.getLogsCalls === 0 && stats.getLogsErrors === 0) {
+        continue;
+      }
+      const interval =
+        entry.blockIntervalEwmaMs === null
+          ? "null"
+          : String(Math.round(entry.blockIntervalEwmaMs));
+      logger.log(
+        `[ChainProviderManager] getlogs-stats chain=${entry.chainId} batching=${this.isBatching(entry)} blockIntervalMs=${interval} windowMs=${BATCH_WINDOW_MS} intervalMs=${STATS_LOG_INTERVAL_MS} getLogsCalls=${stats.getLogsCalls} getLogsErrors=${stats.getLogsErrors} blocksCovered=${stats.blocksCovered} ranges=${stats.ranges} logsDispatched=${stats.logsDispatched} getLogsCallsTotal=${stats.getLogsCallsTotal}`,
+      );
+      stats.getLogsCalls = 0;
+      stats.getLogsErrors = 0;
+      stats.blocksCovered = 0;
+      stats.ranges = 0;
+      stats.logsDispatched = 0;
     }
   }
 

--- a/keeperhub-events/event-tracker/src/main.ts
+++ b/keeperhub-events/event-tracker/src/main.ts
@@ -1,6 +1,7 @@
 import type { NetworksMap, RawWorkflow } from "../lib/types";
 import { fetchActiveWorkflows } from "../lib/utils/fetch-utils";
 import { logger } from "../lib/utils/logger";
+import { chainProviderManager } from "./chains/provider-manager";
 import { createRegistry } from "./listener/factory";
 import type { ListenerRegistry } from "./listener/registry";
 import { buildRegistration } from "./listener/workflow-mapper";
@@ -18,14 +19,21 @@ function getRegistry(): ListenerRegistry {
 }
 
 /**
- * Stops every listener if the registry was constructed. Kept separate from
- * `getRegistry` so shutdown does not lazily construct a registry just to
- * tear it down - that would open a Redis connection for no reason.
+ * Stops every listener if the registry was constructed, then tears down the
+ * shared provider manager. Kept separate from `getRegistry` so shutdown does
+ * not lazily construct a registry just to tear it down - that would open a
+ * Redis connection for no reason.
+ *
+ * `stopAll` unsubscribes every listener, which detaches block listeners and
+ * heartbeats, but the manager also owns providers and a manager-wide stats
+ * interval that only `destroy` clears. Without this call nothing in `src`
+ * ever invoked it, so those outlived the listeners they existed for.
  */
 async function shutdownRegistry(): Promise<void> {
   if (registry) {
     await registry.stopAll();
   }
+  await chainProviderManager.destroy();
 }
 
 async function reconcile(

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -78,7 +78,13 @@ class MockProvider {
     if (this.sendResponses.length === 0) {
       return [];
     }
-    return this.sendResponses.shift();
+    const next = this.sendResponses.shift();
+    // Same convention as blockNumberResponses: a queued Error rejects the
+    // call rather than being returned as a value.
+    if (next instanceof Error) {
+      throw next;
+    }
+    return next;
   }
 
   async destroy(): Promise<void> {
@@ -1676,6 +1682,30 @@ describe("ChainProviderManager", () => {
         expect(second).toHaveLength(2);
         expect(second[1]).toContain("getLogsCalls=1");
         expect(second[1]).toContain("getLogsCallsTotal=4");
+      } finally {
+        logSpy.mockRestore();
+      }
+    });
+
+    it("counts a failed request without counting the blocks it never fetched", async () => {
+      const logSpy = vi
+        .spyOn(console, "log")
+        .mockImplementation(() => undefined);
+      try {
+        const provider = await subscribe();
+        provider.sendResponses = [new Error("upstream refused")];
+        await emitBlocks(provider, 100, 1, 2_000);
+        await vi.advanceTimersByTimeAsync(STATS_INTERVAL_MS);
+
+        const lines = statsLines(logSpy);
+        expect(lines).toHaveLength(1);
+        // The call was issued, so it was billed and is counted. The block was
+        // never fetched, so counting it would make the blocks-per-call ratio
+        // look most efficient exactly when the chain is least working.
+        expect(lines[0]).toContain("getLogsCalls=1");
+        expect(lines[0]).toContain("getLogsErrors=1");
+        expect(lines[0]).toContain("blocksCovered=0");
+        expect(lines[0]).toContain("ranges=0");
       } finally {
         logSpy.mockRestore();
       }

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -1495,6 +1495,27 @@ describe("ChainProviderManager", () => {
       expect(getLogsCalls(provider)).toHaveLength(warmupCalls);
     });
 
+    it("serves a window held open by a dropped connection on the replacement", async () => {
+      await subscribe(manager);
+      const provider = factoryBundle.created[0];
+
+      // One past the warm-up, so this last block is buffered rather than
+      // dispatched, and the connection drops with the window still open.
+      await emitBlocks(provider, 100, WARMUP_SAMPLES + 1, 100);
+      const buffered = 100 + WARMUP_SAMPLES;
+
+      provider.emitError(new Error("socket closed"));
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      const replacement = factoryBundle.created[1];
+      expect(replacement).toBeDefined();
+
+      // Discarding here would lose logs that per-block dispatch never could:
+      // the subscriber is still attached across a reconnect.
+      const served = getLogsCalls(replacement).map(rangeOf);
+      expect(served).toContainEqual({ from: buffered, to: buffered });
+    });
+
     it("re-learns cadence after a reconnect instead of carrying the estimate over", async () => {
       await subscribe(manager);
       const provider = factoryBundle.created[0];

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -1337,6 +1337,232 @@ describe("ChainProviderManager", () => {
     });
   });
 
+  describe("sub-second block batching", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    // Production constants this suite pins behaviour against.
+    const WARMUP_SAMPLES = 20;
+    const WINDOW_MS = 1_000;
+    const MAX_BLOCKS = 25;
+
+    async function subscribe(mgr: ChainProviderManager): Promise<void> {
+      await mgr.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+    }
+
+    function getLogsCalls(provider: MockProvider): SendCall[] {
+      return provider.sendCalls.filter((c) => c.method === "eth_getLogs");
+    }
+
+    function rangeOf(call: SendCall): { from: number; to: number } {
+      const filter = call.params[0] as { fromBlock: string; toBlock: string };
+      return {
+        from: Number.parseInt(filter.fromBlock, 16),
+        to: Number.parseInt(filter.toBlock, 16),
+      };
+    }
+
+    /**
+     * Deliver `count` blocks `intervalMs` apart. The first block establishes
+     * the interval baseline, so `count` blocks yield `count - 1` samples.
+     */
+    async function emitBlocks(
+      provider: MockProvider,
+      firstBlock: number,
+      count: number,
+      intervalMs: number,
+    ): Promise<void> {
+      for (let i = 0; i < count; i += 1) {
+        await provider.emitBlock(firstBlock + i);
+        await vi.advanceTimersByTimeAsync(intervalMs);
+      }
+    }
+
+    it("dispatches one request per block until the cadence estimate is warm", async () => {
+      await subscribe(manager);
+      const provider = factoryBundle.created[0];
+
+      // WARMUP_SAMPLES blocks yield only WARMUP_SAMPLES - 1 intervals, so
+      // batching is still one sample short of engaging.
+      await emitBlocks(provider, 100, WARMUP_SAMPLES, 100);
+
+      const calls = getLogsCalls(provider);
+      expect(calls).toHaveLength(WARMUP_SAMPLES);
+      for (const call of calls) {
+        const { from, to } = rangeOf(call);
+        expect(from).toBe(to);
+      }
+    });
+
+    it("coalesces a window into a single ranged request once the chain proves sub-second", async () => {
+      await subscribe(manager);
+      const provider = factoryBundle.created[0];
+      await emitBlocks(provider, 100, WARMUP_SAMPLES, 100);
+      const warmupCalls = getLogsCalls(provider).length;
+
+      // Five further blocks now fall inside one window rather than issuing
+      // five separate requests.
+      await emitBlocks(provider, 200, 5, 100);
+      expect(getLogsCalls(provider)).toHaveLength(warmupCalls);
+
+      await vi.advanceTimersByTimeAsync(WINDOW_MS);
+
+      const batched = getLogsCalls(provider).slice(warmupCalls);
+      expect(batched).toHaveLength(1);
+      expect(rangeOf(batched[0])).toEqual({ from: 200, to: 204 });
+    });
+
+    it("leaves a chain with second-scale blocks on per-block dispatch", async () => {
+      await subscribe(manager);
+      const provider = factoryBundle.created[0];
+
+      // Well past the warm-up count, at Base's cadence. Every block must
+      // still get its own request: this change must not add latency to any
+      // chain that behaves like the ones supported today.
+      await emitBlocks(provider, 100, WARMUP_SAMPLES + 10, 2_000);
+
+      const calls = getLogsCalls(provider);
+      expect(calls).toHaveLength(WARMUP_SAMPLES + 10);
+      for (const call of calls) {
+        const { from, to } = rangeOf(call);
+        expect(from).toBe(to);
+      }
+    });
+
+    it("flushes at the block cap without waiting out the window", async () => {
+      await subscribe(manager);
+      const provider = factoryBundle.created[0];
+      await emitBlocks(provider, 100, WARMUP_SAMPLES, 100);
+      const warmupCalls = getLogsCalls(provider).length;
+
+      // A burst arriving far faster than the window: the cap, not the timer,
+      // has to bound the range.
+      await emitBlocks(provider, 300, MAX_BLOCKS, 1);
+
+      const batched = getLogsCalls(provider).slice(warmupCalls);
+      expect(batched).toHaveLength(1);
+      expect(rangeOf(batched[0])).toEqual({
+        from: 300,
+        to: 300 + MAX_BLOCKS - 1,
+      });
+    });
+
+    it("spans blocks the subscription skipped inside the window", async () => {
+      await subscribe(manager);
+      const provider = factoryBundle.created[0];
+      await emitBlocks(provider, 100, WARMUP_SAMPLES, 100);
+      const warmupCalls = getLogsCalls(provider).length;
+
+      // 401 to 404 were never pushed. A ranged request covers them anyway,
+      // which recovers logs a per-block loop would have dropped.
+      await provider.emitBlock(400);
+      await vi.advanceTimersByTimeAsync(100);
+      await provider.emitBlock(405);
+      await vi.advanceTimersByTimeAsync(WINDOW_MS);
+
+      const batched = getLogsCalls(provider).slice(warmupCalls);
+      expect(batched).toHaveLength(1);
+      expect(rangeOf(batched[0])).toEqual({ from: 400, to: 405 });
+    });
+
+    it("drops an open window when the last subscriber unsubscribes", async () => {
+      const unsubscribe = await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      const provider = factoryBundle.created[0];
+      await emitBlocks(provider, 100, WARMUP_SAMPLES, 100);
+      const warmupCalls = getLogsCalls(provider).length;
+
+      await provider.emitBlock(500);
+      unsubscribe();
+      await vi.advanceTimersByTimeAsync(WINDOW_MS * 2);
+
+      // No request fires against a provider with nothing left to dispatch to.
+      expect(getLogsCalls(provider)).toHaveLength(warmupCalls);
+    });
+
+    it("re-learns cadence after a reconnect instead of carrying the estimate over", async () => {
+      await subscribe(manager);
+      const provider = factoryBundle.created[0];
+      await emitBlocks(provider, 100, WARMUP_SAMPLES, 100);
+
+      provider.emitError(new Error("socket closed"));
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      const replacement = factoryBundle.created[1];
+      expect(replacement).toBeDefined();
+      const before = getLogsCalls(replacement).length;
+
+      // The new connection starts cold, so these dispatch per block even
+      // though the previous one had been batching.
+      await emitBlocks(replacement, 600, 3, 100);
+      expect(getLogsCalls(replacement)).toHaveLength(before + 3);
+    });
+
+    it("tightens the staleness threshold for a batching chain", async () => {
+      // No blockStalenessTimeoutMs override, so the threshold is derived.
+      const bundle = makeFactory();
+      const mgr = new ChainProviderManager({
+        factory: bundle.factory,
+        onPermanentFailure,
+      });
+      await subscribe(mgr);
+      const provider = bundle.created[0];
+      const reasons: string[] = [];
+      mgr.onDisconnect(CHAIN_A, (ev) => {
+        reasons.push(ev.reason);
+      });
+
+      // One more than WARMUP_SAMPLES: the first block sets the interval
+      // baseline, so batching needs WARMUP_SAMPLES + 1 blocks to engage.
+      await emitBlocks(provider, 100, WARMUP_SAMPLES + 1, 100);
+
+      // A 100 ms chain derives the 30 s floor, so silence trips on the
+      // second heartbeat rather than the fixed 120 s default's fifth.
+      await vi.advanceTimersByTimeAsync(62_000);
+
+      expect(reasons).toContain("block_staleness");
+      await mgr.destroy();
+    });
+
+    it("keeps the fixed staleness threshold for a chain dispatching per block", async () => {
+      const bundle = makeFactory();
+      const mgr = new ChainProviderManager({
+        factory: bundle.factory,
+        onPermanentFailure,
+      });
+      await subscribe(mgr);
+      const provider = bundle.created[0];
+      const reasons: string[] = [];
+      mgr.onDisconnect(CHAIN_A, (ev) => {
+        reasons.push(ev.reason);
+      });
+
+      await emitBlocks(provider, 100, WARMUP_SAMPLES + 10, 2_000);
+
+      // 90 s of silence is past the derived floor a batching chain would get
+      // but well inside the 120 s this chain must keep.
+      await vi.advanceTimersByTimeAsync(90_000);
+
+      expect(reasons).not.toContain("block_staleness");
+      await mgr.destroy();
+    });
+  });
+
   describe("block-staleness watchdog", () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -1,8 +1,18 @@
 import type { ethers } from "ethers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  BLOCK_INTERVAL_MIN_SAMPLES,
+  BLOCK_INTERVAL_MIN_SPAN_MS,
+  BLOCK_STALENESS_BLOCK_MULTIPLIER,
+  BLOCK_STALENESS_FLOOR_MS,
+  BLOCK_STALENESS_TIMEOUT_MS,
   ChainProviderManager,
+  GETLOGS_ADDRESS_BATCH,
+  GETLOGS_MAX_BLOCK_SPAN,
+  GETLOGS_MAX_CATCHUP_BLOCKS,
+  GETLOGS_MIN_INTERVAL_MS,
   type ProviderFactory,
+  STATS_LOG_INTERVAL_MS,
 } from "../../src/chains/provider-manager";
 
 type BlockHandler = (blockNumber: number) => void | Promise<void>;
@@ -26,6 +36,12 @@ class MockProvider {
   // probe's success.
   public unsubscribeFailure: Error | null = null;
   public destroyed = false;
+  // Lets a test hold a request in flight to exercise overlap guards.
+  public beforeSend: ((method: string) => Promise<void> | null) | null = null;
+  // When set, every eth_getLogs rejects until cleared - a persistently
+  // unhealthy upstream, as opposed to the one-shot queued Errors in
+  // sendResponses. Same convention as subscribeFailure.
+  public getLogsFailure: Error | null = null;
   private blockHandler: BlockHandler | null = null;
   private errorHandler: ErrorHandler | null = null;
 
@@ -51,6 +67,10 @@ class MockProvider {
 
   async send(method: string, params: unknown[]): Promise<unknown> {
     this.sendCalls.push({ method, params });
+    const gate = this.beforeSend?.(method);
+    if (gate) {
+      await gate;
+    }
     if (method === "eth_subscribe") {
       if (this.subscribeFailure) {
         throw this.subscribeFailure;
@@ -64,6 +84,9 @@ class MockProvider {
         throw this.unsubscribeFailure;
       }
       return true;
+    }
+    if (method === "eth_getLogs" && this.getLogsFailure) {
+      throw this.getLogsFailure;
     }
     if (method === "eth_blockNumber") {
       if (this.blockNumberResponses.length === 0) {
@@ -755,8 +778,8 @@ describe("ChainProviderManager", () => {
         lastBlockAt: null,
         subscriberCount: 1,
         blockIntervalMs: null,
-        batching: false,
-        getLogsCalls: 0,
+        blocksBehindHead: null,
+        getLogsCallsTotal: 0,
         lastCreateError: null,
       });
     });
@@ -1346,7 +1369,10 @@ describe("ChainProviderManager", () => {
     });
   });
 
-  describe("sub-second block batching", () => {
+  // One place for the dispatch-suite scaffolding. Both suites below drive the
+  // same shape of scenario, and duplicating it once already let a constant
+  // change make an assertion vacuous rather than fail.
+  describe("getLogs dispatch", () => {
     beforeEach(() => {
       vi.useFakeTimers();
     });
@@ -1354,12 +1380,10 @@ describe("ChainProviderManager", () => {
       vi.useRealTimers();
     });
 
-    // Production constants this suite pins behaviour against.
-    const WARMUP_SAMPLES = 20;
-    const WINDOW_MS = 1_000;
-    const MAX_BLOCKS = 25;
-
-    async function subscribe(mgr: ChainProviderManager): Promise<void> {
+    async function subscribe(
+      mgr: ChainProviderManager = manager,
+    ): Promise<MockProvider> {
+      const before = factoryBundle.created.length;
       await mgr.subscribeToLogs({
         chainId: CHAIN_A,
         wssUrl: "ws://a",
@@ -1367,255 +1391,26 @@ describe("ChainProviderManager", () => {
         topic0: TOPIC_EMITTED,
         handler: vi.fn(),
       });
+      return factoryBundle.created[before];
     }
 
     function getLogsCalls(provider: MockProvider): SendCall[] {
       return provider.sendCalls.filter((c) => c.method === "eth_getLogs");
     }
 
-    function rangeOf(call: SendCall): { from: number; to: number } {
-      const filter = call.params[0] as { fromBlock: string; toBlock: string };
-      return {
-        from: Number.parseInt(filter.fromBlock, 16),
-        to: Number.parseInt(filter.toBlock, 16),
-      };
-    }
-
-    /**
-     * Deliver `count` blocks `intervalMs` apart. The first block establishes
-     * the interval baseline, so `count` blocks yield `count - 1` samples.
-     */
-    async function emitBlocks(
+    function ranges(
       provider: MockProvider,
-      firstBlock: number,
-      count: number,
-      intervalMs: number,
-    ): Promise<void> {
-      for (let i = 0; i < count; i += 1) {
-        await provider.emitBlock(firstBlock + i);
-        await vi.advanceTimersByTimeAsync(intervalMs);
-      }
+    ): Array<{ from: number; to: number }> {
+      return getLogsCalls(provider).map((call) => {
+        const filter = call.params[0] as { fromBlock: string; toBlock: string };
+        return {
+          from: Number.parseInt(filter.fromBlock, 16),
+          to: Number.parseInt(filter.toBlock, 16),
+        };
+      });
     }
 
-    it("dispatches one request per block until the cadence estimate is warm", async () => {
-      await subscribe(manager);
-      const provider = factoryBundle.created[0];
-
-      // WARMUP_SAMPLES blocks yield only WARMUP_SAMPLES - 1 intervals, so
-      // batching is still one sample short of engaging.
-      await emitBlocks(provider, 100, WARMUP_SAMPLES, 100);
-
-      const calls = getLogsCalls(provider);
-      expect(calls).toHaveLength(WARMUP_SAMPLES);
-      for (const call of calls) {
-        const { from, to } = rangeOf(call);
-        expect(from).toBe(to);
-      }
-    });
-
-    it("coalesces a window into a single ranged request once the chain proves sub-second", async () => {
-      await subscribe(manager);
-      const provider = factoryBundle.created[0];
-      await emitBlocks(provider, 100, WARMUP_SAMPLES, 100);
-      const warmupCalls = getLogsCalls(provider).length;
-
-      // Five further blocks now fall inside one window rather than issuing
-      // five separate requests.
-      await emitBlocks(provider, 200, 5, 100);
-      expect(getLogsCalls(provider)).toHaveLength(warmupCalls);
-
-      await vi.advanceTimersByTimeAsync(WINDOW_MS);
-
-      const batched = getLogsCalls(provider).slice(warmupCalls);
-      expect(batched).toHaveLength(1);
-      expect(rangeOf(batched[0])).toEqual({ from: 200, to: 204 });
-    });
-
-    it("leaves a chain with second-scale blocks on per-block dispatch", async () => {
-      await subscribe(manager);
-      const provider = factoryBundle.created[0];
-
-      // Well past the warm-up count, at Base's cadence. Every block must
-      // still get its own request: this change must not add latency to any
-      // chain that behaves like the ones supported today.
-      await emitBlocks(provider, 100, WARMUP_SAMPLES + 10, 2_000);
-
-      const calls = getLogsCalls(provider);
-      expect(calls).toHaveLength(WARMUP_SAMPLES + 10);
-      for (const call of calls) {
-        const { from, to } = rangeOf(call);
-        expect(from).toBe(to);
-      }
-    });
-
-    it("flushes at the block cap without waiting out the window", async () => {
-      await subscribe(manager);
-      const provider = factoryBundle.created[0];
-      await emitBlocks(provider, 100, WARMUP_SAMPLES, 100);
-      const warmupCalls = getLogsCalls(provider).length;
-
-      // A burst arriving far faster than the window: the cap, not the timer,
-      // has to bound the range.
-      await emitBlocks(provider, 300, MAX_BLOCKS, 1);
-
-      const batched = getLogsCalls(provider).slice(warmupCalls);
-      expect(batched).toHaveLength(1);
-      expect(rangeOf(batched[0])).toEqual({
-        from: 300,
-        to: 300 + MAX_BLOCKS - 1,
-      });
-    });
-
-    it("spans blocks the subscription skipped inside the window", async () => {
-      await subscribe(manager);
-      const provider = factoryBundle.created[0];
-      await emitBlocks(provider, 100, WARMUP_SAMPLES, 100);
-      const warmupCalls = getLogsCalls(provider).length;
-
-      // 401 to 404 were never pushed. A ranged request covers them anyway,
-      // which recovers logs a per-block loop would have dropped.
-      await provider.emitBlock(400);
-      await vi.advanceTimersByTimeAsync(100);
-      await provider.emitBlock(405);
-      await vi.advanceTimersByTimeAsync(WINDOW_MS);
-
-      const batched = getLogsCalls(provider).slice(warmupCalls);
-      expect(batched).toHaveLength(1);
-      expect(rangeOf(batched[0])).toEqual({ from: 400, to: 405 });
-    });
-
-    it("drops an open window when the last subscriber unsubscribes", async () => {
-      const unsubscribe = await manager.subscribeToLogs({
-        chainId: CHAIN_A,
-        wssUrl: "ws://a",
-        address: ADDR_A,
-        topic0: TOPIC_EMITTED,
-        handler: vi.fn(),
-      });
-      const provider = factoryBundle.created[0];
-      await emitBlocks(provider, 100, WARMUP_SAMPLES, 100);
-      const warmupCalls = getLogsCalls(provider).length;
-
-      await provider.emitBlock(500);
-      unsubscribe();
-      await vi.advanceTimersByTimeAsync(WINDOW_MS * 2);
-
-      // No request fires against a provider with nothing left to dispatch to.
-      expect(getLogsCalls(provider)).toHaveLength(warmupCalls);
-    });
-
-    it("serves a window held open by a dropped connection on the replacement", async () => {
-      await subscribe(manager);
-      const provider = factoryBundle.created[0];
-
-      // One past the warm-up, so this last block is buffered rather than
-      // dispatched, and the connection drops with the window still open.
-      await emitBlocks(provider, 100, WARMUP_SAMPLES + 1, 100);
-      const buffered = 100 + WARMUP_SAMPLES;
-
-      provider.emitError(new Error("socket closed"));
-      await vi.advanceTimersByTimeAsync(2_000);
-
-      const replacement = factoryBundle.created[1];
-      expect(replacement).toBeDefined();
-
-      // Discarding here would lose logs that per-block dispatch never could:
-      // the subscriber is still attached across a reconnect.
-      const served = getLogsCalls(replacement).map(rangeOf);
-      expect(served).toContainEqual({ from: buffered, to: buffered });
-    });
-
-    it("re-learns cadence after a reconnect instead of carrying the estimate over", async () => {
-      await subscribe(manager);
-      const provider = factoryBundle.created[0];
-      await emitBlocks(provider, 100, WARMUP_SAMPLES, 100);
-
-      provider.emitError(new Error("socket closed"));
-      await vi.advanceTimersByTimeAsync(2_000);
-
-      const replacement = factoryBundle.created[1];
-      expect(replacement).toBeDefined();
-      const before = getLogsCalls(replacement).length;
-
-      // The new connection starts cold, so these dispatch per block even
-      // though the previous one had been batching.
-      await emitBlocks(replacement, 600, 3, 100);
-      expect(getLogsCalls(replacement)).toHaveLength(before + 3);
-    });
-
-    it("tightens the staleness threshold for a batching chain", async () => {
-      // No blockStalenessTimeoutMs override, so the threshold is derived.
-      const bundle = makeFactory();
-      const mgr = new ChainProviderManager({
-        factory: bundle.factory,
-        onPermanentFailure,
-      });
-      await subscribe(mgr);
-      const provider = bundle.created[0];
-      const reasons: string[] = [];
-      mgr.onDisconnect(CHAIN_A, (ev) => {
-        reasons.push(ev.reason);
-      });
-
-      // One more than WARMUP_SAMPLES: the first block sets the interval
-      // baseline, so batching needs WARMUP_SAMPLES + 1 blocks to engage.
-      await emitBlocks(provider, 100, WARMUP_SAMPLES + 1, 100);
-
-      // A 100 ms chain derives the 30 s floor, so silence trips on the
-      // second heartbeat rather than the fixed 120 s default's fifth.
-      await vi.advanceTimersByTimeAsync(62_000);
-
-      expect(reasons).toContain("block_staleness");
-      await mgr.destroy();
-    });
-
-    it("keeps the fixed staleness threshold for a chain dispatching per block", async () => {
-      const bundle = makeFactory();
-      const mgr = new ChainProviderManager({
-        factory: bundle.factory,
-        onPermanentFailure,
-      });
-      await subscribe(mgr);
-      const provider = bundle.created[0];
-      const reasons: string[] = [];
-      mgr.onDisconnect(CHAIN_A, (ev) => {
-        reasons.push(ev.reason);
-      });
-
-      await emitBlocks(provider, 100, WARMUP_SAMPLES + 10, 2_000);
-
-      // 90 s of silence is past the derived floor a batching chain would get
-      // but well inside the 120 s this chain must keep.
-      await vi.advanceTimersByTimeAsync(90_000);
-
-      expect(reasons).not.toContain("block_staleness");
-      await mgr.destroy();
-    });
-  });
-
-  describe("getLogs counters", () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-    });
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    const WARMUP_SAMPLES = 20;
-    const WINDOW_MS = 1_000;
-    const STATS_INTERVAL_MS = 60_000;
-
-    async function subscribe(): Promise<MockProvider> {
-      await manager.subscribeToLogs({
-        chainId: CHAIN_A,
-        wssUrl: "ws://a",
-        address: ADDR_A,
-        topic0: TOPIC_EMITTED,
-        handler: vi.fn(),
-      });
-      return factoryBundle.created[0];
-    }
-
+    /** Deliver `count` blocks `intervalMs` apart, starting at `firstBlock`. */
     async function emitBlocks(
       provider: MockProvider,
       firstBlock: number,
@@ -1630,100 +1425,468 @@ describe("ChainProviderManager", () => {
 
     function statsLines(spy: ReturnType<typeof vi.spyOn>): string[] {
       return spy.mock.calls
-        .map((call) => String(call[0]))
+        .map((args) => String(args[0]))
         .filter((line) => line.includes("getlogs-stats"));
     }
 
-    it("counts one request per block while dispatching per block", async () => {
-      const provider = await subscribe();
-      await emitBlocks(provider, 100, 5, 2_000);
-
-      const health = manager.getHealth(CHAIN_A);
-      expect(health?.getLogsCalls).toBe(5);
-      expect(health?.batching).toBe(false);
-      expect(health?.blockIntervalMs).toBeGreaterThan(0);
-    });
-
-    it("counts a coalesced window as one request covering several blocks", async () => {
-      const provider = await subscribe();
-      await emitBlocks(provider, 100, WARMUP_SAMPLES, 100);
-      const warmCalls = manager.getHealth(CHAIN_A)?.getLogsCalls ?? 0;
-
-      await emitBlocks(provider, 200, 5, 100);
-      await vi.advanceTimersByTimeAsync(WINDOW_MS);
-
-      // Five blocks, one request - the ratio the batching exists to move.
-      expect(manager.getHealth(CHAIN_A)?.getLogsCalls).toBe(warmCalls + 1);
-      expect(manager.getHealth(CHAIN_A)?.batching).toBe(true);
-    });
-
-    it("reports the interval's counters and resets them for the next one", async () => {
-      const logSpy = vi
-        .spyOn(console, "log")
-        .mockImplementation(() => undefined);
-      try {
+    describe("rate limiting", () => {
+      it("dispatches every block immediately on a chain slower than the interval", async () => {
         const provider = await subscribe();
-        await emitBlocks(provider, 100, 3, 2_000);
-        await vi.advanceTimersByTimeAsync(STATS_INTERVAL_MS);
 
-        const first = statsLines(logSpy);
-        expect(first).toHaveLength(1);
-        expect(first[0]).toContain(`chain=${CHAIN_A}`);
-        expect(first[0]).toContain("batching=false");
-        expect(first[0]).toContain("getLogsCalls=3");
-        expect(first[0]).toContain("blocksCovered=3");
-        expect(first[0]).toContain("getLogsCallsTotal=3");
+        // Base's cadence. Each block arrives well after the previous request,
+        // so the minimum interval has always already elapsed and nothing is
+        // deferred. This is the property that keeps every chain supported
+        // today on its current latency.
+        await emitBlocks(provider, 100, 5, GETLOGS_MIN_INTERVAL_MS * 2);
 
-        await emitBlocks(provider, 200, 1, 2_000);
-        await vi.advanceTimersByTimeAsync(STATS_INTERVAL_MS);
+        expect(ranges(provider)).toEqual([
+          { from: 100, to: 100 },
+          { from: 101, to: 101 },
+          { from: 102, to: 102 },
+          { from: 103, to: 103 },
+          { from: 104, to: 104 },
+        ]);
+      });
 
-        // Interval counters restart; the cumulative total does not.
-        const second = statsLines(logSpy);
-        expect(second).toHaveLength(2);
-        expect(second[1]).toContain("getLogsCalls=1");
-        expect(second[1]).toContain("getLogsCallsTotal=4");
-      } finally {
-        logSpy.mockRestore();
-      }
+      it("serves a burst of sub-interval blocks in one ranged request", async () => {
+        const provider = await subscribe();
+
+        // 100 ms cadence: the first block goes out immediately, the rest
+        // accumulate against the high-water mark until the interval elapses.
+        await emitBlocks(provider, 200, 6, 100);
+        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS);
+
+        expect(ranges(provider)).toEqual([
+          { from: 200, to: 200 },
+          { from: 201, to: 205 },
+        ]);
+      });
+
+      it("issues at most one request per interval under sustained load", async () => {
+        const provider = await subscribe();
+
+        // 100 blocks at 100 ms is 10 s of chain time. Unlimited, that is 100
+        // requests; the cap is one per second plus the immediate first.
+        await emitBlocks(provider, 300, 100, 100);
+        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 2);
+
+        const calls = getLogsCalls(provider).length;
+        expect(calls).toBeLessThanOrEqual(13);
+        expect(calls).toBeGreaterThan(0);
+      });
+
+      it("covers blocks the subscription never pushed", async () => {
+        const provider = await subscribe();
+
+        // 401-404 are never delivered. The range is contiguous from the mark,
+        // so they are queried anyway - a per-block loop dropped them.
+        await provider.emitBlock(400);
+        await vi.advanceTimersByTimeAsync(100);
+        await provider.emitBlock(405);
+        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS);
+
+        expect(ranges(provider)).toEqual([
+          { from: 400, to: 400 },
+          { from: 401, to: 405 },
+        ]);
+      });
+
+      it("caps the span of one request and carries the remainder", async () => {
+        const provider = await subscribe();
+
+        await provider.emitBlock(500);
+        await vi.advanceTimersByTimeAsync(100);
+        // A jump far past the span cap: the first catch-up request must be
+        // bounded, and the rest must still be owed rather than skipped.
+        await provider.emitBlock(500 + GETLOGS_MAX_BLOCK_SPAN * 2);
+        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 3);
+
+        const served = ranges(provider);
+        expect(served[0]).toEqual({ from: 500, to: 500 });
+        expect(served[1]).toEqual({
+          from: 501,
+          to: 500 + GETLOGS_MAX_BLOCK_SPAN,
+        });
+        for (const r of served) {
+          expect(r.to - r.from + 1).toBeLessThanOrEqual(GETLOGS_MAX_BLOCK_SPAN);
+        }
+        // The remainder is walked, not dropped.
+        expect(served[served.length - 1].to).toBe(
+          500 + GETLOGS_MAX_BLOCK_SPAN * 2,
+        );
+      });
+
+      it("abandons and logs a gap too large to walk", async () => {
+        const warnSpy = vi
+          .spyOn(console, "warn")
+          .mockImplementation(() => undefined);
+        try {
+          const provider = await subscribe();
+          await provider.emitBlock(1_000);
+          await vi.advanceTimersByTimeAsync(100);
+          await provider.emitBlock(1_000 + GETLOGS_MAX_CATCHUP_BLOCKS + 500);
+          await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 2);
+
+          // Skipping is a loss, so it must be recorded rather than silent.
+          const warned = warnSpy.mock.calls
+            .map((a) => String(a[0]))
+            .filter((l) => l.includes("blocks behind head"));
+          expect(warned).toHaveLength(1);
+          // And it must not grind through the gap one span at a time.
+          expect(getLogsCalls(provider).length).toBeLessThan(5);
+        } finally {
+          warnSpy.mockRestore();
+        }
+      });
+
+      it("does not issue overlapping requests while one is in flight", async () => {
+        const provider = await subscribe();
+        let release: (() => void) | null = null;
+        provider.beforeSend = (method) =>
+          method === "eth_getLogs"
+            ? new Promise<void>((r) => {
+                release = r;
+              })
+            : null;
+
+        // Not awaited: this block's request is held open on purpose, so its
+        // handler never settles.
+        const held = provider.emitBlock(600);
+        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 3);
+        // Blocks keep arriving while the first request hangs. Each calls
+        // drain; none may start a second overlapping request.
+        void provider.emitBlock(601);
+        void provider.emitBlock(602);
+        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 3);
+
+        expect(getLogsCalls(provider)).toHaveLength(1);
+
+        provider.beforeSend = null;
+        release?.();
+        await held;
+      });
     });
 
-    it("counts a failed request without counting the blocks it never fetched", async () => {
-      const logSpy = vi
-        .spyOn(console, "log")
-        .mockImplementation(() => undefined);
-      try {
+    describe("failure handling", () => {
+      it("re-queries a failed range instead of losing its blocks", async () => {
         const provider = await subscribe();
+
+        await provider.emitBlock(700);
+        await vi.advanceTimersByTimeAsync(100);
+        // The range covering 701-705 fails once.
         provider.sendResponses = [new Error("upstream refused")];
-        await emitBlocks(provider, 100, 1, 2_000);
-        await vi.advanceTimersByTimeAsync(STATS_INTERVAL_MS);
+        await emitBlocks(provider, 701, 5, 100);
+        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 3);
 
-        const lines = statsLines(logSpy);
-        expect(lines).toHaveLength(1);
-        // The call was issued, so it was billed and is counted. The block was
-        // never fetched, so counting it would make the blocks-per-call ratio
-        // look most efficient exactly when the chain is least working.
-        expect(lines[0]).toContain("getLogsCalls=1");
-        expect(lines[0]).toContain("getLogsErrors=1");
-        expect(lines[0]).toContain("blocksCovered=0");
-        expect(lines[0]).toContain("ranges=0");
-      } finally {
-        logSpy.mockRestore();
-      }
+        // The mark did not advance past a range that never returned, so the
+        // same blocks are asked for again rather than dropped.
+        const served = ranges(provider);
+        const retried = served.filter((r) => r.from === 701);
+        expect(retried.length).toBeGreaterThanOrEqual(2);
+      });
+
+      it("does not advance past a range whose later address chunk failed", async () => {
+        // Two chunks means two requests for one range; the second fails.
+        const mgr = new ChainProviderManager({
+          factory: factoryBundle.factory,
+          onPermanentFailure,
+        });
+        const provider = await subscribe(mgr);
+        for (let i = 0; i < GETLOGS_ADDRESS_BATCH; i += 1) {
+          await mgr.subscribeToLogs({
+            chainId: CHAIN_A,
+            wssUrl: "ws://a",
+            address: `0x${(i + 1).toString(16).padStart(40, "0")}`,
+            topic0: TOPIC_EMITTED,
+            handler: vi.fn(),
+          });
+        }
+        provider.sendResponses = [[], new Error("chunk two refused")];
+        await provider.emitBlock(800);
+        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 3);
+
+        // Block 800 is still owed, so a later drain re-queries from 800.
+        await provider.emitBlock(801);
+        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 2);
+        expect(ranges(provider).some((r) => r.from === 800)).toBe(true);
+        await mgr.destroy();
+      });
     });
 
-    it("stays silent for a chain that issued no requests", async () => {
-      const logSpy = vi
-        .spyOn(console, "log")
-        .mockImplementation(() => undefined);
-      try {
-        await subscribe();
-        await vi.advanceTimersByTimeAsync(STATS_INTERVAL_MS);
+    describe("reconnect", () => {
+      it("resumes from the high-water mark on the replacement connection", async () => {
+        const provider = await subscribe();
+        await provider.emitBlock(900);
+        await vi.advanceTimersByTimeAsync(100);
 
-        // An idle tracker must not emit a line per chain per minute forever.
-        expect(statsLines(logSpy)).toHaveLength(0);
-      } finally {
-        logSpy.mockRestore();
+        provider.emitError(new Error("socket closed"));
+        await vi.advanceTimersByTimeAsync(3_000);
+
+        const replacement = factoryBundle.created[1];
+        expect(replacement).toBeDefined();
+        await replacement.emitBlock(905);
+        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 2);
+
+        // 901-905 were owed across the drop and are served by the new
+        // connection; nothing restarts from the new head and loses them.
+        expect(ranges(replacement).some((r) => r.from === 901)).toBe(true);
+      });
+
+      it("issues no request against the connection that is being replaced", async () => {
+        const provider = await subscribe();
+        await provider.emitBlock(950);
+        await vi.advanceTimersByTimeAsync(100);
+        const before = getLogsCalls(provider).length;
+
+        // A block arriving during the backoff must not start a drain on the
+        // failed socket, whether by timer or by the arrival itself.
+        provider.emitError(new Error("socket closed"));
+        await provider.emitBlock(951);
+        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 2);
+
+        expect(getLogsCalls(provider)).toHaveLength(before);
+      });
+
+      it("clears isReconnecting without waiting for log dispatch", async () => {
+        const provider = await subscribe();
+        await provider.emitBlock(970);
+        await vi.advanceTimersByTimeAsync(100);
+
+        provider.emitError(new Error("socket closed"));
+        await vi.advanceTimersByTimeAsync(3_000);
+
+        // A drain dispatches to handlers that may sleep for seconds. If the
+        // reconnect awaited it, the chain would report degraded and block
+        // getOrCreateProvider long after the socket was healthy.
+        expect(manager.getHealth(CHAIN_A)?.reconnecting).toBe(false);
+        expect(manager.getHealth(CHAIN_A)?.connected).toBe(true);
+      });
+    });
+
+    describe("counters", () => {
+      it("reports one range per block on a chain dispatching per block", async () => {
+        const logSpy = vi
+          .spyOn(console, "log")
+          .mockImplementation(() => undefined);
+        try {
+          const provider = await subscribe();
+          await emitBlocks(provider, 100, 3, GETLOGS_MIN_INTERVAL_MS * 2);
+          await vi.advanceTimersByTimeAsync(STATS_LOG_INTERVAL_MS);
+
+          const lines = statsLines(logSpy);
+          expect(lines).toHaveLength(1);
+          // blocksCovered/ranges is exactly 1 when every request is one block.
+          expect(lines[0]).toContain("blocksCovered=3");
+          expect(lines[0]).toContain("ranges=3");
+        } finally {
+          logSpy.mockRestore();
+        }
+      });
+
+      it("reports blocks ahead of ranges once requests are rate limited", async () => {
+        const logSpy = vi
+          .spyOn(console, "log")
+          .mockImplementation(() => undefined);
+        try {
+          const provider = await subscribe();
+          await emitBlocks(provider, 200, 6, 100);
+          await vi.advanceTimersByTimeAsync(STATS_LOG_INTERVAL_MS);
+
+          const lines = statsLines(logSpy);
+          expect(lines).toHaveLength(1);
+          expect(lines[0]).toContain("blocksCovered=6");
+          expect(lines[0]).toContain("ranges=2");
+        } finally {
+          logSpy.mockRestore();
+        }
+      });
+
+      it("counts a failed request without counting the blocks it never fetched", async () => {
+        const logSpy = vi
+          .spyOn(console, "log")
+          .mockImplementation(() => undefined);
+        try {
+          const provider = await subscribe();
+          // Fails once, then the queue is empty and the mock answers normally,
+          // so the retry succeeds.
+          provider.sendResponses = [new Error("upstream refused")];
+          await emitBlocks(provider, 100, 1, GETLOGS_MIN_INTERVAL_MS * 2);
+          await vi.advanceTimersByTimeAsync(STATS_LOG_INTERVAL_MS);
+
+          const lines = statsLines(logSpy);
+          expect(lines).toHaveLength(1);
+          // Two calls were issued and both were billed, so both are counted.
+          // Only one range returned, and only its block is covered - the
+          // failed attempt contributes cost, never coverage, or the
+          // blocks-per-range ratio would look most efficient exactly when the
+          // chain is least working.
+          expect(lines[0]).toContain("getLogsCalls=2");
+          expect(lines[0]).toContain("getLogsErrors=1");
+          expect(lines[0]).toContain("ranges=1");
+          expect(lines[0]).toContain("blocksCovered=1");
+        } finally {
+          logSpy.mockRestore();
+        }
+      });
+
+      it("never credits coverage to a range that keeps failing", async () => {
+        const logSpy = vi
+          .spyOn(console, "log")
+          .mockImplementation(() => undefined);
+        try {
+          const provider = await subscribe();
+          provider.getLogsFailure = new Error("upstream down");
+          await emitBlocks(provider, 100, 2, GETLOGS_MIN_INTERVAL_MS * 2);
+          await vi.advanceTimersByTimeAsync(STATS_LOG_INTERVAL_MS);
+
+          const lines = statsLines(logSpy);
+          expect(lines).toHaveLength(1);
+          expect(lines[0]).toContain("blocksCovered=0");
+          expect(lines[0]).toContain("ranges=0");
+          expect(lines[0]).not.toContain("getLogsErrors=0");
+        } finally {
+          logSpy.mockRestore();
+        }
+      });
+
+      it("stays silent for a chain that issued no requests", async () => {
+        const logSpy = vi
+          .spyOn(console, "log")
+          .mockImplementation(() => undefined);
+        try {
+          await subscribe();
+          await vi.advanceTimersByTimeAsync(STATS_LOG_INTERVAL_MS);
+          expect(statsLines(logSpy)).toHaveLength(0);
+        } finally {
+          logSpy.mockRestore();
+        }
+      });
+
+      it("names the cumulative health counter for the quantity it holds", async () => {
+        const provider = await subscribe();
+        await emitBlocks(provider, 100, 2, GETLOGS_MIN_INTERVAL_MS * 2);
+
+        // The log line's getLogsCalls is a per-interval count; the health
+        // field is cumulative. Sharing a name invited reading a rate as a
+        // counter, so the health field carries the source's name.
+        const health = manager.getHealth(CHAIN_A);
+        expect(health?.getLogsCallsTotal).toBe(2);
+        expect(
+          (health as unknown as Record<string, unknown>).getLogsCalls,
+        ).toBeUndefined();
+      });
+    });
+  });
+
+  describe("derived block-staleness threshold", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    /**
+     * Run a chain at `intervalMs` until its cadence estimate settles, then go
+     * silent for `silenceMs` and report whether the watchdog reconnected.
+     */
+    async function trippedAfterSilence(
+      intervalMs: number,
+      silenceMs: number,
+    ): Promise<boolean> {
+      const bundle = makeFactory();
+      const mgr = new ChainProviderManager({
+        factory: bundle.factory,
+        onPermanentFailure,
+      });
+      await mgr.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      const reasons: string[] = [];
+      mgr.onDisconnect(CHAIN_A, (ev) => {
+        reasons.push(ev.reason);
+      });
+      const provider = bundle.created[0];
+
+      // Enough samples AND enough wall clock for the estimate to settle.
+      const blocks =
+        Math.ceil(BLOCK_INTERVAL_MIN_SPAN_MS / intervalMs) +
+        BLOCK_INTERVAL_MIN_SAMPLES +
+        1;
+      for (let i = 0; i < blocks; i += 1) {
+        await provider.emitBlock(1_000 + i);
+        await vi.advanceTimersByTimeAsync(intervalMs);
       }
+
+      await vi.advanceTimersByTimeAsync(silenceMs);
+      const tripped = reasons.includes("block_staleness");
+      await mgr.destroy();
+      return tripped;
+    }
+
+    it("leaves a 2 s chain on the historical ceiling", async () => {
+      // 2000 x 60 = 120 s, which is exactly BLOCK_STALENESS_TIMEOUT_MS. Base
+      // must not gain a tighter threshold than it has always had, or this
+      // change introduces reconnect churn on a chain that behaves today.
+      expect(2_000 * BLOCK_STALENESS_BLOCK_MULTIPLIER).toBeGreaterThanOrEqual(
+        BLOCK_STALENESS_TIMEOUT_MS,
+      );
+      expect(await trippedAfterSilence(2_000, 90_000)).toBe(false);
+    });
+
+    it("tightens a sub-second chain to the floor", async () => {
+      // 100 ms x 60 = 6 s, below the floor, so the floor binds: 30 s rather
+      // than 120 s, which on a 100 ms chain is 1.2 million blocks of slack.
+      expect(100 * BLOCK_STALENESS_BLOCK_MULTIPLIER).toBeLessThan(
+        BLOCK_STALENESS_FLOOR_MS,
+      );
+      expect(await trippedAfterSilence(100, 62_000)).toBe(true);
+    });
+
+    it("keeps the multiplier live between the bounds", () => {
+      // If every reachable cadence produced a value outside the clamp, the
+      // constant would be dead and the documented rule unobservable - which
+      // is what a multiplier of 10 did.
+      const derived = 1_000 * BLOCK_STALENESS_BLOCK_MULTIPLIER;
+      expect(derived).toBeGreaterThan(BLOCK_STALENESS_FLOOR_MS);
+      expect(derived).toBeLessThan(BLOCK_STALENESS_TIMEOUT_MS);
+    });
+
+    it("is not poisoned by a burst of blocks arriving together", async () => {
+      const bundle = makeFactory();
+      const mgr = new ChainProviderManager({
+        factory: bundle.factory,
+        onPermanentFailure,
+      });
+      await mgr.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      const reasons: string[] = [];
+      mgr.onDisconnect(CHAIN_A, (ev) => {
+        reasons.push(ev.reason);
+      });
+      const provider = bundle.created[0];
+
+      // A socket buffer flushing after an event-loop stall: enough samples for
+      // a count-only gate, milliseconds apart. Reading this as the chain's
+      // cadence would drop a 12 s chain to the 30 s floor and reconnect it on
+      // any ordinary gap.
+      for (let i = 0; i <= BLOCK_INTERVAL_MIN_SAMPLES; i += 1) {
+        await provider.emitBlock(2_000 + i);
+        await vi.advanceTimersByTimeAsync(1);
+      }
+      await vi.advanceTimersByTimeAsync(90_000);
+
+      expect(reasons).not.toContain("block_staleness");
+      await mgr.destroy();
     });
   });
 

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -748,6 +748,9 @@ describe("ChainProviderManager", () => {
         reconnecting: false,
         lastBlockAt: null,
         subscriberCount: 1,
+        blockIntervalMs: null,
+        batching: false,
+        getLogsCalls: 0,
         lastCreateError: null,
       });
     });
@@ -1581,6 +1584,116 @@ describe("ChainProviderManager", () => {
 
       expect(reasons).not.toContain("block_staleness");
       await mgr.destroy();
+    });
+  });
+
+  describe("getLogs counters", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    const WARMUP_SAMPLES = 20;
+    const WINDOW_MS = 1_000;
+    const STATS_INTERVAL_MS = 60_000;
+
+    async function subscribe(): Promise<MockProvider> {
+      await manager.subscribeToLogs({
+        chainId: CHAIN_A,
+        wssUrl: "ws://a",
+        address: ADDR_A,
+        topic0: TOPIC_EMITTED,
+        handler: vi.fn(),
+      });
+      return factoryBundle.created[0];
+    }
+
+    async function emitBlocks(
+      provider: MockProvider,
+      firstBlock: number,
+      count: number,
+      intervalMs: number,
+    ): Promise<void> {
+      for (let i = 0; i < count; i += 1) {
+        await provider.emitBlock(firstBlock + i);
+        await vi.advanceTimersByTimeAsync(intervalMs);
+      }
+    }
+
+    function statsLines(spy: ReturnType<typeof vi.spyOn>): string[] {
+      return spy.mock.calls
+        .map((call) => String(call[0]))
+        .filter((line) => line.includes("getlogs-stats"));
+    }
+
+    it("counts one request per block while dispatching per block", async () => {
+      const provider = await subscribe();
+      await emitBlocks(provider, 100, 5, 2_000);
+
+      const health = manager.getHealth(CHAIN_A);
+      expect(health?.getLogsCalls).toBe(5);
+      expect(health?.batching).toBe(false);
+      expect(health?.blockIntervalMs).toBeGreaterThan(0);
+    });
+
+    it("counts a coalesced window as one request covering several blocks", async () => {
+      const provider = await subscribe();
+      await emitBlocks(provider, 100, WARMUP_SAMPLES, 100);
+      const warmCalls = manager.getHealth(CHAIN_A)?.getLogsCalls ?? 0;
+
+      await emitBlocks(provider, 200, 5, 100);
+      await vi.advanceTimersByTimeAsync(WINDOW_MS);
+
+      // Five blocks, one request - the ratio the batching exists to move.
+      expect(manager.getHealth(CHAIN_A)?.getLogsCalls).toBe(warmCalls + 1);
+      expect(manager.getHealth(CHAIN_A)?.batching).toBe(true);
+    });
+
+    it("reports the interval's counters and resets them for the next one", async () => {
+      const logSpy = vi
+        .spyOn(console, "log")
+        .mockImplementation(() => undefined);
+      try {
+        const provider = await subscribe();
+        await emitBlocks(provider, 100, 3, 2_000);
+        await vi.advanceTimersByTimeAsync(STATS_INTERVAL_MS);
+
+        const first = statsLines(logSpy);
+        expect(first).toHaveLength(1);
+        expect(first[0]).toContain(`chain=${CHAIN_A}`);
+        expect(first[0]).toContain("batching=false");
+        expect(first[0]).toContain("getLogsCalls=3");
+        expect(first[0]).toContain("blocksCovered=3");
+        expect(first[0]).toContain("getLogsCallsTotal=3");
+
+        await emitBlocks(provider, 200, 1, 2_000);
+        await vi.advanceTimersByTimeAsync(STATS_INTERVAL_MS);
+
+        // Interval counters restart; the cumulative total does not.
+        const second = statsLines(logSpy);
+        expect(second).toHaveLength(2);
+        expect(second[1]).toContain("getLogsCalls=1");
+        expect(second[1]).toContain("getLogsCallsTotal=4");
+      } finally {
+        logSpy.mockRestore();
+      }
+    });
+
+    it("stays silent for a chain that issued no requests", async () => {
+      const logSpy = vi
+        .spyOn(console, "log")
+        .mockImplementation(() => undefined);
+      try {
+        await subscribe();
+        await vi.advanceTimersByTimeAsync(STATS_INTERVAL_MS);
+
+        // An idle tracker must not emit a line per chain per minute forever.
+        expect(statsLines(logSpy)).toHaveLength(0);
+      } finally {
+        logSpy.mockRestore();
+      }
     });
   });
 


### PR DESCRIPTION
Closes KEEP-1088.

## Problem

`processBlock` issued one `eth_getLogs` per block per 500-address batch, driven off each `newHeads` push, so request volume scaled linearly with block rate:

| Chain | Block time | getLogs/day/address-batch |
| -- | -- | -- |
| Ethereum | 12 s | 7,200 |
| Base | 2 s | 43,200 |
| Robinhood Chain (4663) | 0.1 s | 864,000 |

864,000/day from a single subscriber batch on one chain is roughly twice the entire platform's current RPC volume across all 26 chains. Robinhood Chain is `isEnabled: true` in staging and `false` in production, and nothing subscribes to 4663 yet, so the cost is latent rather than live - which makes this the moment to land it, not after.

## Change

Each chain keeps a high-water mark of the last block it has served, and a drain fetches `(mark, head]` **at most once per second per chain**. A 100 ms chain drops from 864,000 to at most 86,400 calls/day/address-batch: a bounded factor of two against Base, down from twenty.

**Nothing branches on how fast a chain is.** A chain whose blocks arrive further apart than that interval always finds it already elapsed and dispatches immediately - one request per block, the historical behaviour and latency, with no threshold deciding it. Every chain supported today is in that case; the fastest produces blocks at 2 s. A faster chain finds the interval has not elapsed, its head runs ahead of the mark, and the accumulated range is served in one request.

The range is contiguous from the mark, so blocks the subscription never pushed are covered too, and the mark survives a reconnect so a replacement connection resumes rather than starting blind. A single request is capped at 25 blocks with the remainder left owed; a gap beyond 5,000 blocks is abandoned with a warning rather than walked at one request per second while current blocks queue behind it.

Latency is not the binding term either way - `EventListener` already applies a deliberate 0-10 s jitter before forwarding any matched event.

### Failure handling

`processBlockRange` reports whether the range was served, and the mark advances only when it was. A failed range stays owed and the next drain re-queries it. A partial multi-chunk failure dispatches nothing rather than delivering the chunks that happened to return and never fetching the rest.

### Reconnect

`drain` refuses to run while `isReconnecting`, so a block arriving during the backoff cannot start a request against the socket that just failed. The reconnect schedules the catch-up rather than awaiting it: `dispatchLog` awaits its handlers, each of which may sleep seconds of jitter, so awaiting would hold `isReconnecting` true long after the socket was healthy - reporting the chain degraded, blocking every `getOrCreateProvider`, and suppressing the checks that would catch a second drop.

### Staleness threshold

`BLOCK_STALENESS_TIMEOUT_MS = 120_000` was slack measured in wall-clock rather than blocks: ten blocks on Ethereum, 1.2 million on a 100 ms chain. The derived value is now `clamp(interval x 60, 30 s, 120 s)`. At 60 blocks Base and Ethereum keep exactly the 120 s they had, a 100 ms chain takes the 30 s floor, and the multiplier decides everything between. Trusting the estimate requires the samples to span real wall clock - measured across the samples, not to now - so a burst of queued `newHeads` messages cannot read as a fast chain.

### Measurement

Per-chain counters behind a `getlogs-stats` line, one per chain that did work, per 60 s.

Nothing outside this process can measure the change. The package ships no prom-client, no OpenTelemetry and no `/metrics` route. Aetherlay cannot stand in either: `aetherlay_endpoint_proxy_requests_total` increments once per WebSocket *connection* (`server.go:761`) and per request only on the HTTP path, while the proxy's own message loop counts nothing - so calls tunnelled through a long-lived socket, which is every call this class makes, never move it on any cluster.

`blocksCovered` against `getLogsCalls` is self-comparing: roughly equal while dispatching per block, blocks far ahead of calls once a window engages. **There is no historical baseline for this quantity - nothing has ever counted it** - so the ratio inside a single reading is what demonstrates the criterion. Reviewers should not go looking for a before number.

Querying needs the inner parse, since the logger has no structured-field API:

```
{namespace="keeperhub"} |= "getlogs-stats" | json | line_format "{{.msg}}" | logfmt
```

## Review history

The first implementation coalesced blocks into a timed window behind a measured-cadence gate. An automated review returned 14 findings, six of which were the same shape: a mechanism that measured the chain, decided whether it qualified, and then had to defend that decision against bursts, threshold drift, reconnects and its own timers. Replacing the mechanism closed them rather than patching each. Two findings had also falsified claims in an earlier version of this description - the staleness formula could never return anything but its floor, and the reconnect fix was reachable around - and both are fixed here rather than only corrected in prose.

## Verification

- `tsc --noEmit`: clean
- `biome check` on both changed files: clean
- unit: **173/173**
- integration: **8/8**, run twice

`event-to-sqs-inproc-config-change.test.ts` fails roughly one full-suite run in four. Measured at baseline on unmodified staging (1 failure in 4 runs) and with this change (1 failure in 4 runs), same test both times, and reproduced independently. Pre-existing, unrelated to this diff, and worth its own ticket.

## Reviewer notes

- **User-visible behaviour change, and it is an improvement.** A ranged request returns every log in `[fromBlock, toBlock]`, including blocks the `newHeads` subscription never pushed. Under per-block dispatch those logs were dropped silently and permanently; on a batching chain they are now fetched, and the dedup layer absorbs anything that arrives twice as a result. So an event that previously would not have fired an execution can now fire one. The trigger payload itself is unchanged - it is built from the `log` object, which is identical either way - so nothing downstream of `buildEventPayload` sees a difference. Covered by `spans blocks the subscription skipped inside the window`.
- **Shared test scaffolding changed.** `MockProvider` gains three additive hooks: a queued `Error` in `sendResponses` now rejects (matching the `blockNumberResponses` convention), `getLogsFailure` makes every `eth_getLogs` reject until cleared, and `beforeSend` lets a test hold a request in flight. No existing test uses any of them.
- **The `/healthz` body widens** by `blockIntervalMs`, `batching` and `getLogsCalls`. Additive - `toHealth` is the only construction site and `health-server` consumes it structurally through `ReturnType<>`.
- **Unrelated pre-existing issue found while verifying the above, being ticketed separately:** `ChainHealth` carries `wssUrl` and `fallbackWssUrl` verbatim into the `/healthz` body, and 19 of 22 chains embed `${DRPC_API_KEY}` in those URLs. It is latent only because the health server binds `HEALTH_PORT` (3001) while the deployment declares 3000. Fixing that reachability bug on its own would turn a latent key leak into a live one. The two must be fixed together, redaction first.
