### PR TITLE
feat: bound the stablecoin value a single call can move

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -312,3 +312,7 @@ EXECUTE_DEFAULT_DAILY_VALUE_CAP_WEI=
 # Same, for Solana native value, in lamports. Defaults to 0.5 SOL. Independent of
 # the wei cap: an unset Solana cap does not fall back to the EVM figure.
 EXECUTE_DEFAULT_DAILY_SOLANA_VALUE_CAP_LAMPORTS=
+
+# Ceiling on a single stablecoin outflow, in micro-USD (6 decimals). Per
+# transaction, not per day. Defaults to 100 USD.
+EXECUTE_DEFAULT_STABLECOIN_CAP_MICRO_USD=

--- a/.env.example
+++ b/.env.example
@@ -316,3 +316,8 @@ EXECUTE_DEFAULT_DAILY_SOLANA_VALUE_CAP_LAMPORTS=
 # Ceiling on a single stablecoin outflow, in micro-USD (6 decimals). Per
 # transaction, not per day. Defaults to 100 USD.
 EXECUTE_DEFAULT_STABLECOIN_CAP_MICRO_USD=
+
+# Ceiling on the TOTAL stablecoin outflow of one transaction, in micro-USD.
+# Applies alongside the per-call figure above, since a batch payout packs many
+# recipients into a single transaction. Defaults to 2000 USD.
+EXECUTE_DEFAULT_BATCH_STABLECOIN_CAP_MICRO_USD=

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -211,8 +211,9 @@ export async function POST(request: Request): Promise<NextResponse> {
   // Solana too (transferFundsCore branches on a Solana chainId), so a SOL
   // transfer is parsed at 9 decimals and charged to the lamports cap rather
   // than being scaled to 18 and charged to the ETH-denominated one. Token
-  // transfers move no native value (token value is not yet priced into the
-  // cap) so reserve 0.
+  // transfers move no native value so reserve 0; a known stablecoin is bounded
+  // separately inside transferTokenCore, which is the choke point every
+  // entrance shares.
   const redactedInput = redactInput(withRejectedSignerOverride(body, body));
   const isSolanaTransfer = isSolanaNetwork(network);
   let reservedValueWei = "0";

--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -269,6 +269,11 @@ app:
     EXECUTE_DEFAULT_DAILY_SOLANA_VALUE_CAP_LAMPORTS:
       type: kv
       value: "500000000"
+    # Ceiling on a single stablecoin outflow, in micro-USD (6 decimals). Per
+    # transaction, not per day. 100 USD.
+    EXECUTE_DEFAULT_STABLECOIN_CAP_MICRO_USD:
+      type: kv
+      value: "100000000"
     METRICS_COLLECTOR:
       type: kv
       value: "prometheus"
@@ -987,6 +992,11 @@ executor:
     EXECUTE_DEFAULT_DAILY_SOLANA_VALUE_CAP_LAMPORTS:
       type: kv
       value: "500000000"
+    # Ceiling on a single stablecoin outflow, in micro-USD (6 decimals). Per
+    # transaction, not per day. 100 USD.
+    EXECUTE_DEFAULT_STABLECOIN_CAP_MICRO_USD:
+      type: kv
+      value: "100000000"
     JOB_TTL_SECONDS:
       type: kv
       value: "300"

--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -274,6 +274,13 @@ app:
     EXECUTE_DEFAULT_STABLECOIN_CAP_MICRO_USD:
       type: kv
       value: "100000000"
+    # Ceiling on the TOTAL stablecoin outflow of one transaction, in micro-USD.
+    # Applies alongside the per-call figure, not instead of it: a batch payout
+    # packs up to 50 recipients into a single transaction, so the per-call
+    # figure alone would cap a payroll run at 2 USD a head. 2,000 USD.
+    EXECUTE_DEFAULT_BATCH_STABLECOIN_CAP_MICRO_USD:
+      type: kv
+      value: "2000000000"
     METRICS_COLLECTOR:
       type: kv
       value: "prometheus"
@@ -997,6 +1004,13 @@ executor:
     EXECUTE_DEFAULT_STABLECOIN_CAP_MICRO_USD:
       type: kv
       value: "100000000"
+    # Ceiling on the TOTAL stablecoin outflow of one transaction, in micro-USD.
+    # Applies alongside the per-call figure, not instead of it: a batch payout
+    # packs up to 50 recipients into a single transaction, so the per-call
+    # figure alone would cap a payroll run at 2 USD a head. 2,000 USD.
+    EXECUTE_DEFAULT_BATCH_STABLECOIN_CAP_MICRO_USD:
+      type: kv
+      value: "2000000000"
     JOB_TTL_SECONDS:
       type: kv
       value: "300"

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -213,6 +213,13 @@ app:
     EXECUTE_DEFAULT_STABLECOIN_CAP_MICRO_USD:
       type: kv
       value: "100000000"
+    # Ceiling on the TOTAL stablecoin outflow of one transaction, in micro-USD.
+    # Applies alongside the per-call figure, not instead of it: a batch payout
+    # packs up to 50 recipients into a single transaction, so the per-call
+    # figure alone would cap a payroll run at 2 USD a head. 2,000 USD.
+    EXECUTE_DEFAULT_BATCH_STABLECOIN_CAP_MICRO_USD:
+      type: kv
+      value: "2000000000"
     METRICS_COLLECTOR:
       type: kv
       value: "prometheus"
@@ -937,6 +944,13 @@ executor:
     EXECUTE_DEFAULT_STABLECOIN_CAP_MICRO_USD:
       type: kv
       value: "100000000"
+    # Ceiling on the TOTAL stablecoin outflow of one transaction, in micro-USD.
+    # Applies alongside the per-call figure, not instead of it: a batch payout
+    # packs up to 50 recipients into a single transaction, so the per-call
+    # figure alone would cap a payroll run at 2 USD a head. 2,000 USD.
+    EXECUTE_DEFAULT_BATCH_STABLECOIN_CAP_MICRO_USD:
+      type: kv
+      value: "2000000000"
     JOB_TTL_SECONDS:
       type: kv
       value: "120"

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -208,6 +208,11 @@ app:
     EXECUTE_DEFAULT_DAILY_SOLANA_VALUE_CAP_LAMPORTS:
       type: kv
       value: "500000000"
+    # Ceiling on a single stablecoin outflow, in micro-USD (6 decimals). Per
+    # transaction, not per day. 100 USD.
+    EXECUTE_DEFAULT_STABLECOIN_CAP_MICRO_USD:
+      type: kv
+      value: "100000000"
     METRICS_COLLECTOR:
       type: kv
       value: "prometheus"
@@ -927,6 +932,11 @@ executor:
     EXECUTE_DEFAULT_DAILY_SOLANA_VALUE_CAP_LAMPORTS:
       type: kv
       value: "500000000"
+    # Ceiling on a single stablecoin outflow, in micro-USD (6 decimals). Per
+    # transaction, not per day. 100 USD.
+    EXECUTE_DEFAULT_STABLECOIN_CAP_MICRO_USD:
+      type: kv
+      value: "100000000"
     JOB_TTL_SECONDS:
       type: kv
       value: "120"

--- a/docs/api/direct-execution.md
+++ b/docs/api/direct-execution.md
@@ -42,7 +42,11 @@ Call `GET /api/analytics/spend-cap` before planning a large transfer. Read `effe
 
 An ERC-20 transfer carries no native value, so the daily caps above cannot see it. A single transaction that moves a recognised stablecoin (any token listed for that chain and flagged as a stablecoin) is limited to **100 USD**, applying the 1:1 peg to the token's own decimals. The limit is per transaction rather than per day, and covers every write path: `/api/execute/transfer`, `/api/execute/contract-call`, protocol actions, `/api/execute/node`, and the equivalent workflow steps. Over the limit nothing is signed or broadcast; the request completes as a failed execution (`202` with `status: "failed"`) whose error reads `Stablecoin transfer of ... exceeds the 100.0 USD per-transaction limit`. Self-hosted deployments can change the figure with `EXECUTE_DEFAULT_STABLECOIN_CAP_MICRO_USD` (micro-USD, so `100000000` is 100 USD).
 
-Two things this does **not** do: it does not price non-stablecoin ERC-20s, which are not bounded at all, and it does not refuse `approve` — a large stablecoin approval is recorded but allowed, because capping approvals would break routine protocol integrations.
+A dry run reports the same refusal: simulating an over-limit transfer returns a failed simulation carrying the limit, rather than a clean estimate for a transfer that would fail at broadcast.
+
+`approve` is bounded by the same figure, with one exception. Approving more than the limit is allowed when the spender is a contract belonging to a protocol integration, which is what makes the usual approve-then-swap pattern work. Approving more than the limit to any other address is refused, because an unbounded allowance to an address outside that set is a standing right to move the balance that no later check can see. An approval at or under the limit is always allowed.
+
+Two things this does **not** do: it does not price non-stablecoin ERC-20s, which are not bounded at all, and it does not cover Solana. SPL token transfers are outside the ceiling, and the daily Solana cap counts native SOL only.
 
 ## Safe First-Write Sequence
 

--- a/docs/api/direct-execution.md
+++ b/docs/api/direct-execution.md
@@ -38,6 +38,12 @@ Both caps count value moved by workflow runs as well as by this API, so the two 
 
 Call `GET /api/analytics/spend-cap` before planning a large transfer. Read `effectiveDailyCapWei` and `effectiveDailySolanaCapLamports` — those are the figures enforcement uses. A null `dailyCapWei` means the organization configured nothing, not that spending is unbounded.
 
+### Stablecoin transfers
+
+An ERC-20 transfer carries no native value, so the daily caps above cannot see it. A single transaction that moves a recognised stablecoin (any token listed for that chain and flagged as a stablecoin) is limited to **100 USD**, applying the 1:1 peg to the token's own decimals. The limit is per transaction rather than per day, and covers every write path: `/api/execute/transfer`, `/api/execute/contract-call`, protocol actions, `/api/execute/node`, and the equivalent workflow steps. Over the limit nothing is signed or broadcast; the request completes as a failed execution (`202` with `status: "failed"`) whose error reads `Stablecoin transfer of ... exceeds the 100.0 USD per-transaction limit`. Self-hosted deployments can change the figure with `EXECUTE_DEFAULT_STABLECOIN_CAP_MICRO_USD` (micro-USD, so `100000000` is 100 USD).
+
+Two things this does **not** do: it does not price non-stablecoin ERC-20s, which are not bounded at all, and it does not refuse `approve` — a large stablecoin approval is recorded but allowed, because capping approvals would break routine protocol integrations.
+
 ## Safe First-Write Sequence
 
 Use the same request body from simulation through broadcast so the transaction

--- a/lib/execute/simulate.ts
+++ b/lib/execute/simulate.ts
@@ -8,7 +8,7 @@ import {
   getNativeSymbol,
   type INSUFFICIENT_BALANCE_CODE,
 } from "@/lib/execute/native-balance";
-import { checkStablecoinTransferAmount } from "@/lib/execute/stablecoin-cap";
+import { checkStablecoinContractCall } from "@/lib/execute/stablecoin-cap";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
@@ -627,6 +627,28 @@ export async function simulateContractCall(
   }
   const { rpc, chainId } = rpcResolution;
 
+  // The ceiling applies to the broadcast, so a simulation that ignored it
+  // would report a clean dry run for a call that then fails at send. Agents
+  // call simulate to decide whether to send, so the limit has to be visible
+  // here. Placed in this function rather than only in simulateTokenTransfer
+  // because the contract-call route reaches this one directly, and
+  // simulateTokenTransfer delegates here, so one check covers both entrances.
+  //
+  // Reported as a failed simulation rather than thrown: the caller asked what
+  // would happen, and this is what would happen.
+  const stablecoinCap = await checkStablecoinContractCall({
+    organizationId: input.organizationId,
+    chainId,
+    contractAddress: to,
+    functionName: abiFn.name ?? input.functionName,
+    inputTypes: (abiFn.inputs ?? []).map((i) => i.type),
+    args: argsOrError,
+    context: "simulate",
+  });
+  if (stablecoinCap.kind !== "allowed") {
+    return failure(from, to, value, stablecoinCap.error);
+  }
+
   const tx: ethers.TransactionRequest = { from, to, data: encodedData, value };
 
   let gasEstimate: bigint;
@@ -846,22 +868,8 @@ export async function simulateTokenTransfer(
     );
   }
 
-  // The ceiling applies to the broadcast, so a simulation that ignored it
-  // would report a clean dry run for a transfer that then fails at send.
-  // Agents call simulate precisely to decide whether to send, so the limit has
-  // to be visible here. Reported as a failed simulation rather than thrown:
-  // the caller asked what would happen, and this is what would happen.
-  const stablecoinCap = await checkStablecoinTransferAmount({
-    organizationId: input.organizationId,
-    chainId,
-    tokenAddress: resolvedTokenAddress,
-    amount: input.amount,
-    context: "simulate-transfer",
-  });
-  if (stablecoinCap.kind !== "allowed") {
-    return failure(from, resolvedTokenAddress, BigInt(0), stablecoinCap.error);
-  }
-
+  // No ceiling check here: this delegates to simulateContractCall below,
+  // which applies it once for both entrances.
   return simulateContractCall({
     organizationId: input.organizationId,
     network: input.network,

--- a/lib/execute/simulate.ts
+++ b/lib/execute/simulate.ts
@@ -8,6 +8,7 @@ import {
   getNativeSymbol,
   type INSUFFICIENT_BALANCE_CODE,
 } from "@/lib/execute/native-balance";
+import { checkStablecoinTransferAmount } from "@/lib/execute/stablecoin-cap";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
@@ -843,6 +844,22 @@ export async function simulateTokenTransfer(
       BigInt(0),
       `Invalid amount for ${decimals} decimals: ${input.amount}`
     );
+  }
+
+  // The ceiling applies to the broadcast, so a simulation that ignored it
+  // would report a clean dry run for a transfer that then fails at send.
+  // Agents call simulate precisely to decide whether to send, so the limit has
+  // to be visible here. Reported as a failed simulation rather than thrown:
+  // the caller asked what would happen, and this is what would happen.
+  const stablecoinCap = await checkStablecoinTransferAmount({
+    organizationId: input.organizationId,
+    chainId,
+    tokenAddress: resolvedTokenAddress,
+    amount: input.amount,
+    context: "simulate-transfer",
+  });
+  if (stablecoinCap.kind !== "allowed") {
+    return failure(from, resolvedTokenAddress, BigInt(0), stablecoinCap.error);
   }
 
   return simulateContractCall({

--- a/lib/execute/spend-cap-defaults.ts
+++ b/lib/execute/spend-cap-defaults.ts
@@ -75,6 +75,21 @@ const DEFAULT_STABLECOIN_CAP_MICRO_USD = "100000000";
 // BigInt() accepts hex-prefixed strings ("0x10" -> 16), so an ops typo would
 // silently turn a cap into a near-zero one. Reject anything that is not a
 // decimal digit run before it is used.
+// 2,000 USD in micro-USD: the ceiling on ONE transaction's total stablecoin
+// outflow, distinct from the per-call figure above.
+//
+// A Tempo batch payout packs up to MAX_PAYOUTS (50) recipients into a single
+// transaction. Measuring that total against the per-call 100 USD would cap a
+// 50-recipient payroll at 2 USD a head, which is not a bound on the feature so
+// much as its removal. The two figures do different jobs: the per-call ceiling
+// stops any one recipient being large, and this one stops the batch as a whole
+// being large, so neither a single 990 USD entry nor fifty 100 USD entries get
+// through.
+//
+// 20x the per-call figure. Sized so an ordinary payroll run clears it while a
+// batch still cannot move materially more than a handful of single transfers.
+const DEFAULT_BATCH_STABLECOIN_CAP_MICRO_USD = "2000000000";
+
 const DECIMAL_INTEGER_RE = /^\d+$/;
 
 function resolveOverride(
@@ -116,5 +131,19 @@ export function getDefaultStablecoinTransferCapMicroUsd(): string {
   return resolveOverride(
     process.env.EXECUTE_DEFAULT_STABLECOIN_CAP_MICRO_USD,
     DEFAULT_STABLECOIN_CAP_MICRO_USD
+  );
+}
+
+/**
+ * Ceiling on the total stablecoin outflow of a single transaction, in
+ * micro-USD (6 decimals).
+ *
+ * Applies alongside the per-call figure rather than instead of it: every call
+ * in a batch is still individually bounded, and this bounds their sum.
+ */
+export function getDefaultBatchStablecoinCapMicroUsd(): string {
+  return resolveOverride(
+    process.env.EXECUTE_DEFAULT_BATCH_STABLECOIN_CAP_MICRO_USD,
+    DEFAULT_BATCH_STABLECOIN_CAP_MICRO_USD
   );
 }

--- a/lib/execute/spend-cap-defaults.ts
+++ b/lib/execute/spend-cap-defaults.ts
@@ -72,9 +72,6 @@ const DEFAULT_DAILY_SOLANA_VALUE_CAP_LAMPORTS = "500000000";
 // execution API's per-transfer ceiling.
 const DEFAULT_STABLECOIN_CAP_MICRO_USD = "100000000";
 
-// BigInt() accepts hex-prefixed strings ("0x10" -> 16), so an ops typo would
-// silently turn a cap into a near-zero one. Reject anything that is not a
-// decimal digit run before it is used.
 // 2,000 USD in micro-USD: the ceiling on ONE transaction's total stablecoin
 // outflow, distinct from the per-call figure above.
 //
@@ -90,6 +87,9 @@ const DEFAULT_STABLECOIN_CAP_MICRO_USD = "100000000";
 // batch still cannot move materially more than a handful of single transfers.
 const DEFAULT_BATCH_STABLECOIN_CAP_MICRO_USD = "2000000000";
 
+// BigInt() accepts hex-prefixed strings ("0x10" -> 16), so an ops typo would
+// silently turn a cap into a near-zero one. Reject anything that is not a
+// decimal digit run before it is used.
 const DECIMAL_INTEGER_RE = /^\d+$/;
 
 function resolveOverride(

--- a/lib/execute/spend-cap-defaults.ts
+++ b/lib/execute/spend-cap-defaults.ts
@@ -55,6 +55,23 @@ const DEFAULT_DAILY_VALUE_CAP_WEI = "20000000000000000";
 // reasoning: stays under the 200 USD anchor until SOL passes roughly 400 USD.
 const DEFAULT_DAILY_SOLANA_VALUE_CAP_LAMPORTS = "500000000";
 
+// 100 USD in micro-USD (6 decimals), the unit stablecoins are compared in.
+//
+// Half the anchor rather than equal to it, because this ceiling is PER
+// TRANSACTION and nothing aggregates it: the per-key rate limit is the only
+// thing bounding the daily total, which leaves far more headroom than the
+// native caps have. What this figure actually sizes is the single worst
+// transaction a leaked key can push through, so it is set below the daily
+// anchor rather than at it.
+//
+// Deliberately its own constant rather than a re-export of the agentic wallet's
+// DEFAULT_DAILY_CAP_MICROS: that figure is a DAILY AGGREGATE for a different
+// subsystem and this one bounds a SINGLE transfer, so they are not the same
+// policy even though they were chosen from the same anchor. Coupling them would
+// mean an edit to the agentic wallet's daily budget silently moved the
+// execution API's per-transfer ceiling.
+const DEFAULT_STABLECOIN_CAP_MICRO_USD = "100000000";
+
 // BigInt() accepts hex-prefixed strings ("0x10" -> 16), so an ops typo would
 // silently turn a cap into a near-zero one. Reject anything that is not a
 // decimal digit run before it is used.
@@ -83,5 +100,21 @@ export function getDefaultDailySolanaValueCapLamports(): string {
   return resolveOverride(
     process.env.EXECUTE_DEFAULT_DAILY_SOLANA_VALUE_CAP_LAMPORTS,
     DEFAULT_DAILY_SOLANA_VALUE_CAP_LAMPORTS
+  );
+}
+
+/**
+ * Ceiling on a single stablecoin outflow, in micro-USD (6 decimals).
+ *
+ * Per transfer, not per day. A daily total would need a third unit column on
+ * the value ledger (micro-USD alongside wei and lamports) and a reserve/settle
+ * lifecycle for token moves; this bounds each individual move instead, which is
+ * what the 1:1 peg and the recorded token decimals support with no oracle. The
+ * residual is that the per-key rate limit, not this cap, bounds the aggregate.
+ */
+export function getDefaultStablecoinTransferCapMicroUsd(): string {
+  return resolveOverride(
+    process.env.EXECUTE_DEFAULT_STABLECOIN_CAP_MICRO_USD,
+    DEFAULT_STABLECOIN_CAP_MICRO_USD
   );
 }

--- a/lib/execute/stablecoin-cap.ts
+++ b/lib/execute/stablecoin-cap.ts
@@ -7,6 +7,7 @@ import { supportedTokens } from "@/lib/db/schema";
 import { getDefaultStablecoinTransferCapMicroUsd } from "@/lib/execute/spend-cap-defaults";
 import { logSecurityEvent } from "@/lib/logging";
 import { getRegisteredProtocols } from "@/lib/protocol-registry";
+import { getOrganizationWalletAddress } from "@/lib/web3/wallet-helpers";
 // Registration is an import side effect: a protocol module calls
 // registerProtocol at load. Without this import the registry is whatever the
 // entry point happened to pull in, and of the execute routes only
@@ -102,6 +103,46 @@ const OUTFLOW_SHAPES: Readonly<Record<OutflowFn, OutflowShape>> = {
   },
 };
 
+/**
+ * Functions whose first argument names the payer rather than the payee.
+ *
+ * `transfer` and `approve` always move or grant from the caller, which is the
+ * org wallet. `transferFrom` does not: it moves from whoever the first
+ * argument names, and the org may just be the one submitting the transaction.
+ */
+const PAYER_IS_FIRST_ARG: ReadonlySet<OutflowFn> = new Set([
+  "transferFrom",
+  "transferFromWithMemo",
+]);
+
+/**
+ * Whether this call actually moves value OUT of the organization's wallet.
+ *
+ * A pull payment is a `transferFrom` where the payer is a counterparty and the
+ * org is collecting: value moves in, nothing leaves. Treating that as an
+ * outflow refused legitimate collections above the ceiling -- a 500 USDC
+ * invoice settlement read as a 500 USDC drain.
+ *
+ * Fails closed. If the wallet cannot be resolved the call is treated as an
+ * outflow and stays subject to the ceiling, because the alternative is letting
+ * a real drain through on a lookup error.
+ */
+async function movesOrgFunds(
+  fn: OutflowFn,
+  payer: string | undefined,
+  organizationId: string
+): Promise<boolean> {
+  if (!(PAYER_IS_FIRST_ARG.has(fn) && typeof payer === "string")) {
+    return true;
+  }
+  try {
+    const wallet = await getOrganizationWalletAddress(organizationId);
+    return wallet ? payer.toLowerCase() === wallet.toLowerCase() : true;
+  } catch {
+    return true;
+  }
+}
+
 type StablecoinToken = { decimals: number; symbol: string };
 
 /**
@@ -185,11 +226,18 @@ export async function checkStablecoinContractCall(params: {
     };
   }
 
+  const firstArg =
+    typeof params.args[0] === "string" ? params.args[0] : undefined;
+  if (!(await movesOrgFunds(fn, firstArg, params.organizationId))) {
+    return ALLOWED;
+  }
+
   return decide({
     ...params,
-    // Argument 0 is the spender for approve. The allowlist check in decide()
-    // needs it from this entry point too, not just the calldata one.
-    spender: typeof params.args[0] === "string" ? params.args[0] : undefined,
+    // Argument 0 is the spender for approve and the payer for transferFrom.
+    // The allowlist check in decide() needs it from this entry point too, not
+    // just the calldata one.
+    spender: firstArg,
     tokenAddress: params.contractAddress,
     token,
     amountBase,
@@ -216,6 +264,12 @@ export async function checkStablecoinCalldata(params: {
 
   const token = await loadStablecoin(params.chainId, params.to);
   if (!token) {
+    return ALLOWED;
+  }
+
+  if (
+    !(await movesOrgFunds(decoded.fn, decoded.spender, params.organizationId))
+  ) {
     return ALLOWED;
   }
 
@@ -281,6 +335,13 @@ export async function checkStablecoinCalldataBatch(params: {
       if (decision.kind !== "allowed") {
         return decision;
       }
+      continue;
+    }
+
+    if (
+      !(await movesOrgFunds(decoded.fn, decoded.spender, params.organizationId))
+    ) {
+      // An inbound collection inside a batch is not org value leaving.
       continue;
     }
 

--- a/lib/execute/stablecoin-cap.ts
+++ b/lib/execute/stablecoin-cap.ts
@@ -314,12 +314,18 @@ export async function checkStablecoinCalldataBatch(params: {
   let totalMicroUsd = BigInt(0);
   let outflowSymbol: string | null = null;
 
+  // One read for the whole batch. Every call in a transaction shares a chain,
+  // so resolving each token separately meant N identical queries.
+  const chainTokens = await loadChainTokens(params.chainId);
+
   for (const call of params.calls) {
     const decoded = decodeErc20Outflow(call.data);
     if (!decoded) {
       continue;
     }
-    const token = await loadStablecoin(params.chainId, call.to);
+    const token = isHexAddress(call.to)
+      ? matchStablecoin(chainTokens, call.to)
+      : null;
     if (!token) {
       continue;
     }
@@ -551,6 +557,23 @@ function isKnownProtocolSpender(spender: string | undefined): boolean {
   return getKnownProtocolSpenders().has(spender.toLowerCase());
 }
 
+/**
+ * Every token row for a chain. Split from loadStablecoin so the batch path can
+ * read once rather than once per call: a 50-recipient payout was 50 identical
+ * round trips on the pre-broadcast path, where the latency is user-visible.
+ */
+async function loadChainTokens(chainId: number): Promise<TokenRow[]> {
+  return await db
+    .select({
+      tokenAddress: supportedTokens.tokenAddress,
+      decimals: supportedTokens.decimals,
+      symbol: supportedTokens.symbol,
+      isStablecoin: supportedTokens.isStablecoin,
+    })
+    .from(supportedTokens)
+    .where(eq(supportedTokens.chainId, chainId));
+}
+
 /** The registry row for a known stablecoin on this chain, or null. */
 async function loadStablecoin(
   chainId: number,
@@ -565,16 +588,20 @@ async function loadStablecoin(
   // lowercase but a resolved address is often checksummed, and an exact SQL
   // comparison against the wrong casing would silently find nothing -- which,
   // for a cap, means failing open.
-  const rows = await db
-    .select({
-      tokenAddress: supportedTokens.tokenAddress,
-      decimals: supportedTokens.decimals,
-      symbol: supportedTokens.symbol,
-      isStablecoin: supportedTokens.isStablecoin,
-    })
-    .from(supportedTokens)
-    .where(eq(supportedTokens.chainId, chainId));
+  return matchStablecoin(await loadChainTokens(chainId), tokenAddress);
+}
 
+type TokenRow = {
+  tokenAddress: string;
+  decimals: number;
+  symbol: string;
+  isStablecoin: boolean;
+};
+
+function matchStablecoin(
+  rows: readonly TokenRow[],
+  tokenAddress: string
+): StablecoinToken | null {
   const wanted = tokenAddress.toLowerCase();
   const token = rows.find(
     (row) => row.tokenAddress.toLowerCase() === wanted && row.isStablecoin

--- a/lib/execute/stablecoin-cap.ts
+++ b/lib/execute/stablecoin-cap.ts
@@ -6,6 +6,7 @@ import { db } from "@/lib/db";
 import { supportedTokens } from "@/lib/db/schema";
 import { getDefaultStablecoinTransferCapMicroUsd } from "@/lib/execute/spend-cap-defaults";
 import { logSecurityEvent } from "@/lib/logging";
+import { getRegisteredProtocols } from "@/lib/protocol-registry";
 
 const MICRO_USD_DECIMALS = 6;
 
@@ -170,6 +171,9 @@ export async function checkStablecoinContractCall(params: {
 
   return decide({
     ...params,
+    // Argument 0 is the spender for approve. The allowlist check in decide()
+    // needs it from this entry point too, not just the calldata one.
+    spender: typeof params.args[0] === "string" ? params.args[0] : undefined,
     tokenAddress: params.contractAddress,
     token,
     amountBase,
@@ -205,7 +209,95 @@ export async function checkStablecoinCalldata(params: {
     token,
     amountBase: decoded.amountBase,
     fn: decoded.fn,
+    spender: decoded.spender,
   });
+}
+
+/**
+ * Apply the ceiling to a batch of calls signed as ONE transaction.
+ *
+ * Checking each call on its own is not equivalent. A Tempo batch payout builds
+ * one call per recipient, so ten entries of 99 USD each clear a 100 USD ceiling
+ * individually while the transaction moves 990 USD, and nothing bounds the
+ * entry count. The transaction is the unit the wallet signs, so it is the unit
+ * the ceiling has to measure.
+ *
+ * Outflows are summed across every recognised stablecoin in the batch and
+ * compared once. Summing across different tokens is deliberate: the ceiling is
+ * denominated in USD and every token it recognises is pegged 1:1, so a batch
+ * splitting value across two stablecoins moves exactly as much as one that does
+ * not.
+ *
+ * Approvals are evaluated individually rather than folded into that sum. An
+ * approval is a standing grant, not a movement, so adding it to a transfer
+ * total would compare two different things.
+ */
+export async function checkStablecoinCalldataBatch(params: {
+  organizationId: string;
+  chainId: number;
+  context: string;
+  calls: readonly { to: string; data: string }[];
+}): Promise<StablecoinCapDecision> {
+  let totalMicroUsd = BigInt(0);
+  let outflowSymbol: string | null = null;
+
+  for (const call of params.calls) {
+    const decoded = decodeErc20Outflow(call.data);
+    if (!decoded) {
+      continue;
+    }
+    const token = await loadStablecoin(params.chainId, call.to);
+    if (!token) {
+      continue;
+    }
+
+    if (decoded.fn === "approve") {
+      const decision = decide({
+        organizationId: params.organizationId,
+        chainId: params.chainId,
+        context: params.context,
+        tokenAddress: call.to,
+        token,
+        amountBase: decoded.amountBase,
+        fn: decoded.fn,
+        spender: decoded.spender,
+      });
+      if (decision.kind !== "allowed") {
+        return decision;
+      }
+      continue;
+    }
+
+    if (decoded.amountBase < BigInt(0)) {
+      return {
+        kind: "invalid",
+        error: `${token.symbol} amount must not be negative`,
+      };
+    }
+    totalMicroUsd += rescaleToMicroUsd(decoded.amountBase, token.decimals);
+    outflowSymbol ??= token.symbol;
+  }
+
+  const capMicroUsd = BigInt(getDefaultStablecoinTransferCapMicroUsd());
+  if (totalMicroUsd <= capMicroUsd) {
+    return ALLOWED;
+  }
+
+  logSecurityEvent("stablecoin_transfer_cap_exceeded", {
+    organizationId: params.organizationId,
+    surface: params.context,
+    chainId: params.chainId,
+    erc20Function: "batch",
+    callCount: params.calls.length,
+    amountMicroUsd: totalMicroUsd.toString(),
+    capMicroUsd: capMicroUsd.toString(),
+    blocked: true,
+  });
+
+  return {
+    kind: "over_cap",
+    error: `Stablecoin transfer of ${formatMicroUsd(totalMicroUsd)} ${outflowSymbol ?? "USD"} across ${params.calls.length} call(s) exceeds the ${formatMicroUsd(capMicroUsd)} USD per-transaction limit`,
+  };
 }
 
 function decide(params: {
@@ -216,6 +308,8 @@ function decide(params: {
   amountBase: bigint;
   fn: OutflowFn;
   context: string;
+  /** First argument of the call: the spender for approve, else the recipient. */
+  spender?: string;
 }): StablecoinCapDecision {
   const { token, amountBase, fn } = params;
 
@@ -233,11 +327,21 @@ function decide(params: {
   }
 
   // An approval moves nothing by itself, and max-uint approvals are how nearly
-  // every DeFi integration works, so refusing them would break legitimate
-  // workflows wholesale. It is still a standing right to drain the wallet, so
-  // it is reported rather than silently allowed. Turning this into a denial
-  // needs a spender allowlist, which is a product decision, not a bug fix.
-  const blocked = fn !== "approve";
+  // every DeFi integration works, so a blanket refusal would break legitimate
+  // workflows wholesale. But an unbounded approval to an address we cannot
+  // account for is the cheapest complete drain path a leaked key has: the
+  // attacker calls transferFrom afterwards, off platform, where none of this
+  // runs and the ceiling never applies to any of it.
+  //
+  // The split is the spender. Every protocol integration approves a contract
+  // this repo already knows about, so an over-cap approval to one of those is
+  // the legitimate pattern and stays allowed. An over-cap approval to anything
+  // else is refused. Contracts declared userSpecifiedAddress carry no static
+  // address and are deliberately absent from the allowlist: a caller-supplied
+  // spender is exactly the case that must not be auto-trusted.
+  const approvingKnownSpender =
+    fn === "approve" && isKnownProtocolSpender(params.spender);
+  const blocked = !approvingKnownSpender;
   const verb = fn === "approve" ? "approval" : "transfer";
 
   logSecurityEvent(
@@ -251,6 +355,7 @@ function decide(params: {
       tokenAddress: params.tokenAddress.toLowerCase(),
       symbol: token.symbol,
       erc20Function: fn,
+      spender: params.spender?.toLowerCase() ?? null,
       amountMicroUsd: microUsd.toString(),
       capMicroUsd: capMicroUsd.toString(),
       blocked,
@@ -265,6 +370,49 @@ function decide(params: {
     kind: "over_cap",
     error: `Stablecoin ${verb} of ${formatMicroUsd(microUsd)} ${token.symbol} exceeds the ${formatMicroUsd(capMicroUsd)} USD per-transaction limit`,
   };
+}
+
+/**
+ * Addresses this repo already directs value at: every contract declared by a
+ * registered protocol, across every network it lists.
+ *
+ * Built once and cached. getRegisteredProtocols() is populated by protocol
+ * modules at import time, and the set only grows as protocols register, so a
+ * miss can only ever be conservative -- it refuses an approval, never admits
+ * one it should not have.
+ *
+ * Contracts flagged userSpecifiedAddress are skipped: their address comes from
+ * the caller at run time, so including them would allowlist whatever the
+ * caller passed, which is the case this control exists to catch.
+ */
+let knownSpenders: Set<string> | null = null;
+
+function getKnownProtocolSpenders(): Set<string> {
+  if (knownSpenders) {
+    return knownSpenders;
+  }
+  const addresses = new Set<string>();
+  for (const protocol of getRegisteredProtocols()) {
+    for (const contract of Object.values(protocol.contracts ?? {})) {
+      if (contract.userSpecifiedAddress) {
+        continue;
+      }
+      for (const address of Object.values(contract.addresses ?? {})) {
+        if (typeof address === "string" && address.length > 0) {
+          addresses.add(address.toLowerCase());
+        }
+      }
+    }
+  }
+  knownSpenders = addresses;
+  return addresses;
+}
+
+function isKnownProtocolSpender(spender: string | undefined): boolean {
+  if (!spender) {
+    return false;
+  }
+  return getKnownProtocolSpenders().has(spender.toLowerCase());
 }
 
 /** The registry row for a known stablecoin on this chain, or null. */
@@ -357,7 +505,7 @@ function canonicalAbiType(type: string): string {
 
 function decodeErc20Outflow(
   data: string
-): { fn: OutflowFn; amountBase: bigint } | null {
+): { fn: OutflowFn; amountBase: bigint; spender: string | undefined } | null {
   if (!data?.startsWith("0x")) {
     return null;
   }
@@ -378,7 +526,11 @@ function decodeErc20Outflow(
   }
 
   const amountBase = toBaseUnits(parsed.args[OUTFLOW_SHAPES[fn].amountIndex]);
-  return amountBase === null ? null : { fn, amountBase };
+  // Argument 0 is the spender for approve and the recipient otherwise. Only
+  // the approve reading is load-bearing; the rest is carried for telemetry.
+  const spender =
+    typeof parsed.args[0] === "string" ? parsed.args[0] : undefined;
+  return amountBase === null ? null : { fn, amountBase, spender };
 }
 
 /** Coerce an ABI uint256 argument, however the caller expressed it, to bigint. */

--- a/lib/execute/stablecoin-cap.ts
+++ b/lib/execute/stablecoin-cap.ts
@@ -1,9 +1,9 @@
 import "server-only";
 
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { db } from "@/lib/db";
-import { supportedTokens } from "@/lib/db/schema";
+import { safeWallets, supportedTokens } from "@/lib/db/schema";
 import {
   getDefaultBatchStablecoinCapMicroUsd,
   getDefaultStablecoinTransferCapMicroUsd,
@@ -119,31 +119,71 @@ const PAYER_IS_FIRST_ARG: ReadonlySet<OutflowFn> = new Set([
 ]);
 
 /**
- * Whether this call actually moves value OUT of the organization's wallet.
+ * Every address the organization can move funds FROM on this chain: its EOA
+ * wallet plus any Safe it controls there.
+ *
+ * The EOA alone is not enough. A `transferFrom` naming a Safe as payer would
+ * compare unequal, read as an inbound collection and skip the ceiling. That is
+ * not a live drain in the ordinary case -- pulling from your own balance needs
+ * `allowance[safe][safe]`, which is zero -- but it becomes one where a Safe has
+ * approved the org EOA as a spender, and the reasoning that makes it safe
+ * otherwise rests on a fact about allowances rather than on anything this
+ * module checks. Cheaper to include the Safes than to depend on that.
+ *
+ * Returns an empty set if neither lookup succeeds, which callers treat as
+ * fail-closed: an unattributable payer stays subject to the ceiling.
+ */
+async function resolveOrgPayers(
+  organizationId: string,
+  chainId: number
+): Promise<Set<string>> {
+  const [wallet, safes] = await Promise.all([
+    getOrganizationWalletAddress(organizationId).catch(() => null),
+    db
+      .select({ safeAddress: safeWallets.safeAddress })
+      .from(safeWallets)
+      .where(
+        and(
+          eq(safeWallets.organizationId, organizationId),
+          eq(safeWallets.chainId, chainId)
+        )
+      )
+      .catch(() => [] as { safeAddress: string }[]),
+  ]);
+
+  const payers = new Set<string>();
+  if (wallet) {
+    payers.add(wallet.toLowerCase());
+  }
+  for (const safe of safes) {
+    payers.add(safe.safeAddress.toLowerCase());
+  }
+  return payers;
+}
+
+/**
+ * Whether this call actually moves value OUT of the organization.
  *
  * A pull payment is a `transferFrom` where the payer is a counterparty and the
  * org is collecting: value moves in, nothing leaves. Treating that as an
  * outflow refused legitimate collections above the ceiling -- a 500 USDC
  * invoice settlement read as a 500 USDC drain.
  *
- * Fails closed. If the wallet cannot be resolved the call is treated as an
- * outflow and stays subject to the ceiling, because the alternative is letting
- * a real drain through on a lookup error.
+ * Fails closed: an empty payer set means neither lookup resolved, and the call
+ * stays subject to the ceiling rather than being waved through on a db error.
  */
-async function movesOrgFunds(
+function movesOrgFunds(
   fn: OutflowFn,
   payer: string | undefined,
-  organizationId: string
-): Promise<boolean> {
+  payers: ReadonlySet<string>
+): boolean {
   if (!(PAYER_IS_FIRST_ARG.has(fn) && typeof payer === "string")) {
     return true;
   }
-  try {
-    const wallet = await getOrganizationWalletAddress(organizationId);
-    return wallet ? payer.toLowerCase() === wallet.toLowerCase() : true;
-  } catch {
+  if (payers.size === 0) {
     return true;
   }
+  return payers.has(payer.toLowerCase());
 }
 
 type StablecoinToken = { decimals: number; symbol: string };
@@ -231,7 +271,14 @@ export async function checkStablecoinContractCall(params: {
 
   const firstArg =
     typeof params.args[0] === "string" ? params.args[0] : undefined;
-  if (!(await movesOrgFunds(fn, firstArg, params.organizationId))) {
+  if (
+    PAYER_IS_FIRST_ARG.has(fn) &&
+    !movesOrgFunds(
+      fn,
+      firstArg,
+      await resolveOrgPayers(params.organizationId, params.chainId)
+    )
+  ) {
     return ALLOWED;
   }
 
@@ -271,7 +318,12 @@ export async function checkStablecoinCalldata(params: {
   }
 
   if (
-    !(await movesOrgFunds(decoded.fn, decoded.spender, params.organizationId))
+    PAYER_IS_FIRST_ARG.has(decoded.fn) &&
+    !movesOrgFunds(
+      decoded.fn,
+      decoded.spender,
+      await resolveOrgPayers(params.organizationId, params.chainId)
+    )
   ) {
     return ALLOWED;
   }
@@ -317,6 +369,7 @@ export async function checkStablecoinCalldataBatch(params: {
   // One read for the whole batch. Every call in a transaction shares a chain,
   // so resolving each token separately meant N identical queries.
   const chainTokens = await loadChainTokens(params.chainId);
+  let orgPayers: Set<string> | undefined;
 
   for (const call of params.calls) {
     const decoded = decodeErc20Outflow(call.data);
@@ -347,11 +400,18 @@ export async function checkStablecoinCalldataBatch(params: {
       continue;
     }
 
-    if (
-      !(await movesOrgFunds(decoded.fn, decoded.spender, params.organizationId))
-    ) {
-      // An inbound collection inside a batch is not org value leaving.
-      continue;
+    if (PAYER_IS_FIRST_ARG.has(decoded.fn)) {
+      // Resolved once for the whole batch, and only when a call actually needs
+      // it. Doing it per call reintroduced an N+1 in the same loop the
+      // token-list hoist above just removed.
+      orgPayers ??= await resolveOrgPayers(
+        params.organizationId,
+        params.chainId
+      );
+      if (!movesOrgFunds(decoded.fn, decoded.spender, orgPayers)) {
+        // An inbound collection inside a batch is not org value leaving.
+        continue;
+      }
     }
 
     if (decoded.amountBase < BigInt(0)) {

--- a/lib/execute/stablecoin-cap.ts
+++ b/lib/execute/stablecoin-cap.ts
@@ -4,7 +4,10 @@ import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
 import { db } from "@/lib/db";
 import { supportedTokens } from "@/lib/db/schema";
-import { getDefaultStablecoinTransferCapMicroUsd } from "@/lib/execute/spend-cap-defaults";
+import {
+  getDefaultBatchStablecoinCapMicroUsd,
+  getDefaultStablecoinTransferCapMicroUsd,
+} from "@/lib/execute/spend-cap-defaults";
 import { logSecurityEvent } from "@/lib/logging";
 import { getRegisteredProtocols } from "@/lib/protocol-registry";
 import { getOrganizationWalletAddress } from "@/lib/web3/wallet-helpers";
@@ -351,30 +354,45 @@ export async function checkStablecoinCalldataBatch(params: {
         error: `${token.symbol} amount must not be negative`,
       };
     }
+
+    // Every entry is still bounded on its own. Summing alone would let one
+    // large recipient hide under a generous batch total.
+    const perCall = decide({
+      organizationId: params.organizationId,
+      chainId: params.chainId,
+      context: params.context,
+      tokenAddress: call.to,
+      token,
+      amountBase: decoded.amountBase,
+      fn: decoded.fn,
+      spender: decoded.spender,
+    });
+    if (perCall.kind !== "allowed") {
+      return perCall;
+    }
+
     totalMicroUsd += rescaleToMicroUsd(decoded.amountBase, token.decimals);
     outflowSymbol ??= token.symbol;
   }
 
-  const capMicroUsd = BigInt(getDefaultStablecoinTransferCapMicroUsd());
-  if (totalMicroUsd <= capMicroUsd) {
-    return ALLOWED;
-  }
-
-  logSecurityEvent("stablecoin_transfer_cap_exceeded", {
-    organizationId: params.organizationId,
-    surface: params.context,
-    chainId: params.chainId,
-    erc20Function: "batch",
-    callCount: params.calls.length,
-    amountMicroUsd: totalMicroUsd.toString(),
-    capMicroUsd: capMicroUsd.toString(),
+  // The transaction total, on its own figure. The per-call ceiling above
+  // bounds any single recipient; this bounds what the whole transaction moves,
+  // so neither one 990 USD entry nor fifty 100 USD entries get through.
+  return compareAgainstCap({
+    microUsd: totalMicroUsd,
+    capMicroUsd: BigInt(getDefaultBatchStablecoinCapMicroUsd()),
     blocked: true,
+    verb: "transfer",
+    unit: `${outflowSymbol ?? "USD"} across ${params.calls.length} call(s)`,
+    limit: "per-transaction batch limit",
+    event: {
+      organizationId: params.organizationId,
+      surface: params.context,
+      chainId: params.chainId,
+      erc20Function: "batch",
+      callCount: params.calls.length,
+    },
   });
-
-  return {
-    kind: "denied",
-    error: `Stablecoin transfer of ${formatMicroUsd(totalMicroUsd)} ${outflowSymbol ?? "USD"} across ${params.calls.length} call(s) exceeds the ${formatMicroUsd(capMicroUsd)} USD per-transaction limit`,
-  };
 }
 
 function decide(params: {
@@ -398,10 +416,6 @@ function decide(params: {
   }
 
   const microUsd = rescaleToMicroUsd(amountBase, token.decimals);
-  const capMicroUsd = BigInt(getDefaultStablecoinTransferCapMicroUsd());
-  if (microUsd <= capMicroUsd) {
-    return ALLOWED;
-  }
 
   // An approval moves nothing by itself, and max-uint approvals are how nearly
   // every DeFi integration works, so a blanket refusal would break legitimate
@@ -416,16 +430,16 @@ function decide(params: {
   // else is refused. Contracts declared userSpecifiedAddress carry no static
   // address and are deliberately absent from the allowlist: a caller-supplied
   // spender is exactly the case that must not be auto-trusted.
-  const approvingKnownSpender =
+  const permittedApproval =
     fn === "approve" && isKnownProtocolSpender(params.spender);
-  const blocked = !approvingKnownSpender;
-  const verb = fn === "approve" ? "approval" : "transfer";
 
-  logSecurityEvent(
-    blocked
-      ? "stablecoin_transfer_cap_exceeded"
-      : "stablecoin_approval_above_cap",
-    {
+  return compareAgainstCap({
+    microUsd,
+    capMicroUsd: BigInt(getDefaultStablecoinTransferCapMicroUsd()),
+    blocked: !permittedApproval,
+    verb: fn === "approve" ? "approval" : "transfer",
+    unit: token.symbol,
+    event: {
       organizationId: params.organizationId,
       surface: params.context,
       chainId: params.chainId,
@@ -433,6 +447,43 @@ function decide(params: {
       symbol: token.symbol,
       erc20Function: fn,
       spender: params.spender?.toLowerCase() ?? null,
+    },
+  });
+}
+
+/**
+ * Shared tail for every entry shape: compare, emit the signal, allow or deny.
+ *
+ * Split out because the batch path had grown its own copy of all four moving
+ * parts -- the comparison, the cap read, the security event and the wording of
+ * the denial -- so a new field on the event or a reworded message silently kept
+ * the old form on one path.
+ *
+ * `blocked: false` is the one case that reports without refusing: an
+ * allowlisted approval above the cap, recorded precisely because it is allowed.
+ */
+function compareAgainstCap(params: {
+  microUsd: bigint;
+  capMicroUsd: bigint;
+  blocked: boolean;
+  verb: string;
+  /** Token symbol for a single call, or a description for a batch. */
+  unit: string;
+  /** What the figure bounds, as it reads in the denial. */
+  limit?: string;
+  event: Record<string, unknown>;
+}): StablecoinCapDecision {
+  const { microUsd, capMicroUsd, blocked, verb, unit } = params;
+  if (microUsd <= capMicroUsd) {
+    return ALLOWED;
+  }
+
+  logSecurityEvent(
+    blocked
+      ? "stablecoin_transfer_cap_exceeded"
+      : "stablecoin_approval_above_cap",
+    {
+      ...params.event,
       amountMicroUsd: microUsd.toString(),
       capMicroUsd: capMicroUsd.toString(),
       blocked,
@@ -445,7 +496,7 @@ function decide(params: {
 
   return {
     kind: "denied",
-    error: `Stablecoin ${verb} of ${formatMicroUsd(microUsd)} ${token.symbol} exceeds the ${formatMicroUsd(capMicroUsd)} USD per-transaction limit`,
+    error: `Stablecoin ${verb} of ${formatMicroUsd(microUsd)} ${unit} exceeds the ${formatMicroUsd(capMicroUsd)} USD ${params.limit ?? "per-transaction limit"}`,
   };
 }
 

--- a/lib/execute/stablecoin-cap.ts
+++ b/lib/execute/stablecoin-cap.ts
@@ -7,6 +7,14 @@ import { supportedTokens } from "@/lib/db/schema";
 import { getDefaultStablecoinTransferCapMicroUsd } from "@/lib/execute/spend-cap-defaults";
 import { logSecurityEvent } from "@/lib/logging";
 import { getRegisteredProtocols } from "@/lib/protocol-registry";
+// Registration is an import side effect: a protocol module calls
+// registerProtocol at load. Without this import the registry is whatever the
+// entry point happened to pull in, and of the execute routes only
+// app/api/execute/[...slug]/route.ts imports the barrel -- so contract-call,
+// transfer, node, swap, check-and-execute and the web3 write-contract step all
+// saw an EMPTY allowlist and refused every over-cap approval, including the
+// max-uint-before-swap that protocol integrations depend on.
+import "@/protocols";
 
 const MICRO_USD_DECIMALS = 6;
 
@@ -394,13 +402,20 @@ function decide(params: {
  * caller passed, which is the case this control exists to catch.
  */
 let knownSpenders: Set<string> | null = null;
+let knownSpendersFrom = -1;
 
 function getKnownProtocolSpenders(): Set<string> {
-  if (knownSpenders) {
+  // Keyed on registry size rather than memoised outright. A protocol that
+  // registers after the first call -- a lazily imported module, a different
+  // entry point warming a different subset -- would otherwise be locked out
+  // for the life of the process, making the verdict depend on which traffic
+  // arrived first.
+  const protocols = getRegisteredProtocols();
+  if (knownSpenders && knownSpendersFrom === protocols.length) {
     return knownSpenders;
   }
   const addresses = new Set<string>();
-  for (const protocol of getRegisteredProtocols()) {
+  for (const protocol of protocols) {
     for (const contract of Object.values(protocol.contracts ?? {})) {
       if (contract.userSpecifiedAddress) {
         continue;
@@ -413,6 +428,7 @@ function getKnownProtocolSpenders(): Set<string> {
     }
   }
   knownSpenders = addresses;
+  knownSpendersFrom = protocols.length;
   return addresses;
 }
 

--- a/lib/execute/stablecoin-cap.ts
+++ b/lib/execute/stablecoin-cap.ts
@@ -1,0 +1,428 @@
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import { ethers } from "ethers";
+import { db } from "@/lib/db";
+import { supportedTokens } from "@/lib/db/schema";
+import { getDefaultStablecoinTransferCapMicroUsd } from "@/lib/execute/spend-cap-defaults";
+import { logSecurityEvent } from "@/lib/logging";
+
+const MICRO_USD_DECIMALS = 6;
+
+/**
+ * `invalid` is caller error (an amount that will not parse); `over_cap` is a
+ * policy denial. Kept apart so a route can answer 400 vs 403 rather than
+ * collapsing a malformed request into "cap exceeded".
+ */
+export type StablecoinCapDecision =
+  | { kind: "allowed" }
+  | { kind: "invalid"; error: string }
+  | { kind: "over_cap"; error: string };
+
+const ALLOWED = { kind: "allowed" } as const;
+
+const DECIMAL_INTEGER_RE = /^-?\d+$/;
+const HEX_INTEGER_RE = /^0x[0-9a-fA-F]+$/;
+const HEX_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+
+/**
+ * The token entry points that let value leave the org's wallet. `transfer` and
+ * `transferFrom` move tokens now; `approve` hands a third party the standing
+ * right to move them later. The `WithMemo` pair is TIP-20 (Tempo), where they
+ * are the ordinary way to send: the memo rides along and the amount sits one
+ * argument earlier than in the ERC-20 forms.
+ */
+const ERC20_OUTFLOW_ABI = [
+  "function transfer(address to, uint256 amount)",
+  "function transferFrom(address from, address to, uint256 amount)",
+  "function approve(address spender, uint256 amount)",
+  "function transferWithMemo(address to, uint256 amount, bytes32 memo)",
+  "function transferFromWithMemo(address from, address to, uint256 amount, bytes32 memo)",
+] as const;
+
+let cachedErc20Interface: ethers.Interface | null = null;
+
+// Built on first use, not at module load: this module is imported by the
+// workflow step cores, and constructing an Interface eagerly would make merely
+// importing them depend on ethers being fully initialised.
+function getErc20Interface(): ethers.Interface {
+  cachedErc20Interface ??= new ethers.Interface(ERC20_OUTFLOW_ABI);
+  return cachedErc20Interface;
+}
+
+function isHexAddress(value: string): boolean {
+  return HEX_ADDRESS_RE.test(value);
+}
+
+type OutflowFn =
+  | "transfer"
+  | "transferFrom"
+  | "approve"
+  | "transferWithMemo"
+  | "transferFromWithMemo";
+
+type OutflowShape = {
+  inputTypes: readonly string[];
+  // Which argument carries the amount. Not always the last one: the TIP-20
+  // memo variants append a bytes32 after it.
+  amountIndex: number;
+};
+
+const OUTFLOW_SHAPES: Readonly<Record<OutflowFn, OutflowShape>> = {
+  transfer: { inputTypes: ["address", "uint256"], amountIndex: 1 },
+  transferFrom: {
+    inputTypes: ["address", "address", "uint256"],
+    amountIndex: 2,
+  },
+  approve: { inputTypes: ["address", "uint256"], amountIndex: 1 },
+  transferWithMemo: {
+    inputTypes: ["address", "uint256", "bytes32"],
+    amountIndex: 1,
+  },
+  transferFromWithMemo: {
+    inputTypes: ["address", "address", "uint256", "bytes32"],
+    amountIndex: 2,
+  },
+};
+
+type StablecoinToken = { decimals: number; symbol: string };
+
+/**
+ * Bound the stablecoin value a single call can move out of the org's wallet.
+ *
+ * The daily value cap counts NATIVE value only: an ERC-20 call carries a
+ * `value` of 0, so a token move reserves 0 against it and a leaked key could
+ * move an unbounded amount of USDC while the cap read zero. Pricing arbitrary
+ * ERC-20s needs an oracle in the pre-broadcast path, but stablecoins do not:
+ * their decimals are recorded in `supported_tokens` and the peg is ~1:1, so the
+ * amount converts to USD by rescaling alone.
+ *
+ * Only tokens the registry knows AND flags as a stablecoin are bounded. An
+ * unrecognised token address passes through -- that is the general ERC-20 case,
+ * which this deliberately does not attempt to price.
+ *
+ * The checks live in the shared cores (transferTokenCore, writeContractCore,
+ * signTempoTx) rather than in any one route, so every entrance reaches them:
+ * /api/execute/transfer, /api/execute/contract-call, /api/execute/[...slug],
+ * /api/execute/check-and-execute, /api/execute/node, and the workflow steps
+ * those cores back. A ceiling on one route would only have told an attacker
+ * which door to use.
+ */
+
+/** Human-decimal amount, e.g. "250.5", as the transfer-token path supplies it. */
+export async function checkStablecoinTransferAmount(params: {
+  organizationId: string;
+  chainId: number;
+  tokenAddress: string;
+  amount: string;
+  context: string;
+}): Promise<StablecoinCapDecision> {
+  const token = await loadStablecoin(params.chainId, params.tokenAddress);
+  if (!token) {
+    return ALLOWED;
+  }
+
+  let amountBase: bigint;
+  try {
+    amountBase = ethers.parseUnits(params.amount, token.decimals);
+  } catch {
+    return {
+      kind: "invalid",
+      error: `Invalid ${token.symbol} amount: ${params.amount}`,
+    };
+  }
+
+  return decide({ ...params, token, amountBase, fn: "transfer" });
+}
+
+/**
+ * A decoded contract call, as `writeContractCore` has it: an ABI function plus
+ * already-coerced argument values.
+ */
+export async function checkStablecoinContractCall(params: {
+  organizationId: string;
+  chainId: number;
+  contractAddress: string;
+  functionName: string;
+  inputTypes: readonly string[];
+  args: readonly unknown[];
+  context: string;
+}): Promise<StablecoinCapDecision> {
+  const fn = matchOutflowFunction(params.functionName, params.inputTypes);
+  if (!fn) {
+    return ALLOWED;
+  }
+
+  const token = await loadStablecoin(params.chainId, params.contractAddress);
+  if (!token) {
+    return ALLOWED;
+  }
+
+  const amountBase = toBaseUnits(params.args[OUTFLOW_SHAPES[fn].amountIndex]);
+  if (amountBase === null) {
+    // The call is a stablecoin outflow whose size cannot be read. Passing it
+    // through would be an unbounded move, so refuse instead.
+    return {
+      kind: "invalid",
+      error: `Could not read the ${token.symbol} amount from the ${fn} arguments`,
+    };
+  }
+
+  return decide({
+    ...params,
+    tokenAddress: params.contractAddress,
+    token,
+    amountBase,
+    fn,
+  });
+}
+
+/**
+ * Raw calldata, as the Tempo path has it: Tempo transactions carry a list of
+ * `{ to, data }` calls with no ABI alongside, and TIP-20 stablecoins are the
+ * chain's primary asset.
+ */
+export async function checkStablecoinCalldata(params: {
+  organizationId: string;
+  chainId: number;
+  to: string;
+  data: string;
+  context: string;
+}): Promise<StablecoinCapDecision> {
+  const decoded = decodeErc20Outflow(params.data);
+  if (!decoded) {
+    return ALLOWED;
+  }
+
+  const token = await loadStablecoin(params.chainId, params.to);
+  if (!token) {
+    return ALLOWED;
+  }
+
+  return decide({
+    ...params,
+    tokenAddress: params.to,
+    token,
+    amountBase: decoded.amountBase,
+    fn: decoded.fn,
+  });
+}
+
+function decide(params: {
+  organizationId: string;
+  chainId: number;
+  tokenAddress: string;
+  token: StablecoinToken;
+  amountBase: bigint;
+  fn: OutflowFn;
+  context: string;
+}): StablecoinCapDecision {
+  const { token, amountBase, fn } = params;
+
+  if (amountBase < BigInt(0)) {
+    return {
+      kind: "invalid",
+      error: `${token.symbol} amount must not be negative`,
+    };
+  }
+
+  const microUsd = rescaleToMicroUsd(amountBase, token.decimals);
+  const capMicroUsd = BigInt(getDefaultStablecoinTransferCapMicroUsd());
+  if (microUsd <= capMicroUsd) {
+    return ALLOWED;
+  }
+
+  // An approval moves nothing by itself, and max-uint approvals are how nearly
+  // every DeFi integration works, so refusing them would break legitimate
+  // workflows wholesale. It is still a standing right to drain the wallet, so
+  // it is reported rather than silently allowed. Turning this into a denial
+  // needs a spender allowlist, which is a product decision, not a bug fix.
+  const blocked = fn !== "approve";
+  const verb = fn === "approve" ? "approval" : "transfer";
+
+  logSecurityEvent(
+    blocked
+      ? "stablecoin_transfer_cap_exceeded"
+      : "stablecoin_approval_above_cap",
+    {
+      organizationId: params.organizationId,
+      surface: params.context,
+      chainId: params.chainId,
+      tokenAddress: params.tokenAddress.toLowerCase(),
+      symbol: token.symbol,
+      erc20Function: fn,
+      amountMicroUsd: microUsd.toString(),
+      capMicroUsd: capMicroUsd.toString(),
+      blocked,
+    }
+  );
+
+  if (!blocked) {
+    return ALLOWED;
+  }
+
+  return {
+    kind: "over_cap",
+    error: `Stablecoin ${verb} of ${formatMicroUsd(microUsd)} ${token.symbol} exceeds the ${formatMicroUsd(capMicroUsd)} USD per-transaction limit`,
+  };
+}
+
+/** The registry row for a known stablecoin on this chain, or null. */
+async function loadStablecoin(
+  chainId: number,
+  tokenAddress: string
+): Promise<StablecoinToken | null> {
+  if (!isHexAddress(tokenAddress)) {
+    return null;
+  }
+
+  // Read the chain's whole token list (a handful of rows, on the chain_id
+  // index) and match in JS. `supported_tokens.token_address` is seeded
+  // lowercase but a resolved address is often checksummed, and an exact SQL
+  // comparison against the wrong casing would silently find nothing -- which,
+  // for a cap, means failing open.
+  const rows = await db
+    .select({
+      tokenAddress: supportedTokens.tokenAddress,
+      decimals: supportedTokens.decimals,
+      symbol: supportedTokens.symbol,
+      isStablecoin: supportedTokens.isStablecoin,
+    })
+    .from(supportedTokens)
+    .where(eq(supportedTokens.chainId, chainId));
+
+  const wanted = tokenAddress.toLowerCase();
+  const token = rows.find(
+    (row) => row.tokenAddress.toLowerCase() === wanted && row.isStablecoin
+  );
+  return token ? { decimals: token.decimals, symbol: token.symbol } : null;
+}
+
+function isOutflowName(name: string): name is OutflowFn {
+  return Object.hasOwn(OUTFLOW_SHAPES, name);
+}
+
+function matchOutflowFunction(
+  functionName: string,
+  inputTypes: readonly string[]
+): OutflowFn | null {
+  // `abiFunction` may arrive fully qualified ("transfer(address,uint256)").
+  const parenIndex = functionName.indexOf("(");
+  const bareName = (
+    parenIndex === -1 ? functionName : functionName.slice(0, parenIndex)
+  ).trim();
+
+  if (!isOutflowName(bareName)) {
+    return null;
+  }
+
+  // A same-named function with a different signature is a different function.
+  const expected = OUTFLOW_SHAPES[bareName].inputTypes;
+  const declared = inputTypes.map(canonicalAbiType);
+  if (
+    declared.length !== expected.length ||
+    !declared.every((type, index) => type === expected[index])
+  ) {
+    return null;
+  }
+  return bareName;
+}
+
+/**
+ * Canonicalise a declared ABI type so an alias cannot slip past the shape
+ * comparison above.
+ *
+ * `inputTypes` reaches this module as the RAW strings from the caller-supplied
+ * ABI, while the selector is computed from the canonical form. Solidity treats
+ * `uint` as an alias of `uint256`, so an ABI declaring
+ * `transfer(address,uint)` encodes selector 0xa9059cbb -- byte-identical to a
+ * real ERC-20 transfer -- yet a literal string comparison against "uint256"
+ * fails, matchOutflowFunction returns null, and the caller short-circuits to
+ * ALLOWED without ever loading the token or comparing an amount. That is a
+ * complete bypass of this ceiling via a one-word change to an
+ * attacker-supplied ABI.
+ *
+ * ParamType.from applies the same normalisation ethers uses when building the
+ * selector, so the two agree. A type ethers cannot parse is passed through
+ * unchanged: it will not match a shape, but it also cannot be encoded into a
+ * transaction, so there is nothing to bypass.
+ */
+function canonicalAbiType(type: string): string {
+  try {
+    return ethers.ParamType.from(type).format("sighash");
+  } catch {
+    return type;
+  }
+}
+
+function decodeErc20Outflow(
+  data: string
+): { fn: OutflowFn; amountBase: bigint } | null {
+  if (!data?.startsWith("0x")) {
+    return null;
+  }
+
+  let parsed: ethers.TransactionDescription | null = null;
+  try {
+    parsed = getErc20Interface().parseTransaction({ data });
+  } catch {
+    return null;
+  }
+
+  const fn = matchOutflowFunction(
+    parsed?.name ?? "",
+    parsed?.fragment.inputs.map((input) => input.type) ?? []
+  );
+  if (!(parsed && fn)) {
+    return null;
+  }
+
+  const amountBase = toBaseUnits(parsed.args[OUTFLOW_SHAPES[fn].amountIndex]);
+  return amountBase === null ? null : { fn, amountBase };
+}
+
+/** Coerce an ABI uint256 argument, however the caller expressed it, to bigint. */
+function toBaseUnits(value: unknown): bigint | null {
+  if (typeof value === "bigint") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) ? BigInt(value) : null;
+  }
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!(DECIMAL_INTEGER_RE.test(trimmed) || HEX_INTEGER_RE.test(trimmed))) {
+    return null;
+  }
+  try {
+    return BigInt(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Restate a token base-unit amount as micro-USD, relying on the ~1:1 peg. Both
+ * directions are exact integer rescales: no rounding is applied, so a
+ * sub-micro-USD remainder on a high-decimal stablecoin is truncated, which can
+ * only ever lower the figure by less than one millionth of a dollar.
+ */
+function rescaleToMicroUsd(amountBase: bigint, decimals: number): bigint {
+  if (decimals === MICRO_USD_DECIMALS) {
+    return amountBase;
+  }
+  if (decimals > MICRO_USD_DECIMALS) {
+    return amountBase / BigInt(10) ** BigInt(decimals - MICRO_USD_DECIMALS);
+  }
+  return amountBase * BigInt(10) ** BigInt(MICRO_USD_DECIMALS - decimals);
+}
+
+/** Render micro-USD as a plain decimal string, e.g. 200000000 -> "200.00". */
+function formatMicroUsd(microUsd: bigint): string {
+  const scale = BigInt(10) ** BigInt(MICRO_USD_DECIMALS);
+  const whole = microUsd / scale;
+  const cents = (microUsd % scale) / BigInt(10_000);
+  return `${whole}.${cents.toString().padStart(2, "0")}`;
+}

--- a/lib/execute/stablecoin-cap.ts
+++ b/lib/execute/stablecoin-cap.ts
@@ -11,14 +11,22 @@ import { getRegisteredProtocols } from "@/lib/protocol-registry";
 const MICRO_USD_DECIMALS = 6;
 
 /**
- * `invalid` is caller error (an amount that will not parse); `over_cap` is a
- * policy denial. Kept apart so a route can answer 400 vs 403 rather than
- * collapsing a malformed request into "cap exceeded".
+ * The ceiling either admits a call or refuses it, and the reason travels in
+ * `error` rather than in the tag.
+ *
+ * This deliberately does not split "malformed" from "over the cap". The split
+ * existed so a route could answer 400 rather than 403, but no route reads it:
+ * the check runs inside the step cores, which return a uniform
+ * `{ success: false, error }` that every entrance surfaces as a 202 with
+ * status "failed". Nothing maps a decision to a status code, so the
+ * distinction described behaviour that did not exist.
+ *
+ * Reintroducing it needs the mapping first -- a route-level translation from
+ * refusal class to status -- not a wider union here.
  */
 export type StablecoinCapDecision =
   | { kind: "allowed" }
-  | { kind: "invalid"; error: string }
-  | { kind: "over_cap"; error: string };
+  | { kind: "denied"; error: string };
 
 const ALLOWED = { kind: "allowed" } as const;
 
@@ -128,7 +136,7 @@ export async function checkStablecoinTransferAmount(params: {
     amountBase = ethers.parseUnits(params.amount, token.decimals);
   } catch {
     return {
-      kind: "invalid",
+      kind: "denied",
       error: `Invalid ${token.symbol} amount: ${params.amount}`,
     };
   }
@@ -164,7 +172,7 @@ export async function checkStablecoinContractCall(params: {
     // The call is a stablecoin outflow whose size cannot be read. Passing it
     // through would be an unbounded move, so refuse instead.
     return {
-      kind: "invalid",
+      kind: "denied",
       error: `Could not read the ${token.symbol} amount from the ${fn} arguments`,
     };
   }
@@ -270,7 +278,7 @@ export async function checkStablecoinCalldataBatch(params: {
 
     if (decoded.amountBase < BigInt(0)) {
       return {
-        kind: "invalid",
+        kind: "denied",
         error: `${token.symbol} amount must not be negative`,
       };
     }
@@ -295,7 +303,7 @@ export async function checkStablecoinCalldataBatch(params: {
   });
 
   return {
-    kind: "over_cap",
+    kind: "denied",
     error: `Stablecoin transfer of ${formatMicroUsd(totalMicroUsd)} ${outflowSymbol ?? "USD"} across ${params.calls.length} call(s) exceeds the ${formatMicroUsd(capMicroUsd)} USD per-transaction limit`,
   };
 }
@@ -315,7 +323,7 @@ function decide(params: {
 
   if (amountBase < BigInt(0)) {
     return {
-      kind: "invalid",
+      kind: "denied",
       error: `${token.symbol} amount must not be negative`,
     };
   }
@@ -367,7 +375,7 @@ function decide(params: {
   }
 
   return {
-    kind: "over_cap",
+    kind: "denied",
     error: `Stablecoin ${verb} of ${formatMicroUsd(microUsd)} ${token.symbol} exceeds the ${formatMicroUsd(capMicroUsd)} USD per-transaction limit`,
   };
 }

--- a/plugins/tempo/steps/tempo-tx-core.ts
+++ b/plugins/tempo/steps/tempo-tx-core.ts
@@ -32,7 +32,7 @@ import { TxEnvelopeTempo } from "ox/tempo";
 import { encodeFunctionData, type Hex, toFunctionSelector } from "viem";
 import { Abis } from "viem/tempo";
 import { toChecksumAddress } from "@/lib/address-utils";
-import { checkStablecoinCalldata } from "@/lib/execute/stablecoin-cap";
+import { checkStablecoinCalldataBatch } from "@/lib/execute/stablecoin-cap";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
@@ -422,22 +422,18 @@ export async function signTempoTx(
   // carries no native value at all, so the daily value cap never sees a Tempo
   // send. Every Tempo write is signed here, so one check covers transfer-with-
   // memo, batch payouts, held payments and swaps.
-  const stablecoinDecisions = await Promise.all(
-    calls.map((call) =>
-      checkStablecoinCalldata({
-        organizationId,
-        chainId,
-        to: call.to,
-        data: call.data,
-        context: "tempo",
-      })
-    )
-  );
-  const blockedCall = stablecoinDecisions.find(
-    (decision) => decision.kind !== "allowed"
-  );
-  if (blockedCall) {
-    throw new Error(blockedCall.error);
+  // Batched, not per call. signTempoTx carries every call of a batch payout in
+  // one 0x76 transaction, so checking each in isolation let ten entries of 99
+  // USD each clear a 100 USD ceiling while the transaction moved 990 USD, with
+  // nothing bounding the entry count.
+  const stablecoinDecision = await checkStablecoinCalldataBatch({
+    organizationId,
+    chainId,
+    context: "tempo",
+    calls,
+  });
+  if (stablecoinDecision.kind !== "allowed") {
+    throw new Error(stablecoinDecision.error);
   }
 
   const wallet = await getOrganizationWallet(organizationId);

--- a/plugins/tempo/steps/tempo-tx-core.ts
+++ b/plugins/tempo/steps/tempo-tx-core.ts
@@ -32,6 +32,7 @@ import { TxEnvelopeTempo } from "ox/tempo";
 import { encodeFunctionData, type Hex, toFunctionSelector } from "viem";
 import { Abis } from "viem/tempo";
 import { toChecksumAddress } from "@/lib/address-utils";
+import { checkStablecoinCalldata } from "@/lib/execute/stablecoin-cap";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
@@ -415,6 +416,28 @@ export async function signTempoTx(
     throw new Error(
       "Tempo transactions require an EOA wallet. Safe accounts are not supported on Tempo; disable Safe mode for this workflow."
     );
+  }
+
+  // Stablecoin ceiling. Tempo moves TIP-20 stablecoins as its primary asset and
+  // carries no native value at all, so the daily value cap never sees a Tempo
+  // send. Every Tempo write is signed here, so one check covers transfer-with-
+  // memo, batch payouts, held payments and swaps.
+  const stablecoinDecisions = await Promise.all(
+    calls.map((call) =>
+      checkStablecoinCalldata({
+        organizationId,
+        chainId,
+        to: call.to,
+        data: call.data,
+        context: "tempo",
+      })
+    )
+  );
+  const blockedCall = stablecoinDecisions.find(
+    (decision) => decision.kind !== "allowed"
+  );
+  if (blockedCall) {
+    throw new Error(blockedCall.error);
   }
 
   const wallet = await getOrganizationWallet(organizationId);

--- a/plugins/web3/steps/approve-token-core.ts
+++ b/plugins/web3/steps/approve-token-core.ts
@@ -9,6 +9,7 @@ import "server-only";
 
 import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
+import { checkStablecoinContractCall } from "@/lib/execute/stablecoin-cap";
 import ERC20_ABI from "@/lib/contracts/abis/erc20.json";
 import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
@@ -21,7 +22,7 @@ import {
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import { rpcRelayErrorClass } from "@/lib/rpc/providers";
-import type { ExecutionErrorType } from "@/lib/errors/execution-error-type";
+import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 import { getErrorMessage } from "@/lib/utils";
 import { generateId } from "@/lib/utils/id";
 import {
@@ -327,6 +328,28 @@ export async function approveTokenCore(
         approvedAmountDisplay = amount;
       }
 
+      // Stablecoin ceiling. This step calls ERC-20 approve directly, so it
+      // never passes through writeContractCore where the ceiling is applied --
+      // it was the one unbounded-allowance path the cap did not cover, and the
+      // cheapest complete drain a leaked key has: grant the allowance here,
+      // call transferFrom off platform afterwards, where nothing checks.
+      const stablecoinCap = await checkStablecoinContractCall({
+        organizationId,
+        chainId,
+        contractAddress: tokenAddress,
+        functionName: "approve",
+        inputTypes: ["address", "uint256"],
+        args: [spenderAddress, amountRaw],
+        context: "approve-token",
+      });
+      if (stablecoinCap.kind !== "allowed") {
+        return {
+          success: false,
+          error: stablecoinCap.error,
+          errorClass: ExecutionErrorType.USER,
+        };
+      }
+
       const sponsoredResult = await executeSponsoredContractTransaction({
         organizationId,
         executionId: _context.executionId ?? "direct-execution",
@@ -462,6 +485,26 @@ export async function approveTokenCore(
             error: `Invalid amount format: ${getErrorMessage(error)}`,
           };
         }
+      }
+
+      // Same ceiling as the sponsored branch above. Both reach ERC-20 approve
+      // directly without passing through writeContractCore, so each needs the
+      // check on its own: this is the Safe/EOA path.
+      const stablecoinCap = await checkStablecoinContractCall({
+        organizationId,
+        chainId,
+        contractAddress: tokenAddress,
+        functionName: "approve",
+        inputTypes: ["address", "uint256"],
+        args: [spenderAddress, amountRaw],
+        context: "approve-token",
+      });
+      if (stablecoinCap.kind !== "allowed") {
+        return {
+          success: false,
+          error: stablecoinCap.error,
+          errorClass: ExecutionErrorType.USER,
+        };
       }
 
       let receipt: Awaited<ReturnType<typeof adapter.executeContractCall>>;

--- a/plugins/web3/steps/transfer-token-core.ts
+++ b/plugins/web3/steps/transfer-token-core.ts
@@ -26,7 +26,7 @@ import {
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import { rpcRelayErrorClass } from "@/lib/rpc/providers";
-import type { ExecutionErrorType } from "@/lib/errors/execution-error-type";
+import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 import { getErrorMessage } from "@/lib/utils";
 import { generateId } from "@/lib/utils/id";
 import {
@@ -323,7 +323,14 @@ export async function transferTokenCore(
     context: "transfer-token",
   });
   if (stablecoinCap.kind !== "allowed") {
-    return { success: false, error: stablecoinCap.error };
+    // Same classification as writeContractCore's identical refusal. Without it
+    // the two cores file the same policy denial under different fault domains
+    // in the metrics, so the deny rate cannot be read across them.
+    return {
+      success: false,
+      error: stablecoinCap.error,
+      errorClass: ExecutionErrorType.USER,
+    };
   }
 
   // Resolve RPC config (with failover)

--- a/plugins/web3/steps/transfer-token-core.ts
+++ b/plugins/web3/steps/transfer-token-core.ts
@@ -16,6 +16,7 @@ import {
   supportedTokens,
   workflowExecutions,
 } from "@/lib/db/schema";
+import { checkStablecoinTransferAmount } from "@/lib/execute/stablecoin-cap";
 import { getTransactionUrl } from "@/lib/explorer";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import {
@@ -309,6 +310,21 @@ export async function transferTokenCore(
   }
 
   const { organizationId, userId } = orgCtx;
+
+  // Stablecoin ceiling. An ERC-20 transfer carries a native value of 0, so the
+  // daily value cap reserves nothing for it and cannot see it at all. Checked
+  // here rather than in the calling route so every entrance is covered: the
+  // direct transfer API, the node-execution API, and the workflow step.
+  const stablecoinCap = await checkStablecoinTransferAmount({
+    organizationId,
+    chainId,
+    tokenAddress,
+    amount,
+    context: "transfer-token",
+  });
+  if (stablecoinCap.kind !== "allowed") {
+    return { success: false, error: stablecoinCap.error };
+  }
 
   // Resolve RPC config (with failover)
   let rpcUrl: string;

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -14,6 +14,7 @@ import { coerceArgsForAbi, reshapeArgsForAbi } from "@/lib/abi/struct-args";
 import { validateArgsForAbi } from "@/lib/abi/validate-args";
 import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
+import { checkStablecoinContractCall } from "@/lib/execute/stablecoin-cap";
 import { getTransactionUrl } from "@/lib/explorer";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { redactAllUrls } from "@/lib/rpc/scrub-rpc-urls";
@@ -364,6 +365,28 @@ export async function writeContractCore(
       // failing; everything else here (unknown chain, disabled chain, our own
       // endpoints) is.
       errorClass: rpcRelayErrorClass(error) ?? ExecutionErrorType.SYSTEM,
+    };
+  }
+
+  // Stablecoin ceiling. An ERC-20 call carries no native value, so the daily
+  // value cap reserves 0 for it: a `transfer` on a USDC contract is invisible
+  // to it. Checked here rather than in any one route because every write
+  // entrance funnels through this core -- the contract-call API, the protocol
+  // action API, check-and-execute, node execution, and the workflow steps.
+  const stablecoinCap = await checkStablecoinContractCall({
+    organizationId,
+    chainId,
+    contractAddress,
+    functionName: functionAbi.name,
+    inputTypes: (functionAbi.inputs ?? []).map((i) => i.type),
+    args,
+    context: "write-contract",
+  });
+  if (stablecoinCap.kind !== "allowed") {
+    return {
+      success: false,
+      error: stablecoinCap.error,
+      errorClass: ExecutionErrorType.USER,
     };
   }
 

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -146,7 +146,7 @@
       "path": "/api/execute/{executionId}/status",
       "route_file": "app/api/execute/[executionId]/status/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 675
+      "line": 681
     },
     {
       "method": "GET",
@@ -384,21 +384,21 @@
       "path": "/api/execute/check-and-execute",
       "route_file": "app/api/execute/check-and-execute/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 414
+      "line": 420
     },
     {
       "method": "POST",
       "path": "/api/execute/contract-call",
       "route_file": "app/api/execute/contract-call/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 346
+      "line": 352
     },
     {
       "method": "POST",
       "path": "/api/execute/transfer",
       "route_file": "app/api/execute/transfer/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 278
+      "line": 284
     },
     {
       "method": "POST",
@@ -538,7 +538,7 @@
       "path": "/api/workflows/{workflowId}/simulate",
       "route_file": "app/api/workflows/[workflowId]/simulate/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 837
+      "line": 843
     },
     {
       "method": "POST",

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -146,7 +146,7 @@
       "path": "/api/execute/{executionId}/status",
       "route_file": "app/api/execute/[executionId]/status/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 681
+      "line": 685
     },
     {
       "method": "GET",
@@ -384,21 +384,21 @@
       "path": "/api/execute/check-and-execute",
       "route_file": "app/api/execute/check-and-execute/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 420
+      "line": 424
     },
     {
       "method": "POST",
       "path": "/api/execute/contract-call",
       "route_file": "app/api/execute/contract-call/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 352
+      "line": 356
     },
     {
       "method": "POST",
       "path": "/api/execute/transfer",
       "route_file": "app/api/execute/transfer/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 284
+      "line": 288
     },
     {
       "method": "POST",
@@ -538,7 +538,7 @@
       "path": "/api/workflows/{workflowId}/simulate",
       "route_file": "app/api/workflows/[workflowId]/simulate/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 843
+      "line": 847
     },
     {
       "method": "POST",

--- a/tests/integration/direct-execution-api.test.ts
+++ b/tests/integration/direct-execution-api.test.ts
@@ -396,6 +396,30 @@ describe("Direct Execution API", () => {
       );
     });
 
+    it("surfaces a stablecoin-ceiling refusal from the core as a failed execution", async () => {
+      // The ceiling lives in transferTokenCore, not in this route, so that the
+      // contract-call, protocol, node and workflow entrances are covered by the
+      // same check. The route's job is to report the refusal without
+      // broadcasting anything.
+      setupPassingGuards();
+      const error =
+        "Stablecoin transfer of 5000.0 USDC exceeds the 100.0 USD per-transaction limit";
+      mocks.transferTokenCore.mockResolvedValue({ success: false, error });
+      mocks.failExecution.mockResolvedValue({ status: "failed" });
+
+      const response = await transferPOST(
+        postRequest("/transfer", {
+          ...validBody,
+          tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        })
+      );
+
+      const data = await response.json();
+      expect(data.status).toBe("failed");
+      expect(data.error).toBe(error);
+      expect(data.transactionHash).toBeUndefined();
+    });
+
     it("returns 400 for an unparseable native amount before reserving", async () => {
       setupPassingGuards();
 

--- a/tests/unit/approve-token.test.ts
+++ b/tests/unit/approve-token.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
@@ -12,15 +12,31 @@ vi.mock("@/lib/logging", () => ({
     TRANSACTION: "transaction",
   },
   logUserError: vi.fn(),
+  // Emitted by the stablecoin ceiling when it refuses an approval.
+  logSecurityEvent: vi.fn(),
 }));
+
+// supported_tokens rows the stablecoin ceiling reads. Empty by default, so
+// the existing cases run against a token the ceiling does not recognise.
+const tokenRegistry = vi.hoisted(() => ({ rows: [] as unknown[] }));
 
 vi.mock("@/lib/db", () => ({
   db: {
     select: () => ({
       from: () => ({
-        where: () => ({
-          limit: () => Promise.resolve([]),
-        }),
+        // Two shapes share this stub: most lookups end in .limit(), while
+        // loadStablecoin in stablecoin-cap.ts awaits .where() directly because
+        // it reads the chain's whole token list and matches in JS. A promise
+        // that also carries .limit satisfies both.
+        where: () => {
+          const pending = Promise.resolve(tokenRegistry.rows) as Promise<
+            unknown[]
+          > & {
+            limit: () => Promise<unknown[]>;
+          };
+          pending.limit = () => Promise.resolve([]);
+          return pending;
+        },
       }),
     }),
     query: {
@@ -39,10 +55,16 @@ vi.mock("@/lib/db/schema", () => ({
     workflowId: "workflowId",
   },
   explorerConfigs: { id: "id", chainId: "chainId" },
+  // decimals/symbol/isStablecoin are read by loadStablecoin: this step calls
+  // ERC-20 approve directly, so the stablecoin ceiling is applied here rather
+  // than in writeContractCore.
   supportedTokens: {
     id: "id",
     chainId: "chainId",
     tokenAddress: "tokenAddress",
+    decimals: "decimals",
+    symbol: "symbol",
+    isStablecoin: "is_stablecoin",
   },
 }));
 
@@ -230,6 +252,10 @@ import { approveTokenCore } from "@/plugins/web3/steps/approve-token-core";
 
 const VALID_TOKEN = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
 const VALID_SPENDER = "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45";
+// Deliberately not a protocol contract: the allowlist admits over-cap
+// approvals to routers this repo already directs value at, and VALID_SPENDER
+// above is one of them, so it cannot exercise the refusal.
+const UNKNOWN_SPENDER = "0x000000000000000000000000000000000000dEaD";
 
 function makeInput(
   overrides: Partial<ApproveTokenCoreInput>
@@ -474,5 +500,83 @@ describe("approve-token - executedCall on direct send", () => {
       "0xtxhash",
       expect.objectContaining({ target: VALID_TOKEN, functionName: "approve" })
     );
+  });
+});
+
+describe("approve-token stablecoin ceiling", () => {
+  // approveTokenCore calls ERC-20 approve directly, so it never passes through
+  // writeContractCore where the ceiling is applied. It was the one unbounded
+  // allowance path the cap did not cover -- and the cheapest complete drain a
+  // leaked key has, since the allowance is granted here and transferFrom
+  // happens off platform afterwards where nothing checks.
+  beforeEach(() => {
+    tokenRegistry.rows = [
+      {
+        tokenAddress: VALID_TOKEN,
+        decimals: 6,
+        symbol: "USDC",
+        isStablecoin: true,
+      },
+    ];
+  });
+
+  afterEach(() => {
+    tokenRegistry.rows = [];
+  });
+
+  it("refuses an unlimited approval to a spender nothing accounts for", async () => {
+    setupMocks();
+
+    const result = await approveTokenCore(
+      makeInput({ amount: "max", spenderAddress: UNKNOWN_SPENDER })
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("per-transaction limit");
+    }
+  });
+
+  it("refuses an over-cap approval to a spender nothing accounts for", async () => {
+    setupMocks();
+
+    const result = await approveTokenCore(
+      makeInput({ amount: "5000", spenderAddress: UNKNOWN_SPENDER })
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  it("leaves an approval under the ceiling alone", async () => {
+    setupMocks();
+
+    const result = await approveTokenCore(makeInput({ amount: "10" }));
+
+    expect(result.success).toBe(true);
+  });
+
+  // The case the allowlist exists to preserve, exercised against the REAL
+  // protocol registry rather than a mock: approving max uint to a router the
+  // platform already directs value at is how nearly every DeFi integration
+  // works, and must keep working. VALID_SPENDER is one such contract.
+  it("allows an unlimited approval to a contract a protocol already uses", async () => {
+    setupMocks();
+
+    const result = await approveTokenCore(
+      makeInput({ amount: "max", spenderAddress: VALID_SPENDER })
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it("does not engage for a token that is not a recognised stablecoin", async () => {
+    setupMocks();
+    tokenRegistry.rows = [];
+
+    const result = await approveTokenCore(
+      makeInput({ amount: "max", spenderAddress: UNKNOWN_SPENDER })
+    );
+
+    expect(result.success).toBe(true);
   });
 });

--- a/tests/unit/execute-simulate.test.ts
+++ b/tests/unit/execute-simulate.test.ts
@@ -36,6 +36,9 @@ const rpcSpies = vi.hoisted(() => ({
   isSolanaChain: vi.fn(),
   parseTokenAddress: vi.fn(),
   chainsLookup: vi.fn(() => Promise.resolve([{ symbol: "ETH" }])),
+  // Empty by default: no row means the token is not a recognised stablecoin,
+  // so the ceiling is not engaged and the existing cases are unaffected.
+  supportedTokensLookup: vi.fn(() => Promise.resolve([] as unknown[])),
 }));
 
 vi.mock("@/lib/web3/wallet-helpers", () => ({
@@ -58,6 +61,9 @@ vi.mock("@/plugins/web3/steps/transfer-token-core", () => ({
 vi.mock("@/lib/logging", () => ({
   logSystemError: vi.fn(),
   ErrorCategory: { DATABASE: "database" },
+  // Emitted by the stablecoin ceiling when it refuses. Absent from this mock
+  // the call throws and the refusal surfaces as an unrelated failure.
+  logSecurityEvent: vi.fn(),
 }));
 
 // getNativeSymbol reads the chain's symbol from the seeded `chains` table.
@@ -68,9 +74,18 @@ vi.mock("@/lib/db", () => ({
   db: {
     select: () => ({
       from: () => ({
-        where: () => ({
-          limit: () => rpcSpies.chainsLookup(),
-        }),
+        // Two call shapes share this stub. The chains lookup ends in .limit();
+        // loadStablecoin in stablecoin-cap.ts awaits .where() directly, because
+        // it reads the chain's whole token list and matches in JS. Returning a
+        // promise that also carries .limit satisfies both without branching on
+        // the table.
+        where: () => {
+          const pending = Promise.resolve(
+            rpcSpies.supportedTokensLookup()
+          ) as Promise<unknown> & { limit: () => unknown };
+          pending.limit = () => rpcSpies.chainsLookup();
+          return pending;
+        },
       }),
     }),
   },
@@ -83,6 +98,15 @@ vi.mock("@/lib/db", () => ({
 // file with "No X export is defined on the mock" — add the table here.
 vi.mock("@/lib/db/schema", () => ({
   chains: { chainId: "chain_id", symbol: "symbol" },
+  // Read by loadStablecoin, which the ceiling calls on the simulate path so a
+  // dry run reports the same refusal a broadcast would.
+  supportedTokens: {
+    chainId: "chain_id",
+    tokenAddress: "token_address",
+    decimals: "decimals",
+    symbol: "symbol",
+    isStablecoin: "is_stablecoin",
+  },
 }));
 
 // Import after mocks so the simulate module binds to the stubbed deps.
@@ -759,6 +783,38 @@ describe("simulateTokenTransfer", () => {
     expect(executeWithFailover).toHaveBeenCalledTimes(2);
     expect(executeWithFailover.mock.calls[0]?.[1]).toBe("preflight");
     expect(executeWithFailover.mock.calls[1]?.[1]).toBe("preflight");
+  });
+
+  // A dry run that ignored the ceiling reported a clean simulation for a
+  // transfer that then failed at broadcast. Agents call simulate to decide
+  // whether to send, so the limit has to be discoverable here.
+  it("reports the stablecoin ceiling instead of simulating a doomed transfer", async () => {
+    resetSpies();
+    parseTokenAddress.mockResolvedValueOnce(CONTRACT_ADDRESS);
+    rpcSpies.supportedTokensLookup.mockResolvedValueOnce([
+      {
+        tokenAddress: CONTRACT_ADDRESS,
+        decimals: 6,
+        symbol: "USDC",
+        isStablecoin: true,
+      },
+    ]);
+
+    const result = await simulateTokenTransfer({
+      organizationId: "org_test",
+      network: "1",
+      tokenAddress: CONTRACT_ADDRESS,
+      recipientAddress: RECIPIENT_ADDRESS,
+      amount: "5000",
+      decimals: 6,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("per-transaction limit");
+    }
+    // Refused before any RPC work: the ceiling is known without simulating.
+    expect(executeWithFailover).not.toHaveBeenCalled();
   });
 
   it("skips the on-chain decimals lookup when decimals is provided", async () => {

--- a/tests/unit/execute-simulate.test.ts
+++ b/tests/unit/execute-simulate.test.ts
@@ -156,6 +156,49 @@ function resetSpies(): void {
 }
 
 describe("simulateContractCall", () => {
+  // The contract-call route calls this function directly rather than going
+  // through simulateTokenTransfer, so gating only the latter left
+  // POST /api/execute/contract-call?simulate=true reporting a clean dry run
+  // for a send the broadcast path then refuses.
+  it("reports the stablecoin ceiling on a direct contract-call simulation", async () => {
+    resetSpies();
+    rpcSpies.supportedTokensLookup.mockResolvedValueOnce([
+      {
+        tokenAddress: CONTRACT_ADDRESS,
+        decimals: 6,
+        symbol: "USDC",
+        isStablecoin: true,
+      },
+    ]);
+
+    const result = await simulateContractCall({
+      organizationId: "org_test",
+      network: "1",
+      contractAddress: CONTRACT_ADDRESS,
+      abi: JSON.stringify([
+        {
+          name: "transfer",
+          type: "function",
+          inputs: [
+            { name: "to", type: "address" },
+            { name: "amount", type: "uint256" },
+          ],
+          outputs: [{ name: "", type: "bool" }],
+        },
+      ]),
+      functionName: "transfer",
+      // 5,000 USDC at 6 decimals, well past the ceiling.
+      functionArgs: JSON.stringify([RECIPIENT_ADDRESS, "5000000000"]),
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("per-transaction limit");
+    }
+    // Refused before any RPC work: the answer is knowable without simulating.
+    expect(executeWithFailover).not.toHaveBeenCalled();
+  });
+
   it("returns gas + decoded return value when the call succeeds", async () => {
     resetSpies();
     // ABI-encoded uint256(123)

--- a/tests/unit/stablecoin-cap-registry.test.ts
+++ b/tests/unit/stablecoin-cap-registry.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Guards the approve allowlist against resolving empty in production.
+ *
+ * The defect: `getRegisteredProtocols()` is populated by import side effect,
+ * and of the execute routes only `[...slug]` imported the protocol barrel. On
+ * every other path the allowlist resolved empty and refused every over-cap
+ * approval to a genuine router -- the exact traffic it was written to permit.
+ *
+ * Why this is asserted against the source text rather than by behaviour:
+ * `tests/setup.ts` does `import "@/plugins"` for the whole suite, which
+ * transitively registers every protocol before any test runs. So the registry
+ * is populated in-process no matter what the module under test imports, and a
+ * behavioural assertion passes identically with the fix reverted. That global
+ * setup, not just the registry mock in the sibling suite, is what made the
+ * original bug invisible to unit tests.
+ *
+ * A source-level assertion is blunt, but it fails exactly when the import is
+ * removed, which is the regression that matters and the one nothing else
+ * catches.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const CAP_SOURCE = readFileSync(
+  join(process.cwd(), "lib/execute/stablecoin-cap.ts"),
+  "utf8"
+);
+
+describe("approve allowlist registry population", () => {
+  it("imports the protocol barrel for its side effect", () => {
+    // Not `from "@/protocols"` -- the import exists only to run registration,
+    // so it is bare and a named import would not be equivalent.
+    expect(CAP_SOURCE).toMatch(/^import\s+["']@\/protocols["'];$/m);
+  });
+
+  // The other half of the fix. Memoising outright meant a protocol registering
+  // after the first call was locked out for the life of the process, so the
+  // verdict depended on which traffic warmed the module first.
+  it("keys the spender cache on registry size rather than memoising once", () => {
+    expect(CAP_SOURCE).toContain("knownSpendersFrom");
+    expect(CAP_SOURCE).toMatch(/knownSpendersFrom\s*===\s*protocols\.length/);
+  });
+
+  // Sanity check on the premise: the allowlist is only meaningful if
+  // registered protocols actually carry static addresses to allowlist.
+  it("finds concrete spender addresses among registered protocols", async () => {
+    const { getRegisteredProtocols } = await import("@/lib/protocol-registry");
+    const addresses: string[] = [];
+    for (const protocol of getRegisteredProtocols()) {
+      for (const contract of Object.values(protocol.contracts ?? {})) {
+        if (contract.userSpecifiedAddress) {
+          continue;
+        }
+        for (const address of Object.values(contract.addresses ?? {})) {
+          if (typeof address === "string" && address.startsWith("0x")) {
+            addresses.push(address);
+          }
+        }
+      }
+    }
+
+    expect(addresses.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/stablecoin-cap.test.ts
+++ b/tests/unit/stablecoin-cap.test.ts
@@ -62,7 +62,10 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
-import { getDefaultStablecoinTransferCapMicroUsd } from "@/lib/execute/spend-cap-defaults";
+import {
+  getDefaultBatchStablecoinCapMicroUsd,
+  getDefaultStablecoinTransferCapMicroUsd,
+} from "@/lib/execute/spend-cap-defaults";
 import {
   checkStablecoinCalldata,
   checkStablecoinCalldataBatch,
@@ -73,6 +76,8 @@ import {
 const CAP_MICRO_USD = BigInt(getDefaultStablecoinTransferCapMicroUsd());
 // The cap in whole dollars, used to build amounts either side of it.
 const CAP_USD = CAP_MICRO_USD / BigInt(1_000_000);
+const BATCH_CAP_MICRO_USD = BigInt(getDefaultBatchStablecoinCapMicroUsd());
+const BATCH_CAP_USD = BATCH_CAP_MICRO_USD / BigInt(1_000_000);
 
 // The registry seeds addresses lowercase; callers usually resolve checksummed
 // ones, so the two casings must still meet.
@@ -555,19 +560,55 @@ describe("checkStablecoinCalldataBatch", () => {
   }
 
   // The bypass this entry point exists for. signTempoTx signs every call of a
-  // batch payout as one transaction, so ten entries that each clear the
-  // ceiling individually moved ten times it, and nothing bounded the entry
-  // count.
-  it("sums a batch whose calls each sit under the ceiling", async () => {
+  // batch payout as one transaction, so entries that each clear the per-call
+  // ceiling still moved a multiple of it, and nothing bounded the entry count.
+  it("sums a batch whose calls each sit under the per-call ceiling", async () => {
     state.tokenRows = [USDC];
-    const under = CAP_USD - BigInt(1);
+    // Each entry clears the 100 USD per-call figure; together they pass the
+    // batch total.
+    const perEntry = CAP_USD - BigInt(10);
+    const count = Number(BATCH_CAP_USD / perEntry) + 1;
 
     const result = await checkStablecoinCalldataBatch({
       ...batchParams,
-      calls: Array.from({ length: 10 }, () => transferCall(under)),
+      calls: Array.from({ length: count }, () => transferCall(perEntry)),
     });
 
     expect(result.kind).toBe("denied");
+    if (result.kind === "denied") {
+      expect(result.error).toContain("per-transaction batch limit");
+    }
+  });
+
+  // The case that made the per-call figure the wrong yardstick for a batch: a
+  // payroll run of many small entries. Measured against 100 USD it capped
+  // batch payouts at 2 USD a head, which removed the feature rather than
+  // bounding it.
+  it("admits a payroll-shaped batch of many small entries", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinCalldataBatch({
+      ...batchParams,
+      calls: Array.from({ length: 50 }, () => transferCall(BigInt(20))),
+    });
+
+    expect(result).toEqual({ kind: "allowed" });
+  });
+
+  // Summing alone is not enough either: without the per-call ceiling a single
+  // large recipient hides under a generous batch total.
+  it("refuses one over-cap entry even when the batch total is small", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinCalldataBatch({
+      ...batchParams,
+      calls: [transferCall(CAP_USD + BigInt(1))],
+    });
+
+    expect(result.kind).toBe("denied");
+    if (result.kind === "denied") {
+      expect(result.error).toContain("per-transaction limit");
+    }
   });
 
   it("admits a batch whose total stays within the ceiling", async () => {
@@ -588,7 +629,7 @@ describe("checkStablecoinCalldataBatch", () => {
       USDC,
       { ...USDC, tokenAddress: DAI_ADDRESS, symbol: "DAI", decimals: 18 },
     ];
-    const half = CAP_USD / BigInt(2) + BigInt(1);
+    const half = BATCH_CAP_USD / BigInt(2) + BigInt(1);
 
     const result = await checkStablecoinCalldataBatch({
       ...batchParams,

--- a/tests/unit/stablecoin-cap.test.ts
+++ b/tests/unit/stablecoin-cap.test.ts
@@ -5,6 +5,17 @@ const KNOWN_ROUTER = "0x1111111111111111111111111111111111111111";
 const UNKNOWN_SPENDER = "0x2222222222222222222222222222222222222222";
 const USER_SUPPLIED = "0x3333333333333333333333333333333333333333";
 
+const ORG_WALLET = "0x4444444444444444444444444444444444444444";
+const COUNTERPARTY = "0x5555555555555555555555555555555555555555";
+
+const { mockGetOrgWallet } = vi.hoisted(() => ({
+  mockGetOrgWallet: vi.fn(),
+}));
+
+vi.mock("@/lib/web3/wallet-helpers", () => ({
+  getOrganizationWalletAddress: mockGetOrgWallet,
+}));
+
 vi.mock("@/lib/protocol-registry", () => ({
   getRegisteredProtocols: () => [
     {
@@ -107,6 +118,8 @@ function units(dollars: bigint, decimals: number): string {
 beforeEach(() => {
   state.tokenRows = [];
   state.selectCalls = 0;
+  mockGetOrgWallet.mockReset();
+  mockGetOrgWallet.mockResolvedValue(ORG_WALLET);
 });
 
 describe("the stablecoin per-transaction ceiling", () => {
@@ -304,7 +317,72 @@ describe("checkStablecoinContractCall", () => {
       ...callParams,
       functionName: "transferFrom",
       inputTypes: ["address", "address", "uint256"],
-      args: [RECIPIENT, RECIPIENT, units(CAP_USD + BigInt(1), 6)],
+      // Payer is the org wallet, so this is a real outflow.
+      args: [ORG_WALLET, RECIPIENT, units(CAP_USD + BigInt(1), 6)],
+    });
+
+    expect(result.kind).toBe("denied");
+  });
+
+  // A pull payment: the counterparty pays and the org collects. Value moves
+  // INTO the wallet, so the outflow ceiling has nothing to say about it.
+  // Treating every transferFrom as an outflow refused invoice settlements.
+  it("allows an over-cap transferFrom that collects from a counterparty", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinContractCall({
+      ...callParams,
+      functionName: "transferFrom",
+      inputTypes: ["address", "address", "uint256"],
+      args: [COUNTERPARTY, ORG_WALLET, units(CAP_USD + BigInt(1), 6)],
+    });
+
+    expect(result).toEqual({ kind: "allowed" });
+  });
+
+  it("compares the payer case-insensitively", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinContractCall({
+      ...callParams,
+      functionName: "transferFrom",
+      inputTypes: ["address", "address", "uint256"],
+      args: [
+        ORG_WALLET.toUpperCase().replace("0X", "0x"),
+        RECIPIENT,
+        units(CAP_USD + BigInt(1), 6),
+      ],
+    });
+
+    expect(result.kind).toBe("denied");
+  });
+
+  // Fail closed: an unresolvable wallet must not become a way to move funds
+  // out under a transferFrom the check can no longer attribute.
+  it("still applies the ceiling when the org wallet cannot be resolved", async () => {
+    state.tokenRows = [USDC];
+    mockGetOrgWallet.mockRejectedValue(new Error("wallet lookup failed"));
+
+    const result = await checkStablecoinContractCall({
+      ...callParams,
+      functionName: "transferFrom",
+      inputTypes: ["address", "address", "uint256"],
+      args: [COUNTERPARTY, ORG_WALLET, units(CAP_USD + BigInt(1), 6)],
+    });
+
+    expect(result.kind).toBe("denied");
+  });
+
+  // transfer has no payer argument -- it always moves from the caller -- so
+  // the payer exemption must not leak into it via args[0], which is the payee.
+  it("does not exempt a plain transfer whose recipient is a counterparty", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinContractCall({
+      ...callParams,
+      functionName: "transfer",
+      inputTypes: ["address", "uint256"],
+      args: [COUNTERPARTY, units(CAP_USD + BigInt(1), 6)],
     });
 
     expect(result.kind).toBe("denied");

--- a/tests/unit/stablecoin-cap.test.ts
+++ b/tests/unit/stablecoin-cap.test.ts
@@ -1,6 +1,28 @@
 import { ethers } from "ethers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const KNOWN_ROUTER = "0x1111111111111111111111111111111111111111";
+const UNKNOWN_SPENDER = "0x2222222222222222222222222222222222222222";
+const USER_SUPPLIED = "0x3333333333333333333333333333333333333333";
+
+vi.mock("@/lib/protocol-registry", () => ({
+  getRegisteredProtocols: () => [
+    {
+      slug: "test-protocol",
+      contracts: {
+        router: { label: "Router", addresses: { mainnet: KNOWN_ROUTER } },
+        // userSpecifiedAddress contracts take their address from the caller at
+        // run time, so they must not seed the allowlist.
+        custom: {
+          label: "Custom",
+          addresses: { mainnet: USER_SUPPLIED },
+          userSpecifiedAddress: true,
+        },
+      },
+    },
+  ],
+}));
+
 vi.mock("server-only", () => ({}));
 
 // Hoisted registry rows the fake supported_tokens lookup returns, set per test.
@@ -32,6 +54,7 @@ vi.mock("@/lib/db", () => ({
 import { getDefaultStablecoinTransferCapMicroUsd } from "@/lib/execute/spend-cap-defaults";
 import {
   checkStablecoinCalldata,
+  checkStablecoinCalldataBatch,
   checkStablecoinContractCall,
   checkStablecoinTransferAmount,
 } from "@/lib/execute/stablecoin-cap";
@@ -43,6 +66,7 @@ const CAP_USD = CAP_MICRO_USD / BigInt(1_000_000);
 // The registry seeds addresses lowercase; callers usually resolve checksummed
 // ones, so the two casings must still meet.
 const USDC_ADDRESS = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const DAI_ADDRESS = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
 const RECIPIENT = "0x1111111111111111111111111111111111111111";
 
 const USDC = {
@@ -299,16 +323,59 @@ describe("checkStablecoinContractCall", () => {
     expect(result.kind).toBe("over_cap");
   });
 
-  it("allows a large approval but does not treat it as capped", async () => {
-    // Refusing approvals would break every protocol integration that approves
-    // max uint before a swap, so this is reported rather than blocked.
+  // Approving max uint before a swap is how nearly every protocol integration
+  // works, so the spender is what separates the legitimate case from the drain.
+  it("allows an over-cap approval to a contract a protocol already uses", async () => {
     state.tokenRows = [USDC];
 
     const result = await checkStablecoinContractCall({
       ...callParams,
       functionName: "approve",
       inputTypes: ["address", "uint256"],
-      args: [RECIPIENT, ethers.MaxUint256.toString()],
+      args: [KNOWN_ROUTER, ethers.MaxUint256.toString()],
+    });
+
+    expect(result).toEqual({ kind: "allowed" });
+  });
+
+  // The complete drain path for a leaked key: grant an unbounded allowance,
+  // then call transferFrom off platform where none of this code runs.
+  it("refuses an over-cap approval to a spender nothing accounts for", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinContractCall({
+      ...callParams,
+      functionName: "approve",
+      inputTypes: ["address", "uint256"],
+      args: [UNKNOWN_SPENDER, ethers.MaxUint256.toString()],
+    });
+
+    expect(result.kind).toBe("over_cap");
+  });
+
+  // A userSpecifiedAddress contract resolves to whatever the caller passed, so
+  // allowlisting it would trust exactly the input this control exists to check.
+  it("does not trust a spender drawn from a user-specified contract", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinContractCall({
+      ...callParams,
+      functionName: "approve",
+      inputTypes: ["address", "uint256"],
+      args: [USER_SUPPLIED, ethers.MaxUint256.toString()],
+    });
+
+    expect(result.kind).toBe("over_cap");
+  });
+
+  it("leaves an approval under the ceiling alone whoever the spender is", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinContractCall({
+      ...callParams,
+      functionName: "approve",
+      inputTypes: ["address", "uint256"],
+      args: [UNKNOWN_SPENDER, units(BigInt(1), 6)],
     });
 
     expect(result).toEqual({ kind: "allowed" });
@@ -386,6 +453,112 @@ describe("checkStablecoinContractCall", () => {
       functionName: "transfer(address,uint256)",
       inputTypes: ["address", "uint256"],
       args: [RECIPIENT, units(CAP_USD + BigInt(1), 6)],
+    });
+
+    expect(result.kind).toBe("over_cap");
+  });
+});
+
+describe("checkStablecoinCalldataBatch", () => {
+  const batchParams = {
+    organizationId: "org_1",
+    chainId: 1,
+    context: "tempo",
+  };
+
+  function transferCall(amountUsd: bigint) {
+    return {
+      to: USDC_ADDRESS,
+      data: erc20.encodeFunctionData("transfer", [
+        RECIPIENT,
+        units(amountUsd, 6),
+      ]),
+    };
+  }
+
+  // The bypass this entry point exists for. signTempoTx signs every call of a
+  // batch payout as one transaction, so ten entries that each clear the
+  // ceiling individually moved ten times it, and nothing bounded the entry
+  // count.
+  it("sums a batch whose calls each sit under the ceiling", async () => {
+    state.tokenRows = [USDC];
+    const under = CAP_USD - BigInt(1);
+
+    const result = await checkStablecoinCalldataBatch({
+      ...batchParams,
+      calls: Array.from({ length: 10 }, () => transferCall(under)),
+    });
+
+    expect(result.kind).toBe("over_cap");
+  });
+
+  it("admits a batch whose total stays within the ceiling", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinCalldataBatch({
+      ...batchParams,
+      calls: [transferCall(BigInt(10)), transferCall(BigInt(20))],
+    });
+
+    expect(result).toEqual({ kind: "allowed" });
+  });
+
+  // Every recognised token is pegged 1:1, so splitting a payout across two of
+  // them moves exactly as much as sending it in one.
+  it("sums across different stablecoins in the same transaction", async () => {
+    state.tokenRows = [
+      USDC,
+      { ...USDC, tokenAddress: DAI_ADDRESS, symbol: "DAI", decimals: 18 },
+    ];
+    const half = CAP_USD / BigInt(2) + BigInt(1);
+
+    const result = await checkStablecoinCalldataBatch({
+      ...batchParams,
+      calls: [
+        transferCall(half),
+        {
+          to: DAI_ADDRESS,
+          data: erc20.encodeFunctionData("transfer", [
+            RECIPIENT,
+            units(half, 18),
+          ]),
+        },
+      ],
+    });
+
+    expect(result.kind).toBe("over_cap");
+  });
+
+  it("ignores calls that are not recognised stablecoin outflows", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinCalldataBatch({
+      ...batchParams,
+      calls: [
+        { to: USDC_ADDRESS, data: "0xdeadbeef" },
+        transferCall(BigInt(1)),
+      ],
+    });
+
+    expect(result).toEqual({ kind: "allowed" });
+  });
+
+  // An approval is a standing grant, not a movement, so it is judged on its
+  // own spender rather than folded into the transfer total.
+  it("refuses a batch carrying an over-cap approval to an unknown spender", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinCalldataBatch({
+      ...batchParams,
+      calls: [
+        {
+          to: USDC_ADDRESS,
+          data: erc20.encodeFunctionData("approve", [
+            UNKNOWN_SPENDER,
+            ethers.MaxUint256.toString(),
+          ]),
+        },
+      ],
     });
 
     expect(result.kind).toBe("over_cap");

--- a/tests/unit/stablecoin-cap.test.ts
+++ b/tests/unit/stablecoin-cap.test.ts
@@ -7,6 +7,7 @@ const USER_SUPPLIED = "0x3333333333333333333333333333333333333333";
 
 const ORG_WALLET = "0x4444444444444444444444444444444444444444";
 const COUNTERPARTY = "0x5555555555555555555555555555555555555555";
+const SAFE_WALLET = "0x6666666666666666666666666666666666666666";
 
 const { mockGetOrgWallet } = vi.hoisted(() => ({
   mockGetOrgWallet: vi.fn(),
@@ -45,17 +46,24 @@ const state = vi.hoisted(() => ({
     isStablecoin: boolean;
   }>,
   selectCalls: 0,
+  safeRows: [] as { safeAddress: string }[],
 }));
 
-// Fake db serving the chain's supported_tokens list, which the cap then matches
-// against in JS: select(...).from(...).where(...).
+// Fake db serving two reads: the chain's supported_tokens list, which the cap
+// matches against in JS, and the org's safe_wallets rows, which feed the payer
+// set for transferFrom. Branches on the selected columns, since that is the
+// only thing distinguishing the two calls through this stub.
 vi.mock("@/lib/db", () => ({
   db: {
-    select: () => {
-      state.selectCalls += 1;
+    select: (columns?: Record<string, unknown>) => {
+      const isSafeQuery = columns !== undefined && "safeAddress" in columns;
+      if (!isSafeQuery) {
+        state.selectCalls += 1;
+      }
       return {
         from: () => ({
-          where: () => Promise.resolve(state.tokenRows),
+          where: () =>
+            Promise.resolve(isSafeQuery ? state.safeRows : state.tokenRows),
         }),
       };
     },
@@ -123,6 +131,7 @@ function units(dollars: bigint, decimals: number): string {
 beforeEach(() => {
   state.tokenRows = [];
   state.selectCalls = 0;
+  state.safeRows = [];
   mockGetOrgWallet.mockReset();
   mockGetOrgWallet.mockResolvedValue(ORG_WALLET);
 });
@@ -334,6 +343,40 @@ describe("checkStablecoinContractCall", () => {
   // Treating every transferFrom as an outflow refused invoice settlements.
   it("allows an over-cap transferFrom that collects from a counterparty", async () => {
     state.tokenRows = [USDC];
+
+    const result = await checkStablecoinContractCall({
+      ...callParams,
+      functionName: "transferFrom",
+      inputTypes: ["address", "address", "uint256"],
+      args: [COUNTERPARTY, ORG_WALLET, units(CAP_USD + BigInt(1), 6)],
+    });
+
+    expect(result).toEqual({ kind: "allowed" });
+  });
+
+  // The EOA is not the only address the org can move funds from. A
+  // transferFrom naming a Safe as payer would otherwise compare unequal, read
+  // as an inbound collection and skip the ceiling. Not a drain in the ordinary
+  // case -- pulling from your own balance needs allowance[safe][safe], which is
+  // zero -- but it becomes one where a Safe has approved the org EOA as a
+  // spender, and nothing in this module checks allowances.
+  it("applies the ceiling when the payer is a Safe the org controls", async () => {
+    state.tokenRows = [USDC];
+    state.safeRows = [{ safeAddress: SAFE_WALLET }];
+
+    const result = await checkStablecoinContractCall({
+      ...callParams,
+      functionName: "transferFrom",
+      inputTypes: ["address", "address", "uint256"],
+      args: [SAFE_WALLET, RECIPIENT, units(CAP_USD + BigInt(1), 6)],
+    });
+
+    expect(result.kind).toBe("denied");
+  });
+
+  it("still exempts a counterparty payer when the org has Safes", async () => {
+    state.tokenRows = [USDC];
+    state.safeRows = [{ safeAddress: SAFE_WALLET }];
 
     const result = await checkStablecoinContractCall({
       ...callParams,

--- a/tests/unit/stablecoin-cap.test.ts
+++ b/tests/unit/stablecoin-cap.test.ts
@@ -1,0 +1,479 @@
+import { ethers } from "ethers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// Hoisted registry rows the fake supported_tokens lookup returns, set per test.
+const state = vi.hoisted(() => ({
+  tokenRows: [] as Array<{
+    tokenAddress: string;
+    decimals: number;
+    symbol: string;
+    isStablecoin: boolean;
+  }>,
+  selectCalls: 0,
+}));
+
+// Fake db serving the chain's supported_tokens list, which the cap then matches
+// against in JS: select(...).from(...).where(...).
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => {
+      state.selectCalls += 1;
+      return {
+        from: () => ({
+          where: () => Promise.resolve(state.tokenRows),
+        }),
+      };
+    },
+  },
+}));
+
+import { getDefaultStablecoinTransferCapMicroUsd } from "@/lib/execute/spend-cap-defaults";
+import {
+  checkStablecoinCalldata,
+  checkStablecoinContractCall,
+  checkStablecoinTransferAmount,
+} from "@/lib/execute/stablecoin-cap";
+
+const CAP_MICRO_USD = BigInt(getDefaultStablecoinTransferCapMicroUsd());
+// The cap in whole dollars, used to build amounts either side of it.
+const CAP_USD = CAP_MICRO_USD / BigInt(1_000_000);
+
+// The registry seeds addresses lowercase; callers usually resolve checksummed
+// ones, so the two casings must still meet.
+const USDC_ADDRESS = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const RECIPIENT = "0x1111111111111111111111111111111111111111";
+
+const USDC = {
+  tokenAddress: USDC_ADDRESS.toLowerCase(),
+  decimals: 6,
+  symbol: "USDC",
+  isStablecoin: true,
+};
+const DAI = {
+  tokenAddress: USDC_ADDRESS.toLowerCase(),
+  decimals: 18,
+  symbol: "DAI",
+  isStablecoin: true,
+};
+
+const transferParams = {
+  organizationId: "org_1",
+  chainId: 1,
+  tokenAddress: USDC_ADDRESS,
+  context: "test",
+};
+
+const erc20 = new ethers.Interface([
+  "function transfer(address to, uint256 amount)",
+  "function transferFrom(address from, address to, uint256 amount)",
+  "function approve(address spender, uint256 amount)",
+  "function transferWithMemo(address to, uint256 amount, bytes32 memo)",
+  "function deposit(uint256 amount)",
+]);
+
+const MEMO = `0x${"0".repeat(64)}`;
+
+/** Base units of a whole-dollar figure at the token's decimals. */
+function units(dollars: bigint, decimals: number): string {
+  return (dollars * BigInt(10) ** BigInt(decimals)).toString();
+}
+
+beforeEach(() => {
+  state.tokenRows = [];
+  state.selectCalls = 0;
+});
+
+describe("the stablecoin per-transaction ceiling", () => {
+  // Pinned so widening the policy is a deliberate test edit. Every other case
+  // here derives its expectations from the getter.
+  it("is 100 USD, expressed in micro-USD", () => {
+    expect(getDefaultStablecoinTransferCapMicroUsd()).toBe("100000000");
+  });
+});
+
+describe("checkStablecoinTransferAmount", () => {
+  it("allows a stablecoin transfer exactly at the cap", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinTransferAmount({
+      ...transferParams,
+      amount: CAP_USD.toString(),
+    });
+
+    expect(result).toEqual({ kind: "allowed" });
+  });
+
+  it("allows a routine stablecoin transfer well under the cap", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinTransferAmount({
+      ...transferParams,
+      amount: "25.5",
+    });
+
+    expect(result).toEqual({ kind: "allowed" });
+  });
+
+  it("denies a stablecoin transfer one micro-USD over the cap", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinTransferAmount({
+      ...transferParams,
+      amount: `${CAP_USD}.000001`,
+    });
+
+    expect(result.kind).toBe("over_cap");
+  });
+
+  it("denies the drain the native cap could never see", async () => {
+    // An ERC-20 call carries a native value of 0, so the daily value cap
+    // reserves 0 for it. This is the only thing bounding the transfer.
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinTransferAmount({
+      ...transferParams,
+      amount: "250000",
+    });
+
+    expect(result.kind).toBe("over_cap");
+  });
+
+  it("rescales an 18-decimal stablecoin to micro-USD before comparing", async () => {
+    state.tokenRows = [DAI];
+
+    const under = await checkStablecoinTransferAmount({
+      ...transferParams,
+      amount: (CAP_USD - BigInt(1)).toString(),
+    });
+    expect(under).toEqual({ kind: "allowed" });
+
+    const over = await checkStablecoinTransferAmount({
+      ...transferParams,
+      amount: (CAP_USD + BigInt(1)).toString(),
+    });
+    expect(over.kind).toBe("over_cap");
+  });
+
+  it("passes through a registered token that is not a stablecoin", async () => {
+    // Pricing an arbitrary ERC-20 needs an oracle in the pre-broadcast path.
+    state.tokenRows = [
+      {
+        tokenAddress: USDC_ADDRESS.toLowerCase(),
+        decimals: 18,
+        symbol: "WETH",
+        isStablecoin: false,
+      },
+    ];
+
+    const result = await checkStablecoinTransferAmount({
+      ...transferParams,
+      amount: "1000",
+    });
+
+    expect(result).toEqual({ kind: "allowed" });
+  });
+
+  it("passes through a token the registry does not know", async () => {
+    state.tokenRows = [];
+
+    const result = await checkStablecoinTransferAmount({
+      ...transferParams,
+      amount: "1000000",
+    });
+
+    expect(result).toEqual({ kind: "allowed" });
+  });
+
+  it("does not query the registry for a malformed token address", async () => {
+    const result = await checkStablecoinTransferAmount({
+      ...transferParams,
+      tokenAddress: "not-an-address",
+      amount: "1000000",
+    });
+
+    expect(result).toEqual({ kind: "allowed" });
+    expect(state.selectCalls).toBe(0);
+  });
+
+  it("reports an unparseable amount as invalid, not as over cap", async () => {
+    // The two must stay distinguishable: one is a 400, the other a policy
+    // denial, and collapsing them would make a typo read as "cap exceeded".
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinTransferAmount({
+      ...transferParams,
+      amount: "1.0000001",
+    });
+
+    expect(result.kind).toBe("invalid");
+  });
+
+  it("matches a checksummed address against the lowercase registry row", async () => {
+    // An exact-casing comparison would find nothing here, and finding nothing
+    // means failing open.
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinTransferAmount({
+      ...transferParams,
+      tokenAddress: USDC_ADDRESS,
+      amount: (CAP_USD + BigInt(1)).toString(),
+    });
+
+    expect(result.kind).toBe("over_cap");
+  });
+
+  it("ignores a different token on the same chain", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinTransferAmount({
+      ...transferParams,
+      tokenAddress: RECIPIENT,
+      amount: "1000000",
+    });
+
+    expect(result).toEqual({ kind: "allowed" });
+  });
+});
+
+describe("checkStablecoinContractCall", () => {
+  const callParams = {
+    organizationId: "org_1",
+    chainId: 1,
+    contractAddress: USDC_ADDRESS,
+    context: "test",
+  };
+
+  it("denies a USDC transfer smuggled through the contract-call path", async () => {
+    // The bypass the route-level check missed: execute_contract_call takes a
+    // caller-supplied address, ABI and args, and reserves 0 native value.
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinContractCall({
+      ...callParams,
+      functionName: "transfer",
+      inputTypes: ["address", "uint256"],
+      args: [RECIPIENT, units(CAP_USD + BigInt(1), 6)],
+    });
+
+    expect(result.kind).toBe("over_cap");
+  });
+
+  it("allows a contract-call transfer under the cap", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinContractCall({
+      ...callParams,
+      functionName: "transfer",
+      inputTypes: ["address", "uint256"],
+      args: [RECIPIENT, units(BigInt(10), 6)],
+    });
+
+    expect(result).toEqual({ kind: "allowed" });
+  });
+
+  it("reads the amount from the third argument of transferFrom", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinContractCall({
+      ...callParams,
+      functionName: "transferFrom",
+      inputTypes: ["address", "address", "uint256"],
+      args: [RECIPIENT, RECIPIENT, units(CAP_USD + BigInt(1), 6)],
+    });
+
+    expect(result.kind).toBe("over_cap");
+  });
+
+  it("accepts a bigint argument as well as a decimal string", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinContractCall({
+      ...callParams,
+      functionName: "transfer",
+      inputTypes: ["address", "uint256"],
+      args: [RECIPIENT, BigInt(units(CAP_USD + BigInt(1), 6))],
+    });
+
+    expect(result.kind).toBe("over_cap");
+  });
+
+  it("allows a large approval but does not treat it as capped", async () => {
+    // Refusing approvals would break every protocol integration that approves
+    // max uint before a swap, so this is reported rather than blocked.
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinContractCall({
+      ...callParams,
+      functionName: "approve",
+      inputTypes: ["address", "uint256"],
+      args: [RECIPIENT, ethers.MaxUint256.toString()],
+    });
+
+    expect(result).toEqual({ kind: "allowed" });
+  });
+
+  it("refuses a stablecoin transfer whose amount cannot be read", async () => {
+    // Failing open here would hand back the unbounded move the cap exists to
+    // stop.
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinContractCall({
+      ...callParams,
+      functionName: "transfer",
+      inputTypes: ["address", "uint256"],
+      args: [RECIPIENT, { toString: () => "1" }],
+    });
+
+    expect(result.kind).toBe("invalid");
+  });
+
+  it("ignores a function that is not an ERC-20 outflow", async () => {
+    const result = await checkStablecoinContractCall({
+      ...callParams,
+      functionName: "deposit",
+      inputTypes: ["uint256"],
+      args: [units(CAP_USD + BigInt(1), 6)],
+    });
+
+    expect(result).toEqual({ kind: "allowed" });
+    expect(state.selectCalls).toBe(0);
+  });
+
+  it("ignores a same-named function with a different signature", async () => {
+    const result = await checkStablecoinContractCall({
+      ...callParams,
+      functionName: "transfer",
+      inputTypes: ["address", "uint256", "bytes"],
+      args: [RECIPIENT, units(CAP_USD + BigInt(1), 6), "0x"],
+    });
+
+    expect(result).toEqual({ kind: "allowed" });
+    expect(state.selectCalls).toBe(0);
+  });
+
+  // Solidity aliases uint to uint256, and ethers canonicalises before it
+  // computes the selector, so transfer(address,uint) encodes 0xa9059cbb -- a
+  // real ERC-20 transfer. inputTypes reaches this module as the RAW declared
+  // strings from a caller-supplied ABI, so a literal comparison against
+  // "uint256" missed it and the call short-circuited to allowed without ever
+  // loading the token. One word in an attacker-supplied ABI defeated the whole
+  // ceiling. selectCalls asserts the token lookup actually ran, so this cannot
+  // pass by accidentally allowing for some other reason.
+  it.each([
+    ["address", "uint"],
+    ["address", "uint256"],
+  ])("applies the ceiling to transfer declared as %j", async (...types) => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinContractCall({
+      ...callParams,
+      functionName: "transfer",
+      inputTypes: types,
+      args: [RECIPIENT, units(CAP_USD + BigInt(1), 6)],
+    });
+
+    expect(result.kind).toBe("over_cap");
+    expect(state.selectCalls).toBe(1);
+  });
+
+  it("accepts a fully qualified overload key", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinContractCall({
+      ...callParams,
+      functionName: "transfer(address,uint256)",
+      inputTypes: ["address", "uint256"],
+      args: [RECIPIENT, units(CAP_USD + BigInt(1), 6)],
+    });
+
+    expect(result.kind).toBe("over_cap");
+  });
+});
+
+describe("checkStablecoinCalldata", () => {
+  const calldataParams = {
+    organizationId: "org_1",
+    chainId: 1,
+    to: USDC_ADDRESS,
+    context: "test",
+  };
+
+  it("decodes and denies an over-cap transfer from raw calldata", async () => {
+    // Tempo carries {to, data} with no ABI alongside, and moves TIP-20
+    // stablecoins as its primary asset.
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinCalldata({
+      ...calldataParams,
+      data: erc20.encodeFunctionData("transfer", [
+        RECIPIENT,
+        units(CAP_USD + BigInt(1), 6),
+      ]),
+    });
+
+    expect(result.kind).toBe("over_cap");
+  });
+
+  it("allows an under-cap transfer from raw calldata", async () => {
+    state.tokenRows = [USDC];
+
+    const result = await checkStablecoinCalldata({
+      ...calldataParams,
+      data: erc20.encodeFunctionData("transfer", [
+        RECIPIENT,
+        units(BigInt(5), 6),
+      ]),
+    });
+
+    expect(result).toEqual({ kind: "allowed" });
+  });
+
+  it("reads the amount from TIP-20 transferWithMemo, not from the memo", async () => {
+    // Tempo's ordinary send is transferWithMemo(to, amount, memo): the amount
+    // is the second argument, so a last-argument decode would read the memo and
+    // wave the transfer through.
+    state.tokenRows = [USDC];
+
+    const over = await checkStablecoinCalldata({
+      ...calldataParams,
+      data: erc20.encodeFunctionData("transferWithMemo", [
+        RECIPIENT,
+        units(CAP_USD + BigInt(1), 6),
+        MEMO,
+      ]),
+    });
+    expect(over.kind).toBe("over_cap");
+
+    const under = await checkStablecoinCalldata({
+      ...calldataParams,
+      data: erc20.encodeFunctionData("transferWithMemo", [
+        RECIPIENT,
+        units(BigInt(5), 6),
+        MEMO,
+      ]),
+    });
+    expect(under).toEqual({ kind: "allowed" });
+  });
+
+  it("ignores calldata for a function that is not an ERC-20 outflow", async () => {
+    const result = await checkStablecoinCalldata({
+      ...calldataParams,
+      data: erc20.encodeFunctionData("deposit", [units(CAP_USD, 6)]),
+    });
+
+    expect(result).toEqual({ kind: "allowed" });
+    expect(state.selectCalls).toBe(0);
+  });
+
+  it("ignores calldata it cannot decode", async () => {
+    const result = await checkStablecoinCalldata({
+      ...calldataParams,
+      data: "0xdeadbeef",
+    });
+
+    expect(result).toEqual({ kind: "allowed" });
+    expect(state.selectCalls).toBe(0);
+  });
+});

--- a/tests/unit/stablecoin-cap.test.ts
+++ b/tests/unit/stablecoin-cap.test.ts
@@ -148,7 +148,7 @@ describe("checkStablecoinTransferAmount", () => {
       amount: `${CAP_USD}.000001`,
     });
 
-    expect(result.kind).toBe("over_cap");
+    expect(result.kind).toBe("denied");
   });
 
   it("denies the drain the native cap could never see", async () => {
@@ -161,7 +161,7 @@ describe("checkStablecoinTransferAmount", () => {
       amount: "250000",
     });
 
-    expect(result.kind).toBe("over_cap");
+    expect(result.kind).toBe("denied");
   });
 
   it("rescales an 18-decimal stablecoin to micro-USD before comparing", async () => {
@@ -177,7 +177,7 @@ describe("checkStablecoinTransferAmount", () => {
       ...transferParams,
       amount: (CAP_USD + BigInt(1)).toString(),
     });
-    expect(over.kind).toBe("over_cap");
+    expect(over.kind).toBe("denied");
   });
 
   it("passes through a registered token that is not a stablecoin", async () => {
@@ -231,7 +231,7 @@ describe("checkStablecoinTransferAmount", () => {
       amount: "1.0000001",
     });
 
-    expect(result.kind).toBe("invalid");
+    expect(result.kind).toBe("denied");
   });
 
   it("matches a checksummed address against the lowercase registry row", async () => {
@@ -245,7 +245,7 @@ describe("checkStablecoinTransferAmount", () => {
       amount: (CAP_USD + BigInt(1)).toString(),
     });
 
-    expect(result.kind).toBe("over_cap");
+    expect(result.kind).toBe("denied");
   });
 
   it("ignores a different token on the same chain", async () => {
@@ -281,7 +281,7 @@ describe("checkStablecoinContractCall", () => {
       args: [RECIPIENT, units(CAP_USD + BigInt(1), 6)],
     });
 
-    expect(result.kind).toBe("over_cap");
+    expect(result.kind).toBe("denied");
   });
 
   it("allows a contract-call transfer under the cap", async () => {
@@ -307,7 +307,7 @@ describe("checkStablecoinContractCall", () => {
       args: [RECIPIENT, RECIPIENT, units(CAP_USD + BigInt(1), 6)],
     });
 
-    expect(result.kind).toBe("over_cap");
+    expect(result.kind).toBe("denied");
   });
 
   it("accepts a bigint argument as well as a decimal string", async () => {
@@ -320,7 +320,7 @@ describe("checkStablecoinContractCall", () => {
       args: [RECIPIENT, BigInt(units(CAP_USD + BigInt(1), 6))],
     });
 
-    expect(result.kind).toBe("over_cap");
+    expect(result.kind).toBe("denied");
   });
 
   // Approving max uint before a swap is how nearly every protocol integration
@@ -350,7 +350,7 @@ describe("checkStablecoinContractCall", () => {
       args: [UNKNOWN_SPENDER, ethers.MaxUint256.toString()],
     });
 
-    expect(result.kind).toBe("over_cap");
+    expect(result.kind).toBe("denied");
   });
 
   // A userSpecifiedAddress contract resolves to whatever the caller passed, so
@@ -365,7 +365,7 @@ describe("checkStablecoinContractCall", () => {
       args: [USER_SUPPLIED, ethers.MaxUint256.toString()],
     });
 
-    expect(result.kind).toBe("over_cap");
+    expect(result.kind).toBe("denied");
   });
 
   it("leaves an approval under the ceiling alone whoever the spender is", async () => {
@@ -393,7 +393,7 @@ describe("checkStablecoinContractCall", () => {
       args: [RECIPIENT, { toString: () => "1" }],
     });
 
-    expect(result.kind).toBe("invalid");
+    expect(result.kind).toBe("denied");
   });
 
   it("ignores a function that is not an ERC-20 outflow", async () => {
@@ -441,7 +441,7 @@ describe("checkStablecoinContractCall", () => {
       args: [RECIPIENT, units(CAP_USD + BigInt(1), 6)],
     });
 
-    expect(result.kind).toBe("over_cap");
+    expect(result.kind).toBe("denied");
     expect(state.selectCalls).toBe(1);
   });
 
@@ -455,7 +455,7 @@ describe("checkStablecoinContractCall", () => {
       args: [RECIPIENT, units(CAP_USD + BigInt(1), 6)],
     });
 
-    expect(result.kind).toBe("over_cap");
+    expect(result.kind).toBe("denied");
   });
 });
 
@@ -489,7 +489,7 @@ describe("checkStablecoinCalldataBatch", () => {
       calls: Array.from({ length: 10 }, () => transferCall(under)),
     });
 
-    expect(result.kind).toBe("over_cap");
+    expect(result.kind).toBe("denied");
   });
 
   it("admits a batch whose total stays within the ceiling", async () => {
@@ -526,7 +526,7 @@ describe("checkStablecoinCalldataBatch", () => {
       ],
     });
 
-    expect(result.kind).toBe("over_cap");
+    expect(result.kind).toBe("denied");
   });
 
   it("ignores calls that are not recognised stablecoin outflows", async () => {
@@ -561,7 +561,7 @@ describe("checkStablecoinCalldataBatch", () => {
       ],
     });
 
-    expect(result.kind).toBe("over_cap");
+    expect(result.kind).toBe("denied");
   });
 });
 
@@ -586,7 +586,7 @@ describe("checkStablecoinCalldata", () => {
       ]),
     });
 
-    expect(result.kind).toBe("over_cap");
+    expect(result.kind).toBe("denied");
   });
 
   it("allows an under-cap transfer from raw calldata", async () => {
@@ -617,7 +617,7 @@ describe("checkStablecoinCalldata", () => {
         MEMO,
       ]),
     });
-    expect(over.kind).toBe("over_cap");
+    expect(over.kind).toBe("denied");
 
     const under = await checkStablecoinCalldata({
       ...calldataParams,

--- a/tests/unit/tempo-tx-core.test.ts
+++ b/tests/unit/tempo-tx-core.test.ts
@@ -1,8 +1,25 @@
 import { decodeFunctionData } from "viem";
 import { Abis } from "viem/tempo";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
+
+// supported_tokens rows the stablecoin ceiling reads, set per test.
+const registry = vi.hoisted(() => ({
+  tokenRows: [] as Array<{
+    tokenAddress: string;
+    decimals: number;
+    symbol: string;
+    isStablecoin: boolean;
+  }>,
+}));
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({ where: () => Promise.resolve(registry.tokenRows) }),
+    }),
+  },
+}));
 
 // tempo-tx-core pulls the Turnkey / signer / wallet / RPC modules at import
 // time; stub them so the pure helpers can be exercised without infra.
@@ -22,8 +39,11 @@ vi.mock("@/lib/rpc/provider-factory", () => ({
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: { TRANSACTION: "transaction" },
   logSystemError: vi.fn(),
+  logSecurityEvent: vi.fn(),
 }));
 
+import { resolveSignerMode } from "@/lib/safe/signer-resolver";
+import { getOrganizationWallet } from "@/lib/web3/wallet-helpers";
 import {
   applyTempoMemoGasFloor,
   buildSwapExactAmountInCall,
@@ -31,6 +51,7 @@ import {
   deriveTempoNonceKey,
   isTempoChain,
   normalizeMemo,
+  signTempoTx,
   TEMPO_MEMO_MIN_GAS,
 } from "@/plugins/tempo/steps/tempo-tx-core";
 
@@ -155,5 +176,69 @@ describe("applyTempoMemoGasFloor", () => {
       BigInt(990_000)
     );
     expect(applyTempoMemoGasFloor(swapCall, UNDERESTIMATE)).toBe(UNDERESTIMATE);
+  });
+});
+
+describe("signTempoTx stablecoin ceiling", () => {
+  beforeEach(() => {
+    vi.mocked(resolveSignerMode).mockResolvedValue({
+      kind: "eoa",
+    } as Awaited<ReturnType<typeof resolveSignerMode>>);
+    registry.tokenRows = [
+      {
+        tokenAddress: USDC,
+        decimals: 6,
+        symbol: "USDC",
+        isStablecoin: true,
+      },
+    ];
+  });
+
+  it("refuses an over-cap TIP-20 transfer before signing", async () => {
+    // Tempo has no native gas token at all, so the daily value cap never sees a
+    // Tempo send; every Tempo write is signed through here.
+    await expect(
+      signTempoTx({
+        organizationId: "org-1",
+        userId: "user-1",
+        chainId: 4217,
+        feeToken: USDC,
+        calls: [
+          buildTransferWithMemoCall(
+            USDC,
+            RECIPIENT,
+            BigInt(5000) * BigInt(10) ** BigInt(6),
+            normalizeMemo("invoice-1")
+          ),
+        ],
+      })
+    ).rejects.toThrow(/per-transaction limit/);
+
+    expect(getOrganizationWallet).not.toHaveBeenCalled();
+  });
+
+  it("checks every call in a batch, not just the first", async () => {
+    await expect(
+      signTempoTx({
+        organizationId: "org-1",
+        userId: "user-1",
+        chainId: 4217,
+        feeToken: USDC,
+        calls: [
+          buildTransferWithMemoCall(
+            USDC,
+            RECIPIENT,
+            BigInt(1) * BigInt(10) ** BigInt(6),
+            normalizeMemo("small")
+          ),
+          buildTransferWithMemoCall(
+            USDC,
+            RECIPIENT,
+            BigInt(9000) * BigInt(10) ** BigInt(6),
+            normalizeMemo("large")
+          ),
+        ],
+      })
+    ).rejects.toThrow(/per-transaction limit/);
   });
 });

--- a/tests/unit/transfer-token-core.test.ts
+++ b/tests/unit/transfer-token-core.test.ts
@@ -2,6 +2,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
+// supported_tokens rows the stablecoin ceiling reads, set per test.
+const registry = vi.hoisted(() => ({
+  tokenRows: [] as Array<{
+    tokenAddress: string;
+    decimals: number;
+    symbol: string;
+    isStablecoin: boolean;
+  }>,
+}));
+
 vi.mock("@/lib/workflow/executor/step-handler", async () =>
   (await import("../mocks/step-mocks")).stepHandlerPassthrough()
 );
@@ -12,15 +22,19 @@ vi.mock("@/lib/logging", () => ({
     TRANSACTION: "transaction",
   },
   logUserError: vi.fn(),
+  logSecurityEvent: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({
   db: {
     select: () => ({
       from: () => ({
-        where: () => ({
-          limit: () => Promise.resolve([]),
-        }),
+        // The stablecoin ceiling awaits where() directly (it reads the chain's
+        // whole token list); other lookups end in limit().
+        where: () =>
+          Object.assign(Promise.resolve(registry.tokenRows), {
+            limit: () => Promise.resolve([]),
+          }),
       }),
     }),
     query: {
@@ -39,6 +53,9 @@ vi.mock("@/lib/db/schema", () => ({
     id: "id",
     chainId: "chainId",
     tokenAddress: "tokenAddress",
+    decimals: "decimals",
+    symbol: "symbol",
+    isStablecoin: "isStablecoin",
   },
 }));
 
@@ -235,7 +252,46 @@ function setupMocks(): void {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  registry.tokenRows = [];
   setupMocks();
+});
+
+describe("transfer-token-core - stablecoin ceiling", () => {
+  it("refuses an over-cap stablecoin transfer before touching the chain", async () => {
+    // A token transfer carries no native value, so the daily value cap reserves
+    // 0 for it and cannot see this at all.
+    registry.tokenRows = [
+      {
+        tokenAddress: VALID_TOKEN.toLowerCase(),
+        decimals: 18,
+        symbol: "USDC",
+        isStablecoin: true,
+      },
+    ];
+
+    const result = await transferTokenCore(makeInput({ amount: "5000" }));
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("per-transaction limit");
+    }
+    expect(mockExecuteContractCall).not.toHaveBeenCalled();
+  });
+
+  it("allows an under-cap stablecoin transfer", async () => {
+    registry.tokenRows = [
+      {
+        tokenAddress: VALID_TOKEN.toLowerCase(),
+        decimals: 18,
+        symbol: "USDC",
+        isStablecoin: true,
+      },
+    ];
+
+    const result = await transferTokenCore(makeInput({ amount: "10" }));
+
+    expect(result.success).toBe(true);
+  });
 });
 
 describe("transfer-token-core - executedCall on direct send", () => {

--- a/tests/unit/write-contract-core.test.ts
+++ b/tests/unit/write-contract-core.test.ts
@@ -4,6 +4,16 @@ const DIRECT_ID_PREFIX_REGEX = /^direct-/;
 
 vi.mock("server-only", () => ({}));
 
+// supported_tokens rows the stablecoin ceiling reads, set per test.
+const registry = vi.hoisted(() => ({
+  tokenRows: [] as Array<{
+    tokenAddress: string;
+    decimals: number;
+    symbol: string;
+    isStablecoin: boolean;
+  }>,
+}));
+
 vi.mock("@/lib/workflow/executor/step-handler", async () =>
   (await import("../mocks/step-mocks")).stepHandlerPassthrough()
 );
@@ -21,15 +31,19 @@ vi.mock("@/lib/logging", () => ({
   },
   logUserError: vi.fn(),
   logSystemWarn: vi.fn(),
+  logSecurityEvent: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({
   db: {
     select: () => ({
       from: () => ({
-        where: () => ({
-          limit: () => Promise.resolve([]),
-        }),
+        // The stablecoin ceiling awaits where() directly (it reads the chain's
+        // whole token list); other lookups end in limit().
+        where: () =>
+          Object.assign(Promise.resolve(registry.tokenRows), {
+            limit: () => Promise.resolve([]),
+          }),
       }),
     }),
   },
@@ -37,6 +51,13 @@ vi.mock("@/lib/db", () => ({
 
 vi.mock("@/lib/db/schema", () => ({
   workflowExecutions: { id: "id", userId: "userId", workflowId: "workflowId" },
+  supportedTokens: {
+    chainId: "chainId",
+    tokenAddress: "tokenAddress",
+    decimals: "decimals",
+    symbol: "symbol",
+    isStablecoin: "isStablecoin",
+  },
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -85,6 +106,7 @@ vi.mock("@/lib/explorer", () => ({
 
 vi.mock("@/lib/abi/struct-args", () => ({
   reshapeArgsForAbi: vi.fn().mockImplementation((args: unknown[]) => args),
+  coerceArgsForAbi: vi.fn().mockImplementation((args: unknown[]) => args),
 }));
 
 vi.mock("@/lib/abi/function-key", () => ({
@@ -218,10 +240,81 @@ const MOCK_EXECUTED_CALL = {
   reverted: false,
 };
 
+const USDC_CONTRACT = "0x1234567890123456789012345678901234567890";
+
+describe("writeContractCore stablecoin ceiling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedTxContext = null;
+    registry.tokenRows = [];
+  });
+
+  it("refuses an over-cap USDC transfer routed through a raw contract call", async () => {
+    // The contract-call, protocol-action, check-and-execute and node APIs all
+    // reach this core with a caller-supplied address, ABI and args, and they
+    // reserve only native value -- which an ERC-20 transfer does not carry. A
+    // ceiling on the transfer route alone would just have said which door to
+    // use.
+    registry.tokenRows = [
+      {
+        tokenAddress: USDC_CONTRACT,
+        decimals: 6,
+        symbol: "USDC",
+        isStablecoin: true,
+      },
+    ];
+
+    const result = await writeContractCore({
+      contractAddress: USDC_CONTRACT,
+      network: "ethereum",
+      abi: VALID_ABI,
+      abiFunction: "transfer",
+      functionArgs: JSON.stringify([
+        "0x1111111111111111111111111111111111111111",
+        "10000000000",
+      ]),
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("per-transaction limit");
+    }
+    // Refused before the wallet is even resolved, so nothing is signed.
+    expect(initializeWalletSigner).not.toHaveBeenCalled();
+  });
+
+  it("allows an under-cap USDC transfer through the same path", async () => {
+    registry.tokenRows = [
+      {
+        tokenAddress: USDC_CONTRACT,
+        decimals: 6,
+        symbol: "USDC",
+        isStablecoin: true,
+      },
+    ];
+
+    const result = await writeContractCore({
+      contractAddress: USDC_CONTRACT,
+      network: "ethereum",
+      abi: VALID_ABI,
+      abiFunction: "transfer",
+      functionArgs: JSON.stringify([
+        "0x1111111111111111111111111111111111111111",
+        "1000000",
+      ]),
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
 describe("writeContractCore executedCall on direct send", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedTxContext = null;
+    registry.tokenRows = [];
     mockTraceExecutedCall.mockResolvedValue(undefined);
   });
 


### PR DESCRIPTION
## What this changes

The daily organization value cap counts **native** value only. An ERC-20 call carries a `value` of 0, so a token move reserves nothing against it and a leaked API key could move an unbounded amount of USDC while the cap read zero. Tempo is worse: it has no native gas token at all, so none of its writes ever register against a native cap.

This adds a per-transaction ceiling on recognised stablecoins, applying the 1:1 peg to each token's recorded decimals so no price oracle is involved.

The check sits in the step cores rather than the routes, which is the choke point the contract-call, protocol-action, node, workflow and Tempo entrances all share. Adding it at the route layer would have left the other four uncovered.

## Relationship to the spend-cap PR

Split out of #2031. That change closes a fail-open on an **existing** control: an absent `organization_spend_caps` row meant unlimited, and now resolves to a platform default. This change adds a **new** control over a value class the cap never covered at all.

They were one branch and raised different questions — the native fix is bounded and settled, this one is not — so the settled half was waiting on the unsettled one.

**Stacked on `fix/spend-cap-fail-open`.** Both touch `lib/execute/spend-cap-defaults.ts`, so this branch is based on that one and its diff will shrink to just this change once #2031 merges.

## Default

| Control | Value | Override |
|---|---|---|
| Per-transaction stablecoin | 100 USD | `EXECUTE_DEFAULT_STABLECOIN_CAP_MICRO_USD` |

Chosen against the 200 USD/day figure `lib/agentic-wallet/daily-spend.ts` already applies to agent-signed spend, set at half rather than equal because this ceiling is per transaction with nothing aggregating it.

The override is now set explicitly for the app and the executor in both `deploy/keeperhub-stack/prod/values.yaml` and the staging equivalent, at the same value as the compiled-in default, so it changes nothing on deploy and exists to be changed. Note it is `type: kv`, so a new figure ships with a helm upgrade rather than instantly; `parameterStore` plus a pod restart is what a live knob would need.

## Verification

- `pnpm check` clean, `pnpm type-check` clean
- 116 tests across 6 suites: the ceiling's own suite plus the four call sites and the direct-execution integration path
- The ABI-canonicalisation fix carries its own negative control: reverting it fails the `uint` case alone

## Blast radius

- A stablecoin outflow above 100 USD is refused on **every EVM write path**: `/api/execute/transfer`, contract-call, protocol actions, check-and-execute, node execution, the web3 workflow steps and Tempo TIP-20 sends.
- **The refusal is not a 403.** It surfaces from the core as a normal pre-broadcast failure — `202` with `status: "failed"` and an error string, the same shape as an invalid token address. Callers that special-case 403 for cap denials will not match it. A simulate request reports the same refusal as a failed simulation.
- Nothing is signed or broadcast when the ceiling refuses.

## Open decisions

1. ~~`approve` is deliberately not capped.~~ **Resolved.** An over-cap approval is now refused unless the spender is a contract a registered protocol already declares, which is the allowlist shape suggested in review. Max-uint approve before a swap keeps working for every protocol integration; an unbounded grant to an address nothing accounts for does not. Contracts declared `userSpecifiedAddress` are excluded, since their address comes from the caller.
2. **Solana SPL transfers are not covered.** `loadStablecoin` matches hex addresses only, so an SPL mint never resolves, and the Solana daily cap counts native lamports alone.
3. **Per transaction, not per day.** A daily aggregate needs a third unit column on the value ledger (micro-USD alongside wei and lamports) and a reserve/settle lifecycle for token moves. As shipped, the per-key rate limit is what bounds the daily total.
4. **`supported_tokens.is_stablecoin` is `notNull().default(true)`.** A chain with no seeded rows is silently uncapped, and a non-stable token inserted later without an explicit `false` would be priced 1:1 against USD.
5. ~~`StablecoinCapDecision` splits `invalid` from `over_cap`.~~ **Resolved.** Collapsed to `allowed | denied`; nothing mapped a decision to a status code, so the split described behaviour that did not exist. Reintroducing it needs the route-level mapping first.
6. ~~Simulate skips the check.~~ **Resolved.** `simulateTokenTransfer` applies the ceiling and reports it as a failed simulation, before any RPC work.


