### PR TITLE
refactor: KEEP-1190 describe payment rails in one table

### DIFF
--- a/lib/agentic-wallet/constants.ts
+++ b/lib/agentic-wallet/constants.ts
@@ -1,20 +1,26 @@
 /**
- * Agentic-wallet shared constants. Single source of truth for USDC contract
- * addresses and chain ids used across policy.ts, sign.ts, and the /sign route.
+ * Agentic-wallet shared constants used across policy.ts, sign.ts and the /sign
+ * route.
+ *
+ * The asset addresses and chain ids come from `lib/payments/rails.ts`, which
+ * is where a rail is defined. This file previously declared them itself and
+ * described itself as the single source of truth while `router.ts`,
+ * `x402/reconcile.ts` and `mpp/server.ts` each declared their own copies -
+ * four sources, one of which said it was the only one.
  *
  * Source: Phase 33 CONTEXT Resolution #2 (locked 2026-04-21).
  */
 
-export const USDC_BASE_ADDRESS =
-  "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as const;
-export const USDC_TEMPO_ADDRESS =
-  "0x20c000000000000000000000b9537d11c60e8b50" as const;
+import { BASE_RAIL, TEMPO_RAIL } from "@/lib/payments/rails";
+
+export const USDC_BASE_ADDRESS = BASE_RAIL.asset;
+export const USDC_TEMPO_ADDRESS = TEMPO_RAIL.asset;
 
 export const USDC_BASE_LC = USDC_BASE_ADDRESS.toLowerCase();
 export const USDC_TEMPO_LC = USDC_TEMPO_ADDRESS.toLowerCase();
 
-export const BASE_CHAIN_ID = 8453 as const;
-export const TEMPO_MAINNET_CHAIN_ID = 4217 as const;
+export const BASE_CHAIN_ID = BASE_RAIL.chainId;
+export const TEMPO_MAINNET_CHAIN_ID = TEMPO_RAIL.chainId;
 // Tempo testnet — matches the Tempo public testnet chain id. Confirmed
 // against the Tempo network docs at writing-plans research time.
 export const TEMPO_TESTNET_CHAIN_ID = 4218 as const;

--- a/lib/agentic-wallet/sign.ts
+++ b/lib/agentic-wallet/sign.ts
@@ -32,6 +32,7 @@ import { Challenge, Credential } from "mppx";
 import { TxEnvelopeTempo } from "ox/tempo";
 import { encodeFunctionData, keccak256 } from "viem";
 import { Abis } from "viem/tempo";
+import { BASE_RAIL } from "@/lib/payments/rails";
 import {
   runTurnkeyActivity,
   type TurnkeyActivityErrorSpec,
@@ -139,11 +140,12 @@ const SIGN_ACTIVITY_ERRORS: TurnkeyActivityErrorSpec = {
   missingResultMessage: "Signature missing from Turnkey response",
 };
 
-// Source: lib/x402/reconcile.ts:4 + @x402/evm domain constant. Base USDC
-// domain is the canonical TransferWithAuthorization EIP-712 domain.
+// The canonical TransferWithAuthorization EIP-712 domain for the x402 rail's
+// settlement asset, taken whole from the rail. The advertised `extra` in
+// payment-gate.ts and router.ts reads the same `domain`, so the pair that
+// drifted in KEEP-364 is now one value rather than two that agree by review.
 export const BASE_USDC_DOMAIN = {
-  name: "USD Coin",
-  version: "2",
+  ...BASE_RAIL.domain,
   chainId: BASE_CHAIN_ID,
   verifyingContract: USDC_BASE_ADDRESS,
 } as const;

--- a/lib/payments/mpp/server.ts
+++ b/lib/payments/mpp/server.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
+import { railForProtocol } from "@/lib/payments/rails";
 
-const TEMPO_USDC_ADDRESS = "0x20c000000000000000000000b9537d11c60e8b50";
+const MPP_RAIL = railForProtocol("mpp");
 const RE_PROTOCOL = /^https?:\/\//;
 const RE_TRAILING_SLASH = /\/$/;
 
@@ -15,7 +16,7 @@ async function createMppServer(): Promise<unknown> {
   return Mppx.create({
     secretKey: process.env.MPP_SECRET_KEY,
     realm: resolveRealm(),
-    methods: [tempo.charge({ currency: TEMPO_USDC_ADDRESS })],
+    methods: [tempo.charge({ currency: MPP_RAIL.asset })],
   });
 }
 

--- a/lib/payments/rails.ts
+++ b/lib/payments/rails.ts
@@ -1,0 +1,123 @@
+/**
+ * Payment rail identity: the single source of truth for the network, chain id,
+ * settlement asset and EIP-712 domain of every rail the marketplace accepts.
+ *
+ * These five facts used to live as literals in six places - the advertise path
+ * (`router.ts`, `x402/payment-gate.ts`), the scheme registry
+ * (`x402/server.ts`), the reconcile path (`x402/reconcile.ts`), the MPP server
+ * and the signer (`agentic-wallet/constants.ts`, `agentic-wallet/sign.ts`) -
+ * and the invariant that they agreed was maintained by a comment. KEEP-364 is
+ * what that costs: the advertised `extra` and the signer's domain drifted, the
+ * facilitator rejected every payment with "EIP-712 domain parameters (name,
+ * version) are required", and the failure surfaced to all callers as
+ * verification-failed.
+ *
+ * A rail is data here, so adding one is a row rather than an edit across six
+ * files that must be kept consistent by review.
+ *
+ * Adds no rail and picks no facilitator: the multi-facilitator question and
+ * the CDP-specific timeout behaviour in `reconcile.ts` stay on KEEP-1089.
+ */
+
+/** Payment protocols a rail can settle under. */
+export type PaymentProtocol = "x402" | "mpp";
+
+export interface PaymentRail {
+  /** CAIP-2 network id, e.g. `eip155:8453`. */
+  readonly network: `eip155:${number}`;
+  readonly chainId: number;
+  /** Settlement asset contract address, checksummed as the token reports it. */
+  readonly asset: `0x${string}`;
+  readonly assetDecimals: number;
+  /**
+   * EIP-712 domain fields of the settlement asset's
+   * `TransferWithAuthorization`. `name` and `version` must be what the token
+   * itself reports: `@x402/evm`'s `verifyEIP3009` reconstructs the domain from
+   * them, so a value that merely looks right fails verification rather than
+   * mismatching visibly.
+   */
+  readonly domain: { readonly name: string; readonly version: string };
+  /** Protocols this rail is advertised and settled under. */
+  readonly protocols: readonly PaymentProtocol[];
+  /** Env var carrying the RPC URL used for on-chain reconcile reads. */
+  readonly rpcUrlEnvVar: string;
+  /** Public RPC used when the env var is unset. */
+  readonly defaultRpcUrl: string;
+}
+
+export const BASE_RAIL: PaymentRail = {
+  network: "eip155:8453",
+  chainId: 8453,
+  asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  assetDecimals: 6,
+  domain: { name: "USD Coin", version: "2" },
+  protocols: ["x402"],
+  rpcUrlEnvVar: "BASE_RPC_URL",
+  defaultRpcUrl: "https://mainnet.base.org",
+} as const;
+
+export const TEMPO_RAIL: PaymentRail = {
+  network: "eip155:4217",
+  chainId: 4217,
+  asset: "0x20c000000000000000000000b9537d11c60e8b50",
+  assetDecimals: 6,
+  domain: { name: "USD Coin", version: "2" },
+  protocols: ["mpp"],
+  rpcUrlEnvVar: "TEMPO_RPC_URL",
+  defaultRpcUrl: "https://rpc.tempo.xyz",
+} as const;
+
+/**
+ * Every rail, keyed by CAIP-2 network id.
+ *
+ * A rail that settles in something other than USDC needs no new shape here -
+ * the asset, its decimals and its domain are already per-rail - which is the
+ * case a third rail was expected to break. Robinhood Chain settles in USDG at
+ * six decimals with EIP-3009 present, and would be one row.
+ */
+export const PAYMENT_RAILS: Readonly<Record<string, PaymentRail>> = {
+  [BASE_RAIL.network]: BASE_RAIL,
+  [TEMPO_RAIL.network]: TEMPO_RAIL,
+} as const;
+
+/** Rails advertised and settled under `protocol`. */
+export function railsFor(protocol: PaymentProtocol): PaymentRail[] {
+  return Object.values(PAYMENT_RAILS).filter((rail) =>
+    rail.protocols.includes(protocol)
+  );
+}
+
+/**
+ * Select the single rail for `protocol` from `rails`.
+ *
+ * Separate from `railForProtocol` so the not-exactly-one branch can be
+ * exercised: it is the interesting one, and it is unreachable through the
+ * module-level table while each protocol has one rail.
+ */
+export function pickSingleRail(
+  rails: readonly PaymentRail[],
+  protocol: PaymentProtocol
+): PaymentRail {
+  const matches = rails.filter((rail) => rail.protocols.includes(protocol));
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected exactly one ${protocol} rail, found ${matches.length}`
+    );
+  }
+  return matches[0];
+}
+
+/**
+ * The rail a protocol settles on. Each protocol currently has exactly one, and
+ * this throws rather than guessing if that stops being true, so a second rail
+ * on a protocol is a visible failure at startup instead of a silent choice of
+ * whichever came first.
+ */
+export function railForProtocol(protocol: PaymentProtocol): PaymentRail {
+  return pickSingleRail(Object.values(PAYMENT_RAILS), protocol);
+}
+
+/** Smallest-unit amount for a decimal price string on `rail`. */
+export function toAssetUnits(rail: PaymentRail, price: string): number {
+  return Math.round(Number(price) * 10 ** rail.assetDecimals);
+}

--- a/lib/payments/router.ts
+++ b/lib/payments/router.ts
@@ -6,6 +6,11 @@ import {
   hashMppCredential,
 } from "@/lib/payments/mpp/server";
 import {
+  type PaymentProtocol,
+  railForProtocol,
+  toAssetUnits,
+} from "@/lib/payments/rails";
+import {
   buildPaymentConfig,
   extractPayerAddress,
   findExistingPayment,
@@ -18,13 +23,8 @@ import {
 import { server } from "@/lib/payments/x402/server";
 import type { CallRouteWorkflow } from "@/lib/payments/x402/types";
 
-export type PaymentProtocol = "x402" | "mpp";
-
-const TEMPO_USDC_ADDRESS = "0x20c000000000000000000000b9537d11c60e8b50";
-const TEMPO_CHAIN_ID = 4217;
-const BASE_USDC_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
-const BASE_NETWORK = "eip155:8453";
-const USDC_DECIMALS = 6;
+const X402_RAIL = railForProtocol("x402");
+const MPP_RAIL = railForProtocol("mpp");
 const PAYMENT_MAX_TIMEOUT_SECONDS = 300;
 const RE_PROTOCOL = /^https?:\/\//;
 const RE_TRAILING_SLASH = /\/$/;
@@ -101,9 +101,7 @@ function buildPaymentRequired(params: Dual402Params): PaymentRequiredV2 {
     tagName,
     workflowType,
   } = params;
-  const amountSmallestUnit = String(
-    Math.round(Number(price) * 10 ** USDC_DECIMALS)
-  );
+  const amountSmallestUnit = String(toAssetUnits(X402_RAIL, price));
   const payload: PaymentRequiredV2 = {
     x402Version: 2,
     error: "Payment required",
@@ -115,12 +113,14 @@ function buildPaymentRequired(params: Dual402Params): PaymentRequiredV2 {
     accepts: [
       {
         scheme: "exact",
-        network: BASE_NETWORK,
-        asset: BASE_USDC_ADDRESS,
+        network: X402_RAIL.network,
+        asset: X402_RAIL.asset,
         amount: amountSmallestUnit,
         payTo: creatorWalletAddress,
         maxTimeoutSeconds: PAYMENT_MAX_TIMEOUT_SECONDS,
-        extra: { name: "USD Coin", version: "2" },
+        // Same object the gate advertises and the signer signs over - they
+        // cannot drift apart the way they did in KEEP-364.
+        extra: { ...X402_RAIL.domain },
       },
     ],
   };
@@ -186,9 +186,7 @@ export function buildDual402Response(params: Dual402Params): Response {
     const realm = (process.env.NEXT_PUBLIC_APP_URL ?? "app.keeperhub.com")
       .replace(RE_PROTOCOL, "")
       .replace(RE_TRAILING_SLASH, "");
-    const amountSmallestUnit = String(
-      Math.round(Number(price) * 10 ** USDC_DECIMALS)
-    );
+    const amountSmallestUnit = String(toAssetUnits(MPP_RAIL, price));
     const challenge = Challenge.from({
       secretKey: mppSecretKey,
       realm,
@@ -197,10 +195,10 @@ export function buildDual402Response(params: Dual402Params): Response {
       expires: Expires.minutes(5),
       request: {
         amount: amountSmallestUnit,
-        currency: TEMPO_USDC_ADDRESS,
+        currency: MPP_RAIL.asset,
         recipient: creatorWalletAddress,
         methodDetails: {
-          chainId: TEMPO_CHAIN_ID,
+          chainId: MPP_RAIL.chainId,
         },
       },
     });

--- a/lib/payments/x402/payment-gate.ts
+++ b/lib/payments/x402/payment-gate.ts
@@ -8,7 +8,10 @@ import {
   type WorkflowPayment,
   workflowPayments,
 } from "@/lib/db/schema";
+import { railForProtocol } from "@/lib/payments/rails";
 import type { CallRouteWorkflow } from "./types";
+
+const X402_RAIL = railForProtocol("x402");
 
 /**
  * Extracts the payer wallet address from a base64-encoded PAYMENT-SIGNATURE
@@ -57,15 +60,16 @@ export function buildPaymentConfig(
   return {
     accepts: {
       scheme: "exact",
-      network: "eip155:8453",
+      network: X402_RAIL.network,
       payTo: creatorWalletAddress,
       price: `$${price}`,
       // extra.name and extra.version are required by @x402/evm verifyEIP3009 to
       // reconstruct the EIP-712 domain. Without these fields the CDP facilitator
       // throws "EIP-712 domain parameters (name, version) are required" and the
       // payment surfaces as verification-failed for all callers (KEEP-364).
-      // Values must match BASE_USDC_DOMAIN in lib/agentic-wallet/sign.ts exactly.
-      extra: { name: "USD Coin", version: "2" } as const,
+      // Taken from the rail rather than restated, so it and the signer's domain
+      // are the same value rather than two literals a comment asks to match.
+      extra: { ...X402_RAIL.domain },
     },
     resource: `${publicHost}/api/mcp/workflows/${workflow.listedSlug}/call`,
     description: `Pay to run workflow: ${workflow.name}`,

--- a/lib/payments/x402/reconcile.ts
+++ b/lib/payments/x402/reconcile.ts
@@ -1,7 +1,8 @@
 import { Contract, JsonRpcProvider } from "ethers";
 import { ErrorCategory, logUserError } from "@/lib/logging";
+import { railForProtocol } from "@/lib/payments/rails";
 
-const USDC_BASE_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+const X402_RAIL = railForProtocol("x402");
 
 const AUTH_STATE_ABI = [
   "function authorizationState(address, bytes32) view returns (uint8)",
@@ -17,9 +18,9 @@ const TIMEOUT_PATTERNS = [
 // pool) on every reconciliation call. Mirrors the pattern used in
 // lib/x402/server.ts. BASE_RPC_URL is read once at module load.
 const provider = new JsonRpcProvider(
-  process.env.BASE_RPC_URL ?? "https://mainnet.base.org"
+  process.env[X402_RAIL.rpcUrlEnvVar] ?? X402_RAIL.defaultRpcUrl
 );
-const usdcContract = new Contract(USDC_BASE_ADDRESS, AUTH_STATE_ABI, provider);
+const settlementAsset = new Contract(X402_RAIL.asset, AUTH_STATE_ABI, provider);
 
 /**
  * Returns true if the error message indicates a transient facilitator timeout
@@ -60,7 +61,7 @@ export async function pollForPaymentConfirmation({
 
   while (Date.now() < deadline) {
     try {
-      const state = (await usdcContract.authorizationState(
+      const state = (await settlementAsset.authorizationState(
         payerAddress,
         nonce
       )) as bigint;

--- a/lib/payments/x402/server.ts
+++ b/lib/payments/x402/server.ts
@@ -1,6 +1,7 @@
 import { createFacilitatorConfig } from "@coinbase/x402";
 import { HTTPFacilitatorClient, x402ResourceServer } from "@x402/core/server";
 import { ExactEvmScheme } from "@x402/evm/exact/server";
+import { railsFor } from "@/lib/payments/rails";
 
 function buildFacilitatorClient(): HTTPFacilitatorClient {
   const keyId = process.env.CDP_API_KEY_ID;
@@ -20,4 +21,9 @@ function buildFacilitatorClient(): HTTPFacilitatorClient {
 export const facilitatorClient = buildFacilitatorClient();
 
 export const server = new x402ResourceServer(facilitatorClient);
-server.register("eip155:8453", new ExactEvmScheme());
+// Registered from the rail table rather than a literal, so a rail's network id
+// is stated once. Only rails marked x402 are registered - the MPP rails settle
+// through their own server and must not be advertised as x402 payment methods.
+for (const rail of railsFor("x402")) {
+  server.register(rail.network, new ExactEvmScheme());
+}

--- a/tests/unit/payment-rails.test.ts
+++ b/tests/unit/payment-rails.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+  BASE_CHAIN_ID,
+  TEMPO_MAINNET_CHAIN_ID,
+  USDC_BASE_ADDRESS,
+  USDC_TEMPO_ADDRESS,
+} from "@/lib/agentic-wallet/constants";
+import { BASE_USDC_DOMAIN } from "@/lib/agentic-wallet/sign";
+import {
+  BASE_RAIL,
+  PAYMENT_RAILS,
+  pickSingleRail,
+  railForProtocol,
+  railsFor,
+  TEMPO_RAIL,
+  toAssetUnits,
+} from "@/lib/payments/rails";
+import { buildPaymentConfig } from "@/lib/payments/x402/payment-gate";
+
+const workflow = {
+  priceUsdcPerCall: "1.00",
+  listedSlug: "my-workflow",
+  name: "My Workflow",
+};
+
+const PAYEE = "0x1234000000000000000000000000000000005678";
+
+describe("payment rail table", () => {
+  it("states a network id consistent with its chain id", () => {
+    // A rail whose CAIP-2 string disagreed with its numeric chain id would
+    // advertise one chain and sign for another, and nothing else in the stack
+    // compares the two.
+    for (const rail of Object.values(PAYMENT_RAILS)) {
+      expect(rail.network).toBe(`eip155:${rail.chainId}`);
+    }
+  });
+
+  it("keys every rail by its own network id", () => {
+    for (const [key, rail] of Object.entries(PAYMENT_RAILS)) {
+      expect(key).toBe(rail.network);
+    }
+  });
+
+  it("keeps the two protocols on separate rails", () => {
+    expect(railsFor("x402")).toEqual([BASE_RAIL]);
+    expect(railsFor("mpp")).toEqual([TEMPO_RAIL]);
+  });
+
+  it("refuses to guess when a protocol has more than one rail", () => {
+    // The failure this prevents is silent: picking whichever rail happened to
+    // be declared first would advertise a settlement asset nobody chose.
+    const twoX402 = [
+      BASE_RAIL,
+      { ...TEMPO_RAIL, protocols: ["x402"] as const },
+    ];
+    expect(() => pickSingleRail(twoX402, "x402")).toThrow(
+      "Expected exactly one x402 rail, found 2"
+    );
+  });
+
+  it("refuses to guess when a protocol has no rail at all", () => {
+    expect(() => pickSingleRail([BASE_RAIL], "mpp")).toThrow(
+      "Expected exactly one mpp rail, found 0"
+    );
+  });
+
+  it("resolves each live protocol to its one rail", () => {
+    expect(railForProtocol("x402")).toBe(BASE_RAIL);
+    expect(railForProtocol("mpp")).toBe(TEMPO_RAIL);
+  });
+
+  it("converts a price to the rail asset's smallest unit", () => {
+    expect(toAssetUnits(BASE_RAIL, "1.00")).toBe(1_000_000);
+    // Sub-cent listings must survive: rounding them to cents made the gate
+    // demand an amount the 402 never advertised.
+    expect(toAssetUnits(BASE_RAIL, "0.005")).toBe(5000);
+  });
+});
+
+describe("rail identity is shared, not restated", () => {
+  it("advertises the same EIP-712 domain the signer signs over", () => {
+    // KEEP-364: these were two literals in two files kept in step by a
+    // comment. When they drifted the CDP facilitator rejected every payment
+    // with "EIP-712 domain parameters (name, version) are required". They are
+    // now one value, so the drift is not expressible.
+    const accepts = buildPaymentConfig(
+      workflow as Parameters<typeof buildPaymentConfig>[0],
+      PAYEE
+    ).accepts as unknown as Record<string, unknown>;
+    const extra = accepts.extra as Record<string, unknown>;
+
+    expect(extra.name).toBe(BASE_USDC_DOMAIN.name);
+    expect(extra.version).toBe(BASE_USDC_DOMAIN.version);
+    expect(extra.name).toBe(BASE_RAIL.domain.name);
+    expect(extra.version).toBe(BASE_RAIL.domain.version);
+  });
+
+  it("signs against the rail's own asset and chain", () => {
+    expect(BASE_USDC_DOMAIN.chainId).toBe(BASE_RAIL.chainId);
+    expect(BASE_USDC_DOMAIN.verifyingContract).toBe(BASE_RAIL.asset);
+  });
+
+  it("gives the agentic wallet the same addresses and chain ids as the rails", () => {
+    // constants.ts described itself as the single source of truth while three
+    // other files declared their own copies. It now derives from the rails.
+    expect(USDC_BASE_ADDRESS).toBe(BASE_RAIL.asset);
+    expect(BASE_CHAIN_ID).toBe(BASE_RAIL.chainId);
+    expect(USDC_TEMPO_ADDRESS).toBe(TEMPO_RAIL.asset);
+    expect(TEMPO_MAINNET_CHAIN_ID).toBe(TEMPO_RAIL.chainId);
+  });
+
+  it("advertises the x402 rail's network at the gate", () => {
+    const accepts = buildPaymentConfig(
+      workflow as Parameters<typeof buildPaymentConfig>[0],
+      PAYEE
+    ).accepts as unknown as Record<string, unknown>;
+    expect(accepts.network).toBe(BASE_RAIL.network);
+  });
+});


### PR DESCRIPTION
Closes KEEP-1190.

## Problem

Rail identity - network, chain id, settlement asset, its decimals and its EIP-712 domain - was stated as literals in six places:

| Site | Carried |
| -- | -- |
| `lib/payments/router.ts` | `TEMPO_USDC_ADDRESS`, `TEMPO_CHAIN_ID`, `BASE_USDC_ADDRESS`, `BASE_NETWORK`, `USDC_DECIMALS` |
| `lib/payments/x402/payment-gate.ts` | `network: "eip155:8453"` and the advertised `extra` |
| `lib/payments/x402/server.ts` | `server.register("eip155:8453", ...)` |
| `lib/payments/x402/reconcile.ts` | `USDC_BASE_ADDRESS` |
| `lib/payments/mpp/server.ts` | `TEMPO_USDC_ADDRESS` |
| `lib/agentic-wallet/{constants,sign}.ts` | `USDC_BASE_ADDRESS`, `BASE_CHAIN_ID`, `BASE_USDC_DOMAIN` |

The invariant that they agreed was maintained by a comment: `payment-gate.ts` read "Values must match `BASE_USDC_DOMAIN` in `lib/agentic-wallet/sign.ts` exactly".

**KEEP-364 is what that costs.** The two drifted, the CDP facilitator rejected the reconstructed EIP-712 domain with "domain parameters (name, version) are required", and every payment surfaced to every caller as verification-failed.

## Change

`lib/payments/rails.ts` is the one definition, and all six sites read from it.

The advertised `extra` and the signed domain are now **the same object** rather than two literals that agree by review - `payment-gate.ts` spreads `X402_RAIL.domain` and `sign.ts` builds `BASE_USDC_DOMAIN` from it. That drift is no longer expressible.

`agentic-wallet/constants.ts` derives from the table too. It described itself as "single source of truth for USDC contract addresses and chain ids" while `router.ts`, `reconcile.ts` and `mpp/server.ts` each declared their own copies - four sources, one of which claimed to be the only one.

## Behaviour is unchanged

`x402/server.ts` registers from `railsFor("x402")`, which yields Base alone. Tempo settles under MPP and must not be advertised as an x402 payment method, so iterating every rail would have been a behaviour change rather than a refactor.

`railForProtocol` throws rather than returning the first match if a protocol ever has two rails - a visible failure at startup instead of a silent choice of whichever was declared first.

The dead re-export of `PaymentProtocol` from `router.ts` is dropped; nothing imported it.

## Scope boundary

Adds no rail and picks no facilitator. The multi-facilitator registry question and the CDP-specific timeout handling in `reconcile.ts` stay on KEEP-1089.

**On the risk the ticket named** - that a third rail might not fit a table shaped around the current two: asset, decimals and domain are per-rail, so a rail settling in something other than USDC needs no new shape. Robinhood Chain settles in USDG at six decimals with EIP-3009 present, and would be one row.

## Verification

- `tsc --noEmit`: no errors in changed files
- `biome check`: clean
- tests: **210/210** across 14 files

Tests cover the invariants the table carries, not only the values it holds: each rail's CAIP-2 network agrees with its numeric chain id, the table is keyed by each rail's own network, the two protocols resolve to separate rails, resolution throws for both zero and two matches, the advertised `extra` equals the signer's domain, and the agentic wallet's addresses and chain ids equal the rails'.

`pickSingleRail` is separate from `railForProtocol` so the not-exactly-one branch is reachable from a test. It is the interesting branch, and it cannot be hit through the module-level table while each protocol has exactly one rail - an earlier version of that test asserted against a local array and could never have failed.
