### PR TITLE
docs(self-hosted): name the client-address trap on ServiceLB clusters

### DIFF
--- a/deploy/keeperhub-stack/self-hosted/INSTALL.md
+++ b/deploy/keeperhub-stack/self-hosted/INSTALL.md
@@ -79,16 +79,25 @@ helm install ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx --create-namespace
 ```
 
-**On a cluster with no cloud load balancer, run the controller on every
-node.** K3s and clusters like it answer a `LoadBalancer` Service with a small
-proxy on each node. A request can arrive at a node that does not hold the
-ingress controller pod. That node forwards the request to the node that does,
-and the source address becomes an address from the cluster's own pod range.
-Per-IP rate limits and any address rule you keep then work on that address
-instead of the caller's. Nothing else looks wrong, because the install works,
-pages load and workflows run. Run the controller as a DaemonSet, so that every
-node holds a pod. The node that receives a request then also terminates it, and
-the caller's address survives.
+**On a cluster with no cloud load balancer, the caller's address needs two
+settings.** K3s and clusters like it answer a `LoadBalancer` Service with a
+small proxy on each node. A request can arrive at a node that does not hold the
+ingress controller pod. That node forwards the request, and the source address
+becomes an address from the cluster's own pod range. Per-IP rate limits and any
+address rule you keep then work on that address instead of the caller's. Nothing
+else looks wrong, because the install works, pages load and workflows run. Set
+the controller Service to `externalTrafficPolicy: Local`, which stops the
+rewrite. Run the controller as a DaemonSet, so that every node holds a pod. One
+setting without the other is not enough. `Local` alone keeps the address only on
+the node that holds the controller, and a DaemonSet alone does not stop the
+rewrite.
+
+```bash
+helm upgrade ingress-nginx ingress-nginx/ingress-nginx \
+  --namespace ingress-nginx --reuse-values \
+  --set controller.kind=DaemonSet \
+  --set controller.service.externalTrafficPolicy=Local
+```
 
 **c) TLS — pick one.**
 

--- a/deploy/keeperhub-stack/self-hosted/INSTALL.md
+++ b/deploy/keeperhub-stack/self-hosted/INSTALL.md
@@ -79,6 +79,17 @@ helm install ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx --create-namespace
 ```
 
+**On a cluster with no cloud load balancer, run the controller on every
+node.** K3s and clusters like it answer a `LoadBalancer` Service with a small
+proxy on each node. A request can arrive at a node that does not hold the
+ingress controller pod. That node forwards the request to the node that does,
+and the source address becomes an address from the cluster's own pod range.
+Per-IP rate limits and any address rule you keep then work on that address
+instead of the caller's. Nothing else looks wrong, because the install works,
+pages load and workflows run. Run the controller as a DaemonSet, so that every
+node holds a pod. The node that receives a request then also terminates it, and
+the caller's address survives.
+
 **c) TLS — pick one.**
 
 *Let the chart request certificates.* It emits a cert-manager `Certificate`


### PR DESCRIPTION
## What

Adds one paragraph to step 2b of the self-hosted install guide.

On a cluster with no cloud load balancer, a request can arrive at a node that does
not hold the ingress controller pod. That node forwards the request, and the source
address becomes an address from the cluster's own pod range. Per-IP rate limits and
any address rule the operator keeps then work on that address instead of the
caller's.

The failure is quiet. The install works, pages load and workflows run, so an
operator has no reason to suspect the ingress controller.

The paragraph names the trap and gives the remedy, which is to run the controller as
a DaemonSet so that the node which receives a request also terminates it.

## Why here and not in the app

This is a deployment property of the operator's cluster. Nothing in the product can
detect it or work around it.

Two limiters do read the address off Cloudflare and are affected. The invitation
fetch limit keys on `getRequestSourceIp`, which falls back to `X-Real-IP`
(`app/api/invitations/_lib/rate-limit.ts:38-41`, `lib/security/request-attribution.ts:94-105`).
The public MCP limit falls back to `X-Forwarded-For` then `X-Real-IP`
(`lib/mcp/rate-limit.ts:102-116`).

better-auth reads only `CF-Connecting-IP` (`lib/auth.ts:1332`), so `sessions.ip_address`
stays null off Cloudflare no matter how the ingress controller runs. The paragraph
does not claim otherwise.

## Evidence

Measured during the M0 acceptance run. The application saw a pod-range address
before, and the real client address after the ingress controller became a DaemonSet.

## Test

Documentation only, one file. The `Maintainability / selfhosted` render matrix is
the check this path triggers; all 8 mode combinations render locally against helm
v3.18.4 with exit 0.