### PR TITLE
fix: KEEP-1218 read the API server target for the self-hosted egress policy

### DIFF
--- a/.github/workflows/maintainability.yml
+++ b/.github/workflows/maintainability.yml
@@ -396,25 +396,11 @@ jobs:
           done
           exit $failed
 
-      # networkpolicy.yaml is the other file here that is rendered rather than
-      # applied as written, and two of the three values it takes are multi-line
-      # YAML lists. A list expanded in the wrong place - inside a comment, for
-      # one - still reads as a file in a diff and is rejected by the API server.
-      # Render it with synthetic values and parse the result.
+      # The values files above are rendered by helm. networkpolicy.yaml is not:
+      # install.sh substitutes it with envsubst, and two of the values it takes
+      # are multi-line YAML lists. The script renders it the way install.sh
+      # does and checks the result. Its docstring says what goes wrong without
+      # it, and it runs locally with no arguments.
       - name: Render the egress policy
         working-directory: deploy/keeperhub-stack/self-hosted
-        run: |
-          set -euo pipefail
-          RENDERED=$(mktemp)
-          trap 'rm -f "$RENDERED"' EXIT
-          export RENDERED
-          cidrs=$'        - ipBlock:\n            cidr: 10.43.0.1/32\n        - ipBlock:\n            cidr: 10.0.0.5/32'
-          ports=$'        - protocol: TCP\n          port: 443\n        - protocol: TCP\n          port: 6443'
-          NAMESPACE=keeperhub APISERVER_CIDRS="$cidrs" APISERVER_PORTS="$ports" \
-            envsubst '${NAMESPACE} ${APISERVER_CIDRS} ${APISERVER_PORTS}' \
-            <networkpolicy.yaml >"$RENDERED"
-          if grep -nE '\$\{[A-Z_]+\}' "$RENDERED"; then
-            echo "::error::networkpolicy.yaml left an envsubst placeholder"
-            exit 1
-          fi
-          python3 -c 'import os, sys, yaml; docs = [d for d in yaml.safe_load_all(open(os.environ["RENDERED"])) if d]; kinds = {d.get("kind") for d in docs}; sys.exit(f"::error::rendered {kinds}, expected only NetworkPolicy") if kinds != {"NetworkPolicy"} else print(f"ok: {len(docs)} NetworkPolicy documents")'
+        run: ./test-harness/check-policy-render.py

--- a/.github/workflows/maintainability.yml
+++ b/.github/workflows/maintainability.yml
@@ -395,3 +395,26 @@ jobs:
             done
           done
           exit $failed
+
+      # networkpolicy.yaml is the other file here that is rendered rather than
+      # applied as written, and two of the three values it takes are multi-line
+      # YAML lists. A list expanded in the wrong place - inside a comment, for
+      # one - still reads as a file in a diff and is rejected by the API server.
+      # Render it with synthetic values and parse the result.
+      - name: Render the egress policy
+        working-directory: deploy/keeperhub-stack/self-hosted
+        run: |
+          set -euo pipefail
+          RENDERED=$(mktemp)
+          trap 'rm -f "$RENDERED"' EXIT
+          export RENDERED
+          cidrs=$'        - ipBlock:\n            cidr: 10.43.0.1/32\n        - ipBlock:\n            cidr: 10.0.0.5/32'
+          ports=$'        - protocol: TCP\n          port: 443\n        - protocol: TCP\n          port: 6443'
+          NAMESPACE=keeperhub APISERVER_CIDRS="$cidrs" APISERVER_PORTS="$ports" \
+            envsubst '${NAMESPACE} ${APISERVER_CIDRS} ${APISERVER_PORTS}' \
+            <networkpolicy.yaml >"$RENDERED"
+          if grep -nE '\$\{[A-Z_]+\}' "$RENDERED"; then
+            echo "::error::networkpolicy.yaml left an envsubst placeholder"
+            exit 1
+          fi
+          python3 -c 'import os, sys, yaml; docs = [d for d in yaml.safe_load_all(open(os.environ["RENDERED"])) if d]; kinds = {d.get("kind") for d in docs}; sys.exit(f"::error::rendered {kinds}, expected only NetworkPolicy") if kinds != {"NetworkPolicy"} else print(f"ok: {len(docs)} NetworkPolicy documents")'

--- a/deploy/keeperhub-stack/self-hosted/.env.example
+++ b/deploy/keeperhub-stack/self-hosted/.env.example
@@ -233,8 +233,15 @@ GEOIP_ENABLED="false"
 
 # Deny all outbound traffic except what the product needs. Leave false for the
 # first install, confirm it works, then turn it on. It only takes effect if
-# your CNI enforces NetworkPolicy; the installer tells you which case you have.
+# your CNI enforces NetworkPolicy, and the installer says which case you are in.
 EGRESS_POLICY="false"
+
+# Measure the policy instead of reporting what the cluster looks like. Two TCP
+# connects from a pod that is already running: one to the API server, which must
+# still work, and one to an address the policy denies, which must not. It
+# creates nothing and it never fails the install. Worth turning on the first
+# time you enable the policy on a cluster.
+EGRESS_POLICY_VERIFY="false"
 
 # IMAGE_TAG is deliberately absent. It identifies one build rather than one
 # install, so it is passed on the command line:

--- a/deploy/keeperhub-stack/self-hosted/INSTALL.md
+++ b/deploy/keeperhub-stack/self-hosted/INSTALL.md
@@ -305,6 +305,7 @@ These fail quietly, leaving every pod green.
 | Install reaches the migration and fails on `CREATE TABLE` or `CREATE SCHEMA` | the role in the URL does not own the database. See the ownership note in step 2d |
 | Workflows fail only when several run at once | the database ran out of connections. Raise `max_connections` or lower `MAX_CONCURRENT_JOBS` |
 | Scheduled workflows stop firing for no obvious reason | a transaction-mode pooler between the app and the database is swallowing `LISTEN`/`NOTIFY` |
+| Every execution stalls after you turned on `EGRESS_POLICY`, and every pod is green | the policy is blocking the API server, so the executor cannot create a Job. Re-run with `EGRESS_POLICY_VERIFY=true`, which names this case |
 
 ---
 
@@ -313,13 +314,27 @@ These fail quietly, leaving every pod green.
 Once it works, deny all egress except what the product needs:
 
 ```bash
-EGRESS_POLICY=true ENV_FILE=.env IMAGE_TAG=v1 ./install.sh
+EGRESS_POLICY=true EGRESS_POLICY_VERIFY=true ENV_FILE=.env IMAGE_TAG=v1 ./install.sh
 ```
 
 This blocks your private network, your nodes and any cloud metadata service,
-while allowing DNS and the public internet. It only takes effect if your CNI
-enforces NetworkPolicy; several do not, and the installer tells you which case
-you are in.
+while allowing DNS, the API server and the public internet. The API server
+address is read from your cluster, so the rule is right on kubeadm, on minikube
+and on k3s, which put it in three different places.
+
+It only takes effect if your CNI enforces NetworkPolicy, and several do not.
+`EGRESS_POLICY_VERIFY=true` measures that rather than guessing at it: it makes
+two TCP connects from a pod that is already running, one to the API server and
+one to an address the policy denies, and reports which of three things happened.
+
+| It says | What it means |
+| --- | --- |
+| the policy is enforced and the API server is still reachable | done |
+| NOT enforced | the objects exist and nothing is restricted. Your CNI ignores NetworkPolicy |
+| BROKEN | the policy is enforced and it blocks the API server. Executions will stall while every pod stays green. Set `APISERVER_CIDR` and `APISERVER_PORT`, or turn the policy off until you have |
+
+The check creates nothing, deletes nothing and never fails the install. Leave it
+off once a cluster has passed it.
 
 ---
 

--- a/deploy/keeperhub-stack/self-hosted/config.sh
+++ b/deploy/keeperhub-stack/self-hosted/config.sh
@@ -159,10 +159,46 @@ SANDBOX_ENABLED="${SANDBOX_ENABLED:-false}"
 # experience; better to install, confirm the product works, then close it down.
 EGRESS_POLICY="${EGRESS_POLICY:-false}"
 
-# The cluster's API server service address, for the egress policy. Read it with
-#   kubectl get svc kubernetes -n default -o jsonpath='{.spec.clusterIP}'
-# The default is the kubeadm convention that minikube follows.
-APISERVER_CIDR="${APISERVER_CIDR:-10.96.0.1/32}"
+# Prove the egress policy rather than report what the cluster looks like.
+#
+# On, install.sh runs two TCP connects from a pod that is already running in the
+# namespace: one to the API server, which the policy allows and which must
+# succeed, and one to the kubelet port on the API server's own node, which the
+# policy denies and which must NOT. That measures both halves - the policy is
+# enforced, and it did not lock out the one caller that needs the API server.
+#
+# It creates nothing and deletes nothing. It costs one kubectl exec, it never
+# fails the install, and it reports "inconclusive" whenever it cannot run.
+#
+# Off by default only because it reaches into a pod, which an operator should
+# opt into rather than discover. Turn it on the first time you enable the
+# policy on a new cluster shape.
+EGRESS_POLICY_VERIFY="${EGRESS_POLICY_VERIFY:-false}"
+
+# The API server addresses and ports the egress policy allows.
+#
+# Leave both empty. install.sh reads them from the cluster it was pointed at,
+# which is the only way to be right on more than one kind of cluster: the
+# address is 10.96.0.1 on kubeadm and minikube, 10.43.0.1 on k3s, and the port
+# is 443 through the Service but 6443 or 8443 behind it.
+#
+# They are settings at all because a discovery can be wrong for a cluster this
+# profile has not seen. Anything set here replaces what was discovered. Give a
+# space- or comma-separated list; a bare address without a prefix becomes /32,
+# or /128 for IPv6:
+#
+#   APISERVER_CIDR="10.43.0.1 192.168.1.10"
+#   APISERVER_PORT="443 6443"
+#
+# BOTH the Service address and the endpoint behind it are allowed, and that is
+# not belt and braces. A pod addresses the API server by the Service ClusterIP,
+# kube-proxy rewrites the destination to the endpoint, and the CNI evaluates
+# egress policy on whichever of the two it sees. Measured on minikube with
+# calico: with only the ClusterIP allowed, every connection to the API server
+# timed out, because calico sees the rewritten address. Allowing both is the
+# only form that holds whichever address the CNI matches on.
+APISERVER_CIDR="${APISERVER_CIDR:-}"
+APISERVER_PORT="${APISERVER_PORT:-}"
 
 # The hostname the app is served on, and how it is exposed.
 #

--- a/deploy/keeperhub-stack/self-hosted/install.sh
+++ b/deploy/keeperhub-stack/self-hosted/install.sh
@@ -59,9 +59,11 @@ warn()    { echo "    warning: $*" >&2; }
 preflight() {
     section "Preflight"
     require_tools kubectl helm
-    # Only the sandbox manifest is substituted, so envsubst is required only
-    # when it is going to be applied.
-    [ "$SANDBOX_ENABLED" = true ] && require_tools envsubst
+    # Two manifests are substituted, and neither is applied on every install, so
+    # envsubst is required only when one of them is going to be.
+    if [ "$SANDBOX_ENABLED" = true ] || [ "$EGRESS_POLICY" = true ]; then
+        require_tools envsubst
+    fi
     require_context
     validate_modes
 
@@ -500,35 +502,311 @@ apply_sandbox() {
     ok "keeperhub-sandbox on ${IMAGE_REPO}:sandbox-${IMAGE_TAG}"
 }
 
+# Turn one address into a CIDR, leaving one that already carries a prefix alone.
+to_cidr() {
+    case "$1" in
+        */*) printf '%s' "$1" ;;
+        *:*) printf '%s/128' "$1" ;;
+        *)   printf '%s/32' "$1" ;;
+    esac
+}
+
+# Read the API server addresses and ports from the cluster, and render them as
+# the two pre-indented YAML lists networkpolicy.yaml substitutes.
+#
+# Nothing here is a default, because no constant is right on more than one kind
+# of cluster. The Service address is 10.96.0.1 on kubeadm and minikube and
+# 10.43.0.1 on k3s; the port is 443 in front of the Service and 6443 or 8443
+# behind it. A profile that shipped the kubeadm pair applied a policy on k3s
+# that allowed nothing at all.
+#
+# Both the Service and the endpoints behind it are collected. A pod dials the
+# ClusterIP, kube-proxy rewrites the destination to an endpoint, and the CNI
+# matches on whichever of the two it sees. Measured on minikube with calico:
+# allowing only the ClusterIP left every connection to the API server timing
+# out, because calico matches the rewritten address.
+#
+# EndpointSlice rather than Endpoints: the v1 Endpoints API is deprecated from
+# 1.33, and reading it makes kubectl print a deprecation warning per call.
+detect_apiserver_target() {
+    local cidrs=() ports=() addr port
+    local svc_ip svc_port ep_addrs ep_ports
+
+    if [ -n "$APISERVER_CIDR" ]; then
+        for addr in ${APISERVER_CIDR//,/ }; do cidrs+=("$(to_cidr "$addr")"); done
+    else
+        svc_ip=$(kube get svc kubernetes -n default \
+            -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)
+        ep_addrs=$(kube get endpointslice -n default \
+            -l kubernetes.io/service-name=kubernetes \
+            -o jsonpath='{range .items[*]}{range .endpoints[*]}{range .addresses[*]}{@}{"\n"}{end}{end}{end}' 2>/dev/null || true)
+        for addr in $svc_ip $ep_addrs; do cidrs+=("$(to_cidr "$addr")"); done
+    fi
+
+    if [ -n "$APISERVER_PORT" ]; then
+        for port in ${APISERVER_PORT//,/ }; do ports+=("$port"); done
+    else
+        svc_port=$(kube get svc kubernetes -n default \
+            -o jsonpath='{.spec.ports[*].port}' 2>/dev/null || true)
+        ep_ports=$(kube get endpointslice -n default \
+            -l kubernetes.io/service-name=kubernetes \
+            -o jsonpath='{range .items[*]}{range .ports[*]}{.port}{"\n"}{end}{end}' 2>/dev/null || true)
+        for port in $svc_port $ep_ports; do ports+=("$port"); done
+    fi
+
+    # Fail rather than render an empty list. An egress rule with no `to` allows
+    # everything and an empty `ports` allows every port, so a failed discovery
+    # would quietly turn the tightest rule in the file into the loosest one.
+    if [ "${#cidrs[@]}" -eq 0 ] || [ "${#ports[@]}" -eq 0 ]; then
+        cat >&2 <<EOF
+Cannot read the API server address from the cluster.
+
+The egress policy needs it, and rendering the rule without it would allow far
+more than intended rather than less. Read the two values and set them:
+
+    kubectl --context $KUBE_CONTEXT get svc kubernetes -n default
+    kubectl --context $KUBE_CONTEXT get endpointslice -n default \\
+      -l kubernetes.io/service-name=kubernetes
+
+    APISERVER_CIDR="10.43.0.1 <endpoint-address>" APISERVER_PORT="443 6443" $0
+EOF
+        exit 1
+    fi
+
+    APISERVER_CIDRS=""
+    for addr in "${cidrs[@]}"; do
+        case " $APISERVER_CIDRS " in *"cidr: $addr"$'\n'*) continue ;; esac
+        APISERVER_CIDRS+="        - ipBlock:"$'\n'"            cidr: ${addr}"$'\n'
+    done
+    APISERVER_CIDRS="${APISERVER_CIDRS%$'\n'}"
+
+    # Deduplicated because the Service port and the endpoint port are the same
+    # number on a cluster that does not remap them, and a duplicate entry is
+    # noise in a file an operator is meant to read.
+    APISERVER_PORTS=""
+    for port in "${ports[@]}"; do
+        case "$APISERVER_PORTS" in *"port: $port"$'\n'*) continue ;; esac
+        APISERVER_PORTS+="        - protocol: TCP"$'\n'"          port: ${port}"$'\n'
+    done
+    APISERVER_PORTS="${APISERVER_PORTS%$'\n'}"
+}
+
+# Which of three cases the install is in, rather than which of two.
+#
+# Every cluster accepts a NetworkPolicy object; only a CNI that implements one
+# acts on it, and the two are identical from kubectl. The previous version of
+# this check scanned kube-system for a DaemonSet and had no third answer, so on
+# k3s - which runs the policy controller inside the agent instead of as a
+# DaemonSet - it found nothing and told the operator that nothing was being
+# restricted, on a cluster that was restricting.
+#
+# Prints what it found and returns 0, or returns 1 for "could not tell". It
+# never returns "not enforced": an inventory cannot prove an absence, and
+# EGRESS_POLICY_VERIFY measures the thing instead of guessing at it.
+detect_policy_enforcer() {
+    local names kubelet
+
+    # Every namespace, not just kube-system. Calico installed by the Tigera
+    # operator runs in calico-system, and cilium usually gets its own namespace.
+    names=$(kube get daemonset -A \
+        -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+    case "$names" in
+        *calico*)      printf 'calico'         ; return 0 ;;
+        *cilium*)      printf 'cilium'         ; return 0 ;;
+        *antrea*)      printf 'antrea'         ; return 0 ;;
+        *kube-router*) printf 'kube-router'    ; return 0 ;;
+        *weave*)       printf 'weave'          ; return 0 ;;
+        *azure-npm*)   printf 'the Azure network policy manager' ; return 0 ;;
+        *anetd*)       printf 'GKE Dataplane V2'; return 0 ;;
+    esac
+
+    # k3s and rke2 have no DaemonSet to find. k3s embeds kube-router's policy
+    # controller in the agent process; rke2 ships canal or cilium. The kubelet
+    # version string is what distinguishes them.
+    kubelet=$(kube get nodes \
+        -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' 2>/dev/null || true)
+    case "$kubelet" in
+        *+k3s*)  printf 'k3s (the controller runs inside the agent)' ; return 0 ;;
+        *+rke2*) printf 'rke2' ; return 0 ;;
+    esac
+
+    return 1
+}
+
+# Set by detect_apiserver_target and by verify_baseline. Declared here so that
+# set -u holds whichever of them a future caller forgets to run first.
+APISERVER_CIDRS=""
+APISERVER_PORTS=""
+VERIFY_POD=""
+VERIFY_ADDR=""
+VERIFY_PORT=""
+VERIFY_BASELINE=""
+
+# The control port for the verification below: the kubelet, which listens on
+# every node that runs a pod and which the egress policy denies. It is a
+# constant rather than a setting because a cluster that moved it has moved the
+# one address this check can rely on, and the check then says so.
+VERIFY_KUBELET_PORT=10250
+
+# One TCP connect from inside the namespace, printed as one word.
+#
+#   open      it connected
+#   refused   something answered with a reset, so the packet arrived
+#   dropped   nothing came back
+#
+# The last two are not the same thing and neither one means "denied" on its own.
+# Calico drops a denied packet and kube-router rejects it, so a refusal is a
+# denial on k3s and an empty port on minikube. What separates them is the
+# before-and-after, which is why the caller takes a baseline first.
+probe_egress() {
+    local pod="$1" host="$2" port="$3"
+    kube_ns exec "$pod" -- node -e '
+      const net = require("net");
+      const s = net.connect({ host: process.argv[1], port: Number(process.argv[2]) });
+      const say = (word) => { console.log(word); process.exit(0); };
+      s.setTimeout(5000);
+      s.on("connect", () => { s.destroy(); say("open"); });
+      s.on("timeout", () => { s.destroy(); say("dropped"); });
+      s.on("error", (e) => say(e.code === "ECONNREFUSED" ? "refused" : "dropped"));
+    ' "$host" "$port" 2>/dev/null | tr -d '\r' | tail -1 || true
+}
+
+# Choose what to probe with and what to probe at, and record how the control
+# target behaves BEFORE the policy exists. Called before the policy is applied.
+#
+# The control target is the kubelet port on the API server's own node. One
+# machine serves both probes - its API server port is allowed and its kubelet
+# port is denied - so a difference between the two results is the policy and
+# not routing, a firewall or a dead host.
+#
+# Sets VERIFY_POD, VERIFY_ADDR, VERIFY_PORT and VERIFY_BASELINE. Leaves
+# VERIFY_POD empty when it cannot run, which the report turns into
+# "inconclusive" rather than into a verdict.
+verify_baseline() {
+    VERIFY_POD=""
+    VERIFY_ADDR=""
+    VERIFY_PORT=""
+    VERIFY_BASELINE=""
+
+    # The executor by preference: it is the workload that actually calls the API
+    # server, and it is a node image, which probe_egress needs. Any running pod
+    # is the fallback, and a pod without node reports inconclusive.
+    VERIFY_POD=$(kube_ns get pods -l app.kubernetes.io/name=executor \
+        --field-selector=status.phase=Running \
+        -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+    if [ -z "$VERIFY_POD" ]; then
+        VERIFY_POD=$(kube_ns get pods --field-selector=status.phase=Running \
+            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+    fi
+    [ -n "$VERIFY_POD" ] || return 0
+
+    VERIFY_ADDR=$(kube get endpointslice -n default \
+        -l kubernetes.io/service-name=kubernetes \
+        -o jsonpath='{.items[0].endpoints[0].addresses[0]}' 2>/dev/null || true)
+    VERIFY_PORT=$(kube get endpointslice -n default \
+        -l kubernetes.io/service-name=kubernetes \
+        -o jsonpath='{.items[0].ports[0].port}' 2>/dev/null || true)
+    if [ -z "$VERIFY_ADDR" ] || [ -z "$VERIFY_PORT" ]; then
+        VERIFY_POD=""
+        return 0
+    fi
+
+    VERIFY_BASELINE=$(probe_egress "$VERIFY_POD" "$VERIFY_ADDR" "$VERIFY_KUBELET_PORT")
+}
+
+# Say what the policy actually does, measured rather than inferred.
+#
+# Two properties, and both matter. The policy has to be enforced at all, and it
+# must not have locked out the executor, which cannot create a Job without the
+# API server. A policy that fails the second is worse than no policy: every
+# execution stalls and every pod stays green.
+verify_policy_enforcement() {
+    local allow deny
+
+    if [ -z "$VERIFY_POD" ]; then
+        warn "verification inconclusive: nothing in $NAMESPACE to probe from, or"
+        warn "the API server endpoint could not be read."
+        return 0
+    fi
+
+    allow=$(probe_egress "$VERIFY_POD" "$VERIFY_ADDR" "$VERIFY_PORT")
+    deny=$(probe_egress "$VERIFY_POD" "$VERIFY_ADDR" "$VERIFY_KUBELET_PORT")
+
+    if [ "$allow" != open ]; then
+        warn "verified BROKEN: the API server is not reachable from $NAMESPACE."
+        warn "The executor cannot create a Job, so every execution will stall"
+        warn "while every pod stays green. Read the address this cluster uses"
+        warn "and set it, or turn EGRESS_POLICY off until you have:"
+        warn "  kubectl --context $KUBE_CONTEXT get endpointslice -n default \\"
+        warn "    -l kubernetes.io/service-name=kubernetes"
+        warn "  APISERVER_CIDR=... APISERVER_PORT=... EGRESS_POLICY=true $0"
+        return 0
+    fi
+
+    # The control target has to have answered before the policy for its silence
+    # after the policy to mean anything. On a cluster where it never answered,
+    # the reachability half above still stands and the enforcement half does not.
+    if [ "$VERIFY_BASELINE" != open ]; then
+        ok "verified: the API server is reachable from $NAMESPACE"
+        warn "whether the policy is enforced was not measured: the control"
+        warn "address ${VERIFY_ADDR}:${VERIFY_KUBELET_PORT} did not answer before the policy"
+        warn "either, so its silence now proves nothing."
+        return 0
+    fi
+
+    if [ "$deny" = open ]; then
+        warn "verified NOT enforced: the objects exist and nothing is restricted."
+        warn "${VERIFY_ADDR}:${VERIFY_KUBELET_PORT} is denied by the policy and answered anyway."
+        warn "Install a CNI that implements NetworkPolicy, or treat the policy"
+        warn "as documentation only."
+        return 0
+    fi
+
+    ok "verified: the policy is enforced and the API server is still reachable"
+    ok "(${VERIFY_ADDR}:${VERIFY_KUBELET_PORT} answered before the policy and is ${deny} now)"
+}
+
 # The egress policy, applied after the chart so a failed install does not leave
 # a namespace that denies its own traffic.
 #
-# Warns rather than fails when the CNI does not enforce policy, because the
-# objects apply cleanly either way and the difference is invisible afterwards.
+# Warns rather than fails throughout, because the objects apply cleanly whether
+# or not anything enforces them and the difference is invisible afterwards.
 apply_egress_policy() {
     [ "$EGRESS_POLICY" = true ] || return 0
     section "Applying the egress policy"
 
+    detect_apiserver_target
+
     if [ "$DRY_RUN" = true ]; then
-        NAMESPACE="$NAMESPACE" APISERVER_CIDR="$APISERVER_CIDR" \
-            envsubst '${NAMESPACE} ${APISERVER_CIDR}' <"$SCRIPT_DIR/networkpolicy.yaml"
+        NAMESPACE="$NAMESPACE" APISERVER_CIDRS="$APISERVER_CIDRS" APISERVER_PORTS="$APISERVER_PORTS" \
+            envsubst '${NAMESPACE} ${APISERVER_CIDRS} ${APISERVER_PORTS}' <"$SCRIPT_DIR/networkpolicy.yaml"
         return 0
     fi
 
-    NAMESPACE="$NAMESPACE" APISERVER_CIDR="$APISERVER_CIDR" \
-        envsubst '${NAMESPACE} ${APISERVER_CIDR}' \
+    # Before the apply, because the verification compares a control address
+    # against how it behaved without the policy.
+    [ "$EGRESS_POLICY_VERIFY" = true ] && verify_baseline
+
+    NAMESPACE="$NAMESPACE" APISERVER_CIDRS="$APISERVER_CIDRS" APISERVER_PORTS="$APISERVER_PORTS" \
+        envsubst '${NAMESPACE} ${APISERVER_CIDRS} ${APISERVER_PORTS}' \
         <"$SCRIPT_DIR/networkpolicy.yaml" | kube apply -f -
 
-    # A NetworkPolicy object is accepted by every cluster. Only a CNI that
-    # implements it does anything with it, and the two look identical from
-    # kubectl, so say which one this is.
-    if kube get daemonset -n kube-system 2>/dev/null | grep -qE 'calico|cilium|weave|antrea|kube-router'; then
-        ok "egress policy applied and the CNI enforces it"
+    ok "API server allowed:$(printf '%s' "$APISERVER_CIDRS" | sed -n 's/.*cidr: */ /p' | tr -d '\n') on TCP$(printf '%s' "$APISERVER_PORTS" | sed -n 's/.*port: */ /p' | tr -d '\n')"
+
+    local enforcer
+    if enforcer=$(detect_policy_enforcer); then
+        ok "egress policy applied; $enforcer implements NetworkPolicy here"
+        [ "$EGRESS_POLICY_VERIFY" = true ] || \
+            ok "that is read from the cluster and not measured; EGRESS_POLICY_VERIFY=true measures it"
     else
-        warn "egress policy applied, but no enforcing CNI was found in kube-system."
-        warn "The objects exist and nothing is being restricted. Install a CNI"
-        warn "that implements NetworkPolicy, or treat this as documentation only."
+        warn "egress policy applied, but whether it is enforced could not be determined."
+        warn "No CNI this profile recognises was found, which is not the same as"
+        warn "none being present. Check what your cluster runs before relying on"
+        warn "the policy, or re-run with EGRESS_POLICY_VERIFY=true to measure it."
     fi
+
+    [ "$EGRESS_POLICY_VERIFY" = true ] && verify_policy_enforcement
+    return 0
 }
 
 chart_ref() {
@@ -577,9 +855,14 @@ main() {
     compose_set
     install_chart
 
+    # Before the dry-run exit, so that --dry-run shows the policy it would
+    # apply. It renders and returns without touching the cluster in that mode,
+    # and an operator inspecting an egress rule before applying it is exactly
+    # the case --dry-run exists for.
+    apply_egress_policy
+
     [ "$DRY_RUN" = true ] && exit 0
 
-    apply_egress_policy
     check_runner_secrets
 
     echo ""

--- a/deploy/keeperhub-stack/self-hosted/networkpolicy.yaml
+++ b/deploy/keeperhub-stack/self-hosted/networkpolicy.yaml
@@ -20,7 +20,14 @@
 # matters - an escaped or hostile workflow step cannot reach the cluster
 # network, the node, the metadata service, or anything else on the private side.
 #
-# ${NAMESPACE} is substituted by install.sh.
+# install.sh substitutes three variables here: NAMESPACE, and APISERVER_CIDRS
+# and APISERVER_PORTS, which it reads from the cluster. The two API server ones
+# are pre-indented YAML lists rather than single values, because the number of
+# API server endpoints is a property of the cluster.
+#
+# Their names are written without the dollar sign on purpose. envsubst does not
+# know a comment from a value, and a multi-line list expanded inside this
+# paragraph breaks out of it and makes the whole document invalid.
 ---
 # Deny every egress packet from every pod. Everything below re-opens a hole.
 apiVersion: networking.k8s.io/v1
@@ -83,10 +90,21 @@ spec:
 # creates a Job per execution, and the dispatchers, which hold a Lease when
 # leader election is on.
 #
-# The address is the cluster's own service IP, which is why this is a values
-# question rather than a constant. 10.96.0.1/32 is the kubeadm default that
-# minikube uses. On another cluster, read it: kubectl get svc kubernetes -o
-# jsonpath='{.spec.clusterIP}'
+# The addresses and ports are read from the cluster by install.sh, because no
+# constant is right on more than one kind of cluster: the Service address is
+# 10.96.0.1 on kubeadm and minikube and 10.43.0.1 on k3s, and the port is 443
+# through the Service but 6443 or 8443 behind it. APISERVER_CIDR and
+# APISERVER_PORT in config.sh override the discovery.
+#
+# Two addresses are allowed, the Service and the endpoint behind it, because
+# only one of them is the address the CNI matches on and which one it is depends
+# on the CNI. A pod dials the ClusterIP, kube-proxy rewrites the destination to
+# the endpoint, and calico evaluates policy on the rewritten address - measured,
+# with only the ClusterIP allowed every connection to the API server timed out.
+#
+# Allowing the endpoint means allowing a node address on the API server port.
+# That is narrower than it looks: it is one port on the machines that already
+# run the workload, and every other port on them stays denied by the rule below.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -98,13 +116,9 @@ spec:
     - Egress
   egress:
     - to:
-        - ipBlock:
-            cidr: ${APISERVER_CIDR}
+${APISERVER_CIDRS}
       ports:
-        - protocol: TCP
-          port: 443
-        - protocol: TCP
-          port: 8443
+${APISERVER_PORTS}
 ---
 # The public internet, minus every private range.
 #

--- a/deploy/keeperhub-stack/self-hosted/test-harness/check-policy-render.py
+++ b/deploy/keeperhub-stack/self-hosted/test-harness/check-policy-render.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Render networkpolicy.yaml the way install.sh does, then check the result.
+
+TEST SCAFFOLDING, not part of the product. It touches no cluster and needs no
+cluster, so CI can run it and so can you:
+
+    ./test-harness/check-policy-render.py
+
+Why this exists. Every other file in this directory is either a values file,
+which the Self-hosted Profile Render job already renders, or a script, which
+shellcheck already reads. networkpolicy.yaml is neither. It is substituted with
+envsubst at install time, and two of the three values it takes are multi-line
+YAML lists rather than single words.
+
+That combination fails in a way review does not catch. envsubst does not know a
+comment from a value, so naming a list variable inside a comment expands the
+list there, breaks out of the comment, and produces a file that still reads like
+YAML in a diff and is rejected by the API server. That happened once while this
+check was being written, which is why the check exists.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit(
+        "This check needs PyYAML.\n"
+        "    pip install pyyaml   (GitHub's ubuntu runners already have it)"
+    )
+
+HERE = Path(__file__).resolve().parent
+PROFILE = HERE.parent
+POLICY = PROFILE / "networkpolicy.yaml"
+INSTALL = PROFILE / "install.sh"
+
+# Synthetic. The point is that the file renders, not that any address is real.
+# Two of each, because one entry cannot show a list rendering as a list.
+NAMESPACE = "keeperhub"
+CIDRS = ["10.43.0.1/32", "10.0.0.5/32"]
+PORTS = [443, 6443]
+
+# The indentation install.sh bakes into each fragment. It belongs to the
+# fragment rather than to the template, because a substituted value carries its
+# own leading whitespace and the template cannot add any.
+#
+# This is a second copy of what install.sh writes, so assert_matches_install
+# below fails when the two drift. Same reason config.sh has assert_overlay: a
+# constant written down twice is a constant that will disagree with itself.
+CIDR_INDENT = " " * 8
+CIDR_FIELD_INDENT = " " * 12
+PORT_INDENT = " " * 8
+PORT_FIELD_INDENT = " " * 10
+
+# The five documents the file is meant to produce. Named rather than counted, so
+# that a lost document is reported as the one it lost.
+EXPECTED_POLICIES = {
+    "keeperhub-default-deny-egress",
+    "keeperhub-allow-dns",
+    "keeperhub-allow-in-namespace",
+    "keeperhub-allow-apiserver",
+    "keeperhub-allow-public-egress",
+}
+
+APISERVER_POLICY = "keeperhub-allow-apiserver"
+
+
+# An `envsubst '<names>'` whose command goes on to read networkpolicy.yaml,
+# across up to two backslash-continued lines. Anchored on the filename because
+# install.sh substitutes sandbox.yaml as well, with a different variable list.
+ENVSUBST_CALL = re.compile(
+    r"envsubst '((?:\$\{[A-Z_]+\} ?)+)'"
+    r"(?:[^\n]*\\\n){0,2}[^\n]*networkpolicy\.yaml"
+)
+
+
+def envsubst_names() -> list[str]:
+    """The variable names install.sh passes to envsubst for networkpolicy.yaml.
+
+    Read out of install.sh rather than repeated here. envsubst given a list
+    substitutes those names and leaves every other one alone, so this check
+    renders what an install renders rather than something close to it.
+
+    install.sh has two of these calls, one for --dry-run and one for the apply.
+    They have to agree, so disagreement is reported here rather than left to
+    produce a dry run that shows something the install would not do.
+    """
+    lists = ENVSUBST_CALL.findall(INSTALL.read_text())
+    if not lists:
+        sys.exit(
+            f"No envsubst call for {POLICY.name} found in {INSTALL.name}.\n"
+            "This check renders the policy the way install.sh does, so it cannot\n"
+            "run without knowing which variables install.sh substitutes."
+        )
+    names = [re.findall(r"\$\{([A-Z_]+)\}", found) for found in lists]
+    if any(entry != names[0] for entry in names):
+        sys.exit(
+            f"{INSTALL.name} substitutes a different variable list per call site:\n"
+            + "\n".join(f"    {entry}" for entry in names)
+        )
+    return names[0]
+
+
+def assert_matches_install() -> None:
+    """Fail when install.sh no longer builds the fragments this check assumes.
+
+    Structural on purpose. A search for the bare number of spaces would be
+    satisfied by any line that happened to have them, so each pattern matches
+    the literal install.sh writes, quotes and all.
+    """
+    text = INSTALL.read_text()
+    literals = {
+        "the ipBlock item": f'"{CIDR_INDENT}- ipBlock:"',
+        "the cidr field": f'"{CIDR_FIELD_INDENT}cidr: ',
+        "the protocol item": f'"{PORT_INDENT}- protocol: TCP"',
+        "the port field": f'"{PORT_FIELD_INDENT}port: ',
+    }
+    drifted = [what for what, literal in literals.items() if literal not in text]
+    if drifted:
+        sys.exit(
+            f"{INSTALL.name} no longer indents {', '.join(drifted)} the way this\n"
+            "check does. The indentation belongs to the fragment rather than to\n"
+            "the template, so a change on one side renders YAML the other side\n"
+            f"does not expect. Update {Path(__file__).name} and {INSTALL.name} together."
+        )
+
+
+def cidr_fragment(cidrs: list[str]) -> str:
+    return "\n".join(
+        f"{CIDR_INDENT}- ipBlock:\n{CIDR_FIELD_INDENT}cidr: {cidr}" for cidr in cidrs
+    )
+
+
+def port_fragment(ports: list[int]) -> str:
+    return "\n".join(
+        f"{PORT_INDENT}- protocol: TCP\n{PORT_FIELD_INDENT}port: {port}"
+        for port in ports
+    )
+
+
+def render(names: list[str]) -> str:
+    """Run the real envsubst, so this checks what install.sh produces."""
+    values = {
+        "NAMESPACE": NAMESPACE,
+        "APISERVER_CIDRS": cidr_fragment(CIDRS),
+        "APISERVER_PORTS": port_fragment(PORTS),
+    }
+    missing = [name for name in names if name not in values]
+    if missing:
+        sys.exit(
+            f"install.sh substitutes {', '.join(missing)} and this check has no "
+            f"value for it.\nAdd one to `values` in {Path(__file__).name}."
+        )
+
+    # Resolved before the call, because the env below carries no PATH for the
+    # child to search.
+    envsubst = shutil.which("envsubst")
+    if not envsubst:
+        sys.exit("envsubst is not installed. It ships with gettext.")
+
+    result = subprocess.run(
+        [envsubst, " ".join(f"${{{name}}}" for name in names)],
+        input=POLICY.read_text(),
+        # Only these, rather than the ambient environment. A variable that
+        # happens to be set on the machine running this would otherwise render
+        # a file no install produces.
+        env={name: values[name] for name in names},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def fail(message: str) -> None:
+    """One error, annotated for GitHub when it is GitHub reading it."""
+    prefix = "::error::" if os.environ.get("GITHUB_ACTIONS") else "  - "
+    print(f"{prefix}{message}")
+
+
+def check(rendered: str) -> list[str]:
+    """Every way the render can be wrong, reported together rather than one per run."""
+    errors: list[str] = []
+
+    leftover = sorted(set(re.findall(r"\$\{[A-Z_]+\}", rendered)))
+    if leftover:
+        errors.append(f"left an envsubst placeholder: {', '.join(leftover)}")
+
+    try:
+        docs = [doc for doc in yaml.safe_load_all(rendered) if doc]
+    except yaml.YAMLError as exc:
+        # The failure a fragment expanded in the wrong place produces. Worth its
+        # own branch, because every check below needs a parsed file.
+        errors.append(f"did not parse as YAML: {exc}")
+        return errors
+
+    kinds = {doc.get("kind") for doc in docs}
+    if kinds != {"NetworkPolicy"}:
+        errors.append(f"rendered {sorted(map(str, kinds))}, expected only NetworkPolicy")
+        return errors
+
+    by_name = {doc["metadata"]["name"]: doc for doc in docs}
+    if set(by_name) != EXPECTED_POLICIES:
+        lost = EXPECTED_POLICIES - set(by_name)
+        extra = set(by_name) - EXPECTED_POLICIES
+        if lost:
+            errors.append(f"did not render {', '.join(sorted(lost))}")
+        if extra:
+            errors.append(f"rendered an unexpected policy: {', '.join(sorted(extra))}")
+
+    for name, doc in by_name.items():
+        if doc["metadata"].get("namespace") != NAMESPACE:
+            errors.append(f"{name} is in namespace {doc['metadata'].get('namespace')!r}")
+
+    # The API server rule specifically, because it is the one that takes the
+    # multi-line lists and the one that fails silently when it is wrong: a rule
+    # that names the wrong address applies cleanly and blocks the executor.
+    apiserver = by_name.get(APISERVER_POLICY)
+    if apiserver:
+        rule = apiserver["spec"]["egress"][0]
+        # An empty `to` allows every destination and an empty `ports` allows
+        # every port, so a fragment that rendered as nothing turns the tightest
+        # rule in the file into the loosest one. It has to read as an error
+        # here rather than as an empty list to compare.
+        if not rule.get("to") or not rule.get("ports"):
+            errors.append(
+                f"{APISERVER_POLICY} rendered to={rule.get('to')} ports={rule.get('ports')}; "
+                "an empty list there allows everything"
+            )
+        else:
+            got_cidrs = [entry["ipBlock"]["cidr"] for entry in rule["to"]]
+            got_ports = [entry["port"] for entry in rule["ports"]]
+            if got_cidrs != CIDRS:
+                errors.append(f"{APISERVER_POLICY} allows {got_cidrs}, expected {CIDRS}")
+            if got_ports != PORTS:
+                errors.append(f"{APISERVER_POLICY} allows {got_ports}, expected {PORTS}")
+
+    return errors
+
+
+def main() -> int:
+    assert_matches_install()
+    rendered = render(envsubst_names())
+    errors = check(rendered)
+    if errors:
+        print(f"{POLICY.name} rendered wrongly:")
+        for error in errors:
+            fail(error)
+        return 1
+    print(f"ok: {POLICY.name} renders {len(EXPECTED_POLICIES)} NetworkPolicy documents")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes [KEEP-1218](https://linear.app/keeperhubapp/issue/KEEP-1218/self-hosted-egress-policy-defaults-suit-kubeadm-clusters-only).

The optional egress policy in `deploy/keeperhub-stack/self-hosted/` assumed a kubeadm-shaped cluster. On K3s it blocked the API server and then reported that nothing was restricted.

## The three reported problems

**The API server address and port are now read from the cluster.** The `kubernetes` Service is `10.96.0.1:443` on kubeadm and minikube and `10.43.0.1:443` on K3s, and the port behind it is 6443 or 8443, so no constant is right on more than one kind of cluster. `APISERVER_CIDR` and `APISERVER_PORT` stay as overrides for a cluster the discovery gets wrong. A failed read aborts rather than render an empty list, because an egress rule with no `to` allows everything.

**The enforcement report no longer claims an absence it cannot prove.** It scans DaemonSets in every namespace instead of `kube-system` alone, which also finds a Tigera-operator calico in `calico-system`, and it reads the kubelet version for K3s and RKE2, which run the policy controller inside the agent. When it finds nothing it says the check was inconclusive, not that nothing is restricted.

## A fourth problem, found while measuring the first

The rule allowed the Service ClusterIP. A pod dials the ClusterIP, kube-proxy rewrites the destination to the endpoint, and the CNI matches the rewritten address. Measured on minikube with calico:

| target | no policy | shipped policy | with the endpoint allowed |
| --- | --- | --- | --- |
| `10.96.0.1:443` (ClusterIP) | ok | **timeout** | ok |
| `192.168.58.2:8443` (endpoint) | ok | **timeout** | ok |
| `192.168.58.2:10250` (kubelet) | ok | - | timeout |
| `1.1.1.1:443` | ok | ok | ok |

So the policy was already broken on the cluster it was verified on, not only on K3s. The rule now allows the Service address and the endpoint behind it, which holds whichever address the CNI matches on. Allowing the endpoint means allowing one port on machines that already run the workload; every other port on them stays denied.

## Measuring instead of guessing

`EGRESS_POLICY_VERIFY=true` runs two TCP connects from a pod that is already running: one to the API server, which must still work, and one to the kubelet port on the same node, which must not. It creates nothing, deletes nothing and never fails the install.

A baseline is taken before the policy is applied, because calico drops a denied packet and kube-router rejects one. A refusal on its own does not separate "denied" from "nothing listening there"; a target that answered before the policy and does not answer after it was denied by the policy.

It reports one of four things: enforced and the API server reachable; **NOT enforced**; **BROKEN**, meaning the policy is enforced and it blocks the API server; or inconclusive.

## Two things found on the way

- `--dry-run` never rendered the policy. `main` exited before `apply_egress_policy` ran, so `EGRESS_POLICY=true ... --dry-run` printed nothing. The call moved above the exit.
- Nothing rendered `networkpolicy.yaml` in CI. The `selfhosted` job renders every values-file combination and skips this one, so the multi-line lists it now takes were unchecked. I hit that during development: naming a list variable inside the header comment made envsubst expand it there and broke the whole document. CI now renders the file and parses the result, and I confirmed the check fails on exactly that defect.

## Verification

Measured live on two clusters, both with the installer's own code path.

**minikube 1.34, calico 3.30.3** - discovered `10.96.0.1/32` + `192.168.58.2/32` on TCP 443, 8443. Reports `calico implements NetworkPolicy here`, then `the policy is enforced and the API server is still reachable (192.168.58.2:10250 answered before the policy and is dropped now)`.

**k3s 1.31.5 via k3d** - discovered `10.43.0.1/32` + `10.200.11.2/32` on TCP 443, 6443. Reports `k3s (the controller runs inside the agent) implements NetworkPolicy here`, then enforced, `refused now`.

Reproduced the reported bug first: on K3s with the shipped file, the old check printed "nothing is being restricted" while the API server was in fact unreachable.

Also exercised the BROKEN branch (old kubeadm values forced onto K3s), the NOT-enforced branch, the fail-closed path when discovery returns nothing, IPv6 `/128`, and comma- and space-separated overrides.

Local CI: repo-wide `shellcheck --severity=warning` clean over all 26 scripts, the `selfhosted` render job green for all 8 mode combinations, the new render step green, and the workflow YAML parses.

No application code is touched. Everything is in the self-hosted layer.