### PR TITLE
fix: KEEP-1213 redact RPC credentials from the health payload

### DIFF
--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -210,6 +210,33 @@ export interface DisconnectEvent {
 
 export type DisconnectHandler = (ev: DisconnectEvent) => void | Promise<void>;
 
+/**
+ * Reduce an RPC URL to what an operator needs and nothing more.
+ *
+ * The configured URLs carry credentials at runtime. `chain-config` stores
+ * `${DRPC_API_KEY}` as a placeholder, but the deploy workflow substitutes the
+ * real key into the value before writing it to SSM, so the string this process
+ * holds is a live secret for 19 of 22 chains.
+ *
+ * Only scheme and host survive. That is the whole diagnostic purpose - which
+ * upstream is serving, and therefore whether failover has kicked in - while
+ * the chain is already identified by `chainId`, so nothing is lost by dropping
+ * the path. Fails closed: a URL that will not parse is replaced entirely
+ * rather than passed through on the assumption it holds no secret.
+ */
+export function redactRpcUrl(url: string | null): string | null {
+  if (url === null) {
+    return null;
+  }
+  try {
+    const parsed = new URL(url);
+    const hasMore = parsed.pathname !== "/" || parsed.search !== "";
+    return `${parsed.protocol}//${parsed.host}${hasMore ? "/[redacted]" : ""}`;
+  } catch {
+    return "[redacted]";
+  }
+}
+
 export interface ChainHealth {
   chainId: number;
   /**
@@ -218,11 +245,15 @@ export interface ChainHealth {
    * fallback when the most recent successful (re)connect landed on it;
    * resets to the configured primary during a mid-reconnect window
    * because `reconnect()` clears `activeWssUrl` before re-attempting.
+   *
+   * Scheme and host only - see `redactRpcUrl`. The configured value carries a
+   * live credential at runtime.
    */
   wssUrl: string;
   /**
    * Configured fallback URL, or null if none. Surfaced so operators can
-   * see whether failover capacity exists for this chain.
+   * see whether failover capacity exists for this chain. Scheme and host
+   * only, for the same reason as `wssUrl`.
    */
   fallbackWssUrl: string | null;
   connected: boolean;
@@ -679,8 +710,11 @@ export class ChainProviderManager {
       // Active URL when a provider is live, primary otherwise. Lets
       // operators see whether failover kicked in without exposing a
       // stale "active" value when nothing is connected.
-      wssUrl: entry.activeWssUrl ?? entry.wssUrl,
-      fallbackWssUrl: entry.fallbackWssUrl,
+      // Redacted here rather than at serialisation: every consumer of
+      // getAllHealth() then gets the safe value, and a future caller cannot
+      // reach a credential by reading the field directly.
+      wssUrl: redactRpcUrl(entry.activeWssUrl ?? entry.wssUrl) ?? "[redacted]",
+      fallbackWssUrl: redactRpcUrl(entry.fallbackWssUrl),
       connected: entry.provider != null && !entry.isReconnecting,
       reconnecting: entry.isReconnecting,
       lastBlockAt: entry.lastBlockAt,

--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -223,6 +223,13 @@ export type DisconnectHandler = (ev: DisconnectEvent) => void | Promise<void>;
  * the chain is already identified by `chainId`, so nothing is lost by dropping
  * the path. Fails closed: a URL that will not parse is replaced entirely
  * rather than passed through on the assumption it holds no secret.
+ *
+ * The host is kept deliberately, and that is an assumption rather than a
+ * guarantee: a provider that puts the token in the subdomain - QuickNode and
+ * Chainstack both do - would survive this untouched. No configured upstream
+ * does today (checked across both env files: no userinfo, no query strings, no
+ * host-borne credentials), and the host is what makes failover diagnosable, so
+ * it stays. Revisit when an upstream of that shape is added.
  */
 export function redactRpcUrl(url: string | null): string | null {
   if (url === null) {
@@ -785,7 +792,7 @@ export class ChainProviderManager {
       // first caller's failover behaviour.
       if (existing.wssUrl !== wssUrl || existing.fallbackWssUrl !== fallback) {
         throw new Error(
-          `chainId ${chainId} already registered with wssUrl=${existing.wssUrl} fallbackWssUrl=${existing.fallbackWssUrl}; refusing to reuse for wssUrl=${wssUrl} fallbackWssUrl=${fallback}`,
+          `chainId ${chainId} already registered with wssUrl=${redactRpcUrl(existing.wssUrl)} fallbackWssUrl=${redactRpcUrl(existing.fallbackWssUrl)}; refusing to reuse for wssUrl=${redactRpcUrl(wssUrl)} fallbackWssUrl=${redactRpcUrl(fallback)}`,
         );
       }
       return existing;
@@ -883,7 +890,11 @@ export class ChainProviderManager {
         return { provider, urlUsed: url };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        failures.push(`${url}: ${message}`);
+        // Redacted here, not at the reader. This string is stored on
+        // `lastCreateError` and served in the /healthz body, logged by the
+        // reconnect loop, and embedded in the stack the listener registry
+        // prints - so a raw URL here leaks through every one of them.
+        failures.push(`${redactRpcUrl(url)}: ${message}`);
         if (provider) {
           try {
             await provider.destroy();
@@ -907,7 +918,7 @@ export class ChainProviderManager {
     entry.activeWssUrl = urlUsed;
     if (urlUsed !== entry.wssUrl) {
       logger.warn(
-        `[ChainProviderManager] chain=${entry.chainId} primary failed; running on fallback ${urlUsed}`,
+        `[ChainProviderManager] chain=${entry.chainId} primary failed; running on fallback ${redactRpcUrl(urlUsed)}`,
       );
     }
     // Clear the prior failure marker now that we have a working provider.
@@ -1492,7 +1503,7 @@ export class ChainProviderManager {
     entry.activeWssUrl = urlUsed;
     if (urlUsed !== entry.wssUrl) {
       logger.warn(
-        `[ChainProviderManager] chain=${entry.chainId} reconnected on fallback ${urlUsed}`,
+        `[ChainProviderManager] chain=${entry.chainId} reconnected on fallback ${redactRpcUrl(urlUsed)}`,
       );
     }
     // Successful reconnect clears any prior failure marker so /healthz

--- a/keeperhub-events/event-tracker/src/listener/workflow-mapper.ts
+++ b/keeperhub-events/event-tracker/src/listener/workflow-mapper.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import type { NetworksMap, RawWorkflow } from "../../lib/types";
 import { logger } from "../../lib/utils/logger";
 import { buildEventAbi } from "../chains/event-serializer";
+import { redactRpcUrl } from "../chains/provider-manager";
 import type { AbiEvent } from "../chains/validation";
 import type { WorkflowRegistration } from "./registry";
 
@@ -75,7 +76,7 @@ export function buildRegistration(
   }
   if (!(wssUrl.startsWith("wss://") || wssUrl.startsWith("ws://"))) {
     logger.warn(
-      `[workflow-mapper] workflow ${workflowId} chain ${chainId} defaultPrimaryWss is not a WebSocket URL ("${wssUrl}"); skipping`,
+      `[workflow-mapper] workflow ${workflowId} chain ${chainId} defaultPrimaryWss is not a WebSocket URL ("${redactRpcUrl(wssUrl)}"); skipping`,
     );
     return null;
   }
@@ -94,7 +95,7 @@ export function buildRegistration(
       fallbackWssUrl = rawFallbackWssUrl;
     } else {
       logger.warn(
-        `[workflow-mapper] workflow ${workflowId} chain ${chainId} defaultFallbackWss is not a WebSocket URL ("${rawFallbackWssUrl}"); ignoring fallback`,
+        `[workflow-mapper] workflow ${workflowId} chain ${chainId} defaultFallbackWss is not a WebSocket URL ("${redactRpcUrl(String(rawFallbackWssUrl))}"); ignoring fallback`,
       );
     }
   }

--- a/keeperhub-events/event-tracker/tests/unit/health-server.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/health-server.test.ts
@@ -200,3 +200,41 @@ describe("RPC URL redaction", () => {
     }
   });
 });
+
+describe("no credential reaches the health payload", () => {
+  // The helper being correct is not the property that matters. The property
+  // is that nothing secret leaves buildHealthResponse - reverting only the
+  // toHealth() call site left the helper intact and the whole suite green
+  // while /healthz served raw credentials.
+  const SECRET = "dk_live_0123456789abcdef0123456789abcdef";
+
+  it("omits the credential from every field, including error strings", async () => {
+    // A factory that always throws: both URLs fail, so the aggregate error -
+    // which names every URL it tried - lands on lastCreateError.
+    const failingFactory: ProviderFactory = () => {
+      throw new Error("ECONNREFUSED");
+    };
+    const mgr = new ChainProviderManager({
+      factory: failingFactory,
+      onPermanentFailure: () => undefined,
+    });
+    const primary = `wss://chain.techops.services/eth-mainnet`;
+    const fallback = `wss://lb.drpc.live/eth-mainnet/${SECRET}`;
+
+    await mgr
+      .subscribeToLogs({
+        chainId: 1,
+        wssUrl: primary,
+        fallbackWssUrl: fallback,
+        address: "0x1111111111111111111111111111111111111111",
+        topic0:
+          "0x6d7747ff9aaba238de658957a12a32c8a94f6ec3aa0508441fe400ca79ed457c",
+        handler: () => undefined,
+      })
+      .catch(() => undefined);
+
+    const body = JSON.stringify(buildHealthResponse(mgr).body);
+    expect(body).not.toContain(SECRET);
+    await mgr.destroy();
+  });
+});

--- a/keeperhub-events/event-tracker/tests/unit/health-server.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/health-server.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   ChainProviderManager,
   type ProviderFactory,
+  redactRpcUrl,
 } from "../../src/chains/provider-manager";
 import {
   type HealthServerHandle,
@@ -145,5 +146,57 @@ describe("health-server", () => {
       const address = handle.server.address() as AddressInfo;
       expect(address.port).toBe(handle.port);
     });
+  });
+});
+
+describe("RPC URL redaction", () => {
+  it("keeps scheme and host, drops the credential-bearing path", () => {
+    // The shape that matters: chain-config stores ${DRPC_API_KEY} as a
+    // placeholder, and the deploy workflow substitutes the real key into the
+    // value before writing it to SSM, so this string is a live secret at
+    // runtime for 19 of 22 chains.
+    expect(
+      redactRpcUrl("wss://lb.drpc.live/robinhood-mainnet/sk_live_abc123"),
+    ).toBe("wss://lb.drpc.live/[redacted]");
+    expect(redactRpcUrl("https://eth-mainnet.g.alchemy.com/v2/SECRETKEY")).toBe(
+      "https://eth-mainnet.g.alchemy.com/[redacted]",
+    );
+  });
+
+  it("redacts a key passed as a query parameter", () => {
+    expect(redactRpcUrl("wss://rpc.example.com/?apiKey=SECRET")).toBe(
+      "wss://rpc.example.com/[redacted]",
+    );
+  });
+
+  it("strips credentials given as URL userinfo", () => {
+    const out = redactRpcUrl("wss://user:hunter2@rpc.example.com/path");
+    expect(out).not.toContain("hunter2");
+    expect(out).not.toContain("user");
+  });
+
+  it("keeps a bare host readable so failover is still diagnosable", () => {
+    // Redaction has to leave the upstream identifiable, or the field stops
+    // answering the question it exists for.
+    expect(redactRpcUrl("wss://chain.techops.services")).toBe(
+      "wss://chain.techops.services",
+    );
+  });
+
+  it("passes null through and fails closed on anything unparseable", () => {
+    expect(redactRpcUrl(null)).toBeNull();
+    expect(redactRpcUrl("not a url")).toBe("[redacted]");
+    expect(redactRpcUrl("")).toBe("[redacted]");
+  });
+
+  it("never returns a string containing the original secret", () => {
+    const secret = "0123456789abcdef0123456789abcdef";
+    for (const url of [
+      `wss://lb.drpc.live/base/${secret}`,
+      `https://host/v2/${secret}?k=${secret}`,
+      `wss://x:${secret}@host/p`,
+    ]) {
+      expect(redactRpcUrl(url)).not.toContain(secret);
+    }
   });
 });

--- a/keeperhub-events/event-tracker/tests/unit/health-server.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/health-server.test.ts
@@ -218,7 +218,7 @@ describe("no credential reaches the health payload", () => {
       factory: failingFactory,
       onPermanentFailure: () => undefined,
     });
-    const primary = `wss://chain.techops.services/eth-mainnet`;
+    const primary = "wss://chain.techops.services/eth-mainnet";
     const fallback = `wss://lb.drpc.live/eth-mainnet/${SECRET}`;
 
     await mgr


### PR DESCRIPTION
Closes KEEP-1213.

## Problem

`ChainHealth` carried `wssUrl` and `fallbackWssUrl` verbatim, and `buildHealthResponse` puts the whole `getAllHealth()` array into the `/healthz` body.

The committed config is safe - `chain-config` stores `${DRPC_API_KEY}` as a placeholder. The runtime value is not: `update-ssm-parameter.yml` substitutes the real key into the value immediately before writing it to SSM, so the string this process holds is a **live credential for 19 of 22 chains**.

## Why now

Nothing reaches the endpoint today. The health server binds `HEALTH_PORT` (default 3001) while the deployment declares only 3000, and that mismatch is the sole control.

**KEEP-405 is written to remove it.** A reasonable reachability cleanup, made by someone with no reason to suspect this, converts a latent leak into a live one that serves the key to anything that can reach the pod. Redaction has to land first — that ordering is the point of this PR, not just the redaction itself.

## Change

Only scheme and host survive:

```
wss://lb.drpc.live/robinhood-mainnet/sk_live_abc  ->  wss://lb.drpc.live/[redacted]
https://eth-mainnet.g.alchemy.com/v2/SECRET       ->  https://eth-mainnet.g.alchemy.com/[redacted]
wss://chain.techops.services                      ->  wss://chain.techops.services
```

That is the whole diagnostic purpose of the fields — which upstream is serving, and therefore whether failover has kicked in — and the chain is already identified by `chainId`, so dropping the path costs an operator nothing they were using. Userinfo and query strings go with it.

Redacted in `toHealth` rather than at serialisation, so every consumer of `getAllHealth()` gets the safe value and a future caller cannot reach a credential by reading the field directly.

**Fails closed:** a URL that will not parse is replaced entirely rather than passed through on the assumption it holds no secret.

## Verification

- `tsc --noEmit`: clean
- `biome check`: clean
- unit: **179/179** (6 new)

Tests cover both real upstream shapes (dRPC's trailing key segment, Alchemy's `/v2/<key>`), a key as a query parameter, credentials as userinfo, a bare host staying readable so failover remains diagnosable, null and unparseable input, and a property check that the output never contains the input secret.

## Not in scope

The port mismatch itself stays on KEEP-405. This PR only makes it safe to fix.
