### PR TITLE
fix: base58-encode pubkey fields in decoded Anchor event args

### DIFF
--- a/lib/web3/anchor-events.ts
+++ b/lib/web3/anchor-events.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { BN, BorshEventCoder, type Idl } from "@coral-xyz/anchor";
+import { PublicKey } from "@solana/web3.js";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 
 // Anchor programs emit events as base64 blobs on a `Program data: <base64>`
@@ -24,18 +25,38 @@ export type DecodedAnchorEvent = {
 };
 
 /**
- * Recursively converts bn.js BN instances (produced by the Borsh layout for
- * u64/i64/u128/i128 IDL fields) to decimal strings. Without this,
- * JSON.stringify would invoke BN's own toJSON and silently produce a hex
- * string instead of the decimal amount a workflow author expects.
+ * Recursively converts the class instances Anchor's Borsh layout produces
+ * into JSON-safe primitives, matching read-solana-program-core's
+ * serializeAnchorValue: PublicKey -> base58, BN -> decimal string, byte
+ * arrays -> base64.
+ *
+ * Every branch here exists because the instance would otherwise reach a
+ * workflow author as an internal representation:
+ * - BN (u64/i64/u128/i128 fields) has its own toJSON that emits a hex
+ *   string, not the decimal amount expected.
+ * - PublicKey (pubkey fields) survives JSON.stringify intact via toBase58,
+ *   which hides the leak, but a structured-clone boundary deep-walks the
+ *   instance into an opaque {"_bn":{"words":[...]}} object.
+ * - Buffer/Uint8Array (bytes fields) serializes to {"type":"Buffer",
+ *   "data":[...]} rather than usable bytes.
  */
 function normalizeEventData(value: unknown): unknown {
+  if (value instanceof PublicKey) {
+    return value.toBase58();
+  }
   if (BN.isBN(value)) {
     return (value as InstanceType<typeof BN>).toString(10);
+  }
+  if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+    return Buffer.from(value).toString("base64");
   }
   if (Array.isArray(value)) {
     return value.map(normalizeEventData);
   }
+  // Anchor resolves defined/option/vec types into plain objects, arrays and
+  // nulls, so recursing into plain objects reaches every nested field - but
+  // the instance branches above must come first, since a class instance is
+  // also typeof "object" and would otherwise be walked into its internals.
   if (
     value !== null &&
     typeof value === "object" &&

--- a/tests/unit/anchor-events.test.ts
+++ b/tests/unit/anchor-events.test.ts
@@ -1,4 +1,5 @@
 import { BN, BorshCoder, type Idl } from "@coral-xyz/anchor";
+import { PublicKey } from "@solana/web3.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
@@ -172,5 +173,105 @@ describe("AnchorEventDecoder.decodeLogs", () => {
     expect(typeof amount).toBe("string");
     expect(amount).toBe("123456");
     expect(JSON.parse(JSON.stringify(events?.[0].data)).amount).toBe("123456");
+  });
+});
+
+const TRADED_DISCRIMINATOR = [99, 98, 97, 96, 95, 94, 93, 92];
+const WHIRLPOOL = "HJPjoWUrhoZzkNfRpHuieeFk9WcZWjwy6PBjZ81ngndJ";
+
+// Covers a pubkey at every nesting Anchor produces: bare, inside a defined
+// struct, inside a vec, and inside an option - plus a bytes field, whose
+// Buffer leaks the same way a PublicKey does.
+const PUBKEY_IDL: Idl = {
+  address: "11111111111111111111111111111111",
+  metadata: { name: "test_program", version: "0.1.0", spec: "0.1.0" },
+  instructions: [],
+  accounts: [],
+  events: [{ name: "Traded", discriminator: TRADED_DISCRIMINATOR }],
+  types: [
+    {
+      name: "Inner",
+      type: {
+        kind: "struct",
+        fields: [{ name: "nested_key", type: "pubkey" }],
+      },
+    },
+    {
+      name: "Traded",
+      type: {
+        kind: "struct",
+        fields: [
+          { name: "whirlpool", type: "pubkey" },
+          { name: "amount", type: "u64" },
+          { name: "keys", type: { vec: "pubkey" } },
+          { name: "maybe_key", type: { option: "pubkey" } },
+          { name: "inner", type: { defined: { name: "Inner" } } },
+          { name: "payload", type: "bytes" },
+        ],
+      },
+    },
+  ],
+};
+
+function tradedLog(): string {
+  const coder = new BorshCoder(PUBKEY_IDL);
+  const encoded = coder.types.encode("Traded", {
+    whirlpool: new PublicKey(WHIRLPOOL),
+    amount: new BN(42),
+    keys: [new PublicKey(WHIRLPOOL)],
+    maybe_key: new PublicKey(WHIRLPOOL),
+    inner: { nested_key: new PublicKey(WHIRLPOOL) },
+    payload: Buffer.from([1, 2, 3]),
+  });
+  const blob = Buffer.concat([Buffer.from(TRADED_DISCRIMINATOR), encoded]);
+  return `Program data: ${blob.toString("base64")}`;
+}
+
+function decodeTraded(): Record<string, unknown> {
+  const decoder = createEventDecoder(JSON.stringify(PUBKEY_IDL), PROGRAM_ID);
+  const events = decoder?.decodeLogs([
+    `Program ${PROGRAM_ID} invoke [1]`,
+    tradedLog(),
+    `Program ${PROGRAM_ID} success`,
+  ]);
+  expect(events).toHaveLength(1);
+  return events?.[0].data as Record<string, unknown>;
+}
+
+describe("AnchorEventDecoder pubkey and bytes normalization", () => {
+  it("normalizes a pubkey field to a base58 string, not a PublicKey instance", () => {
+    const data = decodeTraded();
+    expect(typeof data.whirlpool).toBe("string");
+    expect(data.whirlpool).toBe(WHIRLPOOL);
+  });
+
+  it("normalizes pubkeys nested in a struct, a vec and an option", () => {
+    const data = decodeTraded();
+    expect((data.inner as Record<string, unknown>).nested_key).toBe(WHIRLPOOL);
+    expect(data.keys).toEqual([WHIRLPOOL]);
+    expect(data.maybe_key).toBe(WHIRLPOOL);
+  });
+
+  it("normalizes a bytes field to base64, not a raw Buffer", () => {
+    const data = decodeTraded();
+    expect(data.payload).toBe(Buffer.from([1, 2, 3]).toString("base64"));
+  });
+
+  // The regression this guards: PublicKey.toJSON() returns base58, so a raw
+  // instance survives JSON.stringify looking correct. A structured-clone
+  // boundary - which the executor crosses when scoping for-each outputs -
+  // has no such escape hatch and deep-walks the instance into its internal
+  // {"_bn":{"words":[...]}} representation instead.
+  it("keeps every field JSON-safe across a structured clone", () => {
+    const cloned = structuredClone(decodeTraded());
+    expect(cloned).toEqual({
+      whirlpool: WHIRLPOOL,
+      amount: "42",
+      keys: [WHIRLPOOL],
+      maybe_key: WHIRLPOOL,
+      inner: { nested_key: WHIRLPOOL },
+      payload: Buffer.from([1, 2, 3]).toString("base64"),
+    });
+    expect(JSON.stringify(cloned)).not.toContain("_bn");
   });
 });


### PR DESCRIPTION
## Problem

A `pubkey`-typed field inside a decoded Anchor event's `args` reached workflow authors as an opaque object instead of a base58 address:

```json
"whirlpool": { "_bn": { "red": null, "words": [9389801, ...], "length": 10, "negative": 0 } }
```

Reported against the Orca Whirlpool reference workflow for `web3/query-solana-program-events`. The account-decode sibling `web3/read-solana-program-anchor` was unaffected.

## Root cause

`normalizeEventData` in `lib/web3/anchor-events.ts` walked the decoded value tree converting `BN` to a decimal string and recursing into arrays and plain objects, gated on `value.constructor === Object`. A `PublicKey` is a class instance, so it failed that gate and fell through to the untouched `return value`.

Two things kept this from being obvious:

- `PublicKey.toJSON()` returns base58, so the raw instance survives `JSON.stringify` looking correct. Only a boundary that does not consult `toJSON` exposes it - `structuredClone` deep-walks the instance and reproduces the reported shape byte for byte.
- The account-decode path never had the bug, because its own `serializeAnchorValue` in `plugins/web3/steps/read-solana-program-core.ts` already handles `PublicKey`. The two normalizers had simply diverged.

The same gate leaked `Buffer` on `bytes`-typed fields, which serialize to `{"type":"Buffer","data":[...]}`. That was not in the report, but it is the identical defect on a field type the reporter did not exercise, so it is fixed here rather than left to be refiled.

## Fix

Add `PublicKey` to base58 and `Buffer`/`Uint8Array` to base64 branches to `normalizeEventData`, ordered ahead of the plain-object branch since a class instance is also `typeof "object"`. This gives the event path the same output semantics `serializeAnchorValue` already applies on the account path.

## Tests

Four cases added to `tests/unit/anchor-events.test.ts`, against an IDL carrying a pubkey bare, inside a `defined` struct, inside a `vec`, and inside an `option`, plus a `bytes` field:

- pubkey decodes to a base58 string, not a `PublicKey` instance
- nested pubkeys decode in all three container shapes
- bytes decodes to base64
- every field stays JSON-safe across a `structuredClone`, asserting no `_bn` in the output

All four fail on `staging` with the reported `{"_bn":{...}}` shape and pass with this change. The 13 pre-existing tests in the file pass either way.

Verified locally: `biome check` and `tsc --noEmit` clean; `anchor-events`, `query-solana-program-events-core` and `read-solana-program` unit suites pass (51 tests).

## Scope note

`normalizeEventData` and `serializeAnchorValue` remain two separate functions that must be kept in agreement by hand. Unifying them into one shared serializer would remove that class of divergence, but it touches the working account path, so it is left out of a fix PR.
