### PR TITLE
chore: Increase requested CPU for keeperhub-solana-common

### DIFF
--- a/deploy/solana-tracker/staging/values.yaml
+++ b/deploy/solana-tracker/staging/values.yaml
@@ -43,7 +43,7 @@ resources:
   limits:
     memory: 512Mi
   requests:
-    cpu: 150m
+    cpu: 450m
     memory: 128Mi
 
 env:


### PR DESCRIPTION
CPU usage is consistently 4x the requested value. Setting this at 3x the current value seems like a good middle-ground, based on the past 4 days of usage. It will continue to use more than the requested value but shouldn't be enough to trigger an alert.