### PR TITLE
fix: correct the API-key scope edges around the direct execution API

### DIFF
--- a/app/api/address-book/[entryId]/route.ts
+++ b/app/api/address-book/[entryId]/route.ts
@@ -90,7 +90,9 @@ export async function PATCH(
         { status: authCtx.status }
       );
     }
-    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE, {
+      credentialType: authCtx.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }
@@ -171,7 +173,9 @@ export async function DELETE(
         { status: authCtx.status }
       );
     }
-    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE, {
+      credentialType: authCtx.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/address-book/route.ts
+++ b/app/api/address-book/route.ts
@@ -89,7 +89,9 @@ export async function POST(request: Request) {
         { status: authCtx.status }
       );
     }
-    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE, {
+      credentialType: authCtx.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/ai/generate/route.ts
+++ b/app/api/ai/generate/route.ts
@@ -350,7 +350,9 @@ export async function POST(request: Request) {
       );
     }
 
-    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE, {
+      credentialType: authContext.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/analytics/runs/route.ts
+++ b/app/api/analytics/runs/route.ts
@@ -29,7 +29,9 @@ export async function GET(req: NextRequest): Promise<Response> {
       { status: authCtx.status }
     );
   }
-  const scopeError = requireScope(authCtx.scope, SCOPE_MCP_READ);
+  const scopeError = requireScope(authCtx.scope, SCOPE_MCP_READ, {
+    credentialType: authCtx.authMethod,
+  });
   if (scopeError) {
     return scopeError;
   }

--- a/app/api/analytics/spend-cap/route.ts
+++ b/app/api/analytics/spend-cap/route.ts
@@ -19,7 +19,9 @@ export async function GET(request: Request): Promise<Response> {
       { status: authCtx.status }
     );
   }
-  const scopeError = requireScope(authCtx.scope, SCOPE_MCP_READ);
+  const scopeError = requireScope(authCtx.scope, SCOPE_MCP_READ, {
+    credentialType: authCtx.authMethod,
+  });
   if (scopeError) {
     return scopeError;
   }

--- a/app/api/execute/[...slug]/route.ts
+++ b/app/api/execute/[...slug]/route.ts
@@ -361,6 +361,7 @@ export async function POST(
   const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE, {
     organizationId: apiKeyCtx.organizationId,
     credentialId: apiKeyCtx.apiKeyId,
+    credentialType: apiKeyCtx.credentialType,
     endpoint: `/api/execute/${actionType}`,
   });
   if (scopeError) {

--- a/app/api/execute/[executionId]/status/route.ts
+++ b/app/api/execute/[executionId]/status/route.ts
@@ -32,6 +32,7 @@ export async function GET(
   const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_READ, {
     organizationId: apiKeyCtx.organizationId,
     credentialId: apiKeyCtx.apiKeyId,
+    credentialType: apiKeyCtx.credentialType,
     endpoint: "/api/execute/[executionId]/status",
   });
   if (scopeError) {

--- a/app/api/execute/_lib/auth.ts
+++ b/app/api/execute/_lib/auth.ts
@@ -7,6 +7,13 @@ export type ApiKeyContext = {
   organizationId: string;
   apiKeyId: string;
   scope?: string;
+  /**
+   * Which credential family authenticated the call. A scope denial's
+   * remediation differs between the two -- an OAuth grant is widened by an
+   * admin, an API key's scope is fixed at creation -- so requireScope needs to
+   * know which one it is talking to.
+   */
+  credentialType: "oauth" | "api-key";
 };
 
 export type ApiKeyAuthError = { error: string; status: number };
@@ -32,6 +39,7 @@ export async function validateApiKey(
       organizationId: oauthResult.organizationId,
       apiKeyId: `oauth:${oauthResult.userId ?? "unknown"}`,
       scope: oauthResult.scope,
+      credentialType: "oauth",
     };
   }
 
@@ -48,6 +56,7 @@ export async function validateApiKey(
       organizationId: result.organizationId,
       apiKeyId: result.apiKeyId,
       scope: result.scope,
+      credentialType: "api-key",
     };
   }
 

--- a/app/api/execute/_lib/auth.ts
+++ b/app/api/execute/_lib/auth.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { authenticateApiKey } from "@/lib/api-key-auth";
 import { authenticateOAuthToken } from "@/lib/mcp/oauth-auth";
+import type { AuthMethod } from "@/lib/middleware/auth-helpers";
 
 export type ApiKeyContext = {
   organizationId: string;
@@ -13,7 +14,7 @@ export type ApiKeyContext = {
    * admin, an API key's scope is fixed at creation -- so requireScope needs to
    * know which one it is talking to.
    */
-  credentialType: "oauth" | "api-key";
+  credentialType: Extract<AuthMethod, "oauth" | "api-key">;
 };
 
 export type ApiKeyAuthError = { error: string; status: number };

--- a/app/api/execute/check-and-execute/route.ts
+++ b/app/api/execute/check-and-execute/route.ts
@@ -276,6 +276,7 @@ export async function POST(request: Request): Promise<NextResponse> {
     {
       organizationId: apiKeyCtx.organizationId,
       credentialId: apiKeyCtx.apiKeyId,
+      credentialType: apiKeyCtx.credentialType,
       endpoint: "/api/execute/check-and-execute",
     }
   );

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -294,6 +294,7 @@ export async function POST(request: Request): Promise<NextResponse> {
     {
       organizationId: apiKeyCtx.organizationId,
       credentialId: apiKeyCtx.apiKeyId,
+      credentialType: apiKeyCtx.credentialType,
       endpoint: "/api/execute/contract-call",
     }
   );

--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -501,6 +501,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE, {
     organizationId: apiKeyCtx.organizationId,
     credentialId: apiKeyCtx.apiKeyId,
+    credentialType: apiKeyCtx.credentialType,
     endpoint: "/api/execute/node",
   });
   if (scopeError) {

--- a/app/api/execute/swap/route.ts
+++ b/app/api/execute/swap/route.ts
@@ -17,6 +17,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE, {
     organizationId: apiKeyCtx.organizationId,
     credentialId: apiKeyCtx.apiKeyId,
+    credentialType: apiKeyCtx.credentialType,
     endpoint: "/api/execute/swap",
   });
   if (scopeError) {

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -81,6 +81,7 @@ export async function POST(request: Request): Promise<NextResponse> {
     {
       organizationId: apiKeyCtx.organizationId,
       credentialId: apiKeyCtx.apiKeyId,
+      credentialType: apiKeyCtx.credentialType,
       endpoint: "/api/execute/transfer",
     }
   );

--- a/app/api/gas/estimate/route.ts
+++ b/app/api/gas/estimate/route.ts
@@ -262,7 +262,9 @@ async function validateRequest(request: Request): Promise<
     );
   }
 
-  const scopeError = requireScope(authCtx.scope, SCOPE_MCP_READ);
+  const scopeError = requireScope(authCtx.scope, SCOPE_MCP_READ, {
+    credentialType: authCtx.authMethod,
+  });
   if (scopeError) {
     return scopeError;
   }

--- a/app/api/integrations/[integrationId]/route.ts
+++ b/app/api/integrations/[integrationId]/route.ts
@@ -134,7 +134,9 @@ export async function PUT(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE, {
+      credentialType: authContext.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }
@@ -245,7 +247,9 @@ export async function DELETE(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE, {
+      credentialType: authContext.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/integrations/[integrationId]/test/route.ts
+++ b/app/api/integrations/[integrationId]/test/route.ts
@@ -43,7 +43,9 @@ export async function POST(
       );
     }
 
-    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE, {
+      credentialType: authContext.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/integrations/route.ts
+++ b/app/api/integrations/route.ts
@@ -200,7 +200,9 @@ export async function POST(request: Request) {
       });
     }
 
-    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE, {
+      credentialType: authContext.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/integrations/test/route.ts
+++ b/app/api/integrations/test/route.ts
@@ -29,7 +29,9 @@ export async function POST(request: Request): Promise<NextResponse> {
       );
     }
 
-    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE, {
+      credentialType: authContext.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/keys/[keyId]/route.ts
+++ b/app/api/keys/[keyId]/route.ts
@@ -30,7 +30,9 @@ export async function DELETE(
     // admin/owner + dual-factor gates below reject a Bearer OAuth token), but
     // gate on write scope anyway so the A-03 class stays closed if that ordering
     // is ever refactored. Mirrors the sibling resolveOrganizationId mutations.
-    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE, {
+      credentialType: authCtx.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/mcp/workflows/[slug]/listing/route.ts
+++ b/app/api/mcp/workflows/[slug]/listing/route.ts
@@ -191,7 +191,9 @@ export async function POST(
     );
   }
 
-  const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+  const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE, {
+    credentialType: authContext.authMethod,
+  });
   if (scopeError) {
     return scopeError;
   }
@@ -275,7 +277,9 @@ export async function PATCH(
     );
   }
 
-  const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+  const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE, {
+    credentialType: authContext.authMethod,
+  });
   if (scopeError) {
     return scopeError;
   }
@@ -357,7 +361,9 @@ export async function DELETE(
     );
   }
 
-  const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+  const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE, {
+    credentialType: authContext.authMethod,
+  });
   if (scopeError) {
     return scopeError;
   }

--- a/app/api/organizations/[organizationId]/execution-digest/route.ts
+++ b/app/api/organizations/[organizationId]/execution-digest/route.ts
@@ -9,6 +9,7 @@ import {
 import { isFeatureEnabledForOrg } from "@/lib/features/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import type { AuthMethod } from "@/lib/middleware/auth-helpers";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { requireScope } from "@/lib/middleware/require-scope";
 import {
@@ -27,7 +28,7 @@ const FEATURE_ID = "notifications.execution-digest" as const;
 type ManagerOk = {
   ok: true;
   userId: string;
-  authMethod: string;
+  authMethod: AuthMethod;
   apiKeyId: string | null;
   scope?: string;
 };
@@ -176,7 +177,9 @@ export async function PUT(
       );
     }
 
-    const scopeError = requireScope(manager.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(manager.scope, SCOPE_MCP_WRITE, {
+      credentialType: manager.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/organizations/[organizationId]/mfa-enforcement/route.ts
+++ b/app/api/organizations/[organizationId]/mfa-enforcement/route.ts
@@ -9,6 +9,7 @@ import {
   parseEnforcedFactors,
 } from "@/lib/mfa/org-mfa-enforcement";
 import type { StepUpFactor } from "@/lib/mfa/step-up-policy";
+import type { AuthMethod } from "@/lib/middleware/auth-helpers";
 import { getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { requireScope } from "@/lib/middleware/require-scope";
 import { buildAuditMetadata, recordAuditEvent } from "@/lib/security/audit-log";
@@ -16,7 +17,7 @@ import { buildAuditMetadata, recordAuditEvent } from "@/lib/security/audit-log";
 type OwnerOk = {
   ok: true;
   userId: string;
-  authMethod: string;
+  authMethod: AuthMethod;
   apiKeyId: string | null;
   scope?: string;
 };
@@ -126,7 +127,9 @@ export async function PUT(
       );
     }
 
-    const scopeError = requireScope(owner.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(owner.scope, SCOPE_MCP_WRITE, {
+      credentialType: owner.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/organizations/[organizationId]/route.ts
+++ b/app/api/organizations/[organizationId]/route.ts
@@ -32,7 +32,9 @@ export async function PATCH(
       );
     }
 
-    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE, {
+      credentialType: authContext.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/projects/[projectId]/route.ts
+++ b/app/api/projects/[projectId]/route.ts
@@ -23,7 +23,9 @@ export async function PATCH(
       );
     }
 
-    const scopeError = requireScope(authResult.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authResult.scope, SCOPE_MCP_WRITE, {
+      credentialType: authResult.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }
@@ -146,7 +148,9 @@ export async function DELETE(
       );
     }
 
-    const scopeError = requireScope(authResult.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authResult.scope, SCOPE_MCP_WRITE, {
+      credentialType: authResult.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -92,7 +92,9 @@ export async function POST(request: Request) {
         { status: resolved.status }
       );
     }
-    const scopeError = requireScope(resolved.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(resolved.scope, SCOPE_MCP_WRITE, {
+      credentialType: resolved.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/tags/[tagId]/route.ts
+++ b/app/api/tags/[tagId]/route.ts
@@ -23,7 +23,9 @@ export async function PATCH(
       );
     }
 
-    const scopeError = requireScope(authResult.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authResult.scope, SCOPE_MCP_WRITE, {
+      credentialType: authResult.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }
@@ -123,7 +125,9 @@ export async function DELETE(
       );
     }
 
-    const scopeError = requireScope(authResult.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authResult.scope, SCOPE_MCP_WRITE, {
+      credentialType: authResult.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/tags/route.ts
+++ b/app/api/tags/route.ts
@@ -85,7 +85,9 @@ export async function POST(request: Request): Promise<NextResponse> {
         { status: resolved.status }
       );
     }
-    const scopeError = requireScope(resolved.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(resolved.scope, SCOPE_MCP_WRITE, {
+      credentialType: resolved.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/tempo/held-payments/[id]/broadcast/route.ts
+++ b/app/api/tempo/held-payments/[id]/broadcast/route.ts
@@ -49,7 +49,9 @@ export async function POST(
       { status: resolved.status }
     );
   }
-  const scopeError = requireScope(resolved.scope, SCOPE_MCP_WRITE);
+  const scopeError = requireScope(resolved.scope, SCOPE_MCP_WRITE, {
+    credentialType: resolved.authMethod,
+  });
   if (scopeError) {
     return scopeError;
   }

--- a/app/api/tempo/held-payments/[id]/cancel/route.ts
+++ b/app/api/tempo/held-payments/[id]/cancel/route.ts
@@ -39,7 +39,9 @@ export async function POST(
       { status: resolved.status }
     );
   }
-  const scopeError = requireScope(resolved.scope, SCOPE_MCP_WRITE);
+  const scopeError = requireScope(resolved.scope, SCOPE_MCP_WRITE, {
+    credentialType: resolved.authMethod,
+  });
   if (scopeError) {
     return scopeError;
   }

--- a/app/api/tempo/held-payments/route.ts
+++ b/app/api/tempo/held-payments/route.ts
@@ -164,7 +164,9 @@ export async function POST(request: Request): Promise<NextResponse> {
       { status: resolved.status }
     );
   }
-  const scopeError = requireScope(resolved.scope, SCOPE_MCP_WRITE);
+  const scopeError = requireScope(resolved.scope, SCOPE_MCP_WRITE, {
+    credentialType: resolved.authMethod,
+  });
   if (scopeError) {
     return scopeError;
   }

--- a/app/api/user/wallet/tokens/route.ts
+++ b/app/api/user/wallet/tokens/route.ts
@@ -110,7 +110,9 @@ export async function POST(request: Request) {
       );
     }
 
-    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE, {
+      credentialType: authCtx.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }
@@ -301,7 +303,9 @@ export async function DELETE(request: Request) {
       );
     }
 
-    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_WRITE, {
+      credentialType: authCtx.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/web3/fetch-abi/route.ts
+++ b/app/api/web3/fetch-abi/route.ts
@@ -1309,7 +1309,9 @@ export async function POST(request: Request) {
       );
     }
 
-    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_READ);
+    const scopeError = requireScope(authCtx.scope, SCOPE_MCP_READ, {
+      credentialType: authCtx.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -111,7 +111,9 @@ export async function POST(
         );
       }
 
-      const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+      const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE, {
+      credentialType: authContext.authMethod,
+    });
       if (scopeError) {
         return scopeError;
       }

--- a/app/api/workflows/[workflowId]/duplicate/route.ts
+++ b/app/api/workflows/[workflowId]/duplicate/route.ts
@@ -124,7 +124,9 @@ export async function POST(
       return authFailureResponse(authContext, request.headers);
     }
 
-    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE, {
+      credentialType: authContext.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/workflows/[workflowId]/executions/route.ts
+++ b/app/api/workflows/[workflowId]/executions/route.ts
@@ -158,7 +158,9 @@ export async function DELETE(
       return authFailureResponse(authContext, request.headers);
     }
 
-    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE, {
+      credentialType: authContext.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/workflows/[workflowId]/go-live/route.ts
+++ b/app/api/workflows/[workflowId]/go-live/route.ts
@@ -29,7 +29,9 @@ export async function PUT(
       return authFailureResponse(authContext, request.headers);
     }
 
-    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE, {
+      credentialType: authContext.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -365,7 +365,9 @@ export async function PATCH(
       return authFailureResponse(authContext, request.headers);
     }
 
-    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE, {
+      credentialType: authContext.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }
@@ -923,7 +925,9 @@ export async function DELETE(
       return authFailureResponse(authContext, request.headers);
     }
 
-    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE, {
+      credentialType: authContext.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/workflows/create/route.ts
+++ b/app/api/workflows/create/route.ts
@@ -94,7 +94,9 @@ export async function POST(request: Request) {
       return authFailureResponse(authContext, request.headers);
     }
 
-    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE, {
+      credentialType: authContext.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/api/workflows/import/route.ts
+++ b/app/api/workflows/import/route.ts
@@ -56,7 +56,9 @@ export async function POST(request: Request): Promise<NextResponse> {
       return authFailureResponse(authContext, request.headers);
     }
 
-    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE);
+    const scopeError = requireScope(authContext.scope, SCOPE_MCP_WRITE, {
+      credentialType: authContext.authMethod,
+    });
     if (scopeError) {
       return scopeError;
     }

--- a/app/mcp/route.ts
+++ b/app/mcp/route.ts
@@ -24,6 +24,7 @@ import {
   startCleanupInterval,
   touchSession,
 } from "@/lib/mcp/sessions";
+import type { AuthMethod } from "@/lib/middleware/auth-helpers";
 import {
   applyRateLimitHeaders,
   rateLimitHeaders,
@@ -185,6 +186,17 @@ type BuiltSession = {
   entry: SessionEntry;
 };
 
+/**
+ * The session token carries the credential id but not which family issued it,
+ * and a reconstructed session has nothing else to go on. authenticate() builds
+ * `oauth:<userId>` for OAuth and uses the key row id for kh_ keys, so the
+ * prefix is the one signal that survives. Derived here only, so the convention
+ * has a single reader rather than being re-tested wherever it is needed.
+ */
+function credentialFamily(apiKeyId: string): AuthMethod {
+  return apiKeyId.startsWith("oauth:") ? "oauth" : "api-key";
+}
+
 function buildSession(
   sessionId: string,
   organizationId: string,
@@ -210,7 +222,12 @@ function buildSession(
     enableJsonResponse: true,
   });
 
-  const server = createMcpServer(internalApiBaseUrl, authHeader, scope);
+  const server = createMcpServer(
+    internalApiBaseUrl,
+    authHeader,
+    scope,
+    credentialFamily(apiKeyId)
+  );
 
   const entry: SessionEntry = {
     transport,

--- a/components/overlays/api-keys-overlay.tsx
+++ b/components/overlays/api-keys-overlay.tsx
@@ -89,8 +89,17 @@ export function CreateApiKeyOverlay({
     () => Object.fromEntries(SUPPORTED_SCOPES.map((s) => [s, true]))
   );
 
+  // Scope is only enforced for organisation keys (kh_): authenticateApiKey
+  // reads the column on organizationApiKeys, and requireScope gates on it.
+  // Webhook keys (wfb_) are looked up by hash in the workflow webhook route and
+  // dispatched without consulting scope, so offering the checkboxes there would
+  // promise a restriction nothing applies.
+  const scopesApply = keyType === "organisation";
   const activeScopes = SUPPORTED_SCOPES.filter((s) => selectedScopes[s]);
-  const hasScopeSelected = activeScopes.length > 0;
+  const hasScopeSelected = !scopesApply || activeScopes.length > 0;
+  // Omitted rather than sent-and-ignored for webhook keys, so the stored column
+  // says what is true: this key carries no scope restriction.
+  const scopesForRequest = scopesApply ? activeScopes : undefined;
 
   const toggleScope = (id: string, checked: boolean): void => {
     if (id === "mcp:admin" && checked) {
@@ -108,7 +117,10 @@ export function CreateApiKeyOverlay({
     fetch(endpoint, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: keyName.trim() || null, scopes: activeScopes }),
+      body: JSON.stringify({
+        name: keyName.trim() || null,
+        scopes: scopesForRequest,
+      }),
     });
 
   // Wallet users confirm by signing instead of entering TOTP + email codes.
@@ -128,7 +140,7 @@ export function CreateApiKeyOverlay({
             // The same Permissions block is shown to wallet users, so the
             // selection has to reach the API here too. Omitting it minted an
             // unscoped key that ignored whatever the user unchecked.
-            scopes: activeScopes,
+            scopes: scopesForRequest,
           }),
         })
       );
@@ -159,7 +171,7 @@ export function CreateApiKeyOverlay({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: keyName.trim() || null,
-          scopes: activeScopes,
+          scopes: scopesForRequest,
           code: dual.totpCode.trim(),
           emailOtp: dual.emailOtp.trim() || undefined,
         }),
@@ -255,35 +267,37 @@ export function CreateApiKeyOverlay({
             value={keyName}
           />
         </div>
-        <div className="space-y-2">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-            Permissions
-          </p>
-          <div className="rounded-lg border bg-muted/30 p-4">
-            <ul className="space-y-3">
-              {SUPPORTED_SCOPES.map((scopeId) => {
-                const lockedByAdmin = scopeId !== "mcp:admin" && isAdminSelected;
-                return (
-                  <li key={scopeId}>
-                    <label
-                      className={`flex items-center gap-3 text-sm text-foreground ${lockedByAdmin ? "cursor-default opacity-50" : "cursor-pointer"}`}
-                    >
-                      <input
-                        checked={selectedScopes[scopeId] ?? false}
-                        className="h-4 w-4 shrink-0 rounded border-input accent-[var(--ds-green-accent)]"
-                        disabled={lockedByAdmin}
-                        onChange={(e) => toggleScope(scopeId, e.target.checked)}
-                        type="checkbox"
-                        value={scopeId}
-                      />
-                      {SCOPE_LABELS[scopeId] ?? scopeId}
-                    </label>
-                  </li>
-                );
-              })}
-            </ul>
+        {scopesApply && (
+          <div className="space-y-2">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Permissions
+            </p>
+            <div className="rounded-lg border bg-muted/30 p-4">
+              <ul className="space-y-3">
+                {SUPPORTED_SCOPES.map((scopeId) => {
+                  const lockedByAdmin = scopeId !== "mcp:admin" && isAdminSelected;
+                  return (
+                    <li key={scopeId}>
+                      <label
+                        className={`flex items-center gap-3 text-sm text-foreground ${lockedByAdmin ? "cursor-default opacity-50" : "cursor-pointer"}`}
+                      >
+                        <input
+                          checked={selectedScopes[scopeId] ?? false}
+                          className="h-4 w-4 shrink-0 rounded border-input accent-[var(--ds-green-accent)]"
+                          disabled={lockedByAdmin}
+                          onChange={(e) => toggleScope(scopeId, e.target.checked)}
+                          type="checkbox"
+                          value={scopeId}
+                        />
+                        {SCOPE_LABELS[scopeId] ?? scopeId}
+                      </label>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </Overlay>
   );

--- a/components/overlays/api-keys-overlay.tsx
+++ b/components/overlays/api-keys-overlay.tsx
@@ -22,7 +22,7 @@ import { usePaginatedResource } from "@/lib/hooks/use-paginated-resource";
 import { useActiveMember } from "@/lib/hooks/use-organization";
 import type { Page, PageMeta } from "@/lib/pagination";
 import { useDualFactorState } from "@/lib/mfa/use-dual-factor-state";
-import { SUPPORTED_SCOPES } from "@/lib/mcp/oauth-scopes";
+import { SCOPE_MCP_READ, SUPPORTED_SCOPES } from "@/lib/mcp/oauth-scopes";
 import { ConfirmOverlay } from "./confirm-overlay";
 import { KeyActivityOverlay } from "./key-activity-overlay";
 import { Overlay } from "./overlay";
@@ -85,8 +85,14 @@ export function CreateApiKeyOverlay({
   const [phase, setPhase] = useState<"label" | "codes">("label");
   const dual = useDualFactorState();
   const [creating, setCreating] = useState(false);
+  // Only read is pre-checked. Pre-checking all three made the least-effort
+  // mint a full-access mcp:admin key, which is the widest-by-default outcome
+  // parseScopeInput was just changed to stop producing on the API side.
   const [selectedScopes, setSelectedScopes] = useState<Record<string, boolean>>(
-    () => Object.fromEntries(SUPPORTED_SCOPES.map((s) => [s, true]))
+    () =>
+      Object.fromEntries(
+        SUPPORTED_SCOPES.map((s) => [s, s === SCOPE_MCP_READ])
+      )
   );
 
   // Scope is only enforced for organisation keys (kh_): authenticateApiKey
@@ -442,6 +448,7 @@ function ApiKeysList({
   onDelete,
   onDismissNewKey,
   showCreator = false,
+  showScope = true,
   deleteEndpoint,
   canDelete = true,
   readOnlyReason,
@@ -459,6 +466,12 @@ function ApiKeysList({
   ) => Promise<{ ok: true } | { ok: false; code: string }>;
   onDismissNewKey: () => void;
   showCreator?: boolean;
+  /**
+   * Webhook (wfb_) keys store a scope that nothing reads: the workflow webhook
+   * route looks a key up by hash and dispatches without consulting it. Showing
+   * it there states a restriction that is not applied.
+   */
+  showScope?: boolean;
   deleteEndpoint: (id: string) => string;
   canDelete?: boolean;
   readOnlyReason?: string;
@@ -552,7 +565,7 @@ function ApiKeysList({
                     <span className="truncate text-sm">{apiKey.name}</span>
                   </p>
                 )}
-                {apiKey.scope && (
+                {showScope && apiKey.scope && (
                   <p className="mt-2 mb-2 text-sm">
                     {"Scope: "}
                     {apiKey.scope.split(" ").map((s) => (
@@ -954,6 +967,7 @@ export function ApiKeysPanel({
           ) : (
             <ApiKeysList
               apiKeys={webhookKeys.apiKeys}
+              showScope={false}
               deleteEndpoint={webhookKeys.deleteEndpoint}
               deleting={webhookKeys.deleting}
               highlightId={

--- a/components/settings/hub/api-keys/api-keys-table.tsx
+++ b/components/settings/hub/api-keys/api-keys-table.tsx
@@ -40,12 +40,20 @@ const SCOPE_SEPARATOR = /[\s,]+/;
 export function ApiKeysTable({
   apiKeys,
   showCreator,
+  showScope,
   canDelete,
   deleteEndpoint,
   onDelete,
 }: {
   apiKeys: ApiKey[];
   showCreator: boolean;
+  /**
+   * Webhook (wfb_) keys store a scope nothing reads -- the workflow webhook
+   * route matches on the key hash and dispatches without consulting it -- so
+   * the column is dropped rather than reporting a restriction that is not
+   * applied.
+   */
+  showScope: boolean;
   canDelete: boolean;
   deleteEndpoint: (id: string) => string;
   onDelete: DeleteFn;
@@ -57,7 +65,7 @@ export function ApiKeysTable({
       <TableHeader>
         <TableRow className={SETTINGS_HEAD_ROW}>
           <TableHead>Key</TableHead>
-          <TableHead>Scopes</TableHead>
+          {showScope && <TableHead>Scopes</TableHead>}
           {showCreator && <TableHead>Created by</TableHead>}
           <TableHead>Last used</TableHead>
           <TableHead className="text-right">Actions</TableHead>
@@ -76,24 +84,30 @@ export function ApiKeysTable({
                 </span>
               </div>
             </TableCell>
-            <TableCell>
-              <div className="flex flex-wrap gap-1">
-                {(key.scope ?? "")
-                  .split(SCOPE_SEPARATOR)
-                  .filter(Boolean)
-                  .map((scope) => (
-                    <span
-                      className="rounded-full border px-2 py-0.5 font-mono text-[0.6875rem]"
-                      key={scope}
-                    >
-                      {scope}
+            {showScope && (
+              <TableCell>
+                <div className="flex flex-wrap gap-1">
+                  {(key.scope ?? "")
+                    .split(SCOPE_SEPARATOR)
+                    .filter(Boolean)
+                    .map((scope) => (
+                      <span
+                        className="rounded-full border px-2 py-0.5 font-mono text-[0.6875rem]"
+                        key={scope}
+                      >
+                        {scope}
+                      </span>
+                    ))}
+                  {/* A null scope column is full access, not none. "--" read as
+                      "no permissions" -- the opposite of what it means. */}
+                  {!key.scope && (
+                    <span className="text-muted-foreground text-xs">
+                      unrestricted
                     </span>
-                  ))}
-                {!key.scope && (
-                  <span className="text-muted-foreground text-xs">--</span>
-                )}
-              </div>
-            </TableCell>
+                  )}
+                </div>
+              </TableCell>
+            )}
             {showCreator && (
               <TableCell>
                 <div className="flex min-w-0 flex-col">

--- a/components/settings/hub/api-keys/keys-card.tsx
+++ b/components/settings/hub/api-keys/keys-card.tsx
@@ -125,6 +125,7 @@ export function KeysCard({
               deleteEndpoint={deleteEndpoint}
               onDelete={keys.handleDelete}
               showCreator={showCreator}
+              showScope={keyType === "organisation"}
             />
             {keys.meta && keys.meta.totalPages > 1 && (
               <div className="px-2 pt-2">

--- a/docs/api/direct-execution.md
+++ b/docs/api/direct-execution.md
@@ -800,18 +800,25 @@ this connection is allowed:
 ```json
 {
   "error": "insufficient_scope",
-  "message": "This endpoint requires the `mcp:write` OAuth scope. This connection is allowed `mcp:read`. Reconnecting will not raise it: the limit is set by an organization owner or admin under Settings > Developer > Agents. Do not retry; ask them to raise it.",
+  "message": "This endpoint requires the `mcp:write` scope. This credential is allowed `mcp:read`. Retrying will not widen it. An API key's scope is fixed when the key is created and cannot be raised. A new key has to be issued with the scope this endpoint requires.",
   "retryable": false,
   "required_scope": "mcp:write",
   "granted_scope": "mcp:read"
 }
 ```
 
-`granted_scope` is what the connection may do right now, which is not always the
-scope the token was issued with. An organization can cap what its agents may do,
-and a cap is applied on every call, so a token issued with `mcp:admin` reports
-`mcp:read` here while a read-only cap is in force. Reauthorizing with a wider
-scope does not lift a cap; only an owner or admin can, in the Agents settings.
+The closing sentence names the remedy for the credential that was used, because
+the two families differ. An API key's scope is written into the key when it is
+created and cannot be changed afterwards, so a new key is the only route. An
+OAuth connection is instead told that an owner or admin controls its ceiling
+under Settings > Developer > Agents.
+
+`granted_scope` is what the credential may do right now. For an OAuth token that
+is not always the scope it was issued with: an organization can cap what its
+agents may do, and the cap is applied on every call, so a token issued with
+`mcp:admin` reports `mcp:read` here while a read-only cap is in force.
+Reauthorizing with a wider scope does not lift a cap; only an owner or admin
+can, in the Agents settings. An API key reports the scope stored on the key.
 
 Broadcasting requires `mcp:write`. A dry run (`simulate: true`) neither signs nor broadcasts, so `mcp:read` is sufficient.
 

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -17,6 +17,7 @@ import type {
   NodeExecutionStatus,
   WorkflowExecutionStatus,
 } from "../errors/execution-status";
+import type { ErrorCategory } from "../logging";
 import type { IntegrationType } from "../types/integration";
 import { generateId } from "../utils/id";
 
@@ -699,22 +700,10 @@ export const workflowExecutions = pgTable(
     // biome-ignore lint/suspicious/noExplicitAny: JSONB type - structure validated at application level
     output: jsonb("output").$type<any>(),
     error: text("error"),
-    // Mirrors ErrorCategory in lib/logging.ts. Plain text, not a pg enum, so
-    // keeping the two in step is a type-level change only.
-    errorCategory: text("error_category").$type<
-      | "validation"
-      | "configuration"
-      | "external_service"
-      | "network_rpc"
-      | "transaction"
-      | "billing"
-      | "authorization"
-      | "database"
-      | "auth"
-      | "infrastructure"
-      | "workflow_engine"
-      | "unknown"
-    >(),
+    // $type erases at compile time, so this tracks ErrorCategory in
+    // lib/logging.ts by reference rather than by a hand-copied union that has
+    // to be remembered whenever a category is added.
+    errorCategory: text("error_category").$type<ErrorCategory>(),
     errorType: text("error_type").$type<ExecutionErrorType>(),
     errorCode: text("error_code").$type<ErrorCode>(),
     startedAt: timestamp("started_at").notNull().defaultNow(),

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -699,6 +699,8 @@ export const workflowExecutions = pgTable(
     // biome-ignore lint/suspicious/noExplicitAny: JSONB type - structure validated at application level
     output: jsonb("output").$type<any>(),
     error: text("error"),
+    // Mirrors ErrorCategory in lib/logging.ts. Plain text, not a pg enum, so
+    // keeping the two in step is a type-level change only.
     errorCategory: text("error_category").$type<
       | "validation"
       | "configuration"
@@ -706,6 +708,7 @@ export const workflowExecutions = pgTable(
       | "network_rpc"
       | "transaction"
       | "billing"
+      | "authorization"
       | "database"
       | "auth"
       | "infrastructure"

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -178,6 +178,11 @@ export const ErrorCategory = {
   NETWORK_RPC: "network_rpc",
   TRANSACTION: "transaction",
   BILLING: "billing",
+  // A caller using a valid credential outside its grant. User-caused and
+  // reachable at the caller's own request rate, so it is deliberately not
+  // AUTH -- that is the system-side family (broken sessions, misconfigured
+  // providers) the errors dashboard sums into its System Errors panels.
+  AUTHORIZATION: "authorization",
 
   // System-caused errors
   DATABASE: "database",
@@ -211,6 +216,8 @@ function getMetricName(category: ErrorCategory): string {
       return MetricNames.TRANSACTION_BLOCKCHAIN_ERRORS;
     case ErrorCategory.DATABASE:
       return MetricNames.SYSTEM_DATABASE_ERRORS;
+    case ErrorCategory.AUTHORIZATION:
+      return MetricNames.USER_AUTHORIZATION_ERRORS;
     case ErrorCategory.AUTH:
       return MetricNames.SYSTEM_AUTH_ERRORS;
     case ErrorCategory.INFRASTRUCTURE:

--- a/lib/mcp/oauth-scopes.ts
+++ b/lib/mcp/oauth-scopes.ts
@@ -133,14 +133,19 @@ export function normalizeScope(requestedScope: string): string {
  * Coerce the `scopes` field from an API request body (array or space-separated
  * string) into a normalized scope string, or null when omitted.
  *
- * Null means "no scope restriction" and passes every gate, so it must be
- * reachable only by leaving `scopes` out entirely. A caller that supplies the
- * field gets normalizeScope, which floors at mcp:read -- so `[]`, `[1, 2]` and
- * `""` narrow to the least privilege rather than widening to full access, the
- * same way `["bogus"]` already did. Asking for nothing and receiving
- * everything was the one input shape where the fallback ran the wrong way.
+ * Null means "no scope restriction" and passes every gate, so only omission may
+ * reach it. `scopes` arrives as unvalidated request body, so "supplied" has to
+ * cover more than the two shapes we can read: an object (the shape the creation
+ * UI holds internally), a boolean, a number. Anything present but unusable
+ * floors at mcp:read rather than widening to full access -- the caller asked
+ * for a restriction, and the one thing we must not do is answer that with none.
  */
 export function parseScopeInput(scopes: unknown): string | null {
+  // JSON clients routinely send null for an absent field, so it is read as
+  // omission. undefined is the same case.
+  if (scopes === undefined || scopes === null) {
+    return null;
+  }
   if (Array.isArray(scopes)) {
     return normalizeScope(
       scopes.filter((s): s is string => typeof s === "string").join(" ")
@@ -149,7 +154,7 @@ export function parseScopeInput(scopes: unknown): string | null {
   if (typeof scopes === "string") {
     return normalizeScope(scopes);
   }
-  return null;
+  return SCOPE_MCP_READ;
 }
 
 /**

--- a/lib/mcp/oauth-scopes.ts
+++ b/lib/mcp/oauth-scopes.ts
@@ -132,16 +132,22 @@ export function normalizeScope(requestedScope: string): string {
 /**
  * Coerce the `scopes` field from an API request body (array or space-separated
  * string) into a normalized scope string, or null when omitted.
+ *
+ * Null means "no scope restriction" and passes every gate, so it must be
+ * reachable only by leaving `scopes` out entirely. A caller that supplies the
+ * field gets normalizeScope, which floors at mcp:read -- so `[]`, `[1, 2]` and
+ * `""` narrow to the least privilege rather than widening to full access, the
+ * same way `["bogus"]` already did. Asking for nothing and receiving
+ * everything was the one input shape where the fallback ran the wrong way.
  */
 export function parseScopeInput(scopes: unknown): string | null {
   if (Array.isArray(scopes)) {
-    const raw = scopes
-      .filter((s): s is string => typeof s === "string")
-      .join(" ");
-    return raw.trim() ? normalizeScope(raw) : null;
+    return normalizeScope(
+      scopes.filter((s): s is string => typeof s === "string").join(" ")
+    );
   }
   if (typeof scopes === "string") {
-    return scopes.trim() ? normalizeScope(scopes) : null;
+    return normalizeScope(scopes);
   }
   return null;
 }

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -2,6 +2,7 @@ import {
   McpServer,
   ResourceTemplate,
 } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { AuthMethod } from "@/lib/middleware/auth-helpers";
 import { PUBLIC_TOOLS, SCOPE_MCP_PUBLIC } from "./oauth-scopes";
 import { registerMetaTools, registerTools } from "./tools";
 
@@ -112,7 +113,8 @@ function registerResources(
 export function createMcpServer(
   internalApiBaseUrl: string,
   authHeader: string,
-  scope?: string
+  scope?: string,
+  credentialType?: AuthMethod
 ): McpServer {
   const server = new McpServer({
     name: "keeperhub",
@@ -122,8 +124,20 @@ export function createMcpServer(
   const isPublic = scope === SCOPE_MCP_PUBLIC;
   const registrar = isPublic ? publicToolRegistrar(server) : server;
 
-  registerTools(registrar, internalApiBaseUrl, authHeader, scope);
-  registerMetaTools(registrar, internalApiBaseUrl, authHeader, scope);
+  registerTools(
+    registrar,
+    internalApiBaseUrl,
+    authHeader,
+    scope,
+    credentialType
+  );
+  registerMetaTools(
+    registrar,
+    internalApiBaseUrl,
+    authHeader,
+    scope,
+    credentialType
+  );
 
   // Resources (keeperhub://workflows*) read org-scoped data, so they are never
   // registered on the anonymous public surface.

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -6,6 +6,7 @@ import {
   parseIntervalSeconds,
   validateCronExpression,
 } from "@/lib/cron-utils";
+import type { AuthMethod } from "@/lib/middleware/auth-helpers";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { SUPPORTED_CHAIN_IDS } from "@/lib/rpc/types";
 import { withToolLogging } from "./logging";
@@ -36,26 +37,38 @@ type ScopeDeniedContent = {
  */
 function buildScopeDeniedResult(
   toolName: string,
-  grantedScope: string
+  grantedScope: string,
+  credentialType?: AuthMethod
 ): ScopeDeniedContent {
   const requiredScope = getRequiredScopeForTool(toolName);
-  // Encode the granted/required pair into the upgrade_url so the stub
-  // page at /settings/mcp/reauthorize can render contextual messaging
-  // ("you have mcp:read, this needs mcp:write") without the client
-  // having to thread the original denial state through itself.
-  const upgradeUrl = `/settings/mcp/reauthorize?required=${encodeURIComponent(requiredScope)}&granted=${encodeURIComponent(grantedScope)}`;
+  // An API key's scope is written into the key at creation and there is no
+  // consent screen behind it, so the reauthorize stub is dead ground for one:
+  // sending an agent there is the loop this message exists to avoid. Only an
+  // OAuth connection gets the upgrade_url and the reauthorize hint.
+  const isApiKey = credentialType === "api-key";
+  const upgradeUrl = isApiKey
+    ? undefined
+    : // Encode the granted/required pair into the upgrade_url so the stub
+      // page at /settings/mcp/reauthorize can render contextual messaging
+      // ("you have mcp:read, this needs mcp:write") without the client
+      // having to thread the original denial state through itself.
+      `/settings/mcp/reauthorize?required=${encodeURIComponent(requiredScope)}&granted=${encodeURIComponent(grantedScope)}`;
+  const credentialNoun = isApiKey ? "API key" : "token";
+  const hint = isApiKey
+    ? `An API key's scope is fixed when the key is created and cannot be raised. A new key has to be issued with \`${requiredScope}\`.`
+    : `Reauthorize the MCP integration and request \`${requiredScope}\` on the consent screen.`;
   return {
     content: [
       {
         type: "text" as const,
         text: JSON.stringify({
           error: "insufficient_scope",
-          message: `This tool requires the \`${requiredScope}\` OAuth scope. The current token only has \`${grantedScope || "(none)"}\`.`,
+          message: `This tool requires the \`${requiredScope}\` scope. The current ${credentialNoun} only has \`${grantedScope || "(none)"}\`.`,
           required_scope: requiredScope,
           granted_scope: grantedScope,
           tool: toolName,
-          upgrade_url: upgradeUrl,
-          hint: `Reauthorize the MCP integration and request \`${requiredScope}\` on the consent screen.`,
+          ...(upgradeUrl ? { upgrade_url: upgradeUrl } : {}),
+          hint,
         }),
       },
     ],
@@ -81,7 +94,8 @@ function withScopeCheck<H extends AnyToolHandler>(
   toolName: string,
   scope: string | undefined,
   handler: H,
-  readOnlyWhen?: ReadOnlyWhen
+  readOnlyWhen?: ReadOnlyWhen,
+  credentialType?: AuthMethod
 ): H {
   if (scope === undefined) {
     return handler;
@@ -96,7 +110,7 @@ function withScopeCheck<H extends AnyToolHandler>(
       return handler(...args) as ReturnType<H>;
     }
     if (!isToolAllowed(toolName, scope)) {
-      return buildScopeDeniedResult(toolName, scope);
+      return buildScopeDeniedResult(toolName, scope, credentialType);
     }
     return handler(...args) as ReturnType<H>;
   };
@@ -841,8 +855,19 @@ export function registerTools(
   server: McpServer,
   internalApiBaseUrl: string,
   authHeader: string,
-  scope?: string
+  scope?: string,
+  credentialType?: AuthMethod
 ): void {
+  // Binds the request's scope and credential family once, so every tool below
+  // reads as a gate on the tool name and nothing has to remember to thread the
+  // denial context through 40 call sites.
+  const scoped = <H extends AnyToolHandler>(
+    toolName: string,
+    handler: H,
+    readOnlyWhen?: ReadOnlyWhen
+  ): H =>
+    withScopeCheck(toolName, scope, handler, readOnlyWhen, credentialType);
+
   // =========================================================================
   // Workflow CRUD
   // =========================================================================
@@ -861,7 +886,7 @@ export function registerTools(
         .describe("Optional tag ID to filter workflows"),
     },
     { title: "List Workflows", readOnlyHint: true, destructiveHint: false },
-    withScopeCheck("list_workflows", scope, async (args) =>
+    scoped("list_workflows", async (args) =>
       withToolLogging("list_workflows", undefined, async () => {
         const params = new URLSearchParams();
         if (args.projectId) {
@@ -887,7 +912,7 @@ export function registerTools(
       workflowId: z.string().describe("The workflow ID"),
     },
     { title: "Get Workflow", readOnlyHint: true, destructiveHint: false },
-    withScopeCheck("get_workflow", scope, async (args) =>
+    scoped("get_workflow", async (args) =>
       withToolLogging("get_workflow", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -938,7 +963,7 @@ export function registerTools(
     // webhook trigger on the same call. One call therefore starts a
     // recurring unattended run of arbitrary node content.
     { title: "Create Workflow", readOnlyHint: false, destructiveHint: true },
-    withScopeCheck("create_workflow", scope, async (args) =>
+    scoped("create_workflow", async (args) =>
       withToolLogging("create_workflow", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -999,7 +1024,7 @@ export function registerTools(
     // nodes/edges are a full replace, and enabled toggles live triggers, so
     // this overwrites state a caller may not be able to reconstruct.
     { title: "Update Workflow", readOnlyHint: false, destructiveHint: true },
-    withScopeCheck("update_workflow", scope, async (args) =>
+    scoped("update_workflow", async (args) =>
       withToolLogging("update_workflow", undefined, async () => {
         const { workflowId, ...body } = args;
         const data = await callApi(
@@ -1023,7 +1048,7 @@ export function registerTools(
       workflowId: z.string().describe("The workflow ID to delete"),
     },
     { title: "Delete Workflow", readOnlyHint: false, destructiveHint: true },
-    withScopeCheck("delete_workflow", scope, async (args) =>
+    scoped("delete_workflow", async (args) =>
       withToolLogging("delete_workflow", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -1047,7 +1072,7 @@ export function registerTools(
     "List all projects for the authenticated organization, each with its workflow count. Use a project's id as projectId when creating, updating, or filtering workflows.",
     {},
     { title: "List Projects", readOnlyHint: true, destructiveHint: false },
-    withScopeCheck("list_projects", scope, (_args) =>
+    scoped("list_projects", (_args) =>
       withToolLogging("list_projects", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -1079,7 +1104,7 @@ export function registerTools(
         ),
     },
     { title: "Create Project", readOnlyHint: false, destructiveHint: false },
-    withScopeCheck("create_project", scope, (args) =>
+    scoped("create_project", (args) =>
       withToolLogging("create_project", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -1104,7 +1129,7 @@ export function registerTools(
     "List all tags for the authenticated organization, each with its workflow count. Use a tag's id as tagId when creating, updating, or filtering workflows.",
     {},
     { title: "List Tags", readOnlyHint: true, destructiveHint: false },
-    withScopeCheck("list_tags", scope, (_args) =>
+    scoped("list_tags", (_args) =>
       withToolLogging("list_tags", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -1132,7 +1157,7 @@ export function registerTools(
         ),
     },
     { title: "Create Tag", readOnlyHint: false, destructiveHint: false },
-    withScopeCheck("create_tag", scope, (args) =>
+    scoped("create_tag", (args) =>
       withToolLogging("create_tag", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -1169,7 +1194,7 @@ export function registerTools(
     // The workflow body is arbitrary: a run can transfer funds or call any
     // contract. Nothing in the arguments bounds that, so assume the worst.
     { title: "Execute Workflow", readOnlyHint: false, destructiveHint: true },
-    withScopeCheck("execute_workflow", scope, async (args) =>
+    scoped("execute_workflow", async (args) =>
       withToolLogging("execute_workflow", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -1200,7 +1225,7 @@ export function registerTools(
     "Get combined status and step-by-step logs for a workflow execution. Replaces the v1.11 get_execution_status + get_execution_logs pair. Returns { status, logs } in a single response. `status` and each log's `transactionHashes[].verified`/`receiptStatus` are independently reconciled against on-chain receipts before the execution is allowed to finalize as success -- this, not execute_workflow's trigger acknowledgement, is the authoritative signal for whether a workflow (and any money movement within it) actually completed. By default returns full node input/output data (backward compatible with v1.11 get_execution_logs no-param callers). Pass `includeData: false` to omit input/output/outputRaw blobs, `nodeIds: string[]` to restrict full data to specific nodes (status and error always returned for every node), or `truncateData: number` (bytes) to cap individual input/output/outputRaw payloads. The `error` field is never truncated. One exception to the shape: for an execution owned by another organization that you can see only through its workflow's public share setting, `logs` is null and `status` is redacted (node identifiers omitted) -- includeData, nodeIds and truncateData have no effect there.",
     GET_EXECUTION_SCHEMA,
     { title: "Get Execution", readOnlyHint: true, destructiveHint: false },
-    withScopeCheck("get_execution", scope, async (args) =>
+    scoped("get_execution", async (args) =>
       withToolLogging("get_execution", undefined, async () => {
         const accessRequest = new Request(`${internalApiBaseUrl}/mcp`, {
           headers: { Authorization: authHeader },
@@ -1288,7 +1313,7 @@ export function registerTools(
       readOnlyHint: true,
       destructiveHint: false,
     },
-    withScopeCheck("get_execution_status", scope, async (args) =>
+    scoped("get_execution_status", async (args) =>
       withToolLogging("get_execution_status", undefined, async () => {
         const data = await fetchExecutionData(internalApiBaseUrl, authHeader, {
           executionId: args.executionId,
@@ -1318,7 +1343,7 @@ export function registerTools(
       readOnlyHint: true,
       destructiveHint: false,
     },
-    withScopeCheck("get_execution_logs", scope, async (args) =>
+    scoped("get_execution_logs", async (args) =>
       withToolLogging("get_execution_logs", undefined, async () => {
         const data = await fetchExecutionData(
           internalApiBaseUrl,
@@ -1367,7 +1392,7 @@ export function registerTools(
       readOnlyHint: true,
       destructiveHint: false,
     },
-    withScopeCheck("ai_generate_workflow", scope, async (args) =>
+    scoped("ai_generate_workflow", async (args) =>
       withToolLogging("ai_generate_workflow", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -1411,7 +1436,7 @@ export function registerTools(
       readOnlyHint: true,
       destructiveHint: false,
     },
-    withScopeCheck("list_action_schemas", scope, async (args) =>
+    scoped("list_action_schemas", async (args) =>
       withToolLogging("list_action_schemas", undefined, async () => {
         const params = new URLSearchParams();
         if (args.category) {
@@ -1444,7 +1469,7 @@ export function registerTools(
         ),
     },
     { title: "Search Plugins", readOnlyHint: true, destructiveHint: false },
-    withScopeCheck("search_plugins", scope, async (args) =>
+    scoped("search_plugins", async (args) =>
       withToolLogging("search_plugins", undefined, async () => {
         const params = new URLSearchParams({ category: args.category });
         const data = await callApi(
@@ -1471,7 +1496,7 @@ export function registerTools(
         ),
     },
     { title: "Get Plugin", readOnlyHint: true, destructiveHint: false },
-    withScopeCheck("get_plugin", scope, async (args) =>
+    scoped("get_plugin", async (args) =>
       withToolLogging("get_plugin", undefined, async () => {
         const params = new URLSearchParams({ category: args.pluginType });
         const data = await callApi(
@@ -1492,7 +1517,7 @@ export function registerTools(
     "List all configured integrations (credentials) for the organization, each with its id, name, and type. These are required for actions like Discord notifications, Sendgrid emails, or web3 writes. A web3 integration's entry already includes its checksummed wallet address; config is omitted -- call get_wallet_integration with an entry's id for its decrypted config.",
     {},
     { title: "List Integrations", readOnlyHint: true, destructiveHint: false },
-    withScopeCheck("list_integrations", scope, async (_args) =>
+    scoped("list_integrations", async (_args) =>
       withToolLogging("list_integrations", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -1522,7 +1547,7 @@ export function registerTools(
       readOnlyHint: true,
       destructiveHint: false,
     },
-    withScopeCheck("get_wallet_integration", scope, async (args) =>
+    scoped("get_wallet_integration", async (args) =>
       withToolLogging("get_wallet_integration", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -1552,7 +1577,7 @@ export function registerTools(
       category: z.string().optional().describe("Filter templates by category"),
     },
     { title: "Search Templates", readOnlyHint: true, destructiveHint: false },
-    withScopeCheck("search_templates", scope, async (args) =>
+    scoped("search_templates", async (args) =>
       withToolLogging("search_templates", undefined, async () => {
         const params = new URLSearchParams();
         if (args.query) {
@@ -1581,7 +1606,7 @@ export function registerTools(
       templateId: z.string().describe("The template workflow ID"),
     },
     { title: "Get Template", readOnlyHint: true, destructiveHint: false },
-    withScopeCheck("get_template", scope, async (args) =>
+    scoped("get_template", async (args) =>
       withToolLogging("get_template", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -1610,7 +1635,7 @@ export function registerTools(
     // duplicate route inserts without one so the row falls to the schema
     // default of disabled. The clone is inert until a separate call arms it.
     { title: "Deploy Template", readOnlyHint: false, destructiveHint: false },
-    withScopeCheck("deploy_template", scope, async (args) =>
+    scoped("deploy_template", async (args) =>
       withToolLogging("deploy_template", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -1639,7 +1664,7 @@ export function registerTools(
       readOnlyHint: true,
       destructiveHint: false,
     },
-    withScopeCheck("tools_documentation", scope, (_args) =>
+    scoped("tools_documentation", (_args) =>
       withToolLogging("tools_documentation", undefined, () => {
         const text = [
           "KeeperHub MCP Tools Documentation",
@@ -1730,9 +1755,8 @@ export function registerTools(
       idempotency_key: IDEMPOTENCY_KEY_ARG,
     },
     { title: "Transfer Funds", readOnlyHint: false, destructiveHint: true },
-    withScopeCheck(
+    scoped(
       "execute_transfer",
-      scope,
       async (args) =>
         withToolLogging("execute_transfer", undefined, async () => {
           assertSimulationSupported(args.chain_id, args.simulate);
@@ -1787,9 +1811,8 @@ export function registerTools(
       idempotency_key: IDEMPOTENCY_KEY_ARG,
     },
     { title: "Contract Call", readOnlyHint: false, destructiveHint: true },
-    withScopeCheck(
+    scoped(
       "execute_contract_call",
-      scope,
       async (args) =>
         withToolLogging("execute_contract_call", undefined, async () => {
           assertSimulationSupported(args.chain_id, args.simulate);
@@ -1862,9 +1885,8 @@ export function registerTools(
       idempotency_key: IDEMPOTENCY_KEY_ARG,
     },
     { title: "Check and Execute", readOnlyHint: false, destructiveHint: true },
-    withScopeCheck(
+    scoped(
       "execute_check_and_execute",
-      scope,
       async (args) =>
         withToolLogging("execute_check_and_execute", undefined, async () => {
           assertSimulationSupported(args.chain_id, args.simulate);
@@ -1915,7 +1937,7 @@ export function registerTools(
       readOnlyHint: true,
       destructiveHint: false,
     },
-    withScopeCheck("get_direct_execution_status", scope, async (args) =>
+    scoped("get_direct_execution_status", async (args) =>
       withToolLogging("get_direct_execution_status", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -1951,7 +1973,7 @@ export function registerTools(
         ),
     },
     { title: "Validate Cron", readOnlyHint: true, destructiveHint: false },
-    withScopeCheck("validate_cron", scope, async (args) =>
+    scoped("validate_cron", async (args) =>
       withToolLogging("validate_cron", undefined, () => {
         const cronResult = validateCronExpression(args.cronExpression);
         const description = cronResult.valid
@@ -2023,7 +2045,7 @@ export function registerTools(
         .describe("Time range preset (e.g. 24h, 7d, 30d)"),
     },
     { title: "List Executions", readOnlyHint: true, destructiveHint: false },
-    withScopeCheck("list_executions", scope, async (args) =>
+    scoped("list_executions", async (args) =>
       withToolLogging("list_executions", undefined, async () => {
         const params = new URLSearchParams();
         if (args.cursor) {
@@ -2060,7 +2082,7 @@ export function registerTools(
       readOnlyHint: true,
       destructiveHint: false,
     },
-    withScopeCheck("get_spending_limits", scope, async () =>
+    scoped("get_spending_limits", async () =>
       withToolLogging("get_spending_limits", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -2095,7 +2117,7 @@ export function registerTools(
     // opens a database connection to a host it names. The send cannot be
     // recalled; persisting nothing does not make it additive.
     { title: "Test Notification", readOnlyHint: false, destructiveHint: true },
-    withScopeCheck("test_notification", scope, async (args) =>
+    scoped("test_notification", async (args) =>
       withToolLogging("test_notification", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -2143,7 +2165,7 @@ export function registerTools(
       readOnlyHint: false,
       destructiveHint: true,
     },
-    withScopeCheck("tempo_sign_and_hold", scope, async (args) =>
+    scoped("tempo_sign_and_hold", async (args) =>
       withToolLogging("tempo_sign_and_hold", undefined, async () => {
         const {
           idempotency_key: idempotencyKey,
@@ -2195,7 +2217,7 @@ export function registerTools(
       readOnlyHint: false,
       destructiveHint: true,
     },
-    withScopeCheck("tempo_cancel_hold", scope, async (args) =>
+    scoped("tempo_cancel_hold", async (args) =>
       withToolLogging("tempo_cancel_hold", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -2226,7 +2248,7 @@ export function registerTools(
       readOnlyHint: false,
       destructiveHint: true,
     },
-    withScopeCheck("tempo_release_hold", scope, async (args) =>
+    scoped("tempo_release_hold", async (args) =>
       withToolLogging("tempo_release_hold", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -2277,8 +2299,19 @@ export function registerMetaTools(
   server: McpServer,
   internalApiBaseUrl: string,
   authHeader: string,
-  scope?: string
+  scope?: string,
+  credentialType?: AuthMethod
 ): void {
+  // Binds the request's scope and credential family once, so every tool below
+  // reads as a gate on the tool name and nothing has to remember to thread the
+  // denial context through 40 call sites.
+  const scoped = <H extends AnyToolHandler>(
+    toolName: string,
+    handler: H,
+    readOnlyWhen?: ReadOnlyWhen
+  ): H =>
+    withScopeCheck(toolName, scope, handler, readOnlyWhen, credentialType);
+
   // Meta-tool 1: Search and discover available protocol actions
   server.tool(
     "search_protocol_actions",
@@ -2302,7 +2335,7 @@ export function registerMetaTools(
       readOnlyHint: true,
       destructiveHint: false,
     },
-    withScopeCheck("search_protocol_actions", scope, async (args) =>
+    scoped("search_protocol_actions", async (args) =>
       withToolLogging("search_protocol_actions", undefined, async () => {
         const params = new URLSearchParams();
         if (args.protocol) {
@@ -2402,7 +2435,7 @@ export function registerMetaTools(
       readOnlyHint: false,
       destructiveHint: true,
     },
-    withScopeCheck("execute_protocol_action", scope, async (args) =>
+    scoped("execute_protocol_action", async (args) =>
       withToolLogging("execute_protocol_action", undefined, async () => {
         const parts = args.actionType.split("/");
         if (parts.length < 2) {
@@ -2469,7 +2502,7 @@ export function registerMetaTools(
         ),
     },
     { title: "Search Workflows", readOnlyHint: true, destructiveHint: false },
-    withScopeCheck("search_workflows", scope, async (args) =>
+    scoped("search_workflows", async (args) =>
       withToolLogging("search_workflows", undefined, async () => {
         const params = new URLSearchParams();
         if (args.query) {
@@ -2514,7 +2547,7 @@ export function registerMetaTools(
     // Invokes a third-party listing whose body we do not control, and a paid
     // listing charges USDC on retry after the 402 is settled.
     { title: "Call Workflow", readOnlyHint: false, destructiveHint: true },
-    withScopeCheck("call_workflow", scope, async (args) =>
+    scoped("call_workflow", async (args) =>
       withToolLogging("call_workflow", undefined, async () => {
         try {
           const data = await callApi(
@@ -2585,7 +2618,7 @@ export function registerMetaTools(
     // listing's inputSchema/outputMapping, matching unlist_workflow, its
     // inverse.
     { title: "List Workflow", readOnlyHint: false, destructiveHint: true },
-    withScopeCheck("list_workflow", scope, async (args) =>
+    scoped("list_workflow", async (args) =>
       withToolLogging("list_workflow", undefined, async () => {
         const { workflowId, ...metadata } = args;
         const data = await callApi(
@@ -2612,7 +2645,7 @@ export function registerMetaTools(
         .describe("The internal ID of the workflow to unlist"),
     },
     { title: "Unlist Workflow", readOnlyHint: false, destructiveHint: true },
-    withScopeCheck("unlist_workflow", scope, async (args) =>
+    scoped("unlist_workflow", async (args) =>
       withToolLogging("unlist_workflow", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -2667,7 +2700,7 @@ export function registerMetaTools(
       readOnlyHint: false,
       destructiveHint: true,
     },
-    withScopeCheck("update_workflow_listing", scope, async (args) =>
+    scoped("update_workflow_listing", async (args) =>
       withToolLogging("update_workflow_listing", undefined, async () => {
         const { workflowId, ...patch } = args;
         const data = await callApi(
@@ -2707,7 +2740,7 @@ export function registerMetaTools(
         ),
     },
     { title: "Validate Workflow", readOnlyHint: true, destructiveHint: false },
-    withScopeCheck("validate_workflow", scope, async (args) =>
+    scoped("validate_workflow", async (args) =>
       withToolLogging("validate_workflow", undefined, async () => {
         const path = args.deepCheck
           ? `/api/workflows/${encodeURIComponent(args.workflowId)}/validate?deepCheck=true`
@@ -2744,7 +2777,7 @@ export function registerMetaTools(
       readOnlyHint: true,
       destructiveHint: false,
     },
-    withScopeCheck("prepare_test_pin_data", scope, async (args) =>
+    scoped("prepare_test_pin_data", async (args) =>
       withToolLogging("prepare_test_pin_data", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,
@@ -2773,7 +2806,7 @@ export function registerMetaTools(
       readOnlyHint: true,
       destructiveHint: false,
     },
-    withScopeCheck("get_workflow_listing", scope, async (args) =>
+    scoped("get_workflow_listing", async (args) =>
       withToolLogging("get_workflow_listing", undefined, async () => {
         const data = await callApi(
           internalApiBaseUrl,

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -935,6 +935,13 @@ const userConfigurationErrors = getOrCreateCounter(
   ERROR_LABELS
 );
 
+const userAuthorizationErrors = getOrCreateCounter(
+  apiRegistry,
+  "keeperhub_errors_user_authorization_total",
+  "User authorization errors",
+  ERROR_LABELS
+);
+
 const externalServiceErrors = getOrCreateCounter(
   apiRegistry,
   "keeperhub_errors_external_service_total",
@@ -1433,6 +1440,7 @@ const errorCounterMap: Record<string, Counter> = {
   // User-caused errors
   "errors.user.validation.total": userValidationErrors,
   "errors.user.configuration.total": userConfigurationErrors,
+  "errors.user.authorization.total": userAuthorizationErrors,
   "errors.external.service.total": externalServiceErrors,
   "errors.network.rpc.total": networkRpcErrors,
   "errors.transaction.blockchain.total": transactionBlockchainErrors,

--- a/lib/metrics/types.ts
+++ b/lib/metrics/types.ts
@@ -126,6 +126,7 @@ export const MetricNames = {
   // User-caused error metrics
   USER_VALIDATION_ERRORS: "errors.user.validation.total",
   USER_CONFIGURATION_ERRORS: "errors.user.configuration.total",
+  USER_AUTHORIZATION_ERRORS: "errors.user.authorization.total",
   EXTERNAL_SERVICE_ERRORS: "errors.external.service.total",
   NETWORK_RPC_ERRORS: "errors.network.rpc.total",
   TRANSACTION_BLOCKCHAIN_ERRORS: "errors.transaction.blockchain.total",

--- a/lib/middleware/require-scope.ts
+++ b/lib/middleware/require-scope.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSecurityEvent, logUserError } from "@/lib/logging";
 import { type OAuthScope, scopeSatisfies } from "@/lib/mcp/oauth-scopes";
+import type { AuthMethod } from "@/lib/middleware/auth-helpers";
 
 /**
  * Identifies the denied caller in the security signal. Never carries the
@@ -14,10 +15,15 @@ export type ScopeDenialContext = {
   /**
    * Which credential family is being denied, when the caller knows. Selects the
    * remediation sentence in the 403 body. Omitted by call sites that do not
-   * distinguish the two, which get the requirement without a remediation claim
-   * rather than a guess that may be wrong for the credential in hand.
+   * distinguish the families, which get the requirement without a remediation
+   * claim rather than a guess that may be wrong for the credential in hand.
+   *
+   * Reuses AuthMethod rather than a private union so the ~35 sites that already
+   * hold an `authMethod` can pass it straight through. "session" carries no
+   * scope, so it reaches here only if a future caller passes it, and falls to
+   * the no-remediation branch.
    */
-  credentialType?: "oauth" | "api-key";
+  credentialType?: AuthMethod;
 };
 
 /**
@@ -28,11 +34,9 @@ export type ScopeDenialContext = {
  * creation and `/api/keys/[keyId]` exposes only DELETE -- so there is nothing
  * to raise, only a new key to mint.
  */
-function remediationFor(
-  credentialType: ScopeDenialContext["credentialType"]
-): string {
+function remediationFor(credentialType: AuthMethod | undefined): string {
   if (credentialType === "api-key") {
-    return " An API key's scope is fixed when the key is created and cannot be changed. Create a new key with the scope you need.";
+    return " An API key's scope is fixed when the key is created and cannot be raised. A new key has to be issued with the scope this endpoint requires.";
   }
   if (credentialType === "oauth") {
     return " The ceiling is set by an organization owner or admin under Settings > Developer > Agents. Do not retry; ask them to raise it.";
@@ -74,6 +78,7 @@ export function requireScope(
     granted_scope: grantedScope ?? null,
     organizationId: context?.organizationId,
     credentialId: context?.credentialId,
+    credential_type: context?.credentialType ?? null,
     endpoint: context?.endpoint,
   });
 

--- a/lib/middleware/require-scope.ts
+++ b/lib/middleware/require-scope.ts
@@ -13,15 +13,17 @@ export type ScopeDenialContext = {
   credentialId?: string;
   endpoint?: string;
   /**
-   * Which credential family is being denied, when the caller knows. Selects the
-   * remediation sentence in the 403 body. Omitted by call sites that do not
-   * distinguish the families, which get the requirement without a remediation
-   * claim rather than a guess that may be wrong for the credential in hand.
+   * Which credential family is being denied. Selects the remediation sentence
+   * in the 403 body, since an OAuth grant is widened by an admin and an API
+   * key's scope is fixed at creation. Every route that gates on scope passes
+   * it: the execute routes from validateApiKey, the rest from the authMethod
+   * their auth helper already returns.
    *
-   * Reuses AuthMethod rather than a private union so the ~35 sites that already
-   * hold an `authMethod` can pass it straight through. "session" carries no
-   * scope, so it reaches here only if a future caller passes it, and falls to
-   * the no-remediation branch.
+   * Optional so a caller that genuinely cannot say gets the requirement with no
+   * remediation claim, rather than a guess that may be wrong for the credential
+   * in hand. "session" carries no scope, so scopeSatisfies admits it before a
+   * denial can be built; it falls to the no-remediation branch if it ever
+   * arrives.
    */
   credentialType?: AuthMethod;
 };

--- a/lib/middleware/require-scope.ts
+++ b/lib/middleware/require-scope.ts
@@ -11,7 +11,34 @@ export type ScopeDenialContext = {
   organizationId?: string;
   credentialId?: string;
   endpoint?: string;
+  /**
+   * Which credential family is being denied, when the caller knows. Selects the
+   * remediation sentence in the 403 body. Omitted by call sites that do not
+   * distinguish the two, which get the requirement without a remediation claim
+   * rather than a guess that may be wrong for the credential in hand.
+   */
+  credentialType?: "oauth" | "api-key";
 };
+
+/**
+ * How a caller widens the scope they were denied. The two credential families
+ * have genuinely different answers, and naming the wrong one sends an agent
+ * round a loop it cannot exit: an OAuth grant is clamped by an org-level
+ * ceiling an admin controls, while an API key's scope is fixed in the row at
+ * creation and `/api/keys/[keyId]` exposes only DELETE -- so there is nothing
+ * to raise, only a new key to mint.
+ */
+function remediationFor(
+  credentialType: ScopeDenialContext["credentialType"]
+): string {
+  if (credentialType === "api-key") {
+    return " An API key's scope is fixed when the key is created and cannot be changed. Create a new key with the scope you need.";
+  }
+  if (credentialType === "oauth") {
+    return " The ceiling is set by an organization owner or admin under Settings > Developer > Agents. Do not retry; ask them to raise it.";
+  }
+  return "";
+}
 
 /**
  * A-03: enforce credential scope at the REST sinks that MCP tools forward to.
@@ -64,7 +91,7 @@ export function requireScope(
   // stay out, since per-org labels are the cardinality the allowlist exists to
   // keep off Prometheus.
   logUserError(
-    ErrorCategory.AUTH,
+    ErrorCategory.AUTHORIZATION,
     "[RequireScope] Insufficient scope",
     undefined,
     {
@@ -80,11 +107,12 @@ export function requireScope(
   return NextResponse.json(
     {
       error: "insufficient_scope",
-      // Written for the agent that reads it. It says what the connection may
-      // do, that reconnecting cannot widen it, and who can. Naming the token
-      // instead would send an agent round a loop of re-consenting with a wider
-      // scope that the limit would keep clamping back.
-      message: `This endpoint requires the \`${required}\` OAuth scope. This connection is allowed \`${grantedScope || "(none)"}\`. Reconnecting will not raise it: the limit is set by an organization owner or admin under Settings > Developer > Agents. Do not retry; ask them to raise it.`,
+      // Written for the agent that reads it. It says what the credential may
+      // do and that retrying cannot widen it; remediationFor adds who can, when
+      // the credential family is known. Naming the token instead would send an
+      // agent round a loop of re-consenting with a wider scope that the limit
+      // would keep clamping back.
+      message: `This endpoint requires the \`${required}\` scope. This credential is allowed \`${grantedScope || "(none)"}\`. Retrying will not widen it.${remediationFor(context?.credentialType)}`,
       retryable: false,
       required_scope: required,
       granted_scope: grantedScope ?? "",

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -538,7 +538,7 @@
       "path": "/api/workflows/{workflowId}/simulate",
       "route_file": "app/api/workflows/[workflowId]/simulate/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 820
+      "line": 827
     },
     {
       "method": "POST",

--- a/tests/unit/execute-auth-anonymous.test.ts
+++ b/tests/unit/execute-auth-anonymous.test.ts
@@ -93,6 +93,7 @@ describe("validateApiKey -- anonymous and failure propagation", () => {
       organizationId: "org-1",
       apiKeyId: "oauth:user-1",
       scope: "mcp:write",
+      credentialType: "oauth",
     });
     expect(mockAuthenticateApiKey).not.toHaveBeenCalled();
   });
@@ -110,7 +111,11 @@ describe("validateApiKey -- anonymous and failure propagation", () => {
 
     const result = await validateApiKey(request());
 
-    expect(result).toEqual({ organizationId: "org-2", apiKeyId: "key-1" });
+    expect(result).toEqual({
+      organizationId: "org-2",
+      apiKeyId: "key-1",
+      credentialType: "api-key",
+    });
   });
 
   it("propagates the scope an API key was minted with", async () => {
@@ -132,6 +137,7 @@ describe("validateApiKey -- anonymous and failure propagation", () => {
       organizationId: "org-2",
       apiKeyId: "key-1",
       scope: "mcp:read",
+      credentialType: "api-key",
     });
   });
 

--- a/tests/unit/logging.test.ts
+++ b/tests/unit/logging.test.ts
@@ -168,6 +168,10 @@ describe("Unified Logging Helpers", () => {
           metric: MetricNames.USER_CONFIGURATION_ERRORS,
         },
         {
+          category: ErrorCategory.AUTHORIZATION,
+          metric: MetricNames.USER_AUTHORIZATION_ERRORS,
+        },
+        {
           category: ErrorCategory.EXTERNAL_SERVICE,
           metric: MetricNames.EXTERNAL_SERVICE_ERRORS,
         },

--- a/tests/unit/mcp-scope-required.test.ts
+++ b/tests/unit/mcp-scope-required.test.ts
@@ -109,7 +109,7 @@ type ScopeDeniedEnvelope = {
   required_scope: string;
   granted_scope: string;
   tool: string;
-  upgrade_url: string;
+  upgrade_url?: string;
   hint: string;
 };
 
@@ -188,5 +188,59 @@ describe("buildScopeDeniedResult envelope shape (KEEP-483)", () => {
         SCOPE_MCP_READ
       )}&granted=`
     );
+  });
+});
+
+describe("scope-denied remediation matches the credential family", () => {
+  async function denyCreateWorkflow(
+    credentialType?: "oauth" | "api-key"
+  ): Promise<ScopeDeniedEnvelope> {
+    const { server, registeredTools } = makeMockServer();
+    registerTools(
+      server,
+      "http://internal",
+      "Bearer test",
+      SCOPE_MCP_READ,
+      credentialType
+    );
+    const createTool = registeredTools.find(
+      (t) => t.name === "create_workflow"
+    );
+    if (!createTool) {
+      throw new Error("create_workflow was not registered");
+    }
+    const result = (await createTool.handler({
+      name: "x",
+      nodes: [],
+      edges: [],
+    })) as { content: [{ type: "text"; text: string }] };
+    return JSON.parse(result.content[0].text) as ScopeDeniedEnvelope;
+  }
+
+  it("does not send an API key to the OAuth reauthorize page", async () => {
+    const envelope = await denyCreateWorkflow("api-key");
+
+    // There is no consent screen behind a kh_ key, so an upgrade_url is a
+    // dead end: the agent re-runs the flow and is denied identically.
+    expect(envelope.upgrade_url).toBeUndefined();
+    expect(envelope.hint).toContain("A new key has to be issued");
+    expect(envelope.hint).not.toContain("Reauthorize");
+    expect(envelope.message).toContain("API key");
+    expect(envelope.message).not.toContain("OAuth scope");
+  });
+
+  it("keeps the reauthorize route for an OAuth connection", async () => {
+    const envelope = await denyCreateWorkflow("oauth");
+
+    expect(envelope.upgrade_url).toContain("/settings/mcp/reauthorize");
+    expect(envelope.hint).toContain("Reauthorize");
+    expect(envelope.hint).not.toContain("A new key has to be issued");
+  });
+
+  it("falls back to the OAuth affordance when the family is unknown", async () => {
+    const envelope = await denyCreateWorkflow();
+
+    expect(envelope.upgrade_url).toContain("/settings/mcp/reauthorize");
+    expect(envelope.required_scope).toBe(SCOPE_MCP_WRITE);
   });
 });

--- a/tests/unit/oauth-scope-route-gate.test.ts
+++ b/tests/unit/oauth-scope-route-gate.test.ts
@@ -492,6 +492,9 @@ describe("A-03 leg 3: kh_ API key scope gate at the direct-execution sinks", () 
         granted_scope: "mcp:read",
         organizationId: "org-1",
         credentialId: "key-1",
+        // Proves the route threads the family through, not just that
+        // requireScope forwards whatever it is handed.
+        credential_type: "api-key",
         endpoint: "/api/execute/transfer",
       })
     );

--- a/tests/unit/oauth-scopes.test.ts
+++ b/tests/unit/oauth-scopes.test.ts
@@ -121,7 +121,17 @@ describe("oauth-scopes — scopeSatisfies (A-03)", () => {
 describe("parseScopeInput — null means unrestricted, so only omission may reach it", () => {
   it("returns null only when the field is absent", () => {
     expect(parseScopeInput(undefined)).toBeNull();
+    // JSON clients routinely send null for an absent field.
     expect(parseScopeInput(null)).toBeNull();
+  });
+
+  it("floors a supplied but unreadable scopes value at mcp:read", () => {
+    // scopes is unvalidated request body. An object is the shape the creation
+    // overlay holds internally, and is the likeliest way one reaches the API.
+    expect(parseScopeInput({ "mcp:read": true })).toBe("mcp:read");
+    expect(parseScopeInput(true)).toBe("mcp:read");
+    expect(parseScopeInput(false)).toBe("mcp:read");
+    expect(parseScopeInput(0)).toBe("mcp:read");
   });
 
   it("narrows an explicitly empty scopes array to mcp:read", () => {

--- a/tests/unit/oauth-scopes.test.ts
+++ b/tests/unit/oauth-scopes.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isToolAllowed, scopeSatisfies } from "@/lib/mcp/oauth-scopes";
+import {
+  isToolAllowed,
+  parseScopeInput,
+  scopeSatisfies,
+} from "@/lib/mcp/oauth-scopes";
 
 describe("oauth-scopes — prepare_test_pin_data (TESTWF-06)", () => {
   it("mcp:read allows prepare_test_pin_data", () => {
@@ -111,5 +115,33 @@ describe("oauth-scopes — scopeSatisfies (A-03)", () => {
     expect(scopeSatisfies("bogus:x", "mcp:read")).toBe(false);
     expect(scopeSatisfies("bogus:x", "mcp:write")).toBe(false);
     expect(scopeSatisfies("bogus:x", "mcp:admin")).toBe(false);
+  });
+});
+
+describe("parseScopeInput — null means unrestricted, so only omission may reach it", () => {
+  it("returns null only when the field is absent", () => {
+    expect(parseScopeInput(undefined)).toBeNull();
+    expect(parseScopeInput(null)).toBeNull();
+  });
+
+  it("narrows an explicitly empty scopes array to mcp:read", () => {
+    expect(parseScopeInput([])).toBe("mcp:read");
+  });
+
+  it("narrows a scopes array with no usable strings to mcp:read", () => {
+    expect(parseScopeInput([1, 2])).toBe("mcp:read");
+    expect(parseScopeInput(["bogus"])).toBe("mcp:read");
+    expect(parseScopeInput([""])).toBe("mcp:read");
+  });
+
+  it("narrows an explicitly empty scopes string to mcp:read", () => {
+    expect(parseScopeInput("")).toBe("mcp:read");
+    expect(parseScopeInput("   ")).toBe("mcp:read");
+  });
+
+  it("still normalizes a valid request unchanged", () => {
+    expect(parseScopeInput(["mcp:write"])).toBe("mcp:write");
+    expect(parseScopeInput("mcp:read mcp:write")).toBe("mcp:read mcp:write");
+    expect(parseScopeInput(["mcp:write", "bogus"])).toBe("mcp:write");
   });
 });

--- a/tests/unit/require-scope-denial-message.test.ts
+++ b/tests/unit/require-scope-denial-message.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { AUTHORIZATION: "authorization" },
+  logSecurityEvent: vi.fn(),
+  logUserError: vi.fn(),
+}));
+
+import { requireScope } from "@/lib/middleware/require-scope";
+
+async function denialBody(
+  context?: Parameters<typeof requireScope>[2]
+): Promise<{ message: string; error: string }> {
+  const response = requireScope("mcp:read", "mcp:write", context);
+  if (!response) {
+    throw new Error("expected a denial");
+  }
+  return await response.json();
+}
+
+describe("requireScope denial message — remediation matches the credential", () => {
+  it("tells an API-key caller to mint a new key, not to ask an admin", async () => {
+    const body = await denialBody({ credentialType: "api-key" });
+
+    expect(body.error).toBe("insufficient_scope");
+    expect(body.message).toContain("fixed when the key is created");
+    expect(body.message).toContain("Create a new key");
+    // An API key's scope is not governed by the org ceiling, and the key row
+    // exposes only DELETE, so both of these would send the caller nowhere.
+    expect(body.message).not.toContain("Settings > Developer > Agents");
+    expect(body.message).not.toContain("ask them to raise it");
+  });
+
+  it("keeps the admin-ceiling remediation for an OAuth caller", async () => {
+    const body = await denialBody({ credentialType: "oauth" });
+
+    expect(body.message).toContain("Settings > Developer > Agents");
+    expect(body.message).toContain("ask them to raise it");
+    expect(body.message).not.toContain("Create a new key");
+  });
+
+  it("claims no remediation when the credential family is unknown", async () => {
+    const body = await denialBody();
+
+    expect(body.message).not.toContain("Settings > Developer > Agents");
+    expect(body.message).not.toContain("Create a new key");
+  });
+
+  it("always states the requirement, the grant, and that retrying will not help", async () => {
+    for (const context of [
+      { credentialType: "api-key" as const },
+      { credentialType: "oauth" as const },
+      undefined,
+    ]) {
+      const body = await denialBody(context);
+      expect(body.message).toContain("`mcp:write`");
+      expect(body.message).toContain("`mcp:read`");
+      expect(body.message).toContain("Retrying will not widen it");
+    }
+  });
+
+  it("does not describe the grant as an OAuth scope, since API keys reach it too", async () => {
+    const body = await denialBody({ credentialType: "api-key" });
+    expect(body.message).not.toContain("OAuth scope");
+  });
+
+  it("still allows a satisfied scope regardless of credential type", () => {
+    expect(
+      requireScope("mcp:write", "mcp:read", { credentialType: "api-key" })
+    ).toBeNull();
+  });
+});

--- a/tests/unit/require-scope-denial-message.test.ts
+++ b/tests/unit/require-scope-denial-message.test.ts
@@ -24,7 +24,7 @@ describe("requireScope denial message — remediation matches the credential", (
 
     expect(body.error).toBe("insufficient_scope");
     expect(body.message).toContain("fixed when the key is created");
-    expect(body.message).toContain("Create a new key");
+    expect(body.message).toContain("A new key has to be issued");
     // An API key's scope is not governed by the org ceiling, and the key row
     // exposes only DELETE, so both of these would send the caller nowhere.
     expect(body.message).not.toContain("Settings > Developer > Agents");
@@ -36,14 +36,14 @@ describe("requireScope denial message — remediation matches the credential", (
 
     expect(body.message).toContain("Settings > Developer > Agents");
     expect(body.message).toContain("ask them to raise it");
-    expect(body.message).not.toContain("Create a new key");
+    expect(body.message).not.toContain("A new key has to be issued");
   });
 
   it("claims no remediation when the credential family is unknown", async () => {
     const body = await denialBody();
 
     expect(body.message).not.toContain("Settings > Developer > Agents");
-    expect(body.message).not.toContain("Create a new key");
+    expect(body.message).not.toContain("A new key has to be issued");
   });
 
   it("always states the requirement, the grant, and that retrying will not help", async () => {

--- a/tests/unit/require-scope.test.ts
+++ b/tests/unit/require-scope.test.ts
@@ -79,6 +79,7 @@ describe("requireScope (A-03)", () => {
       requireScope("mcp:read", "mcp:write", {
         organizationId: "org-1",
         credentialId: "key-1",
+        credentialType: "api-key",
         endpoint: "/api/execute/transfer",
       });
 
@@ -90,6 +91,9 @@ describe("requireScope (A-03)", () => {
           granted_scope: "mcp:read",
           organizationId: "org-1",
           credentialId: "key-1",
+          // Without this a Loki query cannot separate an OAuth grant clamped by
+          // a ceiling change from a leaked kh_ key probing above its scope.
+          credential_type: "api-key",
           endpoint: "/api/execute/transfer",
         }
       );

--- a/tests/unit/require-scope.test.ts
+++ b/tests/unit/require-scope.test.ts
@@ -117,7 +117,12 @@ describe("requireScope (A-03)", () => {
 
       expect(mockLogUserError).toHaveBeenCalledTimes(1);
       const [category, message, error, labels] = mockLogUserError.mock.calls[0];
-      expect(category).toBe("auth");
+      // Not "auth": that maps to errors.system.auth.total, which the errors
+      // dashboard sums into its System Errors panels unfiltered. A caller using
+      // a credential outside its grant is user-caused, so it belongs on the
+      // user side of the taxonomy where the deny rate can climb without
+      // reading as a platform fault.
+      expect(category).toBe("authorization");
       expect(message).toBe("[RequireScope] Insufficient scope");
       expect(error).toBeUndefined();
       expect(labels).toMatchObject({


### PR DESCRIPTION
Clears the four follow-up items from the review of #2030 (https://github.com/KeeperHub/keeperhub/pull/2030#issuecomment-5420910368).

They share a cause. Until #2030 propagated `result.scope` on `/api/execute/*`, `scopeSatisfies(undefined, ...)` returned true for every `kh_` key, so API keys never reached these paths. Each of the four was written when OAuth was the only caller that could get here, and each is correct for OAuth and wrong for an API key.

### The 403 body named a control that does not apply to API keys

`lib/middleware/require-scope.ts` told every denied caller the ceiling "is set by an organization owner or admin under Settings > Developer > Agents". For a `kh_` key all of it is wrong: `mcpMaxScope` is read only inside `authenticateOAuthToken`, so `authenticateApiKey` never consults it and raising it does not clear the 403; and `app/api/keys/[keyId]/route.ts` exports only `DELETE`, so a key's scope cannot be changed at all. The remedy - revoke and re-mint - went unmentioned, and the message called the grant an "OAuth scope" to a caller holding an API key.

`requireScope` now takes `credentialType` on its existing context arg and picks the remediation to match. The shared sentence states the requirement, the grant, and that retrying will not widen it - all true for both families - and call sites that do not pass a type get that and no remediation claim, rather than a guess. `validateApiKey` already branches on the two families, so it just reports which one it took.

### `scopes: []` minted an unrestricted key

`parseScopeInput` returned `null` whenever the joined scope string was blank, and `null` means no restriction. So `["bogus"]` correctly floored at `mcp:read` while `[]`, `[1, 2]` and `""` widened to full access - asking for the narrowest key produced the widest one. Only omitting the field reaches `null` now; a supplied value goes through `normalizeScope`, which floors at `mcp:read`. The UI already blocked this, so this closes the API path behind it.

### The Permissions block promised a restriction nothing enforced

`CreateApiKeyOverlay` rendered it for both tabs, but nothing reads `apiKeys.scope`: `authenticateApiKey` selects only from `organizationApiKeys`, and `app/api/workflows/[workflowId]/webhook/route.ts` looks a key up by hash and dispatches without consulting the column. On the webhook tab a user could tick "Read only", read "Cannot run workflows or send transactions", and hold a key that ran workflows which broadcast.

Shown only for organisation keys now. Webhook creation omits `scopes` rather than sending a value that is stored and ignored, so the column says what is true: no restriction. Hiding it is the smaller change; persisting and enforcing scope on `apiKeys` would be the other direction, and is a bigger decision than this PR.

### A client-driven 403 counted as a system fault

The deny incremented `errors.system.auth.total` via `ErrorCategory.AUTH` - the only `logUserError` in the repo using it, every other `AUTH` usage being `logSystemError`/`logSystemWarn`. `specs/logging-and-metrics/keeperhub-errors-dashboard.json` sums that metric into its **System Errors** panels with no `error_type` filter, so a caller using a credential outside its grant raised a panel meant for platform faults.

Added `ErrorCategory.AUTHORIZATION` -> `errors.user.authorization.total` on the user-caused side of the taxonomy. `errorCategory` in `lib/db/schema.ts` is a `text` column with a TypeScript union, not a pg enum, so keeping the two in step is type-level only - **no migration**.

### The MCP tool layer said the same wrong thing

`lib/mcp/tools.ts` denied with an `upgrade_url` to `/settings/mcp/reauthorize` and a hint to request the scope on the consent screen. That is the right answer for OAuth and a dead end for a `kh_` key, which is the credential that reaches those tools most often - there is no consent screen behind it, so the agent re-runs the flow and is denied identically. `registerTools`/`registerMetaTools` now bind the family next to the scope, so the envelope drops `upgrade_url` for an API key and names the actual remedy. `app/mcp/route.ts` derives the family from the credential id in one documented place, because a session rebuilt from its token has nothing else left to read.

### Every scope gate now names the credential, not just the execute routes

The ~35 `requireScope` sites outside `/api/execute/*` passed no context, so an OAuth caller there would have lost the remediation it used to get correctly. Each one's auth helper already returns `authMethod`, so all 39 pass it through. Two route-local `Ok` types widened it to `string` on the way; both narrowed to `AuthMethod` so the compiler keeps them in step.

### Webhook keys no longer display a scope on any surface

Hiding the creation checkboxes was half the fix. The list in the overlay and the table in settings both still rendered `Scope: read` for a `wfb_` key - every one minted before this branch carries a stored scope, and the webhook route dispatches without consulting it. Both surfaces now show scope only where it is enforced. The table's `--` for a null scope also read as "no permissions" when it means the opposite; it says `unrestricted`.

### The narrowest key is now the default outcome

The creation form pre-checked all three scopes, so typing a label and clicking through minted a full-access `mcp:admin` key. That is the same widest-by-default behaviour this branch removed from `parseScopeInput`, in the same component. Read alone is checked.

## What this deliberately does not do

- **No dashboard panel for the new metric.** `errors.user.authorization.total` is now registered and recorded, but nothing charts it yet. Flagging rather than editing the dashboard JSON here.
- **Scope denials still run before `checkRateLimit`.** Reordering security gates across seven routes is a larger and riskier change than the rest of this PR, and moving the deny off the system panels already removes the part that mattered.
- **`view`/`pure` reads still require `mcp:write`.** Whether reads should gate on `mcp:read` is a decision, and the docs correction depends on the answer; fixing the docs now would mean writing them twice.
- **API key creation is still not clamped by `mcpMaxScope`.** `clampScope` is imported only by `lib/mcp/oauth-auth.ts`, so an organization ceiling constrains OAuth tokens and not `kh_` keys. The 403's API-key sentence was reworded so it does not read as an instruction to mint around a ceiling, but the gap itself is a product decision about whether that ceiling is meant to bind API keys at all.

## Verification

- Unit suites covering every input shape of `parseScopeInput`, each remediation branch of the 403 body, the new `AUTHORIZATION` metric mapping, and the MCP envelope - asserting that an API key gets no `upgrade_url` and no "Reauthorize", and that an OAuth connection keeps both.
- `tsc --noEmit` clean. It earned its keep twice: adding the enum member broke three assignment sites against the schema union, and threading `authMethod` surfaced two route-local types that had widened it to `string`.
- `biome check` clean on the changed files.

Review of the first pass caught two defects in it, both fixed here rather than deferred: the new metric was never registered in `errorCounterMap`, so denials recorded nothing and emitted a warn per request - strictly worse than the wrong-panel behaviour it replaced; and `parseScopeInput` still returned `null` for any `scopes` value that was neither array nor string, leaving the widening path open for an object or boolean body.
