### PR TITLE
fix: KEEP-1239 give the e2e test org an explicit daily value cap

### DIFF
--- a/scripts/seed/seed-test-wallet.ts
+++ b/scripts/seed/seed-test-wallet.ts
@@ -2,7 +2,8 @@
  * Seed script for persistent E2E test account (KEEP-529).
  *
  * Seeds a test user (with login credentials) + organization + Turnkey wallet
- * for write-contract E2E tests and Playwright tests.
+ * for write-contract E2E tests and Playwright tests, plus the organization's
+ * daily value cap.
  * Idempotent: skips records that already exist.
  *
  * Para has been decommissioned. On first run the script calls Turnkey to
@@ -40,12 +41,27 @@ import {
   organizationWallets,
   users,
 } from "../../lib/db/schema";
+import { organizationSpendCaps } from "../../lib/db/schema-extensions";
 import { createTurnkeyWallet } from "../../lib/turnkey/turnkey-operations";
 import { generateId } from "../../lib/utils/id";
 
 const TEST_ORG_SLUG = "e2e-test-org";
 const TEST_USER_EMAIL = "pr-test-do-not-delete@techops.services";
 const TEST_PASSWORD = "TestPassword123!";
+
+// Daily EVM native value cap for this organization, in wei. 1 ETH.
+//
+// Every protocol-coverage suite executes as this one organization, so the
+// native value they move accumulates against a single daily ledger per shard.
+// Shard 4 sends 0.04 ETH today: 0.01 for wrapped/wrap, plus 0.01 for each of
+// the three frax-ether-v2 mints. The platform default is 0.02 ETH, so an
+// organization with no cap of its own denies its own writes (KEEP-1239).
+//
+// This figure is 25 times that worst case, so a new payable fixture does not
+// break the suite again. The cap belongs here rather than in
+// EXECUTE_DEFAULT_DAILY_VALUE_CAP_WEI: CI then keeps the same platform default
+// as staging and prod, and this organization carries its own ceiling instead.
+const E2E_DAILY_VALUE_CAP_WEI = "1000000000000000000";
 
 type Db = ReturnType<typeof drizzle>;
 
@@ -165,6 +181,28 @@ async function ensureOrganization(db: Db, userId: string): Promise<string> {
   return orgId;
 }
 
+/** Give the test org an explicit daily value cap. Written as an upsert, not as
+ *  an insert-if-absent: the reservation path creates a row with both cap
+ *  columns NULL on the org's first value-moving request, and such a row still
+ *  resolves to the platform default. A database that already ran the suite
+ *  would otherwise keep that default forever. */
+async function ensureSpendCap(db: Db, orgId: string): Promise<void> {
+  await db
+    .insert(organizationSpendCaps)
+    .values({
+      organizationId: orgId,
+      dailyValueCapWei: E2E_DAILY_VALUE_CAP_WEI,
+    })
+    .onConflictDoUpdate({
+      target: organizationSpendCaps.organizationId,
+      set: {
+        dailyValueCapWei: E2E_DAILY_VALUE_CAP_WEI,
+        updatedAt: new Date(),
+      },
+    });
+  console.log(`Set daily value cap to ${E2E_DAILY_VALUE_CAP_WEI} wei`);
+}
+
 async function ensureTurnkeyWallet(
   db: Db,
   userId: string,
@@ -263,6 +301,7 @@ async function seedTestWallet(): Promise<void> {
     const userId = await ensureUser(db);
     await ensureCredentialAccount(db, userId);
     const orgId = await ensureOrganization(db, userId);
+    await ensureSpendCap(db, orgId);
     await ensureTurnkeyWallet(db, userId, orgId);
 
     const wallet = await db
@@ -277,6 +316,7 @@ async function seedTestWallet(): Promise<void> {
     console.log(`  Org Slug:       ${TEST_ORG_SLUG}`);
     console.log(`  Org ID:         ${orgId}`);
     console.log(`  User ID:        ${userId}`);
+    console.log(`  Value Cap:      ${E2E_DAILY_VALUE_CAP_WEI} wei`);
     if (wallet.length > 0) {
       console.log(`  Wallet Address: ${wallet[0].walletAddress}`);
     }


### PR DESCRIPTION
Fixes KEEP-1239. `protocol-coverage-ephemeral (shard 4)` has failed on every push to `staging` since PR #2031 merged on 2026-08-26T00:33Z. `e2e-tests / e2e-gate` fails only because that shard does. It blocks release PR #2139.

## Cause

PR #2031 made an absent `organization_spend_caps` row resolve to a platform default instead of unlimited. The default is `DEFAULT_DAILY_VALUE_CAP_WEI = "20000000000000000"` (0.02 ETH per day) at `lib/execute/spend-cap-defaults.ts`.

Every protocol-coverage suite executes as the one persistent org `e2e-test-org` (`tests/e2e/vitest/protocol-coverage/_shared/setup.ts`), and each shard gets one Postgres service. So the native value accumulates against a single daily ledger per shard, not per test file. Shard 4 is `ethena yearn aave-v3 frax-ether-v2 wrapped`.

The cap test is `total + reserved > cap`, strictly greater (`lib/execute/value-ledger.ts`), and a denied reservation is released and stops counting. From the shard 4 log of run 32933152459, which ran `wrapped` at 05:27:27Z before `frax-ether-v2` at 05:27:37Z:

| action | sends | running total | vs 0.02 cap | result |
| -- | -- | -- | -- | -- |
| `wrapped/wrap` | 0.01 | 0.01 | under | passes |
| `frax/mint` | 0.01 | 0.02 | equal, not over | passes |
| `frax/mint-and-give` | 0.01 | would be 0.03 | over | denied |
| `frax/mint-and-stake` | 0.01 | would be 0.03 | over | denied |

That matches the observed run exactly. It is deterministic, not a flake.

Every `ethValue` fixture in the repo: `frax-ether-v2` 0.01 x 3, `rocket-pool` 0.02, `wrapped` 0.01. No e2e suite moves native value by any other route. `transferFundsStep` appears in no e2e test, and `ensureNativeGas` funds through `anvil_setBalance`, which never touches the ledger.

## Fix

Seed `e2e-test-org` an explicit `daily_value_cap_wei` of 1 ETH in `scripts/seed/seed-test-wallet.ts`.

Why here and not through `EXECUTE_DEFAULT_DAILY_VALUE_CAP_WEI`:

- `.github/actions/start-app` passes an explicit env allow-list, so the env route needs a new input wired into both the Docker path and the bare-metal path, then repeating on any other job that hits the same wall. The seed runs from the repo checkout via `pnpm db:seed-test-wallet`, so it takes effect on both app paths at once.
- CI keeps the same platform default as staging and prod, which both pin `20000000000000000`. The org configures its own ceiling instead, which is what a real org that moves this much value does.
- It covers the direct-execution route too. That path charges the same `dailyValueCapWei` column.

1 ETH is 25 times the busiest shard's 0.04 ETH, so a new payable fixture does not re-break the suite, while the cap stays a real bound.

The write is an upsert rather than insert-if-absent. `lockOrgSpendCapRow` creates a row with both cap columns NULL on the org's first value-moving request, and such a row still resolves to the platform default, so a database that already ran the suite would otherwise keep that default forever.

`daily_cap_wei` and `daily_solana_value_cap_lamports` stay NULL. There is no Solana protocol-coverage suite and no e2e test that moves native SOL.

The platform-default path keeps its coverage in `tests/unit/spending-cap.test.ts`, which asserts the exact default figure, and in `tests/unit/value-ledger.test.ts`.

## Note on the ticket

KEEP-1239's Option 2 (one organization per fixture file) does not fix this. Frax alone sends 0.03 ETH across three actions, so `mint-and-stake` stays red even with a per-file org.

## Verification

Local, all green:

- `pnpm check` (Biome ignores `scripts/`, so it does not lint this file)
- `pnpm type-check` and `pnpm type-check:executor`
- `pnpm check:api-docs`
- `pnpm test:unit __tests__ keeperhub-metrics-collector`: 558 files, 21447 tests passed
- `pnpm test:integration`: 93 files, 964 tests passed
- the three `pr-checks` grep guards (legacy Tempo id, raw plugin egress, KeeperHub-operated hosts)

Seed behaviour proven against a throwaway Postgres at the current migration head:

- fresh database: one row written, `daily_value_cap_wei = 1000000000000000000`, the other two cap columns NULL
- row forced back to `daily_value_cap_wei = NULL` to imitate what `lockOrgSpendCapRow` writes, then the seed re-run: still one row, cap repaired to 1 ETH, `updated_at` refreshed

This PR carries `run-e2e-tests-ephemeral` so the suite actually runs here. Without it every e2e job is skipped and `e2e-gate` reports success on the skips, which is how #2031 shipped this break.