### PR TITLE
fix: KEEP-1242 default testnet Solana event chains to the signatures source

### DIFF
--- a/keeperhub-events/solana-tracker/src/mapper.ts
+++ b/keeperhub-events/solana-tracker/src/mapper.ts
@@ -105,27 +105,21 @@ function sourceModeOverride(): SourceMode | undefined {
 /**
  * Default ingestion strategy for a chain, from the chain's own shape.
  *
- * Mainnet event ingestion defaults to the server-side filtered `signatures`
- * source: `getBlock` pulls every produced block with full transaction detail,
- * which on mainnet is a firehose (see specs/solana-event-ingestion.md) that no
- * CPU request can absorb, and which silently skips slots - and so misses
- * triggers - once it falls behind. Testnets keep `getBlock`, where whole-block
- * pulls are cheap and one source serves event and block triggers together.
+ * Event ingestion defaults to the server-side filtered `signatures` source:
+ * `getBlock` pulls every produced block with full transaction detail, which is
+ * a firehose (see specs/solana-event-ingestion.md) that no CPU request absorbs,
+ * and which silently skips slots - and so misses triggers - once it falls
+ * behind. This was gated on mainnet, on the assumption that a testnet produces
+ * small blocks. KEEP-1242: that assumption is not the tracker's to make. Chain
+ * 103's endpoint served Solana testnet, whose blocks are ~14x a devnet block,
+ * and the testnet default spent 4x the prod CPU request to parse them.
  *
- * `undefined` means the `getblock` default, matching the factory.
+ * `undefined` means the `getblock` default, matching the factory. A chain with
+ * no event triggers keeps it: `getBlock` runs header-only there, and it is the
+ * only source that serves block triggers.
  */
-function defaultSourceMode(
-  network: NetworkConfig,
-  hasEventTriggers: boolean,
-): SourceMode | undefined {
-  // Explicit `!== false` rather than a truthiness test: discovery payloads are
-  // not runtime-validated and `chains.is_testnet` is nullable, so a null would
-  // otherwise read as mainnet and pull a testnet onto the mainnet path.
-  const isMainnet = network.isTestnet === false;
-  if (!hasEventTriggers || !isMainnet) {
-    return undefined;
-  }
-  return "signatures";
+function defaultSourceMode(hasEventTriggers: boolean): SourceMode | undefined {
+  return hasEventTriggers ? "signatures" : undefined;
 }
 
 interface ChainEndpoints {
@@ -223,8 +217,7 @@ export function buildRegistrations(data: DiscoveryData): ChainRegistration[] {
     const blockTriggers: SolanaBlockTrigger[] = (
       blocksByChain.get(chainId) ?? []
     ).map((t) => ({ ...t, configHash: sha256(t) }));
-    const sourceMode =
-      override ?? defaultSourceMode(network, eventTriggers.length > 0);
+    const sourceMode = override ?? defaultSourceMode(eventTriggers.length > 0);
 
     const configHash = sha256({
       endpoints,

--- a/keeperhub-events/solana-tracker/tests/unit/mapper.test.ts
+++ b/keeperhub-events/solana-tracker/tests/unit/mapper.test.ts
@@ -147,10 +147,9 @@ describe("buildRegistrations", () => {
     expect(regs).toEqual([]);
   });
 
-  it("defaults mainnet event ingestion to the filtered signatures source", () => {
-    // getBlock pulls every produced block in full; on mainnet that is a
-    // firehose no CPU request absorbs, and it skips slots (missing triggers)
-    // once it falls behind.
+  it("defaults event ingestion to the filtered signatures source", () => {
+    // getBlock pulls every produced block in full: a firehose no CPU request
+    // absorbs, and it skips slots (missing triggers) once it falls behind.
     const regs = buildRegistrations(
       data({
         eventWorkflows: [eventWorkflow("wf-1", "101", VALID_PROGRAM)],
@@ -160,26 +159,54 @@ describe("buildRegistrations", () => {
     expect(regs[0].sourceMode).toBe("signatures");
   });
 
-  it("leaves testnet chains on getBlock, where whole-block pulls are cheap", () => {
+  it("defaults a testnet event chain to signatures as well", () => {
+    // KEEP-1242: testnet chains used to keep getBlock, on the assumption that a
+    // testnet produces small blocks. Chain 103's endpoint served Solana
+    // testnet, whose blocks are ~14x a devnet block, and parsing them cost 4x
+    // the prod CPU request. Block size is a property of the endpoint, which the
+    // tracker cannot see, so the default no longer reads isTestnet at all.
     const regs = buildRegistrations(
       data({
         eventWorkflows: [eventWorkflow("wf-1", "103", VALID_PROGRAM)],
         networks: { 103: solanaNetwork(103, { isTestnet: true }) },
       }),
     );
-    expect(regs[0].sourceMode).toBeUndefined();
+    expect(regs[0].sourceMode).toBe("signatures");
   });
 
-  it("leaves a mainnet chain with only block triggers on getBlock", () => {
-    // No event triggers means no full-detail pull: getBlock runs header-only
-    // and is the only source that serves block triggers.
+  it("keeps signatures on a testnet chain that also has block triggers", () => {
+    // The shape of staging chain 103. sourceMode "signatures" plus block
+    // triggers is what routes the chain into a CompositeSource: the signatures
+    // source for events, a header-only getBlock for block height. Falling back
+    // to getBlock for the whole chain would put event matching back on the
+    // full-block pull.
     const regs = buildRegistrations(
       data({
-        blockWorkflows: [blockWorkflow("wf-b", "101", "1")],
-        networks: { 101: solanaNetwork(101) },
+        eventWorkflows: [eventWorkflow("wf-1", "103", VALID_PROGRAM)],
+        blockWorkflows: [blockWorkflow("wf-b", "103", "20")],
+        networks: { 103: solanaNetwork(103, { isTestnet: true }) },
       }),
     );
-    expect(regs[0].sourceMode).toBeUndefined();
+    expect(regs[0].sourceMode).toBe("signatures");
+    expect(regs[0].blockTriggers).toHaveLength(1);
+  });
+
+  it("leaves a chain with only block triggers on getBlock", () => {
+    // No event triggers means no full-detail pull: getBlock runs header-only
+    // and is the only source that serves block triggers. True on either network
+    // kind - the default reads the chain's triggers, nothing else.
+    for (const network of [
+      solanaNetwork(101),
+      solanaNetwork(103, { isTestnet: true }),
+    ]) {
+      const regs = buildRegistrations(
+        data({
+          blockWorkflows: [blockWorkflow("wf-b", String(network.chainId), "1")],
+          networks: { [network.chainId]: network },
+        }),
+      );
+      expect(regs[0].sourceMode).toBeUndefined();
+    }
   });
 
   it("lets SOLANA_SOURCE_MODE override the per-chain default in both directions", () => {
@@ -191,12 +218,20 @@ describe("buildRegistrations", () => {
       eventWorkflows: [eventWorkflow("wf-1", "103", VALID_PROGRAM)],
       networks: { 103: solanaNetwork(103, { isTestnet: true }) },
     });
+    const blockOnly = data({
+      blockWorkflows: [blockWorkflow("wf-b", "101", "1")],
+      networks: { 101: solanaNetwork(101) },
+    });
 
+    // Both chains default to "signatures", so only "getblock" proves the
+    // override fires. "signatures" is proved against a block-only chain, whose
+    // default is getBlock.
     process.env.SOLANA_SOURCE_MODE = "getblock";
     expect(buildRegistrations(mainnet)[0].sourceMode).toBe("getblock");
+    expect(buildRegistrations(testnet)[0].sourceMode).toBe("getblock");
 
     process.env.SOLANA_SOURCE_MODE = "signatures";
-    expect(buildRegistrations(testnet)[0].sourceMode).toBe("signatures");
+    expect(buildRegistrations(blockOnly)[0].sourceMode).toBe("signatures");
   });
 
   it("accepts SOLANA_SOURCE_MODE regardless of case or surrounding space", () => {
@@ -212,20 +247,19 @@ describe("buildRegistrations", () => {
     expect(regs[0].sourceMode).toBe("getblock");
   });
 
-  it("treats a chain with an unknown isTestnet as a testnet, not mainnet", () => {
-    // chains.is_testnet is nullable and discovery payloads are not validated;
-    // a null must not read as mainnet and pull a testnet onto the mainnet path.
-    const regs = buildRegistrations(
-      data({
-        eventWorkflows: [eventWorkflow("wf-1", "103", VALID_PROGRAM)],
-        networks: {
-          103: solanaNetwork(103, {
-            isTestnet: undefined as unknown as boolean,
-          }),
-        },
-      }),
-    );
-    expect(regs[0].sourceMode).toBeUndefined();
+  it("selects the same mode whatever isTestnet says, including a null", () => {
+    // chains.is_testnet is nullable and discovery payloads are not validated.
+    // The default no longer reads the field, so no value of it can change the
+    // source - which is the point of KEEP-1242.
+    for (const isTestnet of [true, false, undefined as unknown as boolean]) {
+      const regs = buildRegistrations(
+        data({
+          eventWorkflows: [eventWorkflow("wf-1", "103", VALID_PROGRAM)],
+          networks: { 103: solanaNetwork(103, { isTestnet }) },
+        }),
+      );
+      expect(regs[0].sourceMode).toBe("signatures");
+    }
   });
 
   it("ignores an unrecognised SOLANA_SOURCE_MODE and keeps the default", () => {


### PR DESCRIPTION
Closes KEEP-1242.

## The defect

`defaultSourceMode` returned the filtered `signatures` source only when `network.isTestnet === false`. Every other chain fell through to `GetBlockSource`, which pulls whole blocks with `transactionDetails: full` as soon as the chain watches one program.

That gate assumed a testnet produces small blocks. The tracker cannot check this. Block size is a property of the endpoint, not of the `is_testnet` flag. Chain 103 points at `chain.techops.services/solana-devnet`, and that route serves Solana **testnet** (KEEP-1202), where blocks are about 550 KB instead of about 38 KB.

Measured on 2026-08-26:

| | prod chain 103 | staging chain 103 |
| --- | --- | --- |
| CPU | ~600m against a 150m request, paged P2 | 592m against a 450m request |
| Network RX | 415 KiB/s | 339 KiB/s |
| Slot loss | `behind by 101..148 slots (> 100); older skipped` | `behind by 122 slots (> 100); older skipped` every ~20s |

Prod is mitigated: the event workflow was disabled at 13:45Z, so chain 103 has no ingestor. Staging is not mitigated and still runs the firehose. It never crossed the alert's 2.0 ratio, so nobody saw it.

Both gateways serve testnet. `getGenesisHash` returns `4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY` on `chain.techops.services/solana-devnet` and on `chain.techops.live/solana-devnet`.

## The change

A chain with event triggers now defaults to `signatures` on every network. The function no longer reads `isTestnet`.

Everything else keeps its behaviour:

- A chain with no event triggers keeps `getBlock`. It runs header-only there, and it is the only source that serves block triggers.
- A chain with event **and** block triggers goes through the `CompositeSource` the factory already builds: `SignaturesSource` for events plus a header-only `GetBlockSource` for block height. Staging chain 103 has 2 event + 2 block triggers, so it exercises that path.
- `SOLANA_SOURCE_MODE` stays the operator override for the case the default gets wrong, such as a chain that watches so many programs that per-program queries cost more than one whole-block pull.

This also stops the silent event loss on chain 103. The signatures source is cursor-based, so it does not skip a window when it falls behind. KEEP-1168 stays open for the block path.

## Tests

`tests/unit/mapper.test.ts`:

- A testnet event chain resolves `signatures` (was `undefined`).
- A testnet chain with event and block triggers resolves `signatures`, which is what routes it into the composite.
- Block-only chains keep `getBlock` on both network kinds.
- `isTestnet` true, false and null all select the same mode. This replaces the old nullable-`is_testnet` guard, whose failure mode no longer exists.
- The `SOLANA_SOURCE_MODE` test now proves both directions against chains whose defaults differ.

The three changed assertions fail against the pre-change `mapper.ts` and pass after it, so they are not vacuous.

Local, mirroring `pr-checks-events.yml`: `pnpm lint`, `pnpm typecheck`, `pnpm -r test:unit` all green (262 unit tests).

## Verification after deploy

Staging carries the live firehose, so it is the real test.

1. `[signatures] chain 103 source started (programs=N)` **and** `[getblock] chain 103 source started (detail=none)` replace today's single `detail=full` line.
2. The `behind by ... slots (> 100)` warnings stop.
3. Pod CPU falls from ~0.59 cores, RX from ~339 KiB/s.
4. `[ingestor] chain 103 enqueued block ...` keeps appearing, which proves the composite kept the block path.

Prod, after the `staging` -> `prod` promotion, re-enables workflow `njxry0ryroltvgx6mleo7` and confirms CPU stays near the 0.016-core baseline.

## Not in this PR

- `specs/solana-event-ingestion.md` still states the mainnet-aware rule as the design. Follow-up.
- `GetBlockSource.processConfirmed` re-reads `this.connection` after two awaits and threw `Cannot read properties of null (reading 'getProducedSlots')` on teardown. `SignaturesSource` has the equivalent guard at `signatures-source.ts:164-168`. Follow-up.
