### PR TITLE
chore: remove redundant currentEdgesBySource parameter from handleForEachExecution

### DIFF
--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -1685,20 +1685,14 @@ export function identifyLoopBody(
 }
 
 /**
- * Pick the edge map a nested For Each's body scan must run against.
+ * Pick the edge map a nested For Each's body scan must run against: always
+ * the workflow-global map, never the outer loop's `bodyEdgesBySource`. Why
+ * the outer map is wrong is recorded at the `identifyLoopBody` call inside
+ * `handleForEachExecution`, where the executor makes that choice inline.
  *
- * The outer loop's `bodyEdgesBySource` only holds edges its own BFS walked,
- * and that BFS stops at a handle-aware nested For Each - it resumes at the
- * inner loop's `done` chain and never descends into the inner `loop` branch.
- * So the outer map has no entry for any edge living purely inside the inner
- * body. Forwarding it to the nested scan leaves every inner body node
- * dangling at the seed, which is issue #2049: the inner Condition never ran.
- *
- * The nested scan therefore runs against the workflow-global map. The outer
- * map is taken as an argument rather than ignored at the call site so this
- * function is the single place the choice is made, and so a test can pin it:
- * return `outerBodyEdgesBySource` here and the nested-handoff regression
- * tests fail.
+ * Nothing in the executor calls this function, so it is off that path. It
+ * still takes both maps so the tests can state the choice explicitly,
+ * naming the map that is rejected rather than asserting its absence.
  */
 export function resolveNestedForEachEdgeMap(maps: {
   globalEdgesBySource: Map<string, string[]>;
@@ -2311,6 +2305,13 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     const itemsToProcess = resolvedArray.slice(0, maxIterations);
 
     // 2. Identify body subgraph
+    //
+    // An outer loop's BFS stops at a handle-aware nested For Each and never
+    // descends into the inner `loop` branch, so an outer `bodyEdgesBySource`
+    // has no entry for edges living purely inside the inner body; passing one
+    // here leaves every inner body node dangling at its seed, which is issue
+    // #2049: the inner Condition never ran. The nested scan therefore runs
+    // against the workflow-global `edgesBySource`.
     const {
       bodyNodeIds,
       collectNodeId,

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -2224,10 +2224,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           currentOutputs: scopedOutputs,
           currentResults: bodyResults,
           currentVisited: bodyVisited,
-          currentEdgesBySource: resolveNestedForEachEdgeMap({
-            globalEdgesBySource: edgesBySource,
-            outerBodyEdgesBySource: bodyEdgesBySource,
-          }),
           continueAfterCollect: async (collectId) => {
             const nextNodes = bodyEdgesBySource.get(collectId) ?? [];
             for (const next of nextNodes) {
@@ -2273,7 +2269,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     currentOutputs: NodeOutputs;
     currentResults: Record<string, ExecutionResult>;
     currentVisited: Set<string>;
-    currentEdgesBySource: Map<string, string[]>;
     /**
      * Dispatch downstream of a Collect node once iterations finish. Used for
      * both the canonical `done`-handle Collect and legacy in-body Collect.
@@ -2302,7 +2297,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       currentOutputs,
       currentResults,
       currentVisited,
-      currentEdgesBySource,
       continueAfterCollect,
       continueWithDoneTargets,
     } = params;
@@ -2326,7 +2320,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       bodyEdgesBySourceHandle,
     } = identifyLoopBody(
       forEachNodeId,
-      currentEdgesBySource,
+      edgesBySource,
       nodeMap,
       edgesBySourceHandle
     );
@@ -3014,7 +3008,6 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
             currentOutputs: outputs,
             currentResults: results,
             currentVisited: visited,
-            currentEdgesBySource: edgesBySource,
             continueAfterCollect: async (collectId) => {
               const nextNodes = edgesBySource.get(collectId) ?? [];
               await executeReadyDownstream(collectId, nextNodes, visited);

--- a/tests/unit/for-each-nested-edge-map.test.ts
+++ b/tests/unit/for-each-nested-edge-map.test.ts
@@ -12,14 +12,16 @@
  * targets past its seed and silently terminated, leaving the Condition node
  * absent from the execution trace.
  *
- * The map choice now lives in one place: `resolveNestedForEachEdgeMap`, which
- * takes both candidate maps and returns the one the nested scan must use.
- * These tests reproduce the recursive handoff around it — run
- * `identifyLoopBody` on the outer loop, feed its real `bodyEdgesBySource` and
- * the global map to the resolver, then run `identifyLoopBody` on the inner
- * loop with whatever came back. Return the outer map from the resolver and
- * the inner-body assertions below fail, which is the guard the earlier
- * direct-call tests did not provide.
+ * The executor does not call `resolveNestedForEachEdgeMap`; it passes the
+ * workflow-global map to `identifyLoopBody` directly. So these tests cover
+ * `identifyLoopBody`, not the executor: they pin its behaviour on the 2-level
+ * and 3-level topologies below, running each nested scan on the map the
+ * resolver returns so the map under test is named explicitly. The depth-3
+ * root-cause case demonstrates the mechanism directly: it chains each level's
+ * own partial map and asserts the depth-3 body is lost.
+ *
+ * Not covered here: no test drives `executeWorkflow`, so the executor's own
+ * map choice at its `identifyLoopBody` call is outside this file.
  */
 import { describe, expect, it, vi } from "vitest";
 


### PR DESCRIPTION
## What this changes

Removes `currentEdgesBySource` from `handleForEachExecution`'s params. Both call sites now pass the same value (`edgesBySource`, the workflow-global map) following the #2049 fix in #2065 -- the top-level call always did, and the nested call was updated there to match. The parameter was read exactly once, in the `identifyLoopBody` call, and `handleForEachExecution` already closes over `edgesBySource` (along with `nodeMap` and `edgesBySourceHandle`), so it carried no information a caller could legitimately vary.

## Why

Requested by @suisuss during #2065 review:

> The parameter can go away entirely. [...] Worth doing here: while the parameter exists, any future caller can re-supply a partial map and silently re-break nested loops, which is exactly how #2049 happened. Deleting it makes the regression unrepresentable. That is not a substitute for the assertion Joel asked for - we still want that, it is what documents the behaviour - but it is the stronger of the two guards.

The comment landed after #2065 had already merged, so this is a standalone follow-up rather than an addition to that PR.

`resolveNestedForEachEdgeMap` stays exported and in use by `tests/unit/for-each-nested-edge-map.test.ts` -- per the quoted comment, it documents why the global map is the only correct choice, which removing the parameter doesn't communicate on its own.

## Scope

No behavior change. Pure internal signature cleanup -- no external API, response shape, or workflow-execution outcome is affected for any workflow, nested-loop or otherwise.

## How it was verified

- `pnpm type-check` -- clean
- `pnpm check` -- clean
- Full for-each/executor unit suite (`for-each-nested-edge-map`, `for-each-executor`, `condition-foreach-multi-loop`, `for-each-body-recursion`, `for-each-body-runner`, `for-each-concurrency`, `for-each-done-handle`): 210/210 passing

---

- [x] Targets `staging`
- [x] `chore` type -- no behavior change, exempt from the issue-link gate per ISSUES.md
- [x] `pnpm check` and `pnpm type-check` pass
- [x] No secrets, `.env` files, or credentials committed
