### PR TITLE
fix: #2020 keep the hash when a broadcast receipt cannot be read

### DIFF
--- a/app/api/execute/_lib/execution-service.ts
+++ b/app/api/execute/_lib/execution-service.ts
@@ -189,8 +189,19 @@ export async function failExecution(
     }));
   }
 
+  // A hash that re-verifies as *successful* means the write threw after its
+  // transaction had already landed: the throw was ours (a receipt we could not
+  // read the first time, a post-broadcast timeout), not the chain's verdict.
+  // Recording that as a definite failure is the same mistake in the opposite
+  // direction -- it invites a retry that re-runs an action which already took
+  // effect. Left non-terminal, the reconciler re-reads the receipt and settles
+  // the row as `completed`, which is what actually happened.
+  const landedSuccessfully = receipts.some((receipt) => receipt.verified);
+
   const status =
-    receipts.length > 0 && isInconclusive(receipts) ? "unconfirmed" : "failed";
+    receipts.length > 0 && (isInconclusive(receipts) || landedSuccessfully)
+      ? "unconfirmed"
+      : "failed";
 
   await db
     .update(directExecutions)

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -227,9 +227,10 @@ async function handleWriteCall(
   }
 
   // The hash is returned whenever one exists, not only when the write
-  // succeeded. A call that broadcast and then reverted comes back with
-  // success: false and a hash (write-contract-core.ts sets it from
-  // revertedTransactionHash), and that is exactly the case where the caller
+  // succeeded. A call that broadcast and then reverted -- or broadcast and
+  // then could not be read back -- comes back with success: false and a hash
+  // (write-contract-core.ts sets it from
+  // broadcastTransactionHash), and that is exactly the case where the caller
   // needs it -- to look up what the chain said about a write it has already
   // paid for. The failure branch above already reads that hash and records it
   // against the execution, so withholding it from the response leaves the

--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -266,7 +266,24 @@ async function handleResult(
   if (!success) {
     const errorMsg =
       output && "error" in output ? String(output.error) : "Execution failed";
-    await failExecution(executionId, errorMsg);
+    // A failure that already reached the chain carries its hash, so the
+    // execution records which transaction failed and what the chain said about
+    // it. failExecution decides from that receipt whether this is terminal or
+    // a broadcast that may still land, and its verdict is authoritative for
+    // the status this reports, in place of the hardcoded "failed" it replaces.
+    // The transport code stays UNPROCESSABLE_ENTITY either way, grouping an
+    // unconfirmed transaction with a failed one exactly as the verified-success
+    // branch below already does.
+    const transactionHash =
+      output && typeof output.transactionHash === "string"
+        ? output.transactionHash
+        : undefined;
+    const chainId =
+      output && typeof output.chainId === "number" ? output.chainId : undefined;
+    const settled = await failExecution(executionId, errorMsg, {
+      transactionHash,
+      chainId,
+    });
     // The step ran (possibly broadcasting): finalize as failed so a retry
     // replays the failure instead of re-executing.
     return recordIdempotentResponse(
@@ -274,8 +291,9 @@ async function handleResult(
       NextResponse.json(
         {
           executionId,
-          status: "failed",
+          status: settled.status,
           error: errorMsg,
+          ...(transactionHash ? { transactionHash } : {}),
           ...(retryCount > 0 ? { retryCount } : {}),
         },
         { status: HttpStatus.UNPROCESSABLE_ENTITY }

--- a/lib/web3/chain-adapter/evm.ts
+++ b/lib/web3/chain-adapter/evm.ts
@@ -3,7 +3,10 @@ import { logWarn } from "@/lib/logging";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { sleep } from "@/lib/sleep";
 import { getErrorMessage } from "@/lib/utils";
-import { OnChainRevertError } from "@/lib/web3/onchain-revert";
+import {
+  OnChainPendingError,
+  OnChainRevertError,
+} from "@/lib/web3/onchain-revert";
 import { submitSignedTransactionWithFailover } from "@/lib/web3/submit-signed";
 import type { AdaptiveGasStrategy, GasConfig } from "../gas-strategy";
 import type { NonceManager, NonceSession } from "../nonce-manager";
@@ -363,7 +366,17 @@ export class EvmChainAdapter implements ChainAdapter {
       ? await this.waitForReceiptByHash(tx, options)
       : await tx.wait();
     if (!receipt) {
-      throw new Error("Transaction sent but receipt not available");
+      // The transaction is on the network -- the nonce manager was handed its
+      // hash a few lines above -- we simply could not read its outcome. That is
+      // unknown, not failed, so the hash rides on the error: the finalizer
+      // re-verifies it, settles the row as `unconfirmed`, and the reconciler
+      // keeps watching until the chain answers. Throwing a bare Error here
+      // dropped the hash and stamped a terminal failure for a transaction that
+      // existed on-chain and nowhere in our data.
+      throw new OnChainPendingError({
+        message: "Transaction sent but receipt not available",
+        transactionHash: tx.hash,
+      });
     }
     // ethers v6 wait() throws CALL_EXCEPTION on reverts it can detect, but
     // that detection is provider-dependent; a tx that passed the staticCall

--- a/lib/web3/chain-adapter/evm.ts
+++ b/lib/web3/chain-adapter/evm.ts
@@ -342,9 +342,15 @@ export class EvmChainAdapter implements ChainAdapter {
       }
       await sleep(TEMPO_RECEIPT_POLL_INTERVAL_MS);
     }
-    throw new Error(
-      `Timed out waiting for Tempo transaction receipt (${tx.hash})`
-    );
+    // The poll ran out of time, but the transaction is on the network: the
+    // same unknown-not-failed case as an empty receipt in confirmTransaction
+    // below. The hash rides on the error rather than living only in the
+    // message text, so the finalizer can settle the row as `unconfirmed` and
+    // hand it to the reconciler.
+    throw new OnChainPendingError({
+      message: `Timed out waiting for Tempo transaction receipt (${tx.hash})`,
+      transactionHash: tx.hash,
+    });
   }
 
   private async confirmTransaction(

--- a/lib/web3/onchain-revert.ts
+++ b/lib/web3/onchain-revert.ts
@@ -48,3 +48,58 @@ export function isOnChainRevertError(
 export function revertedTransactionHash(error: unknown): string | undefined {
   return isOnChainRevertError(error) ? error.transactionHash : undefined;
 }
+
+/**
+ * Thrown when a directly-signed transaction was broadcast and then could not be
+ * read back: `wait()` resolved without a receipt, or the Tempo receipt poll
+ * lapsed before the chain answered.
+ *
+ * Mirrors SponsoredTxPendingError on the sponsored path. The distinction it
+ * carries is the whole point: a transaction whose receipt we cannot read has
+ * not failed. It is unknown, and it may still mine. Keeping the hash on the
+ * error is what lets the finalizer settle the row as `unconfirmed` and hand it
+ * to the reconciler, instead of stamping a terminal failure for a transaction
+ * that exists on-chain and nowhere in our data.
+ *
+ * Callers MUST NOT retry on this error: the first send may still be landing,
+ * and a retry would put a second transaction from the same wallet on-chain.
+ *
+ * The message is unchanged from the plain Error it replaces, so callers that
+ * only read `error.message` behave identically.
+ */
+export class OnChainPendingError extends Error {
+  readonly kind = "onchain-pending" as const;
+  readonly transactionHash: string;
+
+  constructor(opts: { message: string; transactionHash: string }) {
+    super(opts.message);
+    this.name = "OnChainPendingError";
+    this.transactionHash = opts.transactionHash;
+  }
+}
+
+export function isOnChainPendingError(
+  error: unknown
+): error is OnChainPendingError {
+  return (
+    error instanceof Error &&
+    (error as OnChainPendingError).kind === "onchain-pending"
+  );
+}
+
+/**
+ * Recover the hash of a transaction that reached the chain, whatever its
+ * outcome: reverted (conclusive) or unread (unknown). Returns undefined only
+ * for pre-broadcast failures, where no transaction exists.
+ *
+ * Prefer this over `revertedTransactionHash` at the write-path boundary. The
+ * two differ exactly where it matters: a reverted transaction is a settled
+ * failure, an unread one is not settled at all, and both need their hash
+ * persisted for the record to be complete.
+ */
+export function broadcastTransactionHash(error: unknown): string | undefined {
+  if (isOnChainRevertError(error)) {
+    return error.transactionHash;
+  }
+  return isOnChainPendingError(error) ? error.transactionHash : undefined;
+}

--- a/plugins/web3/steps/approve-token-core.ts
+++ b/plugins/web3/steps/approve-token-core.ts
@@ -43,7 +43,7 @@ import {
 import { resolveGasLimitOverrides } from "@/lib/web3/gas-defaults";
 import { isSponsorshipSupported } from "@/lib/web3/turnkey-sponsorship-config";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
-import { revertedTransactionHash } from "@/lib/web3/onchain-revert";
+import { broadcastTransactionHash } from "@/lib/web3/onchain-revert";
 import { resolveSponsoredSendError } from "@/lib/web3/sponsored-send-error";
 import { executeSponsoredContractTransaction } from "@/lib/web3/sponsored-transaction-manager";
 import type { ExecutedCall } from "@/lib/web3/trace-decode";
@@ -610,8 +610,8 @@ export async function approveTokenCore(
         ),
         ...(errorClass ? { errorClass } : {}),
         ...(rejection.kind !== "unknown" ? { rejection } : {}),
-        ...(revertedTransactionHash(error)
-          ? { transactionHash: revertedTransactionHash(error), chainId }
+        ...(broadcastTransactionHash(error)
+          ? { transactionHash: broadcastTransactionHash(error), chainId }
           : {}),
       };
     }

--- a/plugins/web3/steps/approve-token-core.ts
+++ b/plugins/web3/steps/approve-token-core.ts
@@ -43,7 +43,10 @@ import {
 import { resolveGasLimitOverrides } from "@/lib/web3/gas-defaults";
 import { isSponsorshipSupported } from "@/lib/web3/turnkey-sponsorship-config";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
-import { broadcastTransactionHash } from "@/lib/web3/onchain-revert";
+import {
+  broadcastTransactionHash,
+  isOnChainPendingError,
+} from "@/lib/web3/onchain-revert";
 import { resolveSponsoredSendError } from "@/lib/web3/sponsored-send-error";
 import { executeSponsoredContractTransaction } from "@/lib/web3/sponsored-transaction-manager";
 import type { ExecutedCall } from "@/lib/web3/trace-decode";
@@ -600,7 +603,11 @@ export async function approveTokenCore(
         }
       );
       const rejection = classifyRevert(error, contract.interface);
-      const errorClass = rpcRelayErrorClass(error);
+      // Attributed as a system fault so the execution log records a fault
+      // domain for it; a relay-determined class is more specific, so it wins.
+      const errorClass =
+        rpcRelayErrorClass(error) ??
+        (isOnChainPendingError(error) ? ExecutionErrorType.SYSTEM : undefined);
       return {
         success: false,
         error: formatContractError(

--- a/plugins/web3/steps/batch-write-contract-core.ts
+++ b/plugins/web3/steps/batch-write-contract-core.ts
@@ -48,7 +48,7 @@ import {
   parsePriorityFeeGwei,
   resolveGasLimitOverrides,
 } from "@/lib/web3/gas-defaults";
-import { isOnChainRevertError, revertedTransactionHash } from "@/lib/web3/onchain-revert";
+import { broadcastTransactionHash, isOnChainRevertError } from "@/lib/web3/onchain-revert";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
 import type { TransactionContext } from "@/lib/web3/transaction-manager";
 import { withNonceSession } from "@/lib/web3/transaction-manager";
@@ -727,12 +727,12 @@ export async function batchWriteContractCore(
     } catch (error) {
       const rejection = classifyRevert(error, revertIface);
       const errorClass = rpcRelayErrorClass(error);
-      const revertedHash = revertedTransactionHash(error);
+      const broadcastHash = broadcastTransactionHash(error);
       const base = {
         success: false as const,
         error: formatContractError(error, revertIface),
         ...(errorClass ? { errorClass } : {}),
-        ...(revertedHash ? { transactionHash: revertedHash, chainId } : {}),
+        ...(broadcastHash ? { transactionHash: broadcastHash, chainId } : {}),
         ...(rejection.kind !== "unknown" ? { rejection } : {}),
       };
       // aggregate3 is atomic, so a confirmed on-chain revert (receipt status

--- a/plugins/web3/steps/batch-write-contract-core.ts
+++ b/plugins/web3/steps/batch-write-contract-core.ts
@@ -48,7 +48,11 @@ import {
   parsePriorityFeeGwei,
   resolveGasLimitOverrides,
 } from "@/lib/web3/gas-defaults";
-import { broadcastTransactionHash, isOnChainRevertError } from "@/lib/web3/onchain-revert";
+import {
+  broadcastTransactionHash,
+  isOnChainPendingError,
+  isOnChainRevertError,
+} from "@/lib/web3/onchain-revert";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
 import type { TransactionContext } from "@/lib/web3/transaction-manager";
 import { withNonceSession } from "@/lib/web3/transaction-manager";
@@ -726,7 +730,12 @@ export async function batchWriteContractCore(
       };
     } catch (error) {
       const rejection = classifyRevert(error, revertIface);
-      const errorClass = rpcRelayErrorClass(error);
+      // Set so a failOnError=false node cannot soften an unresolved in-flight
+      // send into success. A relay-determined class is the more specific
+      // answer, so it wins.
+      const errorClass =
+        rpcRelayErrorClass(error) ??
+        (isOnChainPendingError(error) ? ExecutionErrorType.SYSTEM : undefined);
       const broadcastHash = broadcastTransactionHash(error);
       const base = {
         success: false as const,

--- a/plugins/web3/steps/transfer-funds-core.ts
+++ b/plugins/web3/steps/transfer-funds-core.ts
@@ -52,7 +52,7 @@ import {
   computeSolanaLamportFee,
   SOLANA_BASE_FEE_LAMPORTS,
 } from "@/lib/web3/solana-fees";
-import { revertedTransactionHash } from "@/lib/web3/onchain-revert";
+import { broadcastTransactionHash } from "@/lib/web3/onchain-revert";
 import { resolveSponsoredSendError } from "@/lib/web3/sponsored-send-error";
 import { executeSponsoredTransaction } from "@/lib/web3/sponsored-transaction-manager";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
@@ -517,8 +517,8 @@ export async function transferFundsCore(
         error: formatContractError(error, undefined, "Transaction failed"),
         ...(errorClass ? { errorClass } : {}),
         ...(rejection.kind !== "unknown" ? { rejection } : {}),
-        ...(revertedTransactionHash(error)
-          ? { transactionHash: revertedTransactionHash(error), chainId }
+        ...(broadcastTransactionHash(error)
+          ? { transactionHash: broadcastTransactionHash(error), chainId }
           : {}),
       };
     }

--- a/plugins/web3/steps/transfer-funds-core.ts
+++ b/plugins/web3/steps/transfer-funds-core.ts
@@ -25,7 +25,7 @@ import {
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
 import { rpcRelayErrorClass } from "@/lib/rpc/providers";
-import type { ExecutionErrorType } from "@/lib/errors/execution-error-type";
+import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 import { getErrorMessage } from "@/lib/utils";
 import { generateId } from "@/lib/utils/id";
 import { validateChainAddress } from "@/lib/web3/validate-chain-address";
@@ -52,7 +52,10 @@ import {
   computeSolanaLamportFee,
   SOLANA_BASE_FEE_LAMPORTS,
 } from "@/lib/web3/solana-fees";
-import { broadcastTransactionHash } from "@/lib/web3/onchain-revert";
+import {
+  broadcastTransactionHash,
+  isOnChainPendingError,
+} from "@/lib/web3/onchain-revert";
 import { resolveSponsoredSendError } from "@/lib/web3/sponsored-send-error";
 import { executeSponsoredTransaction } from "@/lib/web3/sponsored-transaction-manager";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
@@ -511,7 +514,11 @@ export async function transferFundsCore(
         }
       );
       const rejection = classifyRevert(error);
-      const errorClass = rpcRelayErrorClass(error);
+      // Attributed as a system fault so the execution log records a fault
+      // domain for it; a relay-determined class is more specific, so it wins.
+      const errorClass =
+        rpcRelayErrorClass(error) ??
+        (isOnChainPendingError(error) ? ExecutionErrorType.SYSTEM : undefined);
       return {
         success: false,
         error: formatContractError(error, undefined, "Transaction failed"),

--- a/plugins/web3/steps/transfer-token-core.ts
+++ b/plugins/web3/steps/transfer-token-core.ts
@@ -47,7 +47,10 @@ import {
 import { resolveGasLimitOverrides } from "@/lib/web3/gas-defaults";
 import { isSponsorshipSupported } from "@/lib/web3/turnkey-sponsorship-config";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
-import { broadcastTransactionHash } from "@/lib/web3/onchain-revert";
+import {
+  broadcastTransactionHash,
+  isOnChainPendingError,
+} from "@/lib/web3/onchain-revert";
 import { resolveSponsoredSendError } from "@/lib/web3/sponsored-send-error";
 import { executeSponsoredContractTransaction } from "@/lib/web3/sponsored-transaction-manager";
 import type { ExecutedCall } from "@/lib/web3/trace-decode";
@@ -683,7 +686,11 @@ export async function transferTokenCore(
         }
       );
       const rejection = classifyRevert(error, contract.interface);
-      const errorClass = rpcRelayErrorClass(error);
+      // Attributed as a system fault so the execution log records a fault
+      // domain for it; a relay-determined class is more specific, so it wins.
+      const errorClass =
+        rpcRelayErrorClass(error) ??
+        (isOnChainPendingError(error) ? ExecutionErrorType.SYSTEM : undefined);
       return {
         success: false,
         error: formatContractError(

--- a/plugins/web3/steps/transfer-token-core.ts
+++ b/plugins/web3/steps/transfer-token-core.ts
@@ -47,7 +47,7 @@ import {
 import { resolveGasLimitOverrides } from "@/lib/web3/gas-defaults";
 import { isSponsorshipSupported } from "@/lib/web3/turnkey-sponsorship-config";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
-import { revertedTransactionHash } from "@/lib/web3/onchain-revert";
+import { broadcastTransactionHash } from "@/lib/web3/onchain-revert";
 import { resolveSponsoredSendError } from "@/lib/web3/sponsored-send-error";
 import { executeSponsoredContractTransaction } from "@/lib/web3/sponsored-transaction-manager";
 import type { ExecutedCall } from "@/lib/web3/trace-decode";
@@ -693,8 +693,8 @@ export async function transferTokenCore(
         ),
         ...(errorClass ? { errorClass } : {}),
         ...(rejection.kind !== "unknown" ? { rejection } : {}),
-        ...(revertedTransactionHash(error)
-          ? { transactionHash: revertedTransactionHash(error), chainId }
+        ...(broadcastTransactionHash(error)
+          ? { transactionHash: broadcastTransactionHash(error), chainId }
           : {}),
       };
     }

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -52,7 +52,10 @@ import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
 import { executeSponsoredContractTransaction } from "@/lib/web3/sponsored-transaction-manager";
 import type { ExecutedCall } from "@/lib/web3/trace-decode";
 import { traceExecutedCallWithFailover } from "@/lib/web3/trace-executed-call";
-import { broadcastTransactionHash } from "@/lib/web3/onchain-revert";
+import {
+  broadcastTransactionHash,
+  isOnChainPendingError,
+} from "@/lib/web3/onchain-revert";
 import { resolveSponsoredSendError } from "@/lib/web3/sponsored-send-error";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
 import {
@@ -703,7 +706,12 @@ export async function writeContractCore(
       );
       const rejection = classifyRevert(error, contractInterface);
       const broadcastHash = broadcastTransactionHash(error);
-      const errorClass = rpcRelayErrorClass(error);
+      // Set so a failOnError=false node cannot soften an unresolved in-flight
+      // send into success. A relay-determined class is the more specific
+      // answer, so it wins.
+      const errorClass =
+        rpcRelayErrorClass(error) ??
+        (isOnChainPendingError(error) ? ExecutionErrorType.SYSTEM : undefined);
       return {
         success: false,
         error: formatContractError(error, contractInterface),

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -52,7 +52,7 @@ import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
 import { executeSponsoredContractTransaction } from "@/lib/web3/sponsored-transaction-manager";
 import type { ExecutedCall } from "@/lib/web3/trace-decode";
 import { traceExecutedCallWithFailover } from "@/lib/web3/trace-executed-call";
-import { revertedTransactionHash } from "@/lib/web3/onchain-revert";
+import { broadcastTransactionHash } from "@/lib/web3/onchain-revert";
 import { resolveSponsoredSendError } from "@/lib/web3/sponsored-send-error";
 import { isGasSponsorshipEnabled } from "@/lib/web3/sponsorship-feature-flag";
 import {
@@ -702,15 +702,15 @@ export async function writeContractCore(
         }
       );
       const rejection = classifyRevert(error, contractInterface);
-      const revertedHash = revertedTransactionHash(error);
+      const broadcastHash = broadcastTransactionHash(error);
       const errorClass = rpcRelayErrorClass(error);
       return {
         success: false,
         error: formatContractError(error, contractInterface),
         ...(errorClass ? { errorClass } : {}),
         ...(rejection.kind !== "unknown" ? { rejection } : {}),
-        ...(revertedHash
-          ? { transactionHash: revertedHash, chainId }
+        ...(broadcastHash
+          ? { transactionHash: broadcastHash, chainId }
           : {}),
       };
     }

--- a/tests/integration/execute-node-reserved-fields.test.ts
+++ b/tests/integration/execute-node-reserved-fields.test.ts
@@ -134,7 +134,7 @@ beforeEach(() => {
   mocks.createExecution.mockResolvedValue({ executionId: "ex1" });
   mocks.markRunning.mockResolvedValue(undefined);
   mocks.completeExecution.mockResolvedValue({ status: "completed" });
-  mocks.failExecution.mockResolvedValue(undefined);
+  mocks.failExecution.mockResolvedValue({ status: "failed" });
   mocks.setRetryCount.mockResolvedValue(undefined);
   mocks.redactInput.mockImplementation(
     (input: Record<string, unknown>) => input
@@ -334,5 +334,60 @@ describe("POST /api/execute/node reserved-field gating", () => {
     );
 
     expect([200, 202]).toContain(response.status);
+  });
+});
+
+describe("POST /api/execute/node broadcast hash on a failed step", () => {
+  it("hands the step's hash to failExecution and reports its verdict", async () => {
+    // The adapter threw after broadcasting, so the step returns the hash with
+    // success: false. Sibling routes already forward it; this one used to drop
+    // it and stamp a terminal failure, leaving the transaction on-chain and
+    // outside the reconciler's unconfirmed-with-a-hash scan.
+    mocks.stepFn.mockResolvedValue({
+      success: false,
+      error: "Transaction sent but receipt not available",
+      transactionHash: "0xpending",
+      chainId: 1,
+    });
+    mocks.failExecution.mockResolvedValue({ status: "unconfirmed" });
+
+    const response = await nodePOST(
+      postRequest({
+        actionType: "web3/write-contract",
+        config: { network: "1", contractAddress: "0xabc" },
+      })
+    );
+
+    expect(mocks.failExecution).toHaveBeenCalledWith(
+      "ex1",
+      "Transaction sent but receipt not available",
+      expect.objectContaining({ transactionHash: "0xpending", chainId: 1 })
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.status).toBe("unconfirmed");
+    expect(body.transactionHash).toBe("0xpending");
+    // The route groups an unconfirmed transaction with a failed one at the
+    // transport layer, same as its verified-success branch; only the body
+    // distinguishes them.
+    expect(response.status).toBe(422);
+  });
+
+  it("still reports a pre-broadcast failure as terminal with no hash", async () => {
+    mocks.stepFn.mockResolvedValue({
+      success: false,
+      error: "insufficient funds",
+    });
+
+    const response = await nodePOST(
+      postRequest({
+        actionType: "web3/write-contract",
+        config: { network: "1", contractAddress: "0xabc" },
+      })
+    );
+
+    expect(response.status).toBe(422);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.status).toBe("failed");
+    expect(body.transactionHash).toBeUndefined();
   });
 });

--- a/tests/unit/batch-write-contract.test.ts
+++ b/tests/unit/batch-write-contract.test.ts
@@ -164,7 +164,10 @@ vi.mock("ethers", async () => {
 
 import { ethers } from "ethers";
 import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
-import { OnChainRevertError } from "@/lib/web3/onchain-revert";
+import {
+  OnChainPendingError,
+  OnChainRevertError,
+} from "@/lib/web3/onchain-revert";
 import {
   applyBatchFailOnError,
   type BatchWriteContractCoreInput,
@@ -933,6 +936,36 @@ describe("batch-write-contract - failOnError softening", () => {
     // aborting the workflow, matching write-contract-core's own carve-out.
     const softened = applyBatchFailOnError(result, false);
     expect(softened.success).toBe(true);
+  });
+
+  it("refuses to soften a broadcast whose receipt could not be read", async () => {
+    mockStaticCall.mockResolvedValueOnce([SUCCESS_RETURN, SUCCESS_RETURN]);
+    mockExecuteContractCall.mockRejectedValueOnce(
+      new OnChainPendingError({
+        message: "Transaction sent but receipt not available",
+        transactionHash: "0xpending",
+      })
+    );
+
+    const result = await batchWriteContractCore(baseInput({}));
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected failure");
+    }
+    expect(result.transactionHash).toBe("0xpending");
+    expect(result.errorClass).toBe(ExecutionErrorType.SYSTEM);
+    // Unlike the confirmed revert above, nothing about the sub-calls is known:
+    // the batch may still mine, so it must not report them as reverted.
+    expect(result.results).toBeUndefined();
+    expect(result.totalCalls).toBeUndefined();
+
+    // This local copy of the softening rule is a second implementation of the
+    // same carve-out, so it needs its own guard: without the SYSTEM class it
+    // would continue the workflow as though the batch never happened while
+    // the transaction is still in flight.
+    const softened = applyBatchFailOnError(result, false);
+    expect(softened.success).toBe(false);
+    expect(softened).toBe(result);
   });
 });
 

--- a/tests/unit/evm-chain-adapter-tempo-confirm.test.ts
+++ b/tests/unit/evm-chain-adapter-tempo-confirm.test.ts
@@ -1,6 +1,17 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
+
+// The receipt poll's only pause is lib/sleep, so counting what it sleeps and
+// reading Date.now() off that counter walks the 60s deadline in a few real
+// milliseconds.
+const clock = vi.hoisted(() => ({ elapsedMs: 0 }));
+vi.mock("@/lib/sleep", () => ({
+  sleep: (ms: number) => {
+    clock.elapsedMs += ms;
+    return Promise.resolve();
+  },
+}));
 vi.mock("@/lib/db", () => ({ db: {} }));
 vi.mock("@/lib/db/schema", () => ({ explorerConfigs: {} }));
 vi.mock("drizzle-orm", () => ({ eq: () => ({}) }));
@@ -176,5 +187,47 @@ describe("EvmChainAdapter unreadable receipt", () => {
 
     expect(isOnChainPendingError(error)).toBe(false);
     expect(broadcastTransactionHash(error)).toBeUndefined();
+  });
+});
+
+describe("EvmChainAdapter Tempo receipt-poll timeout", () => {
+  let nowSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clock.elapsedMs = 0;
+    const base = Date.now();
+    nowSpy = vi
+      .spyOn(Date, "now")
+      .mockImplementation(() => base + clock.elapsedMs);
+  });
+
+  afterEach(() => {
+    nowSpy?.mockRestore();
+  });
+
+  // Tempo is the one chain that polls precisely because wait() misbehaves
+  // there, so it is the one chain whose broadcast-but-unread case never
+  // reached the empty-receipt branch above. It needs its own carrier.
+  it("keeps the hash on the error when the poll lapses before the chain answers", async () => {
+    const h = createHarness(TEMPO_TESTNET, badDataWait());
+    h.getTransactionReceipt.mockResolvedValue(null);
+
+    const error = await send(h).then(
+      () => undefined,
+      (thrown: unknown) => thrown
+    );
+
+    expect(isOnChainPendingError(error)).toBe(true);
+    expect(broadcastTransactionHash(error)).toBe(TX_HASH);
+  });
+
+  it("leaves the timeout message untouched for callers that only read it", async () => {
+    const h = createHarness(TEMPO_TESTNET, badDataWait());
+    h.getTransactionReceipt.mockResolvedValue(null);
+
+    await expect(send(h)).rejects.toThrow(
+      `Timed out waiting for Tempo transaction receipt (${TX_HASH})`
+    );
   });
 });

--- a/tests/unit/evm-chain-adapter-tempo-confirm.test.ts
+++ b/tests/unit/evm-chain-adapter-tempo-confirm.test.ts
@@ -10,6 +10,10 @@ vi.mock("@/lib/explorer", () => ({
 }));
 
 import { EvmChainAdapter } from "@/lib/web3/chain-adapter/evm";
+import {
+  broadcastTransactionHash,
+  isOnChainPendingError,
+} from "@/lib/web3/onchain-revert";
 
 const FROM = "0x2c9F694183A4240B6431771F6c714a8106179dF5";
 const TO = "0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59";
@@ -121,5 +125,56 @@ describe("EvmChainAdapter Tempo confirmation", () => {
     expect(result.hash).toBe(TX_HASH);
     expect(h.wait).toHaveBeenCalledTimes(1);
     expect(h.getTransactionReceipt).not.toHaveBeenCalled();
+  });
+});
+
+describe("EvmChainAdapter unreadable receipt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps the hash on the error when the receipt cannot be read", async () => {
+    // wait() resolving null is the shape of "broadcast, outcome unknown": the
+    // transaction is on the network, we just cannot see it yet.
+    const h = createHarness(SEPOLIA, vi.fn().mockResolvedValue(null));
+
+    const error = await send(h).then(
+      () => undefined,
+      (thrown: unknown) => thrown
+    );
+
+    expect(isOnChainPendingError(error)).toBe(true);
+    // The regression this guards: a bare Error dropped the hash, so the
+    // finalizer recorded a terminal failure for a transaction that exists
+    // on-chain and nowhere in our data, and the reconciler -- which scans for
+    // unconfirmed rows WITH a hash -- never revisited it.
+    expect(broadcastTransactionHash(error)).toBe(TX_HASH);
+  });
+
+  it("leaves the message untouched for callers that only read it", async () => {
+    const h = createHarness(SEPOLIA, vi.fn().mockResolvedValue(null));
+
+    await expect(send(h)).rejects.toThrow(
+      "Transaction sent but receipt not available"
+    );
+  });
+
+  it("does not mistake a pre-broadcast failure for a broadcast one", async () => {
+    // Nothing reached the chain, so no hash may be attached: recording one
+    // would invent a transaction that does not exist.
+    const h = createHarness(SEPOLIA, vi.fn());
+    (
+      h.signer as { sendTransaction: ReturnType<typeof vi.fn> }
+    ).sendTransaction = vi
+      .fn()
+      .mockRejectedValue(new Error("insufficient funds"));
+
+    const error = await send(h).then(
+      () => undefined,
+      (thrown: unknown) => thrown
+    );
+
+    expect(isOnChainPendingError(error)).toBe(false);
+    expect(broadcastTransactionHash(error)).toBeUndefined();
   });
 });

--- a/tests/unit/onchain-revert.test.ts
+++ b/tests/unit/onchain-revert.test.ts
@@ -9,7 +9,10 @@ vi.mock("@/lib/logging", () => ({
 }));
 
 import {
+  broadcastTransactionHash,
+  isOnChainPendingError,
   isOnChainRevertError,
+  OnChainPendingError,
   OnChainRevertError,
   revertedTransactionHash,
 } from "@/lib/web3/onchain-revert";
@@ -81,5 +84,56 @@ describe("resolveSponsoredSendError", () => {
     const decision = resolveSponsoredSendError(new Error("policy denied"), ctx);
 
     expect(decision.fallback).toBe(true);
+  });
+});
+
+describe("OnChainPendingError", () => {
+  it("keeps the hash of a broadcast whose outcome could not be read", () => {
+    const error = new OnChainPendingError({
+      message: "Transaction sent but receipt not available",
+      transactionHash: HASH,
+    });
+
+    expect(isOnChainPendingError(error)).toBe(true);
+    expect(broadcastTransactionHash(error)).toBe(HASH);
+  });
+
+  it("is not a revert: unknown and failed must stay distinguishable", () => {
+    // The whole point of the carrier. A reverted transaction is a settled
+    // failure; an unread one may still mine, so anything that decides
+    // "terminal or not" has to be able to tell them apart.
+    const pending = new OnChainPendingError({
+      message: "Transaction sent but receipt not available",
+      transactionHash: HASH,
+    });
+
+    expect(isOnChainRevertError(pending)).toBe(false);
+    // revertedTransactionHash answers "did it fail on-chain", so it stays
+    // silent here even though a transaction does exist.
+    expect(revertedTransactionHash(pending)).toBeUndefined();
+  });
+});
+
+describe("broadcastTransactionHash", () => {
+  it("recovers the hash from either carrier", () => {
+    const reverted = new OnChainRevertError({
+      message: "reverted",
+      transactionHash: HASH,
+    });
+    const pending = new OnChainPendingError({
+      message: "receipt not available",
+      transactionHash: HASH,
+    });
+
+    expect(broadcastTransactionHash(reverted)).toBe(HASH);
+    expect(broadcastTransactionHash(pending)).toBe(HASH);
+  });
+
+  it("reports nothing when no transaction was ever broadcast", () => {
+    expect(
+      broadcastTransactionHash(new Error("nonce too low"))
+    ).toBeUndefined();
+    expect(broadcastTransactionHash(undefined)).toBeUndefined();
+    expect(broadcastTransactionHash(null)).toBeUndefined();
   });
 });

--- a/tests/unit/write-contract-core.test.ts
+++ b/tests/unit/write-contract-core.test.ts
@@ -75,9 +75,16 @@ vi.mock("@/lib/utils/id", () => ({
   generateId: () => mockGenerateId(),
 }));
 
-vi.mock("@/lib/utils", async () =>
-  (await import("../mocks/step-mocks")).utilsGetErrorMessage()
-);
+// Spread the real module so applyFailOnError's resolveFailOnError and
+// redactAllUrls run for real; only getErrorMessage is stubbed, as before.
+vi.mock("@/lib/utils", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils");
+  return {
+    ...actual,
+    ...(await import("../mocks/step-mocks")).utilsGetErrorMessage(),
+  };
+});
 
 vi.mock("@/lib/rpc/network-utils", () => ({
   getChainIdFromNetwork: vi.fn().mockReturnValue(1),
@@ -133,6 +140,7 @@ vi.mock("@/lib/web3/chain-adapter", () => ({
 
 vi.mock("@/lib/web3/decode-revert-error", () => ({
   formatContractError: vi.fn().mockReturnValue("contract error"),
+  classifyRevert: vi.fn().mockReturnValue({ kind: "unknown" }),
 }));
 
 vi.mock("@/lib/web3/gas-defaults", () => ({
@@ -211,11 +219,14 @@ import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import { RpcRelayTransportError } from "@/lib/rpc/providers/transport-error";
 import { parsePriorityFeeGwei } from "@/lib/web3/gas-defaults";
+import { OnChainPendingError } from "@/lib/web3/onchain-revert";
 // Import mocks for assertion
 import { initializeWalletSigner } from "@/lib/web3/wallet-helpers";
-
 // Import SUT after all mocks
-import { writeContractCore } from "@/plugins/web3/steps/write-contract-core";
+import {
+  applyFailOnError,
+  writeContractCore,
+} from "@/plugins/web3/steps/write-contract-core";
 
 const VALID_ABI = JSON.stringify([
   {
@@ -534,5 +545,80 @@ describe("writeContractCore RPC resolution failure", () => {
     if (!result.success) {
       expect(result.errorClass).toBe(ExecutionErrorType.EXTERNAL);
     }
+  });
+});
+
+describe("writeContractCore broadcast with an unreadable receipt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedTxContext = null;
+    registry.tokenRows = [];
+  });
+
+  it("classifies the send as SYSTEM so failOnError cannot soften it", async () => {
+    mockExecuteContractCall.mockRejectedValueOnce(
+      new OnChainPendingError({
+        message: "Transaction sent but receipt not available",
+        transactionHash: "0xpending",
+      })
+    );
+
+    const result = await writeContractCore({
+      contractAddress: "0x1234567890123456789012345678901234567890",
+      network: "ethereum",
+      abi: VALID_ABI,
+      abiFunction: "transfer",
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.transactionHash).toBe("0xpending");
+      expect(result.errorClass).toBe(ExecutionErrorType.SYSTEM);
+    }
+
+    // Without a class, applyFailOnError reports the step as a success while
+    // the transaction may still mine: the node continues as though the write
+    // never happened, and the operator never learns otherwise.
+    const softened = applyFailOnError(result, false);
+    expect(softened.success).toBe(false);
+    expect(softened).toEqual(result);
+  });
+
+  it("keeps a relay-determined class rather than overwriting it with SYSTEM", async () => {
+    mockExecuteContractCall.mockRejectedValueOnce(
+      new RpcRelayTransportError("RPC failed on primary endpoint: timeout")
+    );
+
+    const result = await writeContractCore({
+      contractAddress: "0x1234567890123456789012345678901234567890",
+      network: "ethereum",
+      abi: VALID_ABI,
+      abiFunction: "transfer",
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errorClass).toBe(ExecutionErrorType.EXTERNAL);
+    }
+  });
+
+  it("leaves an ordinary send failure unclassified and softenable", async () => {
+    mockExecuteContractCall.mockRejectedValueOnce(new Error("nonce too low"));
+
+    const result = await writeContractCore({
+      contractAddress: "0x1234567890123456789012345678901234567890",
+      network: "ethereum",
+      abi: VALID_ABI,
+      abiFunction: "transfer",
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errorClass).toBeUndefined();
+    }
+    expect(applyFailOnError(result, false).success).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #2020.

## What was wrong

`confirmTransaction` threw a bare `Error` when the receipt came back empty. The
transaction was already on the network — the nonce manager is handed its hash
twelve lines earlier — but the hash went nowhere, so:

- `revertedTransactionHash()` recognised only `OnChainRevertError` and returned nothing;
- the write path's catch returned `success: false` with no `transactionHash`;
- `failExecution` saw no hash, verified no receipts, and settled the row `failed` with `completedAt` stamped;
- the reconciler scans `status = 'unconfirmed' AND transaction_hash IS NOT NULL`, so the row matched neither condition and was never revisited.

The error message said the transaction was sent. The record said terminal
failure, no transaction. Nothing would ever settle it.

## What this changes

**`OnChainPendingError`** (`lib/web3/onchain-revert.ts`) — a pending-outcome
carrier for the direct path, mirroring `SponsoredTxPendingError` on the
sponsored one, and living beside `OnChainRevertError` the same way that one
lives beside `SponsoredTxRevertError`.

**`broadcastTransactionHash()`** — recovers the hash from either carrier.
`revertedTransactionHash()` is unchanged and still answers the narrower
question ("did it fail on-chain"), which is what its name promises; the write
paths now ask the wider one.

**The throw site** (`evm.ts`) carries `tx.hash`. Message text is untouched, so
callers that only read `error.message` behave identically.

**Five write plugins** — write-contract, batch-write-contract, approve-token,
transfer-funds, transfer-token — now forward the hash. They all reach the chain
through the same `confirmTransaction`, so all five had the same hole; the
per-plugin change is one identifier.

Steps 1–3 of the issue's direction then follow on their own: `failExecution`
re-verifies the hash, `hasUnreadableReceipt` finds the receipt unreadable,
and the row settles `unconfirmed` with `completedAt` null — inside the
reconciler's scan.

## The edge the issue flagged

> A write that threw after its transaction actually succeeded must not be
> recorded as a definite failure.

Re-verification returning a *successful* receipt is conclusive, so the old
expression fell through to `failed`. `failExecution` now keeps a
positively-verified hash non-terminal, and `reconcileOne` settles it
`completed` on its next pass — which is what actually happened on chain.
Recording that as failure is the same defect mirrored: it invites a retry of an
action that already took effect.

## Tests

`tests/unit/onchain-revert.test.ts` — the carrier keeps its hash; a pending
error is not a revert (`revertedTransactionHash` stays silent on it, which is
the distinction the whole fix rests on); `broadcastTransactionHash` covers both
carriers and stays undefined when nothing was broadcast.

`tests/unit/evm-chain-adapter-tempo-confirm.test.ts` — a `wait()` that resolves
`null` now throws a carrier holding the hash, the message is unchanged, and a
pre-broadcast failure still yields no hash, so no transaction is invented for
a send that never left.

## Not in scope

The Tempo plugin's own receipt-wait timeout (`plugins/tempo/steps/tempo-tx-core.ts`),
tracked separately. Tempo chains that reach the adapter through
`waitForReceiptByHash` are covered here.
