### PR TITLE
fix: stop draining flag wedging chains after a wss reconnect

### DIFF
--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -1212,8 +1212,9 @@ export class ChainProviderManager {
     // Dedup cannot absorb that: `isProcessed`/`markProcessed` is a
     // check-then-set with the listener's jitter sleep before the check, so
     // two concurrent dispatches of one log both see "not processed".
-    // Nothing needs to force-release it either, because the `eth_getLogs`
-    // timeout below guarantees every drain settles.
+    // The `eth_getLogs` timeout below bounds the fetch, so a stranded request
+    // cannot hold `draining`. Dispatch is not bounded, so a handler that never
+    // settles still can.
     entry.draining = true;
     try {
       entry.lastRequestAt = Date.now();

--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -190,6 +190,15 @@ const PROBE_TIMEOUT_MS = 10_000;
  * connect-time reachability gates fail at the same scale.
  */
 const CONNECT_TIMEOUT_MS = 10_000;
+/**
+ * Cap on an `eth_getLogs` round-trip in `processBlockRange`. A request
+ * already written to the socket has no other timeout: ethers does not
+ * reject it on its own, and a heartbeat on the same socket can keep
+ * passing while this specific request never answers. Matches the other
+ * per-request timeouts in this file so every reachability gate fails at
+ * the same scale.
+ */
+const GETLOGS_TIMEOUT_MS = 10_000;
 
 export type LogHandler = (log: ethers.Log) => void | Promise<void>;
 export type Unsubscribe = () => void;
@@ -408,6 +417,15 @@ interface ChainEntry {
    * requests for overlapping ranges.
    */
   draining: boolean;
+  /**
+   * Bumped by `reconnect()` on every replacement provider. A `drain` call
+   * that started before the bump belongs to the socket that was just
+   * destroyed - ethers does not reject a request that was already written
+   * to that socket, so the call may never settle. Comparing this value
+   * before and after the await lets `drain` tell whether it is still
+   * describing the connection it started on before touching shared state.
+   */
+  connectionGeneration: number;
   /**
    * Populated when `createProvider` rejects (most often the
    * subscription probe). Cleared on the next successful creation.
@@ -821,6 +839,7 @@ export class ChainProviderManager {
       lastRequestAt: null,
       catchUpTimer: null,
       draining: false,
+      connectionGeneration: 0,
       lastCreateError: null,
       disconnectHandlers: new Set(),
       stats: newChainStats(),
@@ -1163,16 +1182,30 @@ export class ChainProviderManager {
     const from = entry.lastProcessedBlock + 1;
     const to = Math.min(entry.headBlock, from + GETLOGS_MAX_BLOCK_SPAN - 1);
 
+    // Ownership token for this connection. `reconnect()` bumps it and clears
+    // `draining` directly when it replaces the provider, so a request
+    // stranded on the socket that was just destroyed - which may never
+    // settle at all - cannot advance the mark or hold the flag for a
+    // connection it no longer belongs to.
+    const generation = entry.connectionGeneration;
     entry.draining = true;
     try {
       entry.lastRequestAt = Date.now();
-      // The mark advances only on success. A failed range stays owed, so the
-      // next drain re-queries it instead of losing every event in it.
-      if (await this.processBlockRange(entry, from, to)) {
+      // The mark advances only on success, and only if this is still the
+      // connection that started the request - a late response from a
+      // connection that has since been replaced must not advance the
+      // replacement's mark.
+      const served = await this.processBlockRange(entry, from, to);
+      if (served && entry.connectionGeneration === generation) {
         entry.lastProcessedBlock = to;
       }
     } finally {
-      entry.draining = false;
+      // A reconnect that happened mid-request already cleared `draining`
+      // for the replacement connection; clearing it again here would race
+      // whatever drain that connection may already have started.
+      if (entry.connectionGeneration === generation) {
+        entry.draining = false;
+      }
     }
 
     // More owed than one request could take, the head moved while the request
@@ -1460,6 +1493,14 @@ export class ChainProviderManager {
     if (this.isDestroyed) {
       return;
     }
+    // A new connection generation, and `draining` cleared directly rather
+    // than left for a `finally` that may never run. A `drain` still
+    // awaiting a response on the socket about to be destroyed belongs to
+    // the previous generation: ethers does not reject a request that was
+    // already written to the socket, so that await can hang forever, and
+    // the flag it owns must not hang with it.
+    entry.connectionGeneration += 1;
+    entry.draining = false;
     // Tear down the old provider (best-effort) and unhook listeners so
     // the old provider cannot trigger another reconnect while we are
     // building the new one.
@@ -1560,14 +1601,42 @@ export class ChainProviderManager {
         // and requests are the quantity the provider bills.
         entry.stats.getLogsCalls += 1;
         entry.stats.getLogsCallsTotal += 1;
-        const batch = (await entry.provider.send("eth_getLogs", [
-          {
-            fromBlock: fromHex,
-            toBlock: toHex,
-            address: chunk,
-            topics: [topic0s],
-          },
-        ])) as ethers.Log[];
+        // Raced against an explicit timeout for the same reason as the
+        // probe in `probeSubscriptionSupport`: ethers gives no externally
+        // controllable timeout on `provider.send`, and a socket that has
+        // gone quiet on this one request - while still answering heartbeat
+        // pings - would otherwise hang the drain for the life of the
+        // socket, with no reconnect ever triggered to replace it.
+        let timeoutHandle: NodeJS.Timeout | null = null;
+        const timeoutPromise = new Promise<never>((_, reject) => {
+          timeoutHandle = setTimeout(
+            () =>
+              reject(
+                new Error(
+                  `eth_getLogs timed out after ${GETLOGS_TIMEOUT_MS}ms`,
+                ),
+              ),
+            GETLOGS_TIMEOUT_MS,
+          );
+        });
+        let batch: ethers.Log[];
+        try {
+          batch = (await Promise.race([
+            entry.provider.send("eth_getLogs", [
+              {
+                fromBlock: fromHex,
+                toBlock: toHex,
+                address: chunk,
+                topics: [topic0s],
+              },
+            ]),
+            timeoutPromise,
+          ])) as ethers.Log[];
+        } finally {
+          if (timeoutHandle) {
+            clearTimeout(timeoutHandle);
+          }
+        }
         logs.push(...batch);
       }
 

--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -1070,7 +1070,10 @@ export class ChainProviderManager {
     entry.blockIntervalSamples = 0;
     entry.blockIntervalFirstSampleAt = null;
     // Per connection, like the cadence estimate above: a run of timeouts is
-    // evidence about one socket, and this is a different one.
+    // evidence about one socket, and this is a different one. `entry` is
+    // shared though, so a request stranded by the old connection settles
+    // after the swap and counts against the replacement. It takes a full run
+    // to matter and any served range clears it.
     entry.consecutiveGetLogsTimeouts = 0;
     entry.provider.on("block", listener);
     this.startStatsTimer();

--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -194,11 +194,30 @@ const CONNECT_TIMEOUT_MS = 10_000;
  * Cap on an `eth_getLogs` round-trip in `processBlockRange`. A request
  * already written to the socket has no other timeout: ethers does not
  * reject it on its own, and a heartbeat on the same socket can keep
- * passing while this specific request never answers. Matches the other
- * per-request timeouts in this file so every reachability gate fails at
- * the same scale.
+ * passing while this specific request never answers.
+ *
+ * Deliberately looser than the 10 s connect and probe gates. Those bound a
+ * handshake and a single trivial frame; this bounds a real query over up to
+ * `GETLOGS_MAX_BLOCK_SPAN` blocks and `GETLOGS_ADDRESS_BATCH` addresses,
+ * which on a busy chain or a loaded upstream can legitimately take many
+ * seconds. Sizing it to match the connect gate would turn slow-but-working
+ * queries into permanent failures, and a range that never succeeds never
+ * advances the mark.
  */
-const GETLOGS_TIMEOUT_MS = 10_000;
+export const GETLOGS_TIMEOUT_MS = 30_000;
+/**
+ * Consecutive `eth_getLogs` timeouts on one connection before the chain is
+ * reconnected. A single timeout is a slow upstream and worth retrying in
+ * place; a run of them is a socket that will not serve this call again, and
+ * no other check in this class notices - the heartbeat is a different
+ * request and still answers, and blocks keep arriving so the staleness
+ * watchdog never fires. Without this the chain retries into the void until
+ * the gap crosses `GETLOGS_MAX_CATCHUP_BLOCKS` and its events are dropped.
+ */
+export const GETLOGS_TIMEOUT_RECONNECT_THRESHOLD = 3;
+
+/** Marks the timeout branch of the `eth_getLogs` race, for escalation. */
+class GetLogsTimeoutError extends Error {}
 
 export type LogHandler = (log: ethers.Log) => void | Promise<void>;
 export type Unsubscribe = () => void;
@@ -209,7 +228,8 @@ export type DisconnectReason =
   | "provider_error"
   | "heartbeat_failure"
   | "heartbeat_timeout"
-  | "block_staleness";
+  | "block_staleness"
+  | "getlogs_timeout";
 
 export interface DisconnectEvent {
   chainId: number;
@@ -418,14 +438,13 @@ interface ChainEntry {
    */
   draining: boolean;
   /**
-   * Bumped by `reconnect()` on every replacement provider. A `drain` call
-   * that started before the bump belongs to the socket that was just
-   * destroyed - ethers does not reject a request that was already written
-   * to that socket, so the call may never settle. Comparing this value
-   * before and after the await lets `drain` tell whether it is still
-   * describing the connection it started on before touching shared state.
+   * Consecutive `eth_getLogs` timeouts on the current connection, reset by
+   * any range that returns and by every fresh connection. A socket that
+   * answers heartbeat pings but never answers `eth_getLogs` passes every
+   * other liveness check this class has, so the timeout has to escalate on
+   * its own or the chain retries into the void forever.
    */
-  connectionGeneration: number;
+  consecutiveGetLogsTimeouts: number;
   /**
    * Populated when `createProvider` rejects (most often the
    * subscription probe). Cleared on the next successful creation.
@@ -839,7 +858,7 @@ export class ChainProviderManager {
       lastRequestAt: null,
       catchUpTimer: null,
       draining: false,
-      connectionGeneration: 0,
+      consecutiveGetLogsTimeouts: 0,
       lastCreateError: null,
       disconnectHandlers: new Set(),
       stats: newChainStats(),
@@ -1050,6 +1069,9 @@ export class ChainProviderManager {
     entry.blockIntervalEwmaMs = null;
     entry.blockIntervalSamples = 0;
     entry.blockIntervalFirstSampleAt = null;
+    // Per connection, like the cadence estimate above: a run of timeouts is
+    // evidence about one socket, and this is a different one.
+    entry.consecutiveGetLogsTimeouts = 0;
     entry.provider.on("block", listener);
     this.startStatsTimer();
   }
@@ -1182,30 +1204,26 @@ export class ChainProviderManager {
     const from = entry.lastProcessedBlock + 1;
     const to = Math.min(entry.headBlock, from + GETLOGS_MAX_BLOCK_SPAN - 1);
 
-    // Ownership token for this connection. `reconnect()` bumps it and clears
-    // `draining` directly when it replaces the provider, so a request
-    // stranded on the socket that was just destroyed - which may never
-    // settle at all - cannot advance the mark or hold the flag for a
-    // connection it no longer belongs to.
-    const generation = entry.connectionGeneration;
+    // `draining` is held for the whole drain, dispatch included, and is
+    // released only here. Nothing else clears it - a reconnect must not,
+    // because releasing a drain that already has its logs and is part way
+    // through dispatching them lets the replacement re-fetch the same
+    // unadvanced range and dispatch those logs a second time, concurrently.
+    // Dedup cannot absorb that: `isProcessed`/`markProcessed` is a
+    // check-then-set with the listener's jitter sleep before the check, so
+    // two concurrent dispatches of one log both see "not processed".
+    // Nothing needs to force-release it either, because the `eth_getLogs`
+    // timeout below guarantees every drain settles.
     entry.draining = true;
     try {
       entry.lastRequestAt = Date.now();
-      // The mark advances only on success, and only if this is still the
-      // connection that started the request - a late response from a
-      // connection that has since been replaced must not advance the
-      // replacement's mark.
-      const served = await this.processBlockRange(entry, from, to);
-      if (served && entry.connectionGeneration === generation) {
+      // The mark advances only on success. A failed range stays owed, so the
+      // next drain re-queries it instead of losing every event in it.
+      if (await this.processBlockRange(entry, from, to)) {
         entry.lastProcessedBlock = to;
       }
     } finally {
-      // A reconnect that happened mid-request already cleared `draining`
-      // for the replacement connection; clearing it again here would race
-      // whatever drain that connection may already have started.
-      if (entry.connectionGeneration === generation) {
-        entry.draining = false;
-      }
+      entry.draining = false;
     }
 
     // More owed than one request could take, the head moved while the request
@@ -1493,14 +1511,12 @@ export class ChainProviderManager {
     if (this.isDestroyed) {
       return;
     }
-    // A new connection generation, and `draining` cleared directly rather
-    // than left for a `finally` that may never run. A `drain` still
-    // awaiting a response on the socket about to be destroyed belongs to
-    // the previous generation: ethers does not reject a request that was
-    // already written to the socket, so that await can hang forever, and
-    // the flag it owns must not hang with it.
-    entry.connectionGeneration += 1;
-    entry.draining = false;
+    // `draining` is deliberately left alone. A drain in flight here is
+    // either waiting on `eth_getLogs` - bounded by `GETLOGS_TIMEOUT_MS`, so
+    // it releases the flag on its own - or already dispatching, and forcing
+    // it open there would let this replacement re-fetch and re-dispatch the
+    // same logs concurrently with it. The drain also captures its provider,
+    // so it cannot issue anything against the connection built below.
     // Tear down the old provider (best-effort) and unhook listeners so
     // the old provider cannot trigger another reconnect while we are
     // building the new one.
@@ -1585,7 +1601,13 @@ export class ChainProviderManager {
     toBlock: number,
   ): Promise<boolean> {
     const subscribers = [...entry.subscribers];
-    if (subscribers.length === 0 || !entry.provider) {
+    // Captured once. A multi-chunk range spans several awaits, and
+    // `entry.provider` can be replaced (or nulled) by a reconnect during
+    // any of them - re-reading it would issue the remaining chunks against
+    // a connection this range does not belong to, or throw a TypeError that
+    // the catch below would report as an ordinary getLogs failure.
+    const provider = entry.provider;
+    if (subscribers.length === 0 || !provider) {
       return false;
     }
 
@@ -1595,6 +1617,12 @@ export class ChainProviderManager {
     try {
       const logs: ethers.Log[] = [];
       for (let i = 0; i < addresses.length; i += GETLOGS_ADDRESS_BATCH) {
+        // A reconnect between chunks means this range is being served by a
+        // socket that is already gone. Stop rather than bill more requests
+        // against it; the mark has not moved, so the range is still owed.
+        if (entry.provider !== provider) {
+          return false;
+        }
         const chunk = addresses.slice(i, i + GETLOGS_ADDRESS_BATCH);
         // Counted at the call rather than the range: one range over more
         // than GETLOGS_ADDRESS_BATCH addresses is still several requests,
@@ -1603,16 +1631,17 @@ export class ChainProviderManager {
         entry.stats.getLogsCallsTotal += 1;
         // Raced against an explicit timeout for the same reason as the
         // probe in `probeSubscriptionSupport`: ethers gives no externally
-        // controllable timeout on `provider.send`, and a socket that has
-        // gone quiet on this one request - while still answering heartbeat
-        // pings - would otherwise hang the drain for the life of the
-        // socket, with no reconnect ever triggered to replace it.
+        // controllable timeout on `provider.send`, and a request already
+        // written to a socket that is then destroyed is never settled by
+        // ethers at all. This race is what guarantees a drain always
+        // finishes, which is in turn what lets `draining` be owned by the
+        // drain alone.
         let timeoutHandle: NodeJS.Timeout | null = null;
         const timeoutPromise = new Promise<never>((_, reject) => {
           timeoutHandle = setTimeout(
             () =>
               reject(
-                new Error(
+                new GetLogsTimeoutError(
                   `eth_getLogs timed out after ${GETLOGS_TIMEOUT_MS}ms`,
                 ),
               ),
@@ -1622,7 +1651,7 @@ export class ChainProviderManager {
         let batch: ethers.Log[];
         try {
           batch = (await Promise.race([
-            entry.provider.send("eth_getLogs", [
+            provider.send("eth_getLogs", [
               {
                 fromBlock: fromHex,
                 toBlock: toHex,
@@ -1652,6 +1681,9 @@ export class ChainProviderManager {
       entry.stats.ranges += 1;
       entry.stats.blocksCovered += toBlock - fromBlock + 1;
       entry.stats.logsDispatched += logs.length;
+      // The connection served a range, so whatever timeouts preceded it were
+      // a slow upstream rather than a socket that stopped answering.
+      entry.consecutiveGetLogsTimeouts = 0;
       return true;
     } catch (err) {
       entry.stats.getLogsErrors += 1;
@@ -1662,6 +1694,27 @@ export class ChainProviderManager {
       logger.warn(
         `[ChainProviderManager] chain=${entry.chainId} ${range} getLogs failed, will retry: ${String(err)}`,
       );
+      if (err instanceof GetLogsTimeoutError) {
+        entry.consecutiveGetLogsTimeouts += 1;
+        if (
+          entry.consecutiveGetLogsTimeouts >=
+          GETLOGS_TIMEOUT_RECONNECT_THRESHOLD
+        ) {
+          // Replace the socket rather than keep retrying against one that
+          // has stopped serving this call. Safe to call from here: the
+          // reconnect loop yields at its first await, so this drain still
+          // returns and releases `draining` before any teardown runs.
+          this.triggerReconnect(
+            entry,
+            "getlogs_timeout",
+            `${entry.consecutiveGetLogsTimeouts} consecutive eth_getLogs timeouts`,
+          );
+        }
+      } else {
+        // Only an unbroken run of timeouts indicates a socket that will not
+        // serve this call again; an ordinary rejection means it answered.
+        entry.consecutiveGetLogsTimeouts = 0;
+      }
       return false;
     }
   }

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -1611,6 +1611,30 @@ describe("ChainProviderManager", () => {
         expect(ranges(provider).some((r) => r.from === 800)).toBe(true);
         await mgr.destroy();
       });
+
+      it("times out a request that never gets a response", async () => {
+        const provider = await subscribe();
+        provider.beforeSend = (method) =>
+          method === "eth_getLogs" ? new Promise<void>(() => undefined) : null;
+
+        // Not awaited: the request never settles on its own, so awaiting it
+        // here would hang the test rather than the chain. Only the timeout
+        // inside processBlockRange unblocks it, and that needs fake time to
+        // advance first.
+        const stuck = provider.emitBlock(850);
+        await vi.advanceTimersByTimeAsync(10_000);
+        await stuck;
+
+        expect(getLogsCalls(provider)).toHaveLength(1);
+
+        // The mark stayed at 849, so the next drain re-issues 850 rather
+        // than treating the timed-out range as served.
+        provider.beforeSend = null;
+        await provider.emitBlock(851);
+        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 2);
+
+        expect(ranges(provider).some((r) => r.from === 850)).toBe(true);
+      });
     });
 
     describe("reconnect", () => {
@@ -1660,6 +1684,76 @@ describe("ChainProviderManager", () => {
         // getOrCreateProvider long after the socket was healthy.
         expect(manager.getHealth(CHAIN_A)?.reconnecting).toBe(false);
         expect(manager.getHealth(CHAIN_A)?.connected).toBe(true);
+      });
+
+      it("does not stay wedged when a request is stranded on the socket a reconnect replaces", async () => {
+        const provider = await subscribe();
+        // Never resolves - the same shape as ethers leaving an in-flight
+        // eth_getLogs unsettled when the socket underneath it is destroyed.
+        provider.beforeSend = (method) =>
+          method === "eth_getLogs" ? new Promise<void>(() => undefined) : null;
+
+        // Not awaited: this request never settles, so awaiting it would
+        // hang the test rather than the chain.
+        void provider.emitBlock(1_000);
+        await vi.advanceTimersByTimeAsync(100);
+
+        // The reconnect replaces the connection while that request is still
+        // open and never coming back.
+        provider.emitError(new Error("socket closed"));
+        await vi.advanceTimersByTimeAsync(3_000);
+
+        const replacement = factoryBundle.created[1];
+        expect(replacement).toBeDefined();
+
+        await replacement.emitBlock(1_005);
+        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 2);
+
+        // The stranded request must not hold the drain flag for a
+        // connection it no longer belongs to - the replacement has to keep
+        // fetching logs.
+        expect(getLogsCalls(replacement).length).toBeGreaterThan(0);
+      });
+
+      it("does not let a late response from the old connection advance the replacement's mark", async () => {
+        const provider = await subscribe();
+        let release: (() => void) | null = null;
+        provider.beforeSend = (method) =>
+          method === "eth_getLogs"
+            ? new Promise<void>((r) => {
+                release = r;
+              })
+            : null;
+
+        const stuck = provider.emitBlock(2_000);
+        await vi.advanceTimersByTimeAsync(100);
+
+        provider.emitError(new Error("socket closed"));
+        await vi.advanceTimersByTimeAsync(3_000);
+
+        const replacement = factoryBundle.created[1];
+        expect(replacement).toBeDefined();
+
+        // The replacement moves on and fetches its own range before the old
+        // request ever answers.
+        await replacement.emitBlock(2_010);
+        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 2);
+        expect(getLogsCalls(replacement).length).toBeGreaterThan(0);
+        const callsBeforeLateResponse = getLogsCalls(replacement).length;
+
+        // The old request finally answers - late, against a connection
+        // nobody is using anymore.
+        provider.sendResponses = [[]];
+        release?.();
+        await stuck;
+
+        // The late settlement must not touch the replacement's flag or
+        // mark: another block should still drain normally.
+        await replacement.emitBlock(2_011);
+        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 2);
+        expect(getLogsCalls(replacement).length).toBeGreaterThan(
+          callsBeforeLateResponse,
+        );
       });
     });
 

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -1605,12 +1605,19 @@ describe("ChainProviderManager", () => {
         }
         provider.sendResponses = [[], new Error("chunk two refused")];
         await provider.emitBlock(800);
+        // Only ranges issued after the failed drain count: that drain already
+        // asked for 800 once per address chunk.
+        const afterFailedDrain = ranges(provider).length;
         await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 3);
 
         // Block 800 is still owed, so a later drain re-queries from 800.
         await provider.emitBlock(801);
         await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 2);
-        expect(ranges(provider).some((r) => r.from === 800)).toBe(true);
+        expect(
+          ranges(provider)
+            .slice(afterFailedDrain)
+            .some((r) => r.from === 800),
+        ).toBe(true);
         await mgr.destroy();
       });
 
@@ -1630,12 +1637,18 @@ describe("ChainProviderManager", () => {
         expect(getLogsCalls(provider)).toHaveLength(1);
 
         // The mark stayed at 849, so the next drain re-issues 850 rather
-        // than treating the timed-out range as served.
+        // than treating the timed-out range as served. Only ranges issued
+        // after this point count: the timed-out call already asked for 850.
+        const beforeRetry = ranges(provider).length;
         provider.beforeSend = null;
         await provider.emitBlock(851);
         await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 2);
 
-        expect(ranges(provider).some((r) => r.from === 850)).toBe(true);
+        expect(
+          ranges(provider)
+            .slice(beforeRetry)
+            .some((r) => r.from === 850),
+        ).toBe(true);
       });
     });
 

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager.test.ts
@@ -11,6 +11,8 @@ import {
   GETLOGS_MAX_BLOCK_SPAN,
   GETLOGS_MAX_CATCHUP_BLOCKS,
   GETLOGS_MIN_INTERVAL_MS,
+  GETLOGS_TIMEOUT_MS,
+  GETLOGS_TIMEOUT_RECONNECT_THRESHOLD,
   type ProviderFactory,
   STATS_LOG_INTERVAL_MS,
 } from "../../src/chains/provider-manager";
@@ -1622,7 +1624,7 @@ describe("ChainProviderManager", () => {
         // inside processBlockRange unblocks it, and that needs fake time to
         // advance first.
         const stuck = provider.emitBlock(850);
-        await vi.advanceTimersByTimeAsync(10_000);
+        await vi.advanceTimersByTimeAsync(GETLOGS_TIMEOUT_MS);
         await stuck;
 
         expect(getLogsCalls(provider)).toHaveLength(1);
@@ -1686,15 +1688,15 @@ describe("ChainProviderManager", () => {
         expect(manager.getHealth(CHAIN_A)?.connected).toBe(true);
       });
 
-      it("does not stay wedged when a request is stranded on the socket a reconnect replaces", async () => {
+      it("recovers once a request stranded by a reconnect times out", async () => {
         const provider = await subscribe();
         // Never resolves - the same shape as ethers leaving an in-flight
         // eth_getLogs unsettled when the socket underneath it is destroyed.
         provider.beforeSend = (method) =>
           method === "eth_getLogs" ? new Promise<void>(() => undefined) : null;
 
-        // Not awaited: this request never settles, so awaiting it would
-        // hang the test rather than the chain.
+        // Not awaited: this request never settles on its own, so awaiting it
+        // would hang the test rather than the chain.
         void provider.emitBlock(1_000);
         await vi.advanceTimersByTimeAsync(100);
 
@@ -1706,54 +1708,98 @@ describe("ChainProviderManager", () => {
         const replacement = factoryBundle.created[1];
         expect(replacement).toBeDefined();
 
+        // The stranded drain still owns the chain here - that is deliberate,
+        // it may be dispatching - so nothing has moved yet.
         await replacement.emitBlock(1_005);
         await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 2);
 
-        // The stranded request must not hold the drain flag for a
-        // connection it no longer belongs to - the replacement has to keep
-        // fetching logs.
+        // Its timeout is what releases the chain, and it always arrives.
+        // Before this fix nothing did, and the chain never fetched again.
+        await vi.advanceTimersByTimeAsync(GETLOGS_TIMEOUT_MS);
+        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 2);
+
         expect(getLogsCalls(replacement).length).toBeGreaterThan(0);
       });
 
-      it("does not let a late response from the old connection advance the replacement's mark", async () => {
-        const provider = await subscribe();
-        let release: (() => void) | null = null;
-        provider.beforeSend = (method) =>
-          method === "eth_getLogs"
-            ? new Promise<void>((r) => {
-                release = r;
-              })
-            : null;
+      it("does not dispatch a log twice when a reconnect lands mid-dispatch", async () => {
+        // The drain holds the chain across dispatch as well as the request.
+        // Releasing it at reconnect would let the replacement re-fetch the
+        // same unadvanced range and dispatch its logs a second time, running
+        // alongside the first dispatch - and the dedup store cannot absorb
+        // that, because isProcessed/markProcessed is a check-then-set with
+        // the listener's jitter sleep in front of the check.
+        const log = {
+          address: ADDR_A.toLowerCase(),
+          topics: [TOPIC_EMITTED],
+        };
+        let releaseHandler: (() => void) | null = null;
+        const handlerGate = new Promise<void>((r) => {
+          releaseHandler = r;
+        });
+        const handler = vi.fn(() => handlerGate);
 
-        const stuck = provider.emitBlock(2_000);
+        const mgr = new ChainProviderManager({
+          factory: factoryBundle.factory,
+          onPermanentFailure,
+        });
+        const before = factoryBundle.created.length;
+        await mgr.subscribeToLogs({
+          chainId: CHAIN_A,
+          wssUrl: "ws://a",
+          address: ADDR_A,
+          topic0: TOPIC_EMITTED,
+          handler,
+        });
+        const provider = factoryBundle.created[before];
+        provider.sendResponses = [[log]];
+
+        // Not awaited: the handler holds this dispatch open.
+        void provider.emitBlock(3_000);
         await vi.advanceTimersByTimeAsync(100);
+        expect(handler).toHaveBeenCalledTimes(1);
 
+        // The socket drops while that dispatch is still in flight.
         provider.emitError(new Error("socket closed"));
         await vi.advanceTimersByTimeAsync(3_000);
 
-        const replacement = factoryBundle.created[1];
+        const replacement = factoryBundle.created[before + 1];
         expect(replacement).toBeDefined();
+        // Armed so that a replacement drain of the same range would deliver
+        // the same log again - the assertion is only meaningful because this
+        // is here.
+        replacement.sendResponses = [[log]];
+        // Not awaited: if the replacement does re-dispatch, it blocks on the
+        // same held handler, and awaiting here would hang the test instead
+        // of reporting the duplicate.
+        void replacement.emitBlock(3_001);
+        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 3);
 
-        // The replacement moves on and fetches its own range before the old
-        // request ever answers.
-        await replacement.emitBlock(2_010);
-        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 2);
-        expect(getLogsCalls(replacement).length).toBeGreaterThan(0);
-        const callsBeforeLateResponse = getLogsCalls(replacement).length;
+        expect(handler).toHaveBeenCalledTimes(1);
 
-        // The old request finally answers - late, against a connection
-        // nobody is using anymore.
-        provider.sendResponses = [[]];
-        release?.();
-        await stuck;
+        releaseHandler?.();
+        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS);
+        await mgr.destroy();
+      });
 
-        // The late settlement must not touch the replacement's flag or
-        // mark: another block should still drain normally.
-        await replacement.emitBlock(2_011);
-        await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 2);
-        expect(getLogsCalls(replacement).length).toBeGreaterThan(
-          callsBeforeLateResponse,
-        );
+      it("reconnects after a run of getLogs timeouts on one socket", async () => {
+        const provider = await subscribe();
+        const reasons: string[] = [];
+        manager.onDisconnect(CHAIN_A, (ev) => {
+          reasons.push(ev.reason);
+        });
+        // Answers the heartbeat, never answers getLogs. Every other liveness
+        // check this class has keeps passing, so the timeout has to escalate
+        // on its own or the chain retries into the void forever.
+        provider.beforeSend = (method) =>
+          method === "eth_getLogs" ? new Promise<void>(() => undefined) : null;
+
+        for (let i = 0; i < GETLOGS_TIMEOUT_RECONNECT_THRESHOLD; i += 1) {
+          void provider.emitBlock(4_000 + i);
+          await vi.advanceTimersByTimeAsync(GETLOGS_TIMEOUT_MS);
+          await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 2);
+        }
+
+        expect(reasons).toContain("getlogs_timeout");
       });
     });
 


### PR DESCRIPTION
## Problem

A wss reconnect can wedge one chain in the event tracker permanently. The
chain keeps its socket open and keeps receiving blocks, but stops all
`eth_getLogs` work and dispatches no events. The pod stays Running and
Ready, and `/healthz` reports `status: ok` throughout.

On prod, six of seven chains wedged one after another over the course of a
day, and event-triggered workflow executions dropped to zero once the last
working chain went silent. A `kubectl rollout restart` was the only
recovery.

## Root cause

The `draining` flag sticks at `true` forever, because an ethers promise
never settles.

1. A reconnect calls `entry.provider.destroy()` on the old socket.
2. ethers 6's `destroy()` only rejects requests still queued and not yet
   written. A request already in flight lives in a different internal map
   that only a matching response settles, and a destroyed socket settles
   nothing.
3. `drain()` sets `draining = true` before awaiting that request and clears
   it in a `finally`. If the request never settles, the `finally` never
   runs.
4. Every later block returns immediately on the `draining` guard. The chain
   dispatches no event again, permanently.

Nothing else catches it: the heartbeat is a different request and still
answers, blocks still arrive so block-staleness never trips, and
`/healthz`'s `connected` measures transport liveness, not dispatch liveness.

## Fix

**Bound the request, and let the drain own its own flag.** Every
`eth_getLogs` is raced against `GETLOGS_TIMEOUT_MS`, the same `Promise.race`
pattern already used for the heartbeat and the subscription probe. That is
what removes the wedge: the drain is now guaranteed to settle, so the
ordinary `finally` always runs and `draining` is set and cleared in exactly
one place, held across dispatch as well as the request.

Notably, `reconnect()` does **not** clear `draining`. An earlier revision of
this PR did, and that was a worse bug than the one being fixed: releasing a
drain that already holds its logs and is part way through dispatching them
lets the replacement re-fetch the same unadvanced range and dispatch those
logs a second time, concurrently with the first dispatch. The dedup store
cannot absorb that - `isProcessed`/`markProcessed` is a check-then-set with
the listener's jitter sleep in front of the check, so both dispatches read
"not processed" and both send to SQS, and the executor has no downstream
dedup. The regression test for this fails with `expected 1 times, but got 2
times` against that revision.

**Escalate a socket that stops serving the call.** One timeout is a slow
upstream and is retried in place. `GETLOGS_TIMEOUT_RECONNECT_THRESHOLD`
consecutive timeouts is a socket that will not serve `eth_getLogs` again,
and nothing else here notices - so it now triggers a reconnect. Without
this the chain retried every 31s indefinitely, delivering nothing, until
the backlog crossed `GETLOGS_MAX_CATCHUP_BLOCKS` and its events were
dropped behind a single warning. This also bounds the abandoned ethers
callbacks each timed-out request leaves registered on the socket.

**Timeout sized to the request, not the handshake.** 30s, not the 10s used
by the connect and probe gates. Those bound a handshake and one trivial
frame; this bounds a real query over up to `GETLOGS_MAX_BLOCK_SPAN` blocks
and `GETLOGS_ADDRESS_BATCH` addresses, which on a loaded upstream can
legitimately take longer. At 10s a slow-but-working query would fail every
time, and a range that never succeeds never advances the mark.

**Pin the provider for the life of a range.** `processBlockRange`
null-checked `entry.provider` once but re-read it per address chunk, so a
multi-chunk range crossing a reconnect could issue its remaining chunks
against the replacement connection, or against `null` - throwing a
`TypeError` that the surrounding catch reported as an ordinary getLogs
failure. It is captured once now, and the range is abandoned if it changes.

## Test plan

- `tsc --noEmit`: clean
- `biome check`: clean
- unit: 184/184

New tests, each confirmed to fail against the code they guard:

- times out a request that never gets a response
- recovers once a request stranded by a reconnect times out
- does not dispatch a log twice when a reconnect lands mid-dispatch
- reconnects after a run of getLogs timeouts on one socket

## Follow-ups not in scope

This fix stops the wedge, but not the eight hours nobody knew about it. Any
future failure that stops dispatch while leaving the transport healthy will
be just as invisible, so the detection gaps are tracked separately:

- [KEEP-1246](https://linear.app/keeperhubapp/issue/KEEP-1246/event-tracker-detect-a-chain-that-stops-dispatching-while-its-socket) -
  give `/healthz` a dispatch-liveness signal (subscribers attached, blocks
  arriving, no completed `getLogs` range for N block intervals), and alert
  per chain rather than only on a platform-wide zero. Five chains died
  without a page because one was still producing executions.
- [KEEP-405](https://linear.app/keeperhubapp/issue/KEEP-405/event-tracker-replace-pgrep-livenessreadiness-probes-http-livez-and) -
  replace the `pgrep` probes with HTTP probes and fix the `HEALTH_PORT`
  3001 vs containerPort 3000 mismatch that makes `/healthz` unreachable
  through the Service.

The ordering between those two matters: pointing a liveness probe at an
endpoint that returns 503 for one degraded chain would restart all seven.
