### PR TITLE
fix(schedule): register schedule triggers on create and on enable

### DIFF
--- a/app/api/workflows/[workflowId]/duplicate/route.ts
+++ b/app/api/workflows/[workflowId]/duplicate/route.ts
@@ -9,6 +9,7 @@ import { db } from "@/lib/db";
 import { workflows } from "@/lib/db/schema";
 import { extractActionTypeNodes } from "@/lib/features";
 import { enforceWorkflowFeatures } from "@/lib/features/route-guard";
+import { syncPersistedWorkflowSchedule } from "@/lib/schedule-service";
 import { generateId } from "@/lib/utils/id";
 import { remapTemplateRefsInString } from "@/lib/utils/template";
 import { getWorkflowAccess } from "@/lib/workflow/access";
@@ -245,6 +246,14 @@ export async function POST(
         sourceWorkflowId: sourceWorkflow.visibility === "public" ? workflowId : null,
       })
       .returning();
+
+    // The copy needs its own schedule row. It is created disabled, so the row
+    // stays inert until the user enables the copy.
+    await syncPersistedWorkflowSchedule(
+      newWorkflow.id,
+      newNodes as Parameters<typeof syncPersistedWorkflowSchedule>[1],
+      "/api/workflows/[workflowId]/duplicate"
+    );
 
     return NextResponse.json({
       ...newWorkflow,

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -1,7 +1,7 @@
 import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
-import { ErrorCategory, logSystemError, logSystemWarn } from "@/lib/logging";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { authFailureResponse, getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { requireScope } from "@/lib/middleware/require-scope";
@@ -21,7 +21,7 @@ import {
 import { IntervalTooSmallError } from "@/lib/cron-utils";
 import {
   extractScheduleConfig,
-  syncWorkflowSchedule,
+  syncPersistedWorkflowSchedule,
 } from "@/lib/schedule-service";
 import { sanitizeDescription } from "@/lib/sanitize-description";
 import { buildAuditMetadata, recordAuditEvent } from "@/lib/security/audit-log";
@@ -316,7 +316,8 @@ async function validateWorkflowAccess(
 
 async function handlePostUpdateSideEffects(
   workflowId: string,
-  body: Record<string, unknown>
+  body: Record<string, unknown>,
+  persistedNodes: unknown
 ): Promise<void> {
   // Tags are Hub-discovery only; clear them on any demote off of "public",
   // including demote-to-unlisted (link-only) and demote-to-private.
@@ -337,19 +338,16 @@ async function handlePostUpdateSideEffects(
     revalidateTag("marketplace", "max");
   }
 
-  if (body.nodes !== undefined) {
-    const syncResult = await syncWorkflowSchedule(
+  // Enabling rebuilds the registration as well, not just a definition save. A
+  // workflow that reached its first enable through /create, duplicate or import
+  // has no schedule row yet, and an UPDATE that matches no row is a silent
+  // no-op, so the toggle alone would leave it unregistered.
+  if (body.nodes !== undefined || body.enabled === true) {
+    await syncPersistedWorkflowSchedule(
       workflowId,
-      body.nodes as Parameters<typeof syncWorkflowSchedule>[1]
+      persistedNodes as Parameters<typeof syncPersistedWorkflowSchedule>[1],
+      "/api/workflows/[workflowId]"
     );
-    if (!syncResult.synced) {
-      logSystemWarn(
-        ErrorCategory.WORKFLOW_ENGINE,
-        "[Workflow] Schedule sync failed",
-        syncResult.error,
-        { workflow_id: workflowId }
-      );
-    }
   }
 }
 
@@ -400,6 +398,8 @@ export async function PATCH(
       );
     }
 
+    const updateData = buildUpdateData(body);
+
     if (Array.isArray(body.nodes)) {
       // KEEP-468: parse every `{{...}}` token at save time so grammar typos
       // (the n8n-style `{{$trigger.input.ts}}`-shaped errors that produced
@@ -420,12 +420,13 @@ export async function PATCH(
 
       // KEEP-581: schedule interval pre-check. Runs before the DB update so
       // a rejected sub-60s value never lands as persisted nodes paired with
-      // an unsynced schedule. extractScheduleConfig is the only thing that
-      // throws here; bad timezones/cron strings still take the warn-and-
+      // an unsynced schedule. It reads the sanitized nodes, the same shape
+      // the post-update sync reads. extractScheduleConfig is the only thing
+      // that throws here; bad timezones/cron strings still take the warn-and-
       // continue path in handlePostUpdateSideEffects.
       try {
         extractScheduleConfig(
-          body.nodes as Parameters<typeof extractScheduleConfig>[0]
+          updateData.nodes as Parameters<typeof extractScheduleConfig>[0]
         );
       } catch (error) {
         if (error instanceof IntervalTooSmallError) {
@@ -519,8 +520,6 @@ export async function PATCH(
         { status: 400 }
       );
     }
-
-    const updateData = buildUpdateData(body);
 
     if (Array.isArray(updateData.nodes)) {
       // What these two gates do NOT do: prove the workflow will run.
@@ -811,7 +810,7 @@ export async function PATCH(
       throw dbError;
     }
 
-    await handlePostUpdateSideEffects(workflowId, body);
+    await handlePostUpdateSideEffects(workflowId, body, updatedWorkflow.nodes);
 
     // Resolve project/tag names so a move/tagging shows "Project: A -> B" in
     // the activity feed rather than opaque ids.

--- a/app/api/workflows/create/route.ts
+++ b/app/api/workflows/create/route.ts
@@ -18,6 +18,11 @@ import {
   idempotencyEarlyResponse,
   recordIdempotentResponse,
 } from "@/lib/idempotency";
+import { IntervalTooSmallError } from "@/lib/cron-utils";
+import {
+  extractScheduleConfig,
+  syncPersistedWorkflowSchedule,
+} from "@/lib/schedule-service";
 import { generateId } from "@/lib/utils/id";
 import { sanitizeWorkflowData } from "@/lib/workflow/editor/sanitize-nodes";
 import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
@@ -176,6 +181,23 @@ export async function POST(request: Request) {
       );
     }
 
+    // Same pre-check the PATCH handler runs: reject a sub-minimum interval
+    // before the insert, so a rejected value never lands as persisted nodes
+    // paired with an unregistered schedule.
+    try {
+      extractScheduleConfig(
+        nodes as Parameters<typeof extractScheduleConfig>[0]
+      );
+    } catch (error) {
+      if (error instanceof IntervalTooSmallError) {
+        return NextResponse.json(
+          { error: "SCHEDULE_INTERVAL_TOO_SMALL", message: error.message },
+          { status: 400 }
+        );
+      }
+      throw error;
+    }
+
     const actionConfigValidation = validateWorkflowActionConfigs(nodes);
     if (!actionConfigValidation.valid) {
       return NextResponse.json(
@@ -252,6 +274,14 @@ export async function POST(request: Request) {
         ...(typeof body.enabled === "boolean" ? { enabled: body.enabled } : {}),
       })
       .returning();
+
+    // A Schedule trigger only reaches the dispatcher through a schedule row,
+    // so create it here rather than leaving it to the next definition save.
+    await syncPersistedWorkflowSchedule(
+      newWorkflow.id,
+      nodes as Parameters<typeof syncPersistedWorkflowSchedule>[1],
+      "/api/workflows/create"
+    );
 
     await recordAuditEvent({
       actor: {

--- a/app/api/workflows/import/route.ts
+++ b/app/api/workflows/import/route.ts
@@ -13,6 +13,11 @@ import { getMetricsCollector } from "@/lib/metrics";
 import { MetricNames } from "@/lib/metrics/types";
 import { type DualAuthContext, auditFromAuth, authFailureResponse, getDualAuthContext } from "@/lib/middleware/auth-helpers";
 import { requireScope } from "@/lib/middleware/require-scope";
+import { IntervalTooSmallError } from "@/lib/cron-utils";
+import {
+  extractScheduleConfig,
+  syncPersistedWorkflowSchedule,
+} from "@/lib/schedule-service";
 import { generateId } from "@/lib/utils/id";
 import {
   stripIntegrationsFromImportNodes,
@@ -138,6 +143,22 @@ export async function POST(request: Request): Promise<NextResponse> {
       );
     }
 
+    // Same pre-check the create and PATCH handlers run, so no import can
+    // persist an interval the dispatcher cannot honour.
+    try {
+      extractScheduleConfig(
+        sanitized.nodes as Parameters<typeof extractScheduleConfig>[0]
+      );
+    } catch (error) {
+      if (error instanceof IntervalTooSmallError) {
+        return NextResponse.json(
+          { error: "SCHEDULE_INTERVAL_TOO_SMALL", message: error.message },
+          { status: 400 }
+        );
+      }
+      throw error;
+    }
+
     const actionConfigValidation = validateWorkflowActionConfigs(
       sanitized.nodes
     );
@@ -170,6 +191,14 @@ export async function POST(request: Request): Promise<NextResponse> {
         isAnonymous: false,
       })
       .returning();
+
+    // An imported Schedule trigger needs its own row. The import lands
+    // disabled, so the row stays inert until the user enables it.
+    await syncPersistedWorkflowSchedule(
+      newWorkflow.id,
+      sanitized.nodes as Parameters<typeof syncPersistedWorkflowSchedule>[1],
+      "/api/workflows/import"
+    );
 
     // Aggregate-only counter to avoid Prometheus label-cardinality blow-up.
     // Per-workflow attribution is available via the structured logs on this

--- a/lib/schedule-service.ts
+++ b/lib/schedule-service.ts
@@ -7,7 +7,12 @@ import {
 } from "@/lib/cron-utils";
 import { db } from "@/lib/db";
 import { workflowSchedules } from "@/lib/db/schema";
-import { ErrorCategory, logSystemError, logUserError } from "@/lib/logging";
+import {
+  ErrorCategory,
+  logSystemError,
+  logSystemWarn,
+  logUserError,
+} from "@/lib/logging";
 import { generateId } from "@/lib/utils/id";
 import type { WorkflowNode } from "@/lib/workflow/store";
 
@@ -338,6 +343,32 @@ export async function syncWorkflowSchedule(
   }
 
   return { synced: true };
+}
+
+/**
+ * Sync a schedule for a workflow row that is already committed, warn-logging a
+ * soft failure instead of surfacing it. The creation routes and the enable path
+ * use this: their write has landed, so a bad timezone or cron expression must
+ * not turn into a failed request.
+ *
+ * Pass the nodes that were persisted, not the raw request body. The sanitizer
+ * moves misplaced trigger fields into `data.config` and canonicalises
+ * `data.type`, and extractScheduleConfig only recognises that canonical shape.
+ */
+export async function syncPersistedWorkflowSchedule(
+  workflowId: string,
+  nodes: WorkflowNode[],
+  endpoint: string
+): Promise<void> {
+  const result = await syncWorkflowSchedule(workflowId, nodes);
+  if (!result.synced) {
+    logSystemWarn(
+      ErrorCategory.WORKFLOW_ENGINE,
+      "[Schedule] Schedule sync failed",
+      result.error,
+      { workflow_id: workflowId, endpoint }
+    );
+  }
 }
 
 /**

--- a/scripts/backfill-workflow-schedules.ts
+++ b/scripts/backfill-workflow-schedules.ts
@@ -1,0 +1,116 @@
+/**
+ * One-shot backfill: create the missing workflow_schedules row for enabled
+ * workflows that carry a Schedule trigger but were never registered with the
+ * dispatcher.
+ *
+ * Those rows were only ever written on a definition save, so a workflow
+ * created through /api/workflows/create, duplicate or import and then enabled
+ * without a further edit never got one and never fired.
+ *
+ * Seeded and featured showcase rows are skipped: they ship enabled so the hub
+ * can render them, and registering their schedules would start running them for
+ * real. Review the dry-run list before applying.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-workflow-schedules.ts                     # dry-run
+ *   npx tsx scripts/backfill-workflow-schedules.ts --apply
+ *   npx tsx scripts/backfill-workflow-schedules.ts --include-disabled
+ */
+
+import { and, eq, isNull } from "drizzle-orm";
+import { IntervalTooSmallError } from "@/lib/cron-utils";
+import { db } from "@/lib/db";
+import { workflowSchedules, workflows } from "@/lib/db/schema";
+import {
+  extractScheduleConfig,
+  syncWorkflowSchedule,
+} from "@/lib/schedule-service";
+import type { WorkflowNode } from "@/lib/workflow/store";
+
+const dryRun = !process.argv.includes("--apply");
+const includeDisabled = process.argv.includes("--include-disabled");
+
+async function main(): Promise<void> {
+  if (dryRun) {
+    console.log("[DRY RUN] No changes will be written.\n");
+  }
+
+  const rows = await db
+    .select({
+      id: workflows.id,
+      name: workflows.name,
+      nodes: workflows.nodes,
+    })
+    .from(workflows)
+    .leftJoin(workflowSchedules, eq(workflowSchedules.workflowId, workflows.id))
+    .where(
+      and(
+        isNull(workflowSchedules.id),
+        isNull(workflows.deletedAt),
+        isNull(workflows.seededAt),
+        eq(workflows.featured, false),
+        includeDisabled ? undefined : eq(workflows.enabled, true)
+      )
+    );
+
+  let created = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const row of rows) {
+    const nodes = Array.isArray(row.nodes) ? (row.nodes as WorkflowNode[]) : [];
+
+    let config: ReturnType<typeof extractScheduleConfig>;
+    try {
+      config = extractScheduleConfig(nodes);
+    } catch (error) {
+      if (error instanceof IntervalTooSmallError) {
+        console.warn(`${row.id} (${row.name}): ${error.message}`);
+        failed += 1;
+        continue;
+      }
+      throw error;
+    }
+
+    if (!config) {
+      skipped += 1;
+      continue;
+    }
+
+    const detail =
+      config.mode === "cron"
+        ? `${config.cronExpression} (${config.timezone})`
+        : `every ${config.intervalSeconds}s (${config.timezone})`;
+    console.log(`${row.id} (${row.name}): ${detail}`);
+
+    if (dryRun) {
+      created += 1;
+      continue;
+    }
+
+    const result = await syncWorkflowSchedule(row.id, nodes);
+    if (result.synced) {
+      created += 1;
+    } else {
+      console.warn(`  sync failed: ${result.error}`);
+      failed += 1;
+    }
+  }
+
+  console.log(
+    `\nScanned ${rows.length} workflow(s) with no schedule row: ` +
+      `${created} ${dryRun ? "would be registered" : "registered"}, ` +
+      `${skipped} without a Schedule trigger, ${failed} failed.`
+  );
+
+  if (dryRun && created > 0) {
+    console.log("Re-run with --apply to write the rows.");
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error("Backfill failed:", error);
+    process.exit(1);
+  });

--- a/tests/integration/workflow-create-route.test.ts
+++ b/tests/integration/workflow-create-route.test.ts
@@ -4,12 +4,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // step-registry, which `import "server-only"`. Stub the guard for vitest.
 vi.mock("server-only", () => ({}));
 
-const { mockGetDualAuthContext, mockInsert, mockValidateWorkflowIntegrations } =
-  vi.hoisted(() => ({
-    mockGetDualAuthContext: vi.fn(),
-    mockInsert: vi.fn(),
-    mockValidateWorkflowIntegrations: vi.fn(),
-  }));
+const {
+  mockGetDualAuthContext,
+  mockInsert,
+  mockValidateWorkflowIntegrations,
+  mockSyncPersistedSchedule,
+} = vi.hoisted(() => ({
+  mockGetDualAuthContext: vi.fn(),
+  mockInsert: vi.fn(),
+  mockValidateWorkflowIntegrations: vi.fn(),
+  mockSyncPersistedSchedule: vi.fn(),
+}));
 
 vi.mock("@/lib/middleware/auth-helpers", () => ({
   getDualAuthContext: mockGetDualAuthContext,
@@ -49,6 +54,22 @@ vi.mock("@/lib/idempotency", () => ({
   beginIdempotentFromRequest: vi.fn().mockResolvedValue(null),
   idempotencyEarlyResponse: vi.fn().mockReturnValue(null),
   recordIdempotentResponse: vi.fn((_idem, response) => response),
+}));
+
+// extractScheduleConfig runs for real so the interval pre-check exercises the
+// actual cron-utils guard; only the write side effect is stubbed.
+vi.mock("@/lib/schedule-service", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/schedule-service")>(
+    "@/lib/schedule-service"
+  );
+  return {
+    ...actual,
+    syncPersistedWorkflowSchedule: mockSyncPersistedSchedule,
+  };
+});
+
+vi.mock("@/lib/metrics/collectors/prometheus", () => ({
+  recordWorkflowCreatedFromSource: vi.fn(),
 }));
 
 vi.mock("@/lib/workflow/history", () => ({
@@ -253,5 +274,81 @@ describe("POST /api/workflows/create action config validation", () => {
 
     expect(response.status).not.toBe(422);
     expect(mockInsert).toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/workflows/create schedule registration", () => {
+  function scheduleTrigger(
+    config: Record<string, unknown>
+  ): Record<string, unknown> {
+    return {
+      id: "trigger-1",
+      type: "trigger",
+      data: {
+        type: "trigger",
+        label: "Schedule",
+        config: { triggerType: "Schedule", ...config },
+      },
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: "user-123",
+      organizationId: "org-123",
+      authMethod: "session",
+    });
+    mockValidateWorkflowIntegrations.mockResolvedValue({ valid: true });
+    mockSyncPersistedSchedule.mockResolvedValue(undefined);
+    mockInsert.mockReturnValue({
+      values: vi.fn((row: Record<string, unknown>) => ({
+        returning: vi
+          .fn()
+          .mockResolvedValue([
+            { ...row, createdAt: new Date(), updatedAt: new Date() },
+          ]),
+      })),
+    });
+  });
+
+  it("registers the schedule so the dispatcher sees the new workflow", async () => {
+    const response = await POST(
+      request({
+        name: "Hourly check",
+        nodes: [
+          scheduleTrigger({
+            scheduleCron: "0 * * * *",
+            scheduleTimezone: "UTC",
+          }),
+        ],
+        edges: [],
+        enabled: true,
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSyncPersistedSchedule).toHaveBeenCalledTimes(1);
+    const [workflowId, nodes] = mockSyncPersistedSchedule.mock.calls[0];
+    const created = await response.json();
+    expect(workflowId).toBe(created.id);
+    expect(nodes[0].data.config.scheduleCron).toBe("0 * * * *");
+  });
+
+  it("rejects a sub-minimum interval before inserting the workflow", async () => {
+    const response = await POST(
+      request({
+        name: "Too fast",
+        nodes: [scheduleTrigger({ scheduleIntervalSeconds: 30 })],
+        edges: [],
+      })
+    );
+
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("SCHEDULE_INTERVAL_TOO_SMALL");
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockSyncPersistedSchedule).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/workflow-export-import-route.test.ts
+++ b/tests/integration/workflow-export-import-route.test.ts
@@ -126,6 +126,11 @@ vi.mock("@/lib/db", () => ({
         }),
       })),
     }),
+    // The route registers the imported schedule after the insert; a non-schedule
+    // import takes the delete branch of syncWorkflowSchedule.
+    delete: vi.fn(() => ({
+      where: vi.fn().mockResolvedValue(undefined),
+    })),
   },
 }));
 

--- a/tests/integration/workflow-listing-route.test.ts
+++ b/tests/integration/workflow-listing-route.test.ts
@@ -102,6 +102,7 @@ vi.mock("@/lib/schedule-service", async () => {
   return {
     ...actual,
     syncWorkflowSchedule: vi.fn().mockResolvedValue({ synced: true }),
+    syncPersistedWorkflowSchedule: vi.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/tests/integration/workflow-schedule-validation-route.test.ts
+++ b/tests/integration/workflow-schedule-validation-route.test.ts
@@ -105,7 +105,7 @@ vi.mock("@/lib/schedule-service", async () => {
   );
   return {
     ...actual,
-    syncWorkflowSchedule: mockSyncWorkflowSchedule,
+    syncPersistedWorkflowSchedule: mockSyncWorkflowSchedule,
   };
 });
 
@@ -245,5 +245,72 @@ describe("KEEP-581: PATCH /api/workflows/[workflowId] schedule interval guard", 
     });
 
     expect(response.status).toBe(200);
+  });
+});
+
+describe("PATCH /api/workflows/[workflowId] schedule registration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: "user-1",
+      organizationId: "org-1",
+      authMethod: "session",
+    });
+    mockValidateWorkflowIntegrations.mockResolvedValue({ valid: true });
+    mockWorkflowsFindFirst.mockResolvedValue({
+      ...existingWorkflow(),
+      enabled: false,
+    });
+    mockSelectFrom.mockResolvedValue([]);
+    mockMemberLimit.mockResolvedValue([{ id: "m-1" }]);
+    mockSyncWorkflowSchedule.mockResolvedValue(undefined);
+    mockUpdateReturning.mockResolvedValue([
+      { ...existingWorkflow(), nodes: [scheduleTriggerNode(null)] },
+    ]);
+  });
+
+  it("registers the schedule on an enable-only PATCH", async () => {
+    const response = await PATCH(makeRequest({ enabled: true }), { params });
+
+    expect(response.status).toBe(200);
+    expect(mockSyncWorkflowSchedule).toHaveBeenCalledTimes(1);
+    expect(mockSyncWorkflowSchedule).toHaveBeenCalledWith(
+      "wf-1",
+      [scheduleTriggerNode(null)],
+      expect.any(String)
+    );
+  });
+
+  it("syncs the persisted nodes rather than the raw request body", async () => {
+    // A trigger in the MCP shape the sanitizer canonicalises. Syncing the raw
+    // body would not see a Schedule trigger at all.
+    const rawTrigger = {
+      id: "trigger-1",
+      type: "Schedule",
+      data: { scheduleCron: "0 9 * * *", scheduleTimezone: "UTC" },
+    };
+
+    await PATCH(makeRequest({ nodes: [rawTrigger] }), { params });
+
+    expect(mockSyncWorkflowSchedule).toHaveBeenCalledWith(
+      "wf-1",
+      [scheduleTriggerNode(null)],
+      expect.any(String)
+    );
+  });
+
+  it("does not touch the schedule when neither nodes nor enable change", async () => {
+    const response = await PATCH(makeRequest({ name: "renamed" }), { params });
+
+    expect(response.status).toBe(200);
+    expect(mockSyncWorkflowSchedule).not.toHaveBeenCalled();
+  });
+
+  it("does not re-register on a disable", async () => {
+    mockWorkflowsFindFirst.mockResolvedValue(existingWorkflow());
+
+    await PATCH(makeRequest({ enabled: false }), { params });
+
+    expect(mockSyncWorkflowSchedule).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## The bug

Enabling a Schedule-trigger workflow did not reliably register it with the cron dispatcher. Toggling `enabled` alone never fixed it; only an edit and save of the trigger config did, producing a new `scheduleId`.

`workflow_schedules` rows were only ever written by one caller: the `body.nodes` branch of `handlePostUpdateSideEffects` in the workflow PATCH handler. Two consequences.

**No creation path registered a schedule.** `create`, `duplicate` and `import` all insert a workflow with full nodes and never touch `workflow_schedules`. `create` even accepts `enabled: true`, so an API or MCP caller could arm a Schedule trigger that had no dispatcher row at all.

**The enable toggle never synced.** The editor sends `{ enabled }` only. An UPDATE that matches no row is a silent no-op, so disable and re-enable could not recover a missing row. That is why the fix always produced a *new* `scheduleId`: sync inserts when no row exists and updates in place when one does, so a new id proves none existed.

The redundant second PATCH in `lib/scan/persist-suggestion.ts` exists purely to trigger the sync, and was the only creation path that worked.

## A second defect found while fixing it

The route sanitizes nodes into `updateData.nodes` and persists that, but synced from the raw `body.nodes`. Those are different shapes: the sanitizer canonicalises `data.type` to `"trigger"`, sets `config.triggerType` for a node typed `Schedule`, and hoists root-level fields such as `scheduleCron` into `data.config`. `extractScheduleConfig` only matches the canonical shape.

So an MCP-shaped or AI-shaped save persisted a working Schedule trigger while the sync saw no trigger at all, and "no schedule config" means *delete the row*. That silently destroyed registrations that were already working.

## The fix

- Sync on the enable transition as well as on a definition save, so the toggle registers and every already-broken workflow heals on its next toggle.
- Sync after the insert in `create`, `duplicate` and `import`. Duplicate and import land disabled, so their row stays inert until the user enables the copy.
- Sync from the persisted nodes, never the request body. `syncPersistedWorkflowSchedule` carries that requirement in its signature and docs.
- The sub-60s interval pre-check now reads the same sanitized shape, and also runs on `create` and `import`, so no path can persist an interval the dispatcher cannot honour.

## Operator step

`scripts/backfill-workflow-schedules.ts` registers workflows that are already enabled and stuck. Dry-run by default; run it to get the inventory before deciding to `--apply`. Seeded and featured showcase rows are skipped, since those ship enabled for the hub to render and registering them would start really running them.

## Verification

Reverting only the source files to staging makes the new tests fail, and restoring the fix makes them pass. The new tests pin behaviour rather than implementation: enable-only PATCH registers, a PATCH syncs the persisted nodes rather than the raw body, rename does not touch the schedule, disable does not re-register, create registers with the right nodes, create rejects a 30s interval before inserting.

Full unit and integration suite passes except `reaper-sh-signing-contract` and `workflow-runner`, which fail identically on a clean tree.

Left alone deliberately: the onboarding fixtures still get no rows, since registering those showcase workflows would run them for every user.
