### PR TITLE
fix(analytics): show chain names instead of chain ids in the runs table

### DIFF
--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -35,8 +35,13 @@ import {
   analyticsStatusFilterAtom,
 } from "@/lib/atoms/analytics";
 import { getCustomerRunErrorMessage } from "@/lib/errors/customer-message";
+import type { ChainDisplay } from "@/lib/hooks/use-chain-display";
+import {
+  ChainDisplayProvider,
+  FALLBACK_CHAIN_DISPLAY,
+  useChainDisplay,
+} from "@/lib/hooks/use-chain-display";
 import { cn } from "@/lib/utils";
-import { SPONSORSHIP_CHAINS } from "@/lib/web3/sponsorship-chains-meta";
 import { ProjectDrawer } from "./project-drawer";
 
 const WHITESPACE_RE = /\s+/;
@@ -44,39 +49,24 @@ const LEADING_ZEROS_RE = /^0+(?=\d)/;
 const TRAILING_ZEROS_RE = /0+$/;
 const NON_DIGIT_RE = /\D/;
 
-const CHAIN_NAME_BY_ID = new Map(
-  SPONSORSHIP_CHAINS.map((c) => [String(c.chainId), c.name])
-);
-
-function networkName(network: string): string {
-  return CHAIN_NAME_BY_ID.get(network) ?? network;
-}
-
-function formatNetworks(networks: string[]): string {
+function formatNetworks(networks: string[], chains: ChainDisplay): string {
   if (networks.length === 0) {
     return "--";
   }
-  const names = networks.map(networkName);
+  const names = networks.map(chains.name);
   if (names.length <= 2) {
     return names.join(", ");
   }
   return `${names.slice(0, 2).join(", ")} +${names.length - 2}`;
 }
 
-const CHAIN_SYMBOL_BY_ID = new Map(
-  SPONSORSHIP_CHAINS.map((c) => [String(c.chainId), c.symbol])
-);
-
-function chainSymbol(network: string | null): string {
-  if (!network) {
-    return "";
-  }
-  return CHAIN_SYMBOL_BY_ID.get(network) ?? "ETH";
-}
-
 // Summary amount for the collapsed run row: up to 6 decimals (trailing zeros
 // trimmed). The exact value is shown per step when the row is expanded.
-function formatGasNative(wei: string | null, network: string | null): string {
+function formatGasNative(
+  wei: string | null,
+  network: string | null,
+  chains: ChainDisplay
+): string {
   const value = Number(wei);
   if (!wei || Number.isNaN(value) || value === 0) {
     return "--";
@@ -85,7 +75,7 @@ function formatGasNative(wei: string | null, network: string | null): string {
     minimumFractionDigits: 2,
     maximumFractionDigits: 6,
   }).format(value / 1e18);
-  return `${amount} ${chainSymbol(network)}`;
+  return `${amount} ${chains.gasSymbol(network)}`.trimEnd();
 }
 
 // Exact native amount from the wei integer string (no float rounding), for the
@@ -99,12 +89,13 @@ function formatWeiToDecimal(wei: string): string {
 
 function formatGasNativeExact(
   wei: string | null,
-  network: string | null
+  network: string | null,
+  chains: ChainDisplay
 ): string {
   if (!wei || wei === "0" || NON_DIGIT_RE.test(wei)) {
     return "--";
   }
-  return `${formatWeiToDecimal(wei)} ${chainSymbol(network)}`;
+  return `${formatWeiToDecimal(wei)} ${chains.gasSymbol(network)}`.trimEnd();
 }
 
 function formatDuration(ms: number | null): string {
@@ -152,7 +143,10 @@ function formatGasAsEth(weiString: string | null): string {
 // transaction the run made. A run that starts sponsored and falls back to
 // direct signing has only its sponsored leg in the ledger, so preferring the
 // ledger would drop the rest.
-export function runGasDisplay(run: UnifiedRun): ReactNode {
+export function runGasDisplay(
+  run: UnifiedRun,
+  chains: ChainDisplay = FALLBACK_CHAIN_DISPLAY
+): ReactNode {
   const spentAcrossChains =
     run.gasNetworks.length > 1 ||
     (run.gasNetworks.length === 0 && run.networks.length > 1);
@@ -163,7 +157,8 @@ export function runGasDisplay(run: UnifiedRun): ReactNode {
   if (wei) {
     return formatGasNative(
       wei,
-      run.gasNetworks[0] ?? run.networks[0] ?? run.network
+      run.gasNetworks[0] ?? run.networks[0] ?? run.network,
+      chains
     );
   }
   return formatGasAsEth(run.gasUsedWei);
@@ -340,6 +335,7 @@ type StepLogRowProps = {
 };
 
 function StepLogRow({ step }: StepLogRowProps): ReactNode {
+  const chains = useChainDisplay();
   return (
     <tr className="border-t border-dashed border-muted">
       <td colSpan={4}>
@@ -363,11 +359,11 @@ function StepLogRow({ step }: StepLogRowProps): ReactNode {
         {formatDuration(step.durationMs)}
       </td>
       <td className="whitespace-nowrap py-1.5 pr-3 text-xs text-muted-foreground">
-        {step.network ? networkName(step.network) : "--"}
+        {step.network ? chains.name(step.network) : "--"}
       </td>
       <td className="whitespace-nowrap py-1.5 pr-3 text-xs text-muted-foreground">
         <span className="inline-flex items-center gap-1.5">
-          {formatGasNativeExact(step.gasCostWei, step.network)}
+          {formatGasNativeExact(step.gasCostWei, step.network, chains)}
           {step.sponsored ? (
             <span className="rounded bg-green-500/10 px-1 py-0.5 text-[10px] text-green-700 dark:text-green-400">
               sponsored
@@ -457,6 +453,7 @@ type ExpandableRunRowProps = {
 };
 
 function ExpandableRunRow({ run }: ExpandableRunRowProps): ReactNode {
+  const chains = useChainDisplay();
   const [expanded, setExpanded] = useState(false);
   const [steps, setSteps] = useState<StepLog[]>([]);
   const [loadingSteps, setLoadingSteps] = useState(false);
@@ -544,12 +541,12 @@ function ExpandableRunRow({ run }: ExpandableRunRowProps): ReactNode {
         </td>
         <td
           className="whitespace-nowrap py-3 pr-3 text-sm text-muted-foreground"
-          title={run.networks.map(networkName).join(", ")}
+          title={run.networks.map(chains.name).join(", ")}
         >
-          {formatNetworks(run.networks)}
+          {formatNetworks(run.networks, chains)}
         </td>
         <td className="whitespace-nowrap py-3 pr-3 text-sm text-muted-foreground">
-          {runGasDisplay(run)}
+          {runGasDisplay(run, chains)}
         </td>
         <td className="whitespace-nowrap py-3 pr-3 text-right text-sm text-muted-foreground">
           {formatTimeAgo(run.startedAt)}
@@ -767,38 +764,40 @@ export function RunsTable(): ReactNode {
   const isReady = !(loading && isEmpty);
 
   return (
-    <div
-      className="flex gap-0 overflow-hidden rounded-xl border"
-      data-ready={String(isReady)}
-      data-testid="runs-table"
-    >
-      <ProjectDrawer />
-      <Card className="flex-1 rounded-none border-0">
-        <CardHeader>
-          <CardTitle className="flex items-center justify-between">
-            <span>Workflow Runs</span>
-            <Pagination
-              loading={pageLoading}
-              onPageChange={(p) => {
-                handlePageChange(p).catch(() => {
-                  /* noop - errors handled with toast in handlePageChange */
-                });
-              }}
-              page={currentPage}
-              pageSize={pageSize}
-              total={runsData?.total ?? 0}
+    <ChainDisplayProvider>
+      <div
+        className="flex gap-0 overflow-hidden rounded-xl border"
+        data-ready={String(isReady)}
+        data-testid="runs-table"
+      >
+        <ProjectDrawer />
+        <Card className="flex-1 rounded-none border-0">
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between">
+              <span>Workflow Runs</span>
+              <Pagination
+                loading={pageLoading}
+                onPageChange={(p) => {
+                  handlePageChange(p).catch(() => {
+                    /* noop - errors handled with toast in handlePageChange */
+                  });
+                }}
+                page={currentPage}
+                pageSize={pageSize}
+                total={runsData?.total ?? 0}
+              />
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <RunsTableContent
+              isEmpty={isEmpty}
+              loading={loading}
+              pageLoading={pageLoading}
+              runs={runs}
             />
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <RunsTableContent
-            isEmpty={isEmpty}
-            loading={loading}
-            pageLoading={pageLoading}
-            runs={runs}
-          />
-        </CardContent>
-      </Card>
-    </div>
+          </CardContent>
+        </Card>
+      </div>
+    </ChainDisplayProvider>
   );
 }

--- a/lib/hooks/use-chain-display.tsx
+++ b/lib/hooks/use-chain-display.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from "react";
 import { createContext, useContext, useMemo } from "react";
 import { useCachedResource } from "@/lib/hooks/use-cached-resource";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { SPONSORSHIP_CHAINS } from "@/lib/web3/sponsorship-chains-meta";
 
 export type ChainRow = {
@@ -25,18 +26,34 @@ export type ChainDisplay = {
   gasSymbol: (network: string | null) => string;
 };
 
+// A step records the chain it ran on as a chain id, but the older plugins
+// record a slug ("tempo-testnet"), so both have to land on the same key.
+function canonicalId(byId: Map<string, ChainRow>, network: string): string {
+  if (byId.has(network) || SPONSORED_BY_ID.has(network)) {
+    return network;
+  }
+  try {
+    return String(getChainIdFromNetwork(network));
+  } catch {
+    return network;
+  }
+}
+
 export function createChainDisplay(rows: ChainRow[] | undefined): ChainDisplay {
-  const byId = new Map((rows ?? []).map((row) => [String(row.chainId), row]));
+  const byId = new Map(
+    (rows ?? []).map((row): [string, ChainRow] => [String(row.chainId), row])
+  );
   return {
-    name: (network: string): string =>
-      byId.get(network)?.name ?? SPONSORED_BY_ID.get(network)?.name ?? network,
+    name: (network: string): string => {
+      const id = canonicalId(byId, network);
+      return byId.get(id)?.name ?? SPONSORED_BY_ID.get(id)?.name ?? network;
+    },
     gasSymbol: (network: string | null): string => {
       if (!network) {
         return "";
       }
-      return (
-        SPONSORED_BY_ID.get(network)?.symbol ?? byId.get(network)?.symbol ?? ""
-      );
+      const id = canonicalId(byId, network);
+      return SPONSORED_BY_ID.get(id)?.symbol ?? byId.get(id)?.symbol ?? "";
     },
   };
 }

--- a/lib/hooks/use-chain-display.tsx
+++ b/lib/hooks/use-chain-display.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { createContext, useContext, useMemo } from "react";
+import { useCachedResource } from "@/lib/hooks/use-cached-resource";
+import { SPONSORSHIP_CHAINS } from "@/lib/web3/sponsorship-chains-meta";
+
+export type ChainRow = {
+  chainId: number;
+  name: string;
+  symbol: string;
+};
+
+// `chains.symbol` is the chain's own ticker, which is not always what pays for
+// gas there (Base's is "BASE", its gas is ETH), so the sponsorship table wins
+// for the chains it covers and the registry answers for the rest.
+const SPONSORED_BY_ID = new Map(
+  SPONSORSHIP_CHAINS.map((chain) => [String(chain.chainId), chain])
+);
+
+export type ChainDisplay = {
+  /** Chain name for a numeric chain id, falling back to the id itself. */
+  name: (network: string) => string;
+  /** Native gas-token ticker, empty when no source names one. */
+  gasSymbol: (network: string | null) => string;
+};
+
+export function createChainDisplay(rows: ChainRow[] | undefined): ChainDisplay {
+  const byId = new Map((rows ?? []).map((row) => [String(row.chainId), row]));
+  return {
+    name: (network: string): string =>
+      byId.get(network)?.name ?? SPONSORED_BY_ID.get(network)?.name ?? network,
+    gasSymbol: (network: string | null): string => {
+      if (!network) {
+        return "";
+      }
+      return (
+        SPONSORED_BY_ID.get(network)?.symbol ?? byId.get(network)?.symbol ?? ""
+      );
+    },
+  };
+}
+
+/** What the chains the platform sponsors are called, before the fetch lands. */
+export const FALLBACK_CHAIN_DISPLAY: ChainDisplay = createChainDisplay([]);
+
+const ChainDisplayContext = createContext<ChainDisplay>(FALLBACK_CHAIN_DISPLAY);
+
+async function fetchChainRows(): Promise<ChainRow[]> {
+  // Disabled chains included: a past run still names the chain it ran on.
+  const response = await fetch("/api/chains?includeDisabled=true");
+  if (!response.ok) {
+    return [];
+  }
+  return (await response.json()) as ChainRow[];
+}
+
+export function ChainDisplayProvider({
+  children,
+}: {
+  children: ReactNode;
+}): ReactNode {
+  const { data } = useCachedResource<ChainRow[]>(
+    "chain-display",
+    fetchChainRows
+  );
+  const value = useMemo(() => createChainDisplay(data), [data]);
+  return (
+    <ChainDisplayContext.Provider value={value}>
+      {children}
+    </ChainDisplayContext.Provider>
+  );
+}
+
+export function useChainDisplay(): ChainDisplay {
+  return useContext(ChainDisplayContext);
+}

--- a/tests/unit/analytics-run-gas-display.test.ts
+++ b/tests/unit/analytics-run-gas-display.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { runGasDisplay } from "@/components/analytics/runs-table";
 import type { UnifiedRun } from "@/lib/analytics/types";
+import { createChainDisplay } from "@/lib/hooks/use-chain-display";
 
 const BASE = "8453"; // ETH
 const POLYGON = "137"; // POL
+const AVALANCHE = "43114"; // AVAX, outside the sponsorship table
 
 const ONE_TENTH = "100000000000000000"; // 0.1e18
 
@@ -117,5 +119,23 @@ describe("runGasDisplay", () => {
         })
       )
     ).toBe("--");
+  });
+
+  it("denominates a run on a chain the sponsorship table does not cover", () => {
+    // Without the chain registry the amount would read as ETH.
+    const chains = createChainDisplay([
+      { chainId: 43_114, name: "Avalanche", symbol: "AVAX" },
+    ]);
+    expect(
+      runGasDisplay(
+        run({
+          networks: [AVALANCHE],
+          gasNetworks: [AVALANCHE],
+          gasUsedWei: ONE_TENTH,
+          network: AVALANCHE,
+        }),
+        chains
+      )
+    ).toBe("0.10 AVAX");
   });
 });

--- a/tests/unit/chain-display.test.ts
+++ b/tests/unit/chain-display.test.ts
@@ -5,6 +5,7 @@ const REGISTRY = [
   { chainId: 1, name: "Ethereum Mainnet", symbol: "ETH" },
   { chainId: 101, name: "Solana", symbol: "SOL" },
   { chainId: 8453, name: "Base", symbol: "BASE" },
+  { chainId: 42_431, name: "Tempo Testnet", symbol: "TEMPO" },
   { chainId: 43_114, name: "Avalanche", symbol: "AVAX" },
 ];
 
@@ -36,5 +37,15 @@ describe("createChainDisplay", () => {
   it("names no token for a chain no source knows", () => {
     expect(createChainDisplay(REGISTRY).gasSymbol("999999")).toBe("");
     expect(createChainDisplay(REGISTRY).gasSymbol(null)).toBe("");
+  });
+
+  it("names a chain a step recorded as a slug", () => {
+    const chains = createChainDisplay(REGISTRY);
+    expect(chains.name("tempo-testnet")).toBe("Tempo Testnet");
+    expect(chains.name("base-sepolia")).toBe("Base Sepolia");
+  });
+
+  it("keeps a slug it cannot resolve rather than showing a bare id", () => {
+    expect(createChainDisplay(REGISTRY).name("some-chain")).toBe("some-chain");
   });
 });

--- a/tests/unit/chain-display.test.ts
+++ b/tests/unit/chain-display.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { createChainDisplay } from "@/lib/hooks/use-chain-display";
+
+const REGISTRY = [
+  { chainId: 1, name: "Ethereum Mainnet", symbol: "ETH" },
+  { chainId: 101, name: "Solana", symbol: "SOL" },
+  { chainId: 8453, name: "Base", symbol: "BASE" },
+  { chainId: 43_114, name: "Avalanche", symbol: "AVAX" },
+];
+
+describe("createChainDisplay", () => {
+  it("names a chain the sponsorship table does not cover", () => {
+    const chains = createChainDisplay(REGISTRY);
+    expect(chains.name("101")).toBe("Solana");
+    expect(chains.name("43114")).toBe("Avalanche");
+  });
+
+  it("falls back to the sponsorship name before the registry arrives", () => {
+    expect(createChainDisplay(undefined).name("137")).toBe("Polygon");
+  });
+
+  it("shows the id for a chain no source knows", () => {
+    expect(createChainDisplay(REGISTRY).name("999999")).toBe("999999");
+  });
+
+  it("denominates gas in the registry ticker for an unsponsored chain", () => {
+    const chains = createChainDisplay(REGISTRY);
+    expect(chains.gasSymbol("101")).toBe("SOL");
+    expect(chains.gasSymbol("43114")).toBe("AVAX");
+  });
+
+  it("keeps the gas token where it differs from the chain ticker", () => {
+    expect(createChainDisplay(REGISTRY).gasSymbol("8453")).toBe("ETH");
+  });
+
+  it("names no token for a chain no source knows", () => {
+    expect(createChainDisplay(REGISTRY).gasSymbol("999999")).toBe("");
+    expect(createChainDisplay(REGISTRY).gasSymbol(null)).toBe("");
+  });
+});


### PR DESCRIPTION
## Problem

The Analytics runs table printed a numeric chain id in the Network column for any chain outside the eight the gas station sponsors. A Solana run read `101`, an Avalanche run `43114`, a BNB run `56`.

The same lookup fed the gas cell, which fell back to a hardcoded `ETH`, so those runs also reported their gas in the wrong token: `0.05 ETH` for an amount actually spent in SOL.

Steps written by the older plugins record their chain as a slug rather than an id, so a Tempo run printed `tempo-testnet`.

## Cause

`components/analytics/runs-table.tsx` built its name and symbol maps from `SPONSORSHIP_CHAINS`, which lists only the chains Turnkey's gas station can sponsor. Everything else fell through to the raw value.

## Fix

A new `lib/hooks/use-chain-display.tsx` reads the chain registry from `/api/chains` through the existing per-session resource cache and hands the runs table a resolver via context, so the fetch happens once for the whole page.

- Names come from the registry, then the sponsorship table, then the value as recorded.
- Gas tickers keep the sponsorship table first, because `chains.symbol` is the chain's own ticker rather than the token that pays for gas there (Base's is `BASE`, its gas is ETH). The registry answers for every other chain, and an unknown chain now renders no ticker rather than a wrong one.
- Slugs resolve through the same map the executor uses, and an unresolvable slug stays readable instead of collapsing to a bare id.
- Disabled chains are included in the fetch, since a past run still names the chain it ran on.

`runGasDisplay` keeps its previous single-argument signature through a default resolver.

## Verification

Seeded one run per chain in the registry, plus two slug-recorded runs, and read the rendered table back. All 22 rows resolve to a name and the correct gas ticker: Ethereum Mainnet / Solana / Solana Devnet / Ethereum Sepolia / Polygon / 0G Galileo / 0G / Arbitrum One / Arbitrum Sepolia / Tempo / Tempo Testnet / Avalanche Fuji / Avalanche / BNB Chain / Polygon Amoy / Base / Base Sepolia / BNB Chain Testnet / Plasma / Plasma Testnet.

Before the change the same rows read `101`, `43114`, `56` and `tempo-testnet`, with every gas amount denominated in ETH.

## Out of scope

- `components/analytics/gas-breakdown-chart.tsx` labels its bars with the same raw ids, but nothing renders that component today.
- The runs-table search box matches on the raw chain id, so typing a chain name does not filter. Pre-existing.