### PR TITLE
fix(analytics): render a run that arrives without its gas chains

### DIFF
--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -21,6 +21,10 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  normalizeRunsResponse,
+  type WireRunsResponse,
+} from "@/lib/analytics/runs-response";
 import type {
   NormalizedStatus,
   StepLog,
@@ -709,14 +713,8 @@ export function RunsTable(): ReactNode {
           `/api/analytics/runs?${params.toString()}`
         );
         if (response.ok) {
-          const data = (await response.json()) as {
-            runs: UnifiedRun[];
-            nextCursor: string | null;
-            total: number;
-            page: number;
-            pageSize: number;
-          };
-          setRunsData(data);
+          const data = (await response.json()) as WireRunsResponse;
+          setRunsData(normalizeRunsResponse(data));
         } else {
           toast.error("Failed to load runs");
         }

--- a/components/analytics/use-analytics.ts
+++ b/components/analytics/use-analytics.ts
@@ -2,10 +2,13 @@
 
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useEffect, useRef } from "react";
+import {
+  normalizeRunsResponse,
+  type WireRunsResponse,
+} from "@/lib/analytics/runs-response";
 import type {
   AnalyticsSummary,
   NetworkBreakdown,
-  RunsResponse,
   TimeSeriesBucket,
 } from "@/lib/analytics/types";
 import {
@@ -208,8 +211,8 @@ export function useAnalytics(): UseAnalyticsReturn {
         )
       ),
       wrapSection(
-        processSection<RunsResponse>(runsPromise, "Runs", ctx, (data) => {
-          setRuns(data);
+        processSection<WireRunsResponse>(runsPromise, "Runs", ctx, (data) => {
+          setRuns(normalizeRunsResponse(data));
         })
       ),
     ]);

--- a/lib/analytics/runs-response.ts
+++ b/lib/analytics/runs-response.ts
@@ -1,0 +1,30 @@
+import type { RunsResponse, UnifiedRun } from "./types";
+
+/**
+ * A run as it arrives over the wire. The analytics page polls every 10s and an
+ * open tab outlives a deploy, so a response can come from a server older than
+ * the bundle reading it and omit array fields this client now indexes into.
+ * They are optional here and filled by `normalizeRunsResponse` so a missing one
+ * renders as empty instead of throwing mid-render.
+ */
+type ArrayFields = "networks" | "gasNetworks" | "transactionHashes";
+type WireRun = Omit<UnifiedRun, ArrayFields> &
+  Partial<Pick<UnifiedRun, ArrayFields>>;
+
+export type WireRunsResponse = Omit<RunsResponse, "runs"> & {
+  runs?: WireRun[];
+};
+
+export function normalizeRunsResponse(
+  response: WireRunsResponse
+): RunsResponse {
+  return {
+    ...response,
+    runs: (response.runs ?? []).map((run) => ({
+      ...run,
+      networks: run.networks ?? [],
+      gasNetworks: run.gasNetworks ?? [],
+      transactionHashes: run.transactionHashes ?? [],
+    })),
+  };
+}

--- a/tests/unit/analytics-runs-response.test.ts
+++ b/tests/unit/analytics-runs-response.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { runGasDisplay } from "@/components/analytics/runs-table";
+import {
+  normalizeRunsResponse,
+  type WireRunsResponse,
+} from "@/lib/analytics/runs-response";
+
+// A response shaped by a server older than this bundle: the run carries the
+// fields that server knew about and none of the ones added since.
+const LEGACY_RESPONSE = {
+  runs: [
+    {
+      id: "run",
+      source: "workflow",
+      status: "success",
+      startedAt: new Date(0).toISOString(),
+      completedAt: null,
+      durationMs: null,
+      workflowId: "wf",
+      workflowName: "wf",
+      directType: null,
+      network: "8453",
+      networks: ["8453"],
+      gasCostWei: null,
+      gasUsedWei: null,
+      totalSteps: null,
+      completedSteps: null,
+      error: null,
+      errorCode: null,
+      errorType: null,
+      errorCategory: null,
+    },
+  ],
+  nextCursor: null,
+  total: 1,
+  page: 1,
+  pageSize: 50,
+} satisfies WireRunsResponse;
+
+describe("normalizeRunsResponse", () => {
+  it("fills the array fields a stale server omitted", () => {
+    const [run] = normalizeRunsResponse(LEGACY_RESPONSE).runs;
+
+    expect(run.gasNetworks).toEqual([]);
+    expect(run.transactionHashes).toEqual([]);
+    expect(run.networks).toEqual(["8453"]);
+  });
+
+  it("renders the gas cell of a normalized stale run without throwing", () => {
+    const [run] = normalizeRunsResponse(LEGACY_RESPONSE).runs;
+
+    expect(runGasDisplay(run)).toBe("--");
+  });
+
+  it("leaves a current response untouched", () => {
+    const response = normalizeRunsResponse({
+      ...LEGACY_RESPONSE,
+      runs: [
+        {
+          ...LEGACY_RESPONSE.runs[0],
+          gasNetworks: ["8453"],
+          transactionHashes: [],
+        },
+      ],
+    });
+
+    expect(response.runs[0].gasNetworks).toEqual(["8453"]);
+  });
+});


### PR DESCRIPTION
The analytics page crashed with `TypeError: Cannot read properties of undefined (reading 'length')` for a user this morning. The throwing expression is `run.gasNetworks.length` in the runs table Gas cell.

`gasNetworks` is a recent field. Every server producer sets it and runs are not cached, so the row came from a server older than the bundle that rendered it. The stack confirms the shape: the Network cell one `<td>` earlier reads `run.networks.map(...)` and did not throw, so that run carried `networks` and no `gasNetworks`, which is exactly the payload from before the field existed. The page polls every 10 seconds and refetches on stream events, so an open tab outlives a deploy and meets that skew.

## Change

Both places that cast the runs JSON now normalize it first. `lib/analytics/runs-response.ts` types the wire shape with `networks`, `gasNetworks` and `transactionHashes` optional, because a renderer indexes into all three, and fills every missing one with an empty array. A stale response renders an empty cell instead of taking the page down.

Applied in `use-analytics.ts` (initial load, polling, stream refetch) and in the pagination fetch in `runs-table.tsx`.

New unit test builds a response without the field and asserts both the fill and that the Gas cell renders from it.