### PR TITLE
fix(errors): attribute a wallet that cannot pay to the wallet, not the platform

### DIFF
--- a/lib/errors/__tests__/classify.test.ts
+++ b/lib/errors/__tests__/classify.test.ts
@@ -285,6 +285,48 @@ describe("classifyExecutionError", () => {
     });
   });
 
+  describe("user: a wallet that cannot pay, however it is wrapped", () => {
+    it.each([
+      "RPC failed on both endpoints. Primary: insufficient funds for intrinsic transaction cost. Fallback: insufficient funds for intrinsic transaction cost",
+      "Token transfer failed: insufficient funds for gas * price + value",
+      "insufficient funds for intrinsic transaction cost (transaction={}, code=INSUFFICIENT_FUNDS, version=6.13.4)",
+    ])("attributes an unfunded sender to the wallet, not the RPC: %s", (input) => {
+      const r = classifyExecutionError(input);
+      expect(r.errorCategory).toBe(ErrorCategory.TRANSACTION);
+      expect(r.errorType).toBe("user");
+      expect(r.code).toBeNull();
+    });
+
+    it.each([
+      '[SolanaChainAdapter] Simulation failed: {"InsufficientFundsForRent":{"account_index":1}}',
+      "Solana RPC failed on both endpoints. Primary: Attempt to debit an account but found no record of a prior credit",
+    ])("attributes a Solana fee payer that cannot pay to the wallet: %s", (input) => {
+      const r = classifyExecutionError(input);
+      expect(r.errorCategory).toBe(ErrorCategory.TRANSACTION);
+      expect(r.errorType).toBe("user");
+      expect(r.code).toBeNull();
+    });
+
+    it.each([
+      "Safe deploy failed: the deployer wallet has no native balance to pay gas. Top up and retry.",
+      "Safe deploy failed: Not enough gas to execute Safe transaction (Safe error GS010). Top up the wallet's native balance and retry.",
+    ])("attributes a Safe that cannot pay for its own deploy to the wallet: %s", (input) => {
+      const r = classifyExecutionError(input);
+      expect(r.errorCategory).toBe(ErrorCategory.TRANSACTION);
+      expect(r.errorType).toBe("user");
+      expect(r.code).toBeNull();
+    });
+
+    it("still pages when an endpoint could not be reached at all", () => {
+      const r = classifyExecutionError(
+        "Solana RPC failed on both endpoints. Primary: request timeout. Fallback: request timeout"
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.NETWORK_RPC);
+      expect(r.errorType).toBe("system");
+      expect(r.code).toBe("N-0001");
+    });
+  });
+
   describe("system: KeeperHub-managed RPC failures", () => {
     it("RPC failed on both endpoints: network_rpc + system", () => {
       const r = classifyExecutionError(

--- a/lib/errors/classify.ts
+++ b/lib/errors/classify.ts
@@ -3,6 +3,7 @@ import {
   type ErrorCode,
 } from "@/lib/errors/error-codes";
 import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
+import { FUNDING_SHORTFALL_PATTERNS } from "@/lib/errors/funding-shortfall";
 import { ErrorCategory } from "@/lib/logging";
 
 export { ExecutionErrorType } from "@/lib/errors/execution-error-type";
@@ -20,11 +21,14 @@ export { ExecutionErrorType } from "@/lib/errors/execution-error-type";
  *                    transport failures such as timeouts, connection resets, DNS
  *                    failures) where neither the customer's config nor KeeperHub
  *                    is at fault. RPC endpoints are KeeperHub-managed, so an
- *                    `RPC failed ...` message stays "system" here; the one
- *                    exception is the private-mempool relay a node opted into,
- *                    which we point at but do not operate. The RPC layer tags
- *                    that at the failure site and the step forwards it as an
- *                    errorClass hint.
+ *                    `RPC failed ...` message stays "system" here. Two things
+ *                    override that. The private-mempool relay a node opted
+ *                    into is one we point at but do not operate: the RPC layer
+ *                    tags it at the failure site and the step forwards it as
+ *                    an errorClass hint. And an exhaustion whose quoted answer
+ *                    is a funding shortfall is not an endpoint failure at all:
+ *                    every endpoint reads the same balance, so it stays with
+ *                    the wallet that could not pay.
  *   - code:          a `PREFIX-NNNN` system error code for system failures, or
  *                    null for user and external failures (which surface their
  *                    raw message).
@@ -268,6 +272,18 @@ const RULES: readonly Rule[] = [
     errorType: ExecutionErrorType.USER,
     code: null,
   },
+
+  // The chain refused the transaction because the paying wallet is short, and
+  // it read the same balance on every endpoint we asked. Unanchored, and above
+  // the RPC rules below, so the shortfall keeps its fault domain even when it
+  // arrives quoted inside a failover exhaustion message, which otherwise reads
+  // as a platform outage.
+  ...FUNDING_SHORTFALL_PATTERNS.map((pattern) => ({
+    pattern,
+    errorCategory: ErrorCategory.TRANSACTION,
+    errorType: ExecutionErrorType.USER,
+    code: null,
+  })),
 
   // System: RPC endpoints are KeeperHub-managed infrastructure, so a failover
   // exhaustion is a platform fault, not a third-party dependency failure.

--- a/lib/errors/funding-shortfall.ts
+++ b/lib/errors/funding-shortfall.ts
@@ -1,0 +1,50 @@
+/**
+ * Failures where the chain refused a transaction because the wallet paying for
+ * it could not cover the cost.
+ *
+ * A shortfall is deterministic: the node read a balance and answered. Every
+ * endpoint on the chain reads the same balance and answers the same way, and
+ * so does the next attempt until the wallet is funded. That makes it the
+ * author's to act on, never KeeperHub's, no matter which layer surfaces it or
+ * what that layer wraps around it.
+ *
+ * Kept free of any import so the execution-error classifier and the send paths
+ * that log these failures share one definition of the boundary.
+ *
+ * Covers every write path we run: EVM (Safe-routed writes and Tempo included,
+ * both EVM underneath), where the node reports the shortfall against gas and
+ * value; and Solana, where the runtime reports it against the fee, against
+ * rent exemption, or as a debit on an account that was never credited.
+ */
+export const FUNDING_SHORTFALL_PATTERNS: readonly RegExp[] = [
+  // EVM: geth's `insufficient funds for gas * price + value`, the
+  // intrinsic-cost variant BNB Chain and friends return, and the ethers code
+  // that accompanies both. Narrow on purpose: our own preflight string
+  // (`Insufficient BNB balance. Have: ...`) has its own rule, so prose merely
+  // containing the words does not land here.
+  /insufficient funds for (gas|intrinsic transaction cost|transfer)/i,
+  /code=INSUFFICIENT_FUNDS/,
+  // Solana: the fee payer cannot cover the fee, cannot leave the account
+  // rent-exempt, or has never been credited at all.
+  /InsufficientFundsForRent|InsufficientFundsForFee/,
+  /Attempt to debit an account but found no record of a prior credit/i,
+  // Safe: the deploy path renders a shortfall into its own sentence before the
+  // message leaves it, in two forms. The node's plain `insufficient funds`
+  // becomes the first; a Safe that reverted on its own gas accounting becomes
+  // the second, labelled by GS code.
+  /no native balance to pay gas/i,
+  /\(Safe error GS01[012]\)/,
+];
+
+/**
+ * Whether a failure message reports a wallet that could not pay. Callers use
+ * this to keep a funding shortfall out of platform alerting.
+ */
+export function isFundingShortfall(
+  message: string | null | undefined
+): boolean {
+  if (!message) {
+    return false;
+  }
+  return FUNDING_SHORTFALL_PATTERNS.some((pattern) => pattern.test(message));
+}

--- a/lib/safe/deployment.ts
+++ b/lib/safe/deployment.ts
@@ -6,7 +6,7 @@ import { recordWalletInAddressBook } from "@/lib/address-book/record-wallet";
 import { normalizeAddressForStorage } from "@/lib/address-utils";
 import { db } from "@/lib/db";
 import { chains, type SafeWallet, safeWallets } from "@/lib/db/schema";
-import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { ErrorCategory, logSystemError, logUserError } from "@/lib/logging";
 import { startSafeDeployMetrics } from "@/lib/metrics/instrumentation/safe";
 import { getRpcProviderFromUrls } from "@/lib/rpc/provider-factory";
 import { getRpcUrlByChainId } from "@/lib/rpc/rpc-config";
@@ -285,10 +285,17 @@ export async function deployOrgSafe(
     return { success: true, safe: inserted, alreadyDeployed: false };
   } catch (error) {
     finishMetrics("failure");
+    const report = formatSafeDeployError(error);
     // Keep the full ethers CALL_EXCEPTION blob in Sentry for triage but
     // return a kind-classified user-readable message via the API. Raw
-    // blobs are 1KB+ and unactionable in a toast.
-    logSystemError(
+    // blobs are 1KB+ and unactionable in a toast. A deployer wallet with no
+    // gas money is the one failure here that is not ours: it stays out of
+    // Sentry so an unfunded wallet does not read as a platform fault. Every
+    // other revert here (an adopted Safe, an unauthorized caller, a paused
+    // contract) is still worth a look, so it keeps paging.
+    const log =
+      report.kind === "insufficient-gas" ? logUserError : logSystemError;
+    log(
       ErrorCategory.TRANSACTION,
       `[Safe] Deployment failed for org=${organizationId}`,
       error,
@@ -297,7 +304,6 @@ export async function deployOrgSafe(
         chain_id: chainId.toString(),
       }
     );
-    const report = formatSafeDeployError(error);
     return {
       success: false,
       error: report.message,

--- a/plugins/tempo/steps/tempo-tx-core.ts
+++ b/plugins/tempo/steps/tempo-tx-core.ts
@@ -33,7 +33,8 @@ import { encodeFunctionData, type Hex, toFunctionSelector } from "viem";
 import { Abis } from "viem/tempo";
 import { toChecksumAddress } from "@/lib/address-utils";
 import { checkStablecoinCalldataBatch } from "@/lib/execute/stablecoin-cap";
-import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { isFundingShortfall } from "@/lib/errors/funding-shortfall";
+import { ErrorCategory, logSystemError, logUserError } from "@/lib/logging";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import { resolveSignerMode, SIGNER_MODE } from "@/lib/safe/signer-resolver";
@@ -555,7 +556,11 @@ export async function broadcastStoredTempoTx(
       provider.send("eth_sendRawTransaction", [serialized])
     );
   } catch (error) {
-    logSystemError(
+    // A node that refuses the envelope because the payer cannot cover it is
+    // answering about this wallet, not reporting that Tempo is unreachable.
+    const message = error instanceof Error ? error.message : String(error);
+    const log = isFundingShortfall(message) ? logUserError : logSystemError;
+    log(
       ErrorCategory.TRANSACTION,
       "[Tempo] Failed to broadcast transaction",
       error,


### PR DESCRIPTION
## Problem

A wallet holding no native token for gas was finalizing as a **system** error, so an ordinary user-side condition paged as a platform fault. Observed on an ERC-20 transfer whose sender held no native balance: both endpoints answered `insufficient funds for intrinsic transaction cost`, and the run was recorded as `network_rpc` / `N-0001`.

## Cause

The failover reports an exhausted round as `RPC failed on both endpoints. Primary: <answer>. Fallback: <answer>`, and the classifier reads any such message as KeeperHub-managed infrastructure. That is right when an endpoint failed to answer, and wrong when what both endpoints returned was the node reading the same balance and refusing on it.

The funding rules that would have caught it are start-anchored (`^Insufficient <X> balance`), so they never match once the shortfall is quoted inside that wrapper, or inside a step's own prefix.

## Fix

One shared list of funding shortfalls in `lib/errors/funding-shortfall.ts`, covering every write path we run:

- **EVM** (Safe-routed writes and Tempo included, both EVM underneath): geth's `insufficient funds for gas * price + value`, the intrinsic-cost variant BNB Chain and friends return, and the ethers `code=INSUFFICIENT_FUNDS` that accompanies both
- **Solana**: the fee payer cannot cover the fee, cannot leave the account rent-exempt, or was never credited at all
- **Safe**: both renderings the deploy path produces, including the GS010-012 gas-accounting form that previously matched nothing

Used in three places:

- **Classification** matches the list unanchored and above the RPC rules, so a shortfall keeps its fault domain no matter what quotes it.
- **The Tempo broadcast path** logs a shortfall as a user error rather than raising it in Sentry.
- **The Safe deploy path** does the same, keyed off the `insufficient-gas` kind it already classifies. Every other Safe deploy revert still pages.

Deliberately unchanged: RPC retry and failover policy. A shortfall still costs a full round, which is wasteful but safe; making it non-retryable would turn a primary lagging a block behind a top-up into a terminal failure instead of a fallback that recovers.

An exhaustion where an endpoint genuinely failed to answer is untouched and still pages, including the existing case where one endpoint quoted a balance error and the other timed out.

## Effect

An unfunded wallet now surfaces its raw, actionable message to the workflow author ("fund this address with at least X on this chain and retry") instead of "Internal network error, please wait 5 minutes and try again", and drops out of the system-error SLI.