### PR TITLE
feat: KEEP-1082 default Robinhood Chain (4663) to enabled

### DIFF
--- a/scripts/seed/seed-chains.ts
+++ b/scripts/seed/seed-chains.ts
@@ -550,13 +550,7 @@ const DEFAULT_CHAINS: NewChain[] = [
       type: "fallback",
     }),
     isTestnet: getChainConfigValue("robinhood-mainnet", "isTestnet", false),
-    // Unlike every other chain here, the hardcoded default is false rather than
-    // true. production.json disables this chain explicitly, so the default is
-    // only reached where CHAIN_RPC_CONFIG is absent or fails to parse -- and on
-    // a parse failure the seed falls back to hardcoded defaults throughout,
-    // which with a `true` default would silently enable mainnet in production.
-    // Flip this to true alongside the production.json entry, not before.
-    isEnabled: getChainConfigValue("robinhood-mainnet", "isEnabled", false),
+    isEnabled: getChainConfigValue("robinhood-mainnet", "isEnabled", true),
     status: "experimental",
     usePrivateMempoolRpc: getUsePrivateMempoolRpc({ rpcConfig, jsonKey: "robinhood-mainnet" }),
     defaultPrivateRpcUrl: getPrivateRpcUrl({ rpcConfig, jsonKey: "robinhood-mainnet" }),


### PR DESCRIPTION
Pairs with KeeperHub/chain-config#40, which sets `isEnabled: true` for `robinhood-mainnet` in `production.json`.

## What this changes

One boolean default, and a comment that no longer applies:

```diff
-    // Unlike every other chain here, the hardcoded default is false rather than
-    // true. production.json disables this chain explicitly, so the default is
-    // only reached where CHAIN_RPC_CONFIG is absent or fails to parse - and on
-    // a parse failure the seed falls back to hardcoded defaults throughout,
-    // which with a `true` default would silently enable mainnet in production.
-    // Flip this to true alongside the production.json entry, not before.
-    isEnabled: getChainConfigValue("robinhood-mainnet", "isEnabled", false),
+    isEnabled: getChainConfigValue("robinhood-mainnet", "isEnabled", true),
```

## Why the special case goes rather than inverts

This default is only reached when `CHAIN_RPC_CONFIG` is absent or fails to parse, because on a parse failure the seed falls back to hardcoded defaults throughout. KEEP-1087 set it to `false`, against the convention every other chain in the file follows, precisely because `production.json` disabled the chain: a `true` default would have made a parse failure silently disagree with the config and enable mainnet.

Now that `production.json` enables it, the same argument runs the other way. So 4663 goes back to matching every other entry in the file, and the comment goes with it, because the line it explained no longer differs from its neighbours.

The comment's own closing instruction was "Flip this to true alongside the production.json entry, not before". This is that.

## Ordering

Land with chain-config#40. If they must be ordered, **chain-config#40 first**: config-on with this default still `false` means a parse failure leaves mainnet off, which is the safe direction. This PR first means a parse failure turns mainnet on against a config that says off, which is what the original comment was guarding against.

## Scope

`status` stays `"experimental"`. No other chain is touched. Robinhood testnet is unaffected here; it already defaults to enabled and is handled in chain-config#39.

## Verification

- No test in the repo references `robinhood` or `4663`, so nothing asserts the old default.
- The change is a boolean literal plus a deleted comment, so there is no type surface to move.
- The chain row only changes when `pnpm db:seed` runs in the `db-migration` initContainer on deploy, so this has no effect until the next production release, and none at all while `CHAIN_RPC_CONFIG` parses.
