### PR TITLE
fix: KEEP-1082 drop five Safe chain prefixes that open Ethereum instead of the chain

### DIFF
--- a/components/safe/chain-prefixes.ts
+++ b/components/safe/chain-prefixes.ts
@@ -6,6 +6,19 @@
  *
  * Unknown chain IDs return null; the caller should hide the "View on Safe"
  * link for those rather than linking to a broken URL.
+ *
+ * Every entry must be a chain Safe's client gateway still serves, and must use
+ * the shortName that gateway reports. Safe's frontend resolves an unrecognised
+ * prefix by falling through to Ethereum rather than erroring, so a stale entry
+ * does not produce a dead link - it silently opens the wrong chain, which is
+ * worse than the hidden link this map is designed to fall back to.
+ *
+ * Checked against safe-client.safe.global/v1/chains (53 chains, paginated in
+ * full) on 2026-08-28. Optimism Sepolia (11155420), Arbitrum Sepolia (421614),
+ * BSC Testnet (97), Polygon Amoy (80002) and Avalanche Fuji (43113) were
+ * removed: Safe no longer lists any of them, so their links had been opening
+ * Ethereum. All five remain in SUPPORTED_SAFE_CHAIN_IDS, so Safes can still be
+ * deployed there; only the deep link is hidden.
  */
 const SAFE_CHAIN_PREFIXES: Record<number, string> = {
   // mainnets
@@ -18,12 +31,7 @@ const SAFE_CHAIN_PREFIXES: Record<number, string> = {
   43114: "avax",
   // testnets
   11155111: "sep",
-  11155420: "opsep",
   84532: "basesep",
-  421614: "arbsep",
-  97: "bnbt",
-  80002: "amoy",
-  43113: "fuji",
 };
 
 export function getSafeChainPrefix(chainId: number): string | null {


### PR DESCRIPTION
Five entries in `SAFE_CHAIN_PREFIXES` name chains Safe's client gateway no longer serves, and the resulting links open the wrong chain rather than failing.

## The bug

`getSafeAppUrl` builds `https://app.safe.global/home?safe=<prefix>:<address>`. Checked every entry against `safe-client.safe.global/v1/chains` on 2026-08-28, paginating all 53 chains:

| chainId | our prefix | Safe gateway | |
| -- | -- | -- | -- |
| 1, 10, 8453, 42161, 56, 137, 43114 | eth, oeth, base, arb1, bnb, matic, avax | same | ok |
| 11155111 | sep | sep | ok |
| 84532 | basesep | basesep | ok |
| **11155420** | opsep | not listed | broken |
| **421614** | arbsep | not listed | broken |
| **97** | bnbt | not listed | broken |
| **80002** | amoy | not listed | broken |
| **43113** | fuji | not listed | broken |

These are not dead links. Safe's frontend resolves an unrecognised prefix by falling through to Ethereum, so the page loads and shows an Ethereum context for a Safe that does not exist there. That is strictly worse than the hidden link this map already falls back to for unmapped chains, and it is the exact outcome the file's own header comment sets out to avoid.

All five are in `SUPPORTED_SAFE_CHAIN_IDS`, so a user can deploy a Safe on them through the product and then be handed one of these links.

## This does not drop chain support

All five chains remain fully supported by KeeperHub and all five remain in `chain-config`. Avalanche Fuji (43113), Polygon Amoy (80002) and the rest are enabled, seeded, and keep their RPC, WSS and explorer links.

The only thing removed is the `app.safe.global` deep-link prefix, because **Safe** stopped serving those chains, not because we did. Verified independently of the chain listing: `safe-client.safe.global/v1/chains/43113` returns 404 while `/43114` returns `avax`, and `api.safe.global/tx-service/{fuji,avalanche-fuji,avax-fuji}` all 404.

## The fix

Remove the five. Nothing else changes:

- All five stay in `SUPPORTED_SAFE_CHAIN_IDS`; Safes can still be deployed there. Only the deep link is hidden, which is the documented behaviour for an unmapped chain.
- Both call sites already handle `null` by omitting the anchor: `deploy-safe-card.tsx:130` and `policies-tab.tsx:27`, each behind a `&&`.
- `EXPLORER_BASE_URLS` in the same file is untouched. Those explorer links are fine; Etherscan still serves all five testnets. Only Safe dropped them.
- No test asserts a removed prefix. `tests/unit/safe-signer-resolver.test.ts` covers 1, 8453, 11155111 and 84532, all retained, plus the unmapped-chain null case at `:406`.

The header comment now records the invariant (every entry must be a chain the gateway still serves, using the shortName it reports) and why a stale entry is worse than a missing one, so the next person does not helpfully add them back.

## Why 4663 is not added here

Safe's gateway does list Robinhood Chain as `robinhood`, and I verified by headless render against a real Safe on 4663 that the deep link resolves correctly. It is still not added, for two reasons:

1. 4663 is absent from `SUPPORTED_SAFE_CHAIN_IDS`, so no Safe can be created there and the entry would be unreachable.
2. Adding it there is blocked on something worth knowing: of the seven addresses in `CANONICAL_ADDRESSES`, six are deployed on 4663 and `allowanceModule` (`0xCFbFaC74C26F8647cBDb8c5caf80BB5b32E43134`) has no code. `lib/safe/contracts.ts:44` asserts that every chain in that list has the canonical Safe v1.4.1 **and Allowance Module** deployments, so 4663 fails the stated criteria. That needs a decision about the invariant, not a map entry.

Safe core being deployed and the Allowance Module being deployed are different facts, and the KEEP-1087 investigation conflated them when it recorded "Safe is fully deployed".

