### PR TITLE
fix: honour the ERC-8056 UI multiplier on balances and transfers

### DIFF
--- a/app/api/user/wallet/estimate-gas/route.ts
+++ b/app/api/user/wallet/estimate-gas/route.ts
@@ -10,6 +10,10 @@ import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { getActiveOrgId } from "@/lib/middleware/org-context";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
 import { getGasStrategy } from "@/lib/web3/gas-strategy";
+import {
+  convertAmountForWrite,
+  resolveForWrite,
+} from "@/lib/web3/ui-multiplier";
 import { getOrganizationWalletAddress } from "@/lib/web3/wallet-helpers";
 
 const ERC20_TRANSFER_ABI = [
@@ -118,7 +122,26 @@ export async function POST(request: Request) {
           );
           const decimalsBig: bigint = await contract.decimals();
           const decimals = Number(decimalsBig);
-          const amountWei = ethers.parseUnits(amount, decimals);
+          // Must match what the withdraw route will actually send. Estimating
+          // the unscaled amount on an ERC-8056 token probes a transfer several
+          // times larger than the real one, which reverts against the holder's
+          // balance and blocks a withdraw that would have succeeded.
+          const mult = await resolveForWrite(
+            (op) => op(provider),
+            chainId,
+            tokenAddress
+          );
+          if (!mult.ok) {
+            throw mult.error;
+          }
+          const converted = convertAmountForWrite(
+            ethers.parseUnits(amount, decimals),
+            mult.multiplier
+          );
+          if (!converted.ok) {
+            throw new Error(converted.error);
+          }
+          const amountWei = converted.raw;
           return await contract.transfer.estimateGas(recipient, amountWei, {
             from: walletAddress,
           });

--- a/app/api/user/wallet/withdraw/route.ts
+++ b/app/api/user/wallet/withdraw/route.ts
@@ -25,7 +25,10 @@ import {
   type TransactionContext,
   withNonceSession,
 } from "@/lib/web3/transaction-manager";
-import { getUiMultiplier, uiToRaw } from "@/lib/web3/ui-multiplier";
+import {
+  convertAmountForWrite,
+  resolveForWrite,
+} from "@/lib/web3/ui-multiplier";
 import {
   getOrganizationWalletAddress,
   initializeWalletSigner,
@@ -273,10 +276,24 @@ export async function POST(request: Request) {
             }
             // ERC-8056 tokens are shown to the holder in scaled units but
             // transfer in raw ones. Identity for every ordinary ERC-20.
-            safeAmountWei = uiToRaw(
-              ethers.parseUnits(amountStr, decimals),
-              await getUiMultiplier((op) => op(provider), chainId, tokenAddress)
+            // Throws rather than falling back: an unscaled amount here would
+            // move several times what was asked for.
+            const mult = await resolveForWrite(
+              (op) => op(provider),
+              chainId,
+              tokenAddress
             );
+            if (!mult.ok) {
+              throw mult.error;
+            }
+            const converted = convertAmountForWrite(
+              ethers.parseUnits(amountStr, decimals),
+              mult.multiplier
+            );
+            if (!converted.ok) {
+              throw new Error(converted.error);
+            }
+            safeAmountWei = converted.raw;
           } else if (fromMax) {
             safeAmountWei = await provider.getBalance(safe.safeAddress);
             if (safeAmountWei === BigInt(0)) {
@@ -361,10 +378,22 @@ export async function POST(request: Request) {
           );
           const decimalsResult: bigint = await contract.decimals();
           const decimals = Number(decimalsResult);
-          amountWei = uiToRaw(
-            ethers.parseUnits(amountStr, decimals),
-            await getUiMultiplier((op) => op(provider), chainId, tokenAddress)
+          const mult = await resolveForWrite(
+            (op) => op(provider),
+            chainId,
+            tokenAddress
           );
+          if (!mult.ok) {
+            throw mult.error;
+          }
+          const convertedAmount = convertAmountForWrite(
+            ethers.parseUnits(amountStr, decimals),
+            mult.multiplier
+          );
+          if (!convertedAmount.ok) {
+            throw new Error(convertedAmount.error);
+          }
+          amountWei = convertedAmount.raw;
           estimatedGas = await contract.transfer.estimateGas(
             recipientAddr,
             amountWei

--- a/app/api/user/wallet/withdraw/route.ts
+++ b/app/api/user/wallet/withdraw/route.ts
@@ -25,6 +25,7 @@ import {
   type TransactionContext,
   withNonceSession,
 } from "@/lib/web3/transaction-manager";
+import { getUiMultiplier, uiToRaw } from "@/lib/web3/ui-multiplier";
 import {
   getOrganizationWalletAddress,
   initializeWalletSigner,
@@ -270,7 +271,12 @@ export async function POST(request: Request) {
             if (!amount) {
               throw new Error("Missing amount for ERC20 Safe withdraw");
             }
-            safeAmountWei = ethers.parseUnits(amountStr, decimals);
+            // ERC-8056 tokens are shown to the holder in scaled units but
+            // transfer in raw ones. Identity for every ordinary ERC-20.
+            safeAmountWei = uiToRaw(
+              ethers.parseUnits(amountStr, decimals),
+              await getUiMultiplier((op) => op(provider), chainId, tokenAddress)
+            );
           } else if (fromMax) {
             safeAmountWei = await provider.getBalance(safe.safeAddress);
             if (safeAmountWei === BigInt(0)) {
@@ -355,7 +361,10 @@ export async function POST(request: Request) {
           );
           const decimalsResult: bigint = await contract.decimals();
           const decimals = Number(decimalsResult);
-          amountWei = ethers.parseUnits(amountStr, decimals);
+          amountWei = uiToRaw(
+            ethers.parseUnits(amountStr, decimals),
+            await getUiMultiplier((op) => op(provider), chainId, tokenAddress)
+          );
           estimatedGas = await contract.transfer.estimateGas(
             recipientAddr,
             amountWei

--- a/lib/execute/simulate.ts
+++ b/lib/execute/simulate.ts
@@ -18,6 +18,10 @@ import {
   decodeRevertReason,
   extractRevertData,
 } from "@/lib/web3/decode-revert-error";
+import {
+  convertAmountForWrite,
+  resolveForWrite,
+} from "@/lib/web3/ui-multiplier";
 import { getOrganizationWalletAddress } from "@/lib/web3/wallet-helpers";
 import { parseTokenAddress } from "@/plugins/web3/steps/transfer-token-core";
 
@@ -867,6 +871,38 @@ export async function simulateTokenTransfer(
       `Invalid amount for ${decimals} decimals: ${input.amount}`
     );
   }
+
+  // The dry run has to interpret the request exactly as the broadcast will.
+  // /api/execute/transfer routes the same body here on simulate and to
+  // transferTokenCore on send, so an unconverted amount would simulate a
+  // different transaction than the one that gets signed - on an ERC-8056 token,
+  // one several times larger.
+  const multiplier = await resolveForWrite(
+    (op) => rpc.executeWithFailover(op),
+    chainId,
+    resolvedTokenAddress
+  );
+  if (!multiplier.ok) {
+    return failure(
+      from,
+      resolvedTokenAddress,
+      BigInt(0),
+      getErrorMessage(multiplier.error)
+    );
+  }
+  const convertedAmount = convertAmountForWrite(
+    amountUnits,
+    multiplier.multiplier
+  );
+  if (!convertedAmount.ok) {
+    return failure(
+      from,
+      resolvedTokenAddress,
+      BigInt(0),
+      convertedAmount.error
+    );
+  }
+  amountUnits = convertedAmount.raw;
 
   // No ceiling check here: this delegates to simulateContractCall below,
   // which applies it once for both entrances.

--- a/lib/web3/ui-multiplier.ts
+++ b/lib/web3/ui-multiplier.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+import { isNonRetryableError } from "@/lib/rpc/providers/error-classification";
 
 /**
  * ERC-8056 UI multiplier handling.
@@ -7,92 +8,118 @@ import { ethers } from "ethers";
  * returns raw units; `balanceOfUI` returns `raw * uiMultiplier / 1e18`. A
  * corporate action such as a stock split changes the multiplier rather than
  * moving tokens, so the raw balance is untouched and the UI balance is what
- * changes. Robinhood's own app shows the UI number, and it is the one that
- * corresponds to a share count.
+ * changes. Robinhood's own app shows the UI number, and it is the share count.
  *
  * `transfer` and `transferFrom` take RAW units, and the standard has no
  * `transferUI`. So the display path and the mutation path speak different units
- * and nothing on-chain reconciles them. Ignoring the multiplier is therefore
- * wrong in both directions at once: a balance reads low by the multiplier, and
- * an amount the user typed against the number they were shown transfers high by
- * it. On CRWD at 4.0 that is a 4x over-send.
+ * and nothing on-chain reconciles them. Ignoring the multiplier is wrong in both
+ * directions at once: a balance reads low by the multiplier, and an amount typed
+ * against the number the user was shown transfers high by it. On CRWD at 4.0
+ * that is a 4x over-send.
  *
- * UI units are canonical here: reads are converted up, writes are converted
- * down. A plain ERC-20 has a multiplier of exactly UNIT, so every conversion is
- * the identity and no other chain changes behaviour.
+ * UI units are canonical: reads convert up, writes convert down.
+ *
+ * READS AND WRITES DO NOT SHARE A FAILURE MODE, and that distinction is the
+ * whole safety argument of this module. If the multiplier cannot be read, a
+ * balance that renders unscaled is a cosmetic degradation, while a transfer that
+ * proceeds unscaled moves several times the intended amount. So the display
+ * helper falls back and the write helper refuses. Use `resolveForDisplay` for
+ * anything that renders and `resolveForWrite` for anything that signs.
  */
 
 /** Fixed-point scale of `uiMultiplier()`, i.e. a multiplier of 1.0. */
 export const UI_MULTIPLIER_UNIT = BigInt("1000000000000000000");
+
+const ZERO = BigInt(0);
 
 const UI_MULTIPLIER_ABI = [
   "function uiMultiplier() view returns (uint256)",
 ] as const;
 
 /**
- * Cache of resolved multipliers, keyed by `chainId:token`.
+ * How long a successfully read multiplier may be reused when rendering.
  *
- * Negative results are cached too. Most tokens are plain ERC-20s where the call
- * reverts, and without caching the miss every balance read would pay for a
- * failed eth_call. A token that does not implement ERC-8056 cannot start doing
- * so, since that would require new code at the same address.
- *
- * Positive results carry a TTL because `updateMultiplier` is callable by the
- * issuer at any time. Five minutes bounds how long a stale multiplier can be
- * applied while keeping the steady-state cost near zero.
+ * Only the display path consults this. `updateMultiplier` is callable by the
+ * issuer at will, so a write must never build a transaction on a cached value:
+ * the cost of re-reading is one `eth_call` against the transaction it is about
+ * to sign, which is negligible, and the cost of being wrong is the bug this
+ * module exists to prevent.
  */
-const POSITIVE_TTL_MS = 5 * 60 * 1000;
+const DISPLAY_TTL_MS = 5 * 60 * 1000;
 
-type CacheEntry = { multiplier: bigint; fetchedAt: number | null };
+/**
+ * Cap on distinct tokens remembered. The generic transfer node accepts any
+ * address, so this map would otherwise grow without bound in a long-lived
+ * process. Eviction is oldest-inserted-first, which is adequate: the entries
+ * worth keeping are re-read and reinserted.
+ */
+const MAX_CACHE_ENTRIES = 5000;
+
+type CacheEntry = {
+  multiplier: bigint;
+  /** null when the token provably has no such function, so it never expires. */
+  fetchedAt: number | null;
+};
 
 const cache = new Map<string, CacheEntry>();
+/** De-duplicates concurrent first reads of the same token. */
+const inFlight = new Map<string, Promise<CacheEntry | null>>();
 
 /** Exposed for tests; not part of the runtime contract. */
 export function __clearUiMultiplierCache(): void {
   cache.clear();
+  inFlight.clear();
+}
+
+function remember(key: string, entry: CacheEntry): void {
+  if (cache.size >= MAX_CACHE_ENTRIES && !cache.has(key)) {
+    const oldest = cache.keys().next();
+    if (!oldest.done) {
+      cache.delete(oldest.value);
+    }
+  }
+  cache.set(key, entry);
 }
 
 /**
  * How to run one read against a provider.
  *
  * A function rather than the RpcManager itself, because the callers are split:
- * the transfer and approve paths hold an RpcManager and want failover, while
- * the balance readers are handed a single provider already. Both express
- * themselves in one line, and neither has to reach for the other's plumbing.
+ * some hold an RpcManager, others are handed a provider already. Pass a runner
+ * that fails over where one is available; the multiplier read should be no less
+ * reliable than the balance read it accompanies.
  */
 export type ProviderRunner = <T>(
   operation: (provider: ethers.ContractRunner) => Promise<T>
 ) => Promise<T>;
 
-/**
- * Resolve a token's ERC-8056 UI multiplier.
- *
- * Returns `UI_MULTIPLIER_UNIT` for any token that does not implement it, which
- * is every token on every chain other than Robinhood Chain. Detection is the
- * call itself rather than a chain-id allowlist, so nothing here has to be
- * updated when a chain is added, and a chain that later gains such tokens works
- * without a code change.
- *
- * Never throws. A multiplier that cannot be read falls back to UNIT, which
- * preserves today's behaviour rather than failing a transfer that would
- * otherwise succeed.
- */
-export async function getUiMultiplier(
-  run: ProviderRunner,
-  chainId: number,
-  tokenAddress: string
-): Promise<bigint> {
-  const key = `${chainId}:${tokenAddress.toLowerCase()}`;
-  const cached = cache.get(key);
-  if (cached !== undefined) {
-    const fresh =
-      cached.fetchedAt === null ||
-      Date.now() - cached.fetchedAt < POSITIVE_TTL_MS;
-    if (fresh) {
-      return cached.multiplier;
-    }
-  }
+export type MultiplierResult =
+  | { ok: true; multiplier: bigint }
+  | { ok: false; error: unknown };
 
+function cacheKey(chainId: number, tokenAddress: string): string {
+  return `${chainId}:${tokenAddress.toLowerCase()}`;
+}
+
+/**
+ * Read `uiMultiplier()` once and decide what the answer means.
+ *
+ * A non-retryable error (`CALL_EXCEPTION`, or a permanent `BAD_DATA`) means the
+ * function is not there, which is every ordinary ERC-20. That verdict is cached
+ * forever, because a contract cannot start implementing an interface at an
+ * address it already occupies, and it is what keeps the steady-state cost of
+ * this module at zero for non-Robinhood tokens.
+ *
+ * A transport failure -- timeout, rate limit, 5xx, dropped connection -- means
+ * we do not know. It is deliberately NOT cached. Caching it would pin a scaled
+ * token to unit for the lifetime of the process on the strength of one bad
+ * second, silently restoring the over-send this module prevents.
+ */
+async function readMultiplier(
+  run: ProviderRunner,
+  key: string,
+  tokenAddress: string
+): Promise<CacheEntry | null> {
   try {
     const value = await run((provider) => {
       const contract = new ethers.Contract(
@@ -103,22 +130,105 @@ export async function getUiMultiplier(
       return contract.uiMultiplier() as Promise<bigint>;
     });
 
-    // A zero multiplier would silently zero every balance and make uiToRaw
-    // divide by zero. Treat it as "not an ERC-8056 token" rather than trusting
-    // it; no legitimate deployment reports zero.
-    if (value <= BigInt(0)) {
-      cache.set(key, { multiplier: UI_MULTIPLIER_UNIT, fetchedAt: null });
-      return UI_MULTIPLIER_UNIT;
+    // A zero or negative multiplier would zero every balance and make the
+    // write conversion divide by zero. No legitimate deployment reports it;
+    // treat it as "not an ERC-8056 token" rather than trusting it.
+    const entry: CacheEntry =
+      value > ZERO
+        ? { multiplier: value, fetchedAt: Date.now() }
+        : { multiplier: UI_MULTIPLIER_UNIT, fetchedAt: null };
+    remember(key, entry);
+    return entry;
+  } catch (error) {
+    if (isNonRetryableError(error)) {
+      const entry: CacheEntry = {
+        multiplier: UI_MULTIPLIER_UNIT,
+        fetchedAt: null,
+      };
+      remember(key, entry);
+      return entry;
     }
-
-    cache.set(key, { multiplier: value, fetchedAt: Date.now() });
-    return value;
-  } catch {
-    // The call reverting is the ordinary case: a plain ERC-20 has no such
-    // function. Cached without a timestamp so it is never re-attempted.
-    cache.set(key, { multiplier: UI_MULTIPLIER_UNIT, fetchedAt: null });
-    return UI_MULTIPLIER_UNIT;
+    return null;
   }
+}
+
+function readMultiplierDeduped(
+  run: ProviderRunner,
+  key: string,
+  tokenAddress: string
+): Promise<CacheEntry | null> {
+  const pending = inFlight.get(key);
+  if (pending) {
+    return pending;
+  }
+  const promise = readMultiplier(run, key, tokenAddress).finally(() => {
+    inFlight.delete(key);
+  });
+  inFlight.set(key, promise);
+  return promise;
+}
+
+/**
+ * The multiplier to render a balance or allowance with.
+ *
+ * Never throws and never fails. When the multiplier cannot be read, a
+ * previously known value is preferred over unit, because a stale scaled value
+ * is closer to the truth than an unscaled one; unit is the last resort.
+ */
+export async function resolveForDisplay(
+  run: ProviderRunner,
+  chainId: number,
+  tokenAddress: string
+): Promise<bigint> {
+  const key = cacheKey(chainId, tokenAddress);
+  const cached = cache.get(key);
+  if (
+    cached &&
+    (cached.fetchedAt === null ||
+      Date.now() - cached.fetchedAt < DISPLAY_TTL_MS)
+  ) {
+    return cached.multiplier;
+  }
+
+  const entry = await readMultiplierDeduped(run, key, tokenAddress);
+  if (entry) {
+    return entry.multiplier;
+  }
+  // Refresh failed. Keep whatever we last knew rather than downgrading a token
+  // we have already established is scaled.
+  return cached?.multiplier ?? UI_MULTIPLIER_UNIT;
+}
+
+/**
+ * The multiplier to build a transaction with.
+ *
+ * Reports failure instead of guessing. The only cached answer it will accept is
+ * the permanent "this token has no such function" verdict; a positive value is
+ * always re-read, because the issuer can change it between the read and the
+ * signature.
+ */
+export async function resolveForWrite(
+  run: ProviderRunner,
+  chainId: number,
+  tokenAddress: string
+): Promise<MultiplierResult> {
+  const key = cacheKey(chainId, tokenAddress);
+  const cached = cache.get(key);
+  if (cached?.fetchedAt === null) {
+    return { ok: true, multiplier: cached.multiplier };
+  }
+
+  const entry = await readMultiplierDeduped(run, key, tokenAddress);
+  if (entry) {
+    return { ok: true, multiplier: entry.multiplier };
+  }
+  return {
+    ok: false,
+    error: new Error(
+      `Could not read the UI multiplier for ${tokenAddress} on chain ${chainId}. ` +
+        "Refusing to build a transfer that could move the wrong amount."
+    ),
+  };
 }
 
 /** Raw on-chain units to the UI units a holder is shown. */
@@ -134,14 +244,42 @@ export function rawToUi(raw: bigint, multiplier: bigint): bigint {
  *
  * Floors. The division is rarely exact once a multiplier drifts off 1.0 through
  * dividend accrual, and rounding up would move more of the asset than the user
- * asked for. Erring low costs the user a rounding-unit of dust; erring high
- * spends their money.
+ * asked for. Erring low costs a rounding unit of dust; erring high spends their
+ * money.
  */
 export function uiToRaw(ui: bigint, multiplier: bigint): bigint {
   if (multiplier === UI_MULTIPLIER_UNIT) {
     return ui;
   }
   return (ui * UI_MULTIPLIER_UNIT) / multiplier;
+}
+
+export type AmountConversion =
+  | { ok: true; raw: bigint }
+  | { ok: false; error: string };
+
+/**
+ * Convert a typed amount for a transfer or an approval.
+ *
+ * Rejects a non-zero request that floors to zero. `transfer(to, 0)` succeeds
+ * on-chain and moves nothing, and `approve(spender, 0)` is a revocation, so
+ * executing either while reporting the amount the user asked for would be a
+ * silent no-op or a silent revocation.
+ */
+export function convertAmountForWrite(
+  ui: bigint,
+  multiplier: bigint
+): AmountConversion {
+  const raw = uiToRaw(ui, multiplier);
+  if (raw === ZERO && ui > ZERO) {
+    return {
+      ok: false,
+      error:
+        "Amount is too small for this token: it rounds to zero once converted " +
+        "to on-chain units. Use a larger amount.",
+    };
+  }
+  return { ok: true, raw };
 }
 
 /** True when this token scales, i.e. the conversions are not the identity. */

--- a/lib/web3/ui-multiplier.ts
+++ b/lib/web3/ui-multiplier.ts
@@ -1,0 +1,150 @@
+import { ethers } from "ethers";
+
+/**
+ * ERC-8056 UI multiplier handling.
+ *
+ * Robinhood Chain's stock tokens split a holding into two numbers. `balanceOf`
+ * returns raw units; `balanceOfUI` returns `raw * uiMultiplier / 1e18`. A
+ * corporate action such as a stock split changes the multiplier rather than
+ * moving tokens, so the raw balance is untouched and the UI balance is what
+ * changes. Robinhood's own app shows the UI number, and it is the one that
+ * corresponds to a share count.
+ *
+ * `transfer` and `transferFrom` take RAW units, and the standard has no
+ * `transferUI`. So the display path and the mutation path speak different units
+ * and nothing on-chain reconciles them. Ignoring the multiplier is therefore
+ * wrong in both directions at once: a balance reads low by the multiplier, and
+ * an amount the user typed against the number they were shown transfers high by
+ * it. On CRWD at 4.0 that is a 4x over-send.
+ *
+ * UI units are canonical here: reads are converted up, writes are converted
+ * down. A plain ERC-20 has a multiplier of exactly UNIT, so every conversion is
+ * the identity and no other chain changes behaviour.
+ */
+
+/** Fixed-point scale of `uiMultiplier()`, i.e. a multiplier of 1.0. */
+export const UI_MULTIPLIER_UNIT = BigInt("1000000000000000000");
+
+const UI_MULTIPLIER_ABI = [
+  "function uiMultiplier() view returns (uint256)",
+] as const;
+
+/**
+ * Cache of resolved multipliers, keyed by `chainId:token`.
+ *
+ * Negative results are cached too. Most tokens are plain ERC-20s where the call
+ * reverts, and without caching the miss every balance read would pay for a
+ * failed eth_call. A token that does not implement ERC-8056 cannot start doing
+ * so, since that would require new code at the same address.
+ *
+ * Positive results carry a TTL because `updateMultiplier` is callable by the
+ * issuer at any time. Five minutes bounds how long a stale multiplier can be
+ * applied while keeping the steady-state cost near zero.
+ */
+const POSITIVE_TTL_MS = 5 * 60 * 1000;
+
+type CacheEntry = { multiplier: bigint; fetchedAt: number | null };
+
+const cache = new Map<string, CacheEntry>();
+
+/** Exposed for tests; not part of the runtime contract. */
+export function __clearUiMultiplierCache(): void {
+  cache.clear();
+}
+
+/**
+ * How to run one read against a provider.
+ *
+ * A function rather than the RpcManager itself, because the callers are split:
+ * the transfer and approve paths hold an RpcManager and want failover, while
+ * the balance readers are handed a single provider already. Both express
+ * themselves in one line, and neither has to reach for the other's plumbing.
+ */
+export type ProviderRunner = <T>(
+  operation: (provider: ethers.ContractRunner) => Promise<T>
+) => Promise<T>;
+
+/**
+ * Resolve a token's ERC-8056 UI multiplier.
+ *
+ * Returns `UI_MULTIPLIER_UNIT` for any token that does not implement it, which
+ * is every token on every chain other than Robinhood Chain. Detection is the
+ * call itself rather than a chain-id allowlist, so nothing here has to be
+ * updated when a chain is added, and a chain that later gains such tokens works
+ * without a code change.
+ *
+ * Never throws. A multiplier that cannot be read falls back to UNIT, which
+ * preserves today's behaviour rather than failing a transfer that would
+ * otherwise succeed.
+ */
+export async function getUiMultiplier(
+  run: ProviderRunner,
+  chainId: number,
+  tokenAddress: string
+): Promise<bigint> {
+  const key = `${chainId}:${tokenAddress.toLowerCase()}`;
+  const cached = cache.get(key);
+  if (cached !== undefined) {
+    const fresh =
+      cached.fetchedAt === null ||
+      Date.now() - cached.fetchedAt < POSITIVE_TTL_MS;
+    if (fresh) {
+      return cached.multiplier;
+    }
+  }
+
+  try {
+    const value = await run((provider) => {
+      const contract = new ethers.Contract(
+        tokenAddress,
+        UI_MULTIPLIER_ABI,
+        provider
+      );
+      return contract.uiMultiplier() as Promise<bigint>;
+    });
+
+    // A zero multiplier would silently zero every balance and make uiToRaw
+    // divide by zero. Treat it as "not an ERC-8056 token" rather than trusting
+    // it; no legitimate deployment reports zero.
+    if (value <= BigInt(0)) {
+      cache.set(key, { multiplier: UI_MULTIPLIER_UNIT, fetchedAt: null });
+      return UI_MULTIPLIER_UNIT;
+    }
+
+    cache.set(key, { multiplier: value, fetchedAt: Date.now() });
+    return value;
+  } catch {
+    // The call reverting is the ordinary case: a plain ERC-20 has no such
+    // function. Cached without a timestamp so it is never re-attempted.
+    cache.set(key, { multiplier: UI_MULTIPLIER_UNIT, fetchedAt: null });
+    return UI_MULTIPLIER_UNIT;
+  }
+}
+
+/** Raw on-chain units to the UI units a holder is shown. */
+export function rawToUi(raw: bigint, multiplier: bigint): bigint {
+  if (multiplier === UI_MULTIPLIER_UNIT) {
+    return raw;
+  }
+  return (raw * multiplier) / UI_MULTIPLIER_UNIT;
+}
+
+/**
+ * UI units a user typed to the raw units `transfer` expects.
+ *
+ * Floors. The division is rarely exact once a multiplier drifts off 1.0 through
+ * dividend accrual, and rounding up would move more of the asset than the user
+ * asked for. Erring low costs the user a rounding-unit of dust; erring high
+ * spends their money.
+ */
+export function uiToRaw(ui: bigint, multiplier: bigint): bigint {
+  if (multiplier === UI_MULTIPLIER_UNIT) {
+    return ui;
+  }
+  return (ui * UI_MULTIPLIER_UNIT) / multiplier;
+}
+
+/** True when this token scales, i.e. the conversions are not the identity. */
+export function isScaledToken(multiplier: bigint): boolean {
+  return multiplier !== UI_MULTIPLIER_UNIT;
+}

--- a/lib/web3/ui-multiplier.ts
+++ b/lib/web3/ui-multiplier.ts
@@ -25,12 +25,43 @@ import { isNonRetryableError } from "@/lib/rpc/providers/error-classification";
  * proceeds unscaled moves several times the intended amount. So the display
  * helper falls back and the write helper refuses. Use `resolveForDisplay` for
  * anything that renders and `resolveForWrite` for anything that signs.
+ *
+ * Because the write helper refuses, the probe is scoped to chains that can
+ * actually host these tokens. Detecting by call alone would be more general,
+ * but it would also make an extra `eth_call` a hard dependency of every ERC-20
+ * transfer on every chain: a transient RPC failure would block a DAI transfer
+ * on Ethereum, where an ERC-8056 token cannot exist. That trades a real bug on
+ * one chain for an availability regression on all of them. The cost of the
+ * probe belongs where the risk is.
  */
 
 /** Fixed-point scale of `uiMultiplier()`, i.e. a multiplier of 1.0. */
 export const UI_MULTIPLIER_UNIT = BigInt("1000000000000000000");
 
 const ZERO = BigInt(0);
+
+/**
+ * Chains whose tokens may implement ERC-8056.
+ *
+ * Robinhood Chain and its testnet are the only deployments of the standard
+ * today. Everywhere else this module is the identity and costs nothing: no
+ * call, no cache entry, and no new way for a transfer to fail.
+ *
+ * Add a chain here when it gains scaled tokens. Until then, a token on an
+ * unlisted chain is treated as unscaled without being asked, which is what it
+ * is. Kept in code rather than on the chains table for the same reason
+ * SPONSORSHIP_CHAINS and GAS_TOKEN_USD_FEEDS are: it is a property of the
+ * standard's deployment, not of our configuration of the chain.
+ */
+const SCALED_TOKEN_CHAIN_IDS: ReadonlySet<number> = new Set([
+  4663, // Robinhood Chain
+  46_630, // Robinhood Chain Testnet
+]);
+
+/** Whether a token on this chain could carry a UI multiplier at all. */
+export function chainMayScaleTokens(chainId: number): boolean {
+  return SCALED_TOKEN_CHAIN_IDS.has(chainId);
+}
 
 const UI_MULTIPLIER_ABI = [
   "function uiMultiplier() view returns (uint256)",
@@ -180,6 +211,10 @@ export async function resolveForDisplay(
   chainId: number,
   tokenAddress: string
 ): Promise<bigint> {
+  if (!chainMayScaleTokens(chainId)) {
+    return UI_MULTIPLIER_UNIT;
+  }
+
   const key = cacheKey(chainId, tokenAddress);
   const cached = cache.get(key);
   if (
@@ -212,6 +247,10 @@ export async function resolveForWrite(
   chainId: number,
   tokenAddress: string
 ): Promise<MultiplierResult> {
+  if (!chainMayScaleTokens(chainId)) {
+    return { ok: true, multiplier: UI_MULTIPLIER_UNIT };
+  }
+
   const key = cacheKey(chainId, tokenAddress);
   const cached = cache.get(key);
   if (cached?.fetchedAt === null) {

--- a/plugins/web3/steps/approve-token-core.ts
+++ b/plugins/web3/steps/approve-token-core.ts
@@ -53,7 +53,10 @@ import {
   type TransactionContext,
   withNonceSession,
 } from "@/lib/web3/transaction-manager";
-import { getUiMultiplier, uiToRaw } from "@/lib/web3/ui-multiplier";
+import {
+  convertAmountForWrite,
+  resolveForWrite,
+} from "@/lib/web3/ui-multiplier";
 import { parseTokenAddress } from "./transfer-token-core";
 
 export type ApproveTokenCoreInput = {
@@ -326,18 +329,25 @@ export async function approveTokenCore(
         approvedAmountDisplay = "unlimited";
       } else {
         // An allowance is spent by transferFrom in raw units, so an amount the
-        // user expressed in the units they were shown has to be converted down
-        // the same way a transfer is. Identity for every ordinary ERC-20.
-        // "max" is untouched: MaxUint256 is a sentinel, not a quantity.
-        const uiMultiplier = await getUiMultiplier(
+        // user expressed in the units they were shown converts down the same
+        // way a transfer does. Identity for every ordinary ERC-20. "max" never
+        // reaches here: MaxUint256 is a sentinel, not a quantity.
+        const multiplier = await resolveForWrite(
           (op) => rpcManager.executeWithFailover(op),
           chainId,
           tokenAddress
         );
-        amountRaw = uiToRaw(
+        if (!multiplier.ok) {
+          return { success: false, error: getErrorMessage(multiplier.error) };
+        }
+        const converted = convertAmountForWrite(
           ethers.parseUnits(amount, Number(decimals)),
-          uiMultiplier
+          multiplier.multiplier
         );
+        if (!converted.ok) {
+          return { success: false, error: converted.error };
+        }
+        amountRaw = converted.raw;
         approvedAmountDisplay = amount;
       }
 
@@ -489,19 +499,26 @@ export async function approveTokenCore(
         amountRaw = ethers.MaxUint256;
         approvedAmountDisplay = "unlimited";
       } else {
+        const multiplier = await resolveForWrite(
+          (op) => rpcManager.executeWithFailover(op),
+          chainId,
+          tokenAddress
+        );
+        if (!multiplier.ok) {
+          return { success: false, error: getErrorMessage(multiplier.error) };
+        }
         try {
           // Same conversion as the sponsored branch above: an allowance is
           // spent in raw units, so a UI amount converts down. Identity for
           // every ordinary ERC-20.
-          const uiMultiplier = await getUiMultiplier(
-            (op) => rpcManager.executeWithFailover(op),
-            chainId,
-            tokenAddress
-          );
-          amountRaw = uiToRaw(
+          const converted = convertAmountForWrite(
             ethers.parseUnits(amount, decimalsNum),
-            uiMultiplier
+            multiplier.multiplier
           );
+          if (!converted.ok) {
+            return { success: false, error: converted.error };
+          }
+          amountRaw = converted.raw;
           approvedAmountDisplay = amount;
         } catch (error) {
           return {

--- a/plugins/web3/steps/approve-token-core.ts
+++ b/plugins/web3/steps/approve-token-core.ts
@@ -53,6 +53,7 @@ import {
   type TransactionContext,
   withNonceSession,
 } from "@/lib/web3/transaction-manager";
+import { getUiMultiplier, uiToRaw } from "@/lib/web3/ui-multiplier";
 import { parseTokenAddress } from "./transfer-token-core";
 
 export type ApproveTokenCoreInput = {
@@ -324,7 +325,19 @@ export async function approveTokenCore(
         amountRaw = ethers.MaxUint256;
         approvedAmountDisplay = "unlimited";
       } else {
-        amountRaw = ethers.parseUnits(amount, Number(decimals));
+        // An allowance is spent by transferFrom in raw units, so an amount the
+        // user expressed in the units they were shown has to be converted down
+        // the same way a transfer is. Identity for every ordinary ERC-20.
+        // "max" is untouched: MaxUint256 is a sentinel, not a quantity.
+        const uiMultiplier = await getUiMultiplier(
+          (op) => rpcManager.executeWithFailover(op),
+          chainId,
+          tokenAddress
+        );
+        amountRaw = uiToRaw(
+          ethers.parseUnits(amount, Number(decimals)),
+          uiMultiplier
+        );
         approvedAmountDisplay = amount;
       }
 
@@ -477,7 +490,18 @@ export async function approveTokenCore(
         approvedAmountDisplay = "unlimited";
       } else {
         try {
-          amountRaw = ethers.parseUnits(amount, decimalsNum);
+          // Same conversion as the sponsored branch above: an allowance is
+          // spent in raw units, so a UI amount converts down. Identity for
+          // every ordinary ERC-20.
+          const uiMultiplier = await getUiMultiplier(
+            (op) => rpcManager.executeWithFailover(op),
+            chainId,
+            tokenAddress
+          );
+          amountRaw = uiToRaw(
+            ethers.parseUnits(amount, decimalsNum),
+            uiMultiplier
+          );
           approvedAmountDisplay = amount;
         } catch (error) {
           return {

--- a/plugins/web3/steps/check-allowance.ts
+++ b/plugins/web3/steps/check-allowance.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { ethers } from "ethers";
 import ERC20_ABI from "@/lib/contracts/abis/erc20.json";
+import { getUiMultiplier, rawToUi } from "@/lib/web3/ui-multiplier";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
@@ -101,20 +102,26 @@ async function stepHandler(
   const adapter = getChainAdapter(chainId);
 
   try {
-    const [allowanceRaw, decimals, symbol] = await adapter.executeWithFailover(
-      rpcManager,
-      (provider) => {
+    const [allowanceRaw, decimals, symbol, uiMultiplier] =
+      await adapter.executeWithFailover(rpcManager, (provider) => {
         const contract = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
         return Promise.all([
           contract.allowance(ownerAddress, spenderAddress) as Promise<bigint>,
           contract.decimals() as Promise<bigint>,
           contract.symbol() as Promise<string>,
+          getUiMultiplier((op) => op(provider), chainId, tokenAddress),
         ]);
-      }
-    );
+      });
 
     const decimalsNum = Number(decimals);
-    const allowance = ethers.formatUnits(allowanceRaw, decimalsNum);
+    // Reported in the same units the approve step accepts, so a user can
+    // compare what they granted against what is left without converting.
+    // `allowanceRaw` keeps the on-chain value, which is what transferFrom
+    // actually spends.
+    const allowance = ethers.formatUnits(
+      rawToUi(allowanceRaw, uiMultiplier),
+      decimalsNum
+    );
 
     return {
       success: true,

--- a/plugins/web3/steps/check-allowance.ts
+++ b/plugins/web3/steps/check-allowance.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { ethers } from "ethers";
 import ERC20_ABI from "@/lib/contracts/abis/erc20.json";
-import { getUiMultiplier, rawToUi } from "@/lib/web3/ui-multiplier";
+import { rawToUi, resolveForDisplay } from "@/lib/web3/ui-multiplier";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
@@ -102,24 +102,38 @@ async function stepHandler(
   const adapter = getChainAdapter(chainId);
 
   try {
-    const [allowanceRaw, decimals, symbol, uiMultiplier] =
-      await adapter.executeWithFailover(rpcManager, (provider) => {
+    const uiMultiplier = await resolveForDisplay(
+      (op) => adapter.executeWithFailover(rpcManager, op),
+      chainId,
+      tokenAddress
+    );
+
+    const [allowanceRaw, decimals, symbol] = await adapter.executeWithFailover(
+      rpcManager,
+      (provider) => {
         const contract = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
         return Promise.all([
           contract.allowance(ownerAddress, spenderAddress) as Promise<bigint>,
           contract.decimals() as Promise<bigint>,
           contract.symbol() as Promise<string>,
-          getUiMultiplier((op) => op(provider), chainId, tokenAddress),
         ]);
-      });
+      }
+    );
 
     const decimalsNum = Number(decimals);
     // Reported in the same units the approve step accepts, so a user can
     // compare what they granted against what is left without converting.
     // `allowanceRaw` keeps the on-chain value, which is what transferFrom
     // actually spends.
+    //
+    // MaxUint256 is left alone. Approve treats "max" as a sentinel rather than
+    // a quantity, so scaling it here would report a number that is not an
+    // allowance and that no longer equals the value a workflow compares
+    // against when deciding whether to re-approve.
     const allowance = ethers.formatUnits(
-      rawToUi(allowanceRaw, uiMultiplier),
+      allowanceRaw === ethers.MaxUint256
+        ? allowanceRaw
+        : rawToUi(allowanceRaw, uiMultiplier),
       decimalsNum
     );
 

--- a/plugins/web3/steps/check-token-balance.ts
+++ b/plugins/web3/steps/check-token-balance.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { ethers } from "ethers";
 import ERC20_ABI from "@/lib/contracts/abis/erc20.json";
+import { getUiMultiplier, rawToUi } from "@/lib/web3/ui-multiplier";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
@@ -68,19 +69,28 @@ async function fetchStringOrBytes32(
 async function fetchTokenBalance(
   provider: ethers.JsonRpcProvider,
   walletAddress: string,
-  tokenAddress: string
+  tokenAddress: string,
+  chainId: number
 ): Promise<TokenBalanceInfo> {
   const contract = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
 
-  const [balanceRaw, decimals, symbol, name] = await Promise.all([
+  const [balanceRaw, decimals, symbol, name, uiMultiplier] = await Promise.all([
     contract.balanceOf(walletAddress) as Promise<bigint>,
     contract.decimals() as Promise<bigint>,
     fetchStringOrBytes32(provider, tokenAddress, "symbol"),
     fetchStringOrBytes32(provider, tokenAddress, "name"),
+    getUiMultiplier((op) => op(provider), chainId, tokenAddress),
   ]);
 
   const decimalsNum = Number(decimals);
-  const balance = ethers.formatUnits(balanceRaw, decimalsNum);
+  // On an ERC-8056 token the holder is shown the scaled balance, so report
+  // that. `balanceRaw` stays the unscaled on-chain value it has always been:
+  // it is what a transfer moves, and a caller comparing it against an explorer
+  // needs it to keep meaning the same thing.
+  const balance = ethers.formatUnits(
+    rawToUi(balanceRaw, uiMultiplier),
+    decimalsNum
+  );
 
   return {
     balance,
@@ -126,7 +136,8 @@ async function checkEvmTokenBalance(
   try {
     const balance = await adapter.executeWithFailover(
       rpcManager,
-      async (provider) => fetchTokenBalance(provider, address, tokenAddress)
+      async (provider) =>
+        fetchTokenBalance(provider, address, tokenAddress, chainId)
     );
     const addressLink = await adapter.getAddressUrl(address);
 

--- a/plugins/web3/steps/check-token-balance.ts
+++ b/plugins/web3/steps/check-token-balance.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { ethers } from "ethers";
 import ERC20_ABI from "@/lib/contracts/abis/erc20.json";
-import { getUiMultiplier, rawToUi } from "@/lib/web3/ui-multiplier";
+import { rawToUi, resolveForDisplay } from "@/lib/web3/ui-multiplier";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
@@ -70,16 +70,15 @@ async function fetchTokenBalance(
   provider: ethers.JsonRpcProvider,
   walletAddress: string,
   tokenAddress: string,
-  chainId: number
+  uiMultiplier: bigint
 ): Promise<TokenBalanceInfo> {
   const contract = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
 
-  const [balanceRaw, decimals, symbol, name, uiMultiplier] = await Promise.all([
+  const [balanceRaw, decimals, symbol, name] = await Promise.all([
     contract.balanceOf(walletAddress) as Promise<bigint>,
     contract.decimals() as Promise<bigint>,
     fetchStringOrBytes32(provider, tokenAddress, "symbol"),
     fetchStringOrBytes32(provider, tokenAddress, "name"),
-    getUiMultiplier((op) => op(provider), chainId, tokenAddress),
   ]);
 
   const decimalsNum = Number(decimals);
@@ -134,10 +133,19 @@ async function checkEvmTokenBalance(
   const adapter = getChainAdapter(chainId);
 
   try {
+    // Resolved through failover in its own right, rather than pinned to the
+    // single provider the balance read happens to land on. A multiplier read
+    // that quietly failed while the balance succeeded on a retry would report
+    // a scaled token's balance understated, as a success.
+    const uiMultiplier = await resolveForDisplay(
+      (op) => adapter.executeWithFailover(rpcManager, op),
+      chainId,
+      tokenAddress
+    );
     const balance = await adapter.executeWithFailover(
       rpcManager,
       async (provider) =>
-        fetchTokenBalance(provider, address, tokenAddress, chainId)
+        fetchTokenBalance(provider, address, tokenAddress, uiMultiplier)
     );
     const addressLink = await adapter.getAddressUrl(address);
 

--- a/plugins/web3/steps/transfer-token-core.ts
+++ b/plugins/web3/steps/transfer-token-core.ts
@@ -57,7 +57,11 @@ import {
   type TransactionContext,
   withNonceSession,
 } from "@/lib/web3/transaction-manager";
-import { getUiMultiplier, rawToUi, uiToRaw } from "@/lib/web3/ui-multiplier";
+import {
+  convertAmountForWrite,
+  rawToUi,
+  resolveForWrite,
+} from "@/lib/web3/ui-multiplier";
 
 export type TransferTokenCoreInput = {
   network: string;
@@ -443,18 +447,26 @@ export async function transferTokenCore(
           ]);
         }
       );
-      // `amount` is expressed in the units the holder is shown. On an ERC-8056
-      // token those are UI units, which `transfer` does not accept, so convert
-      // down. Identity for every ordinary ERC-20.
-      const uiMultiplier = await getUiMultiplier(
+      // `amount` is in the units the holder is shown. On an ERC-8056 token
+      // those are UI units and `transfer` takes raw ones, so convert down.
+      // Identity for every ordinary ERC-20. Refuses rather than guessing: an
+      // unscaled fallback here would move several times the intended amount.
+      const multiplier = await resolveForWrite(
         (op) => rpcManager.executeWithFailover(op),
         chainId,
         tokenAddress
       );
-      const amountRaw = uiToRaw(
+      if (!multiplier.ok) {
+        return { success: false, error: getErrorMessage(multiplier.error) };
+      }
+      const converted = convertAmountForWrite(
         ethers.parseUnits(amount, Number(decimals)),
-        uiMultiplier
+        multiplier.multiplier
       );
+      if (!converted.ok) {
+        return { success: false, error: converted.error };
+      }
+      const amountRaw = converted.raw;
 
       const sponsoredResult = await executeSponsoredContractTransaction({
         organizationId,
@@ -584,21 +596,33 @@ export async function transferTokenCore(
 
       // `amount` is in the units the holder is shown. On an ERC-8056 token
       // those are UI units and `transfer` takes raw ones, so the typed amount
-      // has to be converted down and the on-chain balance converted up before
-      // the two are compared. Identity for every ordinary ERC-20.
-      const uiMultiplier = await getUiMultiplier(
+      // converts down and the on-chain balance converts up before the two are
+      // compared. Identity for every ordinary ERC-20. Refuses rather than
+      // guessing: an unscaled fallback would move several times the ask.
+      const multiplierResult = await resolveForWrite(
         (op) => rpcManager.executeWithFailover(op),
         chainId,
         tokenAddress
       );
+      if (!multiplierResult.ok) {
+        return {
+          success: false,
+          error: getErrorMessage(multiplierResult.error),
+        };
+      }
+      const uiMultiplier = multiplierResult.multiplier;
 
       // Convert amount to raw units
       let amountRaw: bigint;
       try {
-        amountRaw = uiToRaw(
+        const converted = convertAmountForWrite(
           ethers.parseUnits(amount, decimalsNum),
           uiMultiplier
         );
+        if (!converted.ok) {
+          return { success: false, error: converted.error };
+        }
+        amountRaw = converted.raw;
       } catch (error) {
         return {
           success: false,

--- a/plugins/web3/steps/transfer-token-core.ts
+++ b/plugins/web3/steps/transfer-token-core.ts
@@ -57,6 +57,7 @@ import {
   type TransactionContext,
   withNonceSession,
 } from "@/lib/web3/transaction-manager";
+import { getUiMultiplier, rawToUi, uiToRaw } from "@/lib/web3/ui-multiplier";
 
 export type TransferTokenCoreInput = {
   network: string;
@@ -442,7 +443,18 @@ export async function transferTokenCore(
           ]);
         }
       );
-      const amountRaw = ethers.parseUnits(amount, Number(decimals));
+      // `amount` is expressed in the units the holder is shown. On an ERC-8056
+      // token those are UI units, which `transfer` does not accept, so convert
+      // down. Identity for every ordinary ERC-20.
+      const uiMultiplier = await getUiMultiplier(
+        (op) => rpcManager.executeWithFailover(op),
+        chainId,
+        tokenAddress
+      );
+      const amountRaw = uiToRaw(
+        ethers.parseUnits(amount, Number(decimals)),
+        uiMultiplier
+      );
 
       const sponsoredResult = await executeSponsoredContractTransaction({
         organizationId,
@@ -570,10 +582,23 @@ export async function transferTokenCore(
 
       const decimalsNum = Number(decimals);
 
+      // `amount` is in the units the holder is shown. On an ERC-8056 token
+      // those are UI units and `transfer` takes raw ones, so the typed amount
+      // has to be converted down and the on-chain balance converted up before
+      // the two are compared. Identity for every ordinary ERC-20.
+      const uiMultiplier = await getUiMultiplier(
+        (op) => rpcManager.executeWithFailover(op),
+        chainId,
+        tokenAddress
+      );
+
       // Convert amount to raw units
       let amountRaw: bigint;
       try {
-        amountRaw = ethers.parseUnits(amount, decimalsNum);
+        amountRaw = uiToRaw(
+          ethers.parseUnits(amount, decimalsNum),
+          uiMultiplier
+        );
       } catch (error) {
         return {
           success: false,
@@ -583,7 +608,12 @@ export async function transferTokenCore(
 
       // Check balance before transfer
       if (balance < amountRaw) {
-        const balanceFormatted = ethers.formatUnits(balance, decimalsNum);
+        // Report the shortfall in the same units the caller asked in, or the
+        // message compares a UI figure against a raw one and reads as nonsense.
+        const balanceFormatted = ethers.formatUnits(
+          rawToUi(balance, uiMultiplier),
+          decimalsNum
+        );
         return {
           success: false,
           error: `Insufficient ${symbol} balance. Have: ${balanceFormatted}, Need: ${amount}`,

--- a/tests/unit/ui-multiplier.test.ts
+++ b/tests/unit/ui-multiplier.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mockContract = vi.fn();
+vi.mock("ethers", () => ({
+  ethers: {
+    Contract: class {
+      uiMultiplier: () => Promise<bigint>;
+      constructor(address: string) {
+        this.uiMultiplier = () => mockContract(address);
+      }
+    },
+  },
+}));
+
+import {
+  __clearUiMultiplierCache,
+  getUiMultiplier,
+  isScaledToken,
+  rawToUi,
+  UI_MULTIPLIER_UNIT,
+  uiToRaw,
+} from "@/lib/web3/ui-multiplier";
+
+const CRWD = "0xea72Ecca2d0f6bFA1394DBBCff85b52CD4233931";
+const USDG = "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168";
+const FOUR = BigInt(4) * UI_MULTIPLIER_UNIT;
+
+// Runner that just hands the operation a stub provider.
+const run = <T>(op: (p: never) => Promise<T>): Promise<T> =>
+  op(undefined as never);
+
+beforeEach(() => {
+  __clearUiMultiplierCache();
+  mockContract.mockReset();
+});
+
+describe("conversions", () => {
+  it("is the identity at unit multiplier", () => {
+    expect(rawToUi(BigInt(123), UI_MULTIPLIER_UNIT)).toBe(BigInt(123));
+    expect(uiToRaw(BigInt(123), UI_MULTIPLIER_UNIT)).toBe(BigInt(123));
+    expect(isScaledToken(UI_MULTIPLIER_UNIT)).toBe(false);
+  });
+
+  it("scales a real CRWD position the way the chain reports it", () => {
+    // Measured on chain: balanceOf 7.572731046613574564,
+    // balanceOfUI 30.290924186454298256, exactly 4x.
+    const raw = BigInt("7572731046613574564");
+    expect(rawToUi(raw, FOUR)).toBe(BigInt("30290924186454298256"));
+    expect(isScaledToken(FOUR)).toBe(true);
+  });
+
+  it("converts a typed amount down, not up: the over-send bug", () => {
+    // A user asking for 10 CRWD means 10 of what Robinhood shows them.
+    // Before the fix this passed 10e18 straight to transfer, moving 40.
+    const tenUi = BigInt(10) * UI_MULTIPLIER_UNIT;
+    expect(uiToRaw(tenUi, FOUR)).toBe(BigInt("2500000000000000000")); // 2.5e18
+    expect(rawToUi(uiToRaw(tenUi, FOUR), FOUR)).toBe(tenUi);
+  });
+
+  it("floors rather than rounds up, so a transfer never exceeds the ask", () => {
+    // AAPL's live multiplier, which does not divide evenly.
+    const aapl = BigInt("1000566080061092436");
+    const tenUi = BigInt(10) * UI_MULTIPLIER_UNIT;
+    const raw = uiToRaw(tenUi, aapl);
+    expect(raw).toBeLessThan(tenUi);
+    // Round-tripping never gives back more than was asked for.
+    expect(rawToUi(raw, aapl)).toBeLessThanOrEqual(tenUi);
+  });
+});
+
+describe("getUiMultiplier", () => {
+  it("returns the on-chain multiplier for an ERC-8056 token", async () => {
+    mockContract.mockResolvedValue(FOUR);
+    await expect(getUiMultiplier(run, 4663, CRWD)).resolves.toBe(FOUR);
+  });
+
+  it("falls back to unit when the call reverts, as on a plain ERC-20", async () => {
+    mockContract.mockRejectedValue(new Error("execution reverted"));
+    await expect(getUiMultiplier(run, 4663, USDG)).resolves.toBe(
+      UI_MULTIPLIER_UNIT
+    );
+  });
+
+  it("treats a zero multiplier as not-ERC-8056 rather than zeroing balances", async () => {
+    mockContract.mockResolvedValue(BigInt(0));
+    await expect(getUiMultiplier(run, 4663, CRWD)).resolves.toBe(
+      UI_MULTIPLIER_UNIT
+    );
+  });
+
+  it("caches the revert so a plain ERC-20 pays for one failed call, not one per read", async () => {
+    mockContract.mockRejectedValue(new Error("execution reverted"));
+    await getUiMultiplier(run, 4663, USDG);
+    await getUiMultiplier(run, 4663, USDG);
+    await getUiMultiplier(run, 4663, USDG);
+    expect(mockContract).toHaveBeenCalledTimes(1);
+  });
+
+  it("keys the cache by chain as well as address", async () => {
+    mockContract.mockResolvedValue(FOUR);
+    await getUiMultiplier(run, 4663, CRWD);
+    await getUiMultiplier(run, 1, CRWD);
+    expect(mockContract).toHaveBeenCalledTimes(2);
+  });
+
+  it("never throws, so a multiplier read cannot fail an otherwise valid transfer", async () => {
+    mockContract.mockRejectedValue(new Error("boom"));
+    await expect(getUiMultiplier(run, 4663, CRWD)).resolves.toBe(
+      UI_MULTIPLIER_UNIT
+    );
+  });
+});

--- a/tests/unit/ui-multiplier.test.ts
+++ b/tests/unit/ui-multiplier.test.ts
@@ -14,11 +14,23 @@ vi.mock("ethers", () => ({
   },
 }));
 
+// Mirrors the real classifier: CALL_EXCEPTION means the function is not there,
+// a timeout means we simply could not reach the chain.
+vi.mock("@/lib/rpc/providers/error-classification", () => ({
+  isNonRetryableError: (e: unknown) =>
+    typeof e === "object" &&
+    e !== null &&
+    "code" in e &&
+    (e as { code: string }).code === "CALL_EXCEPTION",
+}));
+
 import {
   __clearUiMultiplierCache,
-  getUiMultiplier,
+  convertAmountForWrite,
   isScaledToken,
   rawToUi,
+  resolveForDisplay,
+  resolveForWrite,
   UI_MULTIPLIER_UNIT,
   uiToRaw,
 } from "@/lib/web3/ui-multiplier";
@@ -27,7 +39,13 @@ const CRWD = "0xea72Ecca2d0f6bFA1394DBBCff85b52CD4233931";
 const USDG = "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168";
 const FOUR = BigInt(4) * UI_MULTIPLIER_UNIT;
 
-// Runner that just hands the operation a stub provider.
+const absent = () =>
+  Object.assign(new Error("missing revert data"), {
+    code: "CALL_EXCEPTION",
+  });
+const transient = () =>
+  Object.assign(new Error("timeout"), { code: "TIMEOUT" });
+
 const run = <T>(op: (p: never) => Promise<T>): Promise<T> =>
   op(undefined as never);
 
@@ -44,71 +62,130 @@ describe("conversions", () => {
   });
 
   it("scales a real CRWD position the way the chain reports it", () => {
-    // Measured on chain: balanceOf 7.572731046613574564,
-    // balanceOfUI 30.290924186454298256, exactly 4x.
-    const raw = BigInt("7572731046613574564");
-    expect(rawToUi(raw, FOUR)).toBe(BigInt("30290924186454298256"));
-    expect(isScaledToken(FOUR)).toBe(true);
+    // Live values: balanceOf 7.572731046613574564, balanceOfUI
+    // 30.290924186454298256, exactly 4x.
+    expect(rawToUi(BigInt("7572731046613574564"), FOUR)).toBe(
+      BigInt("30290924186454298256")
+    );
   });
 
   it("converts a typed amount down, not up: the over-send bug", () => {
-    // A user asking for 10 CRWD means 10 of what Robinhood shows them.
-    // Before the fix this passed 10e18 straight to transfer, moving 40.
     const tenUi = BigInt(10) * UI_MULTIPLIER_UNIT;
-    expect(uiToRaw(tenUi, FOUR)).toBe(BigInt("2500000000000000000")); // 2.5e18
-    expect(rawToUi(uiToRaw(tenUi, FOUR), FOUR)).toBe(tenUi);
+    expect(uiToRaw(tenUi, FOUR)).toBe(BigInt("2500000000000000000"));
   });
 
   it("floors rather than rounds up, so a transfer never exceeds the ask", () => {
-    // AAPL's live multiplier, which does not divide evenly.
-    const aapl = BigInt("1000566080061092436");
+    const aapl = BigInt("1000566080061092436"); // AAPL's live multiplier
     const tenUi = BigInt(10) * UI_MULTIPLIER_UNIT;
     const raw = uiToRaw(tenUi, aapl);
     expect(raw).toBeLessThan(tenUi);
-    // Round-tripping never gives back more than was asked for.
     expect(rawToUi(raw, aapl)).toBeLessThanOrEqual(tenUi);
   });
 });
 
-describe("getUiMultiplier", () => {
-  it("returns the on-chain multiplier for an ERC-8056 token", async () => {
+describe("convertAmountForWrite", () => {
+  it("rejects a non-zero amount that floors to zero", () => {
+    // transfer(to, 0) succeeds and moves nothing; approve(spender, 0) is a
+    // revocation. Either would be reported as the amount the user asked for.
+    const result = convertAmountForWrite(BigInt(3), FOUR);
+    expect(result.ok).toBe(false);
+  });
+
+  it("allows a genuine zero through", () => {
+    const result = convertAmountForWrite(BigInt(0), FOUR);
+    expect(result).toEqual({ ok: true, raw: BigInt(0) });
+  });
+});
+
+describe("resolveForDisplay", () => {
+  it("returns the on-chain multiplier", async () => {
     mockContract.mockResolvedValue(FOUR);
-    await expect(getUiMultiplier(run, 4663, CRWD)).resolves.toBe(FOUR);
+    await expect(resolveForDisplay(run, 4663, CRWD)).resolves.toBe(FOUR);
   });
 
-  it("falls back to unit when the call reverts, as on a plain ERC-20", async () => {
-    mockContract.mockRejectedValue(new Error("execution reverted"));
-    await expect(getUiMultiplier(run, 4663, USDG)).resolves.toBe(
+  it("falls back to unit for a plain ERC-20", async () => {
+    mockContract.mockRejectedValue(absent());
+    await expect(resolveForDisplay(run, 4663, USDG)).resolves.toBe(
       UI_MULTIPLIER_UNIT
     );
   });
 
-  it("treats a zero multiplier as not-ERC-8056 rather than zeroing balances", async () => {
-    mockContract.mockResolvedValue(BigInt(0));
-    await expect(getUiMultiplier(run, 4663, CRWD)).resolves.toBe(
-      UI_MULTIPLIER_UNIT
-    );
+  it("keeps a known multiplier when a later refresh fails", async () => {
+    vi.useFakeTimers();
+    try {
+      mockContract.mockResolvedValueOnce(FOUR);
+      await resolveForDisplay(run, 4663, CRWD);
+      expect(mockContract).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(10 * 60 * 1000);
+      mockContract.mockRejectedValue(transient());
+
+      // The refresh must actually be attempted, or this asserts nothing.
+      await expect(resolveForDisplay(run, 4663, CRWD)).resolves.toBe(FOUR);
+      expect(mockContract).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
-  it("caches the revert so a plain ERC-20 pays for one failed call, not one per read", async () => {
-    mockContract.mockRejectedValue(new Error("execution reverted"));
-    await getUiMultiplier(run, 4663, USDG);
-    await getUiMultiplier(run, 4663, USDG);
-    await getUiMultiplier(run, 4663, USDG);
+  it("caches the absent verdict so a plain ERC-20 pays once", async () => {
+    mockContract.mockRejectedValue(absent());
+    await resolveForDisplay(run, 4663, USDG);
+    await resolveForDisplay(run, 4663, USDG);
     expect(mockContract).toHaveBeenCalledTimes(1);
   });
 
-  it("keys the cache by chain as well as address", async () => {
+  it("does NOT cache a transient failure", async () => {
+    mockContract.mockRejectedValueOnce(transient());
+    await expect(resolveForDisplay(run, 4663, CRWD)).resolves.toBe(
+      UI_MULTIPLIER_UNIT
+    );
+    // A five-second blip must not pin the token to unit for the process.
     mockContract.mockResolvedValue(FOUR);
-    await getUiMultiplier(run, 4663, CRWD);
-    await getUiMultiplier(run, 1, CRWD);
+    await expect(resolveForDisplay(run, 4663, CRWD)).resolves.toBe(FOUR);
+  });
+
+  it("de-duplicates concurrent first reads", async () => {
+    mockContract.mockResolvedValue(FOUR);
+    await Promise.all([
+      resolveForDisplay(run, 4663, CRWD),
+      resolveForDisplay(run, 4663, CRWD),
+      resolveForDisplay(run, 4663, CRWD),
+    ]);
+    expect(mockContract).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("resolveForWrite", () => {
+  it("refuses when the multiplier cannot be read", async () => {
+    mockContract.mockRejectedValue(transient());
+    const result = await resolveForWrite(run, 4663, CRWD);
+    // Falling back to unit here would move 4x the intended amount.
+    expect(result.ok).toBe(false);
+  });
+
+  it("accepts the permanent absent verdict without a call", async () => {
+    mockContract.mockRejectedValue(absent());
+    await resolveForWrite(run, 4663, USDG);
+    const second = await resolveForWrite(run, 4663, USDG);
+    expect(second).toEqual({ ok: true, multiplier: UI_MULTIPLIER_UNIT });
+    expect(mockContract).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-reads a positive multiplier rather than trusting the cache", async () => {
+    mockContract.mockResolvedValue(FOUR);
+    await resolveForWrite(run, 4663, CRWD);
+    await resolveForWrite(run, 4663, CRWD);
+    // updateMultiplier is callable at will, so a signature must not be built
+    // on a value cached for a display.
     expect(mockContract).toHaveBeenCalledTimes(2);
   });
 
-  it("never throws, so a multiplier read cannot fail an otherwise valid transfer", async () => {
-    mockContract.mockRejectedValue(new Error("boom"));
-    await expect(getUiMultiplier(run, 4663, CRWD)).resolves.toBe(
-      UI_MULTIPLIER_UNIT
-    );
+  it("treats a zero multiplier as absent rather than dividing by zero", async () => {
+    mockContract.mockResolvedValue(BigInt(0));
+    await expect(resolveForWrite(run, 4663, CRWD)).resolves.toEqual({
+      ok: true,
+      multiplier: UI_MULTIPLIER_UNIT,
+    });
   });
 });

--- a/tests/unit/ui-multiplier.test.ts
+++ b/tests/unit/ui-multiplier.test.ts
@@ -26,6 +26,7 @@ vi.mock("@/lib/rpc/providers/error-classification", () => ({
 
 import {
   __clearUiMultiplierCache,
+  chainMayScaleTokens,
   convertAmountForWrite,
   isScaledToken,
   rawToUi,
@@ -37,6 +38,7 @@ import {
 
 const CRWD = "0xea72Ecca2d0f6bFA1394DBBCff85b52CD4233931";
 const USDG = "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168";
+const DAI = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
 const FOUR = BigInt(4) * UI_MULTIPLIER_UNIT;
 
 const absent = () =>
@@ -187,5 +189,33 @@ describe("resolveForWrite", () => {
       ok: true,
       multiplier: UI_MULTIPLIER_UNIT,
     });
+  });
+});
+
+describe("chain scoping", () => {
+  it("knows which chains can host the standard", () => {
+    expect(chainMayScaleTokens(4663)).toBe(true);
+    expect(chainMayScaleTokens(46_630)).toBe(true);
+    expect(chainMayScaleTokens(1)).toBe(false);
+    expect(chainMayScaleTokens(8453)).toBe(false);
+  });
+
+  it("never probes a chain that cannot host one", async () => {
+    mockContract.mockRejectedValue(transient());
+    await expect(resolveForDisplay(run, 1, DAI)).resolves.toBe(
+      UI_MULTIPLIER_UNIT
+    );
+    expect(mockContract).not.toHaveBeenCalled();
+  });
+
+  it("does not refuse a write on a chain that cannot host one", async () => {
+    // The whole point of the scoping: a transient RPC failure must not block a
+    // DAI transfer on Ethereum, where an ERC-8056 token cannot exist.
+    mockContract.mockRejectedValue(transient());
+    await expect(resolveForWrite(run, 1, DAI)).resolves.toEqual({
+      ok: true,
+      multiplier: UI_MULTIPLIER_UNIT,
+    });
+    expect(mockContract).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Robinhood Chain's stock tokens are ERC-8056. `balanceOf` returns raw units; `balanceOfUI` returns `raw * uiMultiplier / 1e18`. A corporate action changes the multiplier rather than moving tokens, so the UI number is the share count, and it is what Robinhood's own app shows.

`transfer` and `transferFrom` take **raw** units, and the verified `Stock.sol` ABI has no `transferUI`. The display path and the mutation path therefore speak different units and nothing on-chain reconciles them. We ignored the multiplier entirely, which is wrong in both directions at once.

Measured on CRWD (multiplier 4.0) against its largest holder:

```
balanceOf()      7.572731    what we displayed
balanceOfUI()   30.290924    what Robinhood displays
```

- **Reads understated by 4x.** A 30.29 position read as 7.57.
- **Writes over-sent by 4x.** A user asking to move "10 CRWD", meaning the number they had been shown, got `parseUnits("10", 18)` passed to `transfer`, which moves **40 CRWD** in those units.

The second is the serious one. Silently sending four times the intended amount is fund-loss-class, and it is reachable today on the generic transfer node by pasting a stock-token address, with or without any Robinhood plugin.

## Approach

UI units are canonical: reads convert up, writes convert down.

`lib/web3/ui-multiplier.ts` resolves the multiplier by calling `uiMultiplier()` and falling back to unit when it reverts, which is every ordinary ERC-20 on every chain. **Detection is the call, not a chain-id allowlist**, so no chain has to be enumerated here and a chain that later gains such tokens works without a code change. USDG reverts, so the chain's own settlement asset takes the fallback path.

Caching is per chain and token. Negatives are cached permanently, since a token cannot start implementing an interface at the same address; positives carry a five-minute TTL because `updateMultiplier` is callable by the issuer at will. Steady state is one extra `eth_call` per token, once.

`uiToRaw` floors. The division is rarely exact once a multiplier drifts off 1.0 through dividend accrual, and rounding up would move more than was asked for. Erring low costs a rounding unit of dust; erring high spends the user's money.

## Converted

| Direction | Site |
| -- | -- |
| UI to raw | `transfer-token-core`, both the sponsored and direct paths |
| UI to raw | `approve-token-core`, both paths. An allowance is spent by `transferFrom` in raw units, so it needs the same conversion. `"max"` is left alone: `MaxUint256` is a sentinel, not a quantity |
| UI to raw | the withdraw route, Safe and EOA branches |
| raw to UI | `check-token-balance`, and `transfer-token-core`'s balance comparison plus its insufficient-balance message, which otherwise compared a UI figure against a raw one |
| raw to UI | `check-allowance` |

`balanceRaw` and `allowanceRaw` keep reporting the unscaled on-chain values. They are what a transfer actually moves, and a caller reconciling against an explorer needs them to keep meaning the same thing.

## Why this cannot be solved by listing tokens

Eight of the 194 tokens on 4663 carry a non-unit multiplier today: CRWD at 4.0, and AAPL, ASML, COST, DELL, MU, ORCL and SGOV drifting on dividend accrual. `updateMultiplier` is callable at any time, so a token that is unit today can stop being one without a redeploy. Any curated list is a moving target.

## Deliberately not covered

The wallet balances route iterates seeded `supported_tokens` only, and no stock token is seeded, so it cannot reach one. Adding a multiplier read there would put an extra RPC round-trip per token onto an endpoint that already reads them sequentially, for no reachable benefit.

A scheduled multiplier change (`newUIMultiplier` + `effectiveAt`) is also out of scope. A transfer built against multiplier M that lands after a change to M' moves the wrong quantity. A guard that refuses when `effectiveAt` is imminent is worth having and is a separate change.

## Verification

- 10 new unit tests. The CRWD figures are the live on-chain values, and the flooring case uses AAPL's real multiplier (`1.000566080061092436`) rather than a synthetic one that divides evenly.
- `tsc --noEmit`: zero errors in every changed file.
- `biome check`: clean.

Three existing test files (`transfer-token-core`, `approve-token`, `check-allowance`) fail at import on a missing `bs58` in my local environment. They fail identically on an unmodified checkout, so that is environmental rather than a regression; CI is the arbiter.
