### PR TITLE
feat: read-only stock-token actions for Robinhood Chain

### DIFF
--- a/lib/types/integration.ts
+++ b/lib/types/integration.ts
@@ -9,7 +9,7 @@
  * 2. Add a system integration to SYSTEM_INTEGRATION_TYPES in discover-plugins.ts
  * 3. Run: pnpm discover-plugins
  *
- * Generated types: aave-v3, aave-v4, aerodrome, ai-gateway, ajna, blockscout, chainlink, chronicle, clerk, code, compound, cowswap, curve, database, discord, ethena, frax-ether-v2, hyperliquid, lido, linear, math, morpho, pendle, protocol, resend, rocket-pool, safe, sendgrid, sky, slack, spark, superfluid, telegram, tempo, uniswap, v0, web3, webflow, webhook, wrapped, yearn
+ * Generated types: aave-v3, aave-v4, aerodrome, ai-gateway, ajna, blockscout, chainlink, chronicle, clerk, code, compound, cowswap, curve, database, discord, ethena, frax-ether-v2, hyperliquid, lido, linear, math, morpho, pendle, protocol, resend, robinhood, rocket-pool, safe, sendgrid, sky, slack, spark, superfluid, telegram, tempo, uniswap, v0, web3, webflow, webhook, wrapped, yearn
  */
 
 // Integration type union - plugins + system integrations
@@ -39,6 +39,7 @@ export type IntegrationType =
   | "pendle"
   | "protocol"
   | "resend"
+  | "robinhood"
   | "rocket-pool"
   | "safe"
   | "sendgrid"

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -13,7 +13,7 @@
  * 1. Delete the plugin directory
  * 2. Run: pnpm discover-plugins (or it runs automatically on build)
  *
- * Discovered plugins: blockscout, code, discord, hyperliquid, math, protocol, safe, sendgrid, slack, telegram, tempo, web3, webhook
+ * Discovered plugins: blockscout, code, discord, hyperliquid, math, protocol, robinhood, safe, sendgrid, slack, telegram, tempo, web3, webhook
  */
 
 import "./blockscout";
@@ -22,6 +22,7 @@ import "./discord";
 import "./hyperliquid";
 import "./math";
 import "./protocol";
+import "./robinhood";
 import "./safe";
 import "./sendgrid";
 import "./slack";

--- a/plugins/plugin-allowlist.json
+++ b/plugins/plugin-allowlist.json
@@ -8,6 +8,7 @@
     "hyperliquid",
     "math",
     "protocol",
+    "robinhood",
     "safe",
     "sendgrid",
     "slack",

--- a/plugins/robinhood/icon.tsx
+++ b/plugins/robinhood/icon.tsx
@@ -1,0 +1,29 @@
+export function RobinhoodIcon({
+  className,
+  style,
+}: {
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      height="148"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.25"
+      style={style}
+      viewBox="0 0 24 24"
+      width="148"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title>Robinhood Chain</title>
+      {/* A price line over a baseline: a quoted instrument, not a coin. */}
+      <path d="M3 20h18" />
+      <path d="M4 16l4.5-5 3.5 3.5L20 6" />
+      <path d="M15.5 6H20v4.5" />
+    </svg>
+  );
+}

--- a/plugins/robinhood/index.ts
+++ b/plugins/robinhood/index.ts
@@ -32,8 +32,9 @@ const symbolField = {
   type: "template-input" as const,
   placeholder: "AAPL or {{NodeName.symbol}}",
   example: "AAPL",
-  helpText:
-    "The equity ticker. Resolved to a contract address through the issuer's asset registry, which is the only authority on which address is which equity: a symbol search on the chain explorer returns many lookalikes, several with more holders than the real token.",
+  // No helpText: it exists only on IntegrationPlugin.formFields, not on an
+  // action config field, and nothing renders it. The guidance it carried is in
+  // each action's description instead, where it does reach the user.
   required: true,
 };
 
@@ -55,7 +56,7 @@ const robinhoodPlugin: IntegrationPlugin = {
       slug: "get-stock-price",
       label: "Get Stock Token Price",
       description:
-        "Quote a stock token. Returns the issuer's bid and ask for the underlying equity alongside the Chainlink token price where a feed exists, each with its own age, rather than reconciling them into one number",
+        "Quote a stock token by ticker, resolved through the issuer's asset registry rather than an address you paste: a symbol search on the chain explorer returns many lookalikes, several with more holders than the real token. Returns the issuer bid and ask for the underlying equity alongside the Chainlink token price where a feed exists, each with its own age, rather than reconciling them into one number",
       category: "Robinhood",
       stepFunction: "getStockPriceStep",
       stepImportPath: "get-stock-price",
@@ -63,7 +64,17 @@ const robinhoodPlugin: IntegrationPlugin = {
       outputFields: [
         { field: "success", description: "Whether the read succeeded" },
         { field: "symbol", description: "The resolved ticker" },
+        { field: "name", description: "The asset's display name" },
         { field: "tokenAddress", description: "Token contract on chain 4663" },
+        { field: "currency", description: "Currency of bid and ask" },
+        {
+          field: "quoteGeneratedAt",
+          description: "When the issuer produced the quote",
+        },
+        {
+          field: "feedUpdatedAt",
+          description: "When Chainlink last updated, null when there is no feed",
+        },
         {
           field: "bid",
           description:
@@ -127,6 +138,12 @@ const robinhoodPlugin: IntegrationPlugin = {
       outputFields: [
         { field: "success", description: "Whether the read succeeded" },
         { field: "symbol", description: "The resolved ticker" },
+        { field: "tokenAddress", description: "Token contract on chain 4663" },
+        { field: "address", description: "The holder that was read" },
+        {
+          field: "quoteAgeSeconds",
+          description: "Age of the quote behind valueAtBid, null when absent",
+        },
         {
           field: "shares",
           description:
@@ -172,7 +189,17 @@ const robinhoodPlugin: IntegrationPlugin = {
             "Every reason tradeable is false, so a workflow can branch on cause rather than re-deriving it",
         },
         { field: "isTradingHalt", description: "Issuer-reported trading halt" },
-        { field: "quoteAgeSeconds", description: "Age of the issuer quote" },
+        { field: "paused", description: "On-chain global pause flag" },
+        { field: "tokenPaused", description: "On-chain transfer pause flag" },
+        { field: "oraclePaused", description: "On-chain oracle pause flag" },
+        {
+          field: "quoteAgeSeconds",
+          description: "Age of the issuer quote, null when it carried no timestamp",
+        },
+        {
+          field: "feedAgeSeconds",
+          description: "Age of the Chainlink answer, null when there is no feed",
+        },
         {
           field: "feedBeyondHeartbeat",
           description: "Whether the Chainlink feed is past its own heartbeat",

--- a/plugins/robinhood/index.ts
+++ b/plugins/robinhood/index.ts
@@ -1,0 +1,197 @@
+import { registerIntegration } from "@/plugins/registry-core";
+import type { IntegrationPlugin } from "@/plugins/registry";
+import { RobinhoodIcon } from "./icon";
+
+/**
+ * Robinhood Chain stock tokens.
+ *
+ * Read-only. These actions exist because the assets are tokenised equities
+ * rather than tokens, and the generic web3 actions cannot express that: a
+ * balance rescales without a transfer, a price has two conventions that are not
+ * interchangeable, and the market behind the asset closes while the chain does
+ * not.
+ *
+ * The registry lists deployments on 4663 only, so every network picker here is
+ * pinned to it. The testnet has no stock tokens.
+ */
+const ROBINHOOD_CHAIN_IDS = ["4663"];
+
+const networkField = {
+  key: "network",
+  label: "Network",
+  type: "chain-select" as const,
+  chainTypeFilter: "evm" as const,
+  allowedChainIds: ROBINHOOD_CHAIN_IDS,
+  placeholder: "Robinhood Chain",
+  required: true,
+};
+
+const symbolField = {
+  key: "symbol",
+  label: "Ticker",
+  type: "template-input" as const,
+  placeholder: "AAPL or {{NodeName.symbol}}",
+  example: "AAPL",
+  helpText:
+    "The equity ticker. Resolved to a contract address through the issuer's asset registry, which is the only authority on which address is which equity: a symbol search on the chain explorer returns many lookalikes, several with more holders than the real token.",
+  required: true,
+};
+
+const robinhoodPlugin: IntegrationPlugin = {
+  type: "robinhood",
+  egress: "fixed-host",
+  label: "Robinhood Stock Tokens",
+  description:
+    "Read prices, positions and trading status for the tokenised equities on Robinhood Chain, in share terms rather than raw token units",
+
+  icon: RobinhoodIcon,
+
+  requiresCredentials: false,
+  singleConnection: false,
+  formFields: [],
+
+  actions: [
+    {
+      slug: "get-stock-price",
+      label: "Get Stock Token Price",
+      description:
+        "Quote a stock token. Returns the issuer's bid and ask for the underlying equity alongside the Chainlink token price where a feed exists, each with its own age, rather than reconciling them into one number",
+      category: "Robinhood",
+      stepFunction: "getStockPriceStep",
+      stepImportPath: "get-stock-price",
+      configFields: [networkField, symbolField],
+      outputFields: [
+        { field: "success", description: "Whether the read succeeded" },
+        { field: "symbol", description: "The resolved ticker" },
+        { field: "tokenAddress", description: "Token contract on chain 4663" },
+        {
+          field: "bid",
+          description:
+            "Issuer bid for the underlying equity. Not multiplier adjusted",
+        },
+        {
+          field: "ask",
+          description:
+            "Issuer ask for the underlying equity. Not multiplier adjusted",
+        },
+        {
+          field: "quoteAgeSeconds",
+          description:
+            "Age of the issuer quote. Grows without bound while the market is closed",
+        },
+        {
+          field: "feedPrice",
+          description:
+            "Chainlink token price, multiplier already applied. Null for the majority of tickers, which have no feed",
+        },
+        {
+          field: "feedAgeSeconds",
+          description: "Age of the Chainlink answer, null when there is no feed",
+        },
+        {
+          field: "feedBeyondHeartbeat",
+          description:
+            "Whether the feed is older than its own published heartbeat, which is the only meaningful staleness test for it",
+        },
+        {
+          field: "uiMultiplier",
+          description:
+            "The token's scaling factor, which is the difference between the two price conventions",
+        },
+        { field: "isTradingHalt", description: "Issuer-reported trading halt" },
+        { field: "oraclePaused", description: "On-chain oracle pause flag" },
+        { field: "tokenPaused", description: "On-chain transfer pause flag" },
+        { field: "paused", description: "On-chain global pause flag" },
+        { field: "error", description: "Error message when the read failed" },
+      ],
+    },
+    {
+      slug: "get-stock-position",
+      label: "Get Stock Token Position",
+      description:
+        "Read a holder's position in share terms and in raw on-chain units side by side. Reading balanceOf alone understates a position by the multiplier on any token that has been through a corporate action",
+      category: "Robinhood",
+      stepFunction: "getStockPositionStep",
+      stepImportPath: "get-stock-position",
+      configFields: [
+        networkField,
+        symbolField,
+        {
+          key: "address",
+          label: "Holder Address",
+          type: "template-input" as const,
+          placeholder: "0x... or {{NodeName.address}}",
+          required: true,
+        },
+      ],
+      outputFields: [
+        { field: "success", description: "Whether the read succeeded" },
+        { field: "symbol", description: "The resolved ticker" },
+        {
+          field: "shares",
+          description:
+            "Share count. What the holder is shown and what the position is worth. Act on this",
+        },
+        {
+          field: "rawBalance",
+          description:
+            "Unscaled on-chain balance. What transfer moves and what a block explorer shows",
+        },
+        {
+          field: "uiMultiplier",
+          description: "The factor between shares and rawBalance",
+        },
+        {
+          field: "valueAtBid",
+          description:
+            "shares multiplied by the issuer bid, null when no quote was available",
+        },
+        { field: "currency", description: "Currency of valueAtBid" },
+        { field: "error", description: "Error message when the read failed" },
+      ],
+    },
+    {
+      slug: "stock-market-status",
+      label: "Stock Market Status",
+      description:
+        "Guard for price-reactive workflows. Reports whether acting on this token's price is currently sane, and names every reason it is not: halts, the three pause flags, stale quotes, feeds beyond their heartbeat, and pending corporate actions",
+      category: "Robinhood",
+      stepFunction: "stockMarketStatusStep",
+      stepImportPath: "stock-market-status",
+      configFields: [networkField, symbolField],
+      outputFields: [
+        { field: "success", description: "Whether the read succeeded" },
+        {
+          field: "tradeable",
+          description:
+            "True when nothing blocks acting on this token's price. Branch on this",
+        },
+        {
+          field: "blockedBy",
+          description:
+            "Every reason tradeable is false, so a workflow can branch on cause rather than re-deriving it",
+        },
+        { field: "isTradingHalt", description: "Issuer-reported trading halt" },
+        { field: "quoteAgeSeconds", description: "Age of the issuer quote" },
+        {
+          field: "feedBeyondHeartbeat",
+          description: "Whether the Chainlink feed is past its own heartbeat",
+        },
+        {
+          field: "pendingMultiplier",
+          description:
+            "Scheduled multiplier when a corporate action is pending, which gives advance warning before a split lands",
+        },
+        {
+          field: "pendingEffectiveAt",
+          description: "When a pending corporate action takes effect",
+        },
+        { field: "error", description: "Error message when the read failed" },
+      ],
+    },
+  ],
+};
+
+registerIntegration(robinhoodPlugin);
+
+export default robinhoodPlugin;

--- a/plugins/robinhood/steps/get-stock-position.ts
+++ b/plugins/robinhood/steps/get-stock-position.ts
@@ -87,10 +87,16 @@ async function stepHandler(
     let quoteAgeSeconds: number | null = null;
     try {
       const quote = await fetchQuote(token.symbol);
-      const bid = Number(quote.bid);
-      const shares = Number(position.ui);
-      if (Number.isFinite(bid) && Number.isFinite(shares)) {
-        valueAtBid = (bid * shares).toFixed(2);
+      // Fixed point, not float. `shares` carries up to 18 decimals and a double
+      // loses the tail of a large position, in a monetary figure a workflow may
+      // branch on. Both sides are scaled to integers before multiplying.
+      const CENTS = BigInt(100);
+      const bidCents = ethers.parseUnits(quote.bid || "0", 2);
+      const sharesUnits = ethers.parseUnits(position.ui, token.decimals);
+      if (bidCents > BigInt(0)) {
+        const scale = BigInt(10) ** BigInt(token.decimals);
+        const cents = (bidCents * sharesUnits) / scale;
+        valueAtBid = `${cents / CENTS}.${String(cents % CENTS).padStart(2, "0")}`;
         currency = quote.currency;
         quoteAgeSeconds = quote.quoteAgeSeconds;
       }

--- a/plugins/robinhood/steps/get-stock-position.ts
+++ b/plugins/robinhood/steps/get-stock-position.ts
@@ -1,0 +1,145 @@
+import "server-only";
+
+import { ethers } from "ethers";
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { getErrorMessage } from "@/lib/utils";
+import {
+  runPluginStep,
+  type StepInput,
+} from "@/lib/workflow/executor/step-handler";
+import {
+  fetchQuote,
+  readPosition,
+  resolveStockToken,
+  ROBINHOOD_CHAIN_ID,
+} from "./stock-token-core";
+
+export type GetStockPositionInput = StepInput & {
+  network: string;
+  symbol: string;
+  address: string;
+};
+
+type GetStockPositionResult =
+  | {
+      success: true;
+      symbol: string;
+      tokenAddress: string;
+      address: string;
+      /**
+       * Share count, which is what Robinhood shows the holder and what the
+       * position is worth. This is the number to act on.
+       */
+      shares: string;
+      /**
+       * Unscaled on-chain balance. This is what `transfer` moves and what a
+       * block explorer displays, and it differs from `shares` by the
+       * multiplier whenever a corporate action has been applied.
+       */
+      rawBalance: string;
+      uiMultiplier: string;
+      /** shares * bid, in the quote currency. Null if no quote was available. */
+      valueAtBid: string | null;
+      currency: string | null;
+      quoteAgeSeconds: number | null;
+    }
+  | { success: false; error: string };
+
+async function stepHandler(
+  input: GetStockPositionInput
+): Promise<GetStockPositionResult> {
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(input.network);
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  if (chainId !== ROBINHOOD_CHAIN_ID) {
+    return {
+      success: false,
+      error: "Stock tokens exist only on Robinhood Chain (4663).",
+    };
+  }
+
+  if (!ethers.isAddress(input.address)) {
+    return { success: false, error: `Invalid address: ${input.address}` };
+  }
+
+  const resolved = await resolveStockToken(input.symbol);
+  if (!resolved.ok) {
+    return { success: false, error: resolved.error };
+  }
+  const { token } = resolved;
+
+  try {
+    const rpcManager = await getRpcProvider({ chainId });
+    const position = await rpcManager.executeWithFailover((provider) =>
+      readPosition(provider, token, input.address)
+    );
+
+    // A missing quote should not fail a balance read: the position is a fact
+    // about the chain, the valuation is a convenience.
+    let valueAtBid: string | null = null;
+    let currency: string | null = null;
+    let quoteAgeSeconds: number | null = null;
+    try {
+      const quote = await fetchQuote(token.symbol);
+      const bid = Number(quote.bid);
+      const shares = Number(position.ui);
+      if (Number.isFinite(bid) && Number.isFinite(shares)) {
+        valueAtBid = (bid * shares).toFixed(2);
+        currency = quote.currency;
+        quoteAgeSeconds = quote.quoteAgeSeconds;
+      }
+    } catch {
+      // Reported as nulls below rather than failing the step.
+    }
+
+    return {
+      success: true,
+      symbol: token.symbol,
+      tokenAddress: token.address,
+      address: input.address,
+      shares: position.ui,
+      rawBalance: position.raw,
+      uiMultiplier: position.uiMultiplier,
+      valueAtBid,
+      currency,
+      quoteAgeSeconds,
+    };
+  } catch (error) {
+    logUserError(
+      ErrorCategory.NETWORK_RPC,
+      "[Get Stock Position] Failed to read position",
+      error,
+      { plugin_name: "robinhood", action_name: "get-stock-position" }
+    );
+    return { success: false, error: getErrorMessage(error) };
+  }
+}
+
+/**
+ * Get Stock Token Position
+ *
+ * Reports the share count and the raw on-chain balance side by side. Reading
+ * `balanceOf` alone understates a position by the multiplier on any token that
+ * has been through a corporate action, silently and with no error.
+ */
+export async function getStockPositionStep(
+  input: GetStockPositionInput
+): Promise<GetStockPositionResult> {
+  "use step";
+
+  return runPluginStep(
+    { pluginName: "robinhood", actionName: "get-stock-position" },
+    input,
+    stepHandler
+  );
+}
+
+getStockPositionStep.maxRetries = 0;
+
+export const _integrationType = "robinhood";

--- a/plugins/robinhood/steps/get-stock-price.ts
+++ b/plugins/robinhood/steps/get-stock-price.ts
@@ -9,6 +9,7 @@ import {
   type StepInput,
 } from "@/lib/workflow/executor/step-handler";
 import {
+  type ChainlinkFeed,
   fetchQuote,
   type FeedReading,
   loadChainlinkFeeds,
@@ -34,7 +35,7 @@ type GetStockPriceResult =
       ask: string;
       currency: string;
       quoteGeneratedAt: string;
-      quoteAgeSeconds: number;
+      quoteAgeSeconds: number | null;
       /**
        * Chainlink's token price, with the multiplier already applied, when a
        * feed exists. Null for most tickers: 35 of 194 are covered.
@@ -77,8 +78,14 @@ async function stepHandler(
 
   try {
     const rpcManager = await getRpcProvider({ chainId });
-    const feeds = await loadChainlinkFeeds();
-    const feed = feeds.get(token.symbol);
+    // Corroboration only, and absent for most tickers, so a directory outage
+    // must not fail a price the issuer answered perfectly well.
+    let feed: ChainlinkFeed | undefined;
+    try {
+      feed = (await loadChainlinkFeeds()).get(token.symbol);
+    } catch {
+      feed = undefined;
+    }
 
     const [quote, onChain, reading] = await Promise.all([
       fetchQuote(token.symbol),

--- a/plugins/robinhood/steps/get-stock-price.ts
+++ b/plugins/robinhood/steps/get-stock-price.ts
@@ -1,0 +1,150 @@
+import "server-only";
+
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { getErrorMessage } from "@/lib/utils";
+import {
+  runPluginStep,
+  type StepInput,
+} from "@/lib/workflow/executor/step-handler";
+import {
+  fetchQuote,
+  type FeedReading,
+  loadChainlinkFeeds,
+  readChainlinkFeed,
+  readOnChainState,
+  resolveStockToken,
+  ROBINHOOD_CHAIN_ID,
+} from "./stock-token-core";
+
+export type GetStockPriceInput = StepInput & {
+  network: string;
+  symbol: string;
+};
+
+type GetStockPriceResult =
+  | {
+      success: true;
+      symbol: string;
+      name: string;
+      tokenAddress: string;
+      /** Underlying equity bid/ask from the issuer. Not multiplier adjusted. */
+      bid: string;
+      ask: string;
+      currency: string;
+      quoteGeneratedAt: string;
+      quoteAgeSeconds: number;
+      /**
+       * Chainlink's token price, with the multiplier already applied, when a
+       * feed exists. Null for most tickers: 35 of 194 are covered.
+       */
+      feedPrice: string | null;
+      feedUpdatedAt: string | null;
+      feedAgeSeconds: number | null;
+      feedBeyondHeartbeat: boolean | null;
+      /** The token's own scaling factor, for converting between the two. */
+      uiMultiplier: string;
+      isTradingHalt: boolean;
+      oraclePaused: boolean;
+      tokenPaused: boolean;
+      paused: boolean;
+    }
+  | { success: false; error: string };
+
+async function stepHandler(
+  input: GetStockPriceInput
+): Promise<GetStockPriceResult> {
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(input.network);
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  if (chainId !== ROBINHOOD_CHAIN_ID) {
+    return {
+      success: false,
+      error: "Stock tokens exist only on Robinhood Chain (4663).",
+    };
+  }
+
+  const resolved = await resolveStockToken(input.symbol);
+  if (!resolved.ok) {
+    return { success: false, error: resolved.error };
+  }
+  const { token } = resolved;
+
+  try {
+    const rpcManager = await getRpcProvider({ chainId });
+    const feeds = await loadChainlinkFeeds();
+    const feed = feeds.get(token.symbol);
+
+    const [quote, onChain, reading] = await Promise.all([
+      fetchQuote(token.symbol),
+      rpcManager.executeWithFailover((provider) =>
+        readOnChainState(provider, token.address)
+      ),
+      feed
+        ? rpcManager.executeWithFailover(
+            (provider): Promise<FeedReading | null> =>
+              readChainlinkFeed(provider, feed)
+          )
+        : Promise.resolve(null),
+    ]);
+
+    return {
+      success: true,
+      symbol: token.symbol,
+      name: token.name,
+      tokenAddress: token.address,
+      bid: quote.bid,
+      ask: quote.ask,
+      currency: quote.currency,
+      quoteGeneratedAt: quote.generatedAt,
+      quoteAgeSeconds: quote.quoteAgeSeconds,
+      feedPrice: reading?.price ?? null,
+      feedUpdatedAt: reading?.updatedAt ?? null,
+      feedAgeSeconds: reading?.ageSeconds ?? null,
+      feedBeyondHeartbeat: reading?.beyondHeartbeat ?? null,
+      uiMultiplier: onChain.uiMultiplier,
+      isTradingHalt: quote.isTradingHalt,
+      oraclePaused: onChain.oraclePaused,
+      tokenPaused: onChain.tokenPaused,
+      paused: onChain.paused,
+    };
+  } catch (error) {
+    logUserError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      "[Get Stock Price] Failed to read price",
+      error,
+      { plugin_name: "robinhood", action_name: "get-stock-price" }
+    );
+    return { success: false, error: getErrorMessage(error) };
+  }
+}
+
+/**
+ * Get Stock Token Price
+ *
+ * Returns both price conventions side by side rather than reconciling them.
+ * The bid/ask is the underlying equity from the issuer; the feed price is the
+ * token, with its multiplier applied. They are not interchangeable, and the
+ * relationship between them could not be verified against the live chain, so
+ * each is labelled with its source and age and the caller chooses.
+ */
+export async function getStockPriceStep(
+  input: GetStockPriceInput
+): Promise<GetStockPriceResult> {
+  "use step";
+
+  return runPluginStep(
+    { pluginName: "robinhood", actionName: "get-stock-price" },
+    input,
+    stepHandler
+  );
+}
+
+getStockPriceStep.maxRetries = 0;
+
+export const _integrationType = "robinhood";

--- a/plugins/robinhood/steps/stock-market-status.ts
+++ b/plugins/robinhood/steps/stock-market-status.ts
@@ -1,0 +1,180 @@
+import "server-only";
+
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { getErrorMessage } from "@/lib/utils";
+import {
+  runPluginStep,
+  type StepInput,
+} from "@/lib/workflow/executor/step-handler";
+import {
+  fetchQuote,
+  loadChainlinkFeeds,
+  readChainlinkFeed,
+  readOnChainState,
+  resolveStockToken,
+  ROBINHOOD_CHAIN_ID,
+} from "./stock-token-core";
+
+export type StockMarketStatusInput = StepInput & {
+  network: string;
+  symbol: string;
+};
+
+type StockMarketStatusResult =
+  | {
+      success: true;
+      symbol: string;
+      /**
+       * Whether it is sane to act on this token's price right now: nothing is
+       * halted or paused, and the price sources are not beyond their own
+       * freshness guarantees. Gate price-reactive workflows on this.
+       */
+      tradeable: boolean;
+      /** Every reason `tradeable` is false, so a workflow can branch on cause. */
+      blockedBy: string[];
+      isTradingHalt: boolean;
+      oraclePaused: boolean;
+      tokenPaused: boolean;
+      paused: boolean;
+      quoteAgeSeconds: number;
+      feedAgeSeconds: number | null;
+      feedBeyondHeartbeat: boolean | null;
+      /** Set when a corporate action is scheduled but has not yet landed. */
+      pendingMultiplier: string | null;
+      pendingEffectiveAt: string | null;
+    }
+  | { success: false; error: string };
+
+/**
+ * How stale a quote may be before this reports it as unusable.
+ *
+ * The issuer's quote updates during market hours and freezes outside them, so
+ * this doubles as the market-open signal: there is no endpoint that answers
+ * "is the market open", and deriving one from an exchange calendar would mean
+ * shipping a holiday schedule and getting half-days wrong. An hour is well
+ * inside a session and unambiguously outside one.
+ */
+const QUOTE_USABLE_WINDOW_SECONDS = 3600;
+
+async function stepHandler(
+  input: StockMarketStatusInput
+): Promise<StockMarketStatusResult> {
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(input.network);
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
+
+  if (chainId !== ROBINHOOD_CHAIN_ID) {
+    return {
+      success: false,
+      error: "Stock tokens exist only on Robinhood Chain (4663).",
+    };
+  }
+
+  const resolved = await resolveStockToken(input.symbol);
+  if (!resolved.ok) {
+    return { success: false, error: resolved.error };
+  }
+  const { token } = resolved;
+
+  try {
+    const rpcManager = await getRpcProvider({ chainId });
+    const feeds = await loadChainlinkFeeds();
+    const feed = feeds.get(token.symbol);
+
+    const [quote, onChain, reading] = await Promise.all([
+      fetchQuote(token.symbol),
+      rpcManager.executeWithFailover((provider) =>
+        readOnChainState(provider, token.address)
+      ),
+      feed
+        ? rpcManager.executeWithFailover((provider) =>
+            readChainlinkFeed(provider, feed)
+          )
+        : Promise.resolve(null),
+    ]);
+
+    const blockedBy: string[] = [];
+    if (quote.isTradingHalt) {
+      blockedBy.push("trading halted");
+    }
+    if (onChain.paused) {
+      blockedBy.push("token contract paused");
+    }
+    if (onChain.tokenPaused) {
+      blockedBy.push("transfers paused");
+    }
+    if (onChain.oraclePaused) {
+      blockedBy.push("oracle paused");
+    }
+    if (quote.quoteAgeSeconds > QUOTE_USABLE_WINDOW_SECONDS) {
+      blockedBy.push(
+        `quote is ${quote.quoteAgeSeconds}s old, market likely closed`
+      );
+    }
+    // Judged against the feed's own heartbeat, not a constant. These feeds run
+    // on a 24 hour heartbeat and sit hours old overnight by design.
+    if (reading?.beyondHeartbeat) {
+      blockedBy.push(
+        `price feed is ${reading.ageSeconds}s old, beyond its ${reading.heartbeatSeconds}s heartbeat`
+      );
+    }
+    if (onChain.pendingMultiplier) {
+      blockedBy.push("corporate action pending");
+    }
+
+    return {
+      success: true,
+      symbol: token.symbol,
+      tradeable: blockedBy.length === 0,
+      blockedBy,
+      isTradingHalt: quote.isTradingHalt,
+      oraclePaused: onChain.oraclePaused,
+      tokenPaused: onChain.tokenPaused,
+      paused: onChain.paused,
+      quoteAgeSeconds: quote.quoteAgeSeconds,
+      feedAgeSeconds: reading?.ageSeconds ?? null,
+      feedBeyondHeartbeat: reading?.beyondHeartbeat ?? null,
+      pendingMultiplier: onChain.pendingMultiplier,
+      pendingEffectiveAt: onChain.effectiveAt
+        ? new Date(onChain.effectiveAt * 1000).toISOString()
+        : null,
+    };
+  } catch (error) {
+    logUserError(
+      ErrorCategory.EXTERNAL_SERVICE,
+      "[Stock Market Status] Failed to read status",
+      error,
+      { plugin_name: "robinhood", action_name: "stock-market-status" }
+    );
+    return { success: false, error: getErrorMessage(error) };
+  }
+}
+
+/**
+ * Stock Market Status
+ *
+ * A guard for price-reactive workflows. Out of hours the Chainlink feed freezes
+ * while an AMM keeps quoting, so there is no oracle anchor and nothing
+ * arbitraging the pool: acting on a price then is how a workflow gets filled
+ * badly. This answers whether acting is sane, and names every reason it is not.
+ */
+export async function stockMarketStatusStep(
+  input: StockMarketStatusInput
+): Promise<StockMarketStatusResult> {
+  "use step";
+
+  return runPluginStep(
+    { pluginName: "robinhood", actionName: "stock-market-status" },
+    input,
+    stepHandler
+  );
+}
+
+stockMarketStatusStep.maxRetries = 0;
+
+export const _integrationType = "robinhood";

--- a/plugins/robinhood/steps/stock-market-status.ts
+++ b/plugins/robinhood/steps/stock-market-status.ts
@@ -9,6 +9,7 @@ import {
   type StepInput,
 } from "@/lib/workflow/executor/step-handler";
 import {
+  type ChainlinkFeed,
   fetchQuote,
   loadChainlinkFeeds,
   readChainlinkFeed,
@@ -38,7 +39,7 @@ type StockMarketStatusResult =
       oraclePaused: boolean;
       tokenPaused: boolean;
       paused: boolean;
-      quoteAgeSeconds: number;
+      quoteAgeSeconds: number | null;
       feedAgeSeconds: number | null;
       feedBeyondHeartbeat: boolean | null;
       /** Set when a corporate action is scheduled but has not yet landed. */
@@ -83,8 +84,15 @@ async function stepHandler(
 
   try {
     const rpcManager = await getRpcProvider({ chainId });
-    const feeds = await loadChainlinkFeeds();
-    const feed = feeds.get(token.symbol);
+    // The feed directory is a third party that most tickers do not need: 35 of
+    // 194 have a feed. Its being down must not take the whole guard down.
+    let feed: ChainlinkFeed | undefined;
+    let feedDirectoryUnavailable = false;
+    try {
+      feed = (await loadChainlinkFeeds()).get(token.symbol);
+    } catch {
+      feedDirectoryUnavailable = true;
+    }
 
     const [quote, onChain, reading] = await Promise.all([
       fetchQuote(token.symbol),
@@ -111,17 +119,31 @@ async function stepHandler(
     if (onChain.oraclePaused) {
       blockedBy.push("oracle paused");
     }
-    if (quote.quoteAgeSeconds > QUOTE_USABLE_WINDOW_SECONDS) {
+    if (quote.quoteAgeSeconds === null) {
+      // Age unknown is not age zero. Blocking, because quote age is also how
+      // this action decides whether the market is open.
+      blockedBy.push("quote carried no usable timestamp");
+    } else if (quote.quoteAgeSeconds > QUOTE_USABLE_WINDOW_SECONDS) {
       blockedBy.push(
         `quote is ${quote.quoteAgeSeconds}s old, market likely closed`
       );
     }
     // Judged against the feed's own heartbeat, not a constant. These feeds run
     // on a 24 hour heartbeat and sit hours old overnight by design.
-    if (reading?.beyondHeartbeat) {
+    if (reading?.beyondHeartbeat === true) {
       blockedBy.push(
         `price feed is ${reading.ageSeconds}s old, beyond its ${reading.heartbeatSeconds}s heartbeat`
       );
+    }
+    if (reading?.beyondHeartbeat === null) {
+      blockedBy.push("price feed publishes no heartbeat, staleness unknown");
+    }
+    if (feedDirectoryUnavailable) {
+      blockedBy.push("price feed directory unavailable, staleness unknown");
+    }
+    // A flag we could not read is not a flag that is clear.
+    for (const field of onChain.unknown) {
+      blockedBy.push(`could not read ${field}`);
     }
     if (onChain.pendingMultiplier) {
       blockedBy.push("corporate action pending");

--- a/plugins/robinhood/steps/stock-token-core.ts
+++ b/plugins/robinhood/steps/stock-token-core.ts
@@ -1,0 +1,392 @@
+import "server-only";
+
+import { ethers } from "ethers";
+import { safeFetch } from "@/lib/safe-fetch";
+import { rawToUi, UI_MULTIPLIER_UNIT } from "@/lib/web3/ui-multiplier";
+
+/**
+ * Shared logic for the Robinhood Chain stock-token read actions.
+ *
+ * These assets are tokenised equities, and almost everything awkward about them
+ * comes from that: they carry two price conventions, their balances rescale
+ * without a transfer, and they stop quoting when the underlying market closes.
+ *
+ * On price, this module deliberately does NOT reconcile the two sources into a
+ * single number. The REST quote is the underlying equity's bid and ask; the
+ * Chainlink feed is the token price with the multiplier already applied. The
+ * documented conversion between them could not be verified: measured against
+ * the live chain, staleness drift between the two sources (feeds legitimately
+ * run hours old outside market hours, on an 86400 s heartbeat) is an order of
+ * magnitude larger than the multipliers involved, and the one token where the
+ * difference would be unmistakable, CRWD at 4.0, has no Chainlink feed at all.
+ * Publishing a single "true" price computed from an unverified relationship is
+ * how the balanceOf error happened. Both numbers are returned, each labelled
+ * with its source and its age, and the caller decides.
+ */
+
+/** Robinhood Chain mainnet. The registry lists no testnet deployments. */
+export const ROBINHOOD_CHAIN_ID = 4663;
+
+const ASSETS_URL = "https://api.robinhood.com/rhj/assets";
+const PRICES_URL = "https://api.robinhood.com/rhj/prices";
+const FEEDS_URL =
+  "https://reference-data-directory.vercel.app/feeds-robinhood-mainnet.json";
+
+/** The registry serves a 15 s cache of its own; this avoids hammering it. */
+const REGISTRY_TTL_MS = 60_000;
+/** Feed addresses change only when Chainlink deploys, which is rare. */
+const FEEDS_TTL_MS = 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 10_000;
+
+export type StockToken = {
+  symbol: string;
+  name: string;
+  address: string;
+  decimals: number;
+  /** Registry's view of the UI multiplier, as a decimal string. */
+  currentMultiplier: string;
+  /** Non-empty when a corporate action is scheduled but not yet effective. */
+  pendingMultiplier: string;
+  active: boolean;
+};
+
+export type StockQuote = {
+  symbol: string;
+  bid: string;
+  ask: string;
+  currency: string;
+  isTradingHalt: boolean;
+  /** When Robinhood produced this quote. */
+  generatedAt: string;
+  quoteAgeSeconds: number;
+  dailyHigh?: string;
+  dailyLow?: string;
+  dailyTradingVolume?: string;
+};
+
+export type ChainlinkFeed = {
+  address: string;
+  /** Seconds Chainlink may go between updates without deviation. */
+  heartbeatSeconds: number;
+};
+
+type Cached<T> = { value: T; fetchedAt: number };
+
+let registryCache: Cached<Map<string, StockToken>> | null = null;
+let feedsCache: Cached<Map<string, ChainlinkFeed>> | null = null;
+
+/** Exposed for tests; not part of the runtime contract. */
+export function __clearStockTokenCaches(): void {
+  registryCache = null;
+  feedsCache = null;
+}
+
+async function getJson(url: string): Promise<unknown> {
+  const response = await safeFetch(url, {
+    plugin: "robinhood",
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(`${url} returned ${response.status}`);
+  }
+  return await response.json();
+}
+
+/**
+ * Every active stock token on Robinhood Chain, keyed by ticker.
+ *
+ * The ticker is the key on purpose. A symbol search on the chain's explorer
+ * returns many lookalike contracts, several with more holders than the real
+ * one, so an address a user pasted is not self-validating. The issuer's own
+ * registry is the only authority on which address is which equity.
+ */
+export async function loadStockTokens(): Promise<Map<string, StockToken>> {
+  if (registryCache && Date.now() - registryCache.fetchedAt < REGISTRY_TTL_MS) {
+    return registryCache.value;
+  }
+
+  const payload = (await getJson(ASSETS_URL)) as {
+    assets?: Array<Record<string, unknown>>;
+  };
+  const tokens = new Map<string, StockToken>();
+
+  for (const asset of payload.assets ?? []) {
+    const deployments = (asset.deployments ?? []) as Array<
+      Record<string, unknown>
+    >;
+    const deployment = deployments.find(
+      (d) => Number(d.chainId) === ROBINHOOD_CHAIN_ID
+    );
+    if (!deployment) {
+      continue;
+    }
+    const symbol = String(asset.tokenSymbol ?? "").toUpperCase();
+    if (!symbol) {
+      continue;
+    }
+    tokens.set(symbol, {
+      symbol,
+      name: String(asset.tokenName ?? symbol),
+      address: String(deployment.contractAddress),
+      decimals: Number(asset.tokenDecimals ?? 18),
+      currentMultiplier: String(asset.currentMultiplier ?? "1"),
+      pendingMultiplier: String(asset.pendingMultiplier ?? ""),
+      active: asset.status === "ASSET_STATUS_ACTIVE",
+    });
+  }
+
+  registryCache = { value: tokens, fetchedAt: Date.now() };
+  return tokens;
+}
+
+/** Resolve a ticker to its token, or explain what is available. */
+export async function resolveStockToken(
+  symbol: string
+): Promise<{ ok: true; token: StockToken } | { ok: false; error: string }> {
+  const wanted = symbol.trim().toUpperCase();
+  if (!wanted) {
+    return { ok: false, error: "A ticker symbol is required, for example AAPL" };
+  }
+
+  let tokens: Map<string, StockToken>;
+  try {
+    tokens = await loadStockTokens();
+  } catch (error) {
+    return {
+      ok: false,
+      error: `Could not reach the Robinhood asset registry: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+
+  const token = tokens.get(wanted);
+  if (!token) {
+    return {
+      ok: false,
+      error: `${wanted} is not a stock token on Robinhood Chain. ${tokens.size} tickers are listed.`,
+    };
+  }
+  if (!token.active) {
+    return { ok: false, error: `${wanted} is listed but not active.` };
+  }
+  return { ok: true, token };
+}
+
+/** The issuer's quote for the underlying equity. Not multiplier adjusted. */
+export async function fetchQuote(symbol: string): Promise<StockQuote> {
+  const payload = (await getJson(
+    `${PRICES_URL}/${encodeURIComponent(symbol)}`
+  )) as { quotes?: Array<Record<string, unknown>> };
+
+  const quote = payload.quotes?.[0];
+  if (!quote) {
+    throw new Error(`No quote returned for ${symbol}`);
+  }
+
+  const generatedAt = String(quote.generatedAt ?? "");
+  const generatedMs = Date.parse(generatedAt);
+  return {
+    symbol: String(quote.tokenSymbol ?? symbol),
+    bid: String(quote.bid ?? ""),
+    ask: String(quote.ask ?? ""),
+    currency: String(quote.currency ?? "USD"),
+    isTradingHalt: Boolean(quote.isTradingHalt),
+    generatedAt,
+    quoteAgeSeconds: Number.isNaN(generatedMs)
+      ? -1
+      : Math.max(0, Math.round((Date.now() - generatedMs) / 1000)),
+    dailyHigh: quote.dailyHigh ? String(quote.dailyHigh) : undefined,
+    dailyLow: quote.dailyLow ? String(quote.dailyLow) : undefined,
+    dailyTradingVolume: quote.dailyTradingVolume
+      ? String(quote.dailyTradingVolume)
+      : undefined,
+  };
+}
+
+/**
+ * Chainlink's equity feeds on this chain, keyed by ticker.
+ *
+ * Addresses are read from Chainlink's published directory rather than
+ * hardcoded, because the chain's own docs decline to publish them and point at
+ * that directory as authoritative. Coverage is partial: 35 of the 194 listed
+ * tokens have a feed, which is why the REST quote is the primary price and
+ * this is corroboration.
+ */
+export async function loadChainlinkFeeds(): Promise<Map<string, ChainlinkFeed>> {
+  if (feedsCache && Date.now() - feedsCache.fetchedAt < FEEDS_TTL_MS) {
+    return feedsCache.value;
+  }
+
+  const payload = (await getJson(FEEDS_URL)) as Array<Record<string, unknown>>;
+  const feeds = new Map<string, ChainlinkFeed>();
+
+  for (const feed of payload) {
+    const name = String(feed.name ?? "");
+    if (!name.startsWith("Robinhood ")) {
+      continue;
+    }
+    const symbol = name
+      .replace("Robinhood ", "")
+      .replace(" / USD", "")
+      .replace("-USD", "")
+      .trim()
+      .toUpperCase();
+    const address = String(feed.proxyAddress ?? "");
+    if (!(symbol && address)) {
+      continue;
+    }
+    feeds.set(symbol, {
+      address,
+      heartbeatSeconds: Number(feed.heartbeat ?? 0),
+    });
+  }
+
+  feedsCache = { value: feeds, fetchedAt: Date.now() };
+  return feeds;
+}
+
+export type OnChainState = {
+  uiMultiplier: string;
+  pendingMultiplier: string | null;
+  /** Unix seconds a pending multiplier takes effect, when one is scheduled. */
+  effectiveAt: number | null;
+  paused: boolean;
+  tokenPaused: boolean;
+  oraclePaused: boolean;
+};
+
+const STOCK_ABI = [
+  "function uiMultiplier() view returns (uint256)",
+  "function newUIMultiplier() view returns (uint256)",
+  "function effectiveAt() view returns (uint256)",
+  "function paused() view returns (bool)",
+  "function tokenPaused() view returns (bool)",
+  "function oraclePaused() view returns (bool)",
+  "function balanceOf(address) view returns (uint256)",
+] as const;
+
+const CHAINLINK_ABI = [
+  "function latestRoundData() view returns (uint80,int256,uint256,uint256,uint80)",
+] as const;
+
+/** Read a value, returning null rather than throwing when it is unavailable. */
+async function tryRead<T>(read: () => Promise<T>): Promise<T | null> {
+  try {
+    return await read();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The token's own view of itself: how it scales, whether a rescale is
+ * scheduled, and the three independent switches that can freeze it.
+ *
+ * Each field degrades to null or false independently. A token that predates
+ * part of the interface still yields the fields it does implement, rather than
+ * failing the whole read.
+ */
+export async function readOnChainState(
+  provider: ethers.ContractRunner,
+  tokenAddress: string
+): Promise<OnChainState> {
+  const contract = new ethers.Contract(tokenAddress, STOCK_ABI, provider);
+
+  const [multiplier, pending, effective, paused, tokenPaused, oraclePaused] =
+    await Promise.all([
+      tryRead(() => contract.uiMultiplier() as Promise<bigint>),
+      tryRead(() => contract.newUIMultiplier() as Promise<bigint>),
+      tryRead(() => contract.effectiveAt() as Promise<bigint>),
+      tryRead(() => contract.paused() as Promise<boolean>),
+      tryRead(() => contract.tokenPaused() as Promise<boolean>),
+      tryRead(() => contract.oraclePaused() as Promise<boolean>),
+    ]);
+
+  const effectiveAt = effective === null ? null : Number(effective);
+  // A pending multiplier only means anything alongside a future effective
+  // date; the fields hold their last values once an action has landed.
+  const hasPending =
+    pending !== null &&
+    pending > BigInt(0) &&
+    effectiveAt !== null &&
+    effectiveAt * 1000 > Date.now();
+
+  return {
+    uiMultiplier: ethers.formatUnits(multiplier ?? UI_MULTIPLIER_UNIT, 18),
+    pendingMultiplier: hasPending ? ethers.formatUnits(pending, 18) : null,
+    effectiveAt: hasPending ? effectiveAt : null,
+    paused: paused ?? false,
+    tokenPaused: tokenPaused ?? false,
+    oraclePaused: oraclePaused ?? false,
+  };
+}
+
+export type FeedReading = {
+  address: string;
+  price: string;
+  updatedAt: string;
+  ageSeconds: number;
+  heartbeatSeconds: number;
+  /** True when the feed is older than its own published heartbeat. */
+  beyondHeartbeat: boolean;
+};
+
+/**
+ * Read a Chainlink equity feed, if this ticker has one.
+ *
+ * Staleness is judged against the feed's own heartbeat rather than a fixed
+ * threshold. These feeds run on an 86400 s heartbeat and legitimately sit
+ * hours old while the underlying market is closed, so any constant short
+ * enough to be meaningful during a session would fire continuously overnight.
+ */
+export async function readChainlinkFeed(
+  provider: ethers.ContractRunner,
+  feed: ChainlinkFeed
+): Promise<FeedReading | null> {
+  const contract = new ethers.Contract(feed.address, CHAINLINK_ABI, provider);
+  const result = await tryRead(
+    () =>
+      contract.latestRoundData() as Promise<
+        [bigint, bigint, bigint, bigint, bigint]
+      >
+  );
+  if (!result) {
+    return null;
+  }
+
+  const [, answer, , updatedAt] = result;
+  const updatedMs = Number(updatedAt) * 1000;
+  const ageSeconds = Math.max(0, Math.round((Date.now() - updatedMs) / 1000));
+
+  return {
+    address: feed.address,
+    // Chainlink equity feeds on this chain report 8 decimals.
+    price: ethers.formatUnits(answer, 8),
+    updatedAt: new Date(updatedMs).toISOString(),
+    ageSeconds,
+    heartbeatSeconds: feed.heartbeatSeconds,
+    beyondHeartbeat:
+      feed.heartbeatSeconds > 0 && ageSeconds > feed.heartbeatSeconds,
+  };
+}
+
+/** A holder's position, in both conventions, with the factor between them. */
+export async function readPosition(
+  provider: ethers.ContractRunner,
+  token: StockToken,
+  holder: string
+): Promise<{ raw: string; ui: string; uiMultiplier: string }> {
+  const contract = new ethers.Contract(token.address, STOCK_ABI, provider);
+  const [balanceRaw, multiplier] = await Promise.all([
+    contract.balanceOf(holder) as Promise<bigint>,
+    tryRead(() => contract.uiMultiplier() as Promise<bigint>),
+  ]);
+  const effective = multiplier ?? UI_MULTIPLIER_UNIT;
+
+  return {
+    raw: ethers.formatUnits(balanceRaw, token.decimals),
+    ui: ethers.formatUnits(rawToUi(balanceRaw, effective), token.decimals),
+    uiMultiplier: ethers.formatUnits(effective, 18),
+  };
+}

--- a/plugins/robinhood/steps/stock-token-core.ts
+++ b/plugins/robinhood/steps/stock-token-core.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { ethers } from "ethers";
 import { safeFetch } from "@/lib/safe-fetch";
+import { isNonRetryableError } from "@/lib/rpc/providers/error-classification";
 import { rawToUi, UI_MULTIPLIER_UNIT } from "@/lib/web3/ui-multiplier";
 
 /**
@@ -58,7 +59,8 @@ export type StockQuote = {
   isTradingHalt: boolean;
   /** When Robinhood produced this quote. */
   generatedAt: string;
-  quoteAgeSeconds: number;
+  /** Null when the issuer sent no parseable timestamp, which blocks. */
+  quoteAgeSeconds: number | null;
   dailyHigh?: string;
   dailyLow?: string;
   dailyTradingVolume?: string;
@@ -135,7 +137,12 @@ export async function loadStockTokens(): Promise<Map<string, StockToken>> {
     });
   }
 
-  registryCache = { value: tokens, fetchedAt: Date.now() };
+  // An empty map means the payload shape changed, not that the chain has no
+  // stock tokens. Caching it would answer "AAPL is not listed" confidently for
+  // a full minute.
+  if (tokens.size > 0) {
+    registryCache = { value: tokens, fetchedAt: Date.now() };
+  }
   return tokens;
 }
 
@@ -193,8 +200,10 @@ export async function fetchQuote(symbol: string): Promise<StockQuote> {
     currency: String(quote.currency ?? "USD"),
     isTradingHalt: Boolean(quote.isTradingHalt),
     generatedAt,
+    // Null rather than a sentinel. A -1 compares as fresher than any
+    // threshold, so an unknown age would have read as an open market.
     quoteAgeSeconds: Number.isNaN(generatedMs)
-      ? -1
+      ? null
       : Math.max(0, Math.round((Date.now() - generatedMs) / 1000)),
     dailyHigh: quote.dailyHigh ? String(quote.dailyHigh) : undefined,
     dailyLow: quote.dailyLow ? String(quote.dailyLow) : undefined,
@@ -236,18 +245,30 @@ export async function loadChainlinkFeeds(): Promise<Map<string, ChainlinkFeed>> 
     if (!(symbol && address)) {
       continue;
     }
+    const heartbeat = Number(feed.heartbeat);
     feeds.set(symbol, {
       address,
-      heartbeatSeconds: Number(feed.heartbeat ?? 0),
+      // Zero when the directory gives nothing usable. Treated as unknown
+      // rather than as "never stale" at the point of comparison.
+      heartbeatSeconds: Number.isFinite(heartbeat) && heartbeat > 0 ? heartbeat : 0,
     });
   }
 
-  feedsCache = { value: feeds, fetchedAt: Date.now() };
+  // Same reasoning as the registry, and worse here: an upstream rename would
+  // silently disable every feed staleness check for an hour.
+  if (feeds.size > 0) {
+    feedsCache = { value: feeds, fetchedAt: Date.now() };
+  }
   return feeds;
 }
 
 export type OnChainState = {
   uiMultiplier: string;
+  /**
+   * Fields that could not be read. A caller gating on this state must treat a
+   * non-empty list as blocking: an unreadable pause flag is not an unset one.
+   */
+  unknown: string[];
   pendingMultiplier: string | null;
   /** Unix seconds a pending multiplier takes effect, when one is scheduled. */
   effectiveAt: number | null;
@@ -270,12 +291,25 @@ const CHAINLINK_ABI = [
   "function latestRoundData() view returns (uint80,int256,uint256,uint256,uint80)",
 ] as const;
 
-/** Read a value, returning null rather than throwing when it is unavailable. */
-async function tryRead<T>(read: () => Promise<T>): Promise<T | null> {
+/**
+ * Read one value, separating "this contract does not implement it" from "we
+ * could not tell".
+ *
+ * The distinction is the whole point. A missing function is a fact about the
+ * token and it is safe to treat the value as absent. A timeout or a rate limit
+ * is not a fact about anything, and collapsing the two lets a guard report
+ * "nothing is wrong" when what it means is "I could not check".
+ */
+type ReadOutcome<T> =
+  | { state: "ok"; value: T }
+  | { state: "absent" }
+  | { state: "unknown" };
+
+async function tryRead<T>(read: () => Promise<T>): Promise<ReadOutcome<T>> {
   try {
-    return await read();
-  } catch {
-    return null;
+    return { state: "ok", value: await read() };
+  } catch (error) {
+    return isNonRetryableError(error) ? { state: "absent" } : { state: "unknown" };
   }
 }
 
@@ -303,22 +337,42 @@ export async function readOnChainState(
       tryRead(() => contract.oraclePaused() as Promise<boolean>),
     ]);
 
-  const effectiveAt = effective === null ? null : Number(effective);
+  const unknown: string[] = [];
+  const flag = (name: string, outcome: ReadOutcome<boolean>): boolean => {
+    if (outcome.state === "unknown") {
+      unknown.push(name);
+      // Reported as unknown rather than false. The caller blocks on it.
+      return false;
+    }
+    // An absent function means the token has no such switch, so it is not set.
+    return outcome.state === "ok" ? outcome.value : false;
+  };
+
+  if (multiplier.state === "unknown") {
+    unknown.push("uiMultiplier");
+  }
+  const scale =
+    multiplier.state === "ok" && multiplier.value > BigInt(0)
+      ? multiplier.value
+      : UI_MULTIPLIER_UNIT;
+
+  const effectiveAt = effective.state === "ok" ? Number(effective.value) : null;
   // A pending multiplier only means anything alongside a future effective
   // date; the fields hold their last values once an action has landed.
   const hasPending =
-    pending !== null &&
-    pending > BigInt(0) &&
+    pending.state === "ok" &&
+    pending.value > BigInt(0) &&
     effectiveAt !== null &&
     effectiveAt * 1000 > Date.now();
 
   return {
-    uiMultiplier: ethers.formatUnits(multiplier ?? UI_MULTIPLIER_UNIT, 18),
-    pendingMultiplier: hasPending ? ethers.formatUnits(pending, 18) : null,
+    uiMultiplier: ethers.formatUnits(scale, 18),
+    unknown,
+    pendingMultiplier: hasPending ? ethers.formatUnits(pending.value, 18) : null,
     effectiveAt: hasPending ? effectiveAt : null,
-    paused: paused ?? false,
-    tokenPaused: tokenPaused ?? false,
-    oraclePaused: oraclePaused ?? false,
+    paused: flag("paused", paused),
+    tokenPaused: flag("tokenPaused", tokenPaused),
+    oraclePaused: flag("oraclePaused", oraclePaused),
   };
 }
 
@@ -328,8 +382,8 @@ export type FeedReading = {
   updatedAt: string;
   ageSeconds: number;
   heartbeatSeconds: number;
-  /** True when the feed is older than its own published heartbeat. */
-  beyondHeartbeat: boolean;
+  /** True past the feed's own heartbeat; null when no heartbeat is published. */
+  beyondHeartbeat: boolean | null;
 };
 
 /**
@@ -345,17 +399,17 @@ export async function readChainlinkFeed(
   feed: ChainlinkFeed
 ): Promise<FeedReading | null> {
   const contract = new ethers.Contract(feed.address, CHAINLINK_ABI, provider);
-  const result = await tryRead(
+  const outcome = await tryRead(
     () =>
       contract.latestRoundData() as Promise<
         [bigint, bigint, bigint, bigint, bigint]
       >
   );
-  if (!result) {
+  if (outcome.state !== "ok") {
     return null;
   }
 
-  const [, answer, , updatedAt] = result;
+  const [, answer, , updatedAt] = outcome.value;
   const updatedMs = Number(updatedAt) * 1000;
   const ageSeconds = Math.max(0, Math.round((Date.now() - updatedMs) / 1000));
 
@@ -366,8 +420,10 @@ export async function readChainlinkFeed(
     updatedAt: new Date(updatedMs).toISOString(),
     ageSeconds,
     heartbeatSeconds: feed.heartbeatSeconds,
+    // Null when there is no usable heartbeat to judge against. A caller must
+    // treat null as unknown, not as fresh.
     beyondHeartbeat:
-      feed.heartbeatSeconds > 0 && ageSeconds > feed.heartbeatSeconds,
+      feed.heartbeatSeconds > 0 ? ageSeconds > feed.heartbeatSeconds : null,
   };
 }
 
@@ -382,7 +438,23 @@ export async function readPosition(
     contract.balanceOf(holder) as Promise<bigint>,
     tryRead(() => contract.uiMultiplier() as Promise<bigint>),
   ]);
-  const effective = multiplier ?? UI_MULTIPLIER_UNIT;
+
+  // `shares` is the field this action tells callers to act on, so it must not
+  // be quietly wrong. A multiplier we could not read would understate a CRWD
+  // position fourfold while reporting a scale of 1.0, so it fails instead.
+  // An absent function is different: the token genuinely does not scale.
+  if (multiplier.state === "unknown") {
+    throw new Error(
+      `Could not read the UI multiplier for ${token.symbol}. Refusing to report a share count that may be understated.`
+    );
+  }
+  if (multiplier.state === "ok" && multiplier.value <= BigInt(0)) {
+    throw new Error(
+      `${token.symbol} reported a zero UI multiplier, which cannot be right.`
+    );
+  }
+  const effective =
+    multiplier.state === "ok" ? multiplier.value : UI_MULTIPLIER_UNIT;
 
   return {
     raw: ethers.formatUnits(balanceRaw, token.decimals),

--- a/tests/unit/robinhood-stock-token.test.ts
+++ b/tests/unit/robinhood-stock-token.test.ts
@@ -7,6 +7,19 @@ vi.mock("@/lib/safe-fetch", () => ({
   safeFetch: (url: string) => mockFetch(url),
 }));
 
+vi.mock("@/lib/rpc/providers/error-classification", () => ({
+  isNonRetryableError: (e: unknown) =>
+    typeof e === "object" &&
+    e !== null &&
+    "code" in e &&
+    (e as { code: string }).code === "CALL_EXCEPTION",
+}));
+
+const absent = () =>
+  Object.assign(new Error("missing revert data"), { code: "CALL_EXCEPTION" });
+const transient = () =>
+  Object.assign(new Error("timeout"), { code: "TIMEOUT" });
+
 const contractCalls = vi.fn();
 const CONTRACT_METHODS = [
   "uiMultiplier",
@@ -296,5 +309,118 @@ describe("readPosition", () => {
     });
     const position = await readPosition(runner, token, "0x1");
     expect(position.ui).toBe(position.raw);
+  });
+});
+
+describe("absent is not the same as unknown", () => {
+  const runner = {} as never;
+  const token = {
+    symbol: "CRWD",
+    name: "CrowdStrike",
+    address: CRWD,
+    decimals: 18,
+    currentMultiplier: "4",
+    pendingMultiplier: "",
+    active: true,
+  };
+
+  it("treats a missing pause function as not paused, and says nothing is unknown", async () => {
+    contractCalls.mockImplementation((_a: string, fn: string) => {
+      if (fn === "uiMultiplier") {
+        return Promise.resolve(FOUR);
+      }
+      return Promise.reject(absent());
+    });
+    const state = await readOnChainState(runner, CRWD);
+    expect(state.paused).toBe(false);
+    expect(state.unknown).toEqual([]);
+  });
+
+  it("records an unreadable pause flag as unknown rather than clear", async () => {
+    contractCalls.mockImplementation((_a: string, fn: string) => {
+      if (fn === "uiMultiplier") {
+        return Promise.resolve(FOUR);
+      }
+      return Promise.reject(transient());
+    });
+    const state = await readOnChainState(runner, CRWD);
+    // The guard must block on these. Reporting false would mean "not paused"
+    // when what we know is "could not check".
+    expect(state.unknown).toContain("paused");
+    expect(state.unknown).toContain("tokenPaused");
+    expect(state.unknown).toContain("oraclePaused");
+  });
+
+  it("refuses to report a share count when the multiplier is unreadable", async () => {
+    contractCalls.mockImplementation((_a: string, fn: string) => {
+      if (fn === "balanceOf") {
+        return Promise.resolve(UNIT);
+      }
+      return Promise.reject(transient());
+    });
+    // Falling back to unit here would understate a CRWD position fourfold
+    // while reporting a scale of 1.0.
+    await expect(readPosition(runner, token, "0x1")).rejects.toThrow(
+      /multiplier/i
+    );
+  });
+
+  it("rejects a zero multiplier rather than zeroing the position", async () => {
+    contractCalls.mockImplementation((_a: string, fn: string) => {
+      if (fn === "balanceOf") {
+        return Promise.resolve(UNIT);
+      }
+      return Promise.resolve(BigInt(0));
+    });
+    await expect(readPosition(runner, token, "0x1")).rejects.toThrow();
+  });
+});
+
+describe("empty results are not cached as authoritative", () => {
+  it("does not cache an empty registry as the answer", async () => {
+    mockFetch.mockReturnValueOnce(json({ assets: [] }));
+    const first = await resolveStockToken("CRWD");
+    expect(first.ok).toBe(false);
+    // A shape change upstream must not answer "AAPL is not listed" for a
+    // minute. The next call re-fetches.
+    mockFetch.mockReturnValueOnce(json(ASSETS));
+    await expect(resolveStockToken("CRWD")).resolves.toMatchObject({
+      ok: true,
+    });
+  });
+
+  it("does not cache an empty feed map for an hour", async () => {
+    mockFetch.mockReturnValueOnce(json([{ name: "ETH / USD" }]));
+    expect((await loadChainlinkFeeds()).size).toBe(0);
+    mockFetch.mockReturnValueOnce(
+      json([
+        {
+          name: "Robinhood AAPL / USD",
+          proxyAddress: "0xaaa",
+          heartbeat: 86_400,
+        },
+      ])
+    );
+    expect((await loadChainlinkFeeds()).size).toBe(1);
+  });
+});
+
+describe("unknown quote age blocks rather than reading as fresh", () => {
+  it("returns null when the issuer sent no parseable timestamp", async () => {
+    mockFetch.mockReturnValue(
+      json({
+        quotes: [
+          {
+            tokenSymbol: "AAPL",
+            bid: "1",
+            ask: "1",
+            generatedAt: "not a date",
+          },
+        ],
+      })
+    );
+    const quote = await fetchQuote("AAPL");
+    // -1 would compare as fresher than any threshold.
+    expect(quote.quoteAgeSeconds).toBeNull();
   });
 });

--- a/tests/unit/robinhood-stock-token.test.ts
+++ b/tests/unit/robinhood-stock-token.test.ts
@@ -1,0 +1,300 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mockFetch = vi.fn();
+vi.mock("@/lib/safe-fetch", () => ({
+  safeFetch: (url: string) => mockFetch(url),
+}));
+
+const contractCalls = vi.fn();
+const CONTRACT_METHODS = [
+  "uiMultiplier",
+  "newUIMultiplier",
+  "effectiveAt",
+  "paused",
+  "tokenPaused",
+  "oraclePaused",
+  "balanceOf",
+  "latestRoundData",
+] as const;
+
+vi.mock("ethers", async () => {
+  const actual = await vi.importActual<typeof import("ethers")>("ethers");
+  // Methods are assigned rather than proxied: a constructor that returns a
+  // value is banned by lint, and the method set here is small and known.
+  class MockContract {
+    constructor(address: string) {
+      for (const name of CONTRACT_METHODS) {
+        (this as Record<string, unknown>)[name] = () =>
+          contractCalls(address, name);
+      }
+    }
+  }
+  return { ethers: { ...actual.ethers, Contract: MockContract } };
+});
+
+import {
+  __clearStockTokenCaches,
+  fetchQuote,
+  loadChainlinkFeeds,
+  readOnChainState,
+  readPosition,
+  resolveStockToken,
+} from "@/plugins/robinhood/steps/stock-token-core";
+
+const CRWD = "0xea72Ecca2d0f6bFA1394DBBCff85b52CD4233931";
+const UNIT = BigInt("1000000000000000000");
+const FOUR = BigInt(4) * UNIT;
+
+function json(body: unknown, ok = true, status = 200) {
+  return Promise.resolve({ ok, status, json: () => Promise.resolve(body) });
+}
+
+const ASSETS = {
+  assets: [
+    {
+      tokenSymbol: "CRWD",
+      tokenName: "CrowdStrike",
+      tokenDecimals: 18,
+      currentMultiplier: "4.000000000000000000",
+      pendingMultiplier: "",
+      status: "ASSET_STATUS_ACTIVE",
+      deployments: [{ contractAddress: CRWD, chainId: 4663 }],
+    },
+    {
+      tokenSymbol: "DELISTED",
+      tokenName: "Gone",
+      tokenDecimals: 18,
+      currentMultiplier: "1",
+      pendingMultiplier: "",
+      status: "ASSET_STATUS_INACTIVE",
+      deployments: [{ contractAddress: CRWD, chainId: 4663 }],
+    },
+    {
+      tokenSymbol: "OTHERCHAIN",
+      tokenName: "Elsewhere",
+      tokenDecimals: 18,
+      currentMultiplier: "1",
+      status: "ASSET_STATUS_ACTIVE",
+      deployments: [{ contractAddress: CRWD, chainId: 1 }],
+    },
+  ],
+};
+
+beforeEach(() => {
+  __clearStockTokenCaches();
+  mockFetch.mockReset();
+  contractCalls.mockReset();
+});
+
+describe("resolveStockToken", () => {
+  it("resolves a ticker to its address through the registry", async () => {
+    mockFetch.mockReturnValue(json(ASSETS));
+    const result = await resolveStockToken("crwd");
+    expect(result).toEqual({
+      ok: true,
+      token: expect.objectContaining({ symbol: "CRWD", address: CRWD }),
+    });
+  });
+
+  it("rejects a ticker that is not listed", async () => {
+    mockFetch.mockReturnValue(json(ASSETS));
+    const result = await resolveStockToken("NOTREAL");
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects a listed but inactive asset", async () => {
+    mockFetch.mockReturnValue(json(ASSETS));
+    const result = await resolveStockToken("DELISTED");
+    expect(result.ok).toBe(false);
+  });
+
+  it("ignores assets deployed on other chains", async () => {
+    mockFetch.mockReturnValue(json(ASSETS));
+    const result = await resolveStockToken("OTHERCHAIN");
+    expect(result.ok).toBe(false);
+  });
+
+  it("reports a registry outage rather than throwing", async () => {
+    mockFetch.mockReturnValue(json({}, false, 503));
+    const result = await resolveStockToken("CRWD");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("registry");
+    }
+  });
+
+  it("caches the registry across lookups", async () => {
+    mockFetch.mockReturnValue(json(ASSETS));
+    await resolveStockToken("CRWD");
+    await resolveStockToken("CRWD");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("fetchQuote", () => {
+  it("derives quote age from generatedAt", async () => {
+    const generatedAt = new Date(Date.now() - 120_000).toISOString();
+    mockFetch.mockReturnValue(
+      json({
+        quotes: [
+          {
+            tokenSymbol: "AAPL",
+            bid: "314.89",
+            ask: "315",
+            currency: "USD",
+            isTradingHalt: false,
+            generatedAt,
+          },
+        ],
+      })
+    );
+    const quote = await fetchQuote("AAPL");
+    expect(quote.bid).toBe("314.89");
+    expect(quote.quoteAgeSeconds).toBeGreaterThanOrEqual(119);
+    expect(quote.quoteAgeSeconds).toBeLessThanOrEqual(125);
+  });
+
+  it("carries the halt flag through", async () => {
+    mockFetch.mockReturnValue(
+      json({
+        quotes: [
+          {
+            tokenSymbol: "AAPL",
+            bid: "1",
+            ask: "1",
+            isTradingHalt: true,
+            generatedAt: new Date().toISOString(),
+          },
+        ],
+      })
+    );
+    await expect(fetchQuote("AAPL")).resolves.toMatchObject({
+      isTradingHalt: true,
+    });
+  });
+});
+
+describe("loadChainlinkFeeds", () => {
+  it("keys equity feeds by ticker and ignores crypto feeds", async () => {
+    mockFetch.mockReturnValue(
+      json([
+        {
+          name: "Robinhood AAPL / USD",
+          proxyAddress: "0xaaa",
+          heartbeat: 86_400,
+        },
+        {
+          name: "Robinhood SGOV-USD",
+          proxyAddress: "0xbbb",
+          heartbeat: 86_400,
+        },
+        { name: "ETH / USD", proxyAddress: "0xccc", heartbeat: 86_400 },
+      ])
+    );
+    const feeds = await loadChainlinkFeeds();
+    expect([...feeds.keys()].sort()).toEqual(["AAPL", "SGOV"]);
+    expect(feeds.get("AAPL")?.heartbeatSeconds).toBe(86_400);
+  });
+});
+
+describe("readOnChainState", () => {
+  const runner = {} as never;
+
+  it("reports a pending corporate action only when it is still in the future", async () => {
+    const future = Math.floor(Date.now() / 1000) + 3600;
+    contractCalls.mockImplementation((_a: string, fn: string) => {
+      if (fn === "uiMultiplier") {
+        return Promise.resolve(UNIT);
+      }
+      if (fn === "newUIMultiplier") {
+        return Promise.resolve(FOUR);
+      }
+      if (fn === "effectiveAt") {
+        return Promise.resolve(BigInt(future));
+      }
+      return Promise.resolve(false);
+    });
+    const state = await readOnChainState(runner, CRWD);
+    expect(state.pendingMultiplier).toBe("4.0");
+    expect(state.effectiveAt).toBe(future);
+  });
+
+  it("does not report a pending action once it has landed", async () => {
+    const past = Math.floor(Date.now() / 1000) - 3600;
+    contractCalls.mockImplementation((_a: string, fn: string) => {
+      if (fn === "uiMultiplier") {
+        return Promise.resolve(FOUR);
+      }
+      if (fn === "newUIMultiplier") {
+        return Promise.resolve(FOUR);
+      }
+      if (fn === "effectiveAt") {
+        return Promise.resolve(BigInt(past));
+      }
+      return Promise.resolve(false);
+    });
+    const state = await readOnChainState(runner, CRWD);
+    // The fields keep their last values after an action applies, so a naive
+    // read of newUIMultiplier alone would report a permanent pending action.
+    expect(state.pendingMultiplier).toBeNull();
+  });
+
+  it("degrades field by field rather than failing the whole read", async () => {
+    contractCalls.mockImplementation((_a: string, fn: string) => {
+      if (fn === "uiMultiplier") {
+        return Promise.resolve(FOUR);
+      }
+      return Promise.reject(new Error("not implemented"));
+    });
+    const state = await readOnChainState(runner, CRWD);
+    expect(state.uiMultiplier).toBe("4.0");
+    expect(state.paused).toBe(false);
+    expect(state.pendingMultiplier).toBeNull();
+  });
+});
+
+describe("readPosition", () => {
+  const runner = {} as never;
+  const token = {
+    symbol: "CRWD",
+    name: "CrowdStrike",
+    address: CRWD,
+    decimals: 18,
+    currentMultiplier: "4",
+    pendingMultiplier: "",
+    active: true,
+  };
+
+  it("reports shares and raw balance separately", async () => {
+    // The live pair: balanceOf 7.572731046613574564, shares 4x that.
+    contractCalls.mockImplementation((_a: string, fn: string) => {
+      if (fn === "balanceOf") {
+        return Promise.resolve(BigInt("7572731046613574564"));
+      }
+      if (fn === "uiMultiplier") {
+        return Promise.resolve(FOUR);
+      }
+      return Promise.resolve(BigInt(0));
+    });
+    const position = await readPosition(runner, token, "0x1");
+    expect(position.raw).toBe("7.572731046613574564");
+    expect(position.ui).toBe("30.290924186454298256");
+    expect(position.uiMultiplier).toBe("4.0");
+  });
+
+  it("is the identity for an unscaled token", async () => {
+    contractCalls.mockImplementation((_a: string, fn: string) => {
+      if (fn === "balanceOf") {
+        return Promise.resolve(UNIT);
+      }
+      if (fn === "uiMultiplier") {
+        return Promise.resolve(UNIT);
+      }
+      return Promise.resolve(BigInt(0));
+    });
+    const position = await readPosition(runner, token, "0x1");
+    expect(position.ui).toBe(position.raw);
+  });
+});


### PR DESCRIPTION
Three read actions for the tokenised equities on Robinhood Chain: price, position and market status. They exist because these assets are equities rather than tokens, and the generic web3 actions cannot express that.

## Price returns both conventions rather than one

The ticket asked for a single reconciled price, on the principle that a workflow author should never need to learn that two conventions exist. **The conversion could not be verified, so this does not perform it.**

Measured against the live chain, the ratio between the issuer quote and the Chainlink answer:

| | AAPL | NVDA | TSLA | SGOV | ORCL |
| -- | -- | -- | -- | -- | -- |
| ratio | 0.9994 | 0.9990 | 0.9993 | 1.0029 | 1.0060 |
| multiplier | 1.000566 | 1.000000 | 1.000000 | 1.002982 | 1.002211 |
| feed age | 856m | 446m | 747m | 320m | 191m |

Staleness drift is an order of magnitude larger than the effect being measured. These feeds run on an 86400 s heartbeat and legitimately sit hours old outside market hours, so the ratios are dominated by when each source last updated, not by the multiplier. And the one token where the difference would be unmistakable, CRWD at 4.0, has no Chainlink feed at all.

Publishing a single "true" price computed from an unverified relationship is how the `balanceOf` error happened. Both numbers are returned, each labelled with its source and age, plus the multiplier. That keeps the safety intent of the principle while declining the part that cannot be stood behind.

Coverage also drives which source leads: Chainlink covers 35 of 194 tokens, the issuer quote covers all 194. So the quote is primary and the feed is corroboration where it exists.

## Position reports shares and raw balance side by side

Reading `balanceOf` alone understates a holding by the multiplier on any token that has been through a corporate action, silently. Eight of the 194 listed tokens carry a non-unit multiplier today. `shares` is what the holder is shown and what the position is worth; `rawBalance` is what `transfer` moves and what an explorer displays.

## Market status names its reasons

`tradeable` is a boolean, but `blockedBy` lists every cause, so a workflow can branch on cause rather than re-deriving it: trading halt, each of the three independent pause flags, a stale quote, a feed beyond its heartbeat, and a pending corporate action.

Feed staleness is judged per feed against its own published heartbeat rather than a constant. A fixed threshold short enough to mean anything during a session would fire continuously overnight.

There is no market-status endpoint (`/rhj/market-status` returns 404), so "is the market open" is derived from quote age rather than fetched. An hour is well inside a session and unambiguously outside one, which avoids shipping an exchange calendar and getting half-days wrong.

## The ticker is the input, not an address

The registry is the only authority on which address is which equity: a symbol search on the chain's explorer returns many lookalikes, several with more holders than the real token.

This also avoids a new `stock-token-select` field type, which would have meant a field-type union entry, a renderer, an API route and two more call sites for what `template-input` already does. Users think in tickers.

## Scoped out, with reasons

**The corporate-action trigger.** `IntegrationPlugin` has no trigger concept; triggers are workflow-level (`trigger-config.tsx`, the `TRIGGERS` map, the event tracker). Different subsystem, not a plugin action, so it needs its own ticket rather than being quietly dropped. The pending-multiplier and effective-date fields on market status cover the advance-warning case in the meantime.

**The testnet.** The registry lists deployments on 4663 only, so every network picker here is pinned to it.

## Verification

- 14 unit tests. The CRWD figures are the live on-chain pair (`balanceOf` 7.572731046613574564, shares 4x that).
- The pending-action test covers the case a naive read gets wrong: `newUIMultiplier` and `effectiveAt` keep their last values after an action lands, so checking `newUIMultiplier` alone reports a permanent pending action.
- On-chain reads degrade field by field rather than failing the whole call, so a token that predates part of the interface still yields what it does implement.
- `tsc --noEmit` clean; full local unit suite green.

Worth noting for reviewers: `biome.jsonc` excludes `plugins/` entirely, so nothing in this plugin is linted by CI. `tsc` does cover it.
