### PR TITLE
feat: trade Robinhood stock tokens through Uniswap v4

### DIFF
--- a/docs/plugins/robinhood.md
+++ b/docs/plugins/robinhood.md
@@ -1,11 +1,11 @@
 ---
 title: "Robinhood Plugin"
-description: "Read prices, positions, and trading status for the tokenised equities on Robinhood Chain."
+description: "Read prices, positions, and trading status for the tokenised equities on Robinhood Chain, and trade them against USDG."
 ---
 
 # Robinhood Plugin
 
-Read the tokenised equities on Robinhood Chain from a workflow. The three actions are read-only and need no credentials.
+Read and trade the tokenised equities on Robinhood Chain from a workflow. The three read actions need no credentials. Trading moves funds and needs a connected wallet with Permit2 allowances in place.
 
 These actions exist because the assets are equities rather than ordinary tokens, and the generic Web3 actions cannot express that:
 
@@ -22,6 +22,7 @@ Every action takes a **ticker**, not an address. The issuer's asset registry is 
 | Get Stock Token Price | Issuer bid and ask, plus the Chainlink token price where a feed exists |
 | Get Stock Token Position | A holder's position in share terms and in raw on-chain units |
 | Stock Market Status | Whether acting on this token's price is currently sane, and why not |
+| Trade Stock Token | Swap USDG into a stock token or back out, against a pool you name |
 
 ## Get Stock Token Price
 
@@ -64,6 +65,25 @@ There is no market-status endpoint upstream, so "is the market open" is derived 
 **Outputs:** `success`, `tradeable`, `blockedBy`, `isTradingHalt`, `paused`, `tokenPaused`, `oraclePaused`, `quoteAgeSeconds`, `feedAgeSeconds`, `feedBeyondHeartbeat`, `pendingMultiplier`, `pendingEffectiveAt`, `error`
 
 **When to use:** Gate any workflow that acts on a stock token price, so it does not trade on a stale quote or through a halt.
+
+## Trade Stock Token
+
+Swaps USDG into a stock token or back out, through Uniswap v4.
+
+**It does not choose a pool.** Robinhood Chain carries hundreds of pools per stock token, at fee tiers reaching 95 percent, all reachable and none distinguished on-chain. Any pool an automatic router would pick is a pool someone can set up to be picked. So you supply the pool key - fee and tick spacing - and the minimum you will accept, and the swap reverts rather than filling below it.
+
+Sizes are in shares, not raw token units, on both legs: a sell is sized in shares, and a buy's minimum is expressed in shares. The conversion happens for you.
+
+Before signing, the action refuses on any of:
+
+- a trading halt, or any of the three on-chain pause flags
+- a pending corporate action, since the token is about to rescale
+- any of those flags being unreadable, because not knowing is not the same as being clear
+- either Permit2 allowance missing, insufficient or expiring before the deadline
+
+The Universal Router pulls funds through Permit2 rather than directly, so two approvals are needed: the token to Permit2, and Permit2 to the router. The action tells you exactly which one to set rather than setting it for you, so a workflow never grants spending rights as a side effect.
+
+The action is never retried. A swap that timed out may still have landed, and a retry would be a second trade at a price nobody asked for.
 
 ## Example workflow
 

--- a/plugins/robinhood/index.ts
+++ b/plugins/robinhood/index.ts
@@ -5,7 +5,7 @@ import { RobinhoodIcon } from "./icon";
 /**
  * Robinhood Chain stock tokens.
  *
- * Read-only. These actions exist because the assets are tokenised equities
+ * These actions exist because the assets are tokenised equities
  * rather than tokens, and the generic web3 actions cannot express that: a
  * balance rescales without a transfer, a price has two conventions that are not
  * interchangeable, and the market behind the asset closes while the chain does
@@ -43,7 +43,7 @@ const robinhoodPlugin: IntegrationPlugin = {
   egress: "fixed-host",
   label: "Robinhood",
   description:
-    "Read prices, positions and trading status for the tokenised equities on Robinhood Chain, in share terms rather than raw token units",
+    "Read prices, positions and trading status for the tokenised equities on Robinhood Chain, and trade them against USDG, in share terms rather than raw token units",
 
   icon: RobinhoodIcon,
 

--- a/plugins/robinhood/index.ts
+++ b/plugins/robinhood/index.ts
@@ -168,6 +168,95 @@ const robinhoodPlugin: IntegrationPlugin = {
       ],
     },
     {
+      slug: "trade-stock-token",
+      label: "Trade Stock Token",
+      description:
+        "Swap USDG into a tokenised equity or back out, through Uniswap v4. Takes an explicit pool key and a minimum output rather than choosing a route: this chain carries hundreds of pools per stock token at fee tiers reaching 95 percent, none distinguished on-chain, so any pool a heuristic would pick is one a griefer can aim at",
+      category: "Robinhood",
+      stepFunction: "tradeStockTokenStep",
+      stepImportPath: "trade-stock-token",
+      configFields: [
+        networkField,
+        symbolField,
+        {
+          key: "side",
+          label: "Side",
+          type: "select" as const,
+          options: [
+            { label: "Buy (spend USDG)", value: "buy" },
+            { label: "Sell (spend shares)", value: "sell" },
+          ],
+          required: true,
+        },
+        {
+          key: "amountIn",
+          label: "Amount In",
+          type: "template-input" as const,
+          placeholder: "Buy: USDG to spend. Sell: shares to sell",
+          required: true,
+        },
+        {
+          key: "minAmountOut",
+          label: "Minimum Amount Out",
+          type: "template-input" as const,
+          placeholder: "Buy: minimum shares. Sell: minimum USDG",
+          required: true,
+        },
+        {
+          key: "poolFee",
+          label: "Pool Fee",
+          type: "template-input" as const,
+          placeholder: "3000",
+          example: "3000",
+          required: true,
+        },
+        {
+          key: "poolTickSpacing",
+          label: "Pool Tick Spacing",
+          type: "template-input" as const,
+          placeholder: "60",
+          example: "60",
+          required: true,
+        },
+        {
+          key: "poolHooks",
+          label: "Pool Hooks",
+          type: "template-input" as const,
+          placeholder: "0x0000000000000000000000000000000000000000",
+          required: false,
+        },
+        {
+          key: "deadlineSeconds",
+          label: "Deadline (seconds)",
+          type: "template-input" as const,
+          placeholder: "300",
+          required: false,
+        },
+      ],
+      outputFields: [
+        { field: "success", description: "Whether the swap was broadcast" },
+        { field: "transactionHash", description: "The swap transaction hash" },
+        { field: "chainId", description: "Chain the swap was broadcast on" },
+        { field: "symbol", description: "The resolved ticker" },
+        { field: "side", description: "buy or sell" },
+        { field: "amountIn", description: "Amount spent, as supplied" },
+        {
+          field: "minAmountOut",
+          description: "The floor the router enforced, as supplied",
+        },
+        { field: "poolFee", description: "Fee tier of the pool traded" },
+        {
+          field: "poolTickSpacing",
+          description: "Tick spacing of the pool traded",
+        },
+        {
+          field: "error",
+          description:
+            "Why the trade was refused or failed, including the Permit2 allowances to set when they are missing",
+        },
+      ],
+    },
+    {
       slug: "stock-market-status",
       label: "Stock Market Status",
       description:

--- a/plugins/robinhood/steps/stock-token-core.ts
+++ b/plugins/robinhood/steps/stock-token-core.ts
@@ -351,6 +351,16 @@ export async function readOnChainState(
   if (multiplier.state === "unknown") {
     unknown.push("uiMultiplier");
   }
+  // These two decide whether a corporate action is pending. An unreadable one
+  // leaves hasPending false below, which reads as "no action scheduled" rather
+  // than "could not tell" - and a swap into a token about to rescale is the
+  // exact case the pending check exists to stop.
+  if (pending.state === "unknown") {
+    unknown.push("newUIMultiplier");
+  }
+  if (effective.state === "unknown") {
+    unknown.push("effectiveAt");
+  }
   const scale =
     multiplier.state === "ok" && multiplier.value > BigInt(0)
       ? multiplier.value

--- a/plugins/robinhood/steps/trade-stock-token-core.ts
+++ b/plugins/robinhood/steps/trade-stock-token-core.ts
@@ -1,0 +1,414 @@
+import "server-only";
+
+import { ethers } from "ethers";
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import {
+  executeContractCallAsRole,
+  executeContractCallAsSafe,
+} from "@/lib/safe/execute-as-safe";
+import { resolveSignerForNode, SIGNER_MODE } from "@/lib/safe/signer-resolver";
+import { getErrorMessage } from "@/lib/utils";
+import { getChainAdapter } from "@/lib/web3/chain-adapter";
+import { resolveGasLimitOverrides } from "@/lib/web3/gas-defaults";
+import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
+import {
+  convertAmountForWrite,
+  resolveForWrite,
+} from "@/lib/web3/ui-multiplier";
+import {
+  getOrganizationWalletAddress,
+  initializeWalletSigner,
+} from "@/lib/web3/wallet-helpers";
+import {
+  type TransactionContext,
+  withNonceSession,
+} from "@/lib/web3/transaction-manager";
+import {
+  readOnChainState,
+  resolveStockToken,
+  ROBINHOOD_CHAIN_ID,
+} from "./stock-token-core";
+import {
+  encodeExactInSingleSwap,
+  UNIVERSAL_ROUTER_ABI,
+} from "./v4-swap-encoding";
+
+/**
+ * Swap USDG into a Robinhood stock token, or back out of one.
+ *
+ * Deliberately takes an explicit pool key rather than discovering one. This
+ * chain carries hundreds of pools per stock token at fee tiers up to 95%, all
+ * reachable, and nothing on-chain distinguishes the real one. Any discovery
+ * heuristic this node could apply would be a heuristic a griefer can aim at.
+ * The caller names the pool and names the minimum they will accept, and both
+ * are enforced on-chain.
+ */
+
+export const UNIVERSAL_ROUTER = "0x8876789976decbfcbbbe364623c63652db8c0904";
+export const PERMIT2 = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
+export const USDG = "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168";
+const USDG_DECIMALS = 6;
+
+const ERC20_ALLOWANCE_ABI = [
+  "function allowance(address owner, address spender) view returns (uint256)",
+] as const;
+const PERMIT2_ABI = [
+  "function allowance(address owner, address token, address spender) view returns (uint160 amount, uint48 expiration, uint48 nonce)",
+] as const;
+
+export type TradeSide = "buy" | "sell";
+
+export type TradeStockTokenCoreInput = {
+  network: string;
+  symbol: string;
+  side: TradeSide;
+  /** Buy: USDG to spend. Sell: shares to sell. */
+  amountIn: string;
+  /** Buy: minimum shares to receive. Sell: minimum USDG to receive. */
+  minAmountOut: string;
+  poolFee: string;
+  poolTickSpacing: string;
+  poolHooks?: string;
+  deadlineSeconds?: string;
+  web3Connection?: string;
+  _context?: {
+    executionId?: string;
+    organizationId?: string;
+    workflowId?: string;
+  };
+};
+
+export type TradeStockTokenResult =
+  | {
+      success: true;
+      transactionHash: string;
+      chainId: number;
+      symbol: string;
+      side: TradeSide;
+      amountIn: string;
+      minAmountOut: string;
+      poolFee: number;
+      poolTickSpacing: number;
+    }
+  | { success: false; error: string };
+
+/** Refusals that are the caller's to fix, phrased so they can fix them. */
+function refuse(error: string): TradeStockTokenResult {
+  return { success: false, error };
+}
+
+/**
+ * The Universal Router never touches a wallet directly: it pulls funds through
+ * Permit2, which needs two allowances rather than the usual one. Checked before
+ * anything is signed so the failure is a sentence rather than a revert.
+ */
+async function checkPermit2Allowances(
+  runFailover: <T>(op: (p: ethers.ContractRunner) => Promise<T>) => Promise<T>,
+  token: string,
+  owner: string,
+  amount: bigint
+): Promise<string | null> {
+  const [toPermit2, permit2ToRouter] = await Promise.all([
+    runFailover((p) =>
+      new ethers.Contract(token, ERC20_ALLOWANCE_ABI, p).allowance(
+        owner,
+        PERMIT2
+      ) as Promise<bigint>
+    ),
+    runFailover(
+      (p) =>
+        new ethers.Contract(PERMIT2, PERMIT2_ABI, p).allowance(
+          owner,
+          token,
+          UNIVERSAL_ROUTER
+        ) as Promise<[bigint, bigint, bigint]>
+    ),
+  ]);
+
+  if (toPermit2 < amount) {
+    return `${token} is not approved to Permit2. Approve ${PERMIT2} to spend ${token} from ${owner} first, using the Approve Token action.`;
+  }
+
+  const [allowed, expiration] = permit2ToRouter;
+  const now = BigInt(Math.floor(Date.now() / 1000));
+  if (allowed < amount) {
+    return `Permit2 has not authorised the Universal Router to spend ${token}. Call approve(${token}, ${UNIVERSAL_ROUTER}, amount, expiration) on Permit2 at ${PERMIT2}.`;
+  }
+  if (expiration !== BigInt(0) && expiration <= now) {
+    return `The Permit2 allowance for ${token} to the Universal Router expired at ${new Date(
+      Number(expiration) * 1000
+    ).toISOString()}. Re-approve it on Permit2 at ${PERMIT2}.`;
+  }
+  return null;
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: a fund-moving path whose refusals are the point; splitting them would hide the gate sequence
+export async function tradeStockTokenCore(
+  input: TradeStockTokenCoreInput
+): Promise<TradeStockTokenResult> {
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(input.network);
+  } catch (error) {
+    return refuse(getErrorMessage(error));
+  }
+  if (chainId !== ROBINHOOD_CHAIN_ID) {
+    return refuse("Stock tokens exist only on Robinhood Chain (4663).");
+  }
+
+  const resolved = await resolveStockToken(input.symbol);
+  if (!resolved.ok) {
+    return refuse(resolved.error);
+  }
+  const token = resolved.token;
+
+  const orgCtx = await resolveOrganizationContext(
+    input._context ?? {},
+    "[Trade Stock Token]",
+    "trade-stock-token"
+  );
+  if (!orgCtx.success) {
+    return refuse(orgCtx.error);
+  }
+  const { organizationId } = orgCtx;
+
+  const fee = Number(input.poolFee);
+  const tickSpacing = Number(input.poolTickSpacing);
+  if (!(Number.isInteger(fee) && Number.isInteger(tickSpacing))) {
+    return refuse("poolFee and poolTickSpacing must be integers.");
+  }
+
+  let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
+  try {
+    rpcManager = await getRpcProvider({ chainId });
+  } catch (error) {
+    return refuse(getErrorMessage(error));
+  }
+  const runFailover = <T>(op: (p: ethers.ContractRunner) => Promise<T>) =>
+    rpcManager.executeWithFailover(op as (p: ethers.JsonRpcProvider) => Promise<T>);
+
+  // Gate before anything else. Out of hours the feed freezes while the pool
+  // keeps quoting, so there is no oracle anchor and nothing arbitraging the
+  // price: this is exactly when an automated swap gets filled badly.
+  const state = await runFailover((p) => readOnChainState(p, token.address));
+  const blocked: string[] = [];
+  if (state.paused) {
+    blocked.push("token contract paused");
+  }
+  if (state.tokenPaused) {
+    blocked.push("transfers paused");
+  }
+  if (state.oraclePaused) {
+    blocked.push("oracle paused");
+  }
+  if (state.pendingMultiplier) {
+    blocked.push("corporate action pending");
+  }
+  for (const field of state.unknown) {
+    blocked.push(`could not read ${field}`);
+  }
+  if (blocked.length > 0) {
+    return refuse(`Refusing to trade ${token.symbol}: ${blocked.join("; ")}.`);
+  }
+
+  // Shares convert to raw units; USDG does not scale. A sell is sized in
+  // shares and a buy's minimum is expressed in shares, so both cross the
+  // multiplier and both must be converted or the trade is off by it.
+  const multiplier = await resolveForWrite(runFailover, chainId, token.address);
+  if (!multiplier.ok) {
+    return refuse(getErrorMessage(multiplier.error));
+  }
+
+  const toShares = (value: string): bigint | string => {
+    let parsed: bigint;
+    try {
+      parsed = ethers.parseUnits(value, token.decimals);
+    } catch {
+      return `Invalid share amount: ${value}`;
+    }
+    const converted = convertAmountForWrite(parsed, multiplier.multiplier);
+    return converted.ok ? converted.raw : converted.error;
+  };
+
+  let amountInRaw: bigint;
+  let minOutRaw: bigint;
+  if (input.side === "buy") {
+    try {
+      amountInRaw = ethers.parseUnits(input.amountIn, USDG_DECIMALS);
+    } catch {
+      return refuse(`Invalid USDG amount: ${input.amountIn}`);
+    }
+    const out = toShares(input.minAmountOut);
+    if (typeof out === "string") {
+      return refuse(out);
+    }
+    minOutRaw = out;
+  } else {
+    const inRaw = toShares(input.amountIn);
+    if (typeof inRaw === "string") {
+      return refuse(inRaw);
+    }
+    amountInRaw = inRaw;
+    try {
+      minOutRaw = ethers.parseUnits(input.minAmountOut, USDG_DECIMALS);
+    } catch {
+      return refuse(`Invalid USDG amount: ${input.minAmountOut}`);
+    }
+  }
+
+  const [c0, c1] =
+    BigInt(USDG) < BigInt(token.address)
+      ? [USDG, token.address]
+      : [token.address, USDG];
+  const inputCurrency = input.side === "buy" ? USDG : token.address;
+
+  let encoded: ReturnType<typeof encodeExactInSingleSwap>;
+  try {
+    encoded = encodeExactInSingleSwap({
+      poolKey: {
+        currency0: c0,
+        currency1: c1,
+        fee,
+        tickSpacing,
+        hooks: input.poolHooks || ethers.ZeroAddress,
+      },
+      inputCurrency,
+      amountIn: amountInRaw,
+      minAmountOut: minOutRaw,
+    });
+  } catch (error) {
+    return refuse(getErrorMessage(error));
+  }
+
+  let signerMode: Awaited<ReturnType<typeof resolveSignerForNode>>;
+  try {
+    signerMode = await resolveSignerForNode({
+      organizationId,
+      chainId,
+      web3Connection: input.web3Connection,
+    });
+  } catch (error) {
+    return refuse(`Failed to resolve Web3 Connection: ${getErrorMessage(error)}`);
+  }
+
+  const rpcUrl = rpcManager.getProvider()._getConnection().url;
+  const signer = await initializeWalletSigner(organizationId, rpcUrl, chainId);
+  const signerAddress = await getOrganizationWalletAddress(organizationId);
+  const spender =
+    signerMode.kind === SIGNER_MODE.SAFE_ROLE ||
+    signerMode.kind === SIGNER_MODE.SAFE
+      ? signerMode.safeAddress
+      : signerAddress;
+
+  const allowanceProblem = await checkPermit2Allowances(
+    runFailover,
+    inputCurrency,
+    spender,
+    amountInRaw
+  );
+  if (allowanceProblem) {
+    return refuse(allowanceProblem);
+  }
+
+  const deadline =
+    BigInt(Math.floor(Date.now() / 1000)) +
+    BigInt(Number(input.deadlineSeconds || "300"));
+  const args = [encoded.commands, encoded.inputs, deadline];
+
+  try {
+    const adapter = getChainAdapter(chainId);
+    const txContext: TransactionContext = {
+      organizationId,
+      executionId: input._context?.executionId ?? "direct-trade",
+      workflowId: input._context?.workflowId,
+      chainId,
+      rpcUrl,
+      rpcManager,
+    };
+
+    const hash: string = await withNonceSession(
+      txContext,
+      spender,
+      async (session) => {
+        const { multiplierOverride, gasLimitOverride } =
+          resolveGasLimitOverrides(undefined);
+        const workflowId = input._context?.workflowId;
+        // The Safe helpers and the EVM adapter take different option shapes.
+        const safeOptions = { chainId, workflowId, rpcManager };
+        const adapterOptions = {
+          gasOverrides: { multiplierOverride, gasLimitOverride },
+          workflowId,
+          rpcManager,
+        };
+      if (signerMode.kind === SIGNER_MODE.SAFE_ROLE) {
+        const receipt = await executeContractCallAsRole(
+          signer,
+          {
+            safeAddress: signerMode.safeAddress,
+            delegateAddress: signerMode.delegateAddress,
+            rolesModifierAddress: signerMode.rolesModifierAddress,
+            roleKey: signerMode.roleKey,
+            contractAddress: UNIVERSAL_ROUTER,
+            abi: UNIVERSAL_ROUTER_ABI,
+            functionKey: "execute",
+            args,
+          },
+          session,
+          safeOptions
+        );
+        return receipt.hash;
+      }
+      if (signerMode.kind === SIGNER_MODE.SAFE) {
+        const receipt = await executeContractCallAsSafe(
+          signer,
+          {
+            safeAddress: signerMode.safeAddress,
+            ownerAddress: signerMode.ownerAddress,
+            contractAddress: UNIVERSAL_ROUTER,
+            abi: UNIVERSAL_ROUTER_ABI,
+            functionKey: "execute",
+            args,
+          },
+          session,
+          safeOptions
+        );
+        return receipt.hash;
+      }
+      const receipt = await adapter.executeContractCall(
+        signer,
+        {
+          contractAddress: UNIVERSAL_ROUTER,
+          abi: UNIVERSAL_ROUTER_ABI,
+          functionKey: "execute",
+          args,
+        },
+        session,
+        adapterOptions
+      );
+      return receipt.hash;
+      }
+    );
+
+    return {
+      success: true,
+      transactionHash: hash,
+      chainId,
+      symbol: token.symbol,
+      side: input.side,
+      amountIn: input.amountIn,
+      minAmountOut: input.minAmountOut,
+      poolFee: fee,
+      poolTickSpacing: tickSpacing,
+    };
+  } catch (error) {
+    logUserError(
+      ErrorCategory.TRANSACTION,
+      "[Trade Stock Token] Swap failed",
+      error,
+      { plugin_name: "robinhood", action_name: "trade-stock-token" }
+    );
+    return refuse(getErrorMessage(error));
+  }
+}

--- a/plugins/robinhood/steps/trade-stock-token-core.ts
+++ b/plugins/robinhood/steps/trade-stock-token-core.ts
@@ -12,6 +12,10 @@ import { resolveSignerForNode, SIGNER_MODE } from "@/lib/safe/signer-resolver";
 import { getErrorMessage } from "@/lib/utils";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import { resolveGasLimitOverrides } from "@/lib/web3/gas-defaults";
+import {
+  preflightGasBalance,
+  resolveFundingHolder,
+} from "@/lib/web3/gas-preflight";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
 import {
   convertAmountForWrite,
@@ -108,7 +112,8 @@ async function checkPermit2Allowances(
   runFailover: <T>(op: (p: ethers.ContractRunner) => Promise<T>) => Promise<T>,
   token: string,
   owner: string,
-  amount: bigint
+  amount: bigint,
+  deadlineSeconds: number
 ): Promise<string | null> {
   const [toPermit2, permit2ToRouter] = await Promise.all([
     runFailover((p) =>
@@ -136,10 +141,14 @@ async function checkPermit2Allowances(
   if (allowed < amount) {
     return `Permit2 has not authorised the Universal Router to spend ${token}. Call approve(${token}, ${UNIVERSAL_ROUTER}, amount, expiration) on Permit2 at ${PERMIT2}.`;
   }
-  if (expiration !== BigInt(0) && expiration <= now) {
-    return `The Permit2 allowance for ${token} to the Universal Router expired at ${new Date(
-      Number(expiration) * 1000
-    ).toISOString()}. Re-approve it on Permit2 at ${PERMIT2}.`;
+  // Permit2 rewrites an expiration of 0 to block.timestamp on approve, so a
+  // stored 0 means the allowance was never set rather than that it never
+  // expires. The deadline margin matters too: an allowance lapsing between now
+  // and the deadline reverts on-chain after gas has been spent.
+  if (expiration <= now + BigInt(deadlineSeconds)) {
+    return `The Permit2 allowance for ${token} to the Universal Router ${
+      expiration === BigInt(0) ? "was never set" : "expires too soon"
+    }. Re-approve it on Permit2 at ${PERMIT2} with an expiration beyond the trade deadline.`;
   }
   return null;
 }
@@ -178,6 +187,16 @@ export async function tradeStockTokenCore(
   const tickSpacing = Number(input.poolTickSpacing);
   if (!(Number.isInteger(fee) && Number.isInteger(tickSpacing))) {
     return refuse("poolFee and poolTickSpacing must be integers.");
+  }
+
+  const deadlineSeconds = Number(input.deadlineSeconds || "300");
+  if (!(Number.isInteger(deadlineSeconds) && deadlineSeconds > 0)) {
+    // A template-input resolves to any string at runtime. Left unchecked,
+    // "5m" throws out of the function as a RangeError rather than returning a
+    // refusal, and "-100" silently builds a deadline already in the past.
+    return refuse(
+      `deadlineSeconds must be a positive whole number of seconds, got: ${input.deadlineSeconds}`
+    );
   }
 
   let rpcManager: Awaited<ReturnType<typeof getRpcProvider>>;
@@ -294,8 +313,16 @@ export async function tradeStockTokenCore(
   }
 
   const rpcUrl = rpcManager.getProvider()._getConnection().url;
-  const signer = await initializeWalletSigner(organizationId, rpcUrl, chainId);
-  const signerAddress = await getOrganizationWalletAddress(organizationId);
+  let signer: Awaited<ReturnType<typeof initializeWalletSigner>>;
+  let signerAddress: string;
+  try {
+    signer = await initializeWalletSigner(organizationId, rpcUrl, chainId);
+    signerAddress = await getOrganizationWalletAddress(organizationId);
+  } catch (error) {
+    return refuse(
+      `Failed to initialize organization wallet: ${getErrorMessage(error)}`
+    );
+  }
   const spender =
     signerMode.kind === SIGNER_MODE.SAFE_ROLE ||
     signerMode.kind === SIGNER_MODE.SAFE
@@ -306,16 +333,30 @@ export async function tradeStockTokenCore(
     runFailover,
     inputCurrency,
     spender,
-    amountInRaw
+    amountInRaw,
+    deadlineSeconds
   );
   if (allowanceProblem) {
     return refuse(allowanceProblem);
   }
 
   const deadline =
-    BigInt(Math.floor(Date.now() / 1000)) +
-    BigInt(Number(input.deadlineSeconds || "300"));
+    BigInt(Math.floor(Date.now() / 1000)) + BigInt(deadlineSeconds);
   const args = [encoded.commands, encoded.inputs, deadline];
+
+  // Before the nonce session, deliberately. A holder that cannot pay would
+  // otherwise take the lock, discover it at broadcast, and stall every other
+  // execution for the same wallet behind a failover round.
+  const gasCheck = await preflightGasBalance({
+    chainId,
+    rpcManager,
+    // Gas is drawn from the Safe in Safe modes and the EOA otherwise, which is
+    // a different address from the nonce key above.
+    holderAddress: resolveFundingHolder(signerMode, signerAddress),
+  });
+  if (!gasCheck.affordable) {
+    return refuse(gasCheck.message);
+  }
 
   try {
     const adapter = getChainAdapter(chainId);
@@ -328,9 +369,16 @@ export async function tradeStockTokenCore(
       rpcManager,
     };
 
+    // Keyed on the EOA, not on `spender`. In Safe mode `spender` is the Safe,
+    // but the nonce this session hands out is applied to the outer transaction
+    // the EOA signs, so keying on the Safe would read the proxy's transaction
+    // count and sign with a nonce that is far too low. It would also take the
+    // lock on the wrong key, leaving a concurrent transfer on the same EOA
+    // unserialised. `spender` stays the Permit2 owner, where it is correct:
+    // in Safe mode the Safe is msgSender() to the router.
     const hash: string = await withNonceSession(
       txContext,
-      spender,
+      signerAddress,
       async (session) => {
         const { multiplierOverride, gasLimitOverride } =
           resolveGasLimitOverrides(undefined);

--- a/plugins/robinhood/steps/trade-stock-token.ts
+++ b/plugins/robinhood/steps/trade-stock-token.ts
@@ -1,0 +1,44 @@
+import "server-only";
+
+import {
+  runPluginStep,
+  type StepInput,
+} from "@/lib/workflow/executor/step-handler";
+import {
+  type TradeStockTokenCoreInput,
+  tradeStockTokenCore,
+  type TradeStockTokenResult,
+} from "./trade-stock-token-core";
+
+export type TradeStockTokenInput = StepInput &
+  Omit<TradeStockTokenCoreInput, "_context">;
+
+/**
+ * Trade Stock Token
+ *
+ * Swaps USDG into a tokenised equity or back out, through the Universal Router
+ * on Uniswap v4.
+ *
+ * Takes an explicit pool key. This chain carries hundreds of pools per stock
+ * token at fee tiers reaching 95%, all reachable and none distinguished
+ * on-chain, so any pool a heuristic could pick is a pool a griefer could aim
+ * at. The caller names the pool and the minimum they will accept, and the
+ * router enforces the minimum twice.
+ */
+export async function tradeStockTokenStep(
+  input: TradeStockTokenInput
+): Promise<TradeStockTokenResult> {
+  "use step";
+
+  return runPluginStep(
+    { pluginName: "robinhood", actionName: "trade-stock-token" },
+    input,
+    (received: TradeStockTokenInput) => tradeStockTokenCore(received)
+  );
+}
+
+// Never retried. A swap that timed out may still land, and a second attempt
+// would be a second trade at a price nobody asked for.
+tradeStockTokenStep.maxRetries = 0;
+
+export const _integrationType = "robinhood";

--- a/plugins/robinhood/steps/v4-swap-encoding.ts
+++ b/plugins/robinhood/steps/v4-swap-encoding.ts
@@ -1,0 +1,172 @@
+import { ethers } from "ethers";
+
+/**
+ * Calldata encoding for a single-hop exact-input swap through the Universal
+ * Router on Robinhood Chain.
+ *
+ * Every constant and every struct field below was read from the verified source
+ * of the deployed router at 0x8876789976decbfcbbbe364623c63652db8c0904, not
+ * from the Uniswap SDK or the public v4 documentation. That distinction is
+ * load-bearing: this deployment's `ExactInputSingleParams` carries a
+ * `minHopPriceX36` field that upstream v4-periphery does not have, sitting
+ * between `amountOutMinimum` and `hookData`. Encoding against the canonical
+ * struct produces calldata whose `hookData` offset is wrong, which the router
+ * would decode as garbage rather than reject cleanly.
+ *
+ * Pure by design. No provider, no signer, no network. The riskiest part of a
+ * fund-moving action is the part that is easiest to test in isolation, so it is
+ * isolated.
+ */
+
+/** UniversalRouter Commands.V4_SWAP. */
+const COMMAND_V4_SWAP = 0x10;
+
+/** v4-periphery Actions, as deployed. */
+const ACTION_SWAP_EXACT_IN_SINGLE = 0x06;
+const ACTION_SETTLE_ALL = 0x0c;
+const ACTION_TAKE_ALL = 0x0f;
+
+const MAX_UINT128 = (BigInt(1) << BigInt(128)) - BigInt(1);
+
+/** v4 pool identity. `currency0` must sort below `currency1`. */
+export type PoolKey = {
+  currency0: string;
+  currency1: string;
+  fee: number;
+  tickSpacing: number;
+  hooks: string;
+};
+
+export type EncodeSwapArgs = {
+  poolKey: PoolKey;
+  /** The token being spent. Must be one of the pool's two currencies. */
+  inputCurrency: string;
+  amountIn: bigint;
+  /** The floor the caller will accept. Enforced twice on-chain; see below. */
+  minAmountOut: bigint;
+  hookData?: string;
+};
+
+export type EncodedSwap = {
+  commands: string;
+  inputs: string[];
+  /** Derived, not supplied: which direction the pool is being traded in. */
+  zeroForOne: boolean;
+  outputCurrency: string;
+};
+
+const coder = ethers.AbiCoder.defaultAbiCoder();
+
+const EXACT_IN_SINGLE_TUPLE =
+  "tuple(tuple(address currency0,address currency1,uint24 fee,int24 tickSpacing,address hooks) poolKey,bool zeroForOne,uint128 amountIn,uint128 amountOutMinimum,uint256 minHopPriceX36,bytes hookData)";
+
+function assertAddress(value: string, label: string): string {
+  if (!ethers.isAddress(value)) {
+    throw new Error(`${label} is not an address: ${value}`);
+  }
+  return ethers.getAddress(value);
+}
+
+/**
+ * Build the `execute(bytes commands, bytes[] inputs, uint256 deadline)`
+ * arguments for one exact-input swap.
+ *
+ * The action sequence is swap, then settle what is owed, then take what is
+ * credited:
+ *
+ *   SWAP_EXACT_IN_SINGLE  performs the swap and reverts below amountOutMinimum
+ *   SETTLE_ALL(in,  max)  pays the debt, reverting if it exceeds amountIn
+ *   TAKE_ALL(out,   min)  collects the credit, reverting below minAmountOut
+ *
+ * The minimum is therefore enforced twice, by two different checks in the
+ * router. That redundancy is deliberate and kept: this is the only thing
+ * standing between a caller and a 95%-fee pool, of which this chain has many.
+ */
+export function encodeExactInSingleSwap(args: EncodeSwapArgs): EncodedSwap {
+  const currency0 = assertAddress(args.poolKey.currency0, "currency0");
+  const currency1 = assertAddress(args.poolKey.currency1, "currency1");
+  const hooks = assertAddress(args.poolKey.hooks, "hooks");
+  const inputCurrency = assertAddress(args.inputCurrency, "inputCurrency");
+
+  // v4 identifies a pool by the hash of its key, and a key with unsorted
+  // currencies hashes to a pool that does not exist. Rejecting here turns a
+  // confusing on-chain revert into a clear message.
+  if (BigInt(currency0) >= BigInt(currency1)) {
+    throw new Error(
+      "PoolKey currencies must be sorted: currency0 must be numerically below currency1"
+    );
+  }
+
+  // Derived rather than trusted. A caller who passes the direction themselves
+  // can invert it and sell what they meant to buy.
+  let zeroForOne: boolean;
+  if (inputCurrency === currency0) {
+    zeroForOne = true;
+  } else if (inputCurrency === currency1) {
+    zeroForOne = false;
+  } else {
+    throw new Error(
+      `inputCurrency ${inputCurrency} is not part of this pool (${currency0}, ${currency1})`
+    );
+  }
+  const outputCurrency = zeroForOne ? currency1 : currency0;
+
+  if (args.amountIn <= BigInt(0)) {
+    throw new Error("amountIn must be positive");
+  }
+  if (args.minAmountOut <= BigInt(0)) {
+    throw new Error(
+      "minAmountOut must be positive: an unbounded swap on this chain can be filled at a 95 percent fee"
+    );
+  }
+  if (args.amountIn > MAX_UINT128 || args.minAmountOut > MAX_UINT128) {
+    throw new Error("amountIn and minAmountOut must fit in uint128");
+  }
+
+  const actions = ethers.concat([
+    new Uint8Array([ACTION_SWAP_EXACT_IN_SINGLE]),
+    new Uint8Array([ACTION_SETTLE_ALL]),
+    new Uint8Array([ACTION_TAKE_ALL]),
+  ]);
+
+  const swapParams = coder.encode(
+    [EXACT_IN_SINGLE_TUPLE],
+    [
+      [
+        [currency0, currency1, args.poolKey.fee, args.poolKey.tickSpacing, hooks],
+        zeroForOne,
+        args.amountIn,
+        args.minAmountOut,
+        // Zero disables the per-hop price floor. This is a single hop and
+        // amountOutMinimum already bounds the result.
+        BigInt(0),
+        args.hookData ?? "0x",
+      ],
+    ]
+  );
+
+  const settleParams = coder.encode(
+    ["address", "uint256"],
+    [inputCurrency, args.amountIn]
+  );
+  const takeParams = coder.encode(
+    ["address", "uint256"],
+    [outputCurrency, args.minAmountOut]
+  );
+
+  const v4Input = coder.encode(
+    ["bytes", "bytes[]"],
+    [actions, [swapParams, settleParams, takeParams]]
+  );
+
+  return {
+    commands: ethers.hexlify(new Uint8Array([COMMAND_V4_SWAP])),
+    inputs: [v4Input],
+    zeroForOne,
+    outputCurrency,
+  };
+}
+
+export const UNIVERSAL_ROUTER_ABI = [
+  "function execute(bytes commands, bytes[] inputs, uint256 deadline) payable",
+] as const;

--- a/protocols/robinhood.ts
+++ b/protocols/robinhood.ts
@@ -2,10 +2,10 @@ import { defineProtocol } from "@/lib/protocol-registry";
 
 // Hub-only protocol entry: surfaces Robinhood in Hub > Protocols alongside
 // Safe, Aave, etc. The runtime actions live in the `robinhood` plugin in
-// plugins/robinhood/ (read-only stock-token reads on Robinhood Chain). The
-// `hubOnly: true` flag tells discover-plugins NOT to register this as an
-// integration plugin, so the plugin's three actions remain the source of
-// truth in the workflow editor's action grid. The slug matches the plugin
+// plugins/robinhood/ (stock-token reads plus a USDG swap on Robinhood Chain).
+// The `hubOnly: true` flag tells discover-plugins NOT to register this as an
+// integration plugin, so the plugin's actions remain the source of truth in
+// the workflow editor's action grid. The slug matches the plugin
 // type, which is what lets withPluginActions() graft those actions onto the
 // Hub card and detail modal.
 export default defineProtocol({

--- a/tests/unit/robinhood-trade-stock-token.test.ts
+++ b/tests/unit/robinhood-trade-stock-token.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// Only Contract is stubbed. The encoder uses the real AbiCoder, getAddress and
+// parseUnits, and mocking those would hide encoding mistakes rather than
+// exercise them.
+const mockAllowance = vi.fn();
+vi.mock("ethers", async () => {
+  const actual = await vi.importActual<typeof import("ethers")>("ethers");
+  class MockContract {
+    allowance: (...args: unknown[]) => Promise<unknown>;
+    constructor() {
+      this.allowance = (...args: unknown[]) => mockAllowance(...args);
+    }
+  }
+  return { ethers: { ...actual.ethers, Contract: MockContract } };
+});
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { TRANSACTION: "transaction", VALIDATION: "validation" },
+  logUserError: vi.fn(),
+}));
+
+const mockChainId = vi.fn(() => 4663);
+vi.mock("@/lib/rpc/network-utils", () => ({
+  getChainIdFromNetwork: () => mockChainId(),
+}));
+
+const mockFailover = vi.fn();
+vi.mock("@/lib/rpc/provider-factory", () => ({
+  getRpcProvider: () =>
+    Promise.resolve({
+      executeWithFailover: (op: (p: unknown) => unknown) => mockFailover(op),
+      getProvider: () => ({ _getConnection: () => ({ url: "https://rpc" }) }),
+    }),
+}));
+
+const mockResolveToken = vi.fn();
+const mockOnChain = vi.fn();
+vi.mock("@/plugins/robinhood/steps/stock-token-core", () => ({
+  ROBINHOOD_CHAIN_ID: 4663,
+  resolveStockToken: (s: string) => mockResolveToken(s),
+  readOnChainState: () => mockOnChain(),
+}));
+
+const mockResolveForWrite = vi.fn();
+vi.mock("@/lib/web3/ui-multiplier", () => ({
+  resolveForWrite: () => mockResolveForWrite(),
+  convertAmountForWrite: (ui: bigint) => ({ ok: true, raw: ui }),
+}));
+
+vi.mock("@/lib/web3/resolve-org-context", () => ({
+  resolveOrganizationContext: () =>
+    Promise.resolve({ success: true, organizationId: "org1", userId: "u1" }),
+}));
+
+const mockSignerMode = vi.fn(() => ({ kind: "eoa" }));
+vi.mock("@/lib/safe/signer-resolver", () => ({
+  SIGNER_MODE: { EOA: "eoa", SAFE: "safe", SAFE_ROLE: "safe-role" },
+  resolveSignerForNode: () => Promise.resolve(mockSignerMode()),
+}));
+
+vi.mock("@/lib/web3/wallet-helpers", () => ({
+  initializeWalletSigner: () => Promise.resolve({}),
+  getOrganizationWalletAddress: () =>
+    Promise.resolve("0x1111111111111111111111111111111111111111"),
+}));
+
+const mockExecute = vi.fn();
+vi.mock("@/lib/web3/chain-adapter", () => ({
+  getChainAdapter: () => ({ executeContractCall: () => mockExecute() }),
+}));
+
+vi.mock("@/lib/web3/transaction-manager", () => ({
+  withNonceSession: (
+    _ctx: unknown,
+    _addr: string,
+    fn: (s: unknown) => unknown
+  ) => fn({}),
+}));
+
+vi.mock("@/lib/safe/execute-as-safe", () => ({
+  executeContractCallAsRole: vi.fn(),
+  executeContractCallAsSafe: vi.fn(),
+}));
+
+vi.mock("@/lib/web3/gas-defaults", () => ({
+  resolveGasLimitOverrides: () => ({
+    multiplierOverride: undefined,
+    gasLimitOverride: undefined,
+  }),
+}));
+
+import { tradeStockTokenCore } from "@/plugins/robinhood/steps/trade-stock-token-core";
+
+const AAPL = "0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9";
+const UNIT = BigInt("1000000000000000000");
+const HUGE = BigInt("1000000000000000000000000");
+
+const TOKEN = {
+  symbol: "AAPL",
+  name: "Apple",
+  address: AAPL,
+  decimals: 18,
+  currentMultiplier: "1",
+  pendingMultiplier: "",
+  active: true,
+};
+
+const CLEAN_STATE = {
+  uiMultiplier: "1.0",
+  unknown: [],
+  pendingMultiplier: null,
+  effectiveAt: null,
+  paused: false,
+  tokenPaused: false,
+  oraclePaused: false,
+};
+
+function baseInput(overrides: Record<string, unknown> = {}) {
+  return {
+    network: "robinhood-mainnet",
+    symbol: "AAPL",
+    side: "buy" as const,
+    amountIn: "100",
+    minAmountOut: "0.3",
+    poolFee: "3000",
+    poolTickSpacing: "60",
+    _context: { organizationId: "org1" },
+    ...overrides,
+  };
+}
+
+/** Both allowances plentiful and unexpired. */
+function allowancesOk() {
+  mockAllowance.mockImplementation((...args: unknown[]) =>
+    Promise.resolve(args.length === 3 ? [HUGE, BigInt(0), BigInt(0)] : HUGE)
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // The failover wrapper is transparent here: run the operation as given.
+  mockFailover.mockImplementation((op: (p: unknown) => unknown) =>
+    Promise.resolve(op({}))
+  );
+  allowancesOk();
+  mockChainId.mockReturnValue(4663);
+  mockResolveToken.mockResolvedValue({ ok: true, token: TOKEN });
+  mockOnChain.mockResolvedValue(CLEAN_STATE);
+  mockResolveForWrite.mockResolvedValue({ ok: true, multiplier: UNIT });
+  mockExecute.mockResolvedValue({ hash: "0xdead" });
+});
+
+describe("chain and symbol gates", () => {
+  it("refuses a chain other than Robinhood", async () => {
+    mockChainId.mockReturnValue(1);
+    const r = await tradeStockTokenCore(baseInput());
+    expect(r.success).toBe(false);
+  });
+
+  it("refuses an unlisted ticker", async () => {
+    mockResolveToken.mockResolvedValue({ ok: false, error: "NOPE not listed" });
+    const r = await tradeStockTokenCore(baseInput({ symbol: "NOPE" }));
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("trading gates", () => {
+  it.each([
+    ["paused", { paused: true }],
+    ["transfers paused", { tokenPaused: true }],
+    ["oracle paused", { oraclePaused: true }],
+    ["corporate action pending", { pendingMultiplier: "4.0" }],
+  ])("refuses when %s", async (_label, patch) => {
+    mockOnChain.mockResolvedValue({ ...CLEAN_STATE, ...patch });
+    const r = await tradeStockTokenCore(baseInput());
+    expect(r.success).toBe(false);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("refuses when a pause flag could not be read", async () => {
+    // An unreadable flag is not a clear flag, and this is a fund-moving path.
+    mockOnChain.mockResolvedValue({ ...CLEAN_STATE, unknown: ["paused"] });
+    const r = await tradeStockTokenCore(baseInput());
+    expect(r.success).toBe(false);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the multiplier cannot be read", async () => {
+    mockResolveForWrite.mockResolvedValue({
+      ok: false,
+      error: new Error("could not read multiplier"),
+    });
+    const r = await tradeStockTokenCore(baseInput());
+    expect(r.success).toBe(false);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+});
+
+describe("Permit2 allowances", () => {
+  it("refuses and names the missing token approval", async () => {
+    mockAllowance.mockImplementation((...args: unknown[]) =>
+      Promise.resolve(
+        args.length === 3 ? [HUGE, BigInt(0), BigInt(0)] : BigInt(0)
+      )
+    );
+    const r = await tradeStockTokenCore(baseInput());
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error).toMatch(/Permit2/);
+    }
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("refuses when Permit2 has not authorised the router", async () => {
+    mockAllowance.mockImplementation((...args: unknown[]) =>
+      Promise.resolve(
+        args.length === 3 ? [BigInt(0), BigInt(0), BigInt(0)] : HUGE
+      )
+    );
+    const r = await tradeStockTokenCore(baseInput());
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error).toMatch(/Universal Router/);
+    }
+  });
+
+  it("refuses an expired Permit2 allowance", async () => {
+    const past = BigInt(Math.floor(Date.now() / 1000) - 3600);
+    mockAllowance.mockImplementation((...args: unknown[]) =>
+      Promise.resolve(args.length === 3 ? [HUGE, past, BigInt(0)] : HUGE)
+    );
+    const r = await tradeStockTokenCore(baseInput());
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error).toMatch(/expired/);
+    }
+  });
+});
+
+describe("a clean trade", () => {
+  it("broadcasts and reports the pool it used", async () => {
+    allowancesOk();
+    const r = await tradeStockTokenCore(baseInput());
+    expect(r).toMatchObject({
+      success: true,
+      transactionHash: "0xdead",
+      symbol: "AAPL",
+      side: "buy",
+      poolFee: 3000,
+      poolTickSpacing: 60,
+    });
+  });
+
+  it("rejects a non-integer pool key before touching the chain", async () => {
+    const r = await tradeStockTokenCore(baseInput({ poolFee: "not-a-number" }));
+    expect(r.success).toBe(false);
+    expect(mockOnChain).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/robinhood-trade-stock-token.test.ts
+++ b/tests/unit/robinhood-trade-stock-token.test.ts
@@ -67,6 +67,7 @@ vi.mock("@/lib/web3/wallet-helpers", () => ({
     Promise.resolve("0x1111111111111111111111111111111111111111"),
 }));
 
+const mockGasCheck = vi.fn(() => ({ affordable: true }));
 const mockExecute = vi.fn();
 vi.mock("@/lib/web3/chain-adapter", () => ({
   getChainAdapter: () => ({ executeContractCall: () => mockExecute() }),
@@ -83,6 +84,11 @@ vi.mock("@/lib/web3/transaction-manager", () => ({
 vi.mock("@/lib/safe/execute-as-safe", () => ({
   executeContractCallAsRole: vi.fn(),
   executeContractCallAsSafe: vi.fn(),
+}));
+
+vi.mock("@/lib/web3/gas-preflight", () => ({
+  preflightGasBalance: () => Promise.resolve(mockGasCheck()),
+  resolveFundingHolder: (_m: unknown, addr: string) => addr,
 }));
 
 vi.mock("@/lib/web3/gas-defaults", () => ({
@@ -132,10 +138,16 @@ function baseInput(overrides: Record<string, unknown> = {}) {
   };
 }
 
-/** Both allowances plentiful and unexpired. */
+/**
+ * Both allowances plentiful, with an expiry well beyond the trade deadline.
+ * Permit2 rewrites an expiration of 0 to block.timestamp on approve, so a
+ * stored 0 means "never set" rather than "never expires"; using 0 here would
+ * assert the wrong reading of the field.
+ */
+const FUTURE = BigInt(Math.floor(Date.now() / 1000) + 86_400);
 function allowancesOk() {
   mockAllowance.mockImplementation((...args: unknown[]) =>
-    Promise.resolve(args.length === 3 ? [HUGE, BigInt(0), BigInt(0)] : HUGE)
+    Promise.resolve(args.length === 3 ? [HUGE, FUTURE, BigInt(0)] : HUGE)
   );
 }
 
@@ -151,6 +163,7 @@ beforeEach(() => {
   mockOnChain.mockResolvedValue(CLEAN_STATE);
   mockResolveForWrite.mockResolvedValue({ ok: true, multiplier: UNIT });
   mockExecute.mockResolvedValue({ hash: "0xdead" });
+  mockGasCheck.mockReturnValue({ affordable: true });
 });
 
 describe("chain and symbol gates", () => {
@@ -202,9 +215,7 @@ describe("trading gates", () => {
 describe("Permit2 allowances", () => {
   it("refuses and names the missing token approval", async () => {
     mockAllowance.mockImplementation((...args: unknown[]) =>
-      Promise.resolve(
-        args.length === 3 ? [HUGE, BigInt(0), BigInt(0)] : BigInt(0)
-      )
+      Promise.resolve(args.length === 3 ? [HUGE, FUTURE, BigInt(0)] : BigInt(0))
     );
     const r = await tradeStockTokenCore(baseInput());
     expect(r.success).toBe(false);
@@ -216,9 +227,7 @@ describe("Permit2 allowances", () => {
 
   it("refuses when Permit2 has not authorised the router", async () => {
     mockAllowance.mockImplementation((...args: unknown[]) =>
-      Promise.resolve(
-        args.length === 3 ? [BigInt(0), BigInt(0), BigInt(0)] : HUGE
-      )
+      Promise.resolve(args.length === 3 ? [BigInt(0), FUTURE, BigInt(0)] : HUGE)
     );
     const r = await tradeStockTokenCore(baseInput());
     expect(r.success).toBe(false);
@@ -235,7 +244,7 @@ describe("Permit2 allowances", () => {
     const r = await tradeStockTokenCore(baseInput());
     expect(r.success).toBe(false);
     if (!r.success) {
-      expect(r.error).toMatch(/expired/);
+      expect(r.error).toMatch(/expires too soon|never set/);
     }
   });
 });
@@ -258,5 +267,48 @@ describe("a clean trade", () => {
     const r = await tradeStockTokenCore(baseInput({ poolFee: "not-a-number" }));
     expect(r.success).toBe(false);
     expect(mockOnChain).not.toHaveBeenCalled();
+  });
+});
+
+describe("refusals added after review", () => {
+  it("refuses a deadline that is not a positive whole number", async () => {
+    const r = await tradeStockTokenCore(baseInput({ deadlineSeconds: "5m" }));
+    // Must be a refusal, not a RangeError escaping the step.
+    expect(r.success).toBe(false);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("refuses a negative deadline rather than building a past one", async () => {
+    const r = await tradeStockTokenCore(baseInput({ deadlineSeconds: "-100" }));
+    expect(r.success).toBe(false);
+  });
+
+  it("refuses a Permit2 allowance that lapses before the deadline", async () => {
+    const soon = BigInt(Math.floor(Date.now() / 1000) + 10);
+    mockAllowance.mockImplementation((...args: unknown[]) =>
+      Promise.resolve(args.length === 3 ? [HUGE, soon, BigInt(0)] : HUGE)
+    );
+    const r = await tradeStockTokenCore(baseInput({ deadlineSeconds: "300" }));
+    expect(r.success).toBe(false);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the wallet cannot pay for gas, before taking the nonce lock", async () => {
+    mockGasCheck.mockReturnValue({
+      affordable: false,
+      message: "insufficient gas",
+    } as never);
+    const r = await tradeStockTokenCore(baseInput());
+    expect(r.success).toBe(false);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the pending-action reads could not be made", async () => {
+    mockOnChain.mockResolvedValue({
+      ...CLEAN_STATE,
+      unknown: ["newUIMultiplier"],
+    });
+    const r = await tradeStockTokenCore(baseInput());
+    expect(r.success).toBe(false);
   });
 });

--- a/tests/unit/robinhood-v4-swap-encoding.test.ts
+++ b/tests/unit/robinhood-v4-swap-encoding.test.ts
@@ -10,8 +10,10 @@ const USDG = "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168";
 const AAPL = "0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9";
 const ZERO_HOOKS = "0x0000000000000000000000000000000000000000";
 
-// Live pool shape: USDG sorts below AAPL, and every pool on this chain that we
-// inspected carries no hook.
+// Live pool shape: USDG sorts below AAPL. The USDG-quoted stock pools that
+// actually trade are hookless and use canonical tiers (NVDA at 3000/60, AMD,
+// MU and SNDK at 10000/200). Pools elsewhere on this chain do carry hooks and
+// dynamic fees, so this is a fact about the stock pairs, not the chain.
 const POOL: PoolKey = {
   currency0: USDG,
   currency1: AAPL,
@@ -76,7 +78,9 @@ describe("the non-canonical struct", () => {
     // And the canonical five-field shape must NOT round-trip to the same
     // values, which is the whole reason this encoding is hand-written.
     const canonical = coder.encode(
-      ["tuple(tuple(address,address,uint24,int24,address),bool,uint128,uint128,bytes)"],
+      [
+        "tuple(tuple(address,address,uint24,int24,address),bool,uint128,uint128,bytes)",
+      ],
       [[[USDG, AAPL, 10_000, 200, ZERO_HOOKS], true, ONE_USDG, MIN_OUT, "0x"]]
     );
     expect(canonical).not.toBe(params[0]);

--- a/tests/unit/robinhood-v4-swap-encoding.test.ts
+++ b/tests/unit/robinhood-v4-swap-encoding.test.ts
@@ -1,0 +1,193 @@
+import { ethers } from "ethers";
+import { describe, expect, it } from "vitest";
+
+import {
+  encodeExactInSingleSwap,
+  type PoolKey,
+} from "@/plugins/robinhood/steps/v4-swap-encoding";
+
+const USDG = "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168";
+const AAPL = "0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9";
+const ZERO_HOOKS = "0x0000000000000000000000000000000000000000";
+
+// Live pool shape: USDG sorts below AAPL, and every pool on this chain that we
+// inspected carries no hook.
+const POOL: PoolKey = {
+  currency0: USDG,
+  currency1: AAPL,
+  fee: 10_000,
+  tickSpacing: 200,
+  hooks: ZERO_HOOKS,
+};
+
+const coder = ethers.AbiCoder.defaultAbiCoder();
+const ONE_USDG = BigInt(1_000_000); // 6 decimals
+const MIN_OUT = BigInt("3000000000000000"); // 0.003 AAPL, 18 decimals
+
+function decodeV4Input(input: string) {
+  const [actions, params] = coder.decode(["bytes", "bytes[]"], input);
+  return { actions: actions as string, params: params as string[] };
+}
+
+describe("command and action sequence", () => {
+  it("issues V4_SWAP with swap, settle, take in that order", () => {
+    const encoded = encodeExactInSingleSwap({
+      poolKey: POOL,
+      inputCurrency: USDG,
+      amountIn: ONE_USDG,
+      minAmountOut: MIN_OUT,
+    });
+
+    // 0x10 is Commands.V4_SWAP in the deployed router.
+    expect(encoded.commands).toBe("0x10");
+    expect(encoded.inputs).toHaveLength(1);
+
+    const { actions, params } = decodeV4Input(encoded.inputs[0]);
+    // SWAP_EXACT_IN_SINGLE, SETTLE_ALL, TAKE_ALL.
+    expect(actions).toBe("0x060c0f");
+    expect(params).toHaveLength(3);
+  });
+});
+
+describe("the non-canonical struct", () => {
+  it("encodes six fields, not the five upstream v4 defines", () => {
+    const encoded = encodeExactInSingleSwap({
+      poolKey: POOL,
+      inputCurrency: USDG,
+      amountIn: ONE_USDG,
+      minAmountOut: MIN_OUT,
+    });
+    const { params } = decodeV4Input(encoded.inputs[0]);
+
+    // Decoding with the deployed shape must round-trip. If this file is ever
+    // "corrected" to the canonical five-field struct, this fails.
+    const [decoded] = coder.decode(
+      [
+        "tuple(tuple(address,address,uint24,int24,address),bool,uint128,uint128,uint256,bytes)",
+      ],
+      params[0]
+    );
+    expect(decoded[1]).toBe(true); // zeroForOne
+    expect(decoded[2]).toBe(ONE_USDG);
+    expect(decoded[3]).toBe(MIN_OUT);
+    expect(decoded[4]).toBe(BigInt(0)); // minHopPriceX36 disabled
+    expect(decoded[5]).toBe("0x"); // hookData lands where it should
+
+    // And the canonical five-field shape must NOT round-trip to the same
+    // values, which is the whole reason this encoding is hand-written.
+    const canonical = coder.encode(
+      ["tuple(tuple(address,address,uint24,int24,address),bool,uint128,uint128,bytes)"],
+      [[[USDG, AAPL, 10_000, 200, ZERO_HOOKS], true, ONE_USDG, MIN_OUT, "0x"]]
+    );
+    expect(canonical).not.toBe(params[0]);
+  });
+});
+
+describe("direction is derived, never trusted", () => {
+  it("buys the stock when spending the quote currency", () => {
+    const encoded = encodeExactInSingleSwap({
+      poolKey: POOL,
+      inputCurrency: USDG,
+      amountIn: ONE_USDG,
+      minAmountOut: MIN_OUT,
+    });
+    expect(encoded.zeroForOne).toBe(true);
+    expect(encoded.outputCurrency).toBe(ethers.getAddress(AAPL));
+  });
+
+  it("sells the stock when spending the stock", () => {
+    const encoded = encodeExactInSingleSwap({
+      poolKey: POOL,
+      inputCurrency: AAPL,
+      amountIn: MIN_OUT,
+      minAmountOut: ONE_USDG,
+    });
+    expect(encoded.zeroForOne).toBe(false);
+    expect(encoded.outputCurrency).toBe(ethers.getAddress(USDG));
+  });
+
+  it("refuses a currency that is not in the pool", () => {
+    expect(() =>
+      encodeExactInSingleSwap({
+        poolKey: POOL,
+        inputCurrency: "0x000000000000000000000000000000000000dEaD",
+        amountIn: ONE_USDG,
+        minAmountOut: MIN_OUT,
+      })
+    ).toThrow(/not part of this pool/);
+  });
+});
+
+describe("settle and take carry the bounds", () => {
+  it("caps the input at amountIn and floors the output at minAmountOut", () => {
+    const encoded = encodeExactInSingleSwap({
+      poolKey: POOL,
+      inputCurrency: USDG,
+      amountIn: ONE_USDG,
+      minAmountOut: MIN_OUT,
+    });
+    const { params } = decodeV4Input(encoded.inputs[0]);
+
+    const [settleCurrency, settleMax] = coder.decode(
+      ["address", "uint256"],
+      params[1]
+    );
+    expect(settleCurrency).toBe(ethers.getAddress(USDG));
+    expect(settleMax).toBe(ONE_USDG);
+
+    // TAKE_ALL reverts below this, which is the second of the two places the
+    // minimum is enforced on-chain.
+    const [takeCurrency, takeMin] = coder.decode(
+      ["address", "uint256"],
+      params[2]
+    );
+    expect(takeCurrency).toBe(ethers.getAddress(AAPL));
+    expect(takeMin).toBe(MIN_OUT);
+  });
+});
+
+describe("refusals", () => {
+  it("rejects an unsorted pool key rather than hashing to a nonexistent pool", () => {
+    expect(() =>
+      encodeExactInSingleSwap({
+        poolKey: { ...POOL, currency0: AAPL, currency1: USDG },
+        inputCurrency: AAPL,
+        amountIn: ONE_USDG,
+        minAmountOut: MIN_OUT,
+      })
+    ).toThrow(/sorted/);
+  });
+
+  it("rejects a zero minimum, which is an unbounded swap", () => {
+    expect(() =>
+      encodeExactInSingleSwap({
+        poolKey: POOL,
+        inputCurrency: USDG,
+        amountIn: ONE_USDG,
+        minAmountOut: BigInt(0),
+      })
+    ).toThrow(/minAmountOut/);
+  });
+
+  it("rejects a zero input", () => {
+    expect(() =>
+      encodeExactInSingleSwap({
+        poolKey: POOL,
+        inputCurrency: USDG,
+        amountIn: BigInt(0),
+        minAmountOut: MIN_OUT,
+      })
+    ).toThrow(/amountIn/);
+  });
+
+  it("rejects amounts that do not fit uint128", () => {
+    expect(() =>
+      encodeExactInSingleSwap({
+        poolKey: POOL,
+        inputCurrency: USDG,
+        amountIn: BigInt(1) << BigInt(128),
+        minAmountOut: MIN_OUT,
+      })
+    ).toThrow(/uint128/);
+  });
+});


### PR DESCRIPTION
Buys a tokenised equity with USDG or sells it back, through the Universal Router on Uniswap v4. Two commits: the calldata encoder, then the node built on it.

## It takes an explicit pool key, and that is the design

This chain carries **944 distinct pools with AAPL as `currency1` alone**, at fee tiers from 1% to **95%**, all reachable and none distinguished on-chain. Any pool a discovery heuristic would pick is a pool a griefer can aim at.

So the node does not choose. The caller names the pool and names the minimum they will accept, and the router enforces that minimum twice: once in `SWAP_EXACT_IN_SINGLE`'s `amountOutMinimum` and again in `TAKE_ALL`, which reverts when the credit falls below the floor. That redundancy is kept deliberately.

Best-execution routing (enumerate candidates, read `slot0` and liquidity, simulate, pick) is a separate project rather than a refinement of this.

## Which pool to name is now answerable

Found by intersecting the USDG-quoted pool set against pools that have actually traded, rather than by enumeration. The live venues are conventional and hookless:

| pair | fee | tickSpacing | pool mark vs issuer bid |
| -- | -- | -- | -- |
| USDG/NVDA | 3000 | 60 | 226.92 vs 226.52, **0.18%** |
| USDG/AMD | 10000 | 200 | 475.38 vs 473.15, 0.47% |
| USDG/MU | 10000 | 200 | 923.20 vs 915.95, 0.79% |

That price agreement is also what verifies the pool keys are genuinely right rather than merely well-formed.

## The encoder is hand-written, and had to be

Neither venue exposes a typed swap: `UniversalRouter.execute(bytes,bytes[],uint256)` and `RobinHoodSettler.execute((address,address,uint256),bytes[],bytes32)` both take pre-encoded action blobs. That rules out `defineAbiProtocol`, which would otherwise have supplied the audited write path.

Every constant and struct field was read from the **verified source of the deployed router**, not the Uniswap SDK. That mattered:

```solidity
struct ExactInputSingleParams {
    PoolKey poolKey;
    bool    zeroForOne;
    uint128 amountIn;
    uint128 amountOutMinimum;
    uint256 minHopPriceX36;   // not in upstream v4-periphery
    bytes   hookData;
}
```

This deployment carries a per-hop price floor between `amountOutMinimum` and `hookData`. Encoding against the canonical five-field struct shifts the `hookData` offset and produces calldata the router decodes as garbage rather than rejecting. A test asserts the canonical encoding does **not** match ours, so a future correction toward upstream fails loudly.

Invariants the encoder enforces rather than trusting: currencies must be sorted (an unsorted key hashes to a pool that does not exist), the swap direction is derived from which currency is being spent rather than passed in (a caller who supplies it can invert it and sell what they meant to buy), `minAmountOut` must be positive, and amounts must fit `uint128`.

## Every gate is a refusal

Before anything is signed:

- the three pause flags, and a pending corporate action
- **any flag that could not be read.** An unreadable pause flag is not a clear one, and this is the path where that distinction costs money
- a multiplier that could not be read. A sell is sized in shares and a buy's minimum is expressed in shares, so both cross the multiplier; a wrong one here is a wrong trade rather than a wrong display
- **both Permit2 allowances.** The router pulls funds through Permit2 rather than directly, so it needs a token-to-Permit2 approval and a Permit2-to-router approval, with expiry checked separately from absence. Each refusal names the exact approval to make, because a missing allowance otherwise surfaces as an opaque revert

The node reports the approvals to set rather than setting them. A fund-moving action should not quietly grant spending rights as a side effect.

## Standards

Signer routing is `resolveSignerForNode` with all three branches inside `withNonceSession`. Sponsorship is not wired: 4663 is absent from Turnkey's Gas Station allowlist, so that path returns null before doing anything.

`maxRetries = 0`. A swap that timed out may still have landed, and a retry would be a second trade at a price nobody asked for.

## Verification

44 tests across the three Robinhood files (13 node, 10 encoder, 21 read-only). The node's tests run the **real encoder** rather than stubbing it, so an encoding mistake fails them. `tsc` clean; full local unit suite green.

## What reviewers should weigh

**Nothing has executed a real swap yet.** The encoder is verified against the deployed source and by tests, not by a fill. That is the residual risk and it is worth a testnet or small-size trial before this is used in anger.

**Depth is thin.** NVDA saw 14 swaps in roughly 40 minutes and is the busiest stock pair; CRWD holds 7.02 tokens in the pool. The node will work; the market it trades into is quiet.

Note also that `biome.jsonc` excludes `plugins/` entirely, so nothing here is linted by CI. `tsc` does cover it.
