### PR TITLE
fix(executor): keep a run running while a lost step commit lands

### DIFF
--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -453,6 +453,12 @@ async function selfHealWorkflowAfterLateStepCommit(
     .set({
       status: "success",
       error: null,
+      // The classification columns are written alongside `error` at finalize.
+      // Clearing only the message left a success row still labelled with the
+      // spurious failure (e.g. E-0002), which the UI reads as a failed run.
+      errorCategory: null,
+      errorType: null,
+      errorCode: null,
       completedAt: new Date(),
       duration: newDuration,
       currentNodeId: null,

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -55,6 +55,7 @@ import {
   type ReceiptVerificationResult,
   verifyExecutionReceipts,
 } from "@/lib/web3/verify-receipt";
+import { pollForCompletedOutput } from "@/lib/workflow/executor/poll-for-output";
 import {
   EXCEEDED_MAX_RETRIES_REGEX,
   FAILED_AFTER_RETRIES_REGEX,
@@ -700,6 +701,25 @@ const CANCELLED_DUE_TO_SIBLING_ERROR =
   "Cancelled: workflow stopped because another step errored";
 
 /**
+ * True when a step row carries an actionable failure, as opposed to the
+ * placeholder attached to rows that were merely still running when the
+ * workflow finalized.
+ */
+async function hasRealStepFailure(executionId: string): Promise<boolean> {
+  const siblings = await db.query.workflowExecutionLogs.findMany({
+    where: and(
+      eq(workflowExecutionLogs.executionId, executionId),
+      eq(workflowExecutionLogs.status, "error"),
+      isNotNull(workflowExecutionLogs.error),
+      ne(workflowExecutionLogs.error, STEP_INCOMPLETE_ERROR)
+    ),
+    columns: { id: true },
+    limit: 1,
+  });
+  return siblings.length > 0;
+}
+
+/**
  * Pick the message attached to step rows that were still 'running' when the
  * workflow finalized as error.
  *
@@ -714,19 +734,47 @@ const CANCELLED_DUE_TO_SIBLING_ERROR =
 async function pickOrphanCloseErrorMessage(
   executionId: string
 ): Promise<string> {
-  const siblings = await db.query.workflowExecutionLogs.findMany({
-    where: and(
-      eq(workflowExecutionLogs.executionId, executionId),
-      eq(workflowExecutionLogs.status, "error"),
-      isNotNull(workflowExecutionLogs.error),
-      ne(workflowExecutionLogs.error, STEP_INCOMPLETE_ERROR)
-    ),
-    columns: { id: true },
-    limit: 1,
-  });
-  return siblings.length > 0
+  return (await hasRealStepFailure(executionId))
     ? CANCELLED_DUE_TO_SIBLING_ERROR
     : STEP_INCOMPLETE_ERROR;
+}
+
+/**
+ * How long finalization waits for a step commit that is still in flight.
+ *
+ * The step-level recovery in executor.workflow.ts measured this write landing
+ * ~0.3-0.5s after the runner throws, and polls 3s for it. Finalization is the
+ * last chance to get the run's terminal state right, so it allows a wider
+ * margin. It stays far inside the runner's shutdown budget, and inside the
+ * step-completion window a long-running step crosses, so the wait cannot
+ * become the thing that trips the next lost completion.
+ */
+const LATE_STEP_COMMIT_WAIT_MS = 5000;
+const LATE_STEP_COMMIT_POLL_INTERVAL_MS = 250;
+
+/**
+ * Wait for the in-flight commits behind a spurious runner error to land.
+ *
+ * A step that is still executing has only a 'running' row, which
+ * computeTrulyFailedNodes cannot tell apart from a step that failed. Resolves
+ * true once no node is left without a success row.
+ */
+async function awaitLateStepCommits(executionId: string): Promise<boolean> {
+  const settled = await pollForCompletedOutput(
+    async () =>
+      (await listTrulyFailedNodes(executionId)).length === 0 ? true : null,
+    {
+      timeoutMs: LATE_STEP_COMMIT_WAIT_MS,
+      intervalMs: LATE_STEP_COMMIT_POLL_INTERVAL_MS,
+    }
+  );
+
+  getMetricsCollector().incrementCounter(
+    "workflow.executor.late_step_commit_wait.total",
+    { outcome: settled ? "settled" : "timed_out" }
+  );
+
+  return settled === true;
 }
 
 /**
@@ -776,7 +824,9 @@ export async function logWorkflowCompleteDb(
   // completion (e.g. the worker was killed mid-step). That is not a
   // spurious SDK error - the workflow really is incomplete. Keep 'error'
   // and close the orphaned rows below so the UI doesn't show stuck
-  // spinners.
+  // spinners. When the runner error IS one of the spurious shapes, the
+  // running row is ambiguous: the step may simply not have committed yet,
+  // so it gets a bounded wait before that reading is published.
   //
   // KEEP-431: Aggregate by nodeId rather than counting raw rows. Under
   // cross-pod SDK checkpoint resume, a step that already succeeded on pod A
@@ -807,7 +857,24 @@ export async function logWorkflowCompleteDb(
     );
 
     try {
-      const trulyFailedNodes = await listTrulyFailedNodes(params.executionId);
+      let trulyFailedNodes = await listTrulyFailedNodes(params.executionId);
+
+      // A step whose completion event the runner lost may still be executing.
+      // It has only a 'running' row, so it reads as failed here, and
+      // finalizing on that reading publishes a failure the late commit takes
+      // back seconds later: the run flips error -> success in the runs table
+      // and the step row shows "Step did not record completion" until it does.
+      // Wait for the commit instead, so the run stays running until its real
+      // outcome is known. A step row carrying a real error means something
+      // genuinely failed and there is nothing to wait for.
+      if (
+        trulyFailedNodes.length > 0 &&
+        isSpuriousWorkflowError(params.error) &&
+        !(await hasRealStepFailure(params.executionId)) &&
+        (await awaitLateStepCommits(params.executionId))
+      ) {
+        trulyFailedNodes = [];
+      }
 
       if (trulyFailedNodes.length === 0) {
         // KEEP-532: Recovery event -- spurious SDK error overridden to success.

--- a/tests/integration/workflow-logging-self-heal.test.ts
+++ b/tests/integration/workflow-logging-self-heal.test.ts
@@ -218,6 +218,41 @@ describe("logStepCompleteDb self-heal (KEEP-431 follow-up)", () => {
       );
     });
 
+    it("clears the error classification columns on the flipped row", async () => {
+      executionRow = {
+        status: "error",
+        error: "Step did not record completion",
+        completedAt: new Date(),
+        startedAt: new Date(Date.now() - 1000),
+      };
+      allLogs = [
+        { nodeId: "trigger", status: "success" },
+        { nodeId: "combine", status: "success" },
+      ];
+
+      await logStepCompleteDb({
+        logId: "log_combine",
+        startTime: Date.now() - 200,
+        status: "success",
+        output: {},
+        outputRaw: {},
+        executionId,
+      });
+
+      // Leaving these set labels a success row with the spurious failure that
+      // was just healed away, which reads as a failed run downstream.
+      const flip = getWorkflowStatusFlip();
+      expect(flip?.set).toEqual(
+        expect.objectContaining({
+          status: "success",
+          error: null,
+          errorCategory: null,
+          errorType: null,
+          errorCode: null,
+        })
+      );
+    });
+
     it("clears stale error from success rows after flip", async () => {
       executionRow = {
         status: "error",

--- a/tests/integration/workflow-logging.test.ts
+++ b/tests/integration/workflow-logging.test.ts
@@ -140,6 +140,18 @@ vi.mock("@/lib/web3/verify-receipt", () => ({
       .join(", ")}`,
 }));
 
+// The poll loop itself is covered by tests/unit/poll-for-completed-output.test.ts.
+// Collapsing it to two attempts with no sleeping lets the finalize-side wait be
+// driven by lateCommitLogs without wall-clock delay.
+vi.mock("@/lib/workflow/executor/poll-for-output", () => ({
+  pollForCompletedOutput: async <T>(
+    fetchFn: () => Promise<T | null>
+  ): Promise<T | null> => {
+    const first = await fetchFn();
+    return first === null ? await fetchFn() : first;
+  },
+}));
+
 // State the tests mutate between runs.
 type UpdateCall = {
   target: unknown;
@@ -160,6 +172,10 @@ let mockExecution: ExecutionRow | null = null;
 // (status='error' siblings carrying a non-orphan error). Default empty so existing
 // tests keep observing the legacy "Step did not record completion" message.
 let siblingErrorRows: Array<{ id: string }> = [];
+// When set, every listTrulyFailedNodes probe after the first sees these rows:
+// the step commit that was in flight while the runner reported failure.
+let lateCommitLogs: LogRow[] | null = null;
+let trulyFailedProbes = 0;
 // resolveGasTotal issues `db.select(...).from(...).where(...)` and reads
 // rows[0].gasUsedWei. Default to a no-gas run; tests that exercise the gas
 // denormalisation set this to a summed value.
@@ -249,8 +265,12 @@ vi.mock("@/lib/db", () => ({
           const cols = opts?.columns ?? {};
           const isOrphanSiblingProbe =
             cols.id === true && cols.nodeId !== true && cols.status !== true;
+          if (isOrphanSiblingProbe) {
+            return Promise.resolve(siblingErrorRows);
+          }
+          trulyFailedProbes += 1;
           return Promise.resolve(
-            isOrphanSiblingProbe ? siblingErrorRows : allLogs
+            lateCommitLogs && trulyFailedProbes > 1 ? lateCommitLogs : allLogs
           );
         }),
       },
@@ -324,6 +344,8 @@ describe("logWorkflowCompleteDb", () => {
     updateCalls = [];
     updateShouldThrow = false;
     siblingErrorRows = [];
+    lateCommitLogs = null;
+    trulyFailedProbes = 0;
     mockGasRows = [{ gasUsedWei: null }];
     mockReturningRows = [];
     mockOrgRows = [{ slug: "acme" }];
@@ -451,6 +473,80 @@ describe("logWorkflowCompleteDb", () => {
       expect.objectContaining({ execution_id: "exec_1" })
     );
     expect(logSystemError).not.toHaveBeenCalled();
+  });
+
+  // The runner reports a lost completion event while the step body is still
+  // executing. Publishing that reading paints the run red and stamps the step
+  // "Step did not record completion" until the commit lands and self-heal
+  // takes it back; the run was never anything but running.
+  it("waits for an in-flight step commit before finalizing a spurious error", async () => {
+    allLogs = [
+      { id: "log_trigger", nodeId: "trigger", status: "success" },
+      { id: "log_query", nodeId: "query", status: "running" },
+    ];
+    lateCommitLogs = [
+      { id: "log_trigger", nodeId: "trigger", status: "success" },
+      { id: "log_query", nodeId: "query", status: "success" },
+    ];
+
+    await logWorkflowCompleteDb({
+      executionId: "exec_1",
+      status: "error",
+      error: "Step did not record completion",
+      startTime: Date.now() - 1000,
+    });
+
+    expect(getExecUpdate()?.set).toEqual(
+      expect.objectContaining({ status: "success", error: undefined })
+    );
+    // The orphan row is closed as success, so no failure message is attached.
+    expect(getLogUpdate()?.set).toEqual(
+      expect.objectContaining({ status: "success", error: undefined })
+    );
+  });
+
+  it("finalizes as error when the in-flight commit never lands", async () => {
+    allLogs = [{ id: "log_running", nodeId: "node_a", status: "running" }];
+
+    await logWorkflowCompleteDb({
+      executionId: "exec_1",
+      status: "error",
+      error: "Step did not record completion",
+      startTime: Date.now() - 1000,
+    });
+
+    expect(getExecUpdate()?.set).toEqual(
+      expect.objectContaining({
+        status: "system_error",
+        error: "Step did not record completion",
+      })
+    );
+  });
+
+  // A step row carrying a real error means something genuinely failed, so
+  // there is nothing in flight to wait for.
+  it("does not wait when a peer step carries a real error", async () => {
+    allLogs = [
+      { id: "log_running", nodeId: "node_a", status: "running" },
+      { id: "log_error", nodeId: "node_b", status: "error" },
+    ];
+    siblingErrorRows = [{ id: "log_error" }];
+    lateCommitLogs = [
+      { id: "log_running", nodeId: "node_a", status: "success" },
+      { id: "log_error", nodeId: "node_b", status: "error" },
+    ];
+
+    await logWorkflowCompleteDb({
+      executionId: "exec_1",
+      status: "error",
+      error: 'Step "node_b" exceeded max retries (1 retry)',
+      startTime: Date.now() - 1000,
+    });
+
+    expect(trulyFailedProbes).toBe(1);
+    expect(getExecUpdate()?.set).toEqual(
+      expect.objectContaining({ status: "system_error" })
+    );
   });
 
   // KEEP-333: If a step started but never recorded completion, the workflow


### PR DESCRIPTION
## Problem

The Workflow DevKit can lose a step's completion event and report the whole run
as failed while that step is still executing. Two things then went wrong, both
of them on runs that actually succeeded.

**The run is published as failed before its outcome is known.** At finalize the
still-executing step has only a `running` log row, and the reconciliation that
decides the terminal status cannot tell that apart from a step that failed. The
run was written as error: red in the runs table, with its step row stamped
"Step did not record completion". When the commit finally landed, self-heal
flipped the run to success and cleared the step message. What users saw was a
run going from failed to succeeded on its own, on a run that was never anything
but running.

**The healed row kept its failure labels.** The self-heal CAS update cleared
`error` but not `error_category`, `error_type` or `error_code`, so a
`status='success'` row kept a code like `E-0002` permanently.
`logWorkflowCompleteDb` already nulls all three on its own success path; the
self-heal update was the only site that did not.

## Change

Finalization waits for the in-flight commit before publishing that reading. The
wait reuses `pollForCompletedOutput`, the helper the step-level recovery
already uses, bounded at 5s with a 250ms interval. It applies only when the
runner error is one of the three spurious shapes and no step row carries a real
failure. If the commit lands, the run finalizes straight to success and the
orphan step row closes as success with no failure message attached. If it does
not land, the run finalizes to error on exactly the path it took before.

The self-heal CAS update nulls the three classification columns alongside
`error`.

## Evidence

Observed on a scheduled keeper whose scan step runs 15 to 31 seconds, long
enough to cross the step-completion window on most runs. Across the last 24
hours of production: 27,676 successful runs, 3 carrying a stale error code.

## Scope

A genuine failure finalizes immediately, as does any runner error outside the
spurious shapes. The wait sits well inside the runner's shutdown budget and
inside the step-completion window, so it cannot become the thing that trips the
next lost completion. Rows already written are not backfilled.
