### PR TITLE
fix(editor): allow editing a reference path in place, and resolve present-but-empty fields

### DIFF
--- a/components/ui/template-badge-editor.tsx
+++ b/components/ui/template-badge-editor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useAtom } from "jotai";
-import type { CSSProperties } from "react";
+import type { CSSProperties, MouseEvent as ReactMouseEvent } from "react";
 import { useEffect, useRef, useState } from "react";
 import { doesNodeExist, getDisplayTextForTemplate } from "@/lib/workflow/editor/template-utils";
 import { cn } from "@/lib/utils";
@@ -23,6 +23,23 @@ export function hasUsableSelection(
 ): selection is Selection {
   return selection !== null && selection.rangeCount > 0;
 }
+
+// Length of the trailing "}}" so the caret can be parked just inside the token
+// when a badge is opened for editing.
+const CLOSING_BRACES_LENGTH = 2;
+
+/**
+ * Caret offset to use when a badge is opened for editing: just inside the
+ * closing braces, so typing extends the field path rather than appending text
+ * after the token. Falls back to the end for a token that is not brace-closed.
+ */
+export function caretOffsetForBadgeEdit(rawTemplate: string): number {
+  return rawTemplate.endsWith("}}")
+    ? rawTemplate.length - CLOSING_BRACES_LENGTH
+    : rawTemplate.length;
+}
+
+const EDIT_BADGE_HINT = "Double-click to edit this reference";
 
 export type TemplateBadgeEditorMultilineOptions = {
   rows: number;
@@ -394,6 +411,7 @@ export function TemplateBadgeEditor({
         : "inline-flex items-center gap-1 rounded bg-red-500/10 px-1.5 py-0.5 text-red-600 dark:text-red-400 font-mono text-xs border border-red-500/20 mx-0.5";
       badge.contentEditable = "false";
       badge.setAttribute("data-template", fullMatch);
+      badge.title = EDIT_BADGE_HINT;
       // Use current node label for display
       badge.textContent = getDisplayTextForTemplate(fullMatch, nodes);
       container.appendChild(badge);
@@ -553,6 +571,50 @@ export function TemplateBadgeEditor({
 
     pendingCursorPosition.current = targetCursorPosition;
     contentRef.current.focus();
+  };
+
+  // Open a badge for editing: swap it for its raw `{{@nodeId:Label.path}}` text
+  // with the caret just inside the closing braces. The autocomplete can only
+  // offer field paths it has seen in a previous run, so a path on a node that
+  // has never executed is otherwise unreachable -- the badge is
+  // contentEditable=false and there is no cursor position inside it.
+  //
+  // No re-render is needed here: extractValue() reads a badge as its
+  // data-template and raw text as itself, so the serialized value is unchanged.
+  // Typing inside the token keeps the token count stable, which handleInput
+  // treats as "typing around existing badges" and leaves the DOM alone.
+  // handleBlur re-renders the badge with the edited path.
+  const handleDoubleClick = (e: ReactMouseEvent<HTMLDivElement>): void => {
+    if (disabled || !contentRef.current) {
+      return;
+    }
+    const target = e.target as HTMLElement | null;
+    const badge = target?.closest?.("[data-template]") as HTMLElement | null;
+    if (!badge || !contentRef.current.contains(badge)) {
+      return;
+    }
+    const raw = badge.getAttribute("data-template");
+    if (!raw) {
+      return;
+    }
+
+    e.preventDefault();
+    const textNode = document.createTextNode(raw);
+    badge.replaceWith(textNode);
+
+    const caret = caretOffsetForBadgeEdit(raw);
+    const selection = window.getSelection();
+    try {
+      const range = document.createRange();
+      range.setStart(textNode, caret);
+      range.collapse(true);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    } catch {
+      // Caret placement is a convenience; the text is editable regardless.
+    }
+    contentRef.current.focus();
+    shouldUpdateDisplay.current = false;
   };
 
   const handleFocus = (): void => {
@@ -758,6 +820,7 @@ export function TemplateBadgeEditor({
           contentEditable={!disabled}
           id={id}
           onBlur={handleBlur}
+          onDoubleClick={handleDoubleClick}
           onFocus={handleFocus}
           onInput={handleInput}
           onKeyDown={handleKeyDown}

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -80,6 +80,10 @@ import {
   TemplateResolutionError,
   type TemplateResolutionTracker,
 } from "@/lib/workflow/executor/template-resolution";
+import {
+  isMissingReference,
+  makeMissingReference,
+} from "@/lib/workflow/nodes/condition/missing-reference";
 import { resolveConditionExpression } from "@/lib/workflow/nodes/condition/resolver";
 import { safeEvaluateCondition } from "@/lib/workflow/nodes/condition/safe-eval";
 import {
@@ -180,7 +184,7 @@ const ARRAY_ACCESS_PATTERN = /^([^[]+)\[(\d+)\]$/;
  * through plain objects and arrays. Display-only; never fed back into eval.
  */
 function formatConditionValueForDisplay(value: unknown): unknown {
-  if (value === undefined) {
+  if (value === undefined || isMissingReference(value)) {
     return "undefined";
   }
   if (Array.isArray(value)) {
@@ -328,10 +332,9 @@ function replaceTemplateVariable(
     // not there: bind undefined so a presence guard can handle it, and report
     // the path. Only a reference to a node with no output entry at all still
     // throws, since that is a broken reference rather than an empty result.
-    unresolvedFields?.push(
-      `"${rest}": the node output data is ${output.data === null ? "null" : "undefined"}.`
-    );
-    value = undefined;
+    const detail = `"${rest}": the node output data is ${output.data === null ? "null" : "undefined"}.`;
+    unresolvedFields?.push(detail);
+    value = makeMissingReference(detail);
   } else {
     // Wrapper-aware lookup: matches resolveFromOutputData's three-shape walk
     // (top-level → { data: ... } → { result: ... }) so paths like
@@ -354,8 +357,9 @@ function replaceTemplateVariable(
     // `a !== undefined && a == b`, the `&&` never gets to short-circuit
     // because `a` is resolved before evaluation starts. The path is reported
     // on the step output so a mistyped field is still visible in the run.
-    unresolvedFields?.push(describeMissingFieldPath(output.data, fieldPath));
-    value = undefined;
+    const detail = describeMissingFieldPath(output.data, fieldPath);
+    unresolvedFields?.push(detail);
+    value = makeMissingReference(detail);
   }
 
   const varName = `__v${varCounter.value}`;
@@ -379,7 +383,7 @@ type ConditionEvalResult = {
 // Render a resolved value as it should appear inside the resolved expression:
 // strings quoted, numbers/booleans/null bare, undefined as the keyword.
 function renderConditionLiteral(value: unknown): string {
-  if (value === undefined) {
+  if (value === undefined || isMissingReference(value)) {
     return "undefined";
   }
   if (typeof value === "bigint") {

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -848,8 +848,12 @@ function replaceConfigTemplate(
       : [];
   console.log("[Template] Output data top-level keys:", dataKeys);
 
-  const resolved = resolveFromOutputData(data, fieldPath);
-  if (resolved === undefined || resolved === null) {
+  // Checked walk (the same one the Condition path uses) so a key that exists
+  // but holds null/undefined resolves to that value. Inferring "missing" from a
+  // nullish result conflated the two and failed the action on a path that was
+  // present and legitimately empty.
+  const checked = resolveFromOutputDataChecked(data, fieldPath);
+  if (!checked.found) {
     if (hasNestedDataShape(data)) {
       const innerKeys = Object.keys(data.data as Record<string, unknown>);
       console.log("[Template] Trying inner output.data, keys:", innerKeys);
@@ -866,6 +870,7 @@ function replaceConfigTemplate(
     return "";
   }
 
+  const resolved = checked.value;
   console.log(
     "[Template] Resolved, type:",
     typeof resolved,
@@ -1055,8 +1060,10 @@ function resolveStoredCodeRef(
   const fieldPath = rest.includes(".")
     ? rest.substring(rest.indexOf(".") + 1).trim()
     : "";
-  const resolved = resolveFromOutputData(data, fieldPath);
-  if (resolved === undefined || resolved === null) {
+  // Checked walk: a key that exists holding null/undefined is a real value and
+  // renders as the `null` literal, not an unresolved reference.
+  const checked = resolveFromOutputDataChecked(data, fieldPath);
+  if (!checked.found) {
     recordUnresolved(tracker, {
       token: full,
       reason: "no-path",
@@ -1064,7 +1071,7 @@ function resolveStoredCodeRef(
     });
     return "null";
   }
-  return formatCodeValue(resolved);
+  return formatCodeValue(checked.value);
 }
 
 function resolveDisplayCodeRef(

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -12,6 +12,7 @@ import {
   logSystemError,
   logSystemWarn,
   logUserError,
+  logWarn,
 } from "@/lib/logging";
 import { getMetricsCollector } from "@/lib/metrics";
 import {
@@ -236,6 +237,51 @@ export type WorkflowExecutionInput = {
 };
 
 /**
+ * Walk a field path that failed to resolve and describe where it broke, in the
+ * same terms the resolver used to throw in. Returned to the caller so a
+ * mistyped reference is reported on the condition's output instead of being
+ * lost when the path resolves to undefined.
+ */
+function describeMissingFieldPath(data: unknown, fieldPath: string): string {
+  let current: unknown = data;
+
+  for (const segment of fieldPath.split(".")) {
+    if (current === null || current === undefined) {
+      return `"${fieldPath}" could not be resolved: "${segment}" was read from ${current === null ? "null" : "undefined"}.`;
+    }
+    if (typeof current !== "object") {
+      return `"${fieldPath}" could not be resolved: "${segment}" was read from a ${typeof current}.`;
+    }
+
+    const container = current as Record<string, unknown>;
+    const arrayMatch = segment.match(ARRAY_ACCESS_PATTERN);
+    if (arrayMatch) {
+      const [, key, indexStr] = arrayMatch;
+      const index = Number.parseInt(indexStr, 10);
+      if (!(key in container)) {
+        return `"${fieldPath}": "${key}" does not exist on the data. Available fields: ${Object.keys(container).join(", ") || "(none)"}`;
+      }
+      const arr = container[key];
+      if (!Array.isArray(arr)) {
+        return `"${fieldPath}": "${key}" is not an array. Cannot access [${index}].`;
+      }
+      if (index < 0 || index >= arr.length) {
+        return `"${fieldPath}": "${segment}" is out of range (array length ${arr.length}). Use index 0 to ${arr.length - 1}.`;
+      }
+      current = arr[index];
+      continue;
+    }
+
+    if (!(segment in container)) {
+      return `"${fieldPath}": "${segment}" does not exist on the data. Available fields: ${Object.keys(container).join(", ") || "(none)"}`;
+    }
+    current = container[segment];
+  }
+
+  return `"${fieldPath}" could not be resolved.`;
+}
+
+/**
  * Helper to replace template variables in conditions
  */
 function replaceTemplateVariable(
@@ -246,7 +292,8 @@ function replaceTemplateVariable(
   evalContext: Record<string, unknown>,
   varCounter: { value: number },
   nodeMap?: ReadonlyMap<string, unknown>,
-  executionResults?: Record<string, ExecutionResult>
+  executionResults?: Record<string, ExecutionResult>,
+  unresolvedFields?: string[]
 ): string {
   const sanitizedNodeId = nodeId.replace(/[^a-zA-Z0-9]/g, "_");
   const output = outputs[sanitizedNodeId];
@@ -297,53 +344,14 @@ function replaceTemplateVariable(
       return varName;
     }
 
-    const fields = fieldPath.split(".");
-    // biome-ignore lint/suspicious/noExplicitAny: Dynamic data traversal
-    let current: any = output.data;
-
-    for (const segment of fields) {
-      if (current === null || current === undefined) {
-        throw new Error(
-          `Condition references field "${fieldPath}" but it could not be resolved. Check that the field path is correct.`
-        );
-      }
-      if (typeof current !== "object") {
-        throw new Error(
-          `Condition references field "${fieldPath}" but it could not be resolved. Check that the field path is correct.`
-        );
-      }
-
-      const arrayMatch = segment.match(ARRAY_ACCESS_PATTERN);
-      if (arrayMatch) {
-        const [, key, indexStr] = arrayMatch;
-        const index = Number.parseInt(indexStr, 10);
-        if (!(key in current)) {
-          throw new Error(
-            `Condition references field "${fieldPath}" but "${key}" does not exist on the data. Available fields: ${Object.keys(current).join(", ") || "(none)"}`
-          );
-        }
-        const arr = current[key];
-        if (!Array.isArray(arr)) {
-          throw new Error(
-            `Condition references field "${fieldPath}" but "${key}" is not an array. Cannot access [${index}].`
-          );
-        }
-        if (index < 0 || index >= arr.length) {
-          throw new Error(
-            `Condition references field "${fieldPath}" but "${segment}" is out of range (array length ${arr.length}). Use index 0 to ${arr.length - 1}.`
-          );
-        }
-        current = arr[index];
-      } else {
-        if (!(segment in current)) {
-          throw new Error(
-            `Condition references field "${fieldPath}" but "${segment}" does not exist on the data. Available fields: ${Object.keys(current).join(", ") || "(none)"}`
-          );
-        }
-        current = current[segment];
-      }
-    }
-    value = current;
+    // Absent path resolves to undefined rather than throwing. Every reference
+    // in the expression is resolved before the expression runs, so throwing
+    // here also defeats a guard the author wrote for exactly this case: in
+    // `a !== undefined && a == b`, the `&&` never gets to short-circuit
+    // because `a` is resolved before evaluation starts. The path is reported
+    // on the step output so a mistyped field is still visible in the run.
+    unresolvedFields?.push(describeMissingFieldPath(output.data, fieldPath));
+    value = undefined;
   }
 
   const varName = `__v${varCounter.value}`;
@@ -358,6 +366,10 @@ type ConditionEvalResult = {
   // The expression with each {{...}} reference replaced by its resolved value,
   // so observability shows what was actually compared (e.g. "0x1..." == "0x6...").
   resolvedExpression?: string;
+  // Field paths that were not present on their node's output and so resolved
+  // to undefined. The branch is still taken on the evaluated result; this
+  // carries the diagnostic so a mistyped path is visible in the run detail.
+  unresolvedFields?: string[];
 };
 
 // Render a resolved value as it should appear inside the resolved expression:
@@ -422,6 +434,7 @@ export function evaluateConditionExpression(
       let transformedExpression = conditionExpression;
       const templatePattern = /\{\{@([^:]+):([^}]+)\}\}/g;
       const varCounter = { value: 0 };
+      const unresolvedFields: string[] = [];
 
       transformedExpression = transformedExpression.replace(
         templatePattern,
@@ -434,7 +447,8 @@ export function evaluateConditionExpression(
             evalContext,
             varCounter,
             nodeMap,
-            executionResults
+            executionResults,
+            unresolvedFields
           );
           // Store the resolved value with a readable key (the display text
           // from the template), preserving the null/undefined distinction so a
@@ -492,7 +506,17 @@ export function evaluateConditionExpression(
       // Only reads the resolved __v/__b values and applies allowlisted
       // operators and methods.
       const result = safeEvaluateCondition(transformedExpression, evalContext);
-      return { result: Boolean(result), resolvedValues, resolvedExpression };
+      if (unresolvedFields.length > 0) {
+        logWarn("[Condition] Reference(s) resolved to undefined", {
+          unresolved: unresolvedFields.join(" | "),
+        });
+      }
+      return {
+        result: Boolean(result),
+        resolvedValues,
+        resolvedExpression,
+        ...(unresolvedFields.length > 0 ? { unresolvedFields } : {}),
+      };
     } catch (error) {
       // KEEP-1284: Re-throw errors about missing data - these should not be silently swallowed
       if (
@@ -648,6 +672,7 @@ async function executeActionStep(input: {
     let resolvedValues: Record<string, unknown> = {};
     let resolvedExpression: string | undefined;
     let evaluationError: string | undefined;
+    let unresolvedFields: string[] | undefined;
 
     try {
       const result = evaluateConditionExpression(
@@ -659,6 +684,7 @@ async function executeActionStep(input: {
       evaluatedCondition = result.result;
       resolvedValues = result.resolvedValues;
       resolvedExpression = result.resolvedExpression;
+      unresolvedFields = result.unresolvedFields;
     } catch (error) {
       evaluationError = error instanceof Error ? error.message : String(error);
     }
@@ -676,6 +702,7 @@ async function executeActionStep(input: {
       values:
         Object.keys(resolvedValues).length > 0 ? resolvedValues : undefined,
       _evaluationError: evaluationError,
+      unresolvedFields,
       _context: context,
     });
   }

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -324,10 +324,14 @@ function replaceTemplateVariable(
   if (!fieldPath) {
     value = output.data;
   } else if (output.data === null || output.data === undefined) {
-    // KEEP-1284: Throw error when node data is null/undefined
-    throw new Error(
-      `Condition references "${rest}" but the node output data is ${output.data === null ? "null" : "undefined"}. Ensure the referenced node produces valid output.`
+    // A node that produced no data is the same situation as a field that is
+    // not there: bind undefined so a presence guard can handle it, and report
+    // the path. Only a reference to a node with no output entry at all still
+    // throws, since that is a broken reference rather than an empty result.
+    unresolvedFields?.push(
+      `"${rest}": the node output data is ${output.data === null ? "null" : "undefined"}.`
     );
+    value = undefined;
   } else {
     // Wrapper-aware lookup: matches resolveFromOutputData's three-shape walk
     // (top-level → { data: ... } → { result: ... }) so paths like

--- a/lib/workflow/nodes/condition/missing-reference.ts
+++ b/lib/workflow/nodes/condition/missing-reference.ts
@@ -1,0 +1,51 @@
+/**
+ * Marker bound in place of a condition reference whose field path is not
+ * present on the referenced node's output.
+ *
+ * Every reference in a condition is resolved before the expression is
+ * evaluated, so the resolver cannot know which operator a given operand
+ * belongs to. Binding this marker defers that decision to evaluation: the
+ * presence operators (is undefined, is not undefined, exists, does not exist,
+ * is empty, is not empty) read it as `undefined` and evaluate normally, while
+ * any other operator rejects it and the run fails with the resolver's original
+ * diagnostic.
+ *
+ * That keeps a deliberate existence check working without letting a mistyped
+ * path quietly satisfy a comparison and route the workflow down a branch the
+ * author did not intend.
+ */
+
+export type MissingReference = {
+  readonly __keeperhubMissingReference: true;
+  /** Resolver diagnostic, including the available field names. */
+  readonly detail: string;
+};
+
+export function makeMissingReference(detail: string): MissingReference {
+  return { __keeperhubMissingReference: true, detail };
+}
+
+export function isMissingReference(value: unknown): value is MissingReference {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as MissingReference).__keeperhubMissingReference === true
+  );
+}
+
+/** Literals a presence check compares against; the marker reads as undefined. */
+export function isPresenceProbe(other: unknown): boolean {
+  return other === undefined || other === null || other === "";
+}
+
+const EQUALITY_OPERATORS = new Set(["===", "!==", "==", "!="]);
+
+export function isEqualityOperator(operator: string): boolean {
+  return EQUALITY_OPERATORS.has(operator);
+}
+
+export function missingReferenceError(reference: MissingReference): Error {
+  return new Error(
+    `Condition references field ${reference.detail} Use the "is undefined" or "is not undefined" operator to test whether the field is present.`
+  );
+}

--- a/lib/workflow/nodes/condition/safe-eval.ts
+++ b/lib/workflow/nodes/condition/safe-eval.ts
@@ -24,6 +24,14 @@
  * access, and any other call target) throws.
  */
 
+import {
+  isEqualityOperator,
+  isMissingReference,
+  isPresenceProbe,
+  type MissingReference,
+  missingReferenceError,
+} from "./missing-reference";
+
 const HEX_RE = /^[0-9a-fA-F]+$/;
 const WHITESPACE_RE = /\s/;
 
@@ -506,7 +514,47 @@ function parse(expression: string): AstNode {
   return ast;
 }
 
-function applyBinary(operator: string, left: unknown, right: unknown): unknown {
+/**
+ * A reference whose field path was not present resolves to a marker rather
+ * than a bare undefined, so the operator decides what it means. Presence
+ * checks read it as undefined; everything else rejects it, which stops a
+ * mistyped path from quietly satisfying a comparison.
+ */
+function resolveMissingOperands(
+  operator: string,
+  left: unknown,
+  right: unknown
+): { left: unknown; right: unknown } {
+  const leftMissing = isMissingReference(left);
+  const rightMissing = isMissingReference(right);
+  if (!(leftMissing || rightMissing)) {
+    return { left, right };
+  }
+
+  const probesPresence =
+    isEqualityOperator(operator) &&
+    ((leftMissing && isPresenceProbe(right)) ||
+      (rightMissing && isPresenceProbe(left)));
+
+  if (!probesPresence) {
+    throw missingReferenceError(
+      (leftMissing ? left : right) as MissingReference
+    );
+  }
+
+  return {
+    left: leftMissing ? undefined : left,
+    right: rightMissing ? undefined : right,
+  };
+}
+
+function applyBinary(
+  operator: string,
+  rawLeft: unknown,
+  rawRight: unknown
+): unknown {
+  const { left, right } = resolveMissingOperands(operator, rawLeft, rawRight);
+
   switch (operator) {
     case "===":
       return left === right;
@@ -544,6 +592,9 @@ function applyBinary(operator: string, left: unknown, right: unknown): unknown {
 }
 
 function applyUnary(operator: string, argument: unknown): unknown {
+  if (isMissingReference(argument)) {
+    throw missingReferenceError(argument);
+  }
   switch (operator) {
     case "!":
       return !argument;

--- a/lib/workflow/nodes/condition/step.ts
+++ b/lib/workflow/nodes/condition/step.ts
@@ -18,6 +18,12 @@ export type ConditionInput = StepInput & {
   values?: Record<string, unknown>;
   /** KEEP-1284: Error from condition evaluation - if set, the step will throw */
   _evaluationError?: string;
+  /**
+   * Field paths that were not present on their node's output and resolved to
+   * undefined. Logged with the step so a mistyped reference is still visible
+   * in the run even though it no longer fails the branch.
+   */
+  unresolvedFields?: string[];
 };
 
 type ConditionResult = {

--- a/tests/unit/condition-absent-field-paths.test.ts
+++ b/tests/unit/condition-absent-field-paths.test.ts
@@ -67,6 +67,31 @@ describe("condition references to absent field paths", () => {
     expect(r.unresolvedFields).toBeUndefined();
   });
 
+  it("treats a null node output as an absent path, not a throw", () => {
+    const r = evaluateConditionExpression(
+      "{{@blank:Blank.foo}} !== undefined",
+      { ...outputs, blank: { label: "Blank", data: null } }
+    );
+    expect(r.result).toBe(false);
+    expect(r.unresolvedFields?.[0]).toContain("null");
+  });
+
+  it("resolves a path that breaks on an intermediate segment", () => {
+    for (const path of [
+      "Manual.missing.deep",
+      "Manual.nested.nope",
+      "Manual.timestamp.x",
+      "Manual.nested.a.x",
+    ]) {
+      const r = evaluateConditionExpression(
+        `{{@trigger:${path}}} !== undefined`,
+        outputs
+      );
+      expect(r.result).toBe(false);
+      expect(r.unresolvedFields).toHaveLength(1);
+    }
+  });
+
   it("still throws when the referenced node produced no output at all", () => {
     expect(() =>
       evaluateConditionExpression("{{@nope:Nope.x}} == 1", outputs)

--- a/tests/unit/condition-absent-field-paths.test.ts
+++ b/tests/unit/condition-absent-field-paths.test.ts
@@ -98,11 +98,36 @@ describe("condition references to absent field paths", () => {
     ).toThrow(/no output was found/);
   });
 
-  it("compares two absent paths as undefined == undefined", () => {
-    // Documents the JS semantics: a bare self-comparison on a mistyped path is
-    // true, which is why the absent path is reported on the step output.
+  it("rejects an absent path under a comparison operator", () => {
+    expect(() =>
+      evaluateConditionExpression(`${ABSENT} > 100`, outputs)
+    ).toThrow(/does not exist on the data/);
+  });
+
+  it("rejects two absent paths compared to each other", () => {
+    expect(() =>
+      evaluateConditionExpression(`${ABSENT} == ${ABSENT}`, outputs)
+    ).toThrow(/does not exist on the data/);
+  });
+
+  it("points at the presence operators in the rejection", () => {
+    expect(() =>
+      evaluateConditionExpression(`${ABSENT} == 1`, outputs)
+    ).toThrow(/is not undefined/);
+  });
+
+  it("supports the exists and does-not-exist shapes", () => {
     expect(
-      evaluateConditionExpression(`${ABSENT} == ${ABSENT}`, outputs).result
+      evaluateConditionExpression(
+        `${ABSENT} !== null && ${ABSENT} !== undefined`,
+        outputs
+      ).result
+    ).toBe(false);
+    expect(
+      evaluateConditionExpression(
+        `${ABSENT} === null || ${ABSENT} === undefined`,
+        outputs
+      ).result
     ).toBe(true);
   });
 });

--- a/tests/unit/condition-absent-field-paths.test.ts
+++ b/tests/unit/condition-absent-field-paths.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Absent field paths in a condition resolve to undefined rather than throwing.
+ *
+ * Every reference is resolved before the expression is evaluated, so throwing
+ * on an absent path also defeated an author's own `is not undefined` guard --
+ * the `&&` never got to short-circuit.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { evaluateConditionExpression } from "@/lib/workflow/executor/executor.workflow";
+
+const outputs = {
+  trigger: {
+    label: "Manual",
+    data: {
+      triggered: true,
+      timestamp: 1,
+      triggeredAt: "x",
+      nested: { a: null },
+    },
+  },
+};
+const ABSENT = "{{@trigger:Manual.triggeredAtss}}";
+
+describe("condition references to absent field paths", () => {
+  it("lets an is-not-undefined guard short-circuit to false", () => {
+    const r = evaluateConditionExpression(
+      `(${ABSENT} !== undefined) && ${ABSENT} == {{@trigger:Manual.timestamp}}`,
+      outputs
+    );
+    expect(r.result).toBe(false);
+  });
+
+  it("makes the is-undefined operator usable", () => {
+    expect(
+      evaluateConditionExpression(`${ABSENT} === undefined`, outputs).result
+    ).toBe(true);
+  });
+
+  it("reports the absent path with the available fields", () => {
+    const r = evaluateConditionExpression(`${ABSENT} === undefined`, outputs);
+    expect(r.unresolvedFields).toHaveLength(1);
+    expect(r.unresolvedFields?.[0]).toContain("triggeredAtss");
+    expect(r.unresolvedFields?.[0]).toContain(
+      "Available fields: triggered, timestamp, triggeredAt, nested"
+    );
+  });
+
+  it("reports nothing when every reference resolves", () => {
+    const r = evaluateConditionExpression(
+      "{{@trigger:Manual.timestamp}} == 1",
+      outputs
+    );
+    expect(r.result).toBe(true);
+    expect(r.unresolvedFields).toBeUndefined();
+  });
+
+  it("keeps a present-but-null field distinct from an absent one", () => {
+    const r = evaluateConditionExpression(
+      "{{@trigger:Manual.nested.a}} === null",
+      outputs
+    );
+    expect(r.result).toBe(true);
+    expect(r.unresolvedFields).toBeUndefined();
+  });
+
+  it("still throws when the referenced node produced no output at all", () => {
+    expect(() =>
+      evaluateConditionExpression("{{@nope:Nope.x}} == 1", outputs)
+    ).toThrow(/no output was found/);
+  });
+
+  it("compares two absent paths as undefined == undefined", () => {
+    // Documents the JS semantics: a bare self-comparison on a mistyped path is
+    // true, which is why the absent path is reported on the step output.
+    expect(
+      evaluateConditionExpression(`${ABSENT} == ${ABSENT}`, outputs).result
+    ).toBe(true);
+  });
+});

--- a/tests/unit/template-badge-edit-caret.test.ts
+++ b/tests/unit/template-badge-edit-caret.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { caretOffsetForBadgeEdit } from "@/components/ui/template-badge-editor";
+
+describe("caretOffsetForBadgeEdit", () => {
+  it("parks the caret just inside the closing braces", () => {
+    const raw = "{{@abc123:Manual.data}}";
+    expect(caretOffsetForBadgeEdit(raw)).toBe(raw.length - 2);
+    expect(raw.slice(caretOffsetForBadgeEdit(raw))).toBe("}}");
+  });
+
+  it("keeps the whole path to the left of the caret", () => {
+    const raw = "{{@abc123:Manual.data.timestamp}}";
+    expect(raw.slice(0, caretOffsetForBadgeEdit(raw))).toBe(
+      "{{@abc123:Manual.data.timestamp"
+    );
+  });
+
+  it("falls back to the end for a token that is not brace-closed", () => {
+    expect(caretOffsetForBadgeEdit("{{@abc:Manual.data")).toBe(18);
+  });
+
+  it("never returns a negative offset", () => {
+    expect(caretOffsetForBadgeEdit("")).toBe(0);
+  });
+});

--- a/tests/unit/template-fail-closed.test.ts
+++ b/tests/unit/template-fail-closed.test.ts
@@ -162,6 +162,79 @@ describe("processCodeTemplates strict integration", () => {
   });
 });
 
+describe("present-but-empty field paths resolve instead of failing", () => {
+  const nullableOutputs = {
+    trigger: {
+      label: "Trigger",
+      data: { ts: null, note: undefined, nested: { inner: null } },
+    },
+  };
+
+  it("resolves a key that exists holding null to the empty string", () => {
+    const tracker = createTracker();
+    const result = processTemplates(
+      { ts: "{{@trigger:Trigger.ts}}" },
+      nullableOutputs,
+      tracker
+    );
+    expect(result.ts).toBe("");
+    expect(tracker.unresolved).toHaveLength(0);
+  });
+
+  it("resolves a key that exists holding undefined", () => {
+    const tracker = createTracker();
+    const result = processTemplates(
+      { note: "{{@trigger:Trigger.note}}" },
+      nullableOutputs,
+      tracker
+    );
+    expect(result.note).toBe("");
+    expect(tracker.unresolved).toHaveLength(0);
+  });
+
+  it("resolves a nested key that exists holding null", () => {
+    const tracker = createTracker();
+    const result = processTemplates(
+      { inner: "{{@trigger:Trigger.nested.inner}}" },
+      nullableOutputs,
+      tracker
+    );
+    expect(result.inner).toBe("");
+    expect(tracker.unresolved).toHaveLength(0);
+  });
+
+  it("still records no-path when the key is genuinely absent", () => {
+    const tracker = createTracker();
+    processTemplates(
+      { missing: "{{@trigger:Trigger.notAKey}}" },
+      nullableOutputs,
+      tracker
+    );
+    expect(tracker.unresolved[0]?.reason).toBe("no-path");
+  });
+
+  it("renders a present null as the null literal in code nodes", () => {
+    const tracker = createTracker();
+    const out = processCodeTemplates(
+      "const x = {{@trigger:Trigger.ts}};",
+      nullableOutputs,
+      tracker
+    );
+    expect(out).toBe("const x = null;");
+    expect(tracker.unresolved).toHaveLength(0);
+  });
+
+  it("still records no-path in code nodes when the key is absent", () => {
+    const tracker = createTracker();
+    processCodeTemplates(
+      "const x = {{@trigger:Trigger.notAKey}};",
+      nullableOutputs,
+      tracker
+    );
+    expect(tracker.unresolved[0]?.reason).toBe("no-path");
+  });
+});
+
 describe("processCodeTemplates: refs in comments are documentation, not deps", () => {
   const codeOutputs = {
     src: { label: "Src", data: { value: 42, addr: "0xabc" } },

--- a/tests/unit/workflow-codegen-condition.test.ts
+++ b/tests/unit/workflow-codegen-condition.test.ts
@@ -356,24 +356,31 @@ describe("runtime condition evaluation", () => {
       expect(result.unresolvedFields?.[0]).toMatch(FIELD_NOT_EXIST_REGEX);
     });
 
-    it("should throw error when node data is null", () => {
+    it("resolves a field on null node data to undefined and reports it", () => {
+      // Superseded alongside the absent-field case: a node that produced no
+      // data is the same situation as a field that is not there, and throwing
+      // defeats a presence guard the author wrote for it.
       const expression = "{{@node1:Label.value}} > 100";
       const outputs = {
         node1: { label: "Label", data: null },
       };
 
-      expect(() => evaluateConditionExpression(expression, outputs)).toThrow(
+      const result = evaluateConditionExpression(expression, outputs);
+      expect(result.result).toBe(false);
+      expect(result.unresolvedFields?.[0]).toMatch(
         COULD_NOT_RESOLVE_NULL_REGEX
       );
     });
 
-    it("should throw error when node data is undefined", () => {
+    it("resolves a field on undefined node data to undefined and reports it", () => {
       const expression = "{{@node1:Label.value}} > 100";
       const outputs = {
         node1: { label: "Label", data: undefined },
       };
 
-      expect(() => evaluateConditionExpression(expression, outputs)).toThrow(
+      const result = evaluateConditionExpression(expression, outputs);
+      expect(result.result).toBe(false);
+      expect(result.unresolvedFields?.[0]).toMatch(
         COULD_NOT_RESOLVE_UNDEFINED_REGEX
       );
     });

--- a/tests/unit/workflow-codegen-condition.test.ts
+++ b/tests/unit/workflow-codegen-condition.test.ts
@@ -341,46 +341,37 @@ describe("runtime condition evaluation", () => {
       );
     });
 
-    it("resolves an absent field to undefined and reports the path", () => {
-      // Superseded: an absent field no longer throws. Resolution runs for
-      // every reference before the expression does, so throwing here also
-      // defeated an author's own `is not undefined` guard. The path is
-      // reported on the result instead. Node-level misses below still throw.
+    it("should throw error when referenced field is undefined", () => {
+      // Unguarded comparison: the absent path is rejected. A presence operator
+      // is what makes it evaluate instead -- see condition-absent-field-paths.
       const expression = "{{@node1:Label.missingField}} > 100";
       const outputs = {
         node1: { label: "Label", data: { existingField: 42 } },
       };
 
-      const result = evaluateConditionExpression(expression, outputs);
-      expect(result.result).toBe(false);
-      expect(result.unresolvedFields?.[0]).toMatch(FIELD_NOT_EXIST_REGEX);
+      expect(() => evaluateConditionExpression(expression, outputs)).toThrow(
+        FIELD_NOT_EXIST_REGEX
+      );
     });
 
-    it("resolves a field on null node data to undefined and reports it", () => {
-      // Superseded alongside the absent-field case: a node that produced no
-      // data is the same situation as a field that is not there, and throwing
-      // defeats a presence guard the author wrote for it.
+    it("should throw error when node data is null", () => {
       const expression = "{{@node1:Label.value}} > 100";
       const outputs = {
         node1: { label: "Label", data: null },
       };
 
-      const result = evaluateConditionExpression(expression, outputs);
-      expect(result.result).toBe(false);
-      expect(result.unresolvedFields?.[0]).toMatch(
+      expect(() => evaluateConditionExpression(expression, outputs)).toThrow(
         COULD_NOT_RESOLVE_NULL_REGEX
       );
     });
 
-    it("resolves a field on undefined node data to undefined and reports it", () => {
+    it("should throw error when node data is undefined", () => {
       const expression = "{{@node1:Label.value}} > 100";
       const outputs = {
         node1: { label: "Label", data: undefined },
       };
 
-      const result = evaluateConditionExpression(expression, outputs);
-      expect(result.result).toBe(false);
-      expect(result.unresolvedFields?.[0]).toMatch(
+      expect(() => evaluateConditionExpression(expression, outputs)).toThrow(
         COULD_NOT_RESOLVE_UNDEFINED_REGEX
       );
     });

--- a/tests/unit/workflow-codegen-condition.test.ts
+++ b/tests/unit/workflow-codegen-condition.test.ts
@@ -341,15 +341,19 @@ describe("runtime condition evaluation", () => {
       );
     });
 
-    it("should throw error when referenced field is undefined", () => {
+    it("resolves an absent field to undefined and reports the path", () => {
+      // Superseded: an absent field no longer throws. Resolution runs for
+      // every reference before the expression does, so throwing here also
+      // defeated an author's own `is not undefined` guard. The path is
+      // reported on the result instead. Node-level misses below still throw.
       const expression = "{{@node1:Label.missingField}} > 100";
       const outputs = {
         node1: { label: "Label", data: { existingField: 42 } },
       };
 
-      expect(() => evaluateConditionExpression(expression, outputs)).toThrow(
-        FIELD_NOT_EXIST_REGEX
-      );
+      const result = evaluateConditionExpression(expression, outputs);
+      expect(result.result).toBe(false);
+      expect(result.unresolvedFields?.[0]).toMatch(FIELD_NOT_EXIST_REGEX);
     });
 
     it("should throw error when node data is null", () => {


### PR DESCRIPTION
## Problem

Two things that are fine on their own and a dead end together.

The autocomplete builds its field list from a node's recorded output, current
run first, then last run. A node that has never executed has no recorded
output, so it offers nothing.

The badge is `contentEditable = "false"` and Backspace removes the whole pill,
so there is no cursor position inside `{{...}}`. Typing a path lands after the
closing braces and produces:

```
"{{@JRY0lGfsvlwszZ797lIFz:Manual.data}}.timestamp"
```

which resolves the whole object and leaves `.timestamp` as literal text:

```
"{"triggered":true,"timestamp":1788014970885,...}.timestamp" == ...
```

The result is a field path you know will exist at runtime being unreachable
from the UI.

Separately, config and code-node resolution inferred "path missing" from the
resolved value being nullish. A key that exists holding `null` or `undefined`
was reported as unresolved and failed the action, even though the path was
present and legitimately empty. The condition path already got this right.

## Change

**Edit a reference in place.** Double-clicking a badge swaps it for its raw
`{{@nodeId:Label.path}}` text with the caret just inside the closing braces, so
typing extends the path. Blur re-renders the badge. The badge carries a title
so the gesture is discoverable.

No re-render is needed on open: `extractValue()` reads a badge as its
`data-template` and raw text as itself, so the serialized value is unchanged,
and typing inside the token keeps the token count stable, which `handleInput`
already treats as "typing around existing badges".

`TemplateBadgeInput` and `TemplateBadgeTextarea` are thin wrappers over
`TemplateBadgeEditor`, so this covers every badge surface including the
condition expression field.

**Present-but-empty resolves as itself.** `replaceConfigTemplate` and the
code-node resolver now use `resolveFromOutputDataChecked`, the same checked walk
the condition path uses. It distinguishes a key that is absent from a key that
exists holding null or undefined:

- absent, or a non-object on the way down, stays unresolved and fails closed
- present holding null or undefined resolves to that value, rendering as the
  empty string in config and the `null` literal in code nodes

## Tests

- 6 cases covering present-null, present-undefined, nested present-null, and
  absent-key across config and code-node resolution. 4 of the 6 fail without
  the resolver change.
- 4 cases on the caret helper.
- Full unit suite: 573 files, 21701 passed, 1 skipped.

The double-click DOM interaction itself is not unit tested. The vitest
environment is `node` with no DOM harness, and the existing tests for this
component only cover its exported helpers. Worth exercising by hand in the PR
environment: double-click a badge, extend the path, click away, confirm it
re-renders and saves.

---

## Follow-up: absent field paths no longer throw

Referencing a field that is not on the node's output threw, which made the
presence operators unusable and, worse, defeated a guard written for exactly
that case:

```
(Manual.data.triggeredAtss !== undefined) && Manual.data.triggeredAtss == Manual.data.timestamp
```

Every reference is resolved before the expression is evaluated, so the `&&`
never got to short-circuit: `triggeredAtss` was resolved first and the
resolution threw. `is undefined`, `does not exist` and `exists` were all
unusable against an absent field for the same reason.

An absent path now binds `undefined` and the expression evaluates normally. The
guard above evaluates to `false`.

The diagnostic is not lost. The path and the available field names are reported
on the condition result as `unresolvedFields` and threaded onto the step input,
so a mistyped reference is visible in the run detail and logged as a warning.

Unchanged: a referenced node that produced no output at all still throws, and a
key that exists holding `null` or `undefined` is still distinct from an absent
one.

Worth being explicit about the tradeoff, since it is a real one. A bare
self-comparison on a mistyped path, `X == X`, is now `undefined == undefined`,
which is `true` in JS, so it takes the true branch instead of failing the run.
That case is pinned in a test and is why the absent path is surfaced rather
than silently dropped.

`tests/unit/workflow-codegen-condition.test.ts` had a case asserting the old
throw; it now asserts the new contract.
